### PR TITLE
Fix some issues with the formatter

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -2,7 +2,7 @@
 
 FORMAT_OPTS="-i -style=file"
 TIDY_OPTS="-p . --fix --fix-errors"
-COMPILER_OPTS="-fno-builtin -std=gnu90 -Iinclude -Isrc -D_LANGUAGE_C"
+COMPILER_OPTS="-fno-builtin -std=gnu90 -Iinclude -Isrc -D_LANGUAGE_C -DNON_MATCHING"
 
 shopt -s globstar
 

--- a/src/code/fault.c
+++ b/src/code/fault.c
@@ -137,8 +137,9 @@ void Fault_AddClient(FaultClient* client, void* callback, void* param0, void* pa
 
 end:
     osSetIntMask(mask);
-    if (alreadyExists)
+    if (alreadyExists) {
         osSyncPrintf(VT_COL(RED, WHITE) "fault_AddClient: %08x は既にリスト中にある\n" VT_RST, client);
+    }
 }
 #else
 #pragma GLOBAL_ASM("asm/non_matchings/code/fault/Fault_AddClient.s")
@@ -270,27 +271,34 @@ u32 Fault_WaitForInputImpl() {
 
             kDown = curInput->padPressed;
 
-            if (kDown == 0x20)
+            if (kDown == 0x20) {
                 sFaultStructPtr->faultActive = !sFaultStructPtr->faultActive;
+            }
 
-            if (!sFaultStructPtr->faultActive)
+            if (!sFaultStructPtr->faultActive) {
                 break;
+            }
 
-            if (count-- < 1)
+            if (count-- < 1) {
                 return false;
+            }
         }
 
-        if (kDown == 0x8000 || kDown == 0x100)
+        if (kDown == 0x8000 || kDown == 0x100) {
             return false;
+        }
 
-        if (kDown == 0x200)
+        if (kDown == 0x200) {
             return true;
+        }
 
-        if (kDown == 0x800)
+        if (kDown == 0x800) {
             FaultDrawer_SetOsSyncPrintfEnabled(true);
+        }
 
-        if (kDown == 0x400)
+        if (kDown == 0x400) {
             FaultDrawer_SetOsSyncPrintfEnabled(false);
+        }
     }
 
     return false;
