### PR TITLE
Fixed misspelling of circle in z_fbdemo_circle.c

### DIFF
--- a/src/code/z_fbdemo_circle.c
+++ b/src/code/z_fbdemo_circle.c
@@ -1,7 +1,7 @@
 #include <global.h>
 
 // unused
-Gfx sCirlceNullDList[] = {
+Gfx sCircleNullDList[] = {
     gsSPEndDisplayList(),
 };
 


### PR DESCRIPTION
I believe this is a misspelling.