### PR TITLE
Disassemble the rom header and entrypoint function

### DIFF
--- a/asm/entry.s
+++ b/asm/entry.s
@@ -1,0 +1,35 @@
+.include "macro.inc"
+
+# assembler directives
+.set noat      # allow manual use of $at
+.set noreorder # don't insert nops after branches
+.set gp=64     # allow use of 64-bit general purposee registers
+
+.section .text
+
+glabel entrypoint # 0x80000400
+    lui   $t0, %hi(_bootSegmentBssStart) # $t0, 0x8001
+    addiu $t0, %lo(_bootSegmentBssStart) # addiu $t0, $t0, 0x2370
+    li    $t1, %lo(_bootSegmentBssSize) # li $t1, 0x4A30
+.L8000040C:
+    addi  $t1, $t1, -8
+    sw    $zero, ($t0)
+    sw    $zero, 4($t0)
+    bnez  $t1, .L8000040C
+     addi  $t0, $t0, 8
+    lui   $t2, %hi(bootproc) # $t2, 0x8000
+    lui   $sp, %hi(gMainThread) # $sp, 0x8001
+    addiu $t2, %lo(bootproc) # addiu $t2, $t2, 0x0498
+    jr    $t2
+     addiu $sp, %lo(gMainThread) # addiu $sp, $sp, 0x2D60
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop

--- a/asm/ipl3.s
+++ b/asm/ipl3.s
@@ -1,0 +1,10 @@
+.include "macro.inc"
+
+# assembler directives
+.set noat      # allow manual use of $at
+.set noreorder # don't insert nops after branches
+.set gp=64     # allow use of 64-bit general purposee registers
+
+.section .text
+
+.incbin "baserom.z64", 0x40, 0xFC0

--- a/asm/rom_header.s
+++ b/asm/rom_header.s
@@ -1,0 +1,18 @@
+/*
+ * The Legend of Zelda: Ocarina of Time ROM header
+ */
+
+.byte  0x80, 0x37, 0x12, 0x40   /* PI BSD Domain 1 register */
+.word  0x0000000F               /* Clockrate setting */
+.word  0x80000400               /* Entrypoint function (`entrypoint`) */
+.word  0x0000144C               /* Revision */
+.word  0x917D18F6               /* Checksum 1 */
+.word  0x69BC5453               /* Checksum 2 */
+.word  0x00000000               /* Unknown */
+.word  0x00000000               /* Unknown */
+.ascii "THE LEGEND OF ZELDA "   /* Internal ROM name */
+.word  0x00000000               /* Unknown */
+.word  0x0000004E               /* Cartridge */
+.ascii "ZL"                     /* Cartridge ID */
+.ascii "P"                      /* Region */
+.byte  0x0F                     /* Version */

--- a/include/segment_symbols.h
+++ b/include/segment_symbols.h
@@ -40,6 +40,7 @@ DECLARE_ROM_SEGMENT(ger_message_data_static)
 DECLARE_ROM_SEGMENT(fra_message_data_static)
 DECLARE_ROM_SEGMENT(map_grand_static)
 
+DECLARE_SEGMENT(code)
 DECLARE_ROM_SEGMENT(code)
 DECLARE_BSS_SEGMENT(code)
 

--- a/spec
+++ b/spec
@@ -4,12 +4,14 @@
 
 beginseg
     name "makerom"
-    include "build/baserom/makerom.o"
-    address 0x80000000
+    include "build/asm/rom_header.o"
+    include "build/asm/ipl3.o"
+    include "build/asm/entry.o"
 endseg
 
 beginseg
     name "boot"
+    address 0x80000460
     include "build/src/boot/boot_main.o"
     include "build/src/boot/idle.o"
     include "build/src/boot/viconfig.o"
@@ -107,13 +109,11 @@ beginseg
     include "build/src/libultra_boot_O1/__osGetHWIntrRoutine.o"
     include "build/asm/__osSetWatchLo.o"
     include "build/data/rsp_boot.text.o"
-    address 0x80000460
 endseg
 
 beginseg
     name "dmadata"
     include "build/asm/dmadata.o"
-    address 0x80016DA0
 endseg
 
 beginseg
@@ -269,6 +269,7 @@ endseg
 
 beginseg
     name "code"
+    address 0x8001CE60
     include "build/src/code/z_en_a_keep.o"
     include "build/data/z_en_a_keep.data.o"
     include "build/src/code/z_en_item00.o"
@@ -574,7 +575,6 @@ beginseg
     include "build/src/code/z_construct.o"
     include "build/data/rsp.text.o"
     include "build/data/rsp.rodata.o"
-    address 0x8001CE60
 endseg
 
 beginseg
@@ -586,9 +586,9 @@ endseg
 
 beginseg
     name "ovl_title"
+    address 0x80800000
     include "build/src/overlays/gamestates/ovl_title/z_title.o"
     include "build/src/overlays/gamestates/ovl_title/z_title_reloc.o"
-    address 0x80800000
 endseg
 
 beginseg

--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -2,7 +2,7 @@
 #include <global.h>
 #include <vt.h>
 
-OSThread sMainThread;
+OSThread gMainThread;
 u8 sMainStack[0x900];
 StackEntry sMainStackInfo;
 OSMesg sPiMgrCmdBuff[50];
@@ -24,7 +24,7 @@ void Main_ThreadEntry(void* arg0) {
     DmaMgr_Start();
     osSyncPrintf("codeセグメントロード中...");
     var1 = osGetTime();
-    DmaMgr_SendRequest1((u32)_dmadataSegmentEnd, (u32)_codeSegmentRomStart, _codeSegmentRomEnd - _codeSegmentRomStart,
+    DmaMgr_SendRequest1(_codeSegmentStart, (u32)_codeSegmentRomStart, _codeSegmentRomEnd - _codeSegmentRomStart,
                         "../idle.c", 238);
     var1 -= osGetTime();
     osSyncPrintf("\rcodeセグメントロード中...完了\n");
@@ -78,11 +78,11 @@ void Idle_ThreadEntry(void* a0) {
     osViSetMode(&gViConfigMode);
     ViConfig_UpdateVi(1);
     osViBlack(1);
-    osViSwapBuffer(0x803da80);
-    osCreatePiManager(0x96, &gPiMgrCmdQ, sPiMgrCmdBuff, 0x32);
+    osViSwapBuffer(0x803DA80); //! @bug Invalid vram address (probably intended to be 0x803DA800)
+    osCreatePiManager(150, &gPiMgrCmdQ, sPiMgrCmdBuff, 50);
     StackCheck_Init(&sMainStackInfo, sMainStack, sMainStack + sizeof(sMainStack), 0, 0x400, "main");
-    osCreateThread(&sMainThread, 3, Main_ThreadEntry, a0, sMainStack + sizeof(sMainStack), 10);
-    osStartThread(&sMainThread);
+    osCreateThread(&gMainThread, 3, Main_ThreadEntry, a0, sMainStack + sizeof(sMainStack), 10);
+    osStartThread(&gMainThread);
     osSetThreadPri(NULL, 0);
 
     while (1) {


### PR DESCRIPTION
The actual boot code (ipl3) is still only incbin'd. If someone else wants to disassemble it properly, go ahead. I might do it eventually, but for now it doesn't seem required for shiftability or anything interesting.