### PR TITLE
SkelAnime Fix

### DIFF
--- a/include/z64.h
+++ b/include/z64.h
@@ -1024,8 +1024,10 @@ typedef struct
     /* 0x34 */ s32 unk_34;
     /* 0x38 */ s32 unk_38;
     /* 0x3C */ u16 unk_3C;
-    /* 0x3E */ u16 unk_3E; /* Probably Padding */
-} SkelAnime; // size = 0x40
+    /* 0x3E */ u16 unk_3E;
+    /* 0x40 */ u16 unk_40;
+    /* 0x42 */ u16 unk_42;
+} SkelAnime; // size = 0x44
 
 typedef struct
 {

--- a/src/overlays/actors/ovl_Demo_Go/z_demo_go.h
+++ b/src/overlays/actors/ovl_Demo_Go/z_demo_go.h
@@ -8,7 +8,6 @@ typedef struct
 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x018C */ char unk_18C[0x4];
     /* 0x0190 */ s16 unk_190;
     /* 0x0192 */ s16 unk_192;
     /* 0x0194 */ s32 action;

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.c
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.c
@@ -11,7 +11,6 @@ typedef struct
 {
     /* 0x0000 */ Actor     actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x018C */ char      unk_18C[0x4];
     /* 0x0190 */ ActorFunc updateFunc;
     /* 0x0194 */ u32       unk_194;
     /* 0x0198 */ s32       unk_198;

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -11,7 +11,6 @@ typedef struct
 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x018C */ char unk_18C[0x4];
     /* 0x0190 */ UNK_PTR unkSkelAnimeStruct;
     /* 0x0194 */ char unk_194[0x32];
     /* 0x01C6 */ s16 unk_1C6;

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
@@ -14,7 +14,6 @@ typedef struct
 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x018C */ char unk_18C[0x4];
     /* 0x0190 */ ActorFunc actionFunc;
     /* 0x0194 */ s16 timer;
     /* 0x0196 */ s16 switchFlag;


### PR DESCRIPTION
Fixes the SkelAnime struct to be the proper 44 bytes, adjusts usage of SkelAnime struct to account for new size.  