### PR TITLE
Add script to generate REG macros from GameInfo offsets

### DIFF
--- a/tools/asmdiff-old.sh
+++ b/tools/asmdiff-old.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-OBJDUMP="${MIPS_BINUTILS_PREFIX}objdump -D -bbinary -mmips -EB"
-OPTIONS="--start-address=$(($1)) --stop-address=$(($1 + $2))"
-$OBJDUMP $OPTIONS baserom.z64 > baserom.dump
-$OBJDUMP $OPTIONS zelda_ocarina_mq_dbg.z64 > zelda_ocarina_mq_dbg.dump
-diff baserom.dump zelda_ocarina_mq_dbg.dump | colordiff

--- a/tools/regconvert.py
+++ b/tools/regconvert.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import argparse
+
+GROUP_SIZE = 0x60
+DATA_OFFSET = 0x14
+
+REGISTER_NAMES = " SOPQMYDUIZCNKXcsiWAVHGmnBdkb"
+
+def get_reg_macro(offset):
+    reg = (offset - DATA_OFFSET) // 2
+    group = reg // GROUP_SIZE
+    reg_in_group = reg % GROUP_SIZE
+    return "%cREG(%d)\n" % (REGISTER_NAMES[group], reg_in_group)
+
+def main():
+    parser = argparse.ArgumentParser(description="Converts a GameInfo offset to a REG macro.")
+    parser.add_argument("offset", help="offset to GameInfo in hexadecimal")
+    args = parser.parse_args()
+    print(get_reg_macro(int(args.offset, 16)))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Usage is of the form `tools/regconvert.py 12AB` or `tools/regconvert.py 0x12AB`.
I may add support to convert from REG macros to offsets in the future, but it only converts one way atm.

Also removed `asmdiff-old.sh` that I believe is no longer used by anyone.