### PR TITLE
Run gcc checks with NON_MATCHING and Update progress script

### DIFF
--- a/makefile
+++ b/makefile
@@ -26,8 +26,8 @@ OBJDUMP    := $(MIPS_BINUTILS_PREFIX)objdump
 CC         := $(QEMU_IRIX) -L tools/ido7.1_compiler tools/ido7.1_compiler/usr/bin/cc
 CC_OLD     := $(QEMU_IRIX) -L tools/ido5.3_compiler tools/ido5.3_compiler/usr/bin/cc
 
-# Check code syntax with host compiler (TODO: define NON_MATCHING because the non-matching code is utterly broken)
-CC_CHECK   := gcc -fno-builtin -fsyntax-only -fsigned-char -std=gnu90 -Wall -Wextra -Wno-format-security -Wno-unknown-pragmas -D _LANGUAGE_C -I include -include stdarg.h
+# Check code syntax with host compiler
+CC_CHECK   := gcc -fno-builtin -fsyntax-only -fsigned-char -std=gnu90 -Wall -Wextra -Wno-format-security -Wno-unknown-pragmas -D _LANGUAGE_C -D NON_MATCHING -I include -include stdarg.h
 
 CPP        := cpp
 MKLDSCRIPT := tools/mkldscript
@@ -156,10 +156,6 @@ build/assets/%.o: assets/%.c
 	$(CC) -c $(CFLAGS) $(OPTIMIZATION) -o $@ $^
 #	$(CC_CHECK) $^
 	$(OBJCOPY) -O binary $@ $@.bin
-
-#build/src/boot/%.o: src/boot/%.c
-#	$(CC) -c $(CFLAGS) $(OPTIMIZATION) -o $@ $^
-#	@$(OBJDUMP) -d $@ > $(@:.o=.s)
 
 build/src/overlays/%.o: src/overlays/%.c
 	$(CC) -c $(CFLAGS) $(OPTIMIZATION) -o $@ $^

--- a/progress.py
+++ b/progress.py
@@ -88,28 +88,18 @@ nonMatchingASMBoot = GetNonMatchingSize("asm/non_matchings/boot")
 nonMatchingASMCode = GetNonMatchingSize("asm/non_matchings/code") + GetNonMatchingSize("asm/non_matchings/libultra_code")
 nonMatchingASMOvl = GetNonMatchingSize("asm/non_matchings/overlays")
 
-codeSize = 1004128 # 1.00mb
-bootSize = 36752
-#ovlSize = 3727584 # 3.727mb
-ovlSize = 2812000 # .text section only
-libultraSize = 40816 # This is temp
-audioSize = 0 # This is temp
-handwritten = 0 # This is temp
-
 src -= nonMatchingASM
 code -= nonMatchingASMCode
 boot -= nonMatchingASMBoot
 ovl -= nonMatchingASMOvl
 asm += nonMatchingASM
-#print(nonMatchingASM)
 
-#asm = asm - (libultra_size + audio_size + handwritten - boot_size - code_size - ovl_size)
-#asm = asm - (libultra_size + audio_size + handwritten)
-#asm = -(libultra_size + audio_size + handwritten - boot_size - code_size - ovl_size)
-#asm += codeSize
-#asm += bootSize
-#asm += ovlSize
-#asm -= src
+bootSize = 30704 # decompilable code only
+codeSize = 1004128 # .text section except rsp bins (1.00mb)
+ovlSize = 2812000 # .text sections
+handwritten = 5840 # boot only
+
+asm -= handwritten
 
 total = src + asm
 srcPct = 100 * src / total

--- a/src/code/gfxprint.c
+++ b/src/code/gfxprint.c
@@ -223,7 +223,7 @@ void GfxPrint_SetBasePosPx(GfxPrint* this, s32 x, s32 y) {
 
 #ifdef NON_MATCHING
 // regalloc and ordering differences
-void GfxPrint_PrintCharImpl(GfxPrint* this, char c) {
+void GfxPrint_PrintCharImpl(GfxPrint* this, u8 c) {
     if (this->flag & GFXPRINT_UPDATE_MODE) {
         this->flag &= ~GFXPRINT_UPDATE_MODE;
 

--- a/src/code/z_sample.c
+++ b/src/code/z_sample.c
@@ -20,8 +20,8 @@ void Sample_Draw(SampleContext* this) {
 
     func_800C6AC4(gfxArr, gfxCtx, "../z_sample.c", 62);
 
-    gSPSegment(gfxCtx->polyOpa.p++, 0, NULL;
-    gSPSegment(gfxCtx->polyOpa.p++, 1, this->staticSegment);
+    gSPSegment(gfxCtx->polyOpa.p++, 0x00, NULL);
+    gSPSegment(gfxCtx->polyOpa.p++, 0x01, this->staticSegment);
 
     func_80095248(gfxCtx, 0, 0, 0);
 


### PR DESCRIPTION
NON_MATCHING should stay equivalent and correct so gcc checks should be run with them enabled to help keeping it that way. I had to fix 2 very minor issues in non matchings to ensure they pass checks successfully.

Also updated the progress script to account for handwritten asm in "boot".