@@ -555,24 +563,28 @@ void Fault_DrawMemDump(u32 pc, u32 sp, u32 unk0, u32 unk1) {
     s32 off;
 
     while (true) {
-        if (addr < 0x80000000)
+        if (addr < 0x80000000) {
             addr = 0x80000000;
-        if (addr > 0x807fff00)
+        }
+        if (addr > 0x807fff00) {
             addr = 0x807fff00;
+        }
 
         addr &= ~0xF;
         Fault_DrawMemDumpPage("Dump", (u32*)addr, 0);
         count = 600;
 
         while (sFaultStructPtr->faultActive) {
-            if (count == 0)
+            if (count == 0) {
                 return;
+            }
 
             count--;
             Fault_Sleep(0x10);
             Fault_UpdatePadImpl();
-            if (!~(curInput->padPressed | ~0x20))
+            if (!~(curInput->padPressed | ~0x20)) {
                 sFaultStructPtr->faultActive = false;
+            }
         }
 
         do {
@@ -580,31 +592,42 @@ void Fault_DrawMemDump(u32 pc, u32 sp, u32 unk0, u32 unk1) {
             Fault_UpdatePadImpl();
         } while (curInput->padPressed == 0);
 
-        if (!~(curInput->padPressed | ~0x1000))
+        if (!~(curInput->padPressed | ~0x1000)) {
             return;
+        }
 
-        if (!~(curInput->raw.pad | ~0x8000))
+        if (!~(curInput->raw.pad | ~0x8000)) {
             return;
+        }
 
         off = 0x10;
-        if (!~(curInput->raw.pad | ~0x2000))
+        if (!~(curInput->raw.pad | ~0x2000)) {
             off = 0x100;
-        if (!~(curInput->raw.pad | ~0x4000))
+        }
+        if (!~(curInput->raw.pad | ~0x4000)) {
             off <<= 8;
-        if (!~(curInput->raw.pad | ~0x800))
+        }
+        if (!~(curInput->raw.pad | ~0x800)) {
             addr -= off;
-        if (!~(curInput->raw.pad | ~0x400))
+        }
+        if (!~(curInput->raw.pad | ~0x400)) {
             addr += off;
-        if (!~(curInput->raw.pad | ~0x8))
+        }
+        if (!~(curInput->raw.pad | ~0x8)) {
             addr = pc;
-        if (!~(curInput->raw.pad | ~0x4))
+        }
+        if (!~(curInput->raw.pad | ~0x4)) {
             addr = sp;
-        if (!~(curInput->raw.pad | ~0x2))
+        }
+        if (!~(curInput->raw.pad | ~0x2)) {
             addr = unk0;
-        if (!~(curInput->raw.pad | ~0x1))
+        }
+        if (!~(curInput->raw.pad | ~0x1)) {
             addr = unk1;
-        if (!~(curInput->raw.pad | ~0x20))
+        }
+        if (!~(curInput->raw.pad | ~0x20)) {
             break;
+        }
     }
 
     sFaultStructPtr->faultActive = true;
@@ -715,15 +738,16 @@ void Fault_ThreadEntry(void* arg) {
         __osSetFpcCsr(__osGetFpcCsr() & -0xf81);
         sFaultStructPtr->faultedThread = faultedThread;
 
-        while (!sFaultStructPtr->faultHandlerEnabled)
+        while (!sFaultStructPtr->faultHandlerEnabled) {
             Fault_Sleep(1000);
+        }
 
         Fault_Sleep(500);
         Fault_CommitFB();
 
-        if (sFaultStructPtr->faultActive)
+        if (sFaultStructPtr->faultActive) {
             Fault_Wait5Seconds();
-        else {
+        } else {
             Fault_DrawCornerRec(0xF801);
             Fault_WaitForButtonCombo();
         }

--- a/src/code/fault_drawer.c
+++ b/src/code/fault_drawer.c
@@ -114,10 +114,11 @@ void FaultDrawer_DrawChar(char c) {
             u32 mask = 0x10000000 << (c % 4);
             u32 data = *dataPtr;
             for (x = 0; x < sFaultDrawerStruct.charW; x++) {
-                if (mask & data)
+                if (mask & data) {
                     fb[x] = sFaultDrawerStruct.foreColor;
-                else if (sFaultDrawerStruct.backColor & 1)
+                } else if (sFaultDrawerStruct.backColor & 1) {
                     fb[x] = sFaultDrawerStruct.backColor;
+                }
                 mask >>= 4;
             }
             fb += sFaultDrawerStruct.w;

--- a/src/code/gfxprint.c
+++ b/src/code/gfxprint.c
@@ -246,22 +246,24 @@ void GfxPrint_PrintCharImpl(GfxPrint* this, u8 c) {
     if (this->flag & GFXPRINT_FLAG4) {
         gDPSetPrimColorMod(this->dlist++, 0, 0, 0);
 
-        if (this->flag & GFXPRINT_FLAG64)
+        if (this->flag & GFXPRINT_FLAG64) {
             gSPTextureRectangle(this->dlist++, (this->posX + 4) << 1, (this->posY + 4) << 1, (this->posX + 4 + 32) << 1,
                                 (this->posY + 4 + 32) << 1, c * 2, (u16)(c & 4) * 64, (u16)(c >> 3) * 256, 512, 512);
-        else
+        } else {
             gSPTextureRectangle(this->dlist++, this->posX + 4, this->posY + 4, this->posX + 4 + 32, this->posY + 4 + 32,
                                 c * 2, (u16)(c & 4) * 64, (u16)(c >> 3) * 256, 1024, 1024);
+        }
 
         gDPSetPrimColorMod(this->dlist++, 0, 0, *(u32*)&this->color);
     }
 
-    if (this->flag & GFXPRINT_FLAG64)
+    if (this->flag & GFXPRINT_FLAG64) {
         gSPTextureRectangle(this->dlist++, (this->posX) << 1, (this->posY) << 1, (this->posX + 32) << 1,
                             (this->posY + 32) << 1, c * 2, (u16)(c & 4) * 64, (u16)(c >> 3) * 256, 512, 512);
-    else
+    } else {
         gSPTextureRectangle(this->dlist++, this->posX, this->posY, this->posX + 32, this->posY + 32, c * 2,
                             (u16)(c & 4) * 64, (u16)(c >> 3) * 256, 1024, 1024);
+    }
 
     this->posX += 32;
 }

--- a/src/code/sys_matrix.c
+++ b/src/code/sys_matrix.c
@@ -738,12 +738,13 @@ void func_800D20CC(MtxF* mf, Vec3s* vec, s32 flag) {
 
     vec->y = Math_atan2f(mf->zx, mf->zz) * (32768 / M_PI);
 
-    if (!flag)
+    if (!flag) {
         vec->z = Math_atan2f(mf->xy, mf->yy) * (32768 / M_PI);
-    else
+    } else {
         vec->z = Math_atan2f(mf->xy / sqrtf(SQ(mf->xx) + SQ(mf->xz) + SQ(mf->xy)),
                              mf->yy / sqrtf(SQ(mf->yx) + SQ(mf->yz) + SQ(mf->yy))) *
                  (32768 / M_PI);
+    }
 }
 #else
 #pragma GLOBAL_ASM("asm/non_matchings/code/sys_matrix/func_800D20CC.s")
@@ -762,12 +763,13 @@ void func_800D2264(MtxF* mf, Vec3s* vec, s32 flag) {
 
     vec->z = Math_atan2f(mf->xy, mf->xx) * (32768 / M_PI);
 
-    if (!flag)
+    if (!flag) {
         vec->x = Math_atan2f(mf->yz, mf->zz) * (32768 / M_PI);
-    else
+    } else {
         vec->x = Math_atan2f(mf->yz / sqrtf(SQ(mf->yx) + SQ(mf->yy) + SQ(mf->yz)),
                              mf->zz / sqrtf(SQ(mf->zx) + SQ(mf->zy) + SQ(mf->zz))) *
                  (32768 / M_PI);
+    }
 }
 #else
 #pragma GLOBAL_ASM("asm/non_matchings/code/sys_matrix/func_800D2264.s")

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -156,16 +156,19 @@ void ActorShadow_DrawFunc_Teardrop(Actor* actor, LightMapper* lightMapper, Globa
             if ((phi_f2 >= -1.0f) && (phi_f2 < 500.0f)) {
                 phi_s0 = lightMapper->lights;
 
-                if (phi_f2 <= 0.0f)
+                if (phi_f2 <= 0.0f) {
                     actor->shape.unk_15++;
+                }
 
-                if (30.0f < phi_f2)
+                if (30.0f < phi_f2) {
                     phi_f2 = 30.0f;
+                }
 
                 temp_f24 = actor->shape.unk_14 * (1.0f - (phi_f2 * (1.0f / 30)));
 
-                if (30.0f < phi_f2)
+                if (30.0f < phi_f2) {
                     phi_f2 = 30.0f;
+                }
 
                 temp_f20_2 = 1.0f - (phi_f2 * (1.0f / 70));
                 temp_f22_2 = (actor->shape.unk_10 * temp_f20_2) * actor->scale.x;
@@ -187,8 +190,9 @@ void ActorShadow_DrawFunc_Teardrop(Actor* actor, LightMapper* lightMapper, Globa
                     if (phi_s0->l.dir[1] > 0) {
                         temp_a3 = (ABS(phi_s0->l.dir[1]) * ((phi_s0->l.col[0] + phi_s0->l.col[1]) + phi_s0->l.col[2])) -
                                   (phi_s2 * 8);
-                        if (temp_a3 > 0)
+                        if (temp_a3 > 0) {
                             func_8002B66C(globalCtx, phi_s0, &spE8, temp_a3, temp_f24, temp_f22_2, temp_f20_2);
+                        }
                     }
                     phi_s0++;
                 }
@@ -335,18 +339,20 @@ void func_8002C124(TargetContext* targetCtx, GlobalContext* globalCtx) {
         spCE = 0xFF;
         var1 = 1.0f;
 
-        if (targetCtx->unk_4B != 0)
+        if (targetCtx->unk_4B != 0) {
             spB8 = 1;
-        else
+        } else {
             spB8 = 3;
+        }
 
         if (actor != NULL) {
             Math_Vec3f_Copy(&targetCtx->targetCenterPos, &actor->posRot2.pos);
             var1 = (500.0f - targetCtx->unk_44) / 420.0f;
         } else {
             targetCtx->unk_48 -= 120;
-            if (targetCtx->unk_48 < 0)
+            if (targetCtx->unk_48 < 0) {
                 targetCtx->unk_48 = 0;
+            }
             spCE = targetCtx->unk_48;
         }
 
@@ -361,8 +367,9 @@ void func_8002C124(TargetContext* targetCtx, GlobalContext* globalCtx) {
         spBC.z = spBC.z * var1;
 
         targetCtx->unk_4C--;
-        if (targetCtx->unk_4C < 0)
+        if (targetCtx->unk_4C < 0) {
             targetCtx->unk_4C = 2;
+        }
 
         func_8002BE64(targetCtx, targetCtx->unk_4C, spBC.x, spBC.y, spBC.z);
 
@@ -373,10 +380,11 @@ void func_8002C124(TargetContext* targetCtx, GlobalContext* globalCtx) {
                 entry = &targetCtx->arr_50[spAC];
 
                 if (entry->unk_0C < 500.0f) {
-                    if (entry->unk_0C <= 120.0f)
+                    if (entry->unk_0C <= 120.0f) {
                         var2 = 0.15f;
-                    else
+                    } else {
                         var2 = ((entry->unk_0C - 120.0f) * 0.001f) + 0.15f;
+                    }
 
                     Matrix_Translate(entry->pos.x, entry->pos.y, 0.0f, MTXMODE_NEW);
                     Matrix_Scale(var2, 0.15f, 1.0f, MTXMODE_APPLY);
@@ -398,8 +406,9 @@ void func_8002C124(TargetContext* targetCtx, GlobalContext* globalCtx) {
                 }
 
                 spCE = spCE - (0xFF / 3);
-                if (spCE < 0)
+                if (spCE < 0) {
                     spCE = 0;
+                }
                 spAC = (spAC + 1) % 3;
             }
         }
@@ -1437,14 +1446,16 @@ f32 func_8002EFC0(Actor* actor, Player* player, s16 arg2) {
     abs_var = ABS(var);
 
     if (player->unk_664 != NULL) {
-        if ((abs_var > 0x4000) || (actor->flags & 0x8000000))
+        if ((abs_var > 0x4000) || (actor->flags & 0x8000000)) {
             return FLT_MAX;
-        else
+        } else {
             return actor->waterSurfaceDist - actor->waterSurfaceDist * 0.8f * ((0x4000 - abs_var) * 3.0517578125e-05f);
+        }
     }
 
-    if (abs_var > 0x2AAA)
+    if (abs_var > 0x2AAA) {
         return FLT_MAX;
+    }
 
     return actor->waterSurfaceDist;
 }
@@ -1822,10 +1833,11 @@ void func_8002FBAC(GlobalContext* globalCtx) {
     func_800C6AC4(gfxArr, globalCtx->state.gfxCtx, "../z_actor.c", 5308);
 
     if (gSaveContext.respawn[RESPAWN_MODE_TOP].data != 0) {
-        if (LINK_IS_ADULT)
+        if (LINK_IS_ADULT) {
             spD8 = 80.0f;
-        else
+        } else {
             spD8 = 60.0f;
+        }
 
         spD0 = 0xFF;
         spD4 = 1.0f;

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -224,8 +224,9 @@ s32 func_800443A0(Camera* camera, Vec3f* b, Vec3f* c) {
 
     sp34 = NULL; // this is moved to the top when it should be done in the middle of the function args being loaded
     if (func_8003DD6C(&camera->globalCtx->colCtx, b, c, &sp40, &sp34, 1, 1, 1, 0, &sp38) != 0) {
-        if (func_80038B7C(sp34, b) < 0.0f)
+        if (func_80038B7C(sp34, b) < 0.0f) {
             return 1;
+        }
     }
     return 0;
 }
@@ -461,18 +462,20 @@ s32 func_800458D4(Camera* camera, struct_80045714* b, f32 c, f32* d, s16 e) {
     sp60.z = 0.0f;
 
     temp_s1 = &camera->unk_94;
-    if (e != 0)
+    if (e != 0) {
         sp60.y -= func_80045714(&camera->unk_108, temp_s1->rot.y, b->unk_06, OREG(9));
+    }
 
     sp48 = temp_s1->pos.y - *d;
     temp_ret = Math_atan2f(sp48, func_8007C028(&camera->unk_50, &camera->unk_5C)); // f2 and f14 are swapped
 
-    if (OREG(32) * (M_PI / 180) < temp_ret)
+    if (OREG(32) * (M_PI / 180) < temp_ret) {
         phi_f2 = 1.0f - sinf(temp_ret - OREG(32) * (M_PI / 180));
-    else if (OREG(33) * (M_PI / 180) > temp_ret)
+    } else if (OREG(33) * (M_PI / 180) > temp_ret) {
         phi_f2 = 1.0f - sinf(OREG(33) * (M_PI / 180) - temp_ret);
-    else
+    } else {
         phi_f2 = 1.0f;
+    }
 
     sp60.y -= sp48 * phi_f2;
     func_80043A3C(&sp60, &camera->unk_E4, OREG(29) * 0.01f, OREG(30) * 0.01f, 0.1f);

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -44,8 +44,9 @@ void func_801109B0(GlobalContext* globalCtx) {
 
     osSyncPrintf("parameter->parameterSegment=%x", interfaceCtx->parameterSegment);
 
-    if (interfaceCtx->parameterSegment == NULL)
+    if (interfaceCtx->parameterSegment == NULL) {
         __assert("parameter->parameterSegment != NULL", "../z_construct.c", 161);
+    }
 
     DmaMgr_SendRequest1(interfaceCtx->parameterSegment, parameterStart, parameterSize, "../z_construct.c", 162);
 
@@ -55,27 +56,30 @@ void func_801109B0(GlobalContext* globalCtx) {
     osSyncPrintf("ＤＯアクション テクスチャ初期=%x\n", 0x480);
     osSyncPrintf("parameter->do_actionSegment=%x", interfaceCtx->do_actionSegment);
 
-    if (interfaceCtx->do_actionSegment == NULL)
+    if (interfaceCtx->do_actionSegment == NULL) {
         __assert("parameter->do_actionSegment != NULL", "../z_construct.c", 169);
+    }
 
     do_actionStart = _do_action_staticSegmentRomStart;
 
-    if (gSaveContext.language == 0)
+    if (gSaveContext.language == 0) {
         do_actionOffset = 0;
-    else if (gSaveContext.language == 1)
+    } else if (gSaveContext.language == 1) {
         do_actionOffset = 0x2B80;
-    else
+    } else {
         do_actionOffset = 0x5700;
+    }
 
     DmaMgr_SendRequest1(interfaceCtx->do_actionSegment, do_actionStart + do_actionOffset, 0x300, "../z_construct.c",
                         174);
 
-    if (gSaveContext.language == 0)
+    if (gSaveContext.language == 0) {
         do_actionOffset = 0x480;
-    else if (gSaveContext.language == 1)
+    } else if (gSaveContext.language == 1) {
         do_actionOffset = 0x3000;
-    else
+    } else {
         do_actionOffset = 0x5B80;
+    }
 
     DmaMgr_SendRequest1((void*)((u32)interfaceCtx->do_actionSegment + 0x300), do_actionStart + do_actionOffset, 0x180,
                         "../z_construct.c", 178);
@@ -86,36 +90,41 @@ void func_801109B0(GlobalContext* globalCtx) {
     osSyncPrintf("アイコンアイテム テクスチャ初期=%x\n", 0x4000);
     osSyncPrintf("parameter->icon_itemSegment=%x\n", interfaceCtx->icon_itemSegment);
 
-    if (interfaceCtx->icon_itemSegment == NULL)
+    if (interfaceCtx->icon_itemSegment == NULL) {
         __assert("parameter->icon_itemSegment != NULL", "../z_construct.c", 193);
+    }
 
     osSyncPrintf("Register_Item[%x, %x, %x, %x]\n", gSaveContext.equips.button_items[0],
                  gSaveContext.equips.button_items[1], gSaveContext.equips.button_items[2],
                  gSaveContext.equips.button_items[3]);
 
-    if (gSaveContext.equips.button_items[0] < 0xF0)
+    if (gSaveContext.equips.button_items[0] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->icon_itemSegment,
                             _icon_item_staticSegmentRomStart + gSaveContext.equips.button_items[0] * 0x80, 0x1000,
                             "../z_construct.c", 198);
-    else if (gSaveContext.equips.button_items[0] != 0xFF)
+    } else if (gSaveContext.equips.button_items[0] != 0xFF) {
         DmaMgr_SendRequest1(interfaceCtx->icon_itemSegment,
                             _icon_item_staticSegmentRomStart + gSaveContext.equips.button_items[0] * 0x80, 0x1000,
                             "../z_construct.c", 203);
+    }
 
-    if (gSaveContext.equips.button_items[1] < 0xF0)
+    if (gSaveContext.equips.button_items[1] < 0xF0) {
         DmaMgr_SendRequest1((void*)((u32)interfaceCtx->icon_itemSegment + 0x1000),
                             _icon_item_staticSegmentRomStart + gSaveContext.equips.button_items[1] * 0x80, 0x1000,
                             "../z_construct.c", 209);
+    }
 
-    if (gSaveContext.equips.button_items[2] < 0xF0)
+    if (gSaveContext.equips.button_items[2] < 0xF0) {
         DmaMgr_SendRequest1((void*)((u32)interfaceCtx->icon_itemSegment + 0x2000),
                             _icon_item_staticSegmentRomStart + gSaveContext.equips.button_items[2] * 0x80, 0x1000,
                             "../z_construct.c", 214);
+    }
 
-    if (gSaveContext.equips.button_items[3] < 0xF0)
+    if (gSaveContext.equips.button_items[3] < 0xF0) {
         DmaMgr_SendRequest1((void*)((u32)interfaceCtx->icon_itemSegment + 0x3000),
                             _icon_item_staticSegmentRomStart + gSaveContext.equips.button_items[3] * 0x80, 0x1000,
                             "../z_construct.c", 219);
+    }
 
     osSyncPrintf("ＥＶＥＮＴ＝%d\n", gSaveContext.timer_1_state);
 
@@ -131,17 +140,19 @@ void func_801109B0(GlobalContext* globalCtx) {
             }
         }
 
-        if ((gSaveContext.timer_1_state == 4) || (gSaveContext.timer_1_state == 8))
+        if ((gSaveContext.timer_1_state == 4) || (gSaveContext.timer_1_state == 8)) {
             temp = 0;
-        else
+        } else {
             temp = 1;
+        }
 
         gSaveContext.timer_x[temp] = 26;
 
-        if (gSaveContext.health_capacity > 0xA0)
+        if (gSaveContext.health_capacity > 0xA0) {
             gSaveContext.timer_y[temp] = 54;
-        else
+        } else {
             gSaveContext.timer_y[temp] = 46;
+        }
     }
 
     if ((gSaveContext.timer_1_state >= 11) && (gSaveContext.timer_1_state < 16)) {

--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -114,8 +114,9 @@ void func_800645A0(GlobalContext* globalCtx, CutsceneContext* csCtx) {
         gSaveContext.cutscene_trigger = 1;
     }
 
-    if ((gSaveContext.cutscene_trigger != 0) && (globalCtx->sceneLoadFlag == 0x14))
+    if ((gSaveContext.cutscene_trigger != 0) && (globalCtx->sceneLoadFlag == 0x14)) {
         gSaveContext.cutscene_trigger = 0;
+    }
 
     if ((gSaveContext.cutscene_trigger != 0) && (csCtx->state == CS_STATE_IDLE)) {
         // Translates to: "CUTSCENE START REQUEST ANNOUNCEMENT!"
@@ -172,13 +173,15 @@ void func_80064824(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* 
 
     sp3F = 0;
 
-    if ((csCtx->frames < cmd->startFrame) || (csCtx->frames >= cmd->endFrame) && (cmd->endFrame != cmd->startFrame))
+    if ((csCtx->frames < cmd->startFrame) || (csCtx->frames >= cmd->endFrame) && (cmd->endFrame != cmd->startFrame)) {
         return;
+    }
 
     temp = func_8006F93C(cmd->endFrame - 1, cmd->startFrame, csCtx->frames);
 
-    if (csCtx->frames == cmd->startFrame)
+    if (csCtx->frames == cmd->startFrame) {
         sp3F = 1;
+    }
 
     switch (cmd->base) {
         case 1:
@@ -198,13 +201,15 @@ void func_80064824(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* 
         case 3:
             if (sp3F != 0) {
                 func_8006C3D0(globalCtx, 0);
-                if (gSaveContext.entrance_index == 0x0053)
+                if (gSaveContext.entrance_index == 0x0053) {
                     func_8006C3D0(globalCtx, 2);
+                }
             }
             break;
         case 6:
-            if (globalCtx->unk_10AC4 < 0x3200)
+            if (globalCtx->unk_10AC4 < 0x3200) {
                 globalCtx->unk_10AC4 += 0x23;
+            }
             break;
         case 7:
             if (sp3F != 0) {
@@ -219,8 +224,9 @@ void func_80064824(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* 
             }
             break;
         case 8:
-            if (globalCtx->unk_11D30[0] < 0x80)
+            if (globalCtx->unk_11D30[0] < 0x80) {
                 globalCtx->unk_11D30[0] += 4;
+            }
             break;
         case 9:
             globalCtx->unk_10B12[3] = 0x10;
@@ -229,33 +235,40 @@ void func_80064824(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* 
             func_8006C3D0(globalCtx, 1);
             break;
         case 11:
-            if (globalCtx->unk_11D30[0] < 0x672)
+            if (globalCtx->unk_11D30[0] < 0x672) {
                 globalCtx->unk_11D30[0] += 0x14;
-            if (csCtx->frames == 0x30F)
+            }
+            if (csCtx->frames == 0x30F) {
                 func_80078884(NA_SE_EV_DEKU_DEATH);
-            else if (csCtx->frames == 0x2CD)
+            } else if (csCtx->frames == 0x2CD) {
                 globalCtx->unk_11D30[0] = 0;
+            }
             break;
         case 12:
             if (sp3F != 0) {
-                if (csCtx->state != CS_STATE_UNSKIPPABLE_EXEC)
+                if (csCtx->state != CS_STATE_UNSKIPPABLE_EXEC) {
                     csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
+                }
             }
             break;
         case 13:
-            if (globalCtx->unk_11D30[1] == 0)
+            if (globalCtx->unk_11D30[1] == 0) {
                 func_80078884(NA_SE_EV_TRIFORCE_FLASH);
-            if (globalCtx->unk_11D30[1] < 0xFF)
+            }
+            if (globalCtx->unk_11D30[1] < 0xFF) {
                 globalCtx->unk_11D30[1] += 5;
+            }
             break;
         case 14:
-            if (sp3F != 0)
+            if (sp3F != 0) {
                 func_800BC490(globalCtx, 1);
+            }
             break;
         case 15:
-            if (sp3F != 0)
+            if (sp3F != 0) {
                 TitleCard_InitPlaceName(globalCtx, &globalCtx->actorCtx.titleCtx, player->unk_1B0, 0xA0, 0x78, 0x90,
                                         0x18, 0x14);
+            }
             break;
         case 16:
             if (sp3F != 0) {
@@ -266,14 +279,16 @@ void func_80064824(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* 
             }
             break;
         case 17:
-            if (sp3F != 0)
+            if (sp3F != 0) {
                 func_80092FAC(D_8015FCCA);
+            }
             break;
         case 18:
             globalCtx->unk_10B12[0] = 0;
             globalCtx->gloomySkyEvent = 2;
-            if (gSaveContext.day_time < 0x4AAB)
+            if (gSaveContext.day_time < 0x4AAB) {
                 gSaveContext.day_time += 30;
+            }
             if (globalCtx->unk_10B12[1] == 0) {
                 D_8011FB30 = 0;
                 func_800F6D58(14, 1, 0);
@@ -305,17 +320,19 @@ void func_80064824(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* 
             break;
         case 25:
             gSaveContext.day_time += 30;
-            if ((gSaveContext.day_time & 0xFFFF) > 0xCAAA)
+            if ((gSaveContext.day_time & 0xFFFF) > 0xCAAA) {
                 gSaveContext.day_time = 0xCAAA;
+            }
             break;
         case 26:
             if ((gSaveContext.day_time < 0x3000) || (gSaveContext.day_time >= 0x4555)) {
-                if ((gSaveContext.day_time >= 0x4555) && (gSaveContext.day_time < 0xAAAB))
+                if ((gSaveContext.day_time >= 0x4555) && (gSaveContext.day_time < 0xAAAB)) {
                     globalCtx->unk_10AE3 = 1;
-                else if ((gSaveContext.day_time >= 0xAAAB) && (gSaveContext.day_time < 0xC556))
+                } else if ((gSaveContext.day_time >= 0xAAAB) && (gSaveContext.day_time < 0xC556)) {
                     globalCtx->unk_10AE3 = 2;
-                else
+                } else {
                     globalCtx->unk_10AE3 = 3;
+                }
             }
             break;
         case 27:
@@ -346,18 +363,20 @@ void func_80064824(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* 
             func_8006C3D0(globalCtx, 4);
             break;
         case 32:
-            if (sp3F != 0)
+            if (sp3F != 0) {
                 globalCtx->unk_10B0A = 1;
+            }
             func_800788CC(0x20C0);
             break;
         case 33:
             gSaveContext.unk_1422 = 1;
             break;
         case 34:
-            if (!gSaveContext.night_flag)
+            if (!gSaveContext.night_flag) {
                 gSaveContext.day_time -= D_8011FB40;
-            else
+            } else {
                 gSaveContext.day_time -= D_8011FB40 * 2;
+            }
             break;
         case 35:
             func_800EE824(csCtx);

--- a/src/code/z_en_a_keep.c
+++ b/src/code/z_en_a_keep.c
@@ -94,8 +94,9 @@ void En_A_Obj_Init(ActorEnAObj* this, GlobalContext* globalCtx) {
             break;
     }
 
-    if (this->actor.params >= 9)
+    if (this->actor.params >= 9) {
         sp28 = 12.0f;
+    }
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawFunc_Circle, sp28);
 
@@ -154,8 +155,9 @@ void En_A_Obj_Init(ActorEnAObj* this, GlobalContext* globalCtx) {
             break;
     }
 
-    if (this->actor.params < 5)
+    if (this->actor.params < 5) {
         this->actor.sub_98.mass = 0xFF;
+    }
 
     if (this->dynaPolyId != -1) {
         DynaPolyInfo_Alloc(D_8011546C[this->dynaPolyId], &sp34);

--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -289,8 +289,9 @@ void En_Item00_Init(ActorEnItem00* this, GlobalContext* globalCtx) {
             break;
     }
 
-    if ((sp2C != 0) && !func_8002F410(&this->actor, globalCtx))
+    if ((sp2C != 0) && !func_8002F410(&this->actor, globalCtx)) {
         func_8002F554(&this->actor, globalCtx, sp2C);
+    }
 
     En_Item00_SetNewUpdate(this, (ActorFunc)func_8001E5C8);
     this->updateFunc(this, globalCtx);
@@ -480,11 +481,13 @@ void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
     sp3C = 0;
     sp3A = 0;
 
-    if (this->unk_15A > 0)
+    if (this->unk_15A > 0) {
         this->unk_15A--;
+    }
 
-    if ((this->unk_15A > 0) && (this->unk_15A < 41) && (this->unk_154 <= 0))
+    if ((this->unk_15A > 0) && (this->unk_15A < 41) && (this->unk_154 <= 0)) {
         this->unk_156 = this->unk_15A;
+    }
 
     this->updateFunc(this, globalCtx);
 
@@ -533,23 +536,28 @@ void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
         (this->actor.params == DROP_TUNIC_ZORA) || (this->actor.params == DROP_TUNIC_GORON)) {
         f32 newUnkBC = Math_Coss(this->actor.shape.rot.x) * 37.0f;
         this->actor.shape.unk_08 = newUnkBC;
-        if (newUnkBC >= 0.0f)
+        if (newUnkBC >= 0.0f) {
             this->actor.shape.unk_08 = this->actor.shape.unk_08;
-        else
+        } else {
             this->actor.shape.unk_08 = -this->actor.shape.unk_08;
+        }
     }
 
-    if (this->unk_154 > 0)
+    if (this->unk_154 > 0) {
         return;
+    }
 
     // MISMATCH: The first function argument is loaded too early here
     if (!((this->actor.xzDistanceFromLink <= 30.0f) && (this->actor.yDistanceFromLink >= -50.0f) &&
-          (this->actor.yDistanceFromLink <= 50.0f)))
-        if (!func_8002F410(&this->actor, globalCtx))
+          (this->actor.yDistanceFromLink <= 50.0f))) {
+        if (!func_8002F410(&this->actor, globalCtx)) {
             return;
+        }
+    }
 
-    if (globalCtx->unk_10A20 != 0)
+    if (globalCtx->unk_10A20 != 0) {
         return;
+    }
 
     switch (this->actor.params) {
         case DROP_RUPEE_GREEN:
@@ -630,8 +638,9 @@ void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
     }
 
     // MISMATCH: The first function argument is also loaded too early here
-    if ((sp3C != 0) && !func_8002F410(&this->actor, globalCtx))
+    if ((sp3C != 0) && !func_8002F410(&this->actor, globalCtx)) {
         func_8002F554(&this->actor, globalCtx, sp3C);
+    }
 
     switch (this->actor.params) {
         case DROP_HEART_PIECE:

--- a/src/code/z_horse.c
+++ b/src/code/z_horse.c
@@ -159,19 +159,21 @@ void func_8006D684(GlobalContext* globalCtx, Player* player) {
             { 0xF6F7, 0x0139, 0x1766 },
         };
 
-        if (gSaveContext.entrance_index == 0x028A)
+        if (gSaveContext.entrance_index == 0x028A) {
             spawnPos = spawnPositions[0];
-        else if (gSaveContext.entrance_index == 0x028E)
+        } else if (gSaveContext.entrance_index == 0x028E) {
             spawnPos = spawnPositions[1];
-        else if (gSaveContext.entrance_index == 0x0292)
+        } else if (gSaveContext.entrance_index == 0x0292) {
             spawnPos = spawnPositions[2];
-        else
+        } else {
             spawnPos = spawnPositions[3];
+        }
 
         player->rideActor = Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_HORSE, spawnPos.x, spawnPos.y,
                                         spawnPos.z, 0, player->actor.posRot.rot.y, 0, 7);
-        if (player->rideActor == NULL)
+        if (player->rideActor == NULL) {
             __assert("player->ride.actor != NULL", "../z_horse.c", 561);
+        }
 
         func_8002DECC(globalCtx, player, player->rideActor);
         func_8002DE74(globalCtx, player);
@@ -180,15 +182,17 @@ void func_8006D684(GlobalContext* globalCtx, Player* player) {
                (Flags_GetEventChkInf(0x18) == 0) && (DREG(1) == 0)) {
         player->rideActor =
             Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_HORSE, 894.0f, 0.0f, -2084.0f, 0, -0x7FFF, 0, 5);
-        if (player->rideActor == NULL)
+        if (player->rideActor == NULL) {
             __assert("player->ride.actor != NULL", "../z_horse.c", 582);
+        }
 
         func_8002DECC(globalCtx, player, player->rideActor);
         func_8002DE74(globalCtx, player);
         gSaveContext.horse_data.scene = globalCtx->sceneNum;
 
-        if (globalCtx->sceneNum == SCENE_SPOT12)
+        if (globalCtx->sceneNum == SCENE_SPOT12) {
             player->rideActor->room = -1;
+        }
     } else {
         static struct_8011F9B8 D_8011F9B8[] = {
             { 93, 0xFFF0, 0x0E10, 0x0585, 0x0168, 0x8001, 8 }, { 99, 0xFFF0, 0xFF06, 0x0001, 0xF9D4, 0x4000, 6 },
@@ -210,8 +214,9 @@ void func_8006D684(GlobalContext* globalCtx, Player* player) {
                     player->rideActor = Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_HORSE,
                                                     D_8011F9B8[i].pos.x, D_8011F9B8[i].pos.y, D_8011F9B8[i].pos.z, 0,
                                                     player->actor.posRot.rot.y, 0, D_8011F9B8[i].type);
-                    if (player->rideActor == NULL)
+                    if (player->rideActor == NULL) {
                         __assert("player->ride.actor != NULL", "../z_horse.c", 628);
+                    }
 
                     func_8002DECC(globalCtx, player, player->rideActor);
                     func_8002DE74(globalCtx, player);
@@ -221,14 +226,16 @@ void func_8006D684(GlobalContext* globalCtx, Player* player) {
                     s32 pad2;
 
                     temp = 0;
-                    if (((gSaveContext.event_inf[0] & 0x10) >> 4) && D_8011F9B8[i].type == 6)
+                    if (((gSaveContext.event_inf[0] & 0x10) >> 4) && D_8011F9B8[i].type == 6) {
                         temp = 0x8000;
+                    }
 
                     player->rideActor = Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_HORSE,
                                                     D_8011F9B8[i].pos.x, D_8011F9B8[i].pos.y, D_8011F9B8[i].pos.z, 0,
                                                     D_8011F9B8[i].angle, 0, D_8011F9B8[i].type | temp);
-                    if (player->rideActor == NULL)
+                    if (player->rideActor == NULL) {
                         __assert("player->ride.actor != NULL", "../z_horse.c", 667);
+                    }
 
                     player->actor.posRot.pos.x = D_8011F9B8[i].pos.x;
                     player->actor.posRot.pos.y = D_8011F9B8[i].pos.y;

--- a/src/code/z_kaleido_scope_call.c
+++ b/src/code/z_kaleido_scope_call.c
@@ -75,8 +75,9 @@ void KaleidoScopeCall_Update(GlobalContext* globalCtx) {
             pauseCtx->state++;
         } else if (pauseCtx->state == 2 || pauseCtx->state == 9) {
             osSyncPrintf("R_PAUSE_MENU_MODE=%d\n", R_PAUSE_MENU_MODE);
-            if (R_PAUSE_MENU_MODE >= 3)
+            if (R_PAUSE_MENU_MODE >= 3) {
                 pauseCtx->state++;
+            }
         } else if (pauseCtx->state != 0) {
             if (&gKaleidoMgrOverlayTable[KALEIDO_OVL_KALEIDO_SCOPE] != gKaleidoMgrCurOvl) {
                 if (gKaleidoMgrCurOvl) {

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -1141,13 +1141,15 @@ void Inventory_SwapAgeEquipment(void) {
 
     if (LINK_AGE_IN_YEARS == YEARS_CHILD) {
         for (i = 0; i < 4; i++) {
-            if (i != 0)
+            if (i != 0) {
                 gSaveContext.child_equips.button_items[i] = gSaveContext.equips.button_items[i];
-            else
+            } else {
                 gSaveContext.child_equips.button_items[i] = ITEM_SWORD_KOKIRI;
+            }
 
-            if (i != 0)
+            if (i != 0) {
                 gSaveContext.child_equips.c_button_slots[i - 1] = gSaveContext.equips.c_button_slots[i - 1];
+            }
         }
 
         gSaveContext.child_equips.equipment = gSaveContext.equips.equipment;
@@ -1172,8 +1174,9 @@ void Inventory_SwapAgeEquipment(void) {
             for (i = 0; i < 4; i++) {
                 gSaveContext.equips.button_items[i] = gSaveContext.adult_equips.button_items[i];
 
-                if (i != 0)
+                if (i != 0) {
                     gSaveContext.equips.c_button_slots[i - 1] = gSaveContext.adult_equips.c_button_slots[i - 1];
+                }
 
                 if (((gSaveContext.equips.button_items[i] >= ITEM_BOTTLE) &&
                      (gSaveContext.equips.button_items[i] <= ITEM_POE)) ||
@@ -1190,8 +1193,9 @@ void Inventory_SwapAgeEquipment(void) {
         for (i = 0; i < 4; i++) {
             gSaveContext.adult_equips.button_items[i] = gSaveContext.equips.button_items[i];
 
-            if (i != 0)
+            if (i != 0) {
                 gSaveContext.adult_equips.c_button_slots[i - 1] = gSaveContext.equips.c_button_slots[i - 1];
+            }
         }
 
         gSaveContext.adult_equips.equipment = gSaveContext.equips.equipment;
@@ -1200,8 +1204,9 @@ void Inventory_SwapAgeEquipment(void) {
             for (i = 0; i < 4; i++) {
                 gSaveContext.equips.button_items[i] = gSaveContext.child_equips.button_items[i];
 
-                if (i != 0)
+                if (i != 0) {
                     gSaveContext.equips.c_button_slots[i - 1] = gSaveContext.child_equips.c_button_slots[i - 1];
+                }
 
                 if (((gSaveContext.equips.button_items[i] >= ITEM_BOTTLE) &&
                      (gSaveContext.equips.button_items[i] <= ITEM_POE)) ||
@@ -1221,8 +1226,9 @@ void Inventory_SwapAgeEquipment(void) {
     temp = gEquipMasks[EQUIP_SHIELD] & gSaveContext.equips.equipment;
     if (temp != 0) {
         temp >>= gEquipShifts[EQUIP_SHIELD];
-        if (!(gBitFlags[temp + 3] & gSaveContext.equipment))
+        if (!(gBitFlags[temp + 3] & gSaveContext.equipment)) {
             gSaveContext.equips.equipment &= gEquipNegMasks[EQUIP_SHIELD];
+        }
     }
 }
 #else
@@ -1315,8 +1321,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
     s8 bombCount;
 
     slot = SLOT(item);
-    if (item >= ITEM_STICKS_5)
+    if (item >= ITEM_STICKS_5) {
         slot = SLOT(sExtraItemBases[item - ITEM_STICKS_5]);
+    }
 
     osSyncPrintf(VT_FGCOL(YELLOW));
     osSyncPrintf("item_get_setting=%d  pt=%d  z=%x\n", item, slot, gSaveContext.items[slot]);
@@ -1330,8 +1337,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
         osSyncPrintf("封印 = %x\n", gSaveContext.quest_items);
         osSyncPrintf(VT_RST);
 
-        if (item == ITEM_MEDALLION_WATER)
+        if (item == ITEM_MEDALLION_WATER) {
             func_8006D0AC(globalCtx);
+        }
 
         return ITEM_NONE;
     } else if ((item >= ITEM_SONG_MINUET) && (item <= ITEM_SONG_STORMS)) {
@@ -1423,8 +1431,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
             return ITEM_NONE;
         } else {
             AMMO(ITEM_BOW)++;
-            if (AMMO(ITEM_BOW) > CUR_CAPACITY(UPG_QUIVER))
+            if (AMMO(ITEM_BOW) > CUR_CAPACITY(UPG_QUIVER)) {
                 AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
+            }
         }
     } else if (item == ITEM_QUIVER_40) {
         Inventory_ChangeUpgrade(UPG_QUIVER, 2);
@@ -1450,8 +1459,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
             return ITEM_NONE;
         } else {
             AMMO(ITEM_BOMB)++;
-            if (AMMO(ITEM_BOMB) > CUR_CAPACITY(UPG_BOMB_BAG))
+            if (AMMO(ITEM_BOMB) > CUR_CAPACITY(UPG_BOMB_BAG)) {
                 AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
+            }
         }
     } else if (item == ITEM_BOMB_BAG_30) {
         Inventory_ChangeUpgrade(UPG_BOMB_BAG, 2);
@@ -1483,26 +1493,30 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
         Inventory_ChangeUpgrade(UPG_WALLET, 2);
         return ITEM_NONE;
     } else if (item == ITEM_STICK_UPGRADE_20) {
-        if (gSaveContext.items[slot] == ITEM_NONE)
+        if (gSaveContext.items[slot] == ITEM_NONE) {
             INV_CONTENT(ITEM_STICK) = ITEM_STICK;
+        }
         Inventory_ChangeUpgrade(UPG_STICKS, 2);
         AMMO(ITEM_STICK) = CAPACITY(UPG_STICKS, 2);
         return ITEM_NONE;
     } else if (item == ITEM_STICK_UPGRADE_30) {
-        if (gSaveContext.items[slot] == ITEM_NONE)
+        if (gSaveContext.items[slot] == ITEM_NONE) {
             INV_CONTENT(ITEM_STICK) = ITEM_STICK;
+        }
         Inventory_ChangeUpgrade(UPG_STICKS, 3);
         AMMO(ITEM_STICK) = CAPACITY(UPG_STICKS, 3);
         return ITEM_NONE;
     } else if (item == ITEM_NUT_UPGRADE_30) {
-        if (gSaveContext.items[slot] == ITEM_NONE)
+        if (gSaveContext.items[slot] == ITEM_NONE) {
             INV_CONTENT(ITEM_NUT) = ITEM_NUT;
+        }
         Inventory_ChangeUpgrade(UPG_NUTS, 2);
         AMMO(ITEM_NUT) = CAPACITY(UPG_NUTS, 2);
         return ITEM_NONE;
     } else if (item == ITEM_NUT_UPGRADE_40) {
-        if (gSaveContext.items[slot] == ITEM_NONE)
+        if (gSaveContext.items[slot] == ITEM_NONE) {
             INV_CONTENT(ITEM_NUT) = ITEM_NUT;
+        }
         Inventory_ChangeUpgrade(UPG_NUTS, 3);
         AMMO(ITEM_NUT) = CAPACITY(UPG_NUTS, 3);
         return ITEM_NONE;
@@ -1521,8 +1535,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
             AMMO(ITEM_STICK) = 1;
         } else {
             AMMO(ITEM_STICK)++;
-            if (AMMO(ITEM_STICK) > CUR_CAPACITY(UPG_STICKS))
+            if (AMMO(ITEM_STICK) > CUR_CAPACITY(UPG_STICKS)) {
                 AMMO(ITEM_STICK) = CUR_CAPACITY(UPG_STICKS);
+            }
         }
     } else if ((item == ITEM_STICKS_5) || (item == ITEM_STICKS_10)) {
         if (gSaveContext.items[slot] == ITEM_NONE) {
@@ -1530,8 +1545,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
             AMMO(ITEM_STICK) = sAmmoRefillCounts[item - ITEM_STICKS_5];
         } else {
             AMMO(ITEM_STICK) += sAmmoRefillCounts[item - ITEM_STICKS_5];
-            if (AMMO(ITEM_STICK) > CUR_CAPACITY(UPG_STICKS))
+            if (AMMO(ITEM_STICK) > CUR_CAPACITY(UPG_STICKS)) {
                 AMMO(ITEM_STICK) = CUR_CAPACITY(UPG_STICKS);
+            }
         }
         item = ITEM_STICK;
     } else if (item == ITEM_NUT) {
@@ -1540,8 +1556,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
             AMMO(ITEM_NUT) = ITEM_NUT;
         } else {
             AMMO(ITEM_NUT)++;
-            if (AMMO(ITEM_NUT) > CUR_CAPACITY(UPG_NUTS))
+            if (AMMO(ITEM_NUT) > CUR_CAPACITY(UPG_NUTS)) {
                 AMMO(ITEM_NUT) = CUR_CAPACITY(UPG_NUTS);
+            }
         }
     } else if ((item == ITEM_NUTS_5) || (item == ITEM_NUTS_10)) {
         if (gSaveContext.items[slot] == ITEM_NONE) {
@@ -1552,8 +1569,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
                          sAmmoRefillCounts[item - ITEM_NUTS_5]);
         } else {
             AMMO(ITEM_NUT) += sAmmoRefillCounts[item - ITEM_NUTS_5];
-            if (AMMO(ITEM_NUT) > CUR_CAPACITY(UPG_NUTS))
+            if (AMMO(ITEM_NUT) > CUR_CAPACITY(UPG_NUTS)) {
                 AMMO(ITEM_NUT) = CUR_CAPACITY(UPG_NUTS);
+            }
         }
         item = ITEM_NUT;
     } else if (item == ITEM_BOMB) {
@@ -1561,14 +1579,16 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
         osSyncPrintf(" 爆弾  爆弾  爆弾  爆弾 爆弾   爆弾 爆弾 \n");
         bombCount = AMMO(ITEM_BOMB) + 1;
         AMMO(ITEM_BOMB) = bombCount;
-        if (bombCount > CUR_CAPACITY(UPG_BOMB_BAG))
+        if (bombCount > CUR_CAPACITY(UPG_BOMB_BAG)) {
             AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
+        }
         return ITEM_NONE;
     } else if ((item >= ITEM_BOMBS_5) && (item <= ITEM_BOMBS_30)) {
         bombCount = AMMO(ITEM_BOMB) + sAmmoRefillCounts[item - ITEM_BOMBS_5];
         AMMO(ITEM_BOMB) = bombCount;
-        if (bombCount > CUR_CAPACITY(UPG_BOMB_BAG))
+        if (bombCount > CUR_CAPACITY(UPG_BOMB_BAG)) {
             AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
+        }
         return ITEM_NONE;
     } else if (item == ITEM_BOMBCHU) {
         if (gSaveContext.items[slot] == ITEM_NONE) {
@@ -1577,8 +1597,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
             return ITEM_NONE;
         } else {
             AMMO(ITEM_BOMBCHU) += 10;
-            if (AMMO(ITEM_BOMBCHU) > 50)
+            if (AMMO(ITEM_BOMBCHU) > 50) {
                 AMMO(ITEM_BOMBCHU) = 50;
+            }
             return ITEM_NONE;
         }
     } else if ((item == ITEM_BOMBCHUS_5) || (item == ITEM_BOMBCHUS_20)) {
@@ -1588,15 +1609,17 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
             return ITEM_NONE;
         } else {
             AMMO(ITEM_BOMBCHU) += sAmmoRefillCounts[item - ITEM_BOMBCHUS_5 + 8];
-            if (AMMO(ITEM_BOMBCHU) > 50)
+            if (AMMO(ITEM_BOMBCHU) > 50) {
                 AMMO(ITEM_BOMBCHU) = 50;
+            }
             return ITEM_NONE;
         }
     } else if ((item >= ITEM_ARROWS_SMALL) && (item <= ITEM_ARROWS_LARGE)) {
         AMMO(ITEM_BOW) += sAmmoRefillCounts[item - ITEM_ARROWS_SMALL + 4];
 
-        if ((AMMO(ITEM_BOW) >= CUR_CAPACITY(UPG_QUIVER)) || (AMMO(ITEM_BOW) < 0))
+        if ((AMMO(ITEM_BOW) >= CUR_CAPACITY(UPG_QUIVER)) || (AMMO(ITEM_BOW) < 0)) {
             AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
+        }
 
         osSyncPrintf("%d本  Item_MaxGet=%d\n", AMMO(ITEM_BOW), CUR_CAPACITY(UPG_QUIVER));
 
@@ -1609,8 +1632,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
     } else if (item == ITEM_SEEDS) {
         AMMO(ITEM_SLINGSHOT) += 5;
 
-        if (AMMO(ITEM_SLINGSHOT) >= CUR_CAPACITY(UPG_BULLET_BAG))
+        if (AMMO(ITEM_SLINGSHOT) >= CUR_CAPACITY(UPG_BULLET_BAG)) {
             AMMO(ITEM_SLINGSHOT) = CUR_CAPACITY(UPG_BULLET_BAG);
+        }
 
         if (!(gSaveContext.item_get_inf[1] & 8)) {
             gSaveContext.item_get_inf[1] |= 8;
@@ -1621,8 +1645,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
     } else if (item == ITEM_SEEDS_30) {
         AMMO(ITEM_SLINGSHOT) += 30;
 
-        if (AMMO(ITEM_SLINGSHOT) >= CUR_CAPACITY(UPG_BULLET_BAG))
+        if (AMMO(ITEM_SLINGSHOT) >= CUR_CAPACITY(UPG_BULLET_BAG)) {
             AMMO(ITEM_SLINGSHOT) = CUR_CAPACITY(UPG_BULLET_BAG);
+        }
 
         if (!(gSaveContext.item_get_inf[1] & 8)) {
             gSaveContext.item_get_inf[1] |= 8;
@@ -1665,8 +1690,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
         Health_ChangeBy(globalCtx, 0x10);
         return item;
     } else if (item == ITEM_MAGIC_SMALL) {
-        if (gSaveContext.unk_13F0 != 10)
+        if (gSaveContext.unk_13F0 != 10) {
             func_80087680(globalCtx);
+        }
 
         func_80087708(globalCtx, 12, 5);
 
@@ -1677,8 +1703,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
 
         return item;
     } else if (item == ITEM_MAGIC_LARGE) {
-        if (gSaveContext.unk_13F0 != 10)
+        if (gSaveContext.unk_13F0 != 10) {
             func_80087680(globalCtx);
+        }
 
         func_80087708(globalCtx, 24, 5);
 
@@ -1741,8 +1768,9 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
             }
         }
     } else if ((item >= ITEM_WEIRD_EGG) && (item <= ITEM_CLAIM_CHECK)) {
-        if (item == ITEM_SAW)
+        if (item == ITEM_SAW) {
             gSaveContext.item_get_inf[1] |= 0x8000;
+        }
 
         prevTradeItem = INV_CONTENT(item);
         INV_CONTENT(item) = item;
@@ -1990,8 +2018,9 @@ void Inventory_UpdateBottleItem(GlobalContext* globalCtx, u8 item, u8 cButton) {
 
     // Special case to only empty half of a Lon Lon Milk Bottle
     if ((gSaveContext.items[gSaveContext.equips.c_button_slots[cButton - 1]] == ITEM_MILK_BOTTLE) &&
-        (item == ITEM_BOTTLE))
+        (item == ITEM_BOTTLE)) {
         item = ITEM_MILK_HALF;
+    }
 
     gSaveContext.items[gSaveContext.equips.c_button_slots[cButton - 1]] = item;
     gSaveContext.equips.button_items[cButton] = item;
@@ -2052,14 +2081,17 @@ u32 sDoActionTextures[] = { 0x07000000, 0x07000180 };
 #ifdef NON_MATCHING
 // 0x80000000 is reused in the 2 *_TO_VIRTUAL macros when it shouldn't
 void Interface_LoadActionLabel(InterfaceContext* interfaceCtx, u16 action, s16 arg2) {
-    if (action >= 0x1D)
+    if (action >= 0x1D) {
         action = 0x0A;
+    }
 
-    if (gSaveContext.language != 0)
+    if (gSaveContext.language != 0) {
         action += 0x1D;
+    }
 
-    if (gSaveContext.language == 2)
+    if (gSaveContext.language == 2) {
         action += 0x1D;
+    }
 
     if ((action != 0x0A) && (action != 0x27) && (action != 0x44)) {
         osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, OS_MESG_BLOCK);
@@ -2375,12 +2407,14 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
             if (gSaveContext.unk_13F4 != maxMagic) {
                 if (gSaveContext.unk_13F4 < maxMagic) {
                     gSaveContext.unk_13F4 += 8;
-                    if (gSaveContext.unk_13F4 > maxMagic)
+                    if (gSaveContext.unk_13F4 > maxMagic) {
                         gSaveContext.unk_13F4 = maxMagic;
+                    }
                 } else {
                     gSaveContext.unk_13F4 -= 8;
-                    if (gSaveContext.unk_13F4 <= maxMagic)
+                    if (gSaveContext.unk_13F4 <= maxMagic) {
                         gSaveContext.unk_13F4 = maxMagic;
+                    }
                 }
             } else {
                 gSaveContext.unk_13F0 = 9;
@@ -2389,8 +2423,9 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
         case 9:
             gSaveContext.magic += 4;
 
-            if (gSaveContext.game_mode == 0 && gSaveContext.scene_setup_index < 4)
+            if (gSaveContext.game_mode == 0 && gSaveContext.scene_setup_index < 4) {
                 Audio_PlaySoundGeneral(0x401F, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
+            }
 
             // Translates to: "Storage MAGIC_NOW=%d (%d)"
             osSyncPrintf("蓄電 MAGIC_NOW=%d (%d)\n", gSaveContext.magic, gSaveContext.unk_13F6);
@@ -2423,20 +2458,23 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
         case 6:
             color = sMagicBorderColors[sMagicBorderIndexes[sMagicBorderStep]];
 
-            if (sMagicBorderR >= color[0])
+            if (sMagicBorderR >= color[0]) {
                 sMagicBorderR -= ABS(sMagicBorderR - color[0]) / sMagicBorderRatio;
-            else
+            } else {
                 sMagicBorderR += ABS(sMagicBorderR - color[0]) / sMagicBorderRatio;
+            }
 
-            if (sMagicBorderG >= color[1])
+            if (sMagicBorderG >= color[1]) {
                 sMagicBorderG -= ABS(sMagicBorderG - color[1]) / sMagicBorderRatio;
-            else
+            } else {
                 sMagicBorderG += ABS(sMagicBorderG - color[1]) / sMagicBorderRatio;
+            }
 
-            if (sMagicBorderB >= color[2])
+            if (sMagicBorderB >= color[2]) {
                 sMagicBorderB -= ABS(sMagicBorderB - color[2]) / sMagicBorderRatio;
-            else
+            } else {
                 sMagicBorderB += ABS(sMagicBorderB - color[2]) / sMagicBorderRatio;
+            }
 
             sMagicBorderRatio--;
             if (sMagicBorderRatio == 0) {
@@ -2445,8 +2483,9 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
                 sMagicBorderB = color[2];
                 sMagicBorderRatio = YREG(40 + sMagicBorderStep);
                 sMagicBorderStep++;
-                if (sMagicBorderStep >= 4)
+                if (sMagicBorderStep >= 4) {
                     sMagicBorderStep = 0;
+                }
             }
             break;
         case 5:
@@ -2481,20 +2520,23 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
 
             color = sMagicBorderColors[sMagicBorderIndexes[sMagicBorderStep]];
 
-            if (sMagicBorderR >= color[0])
+            if (sMagicBorderR >= color[0]) {
                 sMagicBorderR -= ABS(sMagicBorderR - color[0]) / sMagicBorderRatio;
-            else
+            } else {
                 sMagicBorderR += ABS(sMagicBorderR - color[0]) / sMagicBorderRatio;
+            }
 
-            if (sMagicBorderG >= color[1])
+            if (sMagicBorderG >= color[1]) {
                 sMagicBorderG -= ABS(sMagicBorderG - color[1]) / sMagicBorderRatio;
-            else
+            } else {
                 sMagicBorderG += ABS(sMagicBorderG - color[1]) / sMagicBorderRatio;
+            }
 
-            if (sMagicBorderB >= color[2])
+            if (sMagicBorderB >= color[2]) {
                 sMagicBorderB -= ABS(sMagicBorderB - color[2]) / sMagicBorderRatio;
-            else
+            } else {
                 sMagicBorderB += ABS(sMagicBorderB - color[2]) / sMagicBorderRatio;
+            }
 
             sMagicBorderRatio--;
             if (sMagicBorderRatio == 0) {
@@ -2503,8 +2545,9 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
                 sMagicBorderB = color[2];
                 sMagicBorderRatio = YREG(40 + sMagicBorderStep);
                 sMagicBorderStep++;
-                if (sMagicBorderStep >= 4)
+                if (sMagicBorderStep >= 4) {
                     sMagicBorderStep = 0;
+                }
             }
             break;
         case 10:
@@ -2772,13 +2815,14 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             // C-Up Button Texture, Color & Label (Navi Text)
             gDPPipeSync(gfxCtx->overlay.p++);
 
-            if ((gSaveContext.unk_13EA == 1) || (gSaveContext.unk_13EA == 2) || (gSaveContext.unk_13EA == 5))
+            if ((gSaveContext.unk_13EA == 1) || (gSaveContext.unk_13EA == 2) || (gSaveContext.unk_13EA == 5)) {
                 cUpAlpha = 0;
-            else if ((player->stateFlags2 & 0x00200000) || (func_8008F2F8(globalCtx) == 4) ||
-                     (player->stateFlags2 & 0x00040000))
+            } else if ((player->stateFlags2 & 0x00200000) || (func_8008F2F8(globalCtx) == 4) ||
+                       (player->stateFlags2 & 0x00040000)) {
                 cUpAlpha = 0x46;
-            else
+            } else {
                 cUpAlpha = interfaceCtx->healthAlpha;
+            }
 
             gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), cUpAlpha);
             gDPSetCombineLERP(gfxCtx->overlay.p++, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0, PRIMITIVE, 0, TEXEL0, 0,
@@ -2820,15 +2864,16 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     // Empty C Button Arrows
     for (i = 1; i < 4; i++) {
         if (gSaveContext.equips.button_items[i] > 0xF0) {
-            if (i == 1)
+            if (i == 1) {
                 gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
                                 interfaceCtx->cLeftAlpha);
-            else if (i == 2)
+            } else if (i == 2) {
                 gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
                                 interfaceCtx->cDownAlpha);
-            else
+            } else {
                 gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
                                 interfaceCtx->cRightAlpha);
+            }
 
             gfxCtx->overlay.p =
                 Draw_TextureIA8(gfxCtx->overlay.p, &D_02000A00[i + 1], 0x20, 0x20, R_ITEM_BTN_X(i), R_ITEM_BTN_Y(i),
@@ -3188,12 +3233,13 @@ void Interface_Draw(GlobalContext* globalCtx) {
         // Rupee Counter
         gDPPipeSync(gfxCtx->overlay.p++);
 
-        if (gSaveContext.rupees == CUR_CAPACITY(UPG_WALLET))
+        if (gSaveContext.rupees == CUR_CAPACITY(UPG_WALLET)) {
             gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, 0x78, 0xFF, 0x00, interfaceCtx->magicAlpha);
-        else if (gSaveContext.rupees != 0)
+        } else if (gSaveContext.rupees != 0) {
             gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, 0xFF, 0xFF, 0xFF, interfaceCtx->magicAlpha);
-        else
+        } else {
             gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, 0x64, 0x64, 0x64, interfaceCtx->magicAlpha);
+        }
 
         gDPSetCombineLERP(gfxCtx->overlay.p++, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, PRIMITIVE, TEXEL0,
                           0, PRIMITIVE, 0);
@@ -3201,8 +3247,9 @@ void Interface_Draw(GlobalContext* globalCtx) {
         interfaceCtx->counterDigits[0] = interfaceCtx->counterDigits[1] = 0;
         interfaceCtx->counterDigits[2] = gSaveContext.rupees;
 
-        if ((interfaceCtx->counterDigits[2] >= 10000) || (interfaceCtx->counterDigits[2] < 0))
+        if ((interfaceCtx->counterDigits[2] >= 10000) || (interfaceCtx->counterDigits[2] < 0)) {
             interfaceCtx->counterDigits[2] &= 0xDDD;
+        }
 
         while (interfaceCtx->counterDigits[2] >= 100) {
             interfaceCtx->counterDigits[2] -= 100;
@@ -3225,8 +3272,9 @@ void Interface_Draw(GlobalContext* globalCtx) {
         Interface_DrawMagicBar(globalCtx);
         Interface_DrawMinimap(globalCtx);
 
-        if ((R_PAUSE_MENU_MODE != 2) && (R_PAUSE_MENU_MODE != 3))
+        if ((R_PAUSE_MENU_MODE != 2) && (R_PAUSE_MENU_MODE != 3)) {
             func_8002C124(&globalCtx->actorCtx.targetCtx, globalCtx); // Draw Z-Target
+        }
 
         func_80094520(globalCtx->state.gfxCtx);
 
@@ -3343,10 +3391,11 @@ void Interface_Draw(GlobalContext* globalCtx) {
                   G_MTX_MODELVIEW | G_MTX_LOAD);
         gSPVertex(gfxCtx->overlay.p++, &interfaceCtx->vtx_128[4], 4, 0);
 
-        if ((interfaceCtx->unk_1EC < 2) || (interfaceCtx->unk_1EC == 3))
+        if ((interfaceCtx->unk_1EC < 2) || (interfaceCtx->unk_1EC == 3)) {
             Interface_DrawActionLabel(globalCtx->state.gfxCtx, (void*)(u32)interfaceCtx->do_actionSegment);
-        else
+        } else {
             Interface_DrawActionLabel(globalCtx->state.gfxCtx, (void*)((u32)interfaceCtx->do_actionSegment + 0x180));
+        }
 
         gDPPipeSync(gfxCtx->overlay.p++);
 
@@ -3441,10 +3490,11 @@ void Interface_Draw(GlobalContext* globalCtx) {
                     phi_s1 = ZREG(14);
                     for (phi_s3 = 1; phi_s3 < 7; phi_s3++) {
                         // Carrot Color (based on availability)
-                        if ((interfaceCtx->unk_23A == 0) || (interfaceCtx->unk_23A < phi_s3))
+                        if ((interfaceCtx->unk_23A == 0) || (interfaceCtx->unk_23A < phi_s3)) {
                             gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, 0x00, 0x96, 0xFF, interfaceCtx->aAlpha);
-                        else
+                        } else {
                             gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, 0xFF, 0xFF, 0xFF, interfaceCtx->aAlpha);
+                        }
 
                         gSPTextureRectangle(gfxCtx->overlay.p++, phi_s1 << 2, ZREG(15) << 2, (phi_s1 + 16) << 2,
                                             (ZREG(15) + 16) << 2, G_TX_RENDERTILE, 0, 0, 1024, 1024);
@@ -3507,10 +3557,11 @@ void Interface_Draw(GlobalContext* globalCtx) {
                 (gSaveContext.equips.button_items[0] != ITEM_SWORD_MASTER) &&
                 (gSaveContext.equips.button_items[0] != ITEM_SWORD_BGS) &&
                 (gSaveContext.equips.button_items[0] != ITEM_SWORD_KNIFE)) {
-                if (gSaveContext.button_status[0] != BTN_ENABLED)
+                if (gSaveContext.button_status[0] != BTN_ENABLED) {
                     gSaveContext.equips.button_items[0] = gSaveContext.button_status[0];
-                else
+                } else {
                     gSaveContext.equips.button_items[0] = ITEM_NONE;
+                }
             }
 
             // Revert any spoiling trade quest items
@@ -3553,20 +3604,22 @@ void Interface_Draw(GlobalContext* globalCtx) {
                 case 5:
                 case 11:
                     D_8015FFE0 = D_8015FFE2 = 20;
-                    if (gSaveContext.timer_1_state == 5)
+                    if (gSaveContext.timer_1_state == 5) {
                         gSaveContext.timer_1_state = 6;
-                    else
+                    } else {
                         gSaveContext.timer_1_state = 12;
+                    }
                     break;
                 case 6:
                 case 12:
                     D_8015FFE2--;
                     if (D_8015FFE2 == 0) {
                         D_8015FFE2 = 20;
-                        if (gSaveContext.timer_1_state == 6)
+                        if (gSaveContext.timer_1_state == 6) {
                             gSaveContext.timer_1_state = 7;
-                        else
+                        } else {
                             gSaveContext.timer_1_state = 13;
+                        }
                     }
                     break;
                 case 3:
@@ -3574,10 +3627,11 @@ void Interface_Draw(GlobalContext* globalCtx) {
                     phi_s3 = (gSaveContext.timer_x[0] - 26) / D_8015FFE2;
                     gSaveContext.timer_x[0] -= phi_s3;
 
-                    if (gSaveContext.health_capacity > 0xA0)
+                    if (gSaveContext.health_capacity > 0xA0) {
                         phi_s3 = (gSaveContext.timer_y[0] - 54) / D_8015FFE2;
-                    else
+                    } else {
                         phi_s3 = (gSaveContext.timer_y[0] - 46) / D_8015FFE2;
+                    }
                     gSaveContext.timer_y[0] -= phi_s3;
 
                     D_8015FFE2--;
@@ -3585,30 +3639,34 @@ void Interface_Draw(GlobalContext* globalCtx) {
                         gSaveContext.timer_x[0] = 26;
                         D_8015FFE2 = 20;
 
-                        if (gSaveContext.health_capacity > 0xA0)
+                        if (gSaveContext.health_capacity > 0xA0) {
                             gSaveContext.timer_y[0] = 54;
-                        else
+                        } else {
                             gSaveContext.timer_y[0] = 46;
+                        }
 
-                        if (gSaveContext.timer_1_state == 3)
+                        if (gSaveContext.timer_1_state == 3) {
                             gSaveContext.timer_1_state = 4;
-                        else
+                        } else {
                             gSaveContext.timer_1_state = 8;
+                        }
                     }
                 case 4:
                 case 8:
                     if ((gSaveContext.timer_1_state == 4) || (gSaveContext.timer_1_state == 8)) {
-                        if (gSaveContext.health_capacity > 0xA0)
+                        if (gSaveContext.health_capacity > 0xA0) {
                             gSaveContext.timer_y[0] = 54;
-                        else
+                        } else {
                             gSaveContext.timer_y[0] = 46;
+                        }
                     }
 
                     if ((gSaveContext.timer_1_state >= 3) && (msgCtx->unk_E300 == 0)) {
                         D_8015FFE0--;
                         if (D_8015FFE0 == 0) {
-                            if (gSaveContext.timer_1_value != 0)
+                            if (gSaveContext.timer_1_value != 0) {
                                 gSaveContext.timer_1_value--;
+                            }
 
                             D_8015FFE0 = 20;
 
@@ -3620,13 +3678,15 @@ void Interface_Draw(GlobalContext* globalCtx) {
                                 }
                                 D_80125A5C = 0;
                             } else if (gSaveContext.timer_1_value > 60) {
-                                if (sTimerDigits[4] == 1)
+                                if (sTimerDigits[4] == 1) {
                                     Audio_PlaySoundGeneral(NA_SE_SY_MESSAGE_WOMAN, &D_801333D4, 4, &D_801333E0,
                                                            &D_801333E0, &D_801333E8);
+                                }
                             } else if (gSaveContext.timer_1_value >= 11) {
-                                if (sTimerDigits[4] & 1)
+                                if (sTimerDigits[4] & 1) {
                                     Audio_PlaySoundGeneral(NA_SE_SY_WARNING_COUNT_N, &D_801333D4, 4, &D_801333E0,
                                                            &D_801333E0, &D_801333E8);
+                                }
                             } else {
                                 Audio_PlaySoundGeneral(NA_SE_SY_WARNING_COUNT_E, &D_801333D4, 4, &D_801333E0,
                                                        &D_801333E0, &D_801333E8);
@@ -3638,10 +3698,11 @@ void Interface_Draw(GlobalContext* globalCtx) {
                     phi_s3 = (gSaveContext.timer_x[0] - 26) / D_8015FFE2;
                     gSaveContext.timer_x[0] -= phi_s3;
 
-                    if (gSaveContext.health_capacity > 0xA0)
+                    if (gSaveContext.health_capacity > 0xA0) {
                         phi_s3 = (gSaveContext.timer_y[0] - 54) / D_8015FFE2;
-                    else
+                    } else {
                         phi_s3 = (gSaveContext.timer_y[0] - 46) / D_8015FFE2;
+                    }
                     gSaveContext.timer_y[0] -= phi_s3;
 
                     D_8015FFE2--;
@@ -3649,19 +3710,21 @@ void Interface_Draw(GlobalContext* globalCtx) {
                         gSaveContext.timer_x[0] = 26;
                         D_8015FFE2 = 20;
 
-                        if (gSaveContext.health_capacity > 0xA0)
+                        if (gSaveContext.health_capacity > 0xA0) {
                             gSaveContext.timer_y[0] = 54;
-                        else
+                        } else {
                             gSaveContext.timer_y[0] = 46;
+                        }
 
                         gSaveContext.timer_1_state = 14;
                     }
                 case 14:
                     if (gSaveContext.timer_1_state == 14) {
-                        if (gSaveContext.health_capacity > 0xA0)
+                        if (gSaveContext.health_capacity > 0xA0) {
                             gSaveContext.timer_y[0] = 54;
-                        else
+                        } else {
                             gSaveContext.timer_y[0] = 46;
+                        }
                     }
 
                     if (gSaveContext.timer_1_state >= 3) {
@@ -3686,10 +3749,11 @@ void Interface_Draw(GlobalContext* globalCtx) {
                         gSaveContext.timer_y[1] = 80;
                         D_8015FFE4 = D_8015FFE6 = 20;
 
-                        if (gSaveContext.timer_2_state < 7)
+                        if (gSaveContext.timer_2_state < 7) {
                             gSaveContext.timer_2_state = 2;
-                        else
+                        } else {
                             gSaveContext.timer_2_state = 8;
+                        }
 
                         gSaveContext.timer_1_state = 0;
                     } else {
@@ -3706,20 +3770,22 @@ void Interface_Draw(GlobalContext* globalCtx) {
                             gSaveContext.timer_x[1] = 140;
                             gSaveContext.timer_y[1] = 80;
                             D_8015FFE4 = D_8015FFE6 = 20;
-                            if (gSaveContext.timer_2_state == 1)
+                            if (gSaveContext.timer_2_state == 1) {
                                 gSaveContext.timer_2_state = 2;
-                            else
+                            } else {
                                 gSaveContext.timer_2_state = 8;
+                            }
                             break;
                         case 2:
                         case 8:
                             D_8015FFE6--;
                             if (D_8015FFE6 == 0) {
                                 D_8015FFE6 = 20;
-                                if (gSaveContext.timer_2_state == 2)
+                                if (gSaveContext.timer_2_state == 2) {
                                     gSaveContext.timer_2_state = 3;
-                                else
+                                } else {
                                     gSaveContext.timer_2_state = 9;
+                                }
                             }
                             break;
                         case 3:
@@ -3730,10 +3796,11 @@ void Interface_Draw(GlobalContext* globalCtx) {
                             phi_s3 = (gSaveContext.timer_x[1] - 26) / D_8015FFE2;
                             gSaveContext.timer_x[1] -= phi_s3;
 
-                            if (gSaveContext.health_capacity > 0xA0)
+                            if (gSaveContext.health_capacity > 0xA0) {
                                 phi_s3 = (gSaveContext.timer_y[1] - 54) / D_8015FFE6;
-                            else
+                            } else {
                                 phi_s3 = (gSaveContext.timer_y[1] - 46) / D_8015FFE6;
+                            }
                             gSaveContext.timer_y[1] -= phi_s3;
 
                             D_8015FFE6--;
@@ -3741,23 +3808,26 @@ void Interface_Draw(GlobalContext* globalCtx) {
                                 gSaveContext.timer_x[1] = 26;
                                 D_8015FFE6 = 20;
 
-                                if (gSaveContext.health_capacity > 0xA0)
+                                if (gSaveContext.health_capacity > 0xA0) {
                                     gSaveContext.timer_y[1] = 54;
-                                else
+                                } else {
                                     gSaveContext.timer_y[1] = 46;
+                                }
 
-                                if (gSaveContext.timer_2_state == 3)
+                                if (gSaveContext.timer_2_state == 3) {
                                     gSaveContext.timer_2_state = 4;
-                                else
+                                } else {
                                     gSaveContext.timer_2_state = 10;
+                                }
                             }
                         case 4:
                         case 10:
                             if ((gSaveContext.timer_2_state == 4) || (gSaveContext.timer_2_state == 10)) {
-                                if (gSaveContext.health_capacity > 0xA0)
+                                if (gSaveContext.health_capacity > 0xA0) {
                                     gSaveContext.timer_y[1] = 54;
-                                else
+                                } else {
                                     gSaveContext.timer_y[1] = 46;
+                                }
                             }
 
                             if (gSaveContext.timer_2_state >= 3) {
@@ -3785,13 +3855,15 @@ void Interface_Draw(GlobalContext* globalCtx) {
                                             }
                                         } else {
                                             if (gSaveContext.timer_2_value > 60) {
-                                                if (sTimerDigits[4] == 1)
+                                                if (sTimerDigits[4] == 1) {
                                                     Audio_PlaySoundGeneral(NA_SE_SY_MESSAGE_WOMAN, &D_801333D4, 4,
                                                                            &D_801333E0, &D_801333E0, &D_801333E8);
+                                                }
                                             } else if (gSaveContext.timer_2_value > 10) {
-                                                if (sTimerDigits[4] & 1)
+                                                if (sTimerDigits[4] & 1) {
                                                     Audio_PlaySoundGeneral(NA_SE_SY_WARNING_COUNT_N, &D_801333D4, 4,
                                                                            &D_801333E0, &D_801333E0, &D_801333E8);
+                                                }
                                             } else {
                                                 Audio_PlaySoundGeneral(NA_SE_SY_WARNING_COUNT_E, &D_801333D4, 4,
                                                                        &D_801333E0, &D_801333E0, &D_801333E8);
@@ -3817,8 +3889,9 @@ void Interface_Draw(GlobalContext* globalCtx) {
                             break;
                         case 6:
                             D_8015FFE6--;
-                            if (D_8015FFE6 == 0)
+                            if (D_8015FFE6 == 0) {
                                 gSaveContext.timer_2_state = 0;
+                            }
                             break;
                     }
             }
@@ -3828,10 +3901,11 @@ void Interface_Draw(GlobalContext* globalCtx) {
                 sTimerDigits[0] = sTimerDigits[1] = sTimerDigits[3] = 0;
                 sTimerDigits[2] = 10; // digit 10 is used as ':' (colon)
 
-                if (gSaveContext.timer_1_state != 0)
+                if (gSaveContext.timer_1_state != 0) {
                     sTimerDigits[4] = gSaveContext.timer_1_value;
-                else
+                } else {
                     sTimerDigits[4] = gSaveContext.timer_2_value;
+                }
 
                 while (sTimerDigits[4] >= 60) {
                     sTimerDigits[1]++;
@@ -3860,15 +3934,17 @@ void Interface_Draw(GlobalContext* globalCtx) {
                                   TEXEL0, 0, PRIMITIVE, 0);
 
                 if (gSaveContext.timer_1_state != 0) {
-                    if ((gSaveContext.timer_1_value < 10) && (gSaveContext.timer_1_state < 11))
+                    if ((gSaveContext.timer_1_value < 10) && (gSaveContext.timer_1_state < 11)) {
                         gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, 0xFF, 0x32, 0x00, 0xFF);
-                    else
+                    } else {
                         gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
+                    }
                 } else {
-                    if ((gSaveContext.timer_2_value < 10) && (gSaveContext.timer_2_state < 6))
+                    if ((gSaveContext.timer_2_value < 10) && (gSaveContext.timer_2_state < 6)) {
                         gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, 0xFF, 0x32, 0x00, 0xFF);
-                    else
+                    } else {
                         gDPSetPrimColor(gfxCtx->overlay.p++, 0, 0, 0xFF, 0xFF, 0x00, 0xFF);
+                    }
                 }
 
                 for (phi_s3 = 0; phi_s3 < 5; phi_s3++) {
@@ -3881,8 +3957,9 @@ void Interface_Draw(GlobalContext* globalCtx) {
         }
     }
 
-    if (pauseCtx->flag == 3)
+    if (pauseCtx->flag == 3) {
         func_8002AAB0(globalCtx);
+    }
 
     if (interfaceCtx->unk_244 != 0) {
         gDPPipeSync(gfxCtx->overlay.p++);
@@ -3952,32 +4029,38 @@ void Interface_Update(GlobalContext* globalCtx) {
         case 12:
         case 13:
             alpha = 0xFF - (gSaveContext.unk_13EC << 5);
-            if (alpha < 0)
+            if (alpha < 0) {
                 alpha = 0;
+            }
 
             func_80082850(globalCtx, alpha);
             gSaveContext.unk_13EC++;
 
-            if (alpha == 0)
+            if (alpha == 0) {
                 gSaveContext.unk_13E8 = 0;
+            }
             break;
         case 50:
             alpha = 0xFF - (gSaveContext.unk_13EC << 5);
-            if (alpha < 0)
+            if (alpha < 0) {
                 alpha = 0;
+            }
 
             alpha1 = 0xFF - alpha;
-            if (alpha1 >= 0xFF)
+            if (alpha1 >= 0xFF) {
                 alpha1 = 0xFF;
+            }
 
             osSyncPrintf("case 50 : alpha=%d  alpha1=%d\n", alpha, alpha1);
             func_80082644(globalCtx, alpha1);
 
-            if (interfaceCtx->healthAlpha != 0xFF)
+            if (interfaceCtx->healthAlpha != 0xFF) {
                 interfaceCtx->healthAlpha = alpha1;
+            }
 
-            if (interfaceCtx->magicAlpha != 0xFF)
+            if (interfaceCtx->magicAlpha != 0xFF) {
                 interfaceCtx->magicAlpha = alpha1;
+            }
 
             switch (globalCtx->sceneNum) {
                 case SCENE_SPOT00:
@@ -4000,20 +4083,23 @@ void Interface_Update(GlobalContext* globalCtx) {
                 case SCENE_SPOT18:
                 case SCENE_SPOT20:
                 case SCENE_GANON_TOU:
-                    if (interfaceCtx->minimapAlpha < 0xAA)
+                    if (interfaceCtx->minimapAlpha < 0xAA) {
                         interfaceCtx->minimapAlpha = alpha1;
-                    else
+                    } else {
                         interfaceCtx->minimapAlpha = 0xAA;
+                    }
                     break;
                 default:
-                    if (interfaceCtx->minimapAlpha != 0xFF)
+                    if (interfaceCtx->minimapAlpha != 0xFF) {
                         interfaceCtx->minimapAlpha = alpha1;
+                    }
                     break;
             }
 
             gSaveContext.unk_13EC++;
-            if (alpha1 == 0xFF)
+            if (alpha1 == 0xFF) {
                 gSaveContext.unk_13E8 = 0;
+            }
 
             break;
         case 52:
@@ -4030,8 +4116,9 @@ void Interface_Update(GlobalContext* globalCtx) {
         gSaveContext.health_accumulator -= 4;
         gSaveContext.health += 4;
 
-        if ((gSaveContext.health & 0xF) < 4)
+        if ((gSaveContext.health & 0xF) < 4) {
             Audio_PlaySoundGeneral(NA_SE_SY_HP_RECOVER, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
+        }
 
         osSyncPrintf("now_life=%d  max_life=%d\n", gSaveContext.health, gSaveContext.health_capacity);
 
@@ -4079,8 +4166,9 @@ void Interface_Update(GlobalContext* globalCtx) {
                 gSaveContext.rupee_accumulator += 10;
                 gSaveContext.rupees -= 10;
 
-                if (gSaveContext.rupees < 0)
+                if (gSaveContext.rupees < 0) {
                     gSaveContext.rupees = 0;
+                }
 
                 Audio_PlaySoundGeneral(NA_SE_SY_RUPY_COUNT, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
             } else {
@@ -4108,8 +4196,9 @@ void Interface_Update(GlobalContext* globalCtx) {
                 interfaceCtx->unk_1EC = 0;
                 interfaceCtx->unk_1EE = interfaceCtx->unk_1F0;
                 action = interfaceCtx->unk_1EE;
-                if ((action == 0x1D) || (action == 0x1E))
+                if ((action == 0x1D) || (action == 0x1E)) {
                     action = 0xA;
+                }
                 Interface_LoadActionLabel(interfaceCtx, action, 0);
             }
             break;
@@ -4127,8 +4216,9 @@ void Interface_Update(GlobalContext* globalCtx) {
                 interfaceCtx->unk_1EC = 0;
                 interfaceCtx->unk_1EE = interfaceCtx->unk_1F0;
                 action = interfaceCtx->unk_1EE;
-                if ((action == 0x1D) || (action == 0x1E))
+                if ((action == 0x1D) || (action == 0x1E)) {
                     action = 0xA;
+                }
                 Interface_LoadActionLabel(interfaceCtx, action, 0);
             }
             break;
@@ -4173,11 +4263,13 @@ void Interface_Update(GlobalContext* globalCtx) {
         interfaceCtx->unk_23C = 0;
 
         if (sHBAScoreTier == 0) {
-            if (gSaveContext.minigame_score >= 1000)
+            if (gSaveContext.minigame_score >= 1000) {
                 sHBAScoreTier++;
+            }
         } else if (sHBAScoreTier == 1) {
-            if (gSaveContext.minigame_score >= 1500)
+            if (gSaveContext.minigame_score >= 1500) {
                 sHBAScoreTier++;
+            }
         }
 
         sHBAScoreDigits[1] = 0;
@@ -4202,14 +4294,16 @@ void Interface_Update(GlobalContext* globalCtx) {
     }
 
     if (gSaveContext.unk_1422 != 0) {
-        if ((msgCtx->unk_E3F0 != 0x31) && (gSaveContext.unk_1422 == 1))
+        if ((msgCtx->unk_E3F0 != 0x31) && (gSaveContext.unk_1422 == 1)) {
             globalCtx->msgCtx.unk_E3EE = 4;
+        }
 
         if (globalCtx->unk_10A26 != 0) {
             if (gSaveContext.unk_1422 != 2) {
                 D_80125B60 = 0;
-                if ((gSaveContext.day_time >= 0x4555) && (gSaveContext.day_time <= 0xC001))
+                if ((gSaveContext.day_time >= 0x4555) && (gSaveContext.day_time <= 0xC001)) {
                     D_80125B60 = 1;
+                }
 
                 gSaveContext.unk_1422 = 2;
                 D_80125B64 = D_8011FB40;

--- a/src/code/z_room.c
+++ b/src/code/z_room.c
@@ -129,8 +129,9 @@ void func_80095D04(GlobalContext* globalCtx, Room* room, u32 flags) {
     spA4 = &spB8[0];
     polygonDlist = SEGMENTED_TO_VIRTUAL(room->mesh->polygon2.start);
     polygon2 = &room->mesh->polygon2;
-    if (polygon2->num > SHAPE_SORT_MAX)
+    if (polygon2->num > SHAPE_SORT_MAX) {
         __assert("polygon2->num <= SHAPE_SORT_MAX", "../z_room.c", 317);
+    }
 
     sp78 = polygonDlist;
     for (sp9C = 0; sp9C < polygon2->num; sp9C++) {
@@ -152,8 +153,9 @@ void func_80095D04(GlobalContext* globalCtx, Room* room, u32 flags) {
                     spA4->unk_08 = NULL;
                 } else {
                     do {
-                        if (spA4->unk_04 < phi_v0->unk_04)
+                        if (spA4->unk_04 < phi_v0->unk_04) {
                             break;
+                        }
                         phi_v0 = phi_v0->unk_0C;
                     } while (phi_v0 != NULL);
 
@@ -165,10 +167,11 @@ void func_80095D04(GlobalContext* globalCtx, Room* room, u32 flags) {
                     } else {
                         phi_a0 = phi_v0->unk_08;
                         spA4->unk_08 = phi_a0;
-                        if (phi_a0 == NULL)
+                        if (phi_a0 == NULL) {
                             spB4 = spA4;
-                        else
+                        } else {
                             phi_a0->unk_0C = spA4;
+                        }
                         phi_v0->unk_08 = spA4;
                         spA4->unk_0C = (void*)phi_v0;
                     }
@@ -187,25 +190,30 @@ void func_80095D04(GlobalContext* globalCtx, Room* room, u32 flags) {
         if (iREG(86) != 0) {
             phi_v1 = 0;
             while (phi_v1 < polygon2->num) {
-                if (phi_s0 == sp78)
+                if (phi_s0 == sp78) {
                     break;
+                }
                 phi_v1++;
                 sp78++;
             }
 
             if (((iREG(86) == 1) && (iREG(89) > sp9C)) || ((iREG(86) == 2) && (iREG(89) == sp9C))) {
-                if ((flags & 1) && (phi_s0->opa != NULL))
+                if ((flags & 1) && (phi_s0->opa != NULL)) {
                     gSPDisplayList(gfxCtx->polyOpa.p++, phi_s0->opa);
+                }
 
-                if ((flags & 2) && (phi_s0->xlu != NULL))
+                if ((flags & 2) && (phi_s0->xlu != NULL)) {
                     gSPDisplayList(gfxCtx->polyXlu.p++, phi_s0->xlu);
+                }
             }
         } else {
-            if ((flags & 1) && (phi_s0->opa != NULL))
+            if ((flags & 1) && (phi_s0->opa != NULL)) {
                 gSPDisplayList(gfxCtx->polyOpa.p++, phi_s0->opa);
+            }
 
-            if ((flags & 2) && (phi_s0->xlu != NULL))
+            if ((flags & 2) && (phi_s0->xlu != NULL)) {
                 gSPDisplayList(gfxCtx->polyXlu.p++, phi_s0->xlu);
+            }
         }
 
         spB4 = spB4->unk_0C;
@@ -541,8 +549,9 @@ u32 func_80096FE8(GlobalContext* globalCtx, RoomContext* roomCtx) {
     for (i = 0; i < globalCtx->nbRooms; i++) {
         roomSize = roomList[i].vromEnd - roomList[i].vromStart;
         osSyncPrintf("ROOM%d size=%d\n", i, roomSize);
-        if (maxRoomSize < roomSize)
+        if (maxRoomSize < roomSize) {
             maxRoomSize = roomSize;
+        }
     }
 
     if (globalCtx->nbTransitionActors != 0) {
@@ -559,8 +568,9 @@ u32 func_80096FE8(GlobalContext* globalCtx, RoomContext* roomCtx) {
             cumulRoomSize = (frontRoom != backRoom) ? frontRoomSize + backRoomSize : frontRoomSize;
             osSyncPrintf("DOOR%d=<%d> ROOM1=<%d, %d> ROOM2=<%d, %d>\n", j, cumulRoomSize, frontRoom, frontRoomSize,
                          backRoom, backRoomSize);
-            if (maxRoomSize < cumulRoomSize)
+            if (maxRoomSize < cumulRoomSize) {
                 maxRoomSize = cumulRoomSize;
+            }
             transitionActor++;
         }
     }
@@ -578,10 +588,11 @@ u32 func_80096FE8(GlobalContext* globalCtx, RoomContext* roomCtx) {
     roomCtx->unk_30 = 0;
     roomCtx->status = 0;
 
-    if (gSaveContext.respawn_flag > 0)
+    if (gSaveContext.respawn_flag > 0) {
         nextRoomNum = gSaveContext.respawn[gSaveContext.respawn_flag - 1].room_index;
-    else
+    } else {
         nextRoomNum = globalCtx->setupEntranceList[globalCtx->curSpawn].room;
+    }
     func_8009728C(globalCtx, roomCtx, nextRoomNum);
 
     return maxRoomSize;

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -312,13 +312,15 @@ void func_8009899C(GlobalContext* globalCtx, SceneCmd* cmd) {
         }
     }
 
-    if (cmd->objectList.num > OBJECT_EXCHANGE_BANK_MAX)
+    if (cmd->objectList.num > OBJECT_EXCHANGE_BANK_MAX) {
         __assert("scene_info->object_bank.num <= OBJECT_EXCHANGE_BANK_MAX", "../z_scene.c", 705);
+    }
 
     while (k < cmd->objectList.num) {
         nextPtr = func_800982FC(&globalCtx->objectCtx, i, *objectEntry);
-        if (i < OBJECT_EXCHANGE_BANK_MAX - 1)
+        if (i < OBJECT_EXCHANGE_BANK_MAX - 1) {
             globalCtx->objectCtx.status[i + 1].segment = nextPtr;
+        }
         k++;
         objectEntry++;
         status++;

--- a/src/code/z_scene_table.c
+++ b/src/code/z_scene_table.c
@@ -2271,10 +2271,11 @@ void func_8009FE58(GlobalContext* globalCtx) {
         D_8012A398 += 0.15f + (globalCtx->unk_11D30[1] * 0.001f);
     }
 
-    if (globalCtx->roomCtx.curRoom.num == 2)
+    if (globalCtx->roomCtx.curRoom.num == 2) {
         Matrix_Scale(1, sinf(D_8012A398) * 0.8f, 1, MTXMODE_NEW);
-    else
+    } else {
         Matrix_Scale(1.005f, sinf(D_8012A398) * 0.8f, 1.005f, MTXMODE_NEW);
+    }
 
     gSPSegment(gfxCtx->polyOpa.p++, 0x0D, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_scene_table.c", 7809));
 

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -9,8 +9,7 @@ void ArmsHook_Update(ArmsHook* this, GlobalContext* globalCtx);
 void ArmsHook_Draw(ArmsHook* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Arms_Hook_InitVars =
-{
+const ActorInit Arms_Hook_InitVars = {
     ACTOR_ARMS_HOOK,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
+++ b/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
@@ -9,8 +9,7 @@ void ArrowFire_Update(ArrowFire* this, GlobalContext* globalCtx);
 void ArrowFire_Draw(ArrowFire* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Arrow_Fire_InitVars =
-{
+const ActorInit Arrow_Fire_InitVars = {
     ACTOR_ARROW_FIRE,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
@@ -9,8 +9,7 @@ void ArrowIce_Update(ArrowIce* this, GlobalContext* globalCtx);
 void ArrowIce_Draw(ArrowIce* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Arrow_Ice_InitVars =
-{
+const ActorInit Arrow_Ice_InitVars = {
     ACTOR_ARROW_ICE,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
+++ b/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
@@ -9,8 +9,7 @@ void ArrowLight_Update(ArrowLight* this, GlobalContext* globalCtx);
 void ArrowLight_Draw(ArrowLight* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Arrow_Light_InitVars =
-{
+const ActorInit Arrow_Light_InitVars = {
     ACTOR_ARROW_LIGHT,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
@@ -9,8 +9,7 @@ void BgBdanObjects_Update(BgBdanObjects* this, GlobalContext* globalCtx);
 void BgBdanObjects_Draw(BgBdanObjects* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Bdan_Objects_InitVars =
-{
+const ActorInit Bg_Bdan_Objects_InitVars = {
     ACTOR_BG_BDAN_OBJECTS,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.c
@@ -9,8 +9,7 @@ void BgBombwall_Update(BgBombwall* this, GlobalContext* globalCtx);
 void BgBombwall_Draw(BgBombwall* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Bombwall_InitVars =
-{
+const ActorInit Bg_Bombwall_InitVars = {
     ACTOR_BG_BOMBWALL,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.c
+++ b/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.c
@@ -9,8 +9,7 @@ void BgBowlWall_Update(BgBowlWall* this, GlobalContext* globalCtx);
 void BgBowlWall_Draw(BgBowlWall* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Bowl_Wall_InitVars =
-{
+const ActorInit Bg_Bowl_Wall_InitVars = {
     ACTOR_BG_BOWL_WALL,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -8,8 +8,7 @@ void BgBreakwall_Destroy(BgBreakwall* this, GlobalContext* globalCtx);
 void BgBreakwall_Update(BgBreakwall* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Breakwall_InitVars =
-{
+const ActorInit Bg_Breakwall_InitVars = {
     ACTOR_BG_BREAKWALL,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.c
+++ b/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.c
@@ -9,8 +9,7 @@ void BgDdanJd_Update(BgDdanJd* this, GlobalContext* globalCtx);
 void BgDdanJd_Draw(BgDdanJd* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ddan_Jd_InitVars =
-{
+const ActorInit Bg_Ddan_Jd_InitVars = {
     ACTOR_BG_DDAN_JD,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.c
+++ b/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.c
@@ -9,8 +9,7 @@ void BgDdanKd_Update(BgDdanKd* this, GlobalContext* globalCtx);
 void BgDdanKd_Draw(BgDdanKd* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ddan_Kd_InitVars =
-{
+const ActorInit Bg_Ddan_Kd_InitVars = {
     ACTOR_BG_DDAN_KD,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
+++ b/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
@@ -9,8 +9,7 @@ void BgDodoago_Update(BgDodoago* this, GlobalContext* globalCtx);
 void BgDodoago_Draw(BgDodoago* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Dodoago_InitVars =
-{
+const ActorInit Bg_Dodoago_InitVars = {
     ACTOR_BG_DODOAGO,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -8,8 +8,7 @@ void BgDyYoseizo_Destroy(BgDyYoseizo* this, GlobalContext* globalCtx);
 void BgDyYoseizo_Update(BgDyYoseizo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Dy_Yoseizo_InitVars =
-{
+const ActorInit Bg_Dy_Yoseizo_InitVars = {
     ACTOR_BG_DY_YOSEIZO,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.c
+++ b/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.c
@@ -9,8 +9,7 @@ void BgGanonOtyuka_Update(BgGanonOtyuka* this, GlobalContext* globalCtx);
 void BgGanonOtyuka_Draw(BgGanonOtyuka* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ganon_Otyuka_InitVars =
-{
+const ActorInit Bg_Ganon_Otyuka_InitVars = {
     ACTOR_BG_GANON_OTYUKA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.c
@@ -70,12 +70,10 @@ static void func_8087828C(BgGateShutter* this, GlobalContext* globalCtx) {
     if (this->unk_168 == 1 && !(gSaveContext.inf_table[7] & 0x40)) {
         this->unk_178 = 2;
         this->actionFunc = (ActorFunc)func_80878300;
-    }
-    else if (this->unk_168 == 2) {
+    } else if (this->unk_168 == 2) {
         this->unk_178 = 2;
         this->actionFunc = (ActorFunc)func_80878300;
-    }
-    else if (this->unk_168 < 0) {
+    } else if (this->unk_168 < 0) {
         this->unk_178 = 2;
         this->actionFunc = (ActorFunc)func_808783D4;
     }

--- a/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.c
+++ b/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.c
@@ -9,8 +9,7 @@ void BgGjyoBridge_Update(BgGjyoBridge* this, GlobalContext* globalCtx);
 void BgGjyoBridge_Draw(BgGjyoBridge* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Gjyo_Bridge_InitVars =
-{
+const ActorInit Bg_Gjyo_Bridge_InitVars = {
     ACTOR_BG_GJYO_BRIDGE,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.c
@@ -8,8 +8,7 @@ void BgGndDarkmeiro_Destroy(BgGndDarkmeiro* this, GlobalContext* globalCtx);
 void BgGndDarkmeiro_Update(BgGndDarkmeiro* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Gnd_Darkmeiro_InitVars =
-{
+const ActorInit Bg_Gnd_Darkmeiro_InitVars = {
     ACTOR_BG_GND_DARKMEIRO,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.c
@@ -9,8 +9,7 @@ void BgGndFiremeiro_Update(BgGndFiremeiro* this, GlobalContext* globalCtx);
 void BgGndFiremeiro_Draw(BgGndFiremeiro* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Gnd_Firemeiro_InitVars =
-{
+const ActorInit Bg_Gnd_Firemeiro_InitVars = {
     ACTOR_BG_GND_FIREMEIRO,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
@@ -9,8 +9,7 @@ void BgGndIceblock_Update(BgGndIceblock* this, GlobalContext* globalCtx);
 void BgGndIceblock_Draw(BgGndIceblock* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Gnd_Iceblock_InitVars =
-{
+const ActorInit Bg_Gnd_Iceblock_InitVars = {
     ACTOR_BG_GND_ICEBLOCK,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Gnd_Soulmeiro/z_bg_gnd_soulmeiro.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Soulmeiro/z_bg_gnd_soulmeiro.c
@@ -9,8 +9,7 @@ void BgGndSoulmeiro_Update(BgGndSoulmeiro* this, GlobalContext* globalCtx);
 void BgGndSoulmeiro_Draw(BgGndSoulmeiro* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Gnd_Soulmeiro_InitVars =
-{
+const ActorInit Bg_Gnd_Soulmeiro_InitVars = {
     ACTOR_BG_GND_SOULMEIRO,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
+++ b/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
@@ -9,8 +9,7 @@ void BgHaka_Update(BgHaka* this, GlobalContext* globalCtx);
 void BgHaka_Draw(BgHaka* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_InitVars =
-{
+const ActorInit Bg_Haka_InitVars = {
     ACTOR_BG_HAKA,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
@@ -9,8 +9,7 @@ void BgHakaGate_Update(BgHakaGate* this, GlobalContext* globalCtx);
 void BgHakaGate_Draw(BgHakaGate* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_Gate_InitVars =
-{
+const ActorInit Bg_Haka_Gate_InitVars = {
     ACTOR_BG_HAKA_GATE,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka_Huta/z_bg_haka_huta.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Huta/z_bg_haka_huta.c
@@ -9,8 +9,7 @@ void BgHakaHuta_Update(BgHakaHuta* this, GlobalContext* globalCtx);
 void BgHakaHuta_Draw(BgHakaHuta* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_Huta_InitVars =
-{
+const ActorInit Bg_Haka_Huta_InitVars = {
     ACTOR_BG_HAKA_HUTA,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.c
+++ b/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.c
@@ -9,8 +9,7 @@ void BgHakaMeganeBG_Update(BgHakaMeganeBG* this, GlobalContext* globalCtx);
 void BgHakaMeganeBG_Draw(BgHakaMeganeBG* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_MeganeBG_InitVars =
-{
+const ActorInit Bg_Haka_MeganeBG_InitVars = {
     ACTOR_BG_HAKA_MEGANEBG,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.c
@@ -8,8 +8,7 @@ void BgHakaSgami_Destroy(BgHakaSgami* this, GlobalContext* globalCtx);
 void BgHakaSgami_Update(BgHakaSgami* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_Sgami_InitVars =
-{
+const ActorInit Bg_Haka_Sgami_InitVars = {
     ACTOR_BG_HAKA_SGAMI,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.c
@@ -9,8 +9,7 @@ void BgHakaShip_Update(BgHakaShip* this, GlobalContext* globalCtx);
 void BgHakaShip_Draw(BgHakaShip* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_Ship_InitVars =
-{
+const ActorInit Bg_Haka_Ship_InitVars = {
     ACTOR_BG_HAKA_SHIP,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
@@ -9,8 +9,7 @@ void BgHakaTrap_Update(BgHakaTrap* this, GlobalContext* globalCtx);
 void BgHakaTrap_Draw(BgHakaTrap* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_Trap_InitVars =
-{
+const ActorInit Bg_Haka_Trap_InitVars = {
     ACTOR_BG_HAKA_TRAP,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.c
@@ -9,8 +9,7 @@ void BgHakaTubo_Update(BgHakaTubo* this, GlobalContext* globalCtx);
 void BgHakaTubo_Draw(BgHakaTubo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_Tubo_InitVars =
-{
+const ActorInit Bg_Haka_Tubo_InitVars = {
     ACTOR_BG_HAKA_TUBO,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka_Water/z_bg_haka_water.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Water/z_bg_haka_water.c
@@ -9,8 +9,7 @@ void BgHakaWater_Update(BgHakaWater* this, GlobalContext* globalCtx);
 void BgHakaWater_Draw(BgHakaWater* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_Water_InitVars =
-{
+const ActorInit Bg_Haka_Water_InitVars = {
     ACTOR_BG_HAKA_WATER,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.c
@@ -8,8 +8,7 @@ void BgHakaZou_Destroy(BgHakaZou* this, GlobalContext* globalCtx);
 void BgHakaZou_Update(BgHakaZou* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Haka_Zou_InitVars =
-{
+const ActorInit Bg_Haka_Zou_InitVars = {
     ACTOR_BG_HAKA_ZOU,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.c
+++ b/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.c
@@ -9,8 +9,7 @@ void BgHeavyBlock_Update(BgHeavyBlock* this, GlobalContext* globalCtx);
 void BgHeavyBlock_Draw(BgHeavyBlock* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Heavy_Block_InitVars =
-{
+const ActorInit Bg_Heavy_Block_InitVars = {
     ACTOR_BG_HEAVY_BLOCK,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Curtain/z_bg_hidan_curtain.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Curtain/z_bg_hidan_curtain.c
@@ -9,8 +9,7 @@ void BgHidanCurtain_Update(BgHidanCurtain* this, GlobalContext* globalCtx);
 void BgHidanCurtain_Draw(BgHidanCurtain* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Curtain_InitVars =
-{
+const ActorInit Bg_Hidan_Curtain_InitVars = {
     ACTOR_BG_HIDAN_CURTAIN,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
@@ -9,8 +9,7 @@ void BgHidanDalm_Update(BgHidanDalm* this, GlobalContext* globalCtx);
 void BgHidanDalm_Draw(BgHidanDalm* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Dalm_InitVars =
-{
+const ActorInit Bg_Hidan_Dalm_InitVars = {
     ACTOR_BG_HIDAN_DALM,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
@@ -8,8 +8,7 @@ void BgHidanFirewall_Destroy(BgHidanFirewall* this, GlobalContext* globalCtx);
 void BgHidanFirewall_Update(BgHidanFirewall* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Firewall_InitVars =
-{
+const ActorInit Bg_Hidan_Firewall_InitVars = {
     ACTOR_BG_HIDAN_FIREWALL,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Fwbig/z_bg_hidan_fwbig.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Fwbig/z_bg_hidan_fwbig.c
@@ -9,8 +9,7 @@ void BgHidanFwbig_Update(BgHidanFwbig* this, GlobalContext* globalCtx);
 void BgHidanFwbig_Draw(BgHidanFwbig* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Fwbig_InitVars =
-{
+const ActorInit Bg_Hidan_Fwbig_InitVars = {
     ACTOR_BG_HIDAN_FWBIG,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.c
@@ -9,8 +9,7 @@ void BgHidanHamstep_Update(BgHidanHamstep* this, GlobalContext* globalCtx);
 void BgHidanHamstep_Draw(BgHidanHamstep* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Hamstep_InitVars =
-{
+const ActorInit Bg_Hidan_Hamstep_InitVars = {
     ACTOR_BG_HIDAN_HAMSTEP,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.c
@@ -9,8 +9,7 @@ void BgHidanHrock_Update(BgHidanHrock* this, GlobalContext* globalCtx);
 void BgHidanHrock_Draw(BgHidanHrock* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Hrock_InitVars =
-{
+const ActorInit Bg_Hidan_Hrock_InitVars = {
     ACTOR_BG_HIDAN_HROCK,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.c
@@ -9,8 +9,7 @@ void BgHidanKousi_Update(BgHidanKousi* this, GlobalContext* globalCtx);
 void BgHidanKousi_Draw(BgHidanKousi* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Kousi_InitVars =
-{
+const ActorInit Bg_Hidan_Kousi_InitVars = {
     ACTOR_BG_HIDAN_KOUSI,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.c
@@ -9,8 +9,7 @@ void BgHidanKowarerukabe_Update(BgHidanKowarerukabe* this, GlobalContext* global
 void BgHidanKowarerukabe_Draw(BgHidanKowarerukabe* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Kowarerukabe_InitVars =
-{
+const ActorInit Bg_Hidan_Kowarerukabe_InitVars = {
     ACTOR_BG_HIDAN_KOWARERUKABE,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
@@ -9,8 +9,7 @@ void BgHidanRock_Update(BgHidanRock* this, GlobalContext* globalCtx);
 void BgHidanRock_Draw(BgHidanRock* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Rock_InitVars =
-{
+const ActorInit Bg_Hidan_Rock_InitVars = {
     ACTOR_BG_HIDAN_ROCK,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
@@ -9,8 +9,7 @@ void BgHidanRsekizou_Update(BgHidanRsekizou* this, GlobalContext* globalCtx);
 void BgHidanRsekizou_Draw(BgHidanRsekizou* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Rsekizou_InitVars =
-{
+const ActorInit Bg_Hidan_Rsekizou_InitVars = {
     ACTOR_BG_HIDAN_RSEKIZOU,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
@@ -9,8 +9,7 @@ void BgHidanSekizou_Update(BgHidanSekizou* this, GlobalContext* globalCtx);
 void BgHidanSekizou_Draw(BgHidanSekizou* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Sekizou_InitVars =
-{
+const ActorInit Bg_Hidan_Sekizou_InitVars = {
     ACTOR_BG_HIDAN_SEKIZOU,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
@@ -9,8 +9,7 @@ void BgHidanSima_Update(BgHidanSima* this, GlobalContext* globalCtx);
 void BgHidanSima_Draw(BgHidanSima* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Hidan_Sima_InitVars =
-{
+const ActorInit Bg_Hidan_Sima_InitVars = {
     ACTOR_BG_HIDAN_SIMA,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.c
@@ -9,8 +9,7 @@ void BgIceObjects_Update(BgIceObjects* this, GlobalContext* globalCtx);
 void BgIceObjects_Draw(BgIceObjects* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ice_Objects_InitVars =
-{
+const ActorInit Bg_Ice_Objects_InitVars = {
     ACTOR_BG_ICE_OBJECTS,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
@@ -9,8 +9,7 @@ void BgIceShelter_Update(BgIceShelter* this, GlobalContext* globalCtx);
 void BgIceShelter_Draw(BgIceShelter* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ice_Shelter_InitVars =
-{
+const ActorInit Bg_Ice_Shelter_InitVars = {
     ACTOR_BG_ICE_SHELTER,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.c
@@ -9,8 +9,7 @@ void BgIceShutter_Update(BgIceShutter* this, GlobalContext* globalCtx);
 void BgIceShutter_Draw(BgIceShutter* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ice_Shutter_InitVars =
-{
+const ActorInit Bg_Ice_Shutter_InitVars = {
     ACTOR_BG_ICE_SHUTTER,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.c
@@ -9,8 +9,7 @@ void BgIceTurara_Update(BgIceTurara* this, GlobalContext* globalCtx);
 void BgIceTurara_Draw(BgIceTurara* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ice_Turara_InitVars =
-{
+const ActorInit Bg_Ice_Turara_InitVars = {
     ACTOR_BG_ICE_TURARA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
+++ b/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
@@ -9,8 +9,7 @@ void BgIngate_Update(BgIngate* this, GlobalContext* globalCtx);
 void BgIngate_Draw(BgIngate* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ingate_InitVars =
-{
+const ActorInit Bg_Ingate_InitVars = {
     ACTOR_BG_INGATE,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.c
+++ b/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.c
@@ -9,8 +9,7 @@ void BgJya1flift_Update(BgJya1flift* this, GlobalContext* globalCtx);
 void BgJya1flift_Draw(BgJya1flift* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_1flift_InitVars =
-{
+const ActorInit Bg_Jya_1flift_InitVars = {
     ACTOR_BG_JYA_1FLIFT,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.c
@@ -9,8 +9,7 @@ void BgJyaBigmirror_Update(BgJyaBigmirror* this, GlobalContext* globalCtx);
 void BgJyaBigmirror_Draw(BgJyaBigmirror* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Bigmirror_InitVars =
-{
+const ActorInit Bg_Jya_Bigmirror_InitVars = {
     ACTOR_BG_JYA_BIGMIRROR,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Block/z_bg_jya_block.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Block/z_bg_jya_block.c
@@ -9,8 +9,7 @@ void BgJyaBlock_Update(BgJyaBlock* this, GlobalContext* globalCtx);
 void BgJyaBlock_Draw(BgJyaBlock* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Block_InitVars =
-{
+const ActorInit Bg_Jya_Block_InitVars = {
     ACTOR_BG_JYA_BLOCK,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.c
@@ -9,8 +9,7 @@ void BgJyaBombchuiwa_Update(BgJyaBombchuiwa* this, GlobalContext* globalCtx);
 void BgJyaBombchuiwa_Draw(BgJyaBombchuiwa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Bombchuiwa_InitVars =
-{
+const ActorInit Bg_Jya_Bombchuiwa_InitVars = {
     ACTOR_BG_JYA_BOMBCHUIWA,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Bombiwa/z_bg_jya_bombiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombiwa/z_bg_jya_bombiwa.c
@@ -9,8 +9,7 @@ void BgJyaBombiwa_Update(BgJyaBombiwa* this, GlobalContext* globalCtx);
 void BgJyaBombiwa_Draw(BgJyaBombiwa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Bombiwa_InitVars =
-{
+const ActorInit Bg_Jya_Bombiwa_InitVars = {
     ACTOR_BG_JYA_BOMBIWA,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.c
@@ -9,8 +9,7 @@ void BgJyaCobra_Update(BgJyaCobra* this, GlobalContext* globalCtx);
 void BgJyaCobra_Draw(BgJyaCobra* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Cobra_InitVars =
-{
+const ActorInit Bg_Jya_Cobra_InitVars = {
     ACTOR_BG_JYA_COBRA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
@@ -9,8 +9,7 @@ void BgJyaGoroiwa_Update(BgJyaGoroiwa* this, GlobalContext* globalCtx);
 void BgJyaGoroiwa_Draw(BgJyaGoroiwa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Goroiwa_InitVars =
-{
+const ActorInit Bg_Jya_Goroiwa_InitVars = {
     ACTOR_BG_JYA_GOROIWA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.c
@@ -9,8 +9,7 @@ void BgJyaHaheniron_Update(BgJyaHaheniron* this, GlobalContext* globalCtx);
 void BgJyaHaheniron_Draw(BgJyaHaheniron* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Haheniron_InitVars =
-{
+const ActorInit Bg_Jya_Haheniron_InitVars = {
     ACTOR_BG_JYA_HAHENIRON,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
@@ -9,8 +9,7 @@ void BgJyaIronobj_Update(BgJyaIronobj* this, GlobalContext* globalCtx);
 void BgJyaIronobj_Draw(BgJyaIronobj* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Ironobj_InitVars =
-{
+const ActorInit Bg_Jya_Ironobj_InitVars = {
     ACTOR_BG_JYA_IRONOBJ,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
@@ -9,8 +9,7 @@ void BgJyaLift_Update(BgJyaLift* this, GlobalContext* globalCtx);
 void BgJyaLift_Draw(BgJyaLift* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Lift_InitVars =
-{
+const ActorInit Bg_Jya_Lift_InitVars = {
     ACTOR_BG_JYA_LIFT,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.c
@@ -9,8 +9,7 @@ void BgJyaMegami_Update(BgJyaMegami* this, GlobalContext* globalCtx);
 void BgJyaMegami_Draw(BgJyaMegami* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Megami_InitVars =
-{
+const ActorInit Bg_Jya_Megami_InitVars = {
     ACTOR_BG_JYA_MEGAMI,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Jya_Zurerukabe/z_bg_jya_zurerukabe.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Zurerukabe/z_bg_jya_zurerukabe.c
@@ -9,8 +9,7 @@ void BgJyaZurerukabe_Update(BgJyaZurerukabe* this, GlobalContext* globalCtx);
 void BgJyaZurerukabe_Draw(BgJyaZurerukabe* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Jya_Zurerukabe_InitVars =
-{
+const ActorInit Bg_Jya_Zurerukabe_InitVars = {
     ACTOR_BG_JYA_ZURERUKABE,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
@@ -9,8 +9,7 @@ void BgMenkuriEye_Update(BgMenkuriEye* this, GlobalContext* globalCtx);
 void BgMenkuriEye_Draw(BgMenkuriEye* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Menkuri_Eye_InitVars =
-{
+const ActorInit Bg_Menkuri_Eye_InitVars = {
     ACTOR_BG_MENKURI_EYE,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
@@ -9,8 +9,7 @@ void BgMizuBwall_Update(BgMizuBwall* this, GlobalContext* globalCtx);
 void BgMizuBwall_Draw(BgMizuBwall* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mizu_Bwall_InitVars =
-{
+const ActorInit Bg_Mizu_Bwall_InitVars = {
     ACTOR_BG_MIZU_BWALL,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.c
@@ -9,8 +9,7 @@ void BgMizuMovebg_Update(BgMizuMovebg* this, GlobalContext* globalCtx);
 void BgMizuMovebg_Draw(BgMizuMovebg* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mizu_Movebg_InitVars =
-{
+const ActorInit Bg_Mizu_Movebg_InitVars = {
     ACTOR_BG_MIZU_MOVEBG,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.c
@@ -9,8 +9,7 @@ void BgMizuShutter_Update(BgMizuShutter* this, GlobalContext* globalCtx);
 void BgMizuShutter_Draw(BgMizuShutter* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mizu_Shutter_InitVars =
-{
+const ActorInit Bg_Mizu_Shutter_InitVars = {
     ACTOR_BG_MIZU_SHUTTER,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.c
@@ -9,8 +9,7 @@ void BgMizuWater_Update(BgMizuWater* this, GlobalContext* globalCtx);
 void BgMizuWater_Draw(BgMizuWater* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mizu_Water_InitVars =
-{
+const ActorInit Bg_Mizu_Water_InitVars = {
     ACTOR_BG_MIZU_WATER,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.c
@@ -8,8 +8,7 @@ void BgMoriBigst_Destroy(BgMoriBigst* this, GlobalContext* globalCtx);
 void BgMoriBigst_Update(BgMoriBigst* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mori_Bigst_InitVars =
-{
+const ActorInit Bg_Mori_Bigst_InitVars = {
     ACTOR_BG_MORI_BIGST,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.c
@@ -8,8 +8,7 @@ void BgMoriElevator_Destroy(BgMoriElevator* this, GlobalContext* globalCtx);
 void BgMoriElevator_Update(BgMoriElevator* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mori_Elevator_InitVars =
-{
+const ActorInit Bg_Mori_Elevator_InitVars = {
     ACTOR_BG_MORI_ELEVATOR,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.c
@@ -8,8 +8,7 @@ void BgMoriHashigo_Destroy(BgMoriHashigo* this, GlobalContext* globalCtx);
 void BgMoriHashigo_Update(BgMoriHashigo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mori_Hashigo_InitVars =
-{
+const ActorInit Bg_Mori_Hashigo_InitVars = {
     ACTOR_BG_MORI_HASHIGO,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.c
@@ -8,8 +8,7 @@ void BgMoriHashira4_Destroy(BgMoriHashira4* this, GlobalContext* globalCtx);
 void BgMoriHashira4_Update(BgMoriHashira4* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mori_Hashira4_InitVars =
-{
+const ActorInit Bg_Mori_Hashira4_InitVars = {
     ACTOR_BG_MORI_HASHIRA4,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mori_Hineri/z_bg_mori_hineri.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Hineri/z_bg_mori_hineri.c
@@ -8,8 +8,7 @@ void BgMoriHineri_Destroy(BgMoriHineri* this, GlobalContext* globalCtx);
 void BgMoriHineri_Update(BgMoriHineri* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mori_Hineri_InitVars =
-{
+const ActorInit Bg_Mori_Hineri_InitVars = {
     ACTOR_BG_MORI_HINERI,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mori_Idomizu/z_bg_mori_idomizu.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Idomizu/z_bg_mori_idomizu.c
@@ -8,8 +8,7 @@ void BgMoriIdomizu_Destroy(BgMoriIdomizu* this, GlobalContext* globalCtx);
 void BgMoriIdomizu_Update(BgMoriIdomizu* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mori_Idomizu_InitVars =
-{
+const ActorInit Bg_Mori_Idomizu_InitVars = {
     ACTOR_BG_MORI_IDOMIZU,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
@@ -8,8 +8,7 @@ void BgMoriKaitenkabe_Destroy(BgMoriKaitenkabe* this, GlobalContext* globalCtx);
 void BgMoriKaitenkabe_Update(BgMoriKaitenkabe* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mori_Kaitenkabe_InitVars =
-{
+const ActorInit Bg_Mori_Kaitenkabe_InitVars = {
     ACTOR_BG_MORI_KAITENKABE,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Mori_Rakkatenjo/z_bg_mori_rakkatenjo.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Rakkatenjo/z_bg_mori_rakkatenjo.c
@@ -8,8 +8,7 @@ void BgMoriRakkatenjo_Destroy(BgMoriRakkatenjo* this, GlobalContext* globalCtx);
 void BgMoriRakkatenjo_Update(BgMoriRakkatenjo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Mori_Rakkatenjo_InitVars =
-{
+const ActorInit Bg_Mori_Rakkatenjo_InitVars = {
     ACTOR_BG_MORI_RAKKATENJO,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
+++ b/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
@@ -9,8 +9,7 @@ void BgPoEvent_Update(BgPoEvent* this, GlobalContext* globalCtx);
 void BgPoEvent_Draw(BgPoEvent* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Po_Event_InitVars =
-{
+const ActorInit Bg_Po_Event_InitVars = {
     ACTOR_BG_PO_EVENT,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Po_Syokudai/z_bg_po_syokudai.c
+++ b/src/overlays/actors/ovl_Bg_Po_Syokudai/z_bg_po_syokudai.c
@@ -9,8 +9,7 @@ void BgPoSyokudai_Update(BgPoSyokudai* this, GlobalContext* globalCtx);
 void BgPoSyokudai_Draw(BgPoSyokudai* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Po_Syokudai_InitVars =
-{
+const ActorInit Bg_Po_Syokudai_InitVars = {
     ACTOR_BG_PO_SYOKUDAI,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
+++ b/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
@@ -9,8 +9,7 @@ void BgRelayObjects_Update(BgRelayObjects* this, GlobalContext* globalCtx);
 void BgRelayObjects_Draw(BgRelayObjects* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Relay_Objects_InitVars =
-{
+const ActorInit Bg_Relay_Objects_InitVars = {
     ACTOR_BG_RELAY_OBJECTS,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
+++ b/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
@@ -9,8 +9,7 @@ void BgSpot00Hanebasi_Update(BgSpot00Hanebasi* this, GlobalContext* globalCtx);
 void BgSpot00Hanebasi_Draw(BgSpot00Hanebasi* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot00_Hanebasi_InitVars =
-{
+const ActorInit Bg_Spot00_Hanebasi_InitVars = {
     ACTOR_BG_SPOT00_HANEBASI,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot01_Idohashira/z_bg_spot01_idohashira.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idohashira/z_bg_spot01_idohashira.c
@@ -9,8 +9,7 @@ void BgSpot01Idohashira_Update(BgSpot01Idohashira* this, GlobalContext* globalCt
 void BgSpot01Idohashira_Draw(BgSpot01Idohashira* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot01_Idohashira_InitVars =
-{
+const ActorInit Bg_Spot01_Idohashira_InitVars = {
     ACTOR_BG_SPOT01_IDOHASHIRA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot01_Idomizu/z_bg_spot01_idomizu.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idomizu/z_bg_spot01_idomizu.c
@@ -9,8 +9,7 @@ void BgSpot01Idomizu_Update(BgSpot01Idomizu* this, GlobalContext* globalCtx);
 void BgSpot01Idomizu_Draw(BgSpot01Idomizu* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot01_Idomizu_InitVars =
-{
+const ActorInit Bg_Spot01_Idomizu_InitVars = {
     ACTOR_BG_SPOT01_IDOMIZU,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot01_Objects2/z_bg_spot01_objects2.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Objects2/z_bg_spot01_objects2.c
@@ -8,8 +8,7 @@ void BgSpot01Objects2_Destroy(BgSpot01Objects2* this, GlobalContext* globalCtx);
 void BgSpot01Objects2_Update(BgSpot01Objects2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot01_Objects2_InitVars =
-{
+const ActorInit Bg_Spot01_Objects2_InitVars = {
     ACTOR_BG_SPOT01_OBJECTS2,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.c
+++ b/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.c
@@ -9,8 +9,7 @@ void BgSpot02Objects_Update(BgSpot02Objects* this, GlobalContext* globalCtx);
 void BgSpot02Objects_Draw(BgSpot02Objects* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot02_Objects_InitVars =
-{
+const ActorInit Bg_Spot02_Objects_InitVars = {
     ACTOR_BG_SPOT02_OBJECTS,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
+++ b/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
@@ -9,8 +9,7 @@ void BgSpot03Taki_Update(BgSpot03Taki* this, GlobalContext* globalCtx);
 void BgSpot03Taki_Draw(BgSpot03Taki* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot03_Taki_InitVars =
-{
+const ActorInit Bg_Spot03_Taki_InitVars = {
     ACTOR_BG_SPOT03_TAKI,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.c
+++ b/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.c
@@ -9,8 +9,7 @@ void BgSpot05Soko_Update(BgSpot05Soko* this, GlobalContext* globalCtx);
 void BgSpot05Soko_Draw(BgSpot05Soko* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot05_Soko_InitVars =
-{
+const ActorInit Bg_Spot05_Soko_InitVars = {
     ACTOR_BG_SPOT05_SOKO,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
+++ b/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
@@ -9,8 +9,7 @@ void BgSpot06Objects_Update(BgSpot06Objects* this, GlobalContext* globalCtx);
 void BgSpot06Objects_Draw(BgSpot06Objects* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot06_Objects_InitVars =
-{
+const ActorInit Bg_Spot06_Objects_InitVars = {
     ACTOR_BG_SPOT06_OBJECTS,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot07_Taki/z_bg_spot07_taki.c
+++ b/src/overlays/actors/ovl_Bg_Spot07_Taki/z_bg_spot07_taki.c
@@ -9,8 +9,7 @@ void BgSpot07Taki_Update(BgSpot07Taki* this, GlobalContext* globalCtx);
 void BgSpot07Taki_Draw(BgSpot07Taki* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot07_Taki_InitVars =
-{
+const ActorInit Bg_Spot07_Taki_InitVars = {
     ACTOR_BG_SPOT07_TAKI,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot08_Bakudankabe/z_bg_spot08_bakudankabe.c
+++ b/src/overlays/actors/ovl_Bg_Spot08_Bakudankabe/z_bg_spot08_bakudankabe.c
@@ -9,8 +9,7 @@ void BgSpot08Bakudankabe_Update(BgSpot08Bakudankabe* this, GlobalContext* global
 void BgSpot08Bakudankabe_Draw(BgSpot08Bakudankabe* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot08_Bakudankabe_InitVars =
-{
+const ActorInit Bg_Spot08_Bakudankabe_InitVars = {
     ACTOR_BG_SPOT08_BAKUDANKABE,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot08_Iceblock/z_bg_spot08_iceblock.c
+++ b/src/overlays/actors/ovl_Bg_Spot08_Iceblock/z_bg_spot08_iceblock.c
@@ -9,8 +9,7 @@ void BgSpot08Iceblock_Update(BgSpot08Iceblock* this, GlobalContext* globalCtx);
 void BgSpot08Iceblock_Draw(BgSpot08Iceblock* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot08_Iceblock_InitVars =
-{
+const ActorInit Bg_Spot08_Iceblock_InitVars = {
     ACTOR_BG_SPOT08_ICEBLOCK,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot09_Obj/z_bg_spot09_obj.c
+++ b/src/overlays/actors/ovl_Bg_Spot09_Obj/z_bg_spot09_obj.c
@@ -9,8 +9,7 @@ void BgSpot09Obj_Update(BgSpot09Obj* this, GlobalContext* globalCtx);
 void BgSpot09Obj_Draw(BgSpot09Obj* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot09_Obj_InitVars =
-{
+const ActorInit Bg_Spot09_Obj_InitVars = {
     ACTOR_BG_SPOT09_OBJ,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot11_Bakudankabe/z_bg_spot11_bakudankabe.c
+++ b/src/overlays/actors/ovl_Bg_Spot11_Bakudankabe/z_bg_spot11_bakudankabe.c
@@ -9,8 +9,7 @@ void BgSpot11Bakudankabe_Update(BgSpot11Bakudankabe* this, GlobalContext* global
 void BgSpot11Bakudankabe_Draw(BgSpot11Bakudankabe* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot11_Bakudankabe_InitVars =
-{
+const ActorInit Bg_Spot11_Bakudankabe_InitVars = {
     ACTOR_BG_SPOT11_BAKUDANKABE,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot11_Oasis/z_bg_spot11_oasis.c
+++ b/src/overlays/actors/ovl_Bg_Spot11_Oasis/z_bg_spot11_oasis.c
@@ -7,8 +7,7 @@ void BgSpot11Oasis_Init(BgSpot11Oasis* this, GlobalContext* globalCtx);
 void BgSpot11Oasis_Update(BgSpot11Oasis* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot11_Oasis_InitVars =
-{
+const ActorInit Bg_Spot11_Oasis_InitVars = {
     ACTOR_BG_SPOT11_OASIS,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.c
+++ b/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.c
@@ -9,8 +9,7 @@ void BgSpot12Gate_Update(BgSpot12Gate* this, GlobalContext* globalCtx);
 void BgSpot12Gate_Draw(BgSpot12Gate* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot12_Gate_InitVars =
-{
+const ActorInit Bg_Spot12_Gate_InitVars = {
     ACTOR_BG_SPOT12_GATE,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.c
+++ b/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.c
@@ -9,8 +9,7 @@ void BgSpot12Saku_Update(BgSpot12Saku* this, GlobalContext* globalCtx);
 void BgSpot12Saku_Draw(BgSpot12Saku* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot12_Saku_InitVars =
-{
+const ActorInit Bg_Spot12_Saku_InitVars = {
     ACTOR_BG_SPOT12_SAKU,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.c
+++ b/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.c
@@ -9,8 +9,7 @@ void BgSpot15Rrbox_Update(BgSpot15Rrbox* this, GlobalContext* globalCtx);
 void BgSpot15Rrbox_Draw(BgSpot15Rrbox* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot15_Rrbox_InitVars =
-{
+const ActorInit Bg_Spot15_Rrbox_InitVars = {
     ACTOR_BG_SPOT15_RRBOX,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.c
+++ b/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.c
@@ -9,8 +9,7 @@ void BgSpot16Bombstone_Update(BgSpot16Bombstone* this, GlobalContext* globalCtx)
 void BgSpot16Bombstone_Draw(BgSpot16Bombstone* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot16_Bombstone_InitVars =
-{
+const ActorInit Bg_Spot16_Bombstone_InitVars = {
     ACTOR_BG_SPOT16_BOMBSTONE,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.c
+++ b/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.c
@@ -9,8 +9,7 @@ void BgSpot16Doughnut_Update(BgSpot16Doughnut* this, GlobalContext* globalCtx);
 void BgSpot16Doughnut_Draw(BgSpot16Doughnut* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot16_Doughnut_InitVars =
-{
+const ActorInit Bg_Spot16_Doughnut_InitVars = {
     ACTOR_BG_SPOT16_DOUGHNUT,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.c
+++ b/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.c
@@ -9,8 +9,7 @@ void BgSpot17Bakudankabe_Update(BgSpot17Bakudankabe* this, GlobalContext* global
 void BgSpot17Bakudankabe_Draw(BgSpot17Bakudankabe* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot17_Bakudankabe_InitVars =
-{
+const ActorInit Bg_Spot17_Bakudankabe_InitVars = {
     ACTOR_BG_SPOT17_BAKUDANKABE,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.c
+++ b/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.c
@@ -8,8 +8,7 @@ void BgSpot17Funen_Destroy(BgSpot17Funen* this, GlobalContext* globalCtx);
 void BgSpot17Funen_Update(BgSpot17Funen* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot17_Funen_InitVars =
-{
+const ActorInit Bg_Spot17_Funen_InitVars = {
     ACTOR_BG_SPOT17_FUNEN,
     ACTORTYPE_SWITCH,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
@@ -9,8 +9,7 @@ void BgSpot18Basket_Update(BgSpot18Basket* this, GlobalContext* globalCtx);
 void BgSpot18Basket_Draw(BgSpot18Basket* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot18_Basket_InitVars =
-{
+const ActorInit Bg_Spot18_Basket_InitVars = {
     ACTOR_BG_SPOT18_BASKET,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.c
@@ -9,8 +9,7 @@ void BgSpot18Obj_Update(BgSpot18Obj* this, GlobalContext* globalCtx);
 void BgSpot18Obj_Draw(BgSpot18Obj* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot18_Obj_InitVars =
-{
+const ActorInit Bg_Spot18_Obj_InitVars = {
     ACTOR_BG_SPOT18_OBJ,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.c
@@ -9,8 +9,7 @@ void BgSpot18Shutter_Update(BgSpot18Shutter* this, GlobalContext* globalCtx);
 void BgSpot18Shutter_Draw(BgSpot18Shutter* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Spot18_Shutter_InitVars =
-{
+const ActorInit Bg_Spot18_Shutter_InitVars = {
     ACTOR_BG_SPOT18_SHUTTER,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.c
+++ b/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.c
@@ -9,8 +9,7 @@ void BgSstFloor_Update(BgSstFloor* this, GlobalContext* globalCtx);
 void BgSstFloor_Draw(BgSstFloor* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Sst_Floor_InitVars =
-{
+const ActorInit Bg_Sst_Floor_InitVars = {
     ACTOR_BG_SST_FLOOR,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.c
+++ b/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.c
@@ -9,8 +9,7 @@ void BgTokiHikari_Update(BgTokiHikari* this, GlobalContext* globalCtx);
 void BgTokiHikari_Draw(BgTokiHikari* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Toki_Hikari_InitVars =
-{
+const ActorInit Bg_Toki_Hikari_InitVars = {
     ACTOR_BG_TOKI_HIKARI,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.c
+++ b/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.c
@@ -9,8 +9,7 @@ void BgTreemouth_Update(BgTreemouth* this, GlobalContext* globalCtx);
 void BgTreemouth_Draw(BgTreemouth* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Treemouth_InitVars =
-{
+const ActorInit Bg_Treemouth_InitVars = {
     ACTOR_BG_TREEMOUTH,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Vb_Sima/z_bg_vb_sima.c
+++ b/src/overlays/actors/ovl_Bg_Vb_Sima/z_bg_vb_sima.c
@@ -9,8 +9,7 @@ void BgVbSima_Update(BgVbSima* this, GlobalContext* globalCtx);
 void BgVbSima_Draw(BgVbSima* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Vb_Sima_InitVars =
-{
+const ActorInit Bg_Vb_Sima_InitVars = {
     ACTOR_BG_VB_SIMA,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ydan_Hasi/z_bg_ydan_hasi.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Hasi/z_bg_ydan_hasi.c
@@ -9,8 +9,7 @@ void BgYdanHasi_Update(BgYdanHasi* this, GlobalContext* globalCtx);
 void BgYdanHasi_Draw(BgYdanHasi* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ydan_Hasi_InitVars =
-{
+const ActorInit Bg_Ydan_Hasi_InitVars = {
     ACTOR_BG_YDAN_HASI,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.c
@@ -9,8 +9,7 @@ void BgYdanMaruta_Update(BgYdanMaruta* this, GlobalContext* globalCtx);
 void BgYdanMaruta_Draw(BgYdanMaruta* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ydan_Maruta_InitVars =
-{
+const ActorInit Bg_Ydan_Maruta_InitVars = {
     ACTOR_BG_YDAN_MARUTA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
@@ -9,8 +9,7 @@ void BgYdanSp_Update(BgYdanSp* this, GlobalContext* globalCtx);
 void BgYdanSp_Draw(BgYdanSp* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Bg_Ydan_Sp_InitVars =
-{
+const ActorInit Bg_Ydan_Sp_InitVars = {
     ACTOR_BG_YDAN_SP,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
+++ b/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
@@ -20,11 +20,18 @@ static void func_808C0CD4(BgZg* this, GlobalContext* globalCtx);
 static void func_808C0D08(BgZg* this, GlobalContext* globalCtx);
 static void func_808C0EEC(BgZg* this, GlobalContext* globalCtx);
 
-static const ActorFunc actionFuncs[] = { (ActorFunc)func_808C0CD4, (ActorFunc)func_808C0D08, };
+static const ActorFunc actionFuncs[] = {
+    (ActorFunc)func_808C0CD4,
+    (ActorFunc)func_808C0D08,
+};
 
-static InitChainEntry initChain[] = { ICHAIN_VEC3F_DIV1000(scale, 1000, ICHAIN_STOP), };
+static InitChainEntry initChain[] = {
+    ICHAIN_VEC3F_DIV1000(scale, 1000, ICHAIN_STOP),
+};
 
-static const ActorFunc drawFuncs[] = { (ActorFunc)func_808C0EEC, };
+static const ActorFunc drawFuncs[] = {
+    (ActorFunc)func_808C0EEC,
+};
 
 const ActorInit Bg_Zg_InitVars = {
     ACTOR_BG_ZG,

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -9,8 +9,7 @@ void BossDodongo_Update(BossDodongo* this, GlobalContext* globalCtx);
 void BossDodongo_Draw(BossDodongo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Dodongo_InitVars =
-{
+const ActorInit Boss_Dodongo_InitVars = {
     ACTOR_EN_DODONGO,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -9,8 +9,7 @@ void BossFd_Update(BossFd* this, GlobalContext* globalCtx);
 void BossFd_Draw(BossFd* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Fd_InitVars =
-{
+const ActorInit Boss_Fd_InitVars = {
     ACTOR_BOSS_FD,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
+++ b/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
@@ -9,8 +9,7 @@ void BossFd2_Update(BossFd2* this, GlobalContext* globalCtx);
 void BossFd2_Draw(BossFd2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Fd2_InitVars =
-{
+const ActorInit Boss_Fd2_InitVars = {
     ACTOR_BOSS_FD2,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -9,8 +9,7 @@ void BossGanon_Update(BossGanon* this, GlobalContext* globalCtx);
 void BossGanon_Draw(BossGanon* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Ganon_InitVars =
-{
+const ActorInit Boss_Ganon_InitVars = {
     ACTOR_BOSS_GANON,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -9,8 +9,7 @@ void BossGanon2_Update(BossGanon2* this, GlobalContext* globalCtx);
 void BossGanon2_Draw(BossGanon2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Ganon2_InitVars =
-{
+const ActorInit Boss_Ganon2_InitVars = {
     ACTOR_BOSS_GANON2,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -9,8 +9,7 @@ void BossGanondrof_Update(BossGanondrof* this, GlobalContext* globalCtx);
 void BossGanondrof_Draw(BossGanondrof* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Ganondrof_InitVars =
-{
+const ActorInit Boss_Ganondrof_InitVars = {
     ACTOR_BOSS_GANONDROF,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -9,8 +9,7 @@ void BossGoma_Update(BossGoma* this, GlobalContext* globalCtx);
 void BossGoma_Draw(BossGoma* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Goma_InitVars =
-{
+const ActorInit Boss_Goma_InitVars = {
     ACTOR_BOSS_GOMA,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -9,8 +9,7 @@ void BossMo_Update(BossMo* this, GlobalContext* globalCtx);
 void BossMo_Draw(BossMo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Mo_InitVars =
-{
+const ActorInit Boss_Mo_InitVars = {
     ACTOR_BOSS_MO,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -9,8 +9,7 @@ void BossSst_Update(BossSst* this, GlobalContext* globalCtx);
 void BossSst_Draw(BossSst* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Sst_InitVars =
-{
+const ActorInit Boss_Sst_InitVars = {
     ACTOR_BOSS_SST,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -9,8 +9,7 @@ void BossTw_Update(BossTw* this, GlobalContext* globalCtx);
 void BossTw_Draw(BossTw* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Tw_InitVars =
-{
+const ActorInit Boss_Tw_InitVars = {
     ACTOR_BOSS_TW,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -9,8 +9,7 @@ void BossVa_Update(BossVa* this, GlobalContext* globalCtx);
 void BossVa_Draw(BossVa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Boss_Va_InitVars =
-{
+const ActorInit Boss_Va_InitVars = {
     ACTOR_BOSS_VA,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
+++ b/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
@@ -8,8 +8,7 @@ void Demo6K_Destroy(Demo6K* this, GlobalContext* globalCtx);
 void Demo6K_Update(Demo6K* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_6K_InitVars =
-{
+const ActorInit Demo_6K_InitVars = {
     ACTOR_DEMO_6K,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
@@ -9,8 +9,7 @@ void DemoDu_Update(DemoDu* this, GlobalContext* globalCtx);
 void DemoDu_Draw(DemoDu* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Du_InitVars =
-{
+const ActorInit Demo_Du_InitVars = {
     ACTOR_DEMO_DU,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
+++ b/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
@@ -9,8 +9,7 @@ void DemoEc_Update(DemoEc* this, GlobalContext* globalCtx);
 void DemoEc_Draw(DemoEc* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Ec_InitVars =
-{
+const ActorInit Demo_Ec_InitVars = {
     ACTOR_DEMO_EC,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -8,8 +8,7 @@ void DemoEffect_Destroy(DemoEffect* this, GlobalContext* globalCtx);
 void DemoEffect_Update(DemoEffect* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Effect_InitVars =
-{
+const ActorInit Demo_Effect_InitVars = {
     ACTOR_DEMO_EFFECT,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.c
+++ b/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.c
@@ -9,8 +9,7 @@ void DemoExt_Update(DemoExt* this, GlobalContext* globalCtx);
 void DemoExt_Draw(DemoExt* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Ext_InitVars =
-{
+const ActorInit Demo_Ext_InitVars = {
     ACTOR_DEMO_EXT,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
@@ -9,8 +9,7 @@ void DemoGj_Update(DemoGj* this, GlobalContext* globalCtx);
 void DemoGj_Draw(DemoGj* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Gj_InitVars =
-{
+const ActorInit Demo_Gj_InitVars = {
     ACTOR_DEMO_GJ,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.c
+++ b/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.c
@@ -9,8 +9,7 @@ void DemoGt_Update(DemoGt* this, GlobalContext* globalCtx);
 void DemoGt_Draw(DemoGt* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Gt_InitVars =
-{
+const ActorInit Demo_Gt_InitVars = {
     ACTOR_DEMO_GT,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
+++ b/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
@@ -9,8 +9,7 @@ void DemoIk_Update(DemoIk* this, GlobalContext* globalCtx);
 void DemoIk_Draw(DemoIk* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Ik_InitVars =
-{
+const ActorInit Demo_Ik_InitVars = {
     ACTOR_DEMO_IK,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -9,8 +9,7 @@ void DemoIm_Update(DemoIm* this, GlobalContext* globalCtx);
 void DemoIm_Draw(DemoIm* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Im_InitVars =
-{
+const ActorInit Demo_Im_InitVars = {
     ACTOR_DEMO_IM,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -9,8 +9,7 @@ void DemoKankyo_Update(DemoKankyo* this, GlobalContext* globalCtx);
 void DemoKankyo_Draw(DemoKankyo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Kankyo_InitVars =
-{
+const ActorInit Demo_Kankyo_InitVars = {
     ACTOR_DEMO_KANKYO,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.c
+++ b/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.c
@@ -9,8 +9,7 @@ void DemoKekkai_Update(DemoKekkai* this, GlobalContext* globalCtx);
 void DemoKekkai_Draw(DemoKekkai* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Kekkai_InitVars =
-{
+const ActorInit Demo_Kekkai_InitVars = {
     ACTOR_DEMO_KEKKAI,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
@@ -9,8 +9,7 @@ void DemoSa_Update(DemoSa* this, GlobalContext* globalCtx);
 void DemoSa_Draw(DemoSa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Sa_InitVars =
-{
+const ActorInit Demo_Sa_InitVars = {
     ACTOR_DEMO_SA,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
+++ b/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
@@ -9,8 +9,7 @@ void DemoShd_Update(DemoShd* this, GlobalContext* globalCtx);
 void DemoShd_Draw(DemoShd* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Shd_InitVars =
-{
+const ActorInit Demo_Shd_InitVars = {
     ACTOR_DEMO_SHD,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.c
+++ b/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.c
@@ -9,8 +9,7 @@ void DemoTreLgt_Update(DemoTreLgt* this, GlobalContext* globalCtx);
 void DemoTreLgt_Draw(DemoTreLgt* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Demo_Tre_Lgt_InitVars =
-{
+const ActorInit Demo_Tre_Lgt_InitVars = {
     ACTOR_DEMO_TRE_LGT,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.c
+++ b/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.c
@@ -9,8 +9,7 @@ void DoorGerudo_Update(DoorGerudo* this, GlobalContext* globalCtx);
 void DoorGerudo_Draw(DoorGerudo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Door_Gerudo_InitVars =
-{
+const ActorInit Door_Gerudo_InitVars = {
     ACTOR_DOOR_GERUDO,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -8,8 +8,7 @@ void DoorKiller_Destroy(DoorKiller* this, GlobalContext* globalCtx);
 void DoorKiller_Update(DoorKiller* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Door_Killer_InitVars =
-{
+const ActorInit Door_Killer_InitVars = {
     ACTOR_DOOR_KILLER,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -9,8 +9,7 @@ void DoorShutter_Update(DoorShutter* this, GlobalContext* globalCtx);
 void DoorShutter_Draw(DoorShutter* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Door_Shutter_InitVars =
-{
+const ActorInit Door_Shutter_InitVars = {
     ACTOR_DOOR_SHUTTER,
     ACTORTYPE_DOOR,
     ROOM,

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -9,8 +9,7 @@ void DoorWarp1_Update(DoorWarp1* this, GlobalContext* globalCtx);
 void DoorWarp1_Draw(DoorWarp1* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Door_Warp1_InitVars =
-{
+const ActorInit Door_Warp1_InitVars = {
     ACTOR_DOOR_WARP1,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.c
+++ b/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.c
@@ -9,8 +9,7 @@ void EfcErupc_Update(EfcErupc* this, GlobalContext* globalCtx);
 void EfcErupc_Draw(EfcErupc* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Efc_Erupc_InitVars =
-{
+const ActorInit Efc_Erupc_InitVars = {
     ACTOR_EFC_ERUPC,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
+++ b/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
@@ -9,8 +9,7 @@ void EffDust_Update(EffDust* this, GlobalContext* globalCtx);
 void EffDust_Draw(EffDust* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Eff_Dust_InitVars =
-{
+const ActorInit Eff_Dust_InitVars = {
     ACTOR_EFF_DUST,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
+++ b/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
@@ -9,8 +9,7 @@ void ElfMsg_Update(ElfMsg* this, GlobalContext* globalCtx);
 void ElfMsg_Draw(ElfMsg* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Elf_Msg_InitVars =
-{
+const ActorInit Elf_Msg_InitVars = {
     ACTOR_ELF_MSG,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
+++ b/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
@@ -9,8 +9,7 @@ void ElfMsg2_Update(ElfMsg2* this, GlobalContext* globalCtx);
 void ElfMsg2_Draw(ElfMsg2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Elf_Msg2_InitVars =
-{
+const ActorInit Elf_Msg2_InitVars = {
     ACTOR_ELF_MSG2,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Am/z_en_am.c
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.c
@@ -9,8 +9,7 @@ void EnAm_Update(EnAm* this, GlobalContext* globalCtx);
 void EnAm_Draw(EnAm* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Am_InitVars =
-{
+const ActorInit En_Am_InitVars = {
     ACTOR_EN_AM,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -9,8 +9,7 @@ void EnAni_Update(EnAni* this, GlobalContext* globalCtx);
 void EnAni_Draw(EnAni* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ani_InitVars =
-{
+const ActorInit En_Ani_InitVars = {
     ACTOR_EN_ANI,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Anubice/z_en_anubice.c
+++ b/src/overlays/actors/ovl_En_Anubice/z_en_anubice.c
@@ -9,8 +9,7 @@ void EnAnubice_Update(EnAnubice* this, GlobalContext* globalCtx);
 void EnAnubice_Draw(EnAnubice* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Anubice_InitVars =
-{
+const ActorInit En_Anubice_InitVars = {
     ACTOR_EN_ANUBICE,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
+++ b/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
@@ -9,8 +9,7 @@ void EnAnubiceFire_Update(EnAnubiceFire* this, GlobalContext* globalCtx);
 void EnAnubiceFire_Draw(EnAnubiceFire* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Anubice_Fire_InitVars =
-{
+const ActorInit En_Anubice_Fire_InitVars = {
     ACTOR_EN_ANUBICE_FIRE,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -9,8 +9,7 @@ void EnArrow_Update(EnArrow* this, GlobalContext* globalCtx);
 void EnArrow_Draw(EnArrow* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Arrow_InitVars =
-{
+const ActorInit En_Arrow_InitVars = {
     ACTOR_EN_ARROW,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -9,8 +9,7 @@ void EnAttackNiw_Update(EnAttackNiw* this, GlobalContext* globalCtx);
 void EnAttackNiw_Draw(EnAttackNiw* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Attack_Niw_InitVars =
-{
+const ActorInit En_Attack_Niw_InitVars = {
     ACTOR_EN_ATTACK_NIW,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.c
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.c
@@ -9,8 +9,7 @@ void EnBa_Update(EnBa* this, GlobalContext* globalCtx);
 void EnBa_Draw(EnBa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ba_InitVars =
-{
+const ActorInit En_Ba_InitVars = {
     ACTOR_EN_BA,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -9,8 +9,7 @@ void EnBb_Update(EnBb* this, GlobalContext* globalCtx);
 void EnBb_Draw(EnBb* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bb_InitVars =
-{
+const ActorInit En_Bb_InitVars = {
     ACTOR_EN_BB,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
+++ b/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
@@ -9,8 +9,7 @@ void EnBdfire_Update(EnBdfire* this, GlobalContext* globalCtx);
 void EnBdfire_Draw(EnBdfire* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bdfire_InitVars =
-{
+const ActorInit En_Bdfire_InitVars = {
     ACTOR_PLAYER,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -9,8 +9,7 @@ void EnBigokuta_Update(EnBigokuta* this, GlobalContext* globalCtx);
 void EnBigokuta_Draw(EnBigokuta* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bigokuta_InitVars =
-{
+const ActorInit En_Bigokuta_InitVars = {
     ACTOR_EN_BIGOKUTA,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bili/z_en_bili.c
+++ b/src/overlays/actors/ovl_En_Bili/z_en_bili.c
@@ -9,8 +9,7 @@ void EnBili_Update(EnBili* this, GlobalContext* globalCtx);
 void EnBili_Draw(EnBili* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bili_InitVars =
-{
+const ActorInit En_Bili_InitVars = {
     ACTOR_EN_BILI,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.c
+++ b/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.c
@@ -9,8 +9,7 @@ void EnBlkobj_Update(EnBlkobj* this, GlobalContext* globalCtx);
 void EnBlkobj_Draw(EnBlkobj* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Blkobj_InitVars =
-{
+const ActorInit En_Blkobj_InitVars = {
     ACTOR_EN_BLKOBJ,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -9,8 +9,7 @@ void EnBom_Update(EnBom* this, GlobalContext* globalCtx);
 void EnBom_Draw(EnBom* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bom_InitVars =
-{
+const ActorInit En_Bom_InitVars = {
     ACTOR_EN_BOM,
     ACTORTYPE_EXPLOSIVES,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -9,8 +9,7 @@ void EnBomBowlMan_Update(EnBomBowlMan* this, GlobalContext* globalCtx);
 void EnBomBowlMan_Draw(EnBomBowlMan* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bom_Bowl_Man_InitVars =
-{
+const ActorInit En_Bom_Bowl_Man_InitVars = {
     ACTOR_EN_BOM_BOWL_MAN,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.c
@@ -8,8 +8,7 @@ void EnBomBowlPit_Destroy(EnBomBowlPit* this, GlobalContext* globalCtx);
 void EnBomBowlPit_Update(EnBomBowlPit* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bom_Bowl_Pit_InitVars =
-{
+const ActorInit En_Bom_Bowl_Pit_InitVars = {
     ACTOR_EN_BOM_BOWL_PIT,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
@@ -9,8 +9,7 @@ void EnBomChu_Update(EnBomChu* this, GlobalContext* globalCtx);
 void EnBomChu_Draw(EnBomChu* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bom_Chu_InitVars =
-{
+const ActorInit En_Bom_Chu_InitVars = {
     ACTOR_EN_BOM_CHU,
     ACTORTYPE_EXPLOSIVES,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -9,8 +9,7 @@ void EnBombf_Update(EnBombf* this, GlobalContext* globalCtx);
 void EnBombf_Draw(EnBombf* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bombf_InitVars =
-{
+const ActorInit En_Bombf_InitVars = {
     ACTOR_EN_BOMBF,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -9,8 +9,7 @@ void EnBox_Update(EnBox* this, GlobalContext* globalCtx);
 void EnBox_Draw(EnBox* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Box_InitVars =
-{
+const ActorInit En_Box_InitVars = {
     Chest,
     ACTORTYPE_CHEST,
     ROOM,

--- a/src/overlays/actors/ovl_En_Brob/z_en_brob.c
+++ b/src/overlays/actors/ovl_En_Brob/z_en_brob.c
@@ -9,8 +9,7 @@ void EnBrob_Update(EnBrob* this, GlobalContext* globalCtx);
 void EnBrob_Draw(EnBrob* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Brob_InitVars =
-{
+const ActorInit En_Brob_InitVars = {
     ACTOR_EN_BROB,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -9,8 +9,7 @@ void EnBubble_Update(EnBubble* this, GlobalContext* globalCtx);
 void EnBubble_Draw(EnBubble* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bubble_InitVars =
-{
+const ActorInit En_Bubble_InitVars = {
     ACTOR_EN_BUBBLE,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -9,8 +9,7 @@ void EnButte_Update(EnButte* this, GlobalContext* globalCtx);
 void EnButte_Draw(EnButte* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Butte_InitVars =
-{
+const ActorInit En_Butte_InitVars = {
     ACTOR_EN_BUTTE,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bw/z_en_bw.c
+++ b/src/overlays/actors/ovl_En_Bw/z_en_bw.c
@@ -9,8 +9,7 @@ void EnBw_Update(EnBw* this, GlobalContext* globalCtx);
 void EnBw_Draw(EnBw* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bw_InitVars =
-{
+const ActorInit En_Bw_InitVars = {
     ACTOR_EN_BW,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Bx/z_en_bx.c
+++ b/src/overlays/actors/ovl_En_Bx/z_en_bx.c
@@ -9,8 +9,7 @@ void EnBx_Update(EnBx* this, GlobalContext* globalCtx);
 void EnBx_Draw(EnBx* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Bx_InitVars =
-{
+const ActorInit En_Bx_InitVars = {
     ACTOR_EN_BX,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.c
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.c
@@ -8,8 +8,7 @@ void EnChanger_Destroy(EnChanger* this, GlobalContext* globalCtx);
 void EnChanger_Update(EnChanger* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Changer_InitVars =
-{
+const ActorInit En_Changer_InitVars = {
     ACTOR_EN_CHANGER,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -9,8 +9,7 @@ void EnClearTag_Update(EnClearTag* this, GlobalContext* globalCtx);
 void EnClearTag_Draw(EnClearTag* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Clear_Tag_InitVars =
-{
+const ActorInit En_Clear_Tag_InitVars = {
     ACTOR_EN_CLEAR_TAG,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -9,8 +9,7 @@ void EnCow_Update(EnCow* this, GlobalContext* globalCtx);
 void EnCow_Draw(EnCow* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Cow_InitVars =
-{
+const ActorInit En_Cow_InitVars = {
     ACTOR_EN_COW,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -9,8 +9,7 @@ void EnCrow_Update(EnCrow* this, GlobalContext* globalCtx);
 void EnCrow_Draw(EnCrow* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Crow_InitVars =
-{
+const ActorInit En_Crow_InitVars = {
     ACTOR_EN_CROW,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Cs/z_en_cs.c
+++ b/src/overlays/actors/ovl_En_Cs/z_en_cs.c
@@ -9,8 +9,7 @@ void EnCs_Update(EnCs* this, GlobalContext* globalCtx);
 void EnCs_Draw(EnCs* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Cs_InitVars =
-{
+const ActorInit En_Cs_InitVars = {
     ACTOR_EN_CS,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
+++ b/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
@@ -9,8 +9,7 @@ void EnDaiku_Update(EnDaiku* this, GlobalContext* globalCtx);
 void EnDaiku_Draw(EnDaiku* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Daiku_InitVars =
-{
+const ActorInit En_Daiku_InitVars = {
     ACTOR_EN_DAIKU,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
+++ b/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
@@ -9,8 +9,7 @@ void EnDaikuKakariko_Update(EnDaikuKakariko* this, GlobalContext* globalCtx);
 void EnDaikuKakariko_Draw(EnDaikuKakariko* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Daiku_Kakariko_InitVars =
-{
+const ActorInit En_Daiku_Kakariko_InitVars = {
     ACTOR_EN_DAIKU_KAKARIKO,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
@@ -9,8 +9,7 @@ void EnDekubaba_Update(EnDekubaba* this, GlobalContext* globalCtx);
 void EnDekubaba_Draw(EnDekubaba* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dekubaba_InitVars =
-{
+const ActorInit En_Dekubaba_InitVars = {
     ACTOR_EN_DEKUBABA,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
+++ b/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
@@ -9,8 +9,7 @@ void EnDekunuts_Update(EnDekunuts* this, GlobalContext* globalCtx);
 void EnDekunuts_Draw(EnDekunuts* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dekunuts_InitVars =
-{
+const ActorInit En_Dekunuts_InitVars = {
     ACTOR_EN_DEKUNUTS,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.c
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.c
@@ -9,8 +9,7 @@ void EnDh_Update(EnDh* this, GlobalContext* globalCtx);
 void EnDh_Draw(EnDh* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dh_InitVars =
-{
+const ActorInit En_Dh_InitVars = {
     ACTOR_EN_DH,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dha/z_en_dha.c
+++ b/src/overlays/actors/ovl_En_Dha/z_en_dha.c
@@ -9,8 +9,7 @@ void EnDha_Update(EnDha* this, GlobalContext* globalCtx);
 void EnDha_Draw(EnDha* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dha_InitVars =
-{
+const ActorInit En_Dha_InitVars = {
     ACTOR_EN_DHA,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
+++ b/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
@@ -9,8 +9,7 @@ void EnDivingGame_Update(EnDivingGame* this, GlobalContext* globalCtx);
 void EnDivingGame_Draw(EnDivingGame* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Diving_Game_InitVars =
-{
+const ActorInit En_Diving_Game_InitVars = {
     ACTOR_EN_DIVING_GAME,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -9,8 +9,7 @@ void EnDns_Update(EnDns* this, GlobalContext* globalCtx);
 void EnDns_Draw(EnDns* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dns_InitVars =
-{
+const ActorInit En_Dns_InitVars = {
     ACTOR_EN_DNS,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
+++ b/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
@@ -8,8 +8,7 @@ void EnDntDemo_Destroy(EnDntDemo* this, GlobalContext* globalCtx);
 void EnDntDemo_Update(EnDntDemo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dnt_Demo_InitVars =
-{
+const ActorInit En_Dnt_Demo_InitVars = {
     ACTOR_EN_DNT_DEMO,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
+++ b/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
@@ -9,8 +9,7 @@ void EnDntJiji_Update(EnDntJiji* this, GlobalContext* globalCtx);
 void EnDntJiji_Draw(EnDntJiji* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dnt_Jiji_InitVars =
-{
+const ActorInit En_Dnt_Jiji_InitVars = {
     ACTOR_EN_DNT_JIJI,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -8,8 +8,7 @@ void EnDntNomal_Destroy(EnDntNomal* this, GlobalContext* globalCtx);
 void EnDntNomal_Update(EnDntNomal* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dnt_Nomal_InitVars =
-{
+const ActorInit En_Dnt_Nomal_InitVars = {
     ACTOR_EN_DNT_NOMAL,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
+++ b/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
@@ -9,8 +9,7 @@ void EnDodojr_Update(EnDodojr* this, GlobalContext* globalCtx);
 void EnDodojr_Draw(EnDodojr* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dodojr_InitVars =
-{
+const ActorInit En_Dodojr_InitVars = {
     ACTOR_EN_DODOJR,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -9,8 +9,7 @@ void EnDodongo_Update(EnDodongo* this, GlobalContext* globalCtx);
 void EnDodongo_Draw(EnDodongo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dodongo_InitVars =
-{
+const ActorInit En_Dodongo_InitVars = {
     ACTOR_EN_DODONGO,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Door/z_en_door.c
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.c
@@ -9,8 +9,7 @@ void EnDoor_Update(EnDoor* this, GlobalContext* globalCtx);
 void EnDoor_Draw(EnDoor* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Door_InitVars =
-{
+const ActorInit En_Door_InitVars = {
     ACTOR_EN_DOOR,
     ACTORTYPE_DOOR,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -9,8 +9,7 @@ void EnDs_Update(EnDs* this, GlobalContext* globalCtx);
 void EnDs_Draw(EnDs* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ds_InitVars =
-{
+const ActorInit En_Ds_InitVars = {
     ACTOR_EN_DS,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -9,8 +9,7 @@ void EnDu_Update(EnDu* this, GlobalContext* globalCtx);
 void EnDu_Draw(EnDu* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Du_InitVars =
-{
+const ActorInit En_Du_InitVars = {
     ACTOR_EN_DU,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.c
+++ b/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.c
@@ -9,8 +9,7 @@ void EnDyExtra_Update(EnDyExtra* this, GlobalContext* globalCtx);
 void EnDyExtra_Draw(EnDyExtra* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Dy_Extra_InitVars =
-{
+const ActorInit En_Dy_Extra_InitVars = {
     ACTOR_EN_DY_EXTRA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
+++ b/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
@@ -9,8 +9,7 @@ void EnEiyer_Update(EnEiyer* this, GlobalContext* globalCtx);
 void EnEiyer_Draw(EnEiyer* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Eiyer_InitVars =
-{
+const ActorInit En_Eiyer_InitVars = {
     ACTOR_EN_EIYER,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -9,8 +9,7 @@ void EnElf_Update(EnElf* this, GlobalContext* globalCtx);
 void EnElf_Draw(EnElf* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Elf_InitVars =
-{
+const ActorInit En_Elf_InitVars = {
     ACTOR_EN_ELF,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
@@ -7,8 +7,7 @@ void EnEncount1_Init(EnEncount1* this, GlobalContext* globalCtx);
 void EnEncount1_Update(EnEncount1* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Encount1_InitVars =
-{
+const ActorInit En_Encount1_InitVars = {
     ACTOR_EN_ENCOUNT1,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
+++ b/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
@@ -8,8 +8,7 @@ void EnEncount2_Update(EnEncount2* this, GlobalContext* globalCtx);
 void EnEncount2_Draw(EnEncount2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Encount2_InitVars =
-{
+const ActorInit En_Encount2_InitVars = {
     ACTOR_EN_ENCOUNT2,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
+++ b/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
@@ -9,8 +9,7 @@ void EnExItem_Update(EnExItem* this, GlobalContext* globalCtx);
 void EnExItem_Draw(EnExItem* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ex_Item_InitVars =
-{
+const ActorInit En_Ex_Item_InitVars = {
     ACTOR_EN_EX_ITEM,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
+++ b/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
@@ -9,8 +9,7 @@ void EnExRuppy_Update(EnExRuppy* this, GlobalContext* globalCtx);
 void EnExRuppy_Draw(EnExRuppy* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ex_Ruppy_InitVars =
-{
+const ActorInit En_Ex_Ruppy_InitVars = {
     ACTOR_EN_EX_RUPPY,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -9,8 +9,7 @@ void EnFd_Update(EnFd* this, GlobalContext* globalCtx);
 void EnFd_Draw(EnFd* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Fd_InitVars =
-{
+const ActorInit En_Fd_InitVars = {
     ACTOR_EN_FD,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.c
+++ b/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.c
@@ -9,8 +9,7 @@ void EnFdFire_Update(EnFdFire* this, GlobalContext* globalCtx);
 void EnFdFire_Draw(EnFdFire* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Fd_Fire_InitVars =
-{
+const ActorInit En_Fd_Fire_InitVars = {
     ACTOR_EN_FD_FIRE,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
+++ b/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
@@ -9,8 +9,7 @@ void EnFhgFire_Update(EnFhgFire* this, GlobalContext* globalCtx);
 void EnFhgFire_Draw(EnFhgFire* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Fhg_Fire_InitVars =
-{
+const ActorInit En_Fhg_Fire_InitVars = {
     ACTOR_PLAYER,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -9,8 +9,7 @@ void EnFireRock_Update(EnFireRock* this, GlobalContext* globalCtx);
 void EnFireRock_Draw(EnFireRock* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Fire_Rock_InitVars =
-{
+const ActorInit En_Fire_Rock_InitVars = {
     ACTOR_EN_FIRE_ROCK,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
+++ b/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
@@ -9,8 +9,7 @@ void EnFirefly_Update(EnFirefly* this, GlobalContext* globalCtx);
 void EnFirefly_Draw(EnFirefly* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Firefly_InitVars =
-{
+const ActorInit En_Firefly_InitVars = {
     ACTOR_EN_FIREFLY,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -9,8 +9,7 @@ void EnFish_Update(EnFish* this, GlobalContext* globalCtx);
 void EnFish_Draw(EnFish* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Fish_InitVars =
-{
+const ActorInit En_Fish_InitVars = {
     ACTOR_EN_FISH,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -9,8 +9,7 @@ void EnFloormas_Update(EnFloormas* this, GlobalContext* globalCtx);
 void EnFloormas_Draw(EnFloormas* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Floormas_InitVars =
-{
+const ActorInit En_Floormas_InitVars = {
     ACTOR_EN_FLOORMAS,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -8,8 +8,7 @@ void EnFr_Destroy(EnFr* this, GlobalContext* globalCtx);
 void EnFr_Update(EnFr* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Fr_InitVars =
-{
+const ActorInit En_Fr_InitVars = {
     ACTOR_EN_FR,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -9,8 +9,7 @@ void EnFu_Update(EnFu* this, GlobalContext* globalCtx);
 void EnFu_Draw(EnFu* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Fu_InitVars =
-{
+const ActorInit En_Fu_InitVars = {
     ACTOR_EN_FU,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Fw/z_en_fw.c
+++ b/src/overlays/actors/ovl_En_Fw/z_en_fw.c
@@ -9,8 +9,7 @@ void EnFw_Update(EnFw* this, GlobalContext* globalCtx);
 void EnFw_Draw(EnFw* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Fw_InitVars =
-{
+const ActorInit En_Fw_InitVars = {
     ACTOR_EN_FW,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Fz/z_en_fz.c
+++ b/src/overlays/actors/ovl_En_Fz/z_en_fz.c
@@ -9,8 +9,7 @@ void EnFz_Update(EnFz* this, GlobalContext* globalCtx);
 void EnFz_Draw(EnFz* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Fz_InitVars =
-{
+const ActorInit En_Fz_InitVars = {
     ACTOR_EN_FZ,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
+++ b/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
@@ -8,8 +8,7 @@ void EnGSwitch_Destroy(EnGSwitch* this, GlobalContext* globalCtx);
 void EnGSwitch_Update(EnGSwitch* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_G_Switch_InitVars =
-{
+const ActorInit En_G_Switch_InitVars = {
     ACTOR_EN_G_SWITCH,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.c
+++ b/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.c
@@ -9,8 +9,7 @@ void EnGanonMant_Update(EnGanonMant* this, GlobalContext* globalCtx);
 void EnGanonMant_Draw(EnGanonMant* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ganon_Mant_InitVars =
-{
+const ActorInit En_Ganon_Mant_InitVars = {
     ACTOR_EN_GANON_MANT,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -9,8 +9,7 @@ void EnGb_Update(EnGb* this, GlobalContext* globalCtx);
 void EnGb_Draw(EnGb* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Gb_InitVars =
-{
+const ActorInit En_Gb_InitVars = {
     ACTOR_EN_GB,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -9,8 +9,7 @@ void EnGe1_Update(EnGe1* this, GlobalContext* globalCtx);
 void EnGe1_Draw(EnGe1* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ge1_InitVars =
-{
+const ActorInit En_Ge1_InitVars = {
     ACTOR_EN_GE1,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -9,8 +9,7 @@ void EnGe2_Update(EnGe2* this, GlobalContext* globalCtx);
 void EnGe2_Draw(EnGe2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ge2_InitVars =
-{
+const ActorInit En_Ge2_InitVars = {
     ACTOR_EN_GE2,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -9,8 +9,7 @@ void EnGe3_Update(EnGe3* this, GlobalContext* globalCtx);
 void EnGe3_Draw(EnGe3* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ge3_InitVars =
-{
+const ActorInit En_Ge3_InitVars = {
     ACTOR_EN_GE3,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -9,8 +9,7 @@ void EnGeldB_Update(EnGeldB* this, GlobalContext* globalCtx);
 void EnGeldB_Draw(EnGeldB* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_GeldB_InitVars =
-{
+const ActorInit En_GeldB_InitVars = {
     ACTOR_EN_GELDB,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -8,8 +8,7 @@ void EnGirlA_Destroy(EnGirlA* this, GlobalContext* globalCtx);
 void EnGirlA_Update(EnGirlA* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_GirlA_InitVars =
-{
+const ActorInit En_GirlA_InitVars = {
     ACTOR_EN_GIRLA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Gm/z_en_gm.c
+++ b/src/overlays/actors/ovl_En_Gm/z_en_gm.c
@@ -8,8 +8,7 @@ void EnGm_Destroy(EnGm* this, GlobalContext* globalCtx);
 void EnGm_Update(EnGm* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Gm_InitVars =
-{
+const ActorInit En_Gm_InitVars = {
     ACTOR_EN_GM,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -9,8 +9,7 @@ void EnGo_Update(EnGo* this, GlobalContext* globalCtx);
 void EnGo_Draw(EnGo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Go_InitVars =
-{
+const ActorInit En_Go_InitVars = {
     ACTOR_EN_GO,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -9,8 +9,7 @@ void EnGo2_Update(EnGo2* this, GlobalContext* globalCtx);
 void EnGo2_Draw(EnGo2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Go2_InitVars =
-{
+const ActorInit En_Go2_InitVars = {
     ACTOR_EN_GO2,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Goma/z_en_goma.c
+++ b/src/overlays/actors/ovl_En_Goma/z_en_goma.c
@@ -9,8 +9,7 @@ void EnGoma_Update(EnGoma* this, GlobalContext* globalCtx);
 void EnGoma_Draw(EnGoma* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Goma_InitVars =
-{
+const ActorInit En_Goma_InitVars = {
     ACTOR_BOSS_GOMA,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
@@ -9,8 +9,7 @@ void EnGoroiwa_Update(EnGoroiwa* this, GlobalContext* globalCtx);
 void EnGoroiwa_Draw(EnGoroiwa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Goroiwa_InitVars =
-{
+const ActorInit En_Goroiwa_InitVars = {
     ACTOR_EN_GOROIWA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.c
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.c
@@ -9,8 +9,7 @@ void EnGs_Update(EnGs* this, GlobalContext* globalCtx);
 void EnGs_Draw(EnGs* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Gs_InitVars =
-{
+const ActorInit En_Gs_InitVars = {
     ACTOR_EN_GS,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Guest/z_en_guest.c
+++ b/src/overlays/actors/ovl_En_Guest/z_en_guest.c
@@ -8,8 +8,7 @@ void EnGuest_Destroy(EnGuest* this, GlobalContext* globalCtx);
 void EnGuest_Update(EnGuest* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Guest_InitVars =
-{
+const ActorInit En_Guest_InitVars = {
     ACTOR_EN_GUEST,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Hata/z_en_hata.c
+++ b/src/overlays/actors/ovl_En_Hata/z_en_hata.c
@@ -9,8 +9,7 @@ void EnHata_Update(EnHata* this, GlobalContext* globalCtx);
 void EnHata_Draw(EnHata* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Hata_InitVars =
-{
+const ActorInit En_Hata_InitVars = {
     ACTOR_EN_HATA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
+++ b/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
@@ -9,8 +9,7 @@ void EnHeishi1_Update(EnHeishi1* this, GlobalContext* globalCtx);
 void EnHeishi1_Draw(EnHeishi1* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Heishi1_InitVars =
-{
+const ActorInit En_Heishi1_InitVars = {
     ACTOR_PLAYER,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -9,8 +9,7 @@ void EnHeishi2_Update(EnHeishi2* this, GlobalContext* globalCtx);
 void EnHeishi2_Draw(EnHeishi2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Heishi2_InitVars =
-{
+const ActorInit En_Heishi2_InitVars = {
     ACTOR_EN_HEISHI2,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
+++ b/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
@@ -9,8 +9,7 @@ void EnHeishi3_Update(EnHeishi3* this, GlobalContext* globalCtx);
 void EnHeishi3_Draw(EnHeishi3* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Heishi3_InitVars =
-{
+const ActorInit En_Heishi3_InitVars = {
     ACTOR_EN_HEISHI3,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
+++ b/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
@@ -9,8 +9,7 @@ void EnHeishi4_Update(EnHeishi4* this, GlobalContext* globalCtx);
 void EnHeishi4_Draw(EnHeishi4* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Heishi4_InitVars =
-{
+const ActorInit En_Heishi4_InitVars = {
     ACTOR_EN_HEISHI4,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
@@ -9,8 +9,7 @@ void EnHintnuts_Update(EnHintnuts* this, GlobalContext* globalCtx);
 void EnHintnuts_Draw(EnHintnuts* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Hintnuts_InitVars =
-{
+const ActorInit En_Hintnuts_InitVars = {
     ACTOR_EN_HINTNUTS,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Holl/z_en_holl.c
+++ b/src/overlays/actors/ovl_En_Holl/z_en_holl.c
@@ -9,8 +9,7 @@ void EnHoll_Update(EnHoll* this, GlobalContext* globalCtx);
 void EnHoll_Draw(EnHoll* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Holl_InitVars =
-{
+const ActorInit En_Holl_InitVars = {
     ACTOR_EN_HOLL,
     ACTORTYPE_DOOR,
     ROOM,

--- a/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
+++ b/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
@@ -9,8 +9,7 @@ void EnHonotrap_Update(EnHonotrap* this, GlobalContext* globalCtx);
 void EnHonotrap_Draw(EnHonotrap* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Honotrap_InitVars =
-{
+const ActorInit En_Honotrap_InitVars = {
     ACTOR_EN_HONOTRAP,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -9,8 +9,7 @@ void EnHorse_Update(EnHorse* this, GlobalContext* globalCtx);
 void EnHorse_Draw(EnHorse* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Horse_InitVars =
-{
+const ActorInit En_Horse_InitVars = {
     ACTOR_EN_HORSE,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
+++ b/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
@@ -9,8 +9,7 @@ void EnHorseGameCheck_Update(EnHorseGameCheck* this, GlobalContext* globalCtx);
 void EnHorseGameCheck_Draw(EnHorseGameCheck* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Horse_Game_Check_InitVars =
-{
+const ActorInit En_Horse_Game_Check_InitVars = {
     ACTOR_EN_HORSE_GAME_CHECK,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
+++ b/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
@@ -9,8 +9,7 @@ void EnHorseGanon_Update(EnHorseGanon* this, GlobalContext* globalCtx);
 void EnHorseGanon_Draw(EnHorseGanon* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Horse_Ganon_InitVars =
-{
+const ActorInit En_Horse_Ganon_InitVars = {
     ACTOR_EN_HORSE_GANON,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
@@ -9,8 +9,7 @@ void EnHorseLinkChild_Update(EnHorseLinkChild* this, GlobalContext* globalCtx);
 void EnHorseLinkChild_Draw(EnHorseLinkChild* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Horse_Link_Child_InitVars =
-{
+const ActorInit En_Horse_Link_Child_InitVars = {
     ACTOR_EN_HORSE_LINK_CHILD,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
+++ b/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
@@ -9,8 +9,7 @@ void EnHorseNormal_Update(EnHorseNormal* this, GlobalContext* globalCtx);
 void EnHorseNormal_Draw(EnHorseNormal* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Horse_Normal_InitVars =
-{
+const ActorInit En_Horse_Normal_InitVars = {
     ACTOR_EN_HORSE_NORMAL,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
+++ b/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
@@ -9,8 +9,7 @@ void EnHorseZelda_Update(EnHorseZelda* this, GlobalContext* globalCtx);
 void EnHorseZelda_Draw(EnHorseZelda* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Horse_Zelda_InitVars =
-{
+const ActorInit En_Horse_Zelda_InitVars = {
     ACTOR_EN_HORSE_ZELDA,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -9,8 +9,7 @@ void EnHs_Update(EnHs* this, GlobalContext* globalCtx);
 void EnHs_Draw(EnHs* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Hs_InitVars =
-{
+const ActorInit En_Hs_InitVars = {
     ACTOR_EN_HS,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
+++ b/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
@@ -9,8 +9,7 @@ void EnHs2_Update(EnHs2* this, GlobalContext* globalCtx);
 void EnHs2_Draw(EnHs2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Hs2_InitVars =
-{
+const ActorInit En_Hs2_InitVars = {
     ACTOR_EN_HS2,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -9,8 +9,7 @@ void EnHy_Update(EnHy* this, GlobalContext* globalCtx);
 void EnHy_Draw(EnHy* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Hy_InitVars =
-{
+const ActorInit En_Hy_InitVars = {
     ACTOR_EN_HY,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
+++ b/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
@@ -9,8 +9,7 @@ void EnIceHono_Update(EnIceHono* this, GlobalContext* globalCtx);
 void EnIceHono_Draw(EnIceHono* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ice_Hono_InitVars =
-{
+const ActorInit En_Ice_Hono_InitVars = {
     ACTOR_EN_ICE_HONO,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -9,8 +9,7 @@ void EnIk_Update(EnIk* this, GlobalContext* globalCtx);
 void EnIk_Draw(EnIk* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ik_InitVars =
-{
+const ActorInit En_Ik_InitVars = {
     ACTOR_EN_IK,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -9,8 +9,7 @@ void EnIn_Update(EnIn* this, GlobalContext* globalCtx);
 void EnIn_Draw(EnIn* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_In_InitVars =
-{
+const ActorInit En_In_InitVars = {
     ACTOR_EN_IN,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -9,8 +9,7 @@ void EnInsect_Update(EnInsect* this, GlobalContext* globalCtx);
 void EnInsect_Draw(EnInsect* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Insect_InitVars =
-{
+const ActorInit En_Insect_InitVars = {
     ACTOR_EN_INSECT,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
@@ -9,8 +9,7 @@ void EnIshi_Update(EnIshi* this, GlobalContext* globalCtx);
 void EnIshi_Draw(EnIshi* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ishi_InitVars =
-{
+const ActorInit En_Ishi_InitVars = {
     ACTOR_EN_ISHI,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Jj/z_en_jj.c
+++ b/src/overlays/actors/ovl_En_Jj/z_en_jj.c
@@ -9,8 +9,7 @@ void EnJj_Update(EnJj* this, GlobalContext* globalCtx);
 void EnJj_Draw(EnJj* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Jj_InitVars =
-{
+const ActorInit En_Jj_InitVars = {
     ACTOR_EN_JJ,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -9,8 +9,7 @@ void EnJs_Update(EnJs* this, GlobalContext* globalCtx);
 void EnJs_Draw(EnJs* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Js_InitVars =
-{
+const ActorInit En_Js_InitVars = {
     ACTOR_EN_JS,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.c
+++ b/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.c
@@ -9,8 +9,7 @@ void EnJsjutan_Update(EnJsjutan* this, GlobalContext* globalCtx);
 void EnJsjutan_Draw(EnJsjutan* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Jsjutan_InitVars =
-{
+const ActorInit En_Jsjutan_InitVars = {
     ACTOR_EN_JSJUTAN,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
+++ b/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
@@ -9,8 +9,7 @@ void EnKakasi_Update(EnKakasi* this, GlobalContext* globalCtx);
 void EnKakasi_Draw(EnKakasi* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Kakasi_InitVars =
-{
+const ActorInit En_Kakasi_InitVars = {
     ACTOR_EN_KAKASI,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
+++ b/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
@@ -8,8 +8,7 @@ void EnKakasi2_Destroy(EnKakasi2* this, GlobalContext* globalCtx);
 void EnKakasi2_Update(EnKakasi2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Kakasi2_InitVars =
-{
+const ActorInit En_Kakasi2_InitVars = {
     ACTOR_EN_KAKASI2,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.c
+++ b/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.c
@@ -9,8 +9,7 @@ void EnKakasi3_Update(EnKakasi3* this, GlobalContext* globalCtx);
 void EnKakasi3_Draw(EnKakasi3* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Kakasi3_InitVars =
-{
+const ActorInit En_Kakasi3_InitVars = {
     ACTOR_EN_KAKASI3,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
+++ b/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
@@ -9,8 +9,7 @@ void EnKanban_Update(EnKanban* this, GlobalContext* globalCtx);
 void EnKanban_Draw(EnKanban* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Kanban_InitVars =
-{
+const ActorInit En_Kanban_InitVars = {
     ACTOR_EN_KANBAN,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
+++ b/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
@@ -9,8 +9,7 @@ void EnKarebaba_Update(EnKarebaba* this, GlobalContext* globalCtx);
 void EnKarebaba_Draw(EnKarebaba* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Karebaba_InitVars =
-{
+const ActorInit En_Karebaba_InitVars = {
     ACTOR_EN_KAREBABA,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -9,8 +9,7 @@ void EnKo_Update(EnKo* this, GlobalContext* globalCtx);
 void EnKo_Draw(EnKo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ko_InitVars =
-{
+const ActorInit En_Ko_InitVars = {
     ACTOR_EN_KO,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
+++ b/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
@@ -8,8 +8,7 @@ void EnKusa_Destroy(EnKusa* this, GlobalContext* globalCtx);
 void EnKusa_Update(EnKusa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Kusa_InitVars =
-{
+const ActorInit En_Kusa_InitVars = {
     ACTOR_EN_KUSA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -9,8 +9,7 @@ void EnKz_Update(EnKz* this, GlobalContext* globalCtx);
 void EnKz_Draw(EnKz* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Kz_InitVars =
-{
+const ActorInit En_Kz_InitVars = {
     ACTOR_EN_KZ,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Light/z_en_light.c
+++ b/src/overlays/actors/ovl_En_Light/z_en_light.c
@@ -9,8 +9,7 @@ void EnLight_Update(EnLight* this, GlobalContext* globalCtx);
 void EnLight_Draw(EnLight* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Light_InitVars =
-{
+const ActorInit En_Light_InitVars = {
     ACTOR_EN_LIGHT,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -9,8 +9,7 @@ void EnMThunder_Update(EnMThunder* this, GlobalContext* globalCtx);
 void EnMThunder_Draw(EnMThunder* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_M_Thunder_InitVars =
-{
+const ActorInit En_M_Thunder_InitVars = {
     ACTOR_EN_M_THUNDER,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -9,8 +9,7 @@ void EnMa1_Update(EnMa1* this, GlobalContext* globalCtx);
 void EnMa1_Draw(EnMa1* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ma1_InitVars =
-{
+const ActorInit En_Ma1_InitVars = {
     ACTOR_EN_MA1,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
@@ -9,8 +9,7 @@ void EnMa2_Update(EnMa2* this, GlobalContext* globalCtx);
 void EnMa2_Draw(EnMa2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ma2_InitVars =
-{
+const ActorInit En_Ma2_InitVars = {
     ACTOR_EN_MA2,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -9,8 +9,7 @@ void EnMa3_Update(EnMa3* this, GlobalContext* globalCtx);
 void EnMa3_Draw(EnMa3* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ma3_InitVars =
-{
+const ActorInit En_Ma3_InitVars = {
     ACTOR_EN_MA3,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -9,8 +9,7 @@ void EnMag_Update(EnMag* this, GlobalContext* globalCtx);
 void EnMag_Draw(EnMag* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Mag_InitVars =
-{
+const ActorInit En_Mag_InitVars = {
     ACTOR_EN_MAG,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -9,8 +9,7 @@ void EnMb_Update(EnMb* this, GlobalContext* globalCtx);
 void EnMb_Draw(EnMb* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Mb_InitVars =
-{
+const ActorInit En_Mb_InitVars = {
     ACTOR_EN_MB,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -9,8 +9,7 @@ void EnMd_Update(EnMd* this, GlobalContext* globalCtx);
 void EnMd_Draw(EnMd* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Md_InitVars =
-{
+const ActorInit En_Md_InitVars = {
     ACTOR_EN_MD,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -9,8 +9,7 @@ void EnMk_Update(EnMk* this, GlobalContext* globalCtx);
 void EnMk_Draw(EnMk* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Mk_InitVars =
-{
+const ActorInit En_Mk_InitVars = {
     ACTOR_EN_MK,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -9,8 +9,7 @@ void EnMm_Update(EnMm* this, GlobalContext* globalCtx);
 void EnMm_Draw(EnMm* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Mm_InitVars =
-{
+const ActorInit En_Mm_InitVars = {
     ACTOR_EN_MM,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
@@ -9,8 +9,7 @@ void EnMm2_Update(EnMm2* this, GlobalContext* globalCtx);
 void EnMm2_Draw(EnMm2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Mm2_InitVars =
-{
+const ActorInit En_Mm2_InitVars = {
     ACTOR_EN_MM2,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.c
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.c
@@ -9,8 +9,7 @@ void EnMu_Update(EnMu* this, GlobalContext* globalCtx);
 void EnMu_Draw(EnMu* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Mu_InitVars =
-{
+const ActorInit En_Mu_InitVars = {
     ACTOR_EN_MU,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -9,8 +9,7 @@ void EnNb_Update(EnNb* this, GlobalContext* globalCtx);
 void EnNb_Draw(EnNb* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Nb_InitVars =
-{
+const ActorInit En_Nb_InitVars = {
     ACTOR_EN_NB,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Niw/z_en_niw.c
+++ b/src/overlays/actors/ovl_En_Niw/z_en_niw.c
@@ -9,8 +9,7 @@ void EnNiw_Update(EnNiw* this, GlobalContext* globalCtx);
 void EnNiw_Draw(EnNiw* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Niw_InitVars =
-{
+const ActorInit En_Niw_InitVars = {
     ACTOR_EN_NIW,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.c
+++ b/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.c
@@ -9,8 +9,7 @@ void EnNiwGirl_Update(EnNiwGirl* this, GlobalContext* globalCtx);
 void EnNiwGirl_Draw(EnNiwGirl* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Niw_Girl_InitVars =
-{
+const ActorInit En_Niw_Girl_InitVars = {
     ACTOR_EN_NIW_GIRL,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -8,8 +8,7 @@ void EnNiwLady_Destroy(EnNiwLady* this, GlobalContext* globalCtx);
 void EnNiwLady_Update(EnNiwLady* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Niw_Lady_InitVars =
-{
+const ActorInit En_Niw_Lady_InitVars = {
     ACTOR_EN_NIW_LADY,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Nwc/z_en_nwc.c
+++ b/src/overlays/actors/ovl_En_Nwc/z_en_nwc.c
@@ -9,8 +9,7 @@ void EnNwc_Update(EnNwc* this, GlobalContext* globalCtx);
 void EnNwc_Draw(EnNwc* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Nwc_InitVars =
-{
+const ActorInit En_Nwc_InitVars = {
     ACTOR_EN_NWC,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ny/z_en_ny.c
+++ b/src/overlays/actors/ovl_En_Ny/z_en_ny.c
@@ -9,8 +9,7 @@ void EnNy_Update(EnNy* this, GlobalContext* globalCtx);
 void EnNy_Draw(EnNy* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ny_InitVars =
-{
+const ActorInit En_Ny_InitVars = {
     ACTOR_EN_NY,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -8,8 +8,7 @@ void EnOkarinaTag_Destroy(EnOkarinaTag* this, GlobalContext* globalCtx);
 void EnOkarinaTag_Update(EnOkarinaTag* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Okarina_Tag_InitVars =
-{
+const ActorInit En_Okarina_Tag_InitVars = {
     ACTOR_EN_OKARINA_TAG,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
+++ b/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
@@ -9,8 +9,7 @@ void EnOkuta_Update(EnOkuta* this, GlobalContext* globalCtx);
 void EnOkuta_Draw(EnOkuta* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Okuta_InitVars =
-{
+const ActorInit En_Okuta_InitVars = {
     ACTOR_EN_OKUTA,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -8,8 +8,7 @@ void EnOssan_Destroy(EnOssan* this, GlobalContext* globalCtx);
 void EnOssan_Update(EnOssan* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ossan_InitVars =
-{
+const ActorInit En_Ossan_InitVars = {
     ACTOR_EN_OSSAN,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -9,8 +9,7 @@ void EnOwl_Update(EnOwl* this, GlobalContext* globalCtx);
 void EnOwl_Draw(EnOwl* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Owl_InitVars =
-{
+const ActorInit En_Owl_InitVars = {
     ACTOR_EN_OWL,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -9,8 +9,7 @@ void EnPart_Update(EnPart* this, GlobalContext* globalCtx);
 void EnPart_Draw(EnPart* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Part_InitVars =
-{
+const ActorInit En_Part_InitVars = {
     ACTOR_EN_PART,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -9,8 +9,7 @@ void EnPeehat_Update(EnPeehat* this, GlobalContext* globalCtx);
 void EnPeehat_Draw(EnPeehat* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Peehat_InitVars =
-{
+const ActorInit En_Peehat_InitVars = {
     ACTOR_EN_PEEHAT,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
+++ b/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
@@ -9,8 +9,7 @@ void EnPoDesert_Update(EnPoDesert* this, GlobalContext* globalCtx);
 void EnPoDesert_Draw(EnPoDesert* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Po_Desert_InitVars =
-{
+const ActorInit En_Po_Desert_InitVars = {
     ACTOR_EN_PO_DESERT,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
+++ b/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
@@ -9,8 +9,7 @@ void EnPoField_Update(EnPoField* this, GlobalContext* globalCtx);
 void EnPoField_Draw(EnPoField* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Po_Field_InitVars =
-{
+const ActorInit En_Po_Field_InitVars = {
     ACTOR_EN_PO_FIELD,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -9,8 +9,7 @@ void EnPoRelay_Update(EnPoRelay* this, GlobalContext* globalCtx);
 void EnPoRelay_Draw(EnPoRelay* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Po_Relay_InitVars =
-{
+const ActorInit En_Po_Relay_InitVars = {
     ACTOR_EN_PO_RELAY,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
+++ b/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
@@ -9,8 +9,7 @@ void EnPoSisters_Update(EnPoSisters* this, GlobalContext* globalCtx);
 void EnPoSisters_Draw(EnPoSisters* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Po_Sisters_InitVars =
-{
+const ActorInit En_Po_Sisters_InitVars = {
     ACTOR_EN_PO_SISTERS,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -8,8 +8,7 @@ void EnPoh_Destroy(EnPoh* this, GlobalContext* globalCtx);
 void EnPoh_Update(EnPoh* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Poh_InitVars =
-{
+const ActorInit En_Poh_InitVars = {
     ACTOR_EN_POH,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -9,8 +9,7 @@ void EnRd_Update(EnRd* this, GlobalContext* globalCtx);
 void EnRd_Draw(EnRd* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Rd_InitVars =
-{
+const ActorInit En_Rd_InitVars = {
     ACTOR_EN_RD,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -9,8 +9,7 @@ void EnReeba_Update(EnReeba* this, GlobalContext* globalCtx);
 void EnReeba_Draw(EnReeba* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Reeba_InitVars =
-{
+const ActorInit En_Reeba_InitVars = {
     ACTOR_EN_REEBA,
     ACTORTYPE_MISC,
     ROOM,

--- a/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
+++ b/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
@@ -9,8 +9,7 @@ void EnRiverSound_Update(EnRiverSound* this, GlobalContext* globalCtx);
 void EnRiverSound_Draw(EnRiverSound* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_River_Sound_InitVars =
-{
+const ActorInit En_River_Sound_InitVars = {
     ACTOR_EN_RIVER_SOUND,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Rl/z_en_rl.c
+++ b/src/overlays/actors/ovl_En_Rl/z_en_rl.c
@@ -9,8 +9,7 @@ void EnRl_Update(EnRl* this, GlobalContext* globalCtx);
 void EnRl_Draw(EnRl* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Rl_InitVars =
-{
+const ActorInit En_Rl_InitVars = {
     ACTOR_EN_RL,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -9,8 +9,7 @@ void EnRr_Update(EnRr* this, GlobalContext* globalCtx);
 void EnRr_Draw(EnRr* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Rr_InitVars =
-{
+const ActorInit En_Rr_InitVars = {
     ACTOR_EN_RR,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
+++ b/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
@@ -9,8 +9,7 @@ void EnRu1_Update(EnRu1* this, GlobalContext* globalCtx);
 void EnRu1_Draw(EnRu1* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ru1_InitVars =
-{
+const ActorInit En_Ru1_InitVars = {
     ACTOR_EN_RU1,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -9,8 +9,7 @@ void EnRu2_Update(EnRu2* this, GlobalContext* globalCtx);
 void EnRu2_Draw(EnRu2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ru2_InitVars =
-{
+const ActorInit En_Ru2_InitVars = {
     ACTOR_EN_RU2,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -9,8 +9,7 @@ void EnSa_Update(EnSa* this, GlobalContext* globalCtx);
 void EnSa_Draw(EnSa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Sa_InitVars =
-{
+const ActorInit En_Sa_InitVars = {
     ACTOR_EN_SA,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Sb/z_en_sb.c
+++ b/src/overlays/actors/ovl_En_Sb/z_en_sb.c
@@ -9,8 +9,7 @@ void EnSb_Update(EnSb* this, GlobalContext* globalCtx);
 void EnSb_Draw(EnSb* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Sb_InitVars =
-{
+const ActorInit En_Sb_InitVars = {
     ACTOR_EN_SB,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -9,8 +9,7 @@ void EnSda_Update(EnSda* this, GlobalContext* globalCtx);
 void EnSda_Draw(EnSda* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Sda_InitVars =
-{
+const ActorInit En_Sda_InitVars = {
     ACTOR_EN_SDA,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
+++ b/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
@@ -9,8 +9,7 @@ void EnShopnuts_Update(EnShopnuts* this, GlobalContext* globalCtx);
 void EnShopnuts_Draw(EnShopnuts* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Shopnuts_InitVars =
-{
+const ActorInit En_Shopnuts_InitVars = {
     ACTOR_EN_SHOPNUTS,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -9,8 +9,7 @@ void EnSi_Update(EnSi* this, GlobalContext* globalCtx);
 void EnSi_Draw(EnSi* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Si_InitVars =
-{
+const ActorInit En_Si_InitVars = {
     ACTOR_EN_SI,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.c
+++ b/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.c
@@ -9,8 +9,7 @@ void EnSiofuki_Update(EnSiofuki* this, GlobalContext* globalCtx);
 void EnSiofuki_Draw(EnSiofuki* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Siofuki_InitVars =
-{
+const ActorInit En_Siofuki_InitVars = {
     ACTOR_EN_SIOFUKI,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.c
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.c
@@ -9,8 +9,7 @@ void EnSkb_Update(EnSkb* this, GlobalContext* globalCtx);
 void EnSkb_Draw(EnSkb* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Skb_InitVars =
-{
+const ActorInit En_Skb_InitVars = {
     ACTOR_EN_SKB,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -9,8 +9,7 @@ void EnSkj_Update(EnSkj* this, GlobalContext* globalCtx);
 void EnSkj_Draw(EnSkj* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Skj_InitVars =
-{
+const ActorInit En_Skj_InitVars = {
     ACTOR_EN_SKJ,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Skjneedle/z_en_skjneedle.c
+++ b/src/overlays/actors/ovl_En_Skjneedle/z_en_skjneedle.c
@@ -9,8 +9,7 @@ void EnSkjneedle_Update(EnSkjneedle* this, GlobalContext* globalCtx);
 void EnSkjneedle_Draw(EnSkjneedle* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Skjneedle_InitVars =
-{
+const ActorInit En_Skjneedle_InitVars = {
     ACTOR_EN_SKJNEEDLE,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -9,8 +9,7 @@ void EnSsh_Update(EnSsh* this, GlobalContext* globalCtx);
 void EnSsh_Draw(EnSsh* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ssh_InitVars =
-{
+const ActorInit En_Ssh_InitVars = {
     ACTOR_EN_SSH,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -9,8 +9,7 @@ void EnSt_Update(EnSt* this, GlobalContext* globalCtx);
 void EnSt_Draw(EnSt* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_St_InitVars =
-{
+const ActorInit En_St_InitVars = {
     ACTOR_EN_ST,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -8,8 +8,7 @@ void EnSth_Destroy(EnSth* this, GlobalContext* globalCtx);
 void EnSth_Update(EnSth* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Sth_InitVars =
-{
+const ActorInit En_Sth_InitVars = {
     ACTOR_EN_STH,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Stream/z_en_stream.c
+++ b/src/overlays/actors/ovl_En_Stream/z_en_stream.c
@@ -9,8 +9,7 @@ void EnStream_Update(EnStream* this, GlobalContext* globalCtx);
 void EnStream_Draw(EnStream* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Stream_InitVars =
-{
+const ActorInit En_Stream_InitVars = {
     ACTOR_EN_STREAM,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -9,8 +9,7 @@ void EnSw_Update(EnSw* this, GlobalContext* globalCtx);
 void EnSw_Draw(EnSw* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Sw_InitVars =
-{
+const ActorInit En_Sw_InitVars = {
     ACTOR_EN_SW,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
+++ b/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
@@ -8,8 +8,7 @@ void EnSyatekiItm_Destroy(EnSyatekiItm* this, GlobalContext* globalCtx);
 void EnSyatekiItm_Update(EnSyatekiItm* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Syateki_Itm_InitVars =
-{
+const ActorInit En_Syateki_Itm_InitVars = {
     ACTOR_EN_SYATEKI_ITM,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -9,8 +9,7 @@ void EnSyatekiMan_Update(EnSyatekiMan* this, GlobalContext* globalCtx);
 void EnSyatekiMan_Draw(EnSyatekiMan* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Syateki_Man_InitVars =
-{
+const ActorInit En_Syateki_Man_InitVars = {
     ACTOR_EN_SYATEKI_MAN,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
+++ b/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
@@ -9,8 +9,7 @@ void EnSyatekiNiw_Update(EnSyatekiNiw* this, GlobalContext* globalCtx);
 void EnSyatekiNiw_Draw(EnSyatekiNiw* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Syateki_Niw_InitVars =
-{
+const ActorInit En_Syateki_Niw_InitVars = {
     ACTOR_EN_SYATEKI_NIW,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -9,8 +9,7 @@ void EnTa_Update(EnTa* this, GlobalContext* globalCtx);
 void EnTa_Draw(EnTa* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Ta_InitVars =
-{
+const ActorInit En_Ta_InitVars = {
     ACTOR_EN_TA,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
+++ b/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
@@ -9,8 +9,7 @@ void EnTakaraMan_Update(EnTakaraMan* this, GlobalContext* globalCtx);
 void EnTakaraMan_Draw(EnTakaraMan* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Takara_Man_InitVars =
-{
+const ActorInit En_Takara_Man_InitVars = {
     ACTOR_EN_TAKARA_MAN,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Tana/z_en_tana.c
+++ b/src/overlays/actors/ovl_En_Tana/z_en_tana.c
@@ -8,8 +8,7 @@ void EnTana_Destroy(EnTana* this, GlobalContext* globalCtx);
 void EnTana_Update(EnTana* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Tana_InitVars =
-{
+const ActorInit En_Tana_InitVars = {
     ACTOR_EN_TANA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -9,8 +9,7 @@ void EnTest_Update(EnTest* this, GlobalContext* globalCtx);
 void EnTest_Draw(EnTest* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Test_InitVars =
-{
+const ActorInit En_Test_InitVars = {
     ACTOR_EN_TEST,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Tg/z_en_tg.c
+++ b/src/overlays/actors/ovl_En_Tg/z_en_tg.c
@@ -9,8 +9,7 @@ void EnTg_Update(EnTg* this, GlobalContext* globalCtx);
 void EnTg_Draw(EnTg* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Tg_InitVars =
-{
+const ActorInit En_Tg_InitVars = {
     ACTOR_EN_TG,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -9,8 +9,7 @@ void EnTite_Update(EnTite* this, GlobalContext* globalCtx);
 void EnTite_Draw(EnTite* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Tite_InitVars =
-{
+const ActorInit En_Tite_InitVars = {
     ACTOR_EN_TITE,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -9,8 +9,7 @@ void EnTorch2_Update(EnTorch2* this, GlobalContext* globalCtx);
 void EnTorch2_Draw(EnTorch2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Torch2_InitVars =
-{
+const ActorInit En_Torch2_InitVars = {
     ACTOR_EN_TORCH2,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -9,8 +9,7 @@ void EnToryo_Update(EnToryo* this, GlobalContext* globalCtx);
 void EnToryo_Draw(EnToryo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Toryo_InitVars =
-{
+const ActorInit En_Toryo_InitVars = {
     ACTOR_EN_TORYO,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Tp/z_en_tp.c
+++ b/src/overlays/actors/ovl_En_Tp/z_en_tp.c
@@ -9,8 +9,7 @@ void EnTp_Update(EnTp* this, GlobalContext* globalCtx);
 void EnTp_Draw(EnTp* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Tp_InitVars =
-{
+const ActorInit En_Tp_InitVars = {
     ACTOR_EN_TP,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Tr/z_en_tr.c
+++ b/src/overlays/actors/ovl_En_Tr/z_en_tr.c
@@ -9,8 +9,7 @@ void EnTr_Update(EnTr* this, GlobalContext* globalCtx);
 void EnTr_Draw(EnTr* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Tr_InitVars =
-{
+const ActorInit En_Tr_InitVars = {
     ACTOR_EN_TR,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Trap/z_en_trap.c
+++ b/src/overlays/actors/ovl_En_Trap/z_en_trap.c
@@ -9,8 +9,7 @@ void EnTrap_Update(EnTrap* this, GlobalContext* globalCtx);
 void EnTrap_Draw(EnTrap* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Trap_InitVars =
-{
+const ActorInit En_Trap_InitVars = {
     ACTOR_EN_TRAP,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
@@ -98,12 +98,13 @@ void EnTuboTrap_SpawnFragments(EnTuboTrap* this, GlobalContext* globalCtx) {
         spC8.z += actorPos->z;
 
         rand = Math_Rand_ZeroOne();
-        if (rand < 0.2f)
+        if (rand < 0.2f) {
             temp = 96;
-        else if (rand < 0.6f)
+        } else if (rand < 0.6f) {
             temp = 64;
-        else
+        } else {
             temp = 32;
+        }
 
         Effect_SpawnFragment(globalCtx, &spC8, &spBC, actorPos, -240, temp, 10, 10, 0,
                              (Math_Rand_ZeroOne() * 65.0f) + 15.0f, 0, 32, 60, -1, 3, addr);
@@ -153,10 +154,11 @@ void EnTuboTrap_SpawnWaterFragments(EnTuboTrap* this, GlobalContext* globalCtx) 
         spC8.z += actorPos->z;
 
         rand = Math_Rand_ZeroOne();
-        if (rand < 0.2f)
+        if (rand < 0.2f) {
             temp = 64;
-        else
+        } else {
             temp = 32;
+        }
 
         Effect_SpawnFragment(globalCtx, &spC8, &spBC, actorPos, -180, temp, 30, 30, 0,
                              (Math_Rand_ZeroOne() * 65.0f) + 15.0f, 0, 32, 70, -1, 3, addr);

--- a/src/overlays/actors/ovl_En_Vali/z_en_vali.c
+++ b/src/overlays/actors/ovl_En_Vali/z_en_vali.c
@@ -9,8 +9,7 @@ void EnVali_Update(EnVali* this, GlobalContext* globalCtx);
 void EnVali_Draw(EnVali* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Vali_InitVars =
-{
+const ActorInit En_Vali_InitVars = {
     ACTOR_EN_VALI,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.c
+++ b/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.c
@@ -9,8 +9,7 @@ void EnVbBall_Update(EnVbBall* this, GlobalContext* globalCtx);
 void EnVbBall_Draw(EnVbBall* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Vb_Ball_InitVars =
-{
+const ActorInit En_Vb_Ball_InitVars = {
     ACTOR_PLAYER,
     ACTORTYPE_BOSS,
     ROOM,

--- a/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
+++ b/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
@@ -9,8 +9,7 @@ void EnViewer_Update(EnViewer* this, GlobalContext* globalCtx);
 void EnViewer_Draw(EnViewer* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Viewer_InitVars =
-{
+const ActorInit En_Viewer_InitVars = {
     ACTOR_EN_VIEWER,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Vm/z_en_vm.c
+++ b/src/overlays/actors/ovl_En_Vm/z_en_vm.c
@@ -9,8 +9,7 @@ void EnVm_Update(EnVm* this, GlobalContext* globalCtx);
 void EnVm_Draw(EnVm* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Vm_InitVars =
-{
+const ActorInit En_Vm_InitVars = {
     ACTOR_EN_VM,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
+++ b/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
@@ -8,8 +8,7 @@ void EnWallTubo_Destroy(EnWallTubo* this, GlobalContext* globalCtx);
 void EnWallTubo_Update(EnWallTubo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Wall_Tubo_InitVars =
-{
+const ActorInit En_Wall_Tubo_InitVars = {
     ACTOR_EN_WALL_TUBO,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -8,8 +8,7 @@ void EnWeatherTag_Destroy(EnWeatherTag* this, GlobalContext* globalCtx);
 void EnWeatherTag_Update(EnWeatherTag* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Weather_Tag_InitVars =
-{
+const ActorInit En_Weather_Tag_InitVars = {
     ACTOR_EN_WEATHER_TAG,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
+++ b/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
@@ -9,8 +9,7 @@ void EnWeiyer_Update(EnWeiyer* this, GlobalContext* globalCtx);
 void EnWeiyer_Draw(EnWeiyer* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Weiyer_InitVars =
-{
+const ActorInit En_Weiyer_InitVars = {
     ACTOR_EN_WEIYER,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -9,8 +9,7 @@ void EnWf_Update(EnWf* this, GlobalContext* globalCtx);
 void EnWf_Draw(EnWf* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Wf_InitVars =
-{
+const ActorInit En_Wf_InitVars = {
     ACTOR_EN_WF,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
@@ -8,8 +8,7 @@ void EnWonderItem_Destroy(EnWonderItem* this, GlobalContext* globalCtx);
 void EnWonderItem_Update(EnWonderItem* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Wonder_Item_InitVars =
-{
+const ActorInit En_Wonder_Item_InitVars = {
     ACTOR_EN_WONDER_ITEM,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.c
+++ b/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.c
@@ -8,8 +8,7 @@ void EnWonderTalk_Destroy(EnWonderTalk* this, GlobalContext* globalCtx);
 void EnWonderTalk_Update(EnWonderTalk* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Wonder_Talk_InitVars =
-{
+const ActorInit En_Wonder_Talk_InitVars = {
     ACTOR_EN_WONDER_TALK,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
+++ b/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
@@ -8,8 +8,7 @@ void EnWonderTalk2_Destroy(EnWonderTalk2* this, GlobalContext* globalCtx);
 void EnWonderTalk2_Update(EnWonderTalk2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Wonder_Talk2_InitVars =
-{
+const ActorInit En_Wonder_Talk2_InitVars = {
     ACTOR_EN_WONDER_TALK2,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -9,8 +9,7 @@ void EnWood02_Update(EnWood02* this, GlobalContext* globalCtx);
 void EnWood02_Draw(EnWood02* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Wood02_InitVars =
-{
+const ActorInit En_Wood02_InitVars = {
     ACTOR_EN_WOOD02,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -9,8 +9,7 @@ void EnXc_Update(EnXc* this, GlobalContext* globalCtx);
 void EnXc_Draw(EnXc* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Xc_InitVars =
-{
+const ActorInit En_Xc_InitVars = {
     ACTOR_EN_XC,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
+++ b/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
@@ -8,8 +8,7 @@ void EnYabusameMark_Destroy(EnYabusameMark* this, GlobalContext* globalCtx);
 void EnYabusameMark_Update(EnYabusameMark* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Yabusame_Mark_InitVars =
-{
+const ActorInit En_Yabusame_Mark_InitVars = {
     ACTOR_EN_YABUSAME_MARK,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.c
+++ b/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.c
@@ -9,8 +9,7 @@ void EnYukabyun_Update(EnYukabyun* this, GlobalContext* globalCtx);
 void EnYukabyun_Draw(EnYukabyun* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Yukabyun_InitVars =
-{
+const ActorInit En_Yukabyun_InitVars = {
     ACTOR_EN_YUKABYUN,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Zf/z_en_zf.c
+++ b/src/overlays/actors/ovl_En_Zf/z_en_zf.c
@@ -9,8 +9,7 @@ void EnZf_Update(EnZf* this, GlobalContext* globalCtx);
 void EnZf_Draw(EnZf* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Zf_InitVars =
-{
+const ActorInit En_Zf_InitVars = {
     ACTOR_EN_ZF,
     ACTORTYPE_ENEMY,
     ROOM,

--- a/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
+++ b/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
@@ -9,8 +9,7 @@ void EnZl1_Update(EnZl1* this, GlobalContext* globalCtx);
 void EnZl1_Draw(EnZl1* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Zl1_InitVars =
-{
+const ActorInit En_Zl1_InitVars = {
     ACTOR_EN_ZL1,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Zl2/z_en_zl2.c
+++ b/src/overlays/actors/ovl_En_Zl2/z_en_zl2.c
@@ -9,8 +9,7 @@ void EnZl2_Update(EnZl2* this, GlobalContext* globalCtx);
 void EnZl2_Draw(EnZl2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Zl2_InitVars =
-{
+const ActorInit En_Zl2_InitVars = {
     ACTOR_EN_ZL2,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Zl3/z_en_zl3.c
+++ b/src/overlays/actors/ovl_En_Zl3/z_en_zl3.c
@@ -9,8 +9,7 @@ void EnZl3_Update(EnZl3* this, GlobalContext* globalCtx);
 void EnZl3_Draw(EnZl3* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Zl3_InitVars =
-{
+const ActorInit En_Zl3_InitVars = {
     ACTOR_EN_ZL3,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -9,8 +9,7 @@ void EnZl4_Update(EnZl4* this, GlobalContext* globalCtx);
 void EnZl4_Draw(EnZl4* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Zl4_InitVars =
-{
+const ActorInit En_Zl4_InitVars = {
     ACTOR_EN_ZL4,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -9,8 +9,7 @@ void EnZo_Update(EnZo* this, GlobalContext* globalCtx);
 void EnZo_Draw(EnZo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_Zo_InitVars =
-{
+const ActorInit En_Zo_InitVars = {
     ACTOR_EN_ZO,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
+++ b/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
@@ -9,8 +9,7 @@ void EnfHG_Update(EnfHG* this, GlobalContext* globalCtx);
 void EnfHG_Draw(EnfHG* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit En_fHG_InitVars =
-{
+const ActorInit En_fHG_InitVars = {
     ACTOR_EN_FHG,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_End_Title/z_end_title.c
+++ b/src/overlays/actors/ovl_End_Title/z_end_title.c
@@ -9,8 +9,7 @@ void EndTitle_Update(EndTitle* this, GlobalContext* globalCtx);
 void EndTitle_Draw(EndTitle* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit End_Title_InitVars =
-{
+const ActorInit End_Title_InitVars = {
     ACTOR_END_TITLE,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -9,8 +9,7 @@ void Fishing_Update(Fishing* this, GlobalContext* globalCtx);
 void Fishing_Draw(Fishing* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Fishing_InitVars =
-{
+const ActorInit Fishing_InitVars = {
     ACTOR_FISHING,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.c
+++ b/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.c
@@ -9,8 +9,7 @@ void ItemBHeart_Update(ItemBHeart* this, GlobalContext* globalCtx);
 void ItemBHeart_Draw(ItemBHeart* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Item_B_Heart_InitVars =
-{
+const ActorInit Item_B_Heart_InitVars = {
     ACTOR_ITEM_B_HEART,
     ACTORTYPE_MISC,
     ROOM,

--- a/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
+++ b/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
@@ -8,8 +8,7 @@ void ItemEtcetera_Destroy(ItemEtcetera* this, GlobalContext* globalCtx);
 void ItemEtcetera_Update(ItemEtcetera* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Item_Etcetera_InitVars =
-{
+const ActorInit Item_Etcetera_InitVars = {
     ACTOR_ITEM_ETCETERA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
+++ b/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
@@ -9,8 +9,7 @@ void ItemOcarina_Update(ItemOcarina* this, GlobalContext* globalCtx);
 void ItemOcarina_Draw(ItemOcarina* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Item_Ocarina_InitVars =
-{
+const ActorInit Item_Ocarina_InitVars = {
     ACTOR_ITEM_OCARINA,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Item_Shield/z_item_shield.c
+++ b/src/overlays/actors/ovl_Item_Shield/z_item_shield.c
@@ -9,8 +9,7 @@ void ItemShield_Update(ItemShield* this, GlobalContext* globalCtx);
 void ItemShield_Draw(ItemShield* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Item_Shield_InitVars =
-{
+const ActorInit Item_Shield_InitVars = {
     ACTOR_ITEM_SHIELD,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
+++ b/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
@@ -9,8 +9,7 @@ void MagicDark_Update(MagicDark* this, GlobalContext* globalCtx);
 void MagicDark_Draw(MagicDark* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Magic_Dark_InitVars =
-{
+const ActorInit Magic_Dark_InitVars = {
     ACTOR_MAGIC_DARK,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.c
+++ b/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.c
@@ -9,8 +9,7 @@ void MagicFire_Update(MagicFire* this, GlobalContext* globalCtx);
 void MagicFire_Draw(MagicFire* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Magic_Fire_InitVars =
-{
+const ActorInit Magic_Fire_InitVars = {
     ACTOR_MAGIC_FIRE,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.c
+++ b/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.c
@@ -9,8 +9,7 @@ void MagicWind_Update(MagicWind* this, GlobalContext* globalCtx);
 void MagicWind_Draw(MagicWind* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Magic_Wind_InitVars =
-{
+const ActorInit Magic_Wind_InitVars = {
     ACTOR_MAGIC_WIND,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
@@ -9,8 +9,7 @@ void MirRay_Update(MirRay* this, GlobalContext* globalCtx);
 void MirRay_Draw(MirRay* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Mir_Ray_InitVars =
-{
+const ActorInit Mir_Ray_InitVars = {
     ACTOR_MIR_RAY,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -9,8 +9,7 @@ void ObjBean_Update(ObjBean* this, GlobalContext* globalCtx);
 void ObjBean_Draw(ObjBean* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Bean_InitVars =
-{
+const ActorInit Obj_Bean_InitVars = {
     ACTOR_OBJ_BEAN,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
@@ -9,8 +9,7 @@ void ObjComb_Update(ObjComb* this, GlobalContext* globalCtx);
 void ObjComb_Draw(ObjComb* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Comb_InitVars =
-{
+const ActorInit Obj_Comb_InitVars = {
     ACTOR_OBJ_COMB,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
+++ b/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
@@ -9,8 +9,7 @@ void ObjDekujr_Update(ObjDekujr* this, GlobalContext* globalCtx);
 void ObjDekujr_Draw(ObjDekujr* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Dekujr_InitVars =
-{
+const ActorInit Obj_Dekujr_InitVars = {
     ACTOR_OBJ_DEKUJR,
     ACTORTYPE_NPC,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
+++ b/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
@@ -9,8 +9,7 @@ void ObjHamishi_Update(ObjHamishi* this, GlobalContext* globalCtx);
 void ObjHamishi_Draw(ObjHamishi* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Hamishi_InitVars =
-{
+const ActorInit Obj_Hamishi_InitVars = {
     ACTOR_OBJ_HAMISHI,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Hana/z_obj_hana.c
+++ b/src/overlays/actors/ovl_Obj_Hana/z_obj_hana.c
@@ -9,8 +9,7 @@ void ObjHana_Update(ObjHana* this, GlobalContext* globalCtx);
 void ObjHana_Draw(ObjHana* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Hana_InitVars =
-{
+const ActorInit Obj_Hana_InitVars = {
     ACTOR_OBJ_HANA,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.c
+++ b/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.c
@@ -9,8 +9,7 @@ void ObjHsblock_Update(ObjHsblock* this, GlobalContext* globalCtx);
 void ObjHsblock_Draw(ObjHsblock* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Hsblock_InitVars =
-{
+const ActorInit Obj_Hsblock_InitVars = {
     ACTOR_OBJ_HSBLOCK,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
@@ -9,8 +9,7 @@ void ObjIcePoly_Update(ObjIcePoly* this, GlobalContext* globalCtx);
 void ObjIcePoly_Draw(ObjIcePoly* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Ice_Poly_InitVars =
-{
+const ActorInit Obj_Ice_Poly_InitVars = {
     ACTOR_OBJ_ICE_POLY,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
+++ b/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
@@ -9,8 +9,7 @@ void ObjKibako_Update(ObjKibako* this, GlobalContext* globalCtx);
 void ObjKibako_Draw(ObjKibako* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Kibako_InitVars =
-{
+const ActorInit Obj_Kibako_InitVars = {
     ACTOR_OBJ_KIBAKO,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.c
+++ b/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.c
@@ -9,8 +9,7 @@ void ObjKibako2_Update(ObjKibako2* this, GlobalContext* globalCtx);
 void ObjKibako2_Draw(ObjKibako2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Kibako2_InitVars =
-{
+const ActorInit Obj_Kibako2_InitVars = {
     ACTOR_OBJ_KIBAKO2,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.c
+++ b/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.c
@@ -9,8 +9,7 @@ void ObjLift_Update(ObjLift* this, GlobalContext* globalCtx);
 void ObjLift_Draw(ObjLift* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Lift_InitVars =
-{
+const ActorInit Obj_Lift_InitVars = {
     ACTOR_OBJ_LIFT,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
+++ b/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
@@ -9,8 +9,7 @@ void ObjLightswitch_Update(ObjLightswitch* this, GlobalContext* globalCtx);
 void ObjLightswitch_Draw(ObjLightswitch* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Lightswitch_InitVars =
-{
+const ActorInit Obj_Lightswitch_InitVars = {
     ACTOR_OBJ_LIGHTSWITCH,
     ACTORTYPE_SWITCH,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Makeoshihiki/z_obj_makeoshihiki.c
+++ b/src/overlays/actors/ovl_Obj_Makeoshihiki/z_obj_makeoshihiki.c
@@ -7,8 +7,7 @@ void ObjMakeoshihiki_Init(ObjMakeoshihiki* this, GlobalContext* globalCtx);
 void ObjMakeoshihiki_Draw(ObjMakeoshihiki* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Makeoshihiki_InitVars =
-{
+const ActorInit Obj_Makeoshihiki_InitVars = {
     ACTOR_OBJ_MAKEOSHIHIKI,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -8,8 +8,7 @@ void ObjMure_Destroy(ObjMure* this, GlobalContext* globalCtx);
 void ObjMure_Update(ObjMure* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Mure_InitVars =
-{
+const ActorInit Obj_Mure_InitVars = {
     ACTOR_OBJ_MURE,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
+++ b/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
@@ -7,8 +7,7 @@ void ObjMure2_Init(ObjMure2* this, GlobalContext* globalCtx);
 void ObjMure2_Update(ObjMure2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Mure2_InitVars =
-{
+const ActorInit Obj_Mure2_InitVars = {
     ACTOR_OBJ_MURE2,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.c
+++ b/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.c
@@ -8,8 +8,7 @@ void ObjMure3_Destroy(ObjMure3* this, GlobalContext* globalCtx);
 void ObjMure3_Update(ObjMure3* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Mure3_InitVars =
-{
+const ActorInit Obj_Mure3_InitVars = {
     ACTOR_OBJ_MURE3,
     ACTORTYPE_BG,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
+++ b/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
@@ -9,8 +9,7 @@ void ObjOshihiki_Update(ObjOshihiki* this, GlobalContext* globalCtx);
 void ObjOshihiki_Draw(ObjOshihiki* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Oshihiki_InitVars =
-{
+const ActorInit Obj_Oshihiki_InitVars = {
     ACTOR_OBJ_OSHIHIKI,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -9,8 +9,7 @@ void ObjSwitch_Update(ObjSwitch* this, GlobalContext* globalCtx);
 void ObjSwitch_Draw(ObjSwitch* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Switch_InitVars =
-{
+const ActorInit Obj_Switch_InitVars = {
     ACTOR_OBJ_SWITCH,
     ACTORTYPE_SWITCH,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
+++ b/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
@@ -9,8 +9,7 @@ void ObjSyokudai_Update(ObjSyokudai* this, GlobalContext* globalCtx);
 void ObjSyokudai_Draw(ObjSyokudai* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Syokudai_InitVars =
-{
+const ActorInit Obj_Syokudai_InitVars = {
     ACTOR_OBJ_SYOKUDAI,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.c
+++ b/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.c
@@ -9,8 +9,7 @@ void ObjTimeblock_Update(ObjTimeblock* this, GlobalContext* globalCtx);
 void ObjTimeblock_Draw(ObjTimeblock* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Timeblock_InitVars =
-{
+const ActorInit Obj_Timeblock_InitVars = {
     ACTOR_OBJ_TIMEBLOCK,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
@@ -8,8 +8,7 @@ void ObjTsubo_Destroy(ObjTsubo* this, GlobalContext* globalCtx);
 void ObjTsubo_Update(ObjTsubo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Tsubo_InitVars =
-{
+const ActorInit Obj_Tsubo_InitVars = {
     ACTOR_OBJ_TSUBO,
     ACTORTYPE_PROP,
     ROOM,

--- a/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.c
+++ b/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.c
@@ -9,8 +9,7 @@ void ObjWarp2block_Update(ObjWarp2block* this, GlobalContext* globalCtx);
 void ObjWarp2block_Draw(ObjWarp2block* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Obj_Warp2block_InitVars =
-{
+const ActorInit Obj_Warp2block_InitVars = {
     ACTOR_OBJ_WARP2BLOCK,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -9,8 +9,7 @@ void ObjectKankyo_Update(ObjectKankyo* this, GlobalContext* globalCtx);
 void ObjectKankyo_Draw(ObjectKankyo* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Object_Kankyo_InitVars =
-{
+const ActorInit Object_Kankyo_InitVars = {
     ACTOR_OBJECT_KANKYO,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.c
+++ b/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.c
@@ -9,8 +9,7 @@ void OceffSpot_Update(OceffSpot* this, GlobalContext* globalCtx);
 void OceffSpot_Draw(OceffSpot* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Oceff_Spot_InitVars =
-{
+const ActorInit Oceff_Spot_InitVars = {
     ACTOR_OCEFF_SPOT,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
+++ b/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
@@ -9,8 +9,7 @@ void OceffStorm_Update(OceffStorm* this, GlobalContext* globalCtx);
 void OceffStorm_Draw(OceffStorm* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Oceff_Storm_InitVars =
-{
+const ActorInit Oceff_Storm_InitVars = {
     ACTOR_OCEFF_STORM,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
@@ -9,8 +9,7 @@ void OceffWipe_Update(OceffWipe* this, GlobalContext* globalCtx);
 void OceffWipe_Draw(OceffWipe* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Oceff_Wipe_InitVars =
-{
+const ActorInit Oceff_Wipe_InitVars = {
     ACTOR_OCEFF_WIPE,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
@@ -9,8 +9,7 @@ void OceffWipe2_Update(OceffWipe2* this, GlobalContext* globalCtx);
 void OceffWipe2_Draw(OceffWipe2* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Oceff_Wipe2_InitVars =
-{
+const ActorInit Oceff_Wipe2_InitVars = {
     ACTOR_OCEFF_WIPE2,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
@@ -9,8 +9,7 @@ void OceffWipe3_Update(OceffWipe3* this, GlobalContext* globalCtx);
 void OceffWipe3_Draw(OceffWipe3* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Oceff_Wipe3_InitVars =
-{
+const ActorInit Oceff_Wipe3_InitVars = {
     ACTOR_OCEFF_WIPE3,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
@@ -9,8 +9,7 @@ void OceffWipe4_Update(OceffWipe4* this, GlobalContext* globalCtx);
 void OceffWipe4_Draw(OceffWipe4* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Oceff_Wipe4_InitVars =
-{
+const ActorInit Oceff_Wipe4_InitVars = {
     ACTOR_OCEFF_WIPE4,
     ACTORTYPE_ITEMACTION,
     ROOM,

--- a/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
+++ b/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
@@ -8,8 +8,7 @@ void ShotSun_Destroy(ShotSun* this, GlobalContext* globalCtx);
 void ShotSun_Update(ShotSun* this, GlobalContext* globalCtx);
 
 /*
-const ActorInit Shot_Sun_InitVars =
-{
+const ActorInit Shot_Sun_InitVars = {
     ACTOR_SHOT_SUN,
     ACTORTYPE_PROP,
     ROOM,


### PR DESCRIPTION
clang-tidy should now properly fix braces under NON_MATCHING blocks, and I fixed the brace style for all init vars that are still under comments since clang-format doesn't seem to format anything commented out.