### PR TITLE
Added 'setup' target to makefile, details in description.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ baserom/
 *.elf
 *.sra
 *.z64
+*.n64
+*.v64
 *.map
 *.dump
 out.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,13 +5,11 @@ pipeline {
         stage('Setup') {
             steps {
                 echo 'Setting up...'
-                sh 'cp /usr/local/etc/roms/baserom_oot.z64 baserom.z64'
+                sh 'cp /usr/local/etc/roms/baserom_oot.z64 baserom_original.z64'
                 sh 'git submodule update --init --recursive'
-                sh 'make -C tools'
                 sh 'cp -r /usr/local/etc/ido/ido7.1_compiler tools/ido7.1_compiler'
                 sh 'chmod +x -R tools/ido*'
-                sh 'python3 extract_baserom.py'
-                sh 'python3 extract_assets.py'
+                sh 'make setup'
             }
         }
         stage('Build') {

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ This repo does not include all assets necessary for compiling the ROM. A prior c
 This is a disassembly and decompilation of Legend of Zelda: Ocarina of Time Master Quest (debug)
 
 It builds the following ROM:
-* zelda_ocarina_mq_dbg.z64 `md5: 717179476af84133b14ff73af87db57a`
+* zelda_ocarina_mq_dbg.z64 `md5: f0b7f35375f9cc8ca1b2d59d78e35405`
 
 Please refer to the Getting Started guide in the Wiki for setup instructions.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,3 @@ It builds the following ROM:
 * zelda_ocarina_mq_dbg.z64 `md5: 717179476af84133b14ff73af87db57a`
 
 Please refer to the Getting Started guide in the Wiki for setup instructions.
-
-Thanks to z64me and CrookedPoe for their actor documentation. https://github.com/CrookedPoe/z64-rw

--- a/THANKS.md
+++ b/THANKS.md
@@ -1,0 +1,1 @@
+Thanks to z64me and CrookedPoe for their actor documentation. https://github.com/CrookedPoe/z64-rw

--- a/checksum.md5
+++ b/checksum.md5
@@ -1,1 +1,1 @@
-717179476af84133b14ff73af87db57a  zelda_ocarina_mq_dbg.z64
+f0b7f35375f9cc8ca1b2d59d78e35405  zelda_ocarina_mq_dbg.z64

--- a/checksum_old.md5
+++ b/checksum_old.md5
@@ -1,0 +1,1 @@
+717179476af84133b14ff73af87db57a  zelda_ocarina_mq_dbg.z64

--- a/checksum_old.md5
+++ b/checksum_old.md5
@@ -1,1 +1,0 @@
-717179476af84133b14ff73af87db57a  zelda_ocarina_mq_dbg.z64

--- a/fixbaserom.py
+++ b/fixbaserom.py
@@ -4,10 +4,18 @@ import sys
 import struct
 import hashlib
 
-# Read in the original ROM
+
+# Determine if we have a ROM file
+romFileName = ""
 if (path.exists("baserom_original.z64")):
-    print("File 'baserom_original.z64' found.")
-    with open("baserom_original.z64", mode='rb') as file:
+    romFileName = "baserom_original.z64"
+elif (path.exists("baserom_original.n64")):
+    romFileName = "baserom_original.n64"
+
+# Read in the original ROM
+if (romFileName != ""):
+    print("File '" + romFileName + "' found.")
+    with open(romFileName, mode='rb') as file:
         fileContent = bytearray(file.read())
 
         # Check if ROM needs to be byte swapped
@@ -28,9 +36,9 @@ if (path.exists("baserom_original.z64")):
         
             print("Byte swapping done.")
 else:
-    print("Error: Could not find baserom_original.z64.")
+    print("Error: Could not find baserom_original.z64/baserom_original.n64.")
     sys.exit(1)
-
+    
 # Strip the overdump
 print("Stripping overdump...")
 strippedContent = list(fileContent[0:0x3600000])

--- a/fixbaserom.py
+++ b/fixbaserom.py
@@ -2,34 +2,33 @@ import os.path
 from os import path
 import sys
 import struct
+import hashlib
 
 # Read in the original ROM
 if (path.exists("baserom_original.z64")):
     print("File 'baserom_original.z64' found.")
     with open("baserom_original.z64", mode='rb') as file:
-        fileContent = file.read()
-elif (path.exists("baserom_original.n64")):
-    print("File 'baserom_original.n64' found.")
-    print("Byte swapping...")
-    with open("baserom_original.n64", mode='rb') as file:
         fileContent = bytearray(file.read())
-        
-        # Byte Swap ROM
-        # TODO: This is pretty slow at the moment. Look into optimizing it later...
-        i = 0
-        while (i < len(fileContent)):
-            tmp = struct.unpack_from("BBBB", fileContent, i)
-            struct.pack_into("BBBB", fileContent, i + 0, tmp[3], tmp[2], tmp[1], tmp[0])
-            i += 4
 
-            perc = float(i) / float(len(fileContent))
+        # Check if ROM needs to be byte swapped
+        if (fileContent[0] == 0x40):
+             # Byte Swap ROM
+            # TODO: This is pretty slow at the moment. Look into optimizing it later...
+            print("ROM needs to be byte swapped...")
+            i = 0
+            while (i < len(fileContent)):
+                tmp = struct.unpack_from("BBBB", fileContent, i)
+                struct.pack_into("BBBB", fileContent, i + 0, tmp[3], tmp[2], tmp[1], tmp[0])
+                i += 4
 
-            if (i % (1024 * 1024 * 4) == 0):
-                print(str(perc * 100) + "%")
+                perc = float(i) / float(len(fileContent))
+
+                if (i % (1024 * 1024 * 4) == 0):
+                    print(str(perc * 100) + "%")
         
-    print("Byte swapping done.")
+            print("Byte swapping done.")
 else:
-    print("Error: Could not find a baserom_original.z64 or baserom_original.n64.")
+    print("Error: Could not find baserom_original.z64.")
     sys.exit(1)
 
 # Strip the overdump
@@ -40,6 +39,12 @@ strippedContent = list(fileContent[0:0x3600000])
 print("Patching header...")
 strippedContent[0x3E] = 0x50
 
+# Check to see if the ROM is a "vanilla" Debug ROM
+md5Hash = hashlib.md5(bytearray(strippedContent)).hexdigest()
+
+if (str(md5Hash) != "f0b7f35375f9cc8ca1b2d59d78e35405"):
+    print("Error: Expected a hash of f0b7f35375f9cc8ca1b2d59d78e35405 but got " + str(md5Hash) + ". The baserom is probably not \"vanilla\"")
+    sys.exit(1)
 
 # Write out our new ROM
 print("Writing new ROM 'baserom.z64'.")

--- a/fixbaserom.py
+++ b/fixbaserom.py
@@ -1,0 +1,50 @@
+import os.path
+from os import path
+import sys
+import struct
+
+# Read in the original ROM
+if (path.exists("baserom_original.z64")):
+    print("File 'baserom_original.z64' found.")
+    with open("baserom_original.z64", mode='rb') as file:
+        fileContent = file.read()
+elif (path.exists("baserom_original.n64")):
+    print("File 'baserom_original.n64' found.")
+    print("Byte swapping...")
+    with open("baserom_original.n64", mode='rb') as file:
+        fileContent = bytearray(file.read())
+        
+        # Byte Swap ROM
+        # TODO: This is pretty slow at the moment. Look into optimizing it later...
+        i = 0
+        while (i < len(fileContent)):
+            tmp = struct.unpack_from("BBBB", fileContent, i)
+            struct.pack_into("BBBB", fileContent, i + 0, tmp[3], tmp[2], tmp[1], tmp[0])
+            i += 4
+
+            perc = float(i) / float(len(fileContent))
+
+            if (i % (1024 * 1024 * 4) == 0):
+                print(str(perc * 100) + "%")
+        
+    print("Byte swapping done.")
+else:
+    print("Error: Could not find a baserom_original.z64 or baserom_original.n64.")
+    sys.exit(1)
+
+# Strip the overdump
+print("Stripping overdump...")
+strippedContent = list(fileContent[0:0x3600000])
+
+# Patch the header
+print("Patching header...")
+strippedContent[0x3E] = 0x50
+
+
+# Write out our new ROM
+print("Writing new ROM 'baserom.z64'.")
+with open("baserom.z64", mode="wb") as file:
+    file.write(bytes(strippedContent))
+
+print("Done!")
+

--- a/makefile
+++ b/makefile
@@ -129,6 +129,11 @@ build/undefined_syms.txt: undefined_syms.txt
 clean:
 	$(RM) $(ROM) $(ELF) -r build
 
+extract:
+	make -C tools
+	python3 fixbaserom.py
+	python3 extract_baserom.py
+	python3 extract_assets.py
 
 #### Various Recipes ####
 

--- a/makefile
+++ b/makefile
@@ -129,7 +129,7 @@ build/undefined_syms.txt: undefined_syms.txt
 clean:
 	$(RM) $(ROM) $(ELF) -r build
 
-extract:
+setup:
 	make -C tools
 	python3 fixbaserom.py
 	python3 extract_baserom.py


### PR DESCRIPTION
- Created a THANKS.md file for credits.
- Updated checksum.md5 for a "vanilla" debug ROM
- Added fixbaserom.py which automatically removes the overdump, byte swaps, and patches the ROM header. Users drop in their ROM as 'baserom_original.z64', then run 'make extract'. A 'baserom.z64' file is generated, with the assets extracted and decompiled.