### PR TITLE
More actor cleanup Part 1

### DIFF
--- a/asm/non_matchings/code/z_en_a_keep/EnAObj_Init.s
+++ b/asm/non_matchings/code/z_en_a_keep/EnAObj_Init.s
@@ -22,7 +22,7 @@ glabel jtbl_80134D88
     .word L8001D104
 
 .text
-glabel En_A_Obj_Init
+glabel EnAObj_Init
 /* A94008 8001CE68 27BDFFC8 */  addiu $sp, $sp, -0x38
 /* A9400C 8001CE6C 3C0140C0 */  li    $at, 0x40C00000 # 0.000000
 /* A94010 8001CE70 44812000 */  mtc1  $at, $f4

--- a/asm/non_matchings/code/z_en_item00/EnItem00_Init.s
+++ b/asm/non_matchings/code/z_en_item00/EnItem00_Init.s
@@ -116,7 +116,7 @@ glabel jtbl_80134F7C
     .word L8001DF3C
 
 .text
-glabel En_Item00_Init
+glabel EnItem00_Init
 /* A94AD8 8001D938 3C014475 */  li    $at, 0x44750000 # 0.000000
 /* A94ADC 8001D93C 44811000 */  mtc1  $at, $f2
 /* A94AE0 8001D940 27BDFFC0 */  addiu $sp, $sp, -0x40
@@ -420,7 +420,7 @@ glabel L8001DCFC
 /* A94F44 8001DDA4 44800000 */   mtc1  $zero, $f0
 /* A94F48 8001DDA8 3C058002 */  lui   $a1, %hi(func_8001DFC8)
 /* A94F4C 8001DDAC 24A5DFC8 */  addiu $a1, %lo(func_8001DFC8) # addiu $a1, $a1, -0x2038
-/* A94F50 8001DDB0 0C00764C */  jal   En_Item00_SetNewUpdate
+/* A94F50 8001DDB0 0C00764C */  jal   EnItem00_SetupAction
 /* A94F54 8001DDB4 02002025 */   move  $a0, $s0
 /* A94F58 8001DDB8 2409FFFF */  li    $t1, -1
 /* A94F5C 8001DDBC 10000073 */  b     .L8001DF8C
@@ -555,7 +555,7 @@ glabel L8001DF3C
 .L8001DF68:
 /* A95108 8001DF68 3C058002 */  lui   $a1, %hi(func_8001E5C8) # $a1, 0x8002
 /* A9510C 8001DF6C 24A5E5C8 */  addiu $a1, %lo(func_8001E5C8) # addiu $a1, $a1, -0x1a38
-/* A95110 8001DF70 0C00764C */  jal   En_Item00_SetNewUpdate
+/* A95110 8001DF70 0C00764C */  jal   EnItem00_SetupAction
 /* A95114 8001DF74 02002025 */   move  $a0, $s0
 /* A95118 8001DF78 8E19014C */  lw    $t9, 0x14c($s0)
 /* A9511C 8001DF7C 02002025 */  move  $a0, $s0

--- a/asm/non_matchings/code/z_en_item00/EnItem00_Update.s
+++ b/asm/non_matchings/code/z_en_item00/EnItem00_Update.s
@@ -55,7 +55,7 @@ glabel jtbl_80135064
     .word L8001EC60
 
 .text
-glabel En_Item00_Update
+glabel EnItem00_Update
 /* A958BC 8001E71C 27BDFFB8 */  addiu $sp, $sp, -0x48
 /* A958C0 8001E720 AFBF0024 */  sw    $ra, 0x24($sp)
 /* A958C4 8001E724 AFB10020 */  sw    $s1, 0x20($sp)
@@ -518,7 +518,7 @@ glabel L8001EC8C
 /* A95F14 8001ED74 3C058002 */  lui   $a1, %hi(func_8001E5C8) # $a1, 0x8002
 /* A95F18 8001ED78 A6000152 */  sh    $zero, 0x152($s0)
 /* A95F1C 8001ED7C 24A5E5C8 */  addiu $a1, %lo(func_8001E5C8) # addiu $a1, $a1, -0x1a38
-/* A95F20 8001ED80 0C00764C */  jal   En_Item00_SetNewUpdate
+/* A95F20 8001ED80 0C00764C */  jal   EnItem00_SetupAction
 /* A95F24 8001ED84 02002025 */   move  $a0, $s0
 .L8001ED88:
 /* A95F28 8001ED88 8FBF0024 */  lw    $ra, 0x24($sp)

--- a/data/z_en_a_keep.data.s
+++ b/data/z_en_a_keep.data.s
@@ -7,9 +7,6 @@
 
 .section .data
 
-glabel En_A_Obj_InitVars
-    .incbin "baserom.z64", 0xB8C5C0, 0x20
-
 glabel D_80115440
     .incbin "baserom.z64", 0xB8C5E0, 0x2C
 

--- a/data/z_en_item00.data.s
+++ b/data/z_en_item00.data.s
@@ -7,9 +7,6 @@
 
 .section .data
 
-glabel En_Item00_InitVars
-    .incbin "baserom.z64", 0xB8C660, 0x20
-
 glabel D_801154E0
     .incbin "baserom.z64", 0xB8C680, 0x2C
 

--- a/include/functions.h
+++ b/include/functions.h
@@ -168,12 +168,6 @@ void __osSetHWIntrRoutine(s32 idx, OSMesgQueue* queue, OSMesg msg);
 void __osGetHWIntrRoutine(s32 idx, OSMesgQueue** outQueue, OSMesg* outMsg);
 void __osSetWatchLo(u32);
 
-// ? func_80009320(?);
-// ? func_800093F0(?);
-// ? func_8001D234(?);
-// ? func_8001D310(?);
-// ? func_8001D480(?);
-// ? func_8001D5C8(?);
 Actor* Item_DropCollectible(GlobalContext* globalCtx, Vec3f* spawnPos, s16 params);
 Actor* Item_DropCollectible2(GlobalContext* globalCtx, Vec3f* spawnPos, s16 params);
 void Item_DropCollectibleRandom(GlobalContext* globalCtx, Actor* fromActor, Vec3f* spawnPos, s16 params);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2,6 +2,8 @@
 #include <global.h>
 #include <vt.h>
 
+#include "overlays/actors/ovl_En_Part/z_en_part.h"
+
 void ActorShape_Init(ActorShape* shape, f32 arg1, void* shadowDrawFunc, f32 arg3) {
     shape->unk_08 = arg1;
     shape->shadowDrawFunc = shadowDrawFunc;
@@ -3155,17 +3157,8 @@ void func_80032F54(struct_80032E24* arg0, s32 arg1, s32 arg2, s32 arg3, u32 arg4
     arg0->unk_14 = arg1;
 }
 
-typedef struct {
-    /* 0x000 */ Actor actor;
-    /* 0x14C */ u8 unk_14C;
-    /* 0x14E */ s16 unk_14E;
-    /* 0x150 */ s32 unk_150;
-    /* 0x154 */ f32 unk_154;
-    /* 0x158 */ f32 unk_158;
-} ActorEnPart;
-
 s32 func_8003305C(Actor* actor, struct_80032E24* arg1, GlobalContext* globalCtx, s16 params) {
-    ActorEnPart* spawnedEnPart;
+    EnPart* spawnedEnPart;
     MtxF* mtx;
     s16 objBankIndex;
 
@@ -3187,8 +3180,8 @@ s32 func_8003305C(Actor* actor, struct_80032E24* arg1, GlobalContext* globalCtx,
         }
 
         mtx = &arg1->unk_00[arg1->unk_08];
-        spawnedEnPart = (ActorEnPart*)Actor_SpawnAttached(&globalCtx->actorCtx, actor, globalCtx, ACTOR_EN_PART,
-                                                          mtx->wx, mtx->wy, mtx->wz, 0, 0, objBankIndex, params);
+        spawnedEnPart = (EnPart*)Actor_SpawnAttached(&globalCtx->actorCtx, actor, globalCtx, ACTOR_EN_PART, mtx->wx,
+                                                     mtx->wy, mtx->wz, 0, 0, objBankIndex, params);
         if (spawnedEnPart != NULL) {
             func_800D20CC(&arg1->unk_00[arg1->unk_08], &spawnedEnPart->actor.shape.rot, 0);
             spawnedEnPart->unk_150 = arg1->unk_0C[arg1->unk_08];
@@ -4158,13 +4151,13 @@ void func_80035844(Vec3f* arg0, Vec3f* arg1, s16* arg2, s32 arg3) {
 /**
  * Spawns En_Part (Dissipating Flames) actor attached to the given actor.
  */
-ActorEnPart* func_800358DC(Actor* actor, Vec3f* spawnPos, Vec3s* spawnRot, Vec3f* arg3, s32 arg4, s32 unused,
-                           GlobalContext* globalCtx, s16 params, s32 arg8) {
-    ActorEnPart* spawnedEnPart;
+EnPart* func_800358DC(Actor* actor, Vec3f* spawnPos, Vec3s* spawnRot, Vec3f* arg3, s32 arg4, s32 unused,
+                      GlobalContext* globalCtx, s16 params, s32 arg8) {
+    EnPart* spawnedEnPart;
 
-    spawnedEnPart = (ActorEnPart*)Actor_SpawnAttached(&globalCtx->actorCtx, actor, globalCtx, ACTOR_EN_PART,
-                                                      spawnPos->x, spawnPos->y, spawnPos->z, spawnRot->x, spawnRot->y,
-                                                      actor->objBankIndex, params);
+    spawnedEnPart =
+        (EnPart*)Actor_SpawnAttached(&globalCtx->actorCtx, actor, globalCtx, ACTOR_EN_PART, spawnPos->x, spawnPos->y,
+                                     spawnPos->z, spawnRot->x, spawnRot->y, actor->objBankIndex, params);
     if (spawnedEnPart != NULL) {
         spawnedEnPart->actor.scale = actor->scale;
         spawnedEnPart->actor.speedXZ = arg3->x;

--- a/src/code/z_en_a_keep.c
+++ b/src/code/z_en_a_keep.c
@@ -17,14 +17,8 @@ typedef enum {
 } AObjType;
 
 typedef struct {
-    /* 0x000 */ Actor actor;
-    /* 0x14C */ u32 dynaPolyId;
-    /* 0x150 */ f32 unk_150;
-    /* 0x154 */ f32 unk_154;
-    /* 0x158 */ s16 unk_158;
-    /* 0x15C */ u32 unk_15C;
-    /* 0x160 */ u8 unk_160;
-    /* 0x164 */ ActorFunc updateFunc;
+    /* 0x000 */ DynaPolyActor dyna;
+    /* 0x164 */ ActorFunc actionFunc;
     /* 0x168 */ s32 unk_168;
     /* 0x16C */ s16 textId;
     /* 0x16E */ s16 unk_16E;
@@ -32,19 +26,19 @@ typedef struct {
     /* 0x172 */ s16 unk_172;
     /* 0x174 */ s16 unk_174;
     /* 0x178 */ f32 unk_178;
-    /* 0x17C */ ColliderCylinder cylinderCollider;
-} ActorEnAObj; // size = 0x1C8
+    /* 0x17C */ ColliderCylinder collider;
+} EnAObj; // size = 0x1C8
 
-void func_8001D204(ActorEnAObj* this, GlobalContext* globalCtx);
-void func_8001D25C(ActorEnAObj* this, GlobalContext* globalCtx);
-void func_8001D360(ActorEnAObj* this, GlobalContext* globalCtx);
-void func_8001D4A8(ActorEnAObj* this, GlobalContext* globalCtx);
-void func_8001D608(ActorEnAObj* this, GlobalContext* globalCtx);
+void func_8001D204(EnAObj* this, GlobalContext* globalCtx);
+void func_8001D25C(EnAObj* this, GlobalContext* globalCtx);
+void func_8001D360(EnAObj* this, GlobalContext* globalCtx);
+void func_8001D4A8(EnAObj* this, GlobalContext* globalCtx);
+void func_8001D608(EnAObj* this, GlobalContext* globalCtx);
 
-void func_8001D234(ActorEnAObj* this, s16 params);
-void func_8001D310(ActorEnAObj* this, s16 params);
-void func_8001D480(ActorEnAObj* this, s16 params);
-void func_8001D5C8(ActorEnAObj* this, s16 params);
+void func_8001D234(EnAObj* this, s16 params);
+void func_8001D310(EnAObj* this, s16 params);
+void func_8001D480(EnAObj* this, s16 params);
+void func_8001D5C8(EnAObj* this, s16 params);
 
 // TODO: Define this part of code .data here and rename the symbols
 extern ActorInit En_A_Obj_InitVars;
@@ -52,13 +46,13 @@ extern ColliderCylinderInit D_80115440;
 extern u32 D_8011546C[];
 extern u32 D_80115484[];
 
-void En_A_Obj_SetNewUpdate(ActorEnAObj* this, ActorFunc newUpdateFunc) {
-    this->updateFunc = newUpdateFunc;
+void EnAObj_SetupAction(EnAObj* this, ActorFunc actionFunc) {
+    this->actionFunc = actionFunc;
 }
 
 #ifdef NON_MATCHING
 // minor ordering and regalloc differences
-void En_A_Obj_Init(ActorEnAObj* this, GlobalContext* globalCtx) {
+void EnAObj_Init(EnAObj* this, GlobalContext* globalCtx) {
     u32 sp34;
     s16 type;
     s16 initialParams;
@@ -68,164 +62,164 @@ void En_A_Obj_Init(ActorEnAObj* this, GlobalContext* globalCtx) {
     sp34 = 0;
     sp28 = 6.0f;
 
-    initialParams = this->actor.params;
+    initialParams = this->dyna.actor.params;
     type = initialParams & 0xFF;
     this->textId = (initialParams >> 8) & 0xFF;
-    this->actor.params = type;
+    this->dyna.actor.params = type;
 
     switch (type & 0xFFFF) {
         case A_OBJ_BLOCK_SMALL:
-            Actor_SetScale(&this->actor, 0.025f);
+            Actor_SetScale(&this->dyna.actor, 0.025f);
             break;
         case A_OBJ_BLOCK_LARGE:
-            Actor_SetScale(&this->actor, 0.05f);
+            Actor_SetScale(&this->dyna.actor, 0.05f);
             break;
         case A_OBJ_BLOCK_HUGE:
         case A_OBJ_CUBE_SMALL:
         case A_OBJ_UNKNOWN_6:
-            Actor_SetScale(&this->actor, 0.1f);
+            Actor_SetScale(&this->dyna.actor, 0.1f);
             break;
         case A_OBJ_BLOCK_SMALL_ROT:
-            Actor_SetScale(&this->actor, 0.005f);
+            Actor_SetScale(&this->dyna.actor, 0.005f);
             break;
         case A_OBJ_BLOCK_LARGE_ROT:
         default:
-            Actor_SetScale(&this->actor, 0.01f);
+            Actor_SetScale(&this->dyna.actor, 0.01f);
             break;
     }
 
-    if (this->actor.params >= 9) {
+    if (this->dyna.actor.params >= 9) {
         sp28 = 12.0f;
     }
 
-    ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawFunc_Circle, sp28);
+    ActorShape_Init(&this->dyna.actor.shape, 0.0f, ActorShadow_DrawFunc_Circle, sp28);
 
-    this->dynaPolyId = -1;
-    this->unk_160 = 0;
-    this->unk_15C = 0;
-    this->actor.unk_FC = 1200.0f;
-    this->actor.unk_F8 = 200.0f;
-    params = this->actor.params;
-    this->actor.posRot2.pos = this->actor.posRot.pos;
+    this->dyna.dynaPolyId = -1;
+    this->dyna.unk_160 = 0;
+    this->dyna.unk_15C = 0;
+    this->dyna.actor.unk_FC = 1200.0f;
+    this->dyna.actor.unk_F8 = 200.0f;
+    params = this->dyna.actor.params;
+    this->dyna.actor.posRot2.pos = this->dyna.actor.posRot.pos;
 
     switch (params) {
         case A_OBJ_BLOCK_LARGE:
         case A_OBJ_BLOCK_HUGE:
-            this->dynaPolyId = 1;
-            Actor_ChangeType(globalCtx, &globalCtx->actorCtx, &this->actor, ACTORTYPE_BG);
-            func_8001D5C8(this, this->actor.params);
+            this->dyna.dynaPolyId = 1;
+            Actor_ChangeType(globalCtx, &globalCtx->actorCtx, &this->dyna.actor, ACTORTYPE_BG);
+            func_8001D5C8(this, this->dyna.actor.params);
             break;
         case A_OBJ_BLOCK_SMALL_ROT:
         case A_OBJ_BLOCK_LARGE_ROT:
-            this->dynaPolyId = 3;
-            Actor_ChangeType(globalCtx, &globalCtx->actorCtx, &this->actor, ACTORTYPE_BG);
-            func_8001D310(this, this->actor.params);
+            this->dyna.dynaPolyId = 3;
+            Actor_ChangeType(globalCtx, &globalCtx->actorCtx, &this->dyna.actor, ACTORTYPE_BG);
+            func_8001D310(this, this->dyna.actor.params);
             break;
         case A_OBJ_UNKNOWN_6:
-            this->actor.flags |= 0x1;
-            this->dynaPolyId = 5;
+            this->dyna.actor.flags |= 0x1;
+            this->dyna.dynaPolyId = 5;
             this->unk_178 = 10.0f;
-            this->actor.gravity = -2.0f;
-            func_8001D234(this, this->actor.params);
+            this->dyna.actor.gravity = -2.0f;
+            func_8001D234(this, this->dyna.actor.params);
             break;
         case A_OBJ_GRASS_CLUMP:
         case A_OBJ_TREE_STUMP:
-            this->dynaPolyId = 0;
-            func_8001D234(this, this->actor.params);
+            this->dyna.dynaPolyId = 0;
+            func_8001D234(this, this->dyna.actor.params);
             break;
         case A_OBJ_SIGNPOST_OBLONG:
         case A_OBJ_SIGNPOST_ARROW:
-            this->actor.textId = (this->textId & 0xFF) | 0x300;
-            this->actor.flags |= 0x8 | 0x1;
-            this->actor.unk_4C = 500.0f;
+            this->dyna.actor.textId = (this->textId & 0xFF) | 0x300;
+            this->dyna.actor.flags |= 0x8 | 0x1;
+            this->dyna.actor.unk_4C = 500.0f;
             this->unk_178 = 45.0f;
-            func_8001D234(this, this->actor.params);
-            Collider_InitCylinder(globalCtx, &this->cylinderCollider);
-            Collider_SetCylinder(globalCtx, &this->cylinderCollider, &this->actor, &D_80115440);
-            this->actor.colChkInfo.mass = 0xFF;
-            this->actor.unk_1F = 0;
+            func_8001D234(this, this->dyna.actor.params);
+            Collider_InitCylinder(globalCtx, &this->collider);
+            Collider_SetCylinder(globalCtx, &this->collider, &this->dyna.actor, &D_80115440);
+            this->dyna.actor.colChkInfo.mass = 0xFF;
+            this->dyna.actor.unk_1F = 0;
             break;
         case A_OBJ_KNOB:
-            this->actor.gravity = -1.5f;
+            this->dyna.actor.gravity = -1.5f;
             func_8001D480(this, params);
             break;
         default:
-            this->actor.gravity = -2.0f;
+            this->dyna.actor.gravity = -2.0f;
             func_8001D234(this, params);
             break;
     }
 
-    if (this->actor.params < 5) {
-        this->actor.colChkInfo.mass = 0xFF;
+    if (this->dyna.actor.params < 5) {
+        this->dyna.actor.colChkInfo.mass = 0xFF;
     }
 
-    if (this->dynaPolyId != -1) {
-        DynaPolyInfo_Alloc(D_8011546C[this->dynaPolyId], &sp34);
-        this->dynaPolyId = DynaPolyInfo_RegisterActor(globalCtx, &globalCtx->colCtx.dyna, &this->actor, sp34);
+    if (this->dyna.dynaPolyId != -1) {
+        DynaPolyInfo_Alloc(D_8011546C[this->dyna.dynaPolyId], &sp34);
+        this->dyna.dynaPolyId = DynaPolyInfo_RegisterActor(globalCtx, &globalCtx->colCtx.dyna, &this->dyna.actor, sp34);
     }
 }
 #else
-#pragma GLOBAL_ASM("asm/non_matchings/code/z_en_a_keep/En_A_Obj_Init.s")
+#pragma GLOBAL_ASM("asm/non_matchings/code/z_en_a_keep/EnAObj_Init.s")
 #endif
 
-void En_A_Obj_Destroy(ActorEnAObj* this, GlobalContext* globalCtx) {
-    ColliderCylinder* cylinderCollider = &this->cylinderCollider;
+void EnAObj_Destroy(EnAObj* this, GlobalContext* globalCtx) {
+    ColliderCylinder* collider = &this->collider;
 
-    DynaPolyInfo_Free(globalCtx, &globalCtx->colCtx.dyna, this->dynaPolyId);
+    DynaPolyInfo_Free(globalCtx, &globalCtx->colCtx.dyna, this->dyna.dynaPolyId);
 
-    switch (this->actor.params) {
+    switch (this->dyna.actor.params) {
         case A_OBJ_SIGNPOST_OBLONG:
         case A_OBJ_SIGNPOST_ARROW:
-            Collider_DestroyCylinder(globalCtx, cylinderCollider);
+            Collider_DestroyCylinder(globalCtx, collider);
     }
 }
 
-void func_8001D204(ActorEnAObj* this, GlobalContext* globalCtx) {
-    if (func_8002F334(&this->actor, globalCtx)) {
-        func_8001D234(this, this->actor.params);
+void func_8001D204(EnAObj* this, GlobalContext* globalCtx) {
+    if (func_8002F334(&this->dyna.actor, globalCtx)) {
+        func_8001D234(this, this->dyna.actor.params);
     }
 }
 
-void func_8001D234(ActorEnAObj* this, s16 params) {
-    En_A_Obj_SetNewUpdate(this, (ActorFunc)func_8001D25C);
+void func_8001D234(EnAObj* this, s16 params) {
+    EnAObj_SetupAction(this, (ActorFunc)func_8001D25C);
 }
 
-void func_8001D25C(ActorEnAObj* this, GlobalContext* globalCtx) {
+void func_8001D25C(EnAObj* this, GlobalContext* globalCtx) {
     s16 var;
 
-    if (this->actor.textId != 0) {
-        var = this->actor.rotTowardsLinkY - this->actor.shape.rot.y;
-        if ((ABS(var) < 0x2800) || ((this->actor.params == 0xA) && (ABS(var) > 0x5800))) {
-            if (func_8002F194(&this->actor, globalCtx)) {
-                En_A_Obj_SetNewUpdate(this, (ActorFunc)func_8001D204);
+    if (this->dyna.actor.textId != 0) {
+        var = this->dyna.actor.rotTowardsLinkY - this->dyna.actor.shape.rot.y;
+        if ((ABS(var) < 0x2800) || ((this->dyna.actor.params == 0xA) && (ABS(var) > 0x5800))) {
+            if (func_8002F194(&this->dyna.actor, globalCtx)) {
+                EnAObj_SetupAction(this, (ActorFunc)func_8001D204);
             } else {
-                func_8002F2F4(&this->actor, globalCtx);
+                func_8002F2F4(&this->dyna.actor, globalCtx);
             }
         }
     }
 }
 
-void func_8001D310(ActorEnAObj* this, s16 params) {
+void func_8001D310(EnAObj* this, s16 params) {
     this->unk_16E = 0;
     this->unk_168 = 10;
-    this->actor.posRot.rot.y = 0;
-    this->actor.shape.rot = this->actor.posRot.rot;
-    En_A_Obj_SetNewUpdate(this, (ActorFunc)func_8001D360);
+    this->dyna.actor.posRot.rot.y = 0;
+    this->dyna.actor.shape.rot = this->dyna.actor.posRot.rot;
+    EnAObj_SetupAction(this, (ActorFunc)func_8001D360);
 }
 
-void func_8001D360(ActorEnAObj* this, GlobalContext* globalCtx) {
+void func_8001D360(EnAObj* this, GlobalContext* globalCtx) {
     if (this->unk_16E == 0) {
-        if (this->unk_160 != 0) {
+        if (this->dyna.unk_160 != 0) {
             this->unk_16E++;
             this->unk_170 = 20;
 
-            if ((s16)(this->actor.rotTowardsLinkY + 0x4000) < 0) {
+            if ((s16)(this->dyna.actor.rotTowardsLinkY + 0x4000) < 0) {
                 this->unk_174 = -1000;
             } else {
                 this->unk_174 = 1000;
             }
 
-            if (this->actor.rotTowardsLinkY < 0) {
+            if (this->dyna.actor.rotTowardsLinkY < 0) {
                 this->unk_172 = -this->unk_174;
             } else {
                 this->unk_172 = this->unk_174;
@@ -235,101 +229,103 @@ void func_8001D360(ActorEnAObj* this, GlobalContext* globalCtx) {
         if (this->unk_168 != 0) {
             this->unk_168--;
         } else {
-            this->actor.shape.rot.y += this->unk_172;
-            this->actor.shape.rot.x += this->unk_174;
+            this->dyna.actor.shape.rot.y += this->unk_172;
+            this->dyna.actor.shape.rot.x += this->unk_174;
             this->unk_170--;
-            this->actor.gravity = -1.0f;
+            this->dyna.actor.gravity = -1.0f;
 
             if (this->unk_170 == 0) {
-                this->actor.posRot.pos = this->actor.initPosRot.pos;
+                this->dyna.actor.posRot.pos = this->dyna.actor.initPosRot.pos;
                 this->unk_16E = 0;
                 this->unk_168 = 10;
-                this->actor.velocity.y = 0.0f;
-                this->actor.gravity = 0.0f;
-                this->actor.shape.rot = this->actor.posRot.rot;
+                this->dyna.actor.velocity.y = 0.0f;
+                this->dyna.actor.gravity = 0.0f;
+                this->dyna.actor.shape.rot = this->dyna.actor.posRot.rot;
             }
         }
     }
 }
 
-void func_8001D480(ActorEnAObj* this, s16 params) {
-    En_A_Obj_SetNewUpdate(this, (ActorFunc)func_8001D4A8);
+void func_8001D480(EnAObj* this, s16 params) {
+    EnAObj_SetupAction(this, (ActorFunc)func_8001D4A8);
 }
 
-void func_8001D4A8(ActorEnAObj* this, GlobalContext* globalCtx) {
-    Math_SmoothScaleMaxMinF(&this->actor.speedXZ, 1.0f, 1.0f, 0.5f, 0.0f);
-    this->actor.shape.rot.x = this->actor.shape.rot.x + (this->actor.posRot.rot.x >> 1);
-    this->actor.shape.rot.z = this->actor.shape.rot.z + (this->actor.posRot.rot.z >> 1);
+void func_8001D4A8(EnAObj* this, GlobalContext* globalCtx) {
+    Math_SmoothScaleMaxMinF(&this->dyna.actor.speedXZ, 1.0f, 1.0f, 0.5f, 0.0f);
+    this->dyna.actor.shape.rot.x = this->dyna.actor.shape.rot.x + (this->dyna.actor.posRot.rot.x >> 1);
+    this->dyna.actor.shape.rot.z = this->dyna.actor.shape.rot.z + (this->dyna.actor.posRot.rot.z >> 1);
 
-    if ((this->actor.speedXZ != 0.0f) && (this->actor.bgCheckFlags & 0x8)) {
+    if ((this->dyna.actor.speedXZ != 0.0f) && (this->dyna.actor.bgCheckFlags & 0x8)) {
         if (1) { // Necessary to match
-            this->actor.posRot.rot.y = ((this->actor.unk_7E - this->actor.posRot.rot.y) + this->actor.unk_7E) - 0x8000;
+            this->dyna.actor.posRot.rot.y =
+                ((this->dyna.actor.unk_7E - this->dyna.actor.posRot.rot.y) + this->dyna.actor.unk_7E) - 0x8000;
         }
-        this->actor.bgCheckFlags &= ~0x8;
+        this->dyna.actor.bgCheckFlags &= ~0x8;
     }
 
-    if (this->actor.bgCheckFlags & 0x2) {
-        if (this->actor.velocity.y < -8.0f) {
-            this->actor.velocity.y *= -0.6f;
-            this->actor.speedXZ *= 0.6f;
-            this->actor.bgCheckFlags &= ~0x3;
+    if (this->dyna.actor.bgCheckFlags & 0x2) {
+        if (this->dyna.actor.velocity.y < -8.0f) {
+            this->dyna.actor.velocity.y *= -0.6f;
+            this->dyna.actor.speedXZ *= 0.6f;
+            this->dyna.actor.bgCheckFlags &= ~0x3;
         } else {
-            Actor_Kill(&this->actor);
+            Actor_Kill(&this->dyna.actor);
         }
     }
 }
 
-void func_8001D5C8(ActorEnAObj* this, s16 params) {
-    this->actor.unk_FC = 1200.0f;
-    this->actor.unk_F8 = 720.0f;
-    En_A_Obj_SetNewUpdate(this, (ActorFunc)func_8001D608);
+void func_8001D5C8(EnAObj* this, s16 params) {
+    this->dyna.actor.unk_FC = 1200.0f;
+    this->dyna.actor.unk_F8 = 720.0f;
+    EnAObj_SetupAction(this, (ActorFunc)func_8001D608);
 }
 
-void func_8001D608(ActorEnAObj* this, GlobalContext* globalCtx) {
-    this->actor.speedXZ += this->unk_150;
-    this->actor.posRot.rot.y = this->unk_158;
+void func_8001D608(EnAObj* this, GlobalContext* globalCtx) {
+    this->dyna.actor.speedXZ += this->dyna.unk_150;
+    this->dyna.actor.posRot.rot.y = this->dyna.unk_158;
 
-    this->actor.speedXZ =
-        (this->actor.speedXZ < -2.5f) ? -2.5f : ((this->actor.speedXZ > 2.5f) ? 2.5f : this->actor.speedXZ);
+    this->dyna.actor.speedXZ = (this->dyna.actor.speedXZ < -2.5f)
+                                   ? -2.5f
+                                   : ((this->dyna.actor.speedXZ > 2.5f) ? 2.5f : this->dyna.actor.speedXZ);
 
-    Math_SmoothScaleMaxMinF(&this->actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
+    Math_SmoothScaleMaxMinF(&this->dyna.actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
 
-    if (this->actor.speedXZ != 0.0f) {
-        Audio_PlayActorSound2(&this->actor, 0x200A);
+    if (this->dyna.actor.speedXZ != 0.0f) {
+        Audio_PlayActorSound2(&this->dyna.actor, 0x200A);
     }
 
-    this->unk_154 = 0.0f;
-    this->unk_150 = 0.0f;
+    this->dyna.unk_154 = 0.0f;
+    this->dyna.unk_150 = 0.0f;
 }
 
-void En_A_Obj_Update(ActorEnAObj* this, GlobalContext* globalCtx) {
+void EnAObj_Update(EnAObj* this, GlobalContext* globalCtx) {
     Collider* collider;
 
-    this->updateFunc(this, globalCtx);
-    Actor_MoveForward(&this->actor);
+    this->actionFunc(this, globalCtx);
+    Actor_MoveForward(&this->dyna.actor);
 
-    if (this->actor.gravity != 0.0f) {
-        if (this->actor.params != A_OBJ_KNOB) {
-            func_8002E4B4(globalCtx, &this->actor, 5.0f, 40.0f, 0.0f, 0x1D);
+    if (this->dyna.actor.gravity != 0.0f) {
+        if (this->dyna.actor.params != A_OBJ_KNOB) {
+            func_8002E4B4(globalCtx, &this->dyna.actor, 5.0f, 40.0f, 0.0f, 0x1D);
         } else {
-            func_8002E4B4(globalCtx, &this->actor, 5.0f, 20.0f, 0.0f, 0x1D);
+            func_8002E4B4(globalCtx, &this->dyna.actor, 5.0f, 20.0f, 0.0f, 0x1D);
         }
     }
 
-    this->actor.posRot2.pos = this->actor.posRot.pos;
-    this->actor.posRot2.pos.y += this->unk_178;
+    this->dyna.actor.posRot2.pos = this->dyna.actor.posRot.pos;
+    this->dyna.actor.posRot2.pos.y += this->unk_178;
 
-    switch (this->actor.params) {
+    switch (this->dyna.actor.params) {
         case A_OBJ_SIGNPOST_OBLONG:
         case A_OBJ_SIGNPOST_ARROW:
-            collider = (Collider*)&this->cylinderCollider;
-            Collider_CylinderUpdate(&this->actor, &this->cylinderCollider);
+            collider = (Collider*)&this->collider;
+            Collider_CylinderUpdate(&this->dyna.actor, &this->collider);
             CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, collider);
     }
 }
 
-void En_A_Obj_Draw(ActorEnAObj* this, GlobalContext* globalCtx) {
-    s32 type = this->actor.params;
+void EnAObj_Draw(EnAObj* this, GlobalContext* globalCtx) {
+    s32 type = this->dyna.actor.params;
     GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
     Gfx* dispRefs[4];
 
@@ -341,7 +337,7 @@ void En_A_Obj_Draw(ActorEnAObj* this, GlobalContext* globalCtx) {
         type = A_OBJ_KNOB;
     }
 
-    if (this->actor.params == A_OBJ_KNOB) {
+    if (this->dyna.actor.params == A_OBJ_KNOB) {
         gDPSetPrimColor(gfxCtx->polyOpa.p++, 0, 1, 0x3C, 0x3C, 0x3C, 0x32);
     }
 

--- a/src/code/z_en_a_keep.c
+++ b/src/code/z_en_a_keep.c
@@ -29,6 +29,8 @@ typedef struct {
     /* 0x17C */ ColliderCylinder collider;
 } EnAObj; // size = 0x1C8
 
+#define FLAGS 0x00000010
+
 void func_8001D204(EnAObj* this, GlobalContext* globalCtx);
 void func_8001D25C(EnAObj* this, GlobalContext* globalCtx);
 void func_8001D360(EnAObj* this, GlobalContext* globalCtx);
@@ -40,8 +42,24 @@ void func_8001D310(EnAObj* this, s16 params);
 void func_8001D480(EnAObj* this, s16 params);
 void func_8001D5C8(EnAObj* this, s16 params);
 
-// TODO: Define this part of code .data here and rename the symbols
-extern ActorInit En_A_Obj_InitVars;
+void EnAObj_Init(EnAObj* this, GlobalContext* globalCtx);
+void EnAObj_Destroy(EnAObj* this, GlobalContext* globalCtx);
+void EnAObj_Update(EnAObj* this, GlobalContext* globalCtx);
+void EnAObj_Draw(EnAObj* this, GlobalContext* globalCtx);
+
+const ActorInit En_A_Obj_InitVars = {
+    ACTOR_EN_A_OBJ,
+    ACTORTYPE_PROP,
+    FLAGS,
+    OBJECT_GAMEPLAY_KEEP,
+    sizeof(EnAObj),
+    (ActorFunc)EnAObj_Init,
+    (ActorFunc)EnAObj_Destroy,
+    (ActorFunc)EnAObj_Update,
+    (ActorFunc)EnAObj_Draw,
+};
+
+// TODO: Define this section of .data here and rename the symbols
 extern ColliderCylinderInit D_80115440;
 extern u32 D_8011546C[];
 extern u32 D_80115484[];

--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -41,15 +41,33 @@ typedef struct {
     /* 0x15A */ s16 unk_15A;
     /* 0x15C */ f32 unk_15C;
     /* 0x160 */ ColliderCylinder collider;
-} EnItem00;
+} EnItem00; // size = 0x1AC
+
+#define FLAGS 0x00000000
+
+void EnItem00_Init(EnItem00* this, GlobalContext* globalCtx);
+void EnItem00_Destroy(EnItem00* this, GlobalContext* globalCtx);
+void EnItem00_Update(EnItem00* this, GlobalContext* globalCtx);
+void EnItem00_Draw(EnItem00* this, GlobalContext* globalCtx);
 
 void func_8001DFC8(EnItem00* this, GlobalContext* globalCtx);
 void func_8001E1C8(EnItem00* this, GlobalContext* globalCtx);
 void func_8001E304(EnItem00* this, GlobalContext* globalCtx);
 void func_8001E5C8(EnItem00* this, GlobalContext* globalCtx);
 
-// TODO: Define this part of code .data here and rename the symbols
-extern ActorInit En_Item00_InitVars;
+const ActorInit En_Item00_InitVars = {
+    ACTOR_EN_ITEM00,
+    ACTORTYPE_MISC,
+    FLAGS,
+    OBJECT_GAMEPLAY_KEEP,
+    sizeof(EnItem00),
+    (ActorFunc)EnItem00_Init,
+    (ActorFunc)EnItem00_Destroy,
+    (ActorFunc)EnItem00_Update,
+    (ActorFunc)EnItem00_Draw,
+};
+
+// TODO: Define this section of .data here and rename the symbols
 extern ColliderCylinderInit D_801154E0;
 extern InitChainEntry D_8011550C[];
 extern Color_RGB8 D_80115510;

--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -2,37 +2,37 @@
 #include <global.h>
 
 typedef enum {
-    /* 0x00 */ DROP_RUPEE_GREEN,
-    /* 0x01 */ DROP_RUPEE_BLUE,
-    /* 0x02 */ DROP_RUPEE_RED,
-    /* 0x03 */ DROP_HEART,
-    /* 0x04 */ DROP_BOMBS_A,
-    /* 0x05 */ DROP_ARROWS_SINGLE,
-    /* 0x06 */ DROP_HEART_PIECE,
-    /* 0x07 */ DROP_HEART_CONTAINER,
-    /* 0x08 */ DROP_ARROWS_SMALL,
-    /* 0x09 */ DROP_ARROWS_MEDIUM,
-    /* 0x0A */ DROP_ARROWS_LARGE,
-    /* 0x0B */ DROP_BOMBS_B,
-    /* 0x0C */ DROP_NUTS,
-    /* 0x0D */ DROP_STICK,
-    /* 0x0E */ DROP_MAGIC_LARGE,
-    /* 0x0F */ DROP_MAGIC_SMALL,
-    /* 0x10 */ DROP_SEEDS,
-    /* 0x11 */ DROP_SMALL_KEY,
-    /* 0x12 */ DROP_FLEXIBLE,
-    /* 0x13 */ DROP_RUPEE_ORANGE,
-    /* 0x14 */ DROP_RUPEE_PURPLE,
-    /* 0x15 */ DROP_SHIELD_DEKU,
-    /* 0x16 */ DROP_SHIELD_HYLIAN,
-    /* 0x17 */ DROP_TUNIC_ZORA,
-    /* 0x18 */ DROP_TUNIC_GORON,
-    /* 0x19 */ DROP_BOMBS_SPECIAL
-} DropType;
+    /* 0x00 */ ITEM00_RUPEE_GREEN,
+    /* 0x01 */ ITEM00_RUPEE_BLUE,
+    /* 0x02 */ ITEM00_RUPEE_RED,
+    /* 0x03 */ ITEM00_HEART,
+    /* 0x04 */ ITEM00_BOMBS_A,
+    /* 0x05 */ ITEM00_ARROWS_SINGLE,
+    /* 0x06 */ ITEM00_HEART_PIECE,
+    /* 0x07 */ ITEM00_HEART_CONTAINER,
+    /* 0x08 */ ITEM00_ARROWS_SMALL,
+    /* 0x09 */ ITEM00_ARROWS_MEDIUM,
+    /* 0x0A */ ITEM00_ARROWS_LARGE,
+    /* 0x0B */ ITEM00_BOMBS_B,
+    /* 0x0C */ ITEM00_NUTS,
+    /* 0x0D */ ITEM00_STICK,
+    /* 0x0E */ ITEM00_MAGIC_LARGE,
+    /* 0x0F */ ITEM00_MAGIC_SMALL,
+    /* 0x10 */ ITEM00_SEEDS,
+    /* 0x11 */ ITEM00_SMALL_KEY,
+    /* 0x12 */ ITEM00_FLEXIBLE,
+    /* 0x13 */ ITEM00_RUPEE_ORANGE,
+    /* 0x14 */ ITEM00_RUPEE_PURPLE,
+    /* 0x15 */ ITEM00_SHIELD_DEKU,
+    /* 0x16 */ ITEM00_SHIELD_HYLIAN,
+    /* 0x17 */ ITEM00_TUNIC_ZORA,
+    /* 0x18 */ ITEM00_TUNIC_GORON,
+    /* 0x19 */ ITEM00_BOMBS_SPECIAL
+} Item00Type;
 
 typedef struct {
     /* 0x000 */ Actor actor;
-    /* 0x14C */ ActorFunc updateFunc;
+    /* 0x14C */ ActorFunc actionFunc;
     /* 0x150 */ s16 collectibleFlag;
     /* 0x152 */ s16 unk_152;
     /* 0x154 */ s16 unk_154;
@@ -40,13 +40,13 @@ typedef struct {
     /* 0x158 */ s16 unk_158;
     /* 0x15A */ s16 unk_15A;
     /* 0x15C */ f32 unk_15C;
-    /* 0x160 */ ColliderCylinder cylinderCollider;
-} ActorEnItem00;
+    /* 0x160 */ ColliderCylinder collider;
+} EnItem00;
 
-void func_8001DFC8(ActorEnItem00* this, GlobalContext* globalCtx);
-void func_8001E1C8(ActorEnItem00* this, GlobalContext* globalCtx);
-void func_8001E304(ActorEnItem00* this, GlobalContext* globalCtx);
-void func_8001E5C8(ActorEnItem00* this, GlobalContext* globalCtx);
+void func_8001DFC8(EnItem00* this, GlobalContext* globalCtx);
+void func_8001E1C8(EnItem00* this, GlobalContext* globalCtx);
+void func_8001E304(EnItem00* this, GlobalContext* globalCtx);
+void func_8001E5C8(EnItem00* this, GlobalContext* globalCtx);
 
 // TODO: Define this part of code .data here and rename the symbols
 extern ActorInit En_Item00_InitVars;
@@ -63,13 +63,13 @@ extern u8 D_80115664[];
 
 // Internal Actor Functions
 
-void En_Item00_SetNewUpdate(ActorEnItem00* this, ActorFunc newUpdateFunc) {
-    this->updateFunc = newUpdateFunc;
+void EnItem00_SetupAction(EnItem00* this, ActorFunc actionFunc) {
+    this->actionFunc = actionFunc;
 }
 
 #ifdef NON_MATCHING
 // Very close to matching, just a single ordering issue
-void En_Item00_Init(ActorEnItem00* this, GlobalContext* globalCtx) {
+void EnItem00_Init(EnItem00* this, GlobalContext* globalCtx) {
     s32 pad1;
     s32 pad2;
     f32 sp34;
@@ -93,87 +93,87 @@ void En_Item00_Init(ActorEnItem00* this, GlobalContext* globalCtx) {
     }
 
     Actor_ProcessInitChain(&this->actor, D_8011550C);
-    Collider_InitCylinder(globalCtx, &this->cylinderCollider);
-    Collider_SetCylinder(globalCtx, &this->cylinderCollider, &this->actor, &D_801154E0);
+    Collider_InitCylinder(globalCtx, &this->collider);
+    Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &D_801154E0);
 
     this->unk_158 = 1;
 
     switch (this->actor.params) {
-        case DROP_RUPEE_GREEN:
-        case DROP_RUPEE_BLUE:
-        case DROP_RUPEE_RED:
+        case ITEM00_RUPEE_GREEN:
+        case ITEM00_RUPEE_BLUE:
+        case ITEM00_RUPEE_RED:
             Actor_SetScale(&this->actor, 0.015f);
             this->unk_15C = 0.015f;
             sp34 = 750.0f;
             break;
-        case DROP_SMALL_KEY:
+        case ITEM00_SMALL_KEY:
             this->unk_158 = 0;
             Actor_SetScale(&this->actor, 0.03f);
             this->unk_15C = 0.03f;
             sp34 = 350.0f;
             break;
-        case DROP_HEART_PIECE:
+        case ITEM00_HEART_PIECE:
             this->unk_158 = 0;
             sp34 = 650.0f;
             Actor_SetScale(&this->actor, 0.02f);
             this->unk_15C = 0.02f;
             break;
-        case DROP_HEART:
+        case ITEM00_HEART:
             this->actor.initPosRot.rot.z = Math_Rand_CenteredFloat(65535.0f);
             sp34 = 430.0f;
             Actor_SetScale(&this->actor, 0.02f);
             this->unk_15C = 0.02f;
             break;
-        case DROP_HEART_CONTAINER:
+        case ITEM00_HEART_CONTAINER:
             sp34 = 430.0f;
             this->unk_158 = 0;
             Actor_SetScale(&this->actor, 0.02f);
             this->unk_15C = 0.02f;
             break;
-        case DROP_ARROWS_SINGLE:
+        case ITEM00_ARROWS_SINGLE:
             sp34 = 400.0f;
             Actor_SetScale(&this->actor, 0.02f);
             this->unk_15C = 0.02f;
             break;
-        case DROP_ARROWS_SMALL:
-        case DROP_ARROWS_MEDIUM:
-        case DROP_ARROWS_LARGE:
+        case ITEM00_ARROWS_SMALL:
+        case ITEM00_ARROWS_MEDIUM:
+        case ITEM00_ARROWS_LARGE:
             Actor_SetScale(&this->actor, 0.035f);
             this->unk_15C = 0.035f;
             sp34 = 250.0f;
             break;
-        case DROP_BOMBS_A:
-        case DROP_BOMBS_B:
-        case DROP_NUTS:
-        case DROP_STICK:
-        case DROP_MAGIC_SMALL:
-        case DROP_SEEDS:
-        case DROP_BOMBS_SPECIAL:
+        case ITEM00_BOMBS_A:
+        case ITEM00_BOMBS_B:
+        case ITEM00_NUTS:
+        case ITEM00_STICK:
+        case ITEM00_MAGIC_SMALL:
+        case ITEM00_SEEDS:
+        case ITEM00_BOMBS_SPECIAL:
             Actor_SetScale(&this->actor, 0.03f);
             this->unk_15C = 0.03f;
             sp34 = 320.0f;
             break;
-        case DROP_MAGIC_LARGE:
+        case ITEM00_MAGIC_LARGE:
             Actor_SetScale(&this->actor, 0.045 - 1e-10);
             this->unk_15C = 0.045 - 1e-10;
             sp34 = 320.0f;
             break;
-        case DROP_RUPEE_ORANGE:
+        case ITEM00_RUPEE_ORANGE:
             Actor_SetScale(&this->actor, 0.045 - 1e-10);
             this->unk_15C = 0.045 - 1e-10;
             sp34 = 750.0f;
             break;
-        case DROP_RUPEE_PURPLE:
+        case ITEM00_RUPEE_PURPLE:
             Actor_SetScale(&this->actor, 0.03f);
             this->unk_15C = 0.03f;
             sp34 = 750.0f;
             break;
-        case DROP_FLEXIBLE:
+        case ITEM00_FLEXIBLE:
             sp34 = 500.0f;
             Actor_SetScale(&this->actor, 0.01f);
             this->unk_15C = 0.01f;
             break;
-        case DROP_SHIELD_DEKU:
+        case ITEM00_SHIELD_DEKU:
             this->actor.objBankIndex = Object_GetIndex(&globalCtx->objectCtx, OBJECT_GI_SHIELD_1);
             Actor_SetObjectDependency(globalCtx, &this->actor);
             Actor_SetScale(&this->actor, 0.5f);
@@ -182,7 +182,7 @@ void En_Item00_Init(ActorEnItem00* this, GlobalContext* globalCtx) {
             sp30 = 0.6f;
             this->actor.posRot.rot.x = 0x4000;
             break;
-        case DROP_SHIELD_HYLIAN:
+        case ITEM00_SHIELD_HYLIAN:
             this->actor.objBankIndex = Object_GetIndex(&globalCtx->objectCtx, OBJECT_GI_SHIELD_2);
             Actor_SetObjectDependency(globalCtx, &this->actor);
             Actor_SetScale(&this->actor, 0.5f);
@@ -191,8 +191,8 @@ void En_Item00_Init(ActorEnItem00* this, GlobalContext* globalCtx) {
             sp30 = 0.6f;
             this->actor.posRot.rot.x = 0x4000;
             break;
-        case DROP_TUNIC_ZORA:
-        case DROP_TUNIC_GORON:
+        case ITEM00_TUNIC_ZORA:
+        case ITEM00_TUNIC_GORON:
             this->actor.objBankIndex = Object_GetIndex(&globalCtx->objectCtx, OBJECT_GI_CLOTHES);
             Actor_SetObjectDependency(globalCtx, &this->actor);
             Actor_SetScale(&this->actor, 0.5f);
@@ -211,7 +211,7 @@ void En_Item00_Init(ActorEnItem00* this, GlobalContext* globalCtx) {
 
     // MISMATCH: minor ordering issues here
     if (!spawnParam8000) {
-        En_Item00_SetNewUpdate(this, (ActorFunc)func_8001DFC8);
+        EnItem00_SetupAction(this, (ActorFunc)func_8001DFC8);
         this->unk_15A = -1;
         return;
     }
@@ -224,68 +224,68 @@ void En_Item00_Init(ActorEnItem00* this, GlobalContext* globalCtx) {
     this->actor.gravity = 0.0f;
 
     switch (this->actor.params) {
-        case DROP_RUPEE_GREEN:
+        case ITEM00_RUPEE_GREEN:
             Item_Give(globalCtx, ITEM_RUPEE_GREEN);
             break;
-        case DROP_RUPEE_BLUE:
+        case ITEM00_RUPEE_BLUE:
             Item_Give(globalCtx, ITEM_RUPEE_BLUE);
             break;
-        case DROP_RUPEE_RED:
+        case ITEM00_RUPEE_RED:
             Item_Give(globalCtx, ITEM_RUPEE_RED);
             break;
-        case DROP_RUPEE_PURPLE:
+        case ITEM00_RUPEE_PURPLE:
             Item_Give(globalCtx, ITEM_RUPEE_PURPLE);
             break;
-        case DROP_RUPEE_ORANGE:
+        case ITEM00_RUPEE_ORANGE:
             Item_Give(globalCtx, ITEM_RUPEE_GOLD);
             break;
-        case DROP_HEART:
+        case ITEM00_HEART:
             Item_Give(globalCtx, ITEM_HEART);
             break;
-        case DROP_FLEXIBLE:
+        case ITEM00_FLEXIBLE:
             Health_ChangeBy(globalCtx, 0x70);
             break;
-        case DROP_BOMBS_A:
-        case DROP_BOMBS_B:
+        case ITEM00_BOMBS_A:
+        case ITEM00_BOMBS_B:
             Item_Give(globalCtx, ITEM_BOMBS_5);
             break;
-        case DROP_ARROWS_SINGLE:
+        case ITEM00_ARROWS_SINGLE:
             Item_Give(globalCtx, ITEM_BOW);
             break;
-        case DROP_ARROWS_SMALL:
+        case ITEM00_ARROWS_SMALL:
             Item_Give(globalCtx, ITEM_ARROWS_SMALL);
             break;
-        case DROP_ARROWS_MEDIUM:
+        case ITEM00_ARROWS_MEDIUM:
             Item_Give(globalCtx, ITEM_ARROWS_MEDIUM);
             break;
-        case DROP_ARROWS_LARGE:
+        case ITEM00_ARROWS_LARGE:
             Item_Give(globalCtx, ITEM_ARROWS_LARGE);
             break;
-        case DROP_MAGIC_SMALL:
+        case ITEM00_MAGIC_SMALL:
             sp2C = GI_MAGIC_SMALL;
             break;
-        case DROP_MAGIC_LARGE:
+        case ITEM00_MAGIC_LARGE:
             sp2C = GI_MAGIC_LARGE;
             break;
-        case DROP_SMALL_KEY:
+        case ITEM00_SMALL_KEY:
             Item_Give(globalCtx, ITEM_KEY_SMALL);
             break;
-        case DROP_SEEDS:
+        case ITEM00_SEEDS:
             sp2C = GI_SEEDS_5;
             break;
-        case DROP_NUTS:
+        case ITEM00_NUTS:
             sp2C = GI_NUTS_5;
             break;
-        case DROP_STICK:
+        case ITEM00_STICK:
             sp2C = GI_STICKS_1;
             break;
-        case DROP_HEART_PIECE:
-        case DROP_HEART_CONTAINER:
-        case DROP_SHIELD_DEKU:
-        case DROP_SHIELD_HYLIAN:
-        case DROP_TUNIC_ZORA:
-        case DROP_TUNIC_GORON:
-        case DROP_BOMBS_SPECIAL:
+        case ITEM00_HEART_PIECE:
+        case ITEM00_HEART_CONTAINER:
+        case ITEM00_SHIELD_DEKU:
+        case ITEM00_SHIELD_HYLIAN:
+        case ITEM00_TUNIC_ZORA:
+        case ITEM00_TUNIC_GORON:
+        case ITEM00_BOMBS_SPECIAL:
             break;
     }
 
@@ -293,24 +293,24 @@ void En_Item00_Init(ActorEnItem00* this, GlobalContext* globalCtx) {
         func_8002F554(&this->actor, globalCtx, sp2C);
     }
 
-    En_Item00_SetNewUpdate(this, (ActorFunc)func_8001E5C8);
-    this->updateFunc(this, globalCtx);
+    EnItem00_SetupAction(this, (ActorFunc)func_8001E5C8);
+    this->actionFunc(this, globalCtx);
 }
 #else
-#pragma GLOBAL_ASM("asm/non_matchings/code/z_en_item00/En_Item00_Init.s")
+#pragma GLOBAL_ASM("asm/non_matchings/code/z_en_item00/EnItem00_Init.s")
 #endif
 
-void En_Item00_Destroy(ActorEnItem00* this, GlobalContext* globalCtx) {
-    ColliderCylinder* cylinderCollider = &this->cylinderCollider;
-    Collider_DestroyCylinder(globalCtx, cylinderCollider);
+void EnItem00_Destroy(EnItem00* this, GlobalContext* globalCtx) {
+    ColliderCylinder* collider = &this->collider;
+    Collider_DestroyCylinder(globalCtx, collider);
 }
 
-void func_8001DFC8(ActorEnItem00* this, GlobalContext* globalCtx) {
-    if ((this->actor.params <= DROP_RUPEE_RED) || ((this->actor.params == DROP_HEART) && (this->unk_15A < 0)) ||
-        (this->actor.params == DROP_HEART_PIECE)) {
+void func_8001DFC8(EnItem00* this, GlobalContext* globalCtx) {
+    if ((this->actor.params <= ITEM00_RUPEE_RED) || ((this->actor.params == ITEM00_HEART) && (this->unk_15A < 0)) ||
+        (this->actor.params == ITEM00_HEART_PIECE)) {
         this->actor.shape.rot.y += 960;
     } else {
-        if ((this->actor.params >= DROP_SHIELD_DEKU) && (this->actor.params != DROP_BOMBS_SPECIAL)) {
+        if ((this->actor.params >= ITEM00_SHIELD_DEKU) && (this->actor.params != ITEM00_BOMBS_SPECIAL)) {
             if (this->unk_15A == -1) {
                 if (!Math_SmoothScaleMaxMinS(&this->actor.shape.rot.x, this->actor.posRot.rot.x - 0x4000, 2, 3000,
                                              1500)) {
@@ -326,36 +326,36 @@ void func_8001DFC8(ActorEnItem00* this, GlobalContext* globalCtx) {
         }
     }
 
-    if (this->actor.params == DROP_HEART_PIECE) {
+    if (this->actor.params == ITEM00_HEART_PIECE) {
         this->actor.shape.unk_08 = Math_Sins(this->actor.shape.rot.y) * 150.0f + 850.0f;
     }
 
     Math_SmoothScaleMaxMinF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
 
     if (this->unk_154 == 0) {
-        if ((this->actor.params != DROP_SMALL_KEY) && (this->actor.params != DROP_HEART_PIECE) &&
-            (this->actor.params != DROP_HEART_CONTAINER)) {
+        if ((this->actor.params != ITEM00_SMALL_KEY) && (this->actor.params != ITEM00_HEART_PIECE) &&
+            (this->actor.params != ITEM00_HEART_CONTAINER)) {
             this->unk_154 = -1;
         }
     }
 
     if (this->unk_15A == 0) {
-        if ((this->actor.params != DROP_SMALL_KEY) && (this->actor.params != DROP_HEART_PIECE) &&
-            (this->actor.params != DROP_HEART_CONTAINER)) {
+        if ((this->actor.params != ITEM00_SMALL_KEY) && (this->actor.params != ITEM00_HEART_PIECE) &&
+            (this->actor.params != ITEM00_HEART_CONTAINER)) {
             Actor_Kill(&this->actor);
         }
     }
 
     if ((this->actor.gravity != 0.0f) && !(this->actor.bgCheckFlags & 0x0001)) {
-        En_Item00_SetNewUpdate(this, (ActorFunc)func_8001E1C8);
+        EnItem00_SetupAction(this, (ActorFunc)func_8001E1C8);
     }
 }
 
-void func_8001E1C8(ActorEnItem00* this, GlobalContext* globalCtx) {
+void func_8001E1C8(EnItem00* this, GlobalContext* globalCtx) {
     f32 originalVelocity;
     Vec3f pos;
 
-    if (this->actor.params <= DROP_RUPEE_RED) {
+    if (this->actor.params <= ITEM00_RUPEE_RED) {
         this->actor.shape.rot.y += 960;
     }
 
@@ -369,7 +369,7 @@ void func_8001E1C8(ActorEnItem00* this, GlobalContext* globalCtx) {
     if (this->actor.bgCheckFlags & 0x0003) {
         originalVelocity = this->actor.velocity.y;
         if (originalVelocity > -2.0f) {
-            En_Item00_SetNewUpdate(this, (ActorFunc)func_8001DFC8);
+            EnItem00_SetupAction(this, (ActorFunc)func_8001DFC8);
             this->actor.velocity.y = 0.0f;
         } else {
             this->actor.velocity.y = originalVelocity * -0.8f;
@@ -378,14 +378,14 @@ void func_8001E1C8(ActorEnItem00* this, GlobalContext* globalCtx) {
     }
 }
 
-void func_8001E304(ActorEnItem00* this, GlobalContext* globalCtx) {
+void func_8001E304(EnItem00* this, GlobalContext* globalCtx) {
     s32 pad;
     Vec3f pos;
     s32 var1;
 
     this->unk_15A++;
 
-    if (this->actor.params == DROP_HEART) {
+    if (this->actor.params == ITEM00_HEART) {
         if (this->actor.velocity.y < 0.0f) {
             this->actor.speedXZ = 0.0f;
             this->actor.gravity = -0.4f;
@@ -400,9 +400,9 @@ void func_8001E304(ActorEnItem00* this, GlobalContext* globalCtx) {
         }
     }
 
-    if (this->actor.params <= DROP_RUPEE_RED) {
+    if (this->actor.params <= ITEM00_RUPEE_RED) {
         this->actor.shape.rot.y += 960;
-    } else if ((this->actor.params >= DROP_SHIELD_DEKU) && (this->actor.params != DROP_BOMBS_SPECIAL)) {
+    } else if ((this->actor.params >= ITEM00_SHIELD_DEKU) && (this->actor.params != ITEM00_BOMBS_SPECIAL)) {
         this->actor.posRot.rot.x -= 700;
         this->actor.shape.rot.y += 400;
         this->actor.shape.rot.x = this->actor.posRot.rot.x - 0x4000;
@@ -425,14 +425,14 @@ void func_8001E304(ActorEnItem00* this, GlobalContext* globalCtx) {
     }
 
     if (this->actor.bgCheckFlags & 0x0003) {
-        En_Item00_SetNewUpdate(this, (ActorFunc)func_8001DFC8);
+        EnItem00_SetupAction(this, (ActorFunc)func_8001DFC8);
         this->actor.shape.rot.z = 0;
         this->actor.velocity.y = 0.0f;
         this->actor.speedXZ = 0.0f;
     }
 }
 
-void func_8001E5C8(ActorEnItem00* this, GlobalContext* globalCtx) {
+void func_8001E5C8(EnItem00* this, GlobalContext* globalCtx) {
     Player* player = PLAYER;
 
     if (this->unk_152 != 0) {
@@ -451,9 +451,9 @@ void func_8001E5C8(ActorEnItem00* this, GlobalContext* globalCtx) {
 
     this->actor.posRot.pos = player->actor.posRot.pos;
 
-    if (this->actor.params <= DROP_RUPEE_RED) {
+    if (this->actor.params <= ITEM00_RUPEE_RED) {
         this->actor.shape.rot.y += 960;
-    } else if (this->actor.params == DROP_HEART) {
+    } else if (this->actor.params == ITEM00_HEART) {
         this->actor.shape.rot.y = 0;
     }
 
@@ -465,12 +465,12 @@ void func_8001E5C8(ActorEnItem00* this, GlobalContext* globalCtx) {
 }
 
 extern s32 D_80157D90;
-extern u32 D_80157D90_; // these must be defined separately for En_Item00_Update to match
+extern u32 D_80157D90_; // these must be defined separately for EnItem00_Update to match
 extern s16 D_80157D94;
 
 #ifdef NON_MATCHING
 // Almost matching, just a few minor ordering issues
-void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
+void EnItem00_Update(EnItem00* this, GlobalContext* globalCtx) {
     s32 pad1;
     s32 pad2;
     s32 sp3C;
@@ -489,7 +489,7 @@ void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
         this->unk_156 = this->unk_15A;
     }
 
-    this->updateFunc(this, globalCtx);
+    this->actionFunc(this, globalCtx);
 
     Math_SmoothScaleMaxMinF(&this->actor.scale.x, this->unk_15C, 0.1f, this->unk_15C * 0.1f, 0.0f);
     this->actor.scale.z = this->actor.scale.x;
@@ -529,11 +529,11 @@ void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
         }
     }
 
-    Collider_CylinderUpdate(&this->actor, &this->cylinderCollider);
-    CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->cylinderCollider);
+    Collider_CylinderUpdate(&this->actor, &this->collider);
+    CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->collider);
 
-    if ((this->actor.params == DROP_SHIELD_DEKU) || (this->actor.params == DROP_SHIELD_HYLIAN) ||
-        (this->actor.params == DROP_TUNIC_ZORA) || (this->actor.params == DROP_TUNIC_GORON)) {
+    if ((this->actor.params == ITEM00_SHIELD_DEKU) || (this->actor.params == ITEM00_SHIELD_HYLIAN) ||
+        (this->actor.params == ITEM00_TUNIC_ZORA) || (this->actor.params == ITEM00_TUNIC_GORON)) {
         f32 newUnkBC = Math_Coss(this->actor.shape.rot.x) * 37.0f;
         this->actor.shape.unk_08 = newUnkBC;
         if (newUnkBC >= 0.0f) {
@@ -560,80 +560,80 @@ void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
     }
 
     switch (this->actor.params) {
-        case DROP_RUPEE_GREEN:
+        case ITEM00_RUPEE_GREEN:
             Item_Give(globalCtx, ITEM_RUPEE_GREEN);
             break;
-        case DROP_RUPEE_BLUE:
+        case ITEM00_RUPEE_BLUE:
             Item_Give(globalCtx, ITEM_RUPEE_BLUE);
             break;
-        case DROP_RUPEE_RED:
+        case ITEM00_RUPEE_RED:
             Item_Give(globalCtx, ITEM_RUPEE_RED);
             break;
-        case DROP_RUPEE_PURPLE:
+        case ITEM00_RUPEE_PURPLE:
             Item_Give(globalCtx, ITEM_RUPEE_PURPLE);
             break;
-        case DROP_RUPEE_ORANGE:
+        case ITEM00_RUPEE_ORANGE:
             Item_Give(globalCtx, ITEM_RUPEE_GOLD);
             break;
-        case DROP_STICK:
+        case ITEM00_STICK:
             sp3C = GI_STICKS_1;
             break;
-        case DROP_NUTS:
+        case ITEM00_NUTS:
             sp3C = GI_NUTS_5;
             break;
-        case DROP_HEART:
+        case ITEM00_HEART:
             Item_Give(globalCtx, ITEM_HEART);
             break;
-        case DROP_FLEXIBLE:
+        case ITEM00_FLEXIBLE:
             Health_ChangeBy(globalCtx, 0x70);
             break;
-        case DROP_BOMBS_A:
-        case DROP_BOMBS_B:
+        case ITEM00_BOMBS_A:
+        case ITEM00_BOMBS_B:
             Item_Give(globalCtx, ITEM_BOMBS_5);
             break;
-        case DROP_ARROWS_SINGLE:
+        case ITEM00_ARROWS_SINGLE:
             Item_Give(globalCtx, ITEM_BOW);
             break;
-        case DROP_ARROWS_SMALL:
+        case ITEM00_ARROWS_SMALL:
             Item_Give(globalCtx, ITEM_ARROWS_SMALL);
             break;
-        case DROP_ARROWS_MEDIUM:
+        case ITEM00_ARROWS_MEDIUM:
             Item_Give(globalCtx, ITEM_ARROWS_MEDIUM);
             break;
-        case DROP_ARROWS_LARGE:
+        case ITEM00_ARROWS_LARGE:
             Item_Give(globalCtx, ITEM_ARROWS_LARGE);
             break;
-        case DROP_SEEDS:
+        case ITEM00_SEEDS:
             sp3C = GI_SEEDS_5;
             break;
-        case DROP_SMALL_KEY:
+        case ITEM00_SMALL_KEY:
             sp3C = GI_KEY_SMALL;
             break;
-        case DROP_HEART_PIECE:
+        case ITEM00_HEART_PIECE:
             sp3C = GI_HEART_PIECE;
             break;
-        case DROP_HEART_CONTAINER:
+        case ITEM00_HEART_CONTAINER:
             sp3C = GI_HEART_CONTAINER;
             break;
-        case DROP_MAGIC_LARGE:
+        case ITEM00_MAGIC_LARGE:
             sp3C = GI_MAGIC_LARGE;
             break;
-        case DROP_MAGIC_SMALL:
+        case ITEM00_MAGIC_SMALL:
             sp3C = GI_MAGIC_SMALL;
             break;
-        case DROP_SHIELD_DEKU:
+        case ITEM00_SHIELD_DEKU:
             sp3C = GI_SHIELD_DEKU;
             break;
-        case DROP_SHIELD_HYLIAN:
+        case ITEM00_SHIELD_HYLIAN:
             sp3C = GI_SHIELD_HYLIAN;
             break;
-        case DROP_TUNIC_ZORA:
+        case ITEM00_TUNIC_ZORA:
             sp3C = GI_TUNIC_ZORA;
             break;
-        case DROP_TUNIC_GORON:
+        case ITEM00_TUNIC_GORON:
             sp3C = GI_TUNIC_GORON;
             break;
-        case DROP_BOMBS_SPECIAL:
+        case ITEM00_BOMBS_SPECIAL:
             break;
     }
 
@@ -643,13 +643,13 @@ void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
     }
 
     switch (this->actor.params) {
-        case DROP_HEART_PIECE:
-        case DROP_HEART_CONTAINER:
-        case DROP_SMALL_KEY:
-        case DROP_SHIELD_DEKU:
-        case DROP_SHIELD_HYLIAN:
-        case DROP_TUNIC_ZORA:
-        case DROP_TUNIC_GORON:
+        case ITEM00_HEART_PIECE:
+        case ITEM00_HEART_CONTAINER:
+        case ITEM00_SMALL_KEY:
+        case ITEM00_SHIELD_DEKU:
+        case ITEM00_SHIELD_HYLIAN:
+        case ITEM00_TUNIC_ZORA:
+        case ITEM00_TUNIC_GORON:
             if (func_8002F410(&this->actor, globalCtx)) {
                 Flags_SetCollectible(globalCtx, this->collectibleFlag);
                 Actor_Kill(&this->actor);
@@ -657,7 +657,7 @@ void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
             return;
     }
 
-    if ((this->actor.params <= DROP_RUPEE_RED) || (this->actor.params == DROP_RUPEE_ORANGE)) {
+    if ((this->actor.params <= ITEM00_RUPEE_RED) || (this->actor.params == ITEM00_RUPEE_ORANGE)) {
         Audio_PlaySoundGeneral(NA_SE_SY_GET_RUPY, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
     } else if (sp3C != 0) {
         if (func_8002F410(&this->actor, globalCtx)) {
@@ -681,38 +681,38 @@ void En_Item00_Update(ActorEnItem00* this, GlobalContext* globalCtx) {
     Actor_SetScale(&this->actor, this->unk_15C);
 
     this->unk_152 = 0;
-    En_Item00_SetNewUpdate(this, (ActorFunc)func_8001E5C8);
+    EnItem00_SetupAction(this, (ActorFunc)func_8001E5C8);
 }
 #else
-#pragma GLOBAL_ASM("asm/non_matchings/code/z_en_item00/En_Item00_Update.s")
+#pragma GLOBAL_ASM("asm/non_matchings/code/z_en_item00/EnItem00_Update.s")
 #endif
 
-// Draw Function prototypes (used in En_Item00_Draw)
-void func_8001EF30(ActorEnItem00* this, GlobalContext* globalCtx);
-void func_8001F080(ActorEnItem00* this, GlobalContext* globalCtx);
-void func_8001F1F4(ActorEnItem00* this, GlobalContext* globalCtx);
-void func_8001F334(ActorEnItem00* this, GlobalContext* globalCtx);
+// Draw Function prototypes (used in EnItem00_Draw)
+void func_8001EF30(EnItem00* this, GlobalContext* globalCtx);
+void func_8001F080(EnItem00* this, GlobalContext* globalCtx);
+void func_8001F1F4(EnItem00* this, GlobalContext* globalCtx);
+void func_8001F334(EnItem00* this, GlobalContext* globalCtx);
 
-void En_Item00_Draw(ActorEnItem00* this, GlobalContext* globalCtx) {
+void EnItem00_Draw(EnItem00* this, GlobalContext* globalCtx) {
     s32 pad;
     f32 unkFloat;
 
     if (!(this->unk_156 & this->unk_158)) {
         switch (this->actor.params) {
-            case DROP_RUPEE_GREEN:
-            case DROP_RUPEE_BLUE:
-            case DROP_RUPEE_RED:
-            case DROP_RUPEE_ORANGE:
-            case DROP_RUPEE_PURPLE:
+            case ITEM00_RUPEE_GREEN:
+            case ITEM00_RUPEE_BLUE:
+            case ITEM00_RUPEE_RED:
+            case ITEM00_RUPEE_ORANGE:
+            case ITEM00_RUPEE_PURPLE:
                 func_8001EF30(this, globalCtx);
                 break;
-            case DROP_HEART_PIECE:
+            case ITEM00_HEART_PIECE:
                 func_8001F334(this, globalCtx);
                 break;
-            case DROP_HEART_CONTAINER:
+            case ITEM00_HEART_CONTAINER:
                 func_8001F1F4(this, globalCtx);
                 break;
-            case DROP_HEART:
+            case ITEM00_HEART:
                 if (this->unk_15A < 0) {
                     if (this->unk_15A == -1) {
                         s8 bankIndex = Object_GetIndex(&globalCtx->objectCtx, OBJECT_GI_HEART);
@@ -728,34 +728,34 @@ void En_Item00_Draw(ActorEnItem00* this, GlobalContext* globalCtx) {
                     }
                     break;
                 }
-            case DROP_BOMBS_A:
-            case DROP_BOMBS_B:
-            case DROP_BOMBS_SPECIAL:
-            case DROP_ARROWS_SINGLE:
-            case DROP_ARROWS_SMALL:
-            case DROP_ARROWS_MEDIUM:
-            case DROP_ARROWS_LARGE:
-            case DROP_NUTS:
-            case DROP_STICK:
-            case DROP_MAGIC_LARGE:
-            case DROP_MAGIC_SMALL:
-            case DROP_SEEDS:
-            case DROP_SMALL_KEY:
+            case ITEM00_BOMBS_A:
+            case ITEM00_BOMBS_B:
+            case ITEM00_BOMBS_SPECIAL:
+            case ITEM00_ARROWS_SINGLE:
+            case ITEM00_ARROWS_SMALL:
+            case ITEM00_ARROWS_MEDIUM:
+            case ITEM00_ARROWS_LARGE:
+            case ITEM00_NUTS:
+            case ITEM00_STICK:
+            case ITEM00_MAGIC_LARGE:
+            case ITEM00_MAGIC_SMALL:
+            case ITEM00_SEEDS:
+            case ITEM00_SMALL_KEY:
                 func_8001F080(this, globalCtx);
                 break;
-            case DROP_SHIELD_DEKU:
+            case ITEM00_SHIELD_DEKU:
                 func_800694A0(globalCtx, 0x1C);
                 break;
-            case DROP_SHIELD_HYLIAN:
+            case ITEM00_SHIELD_HYLIAN:
                 func_800694A0(globalCtx, 0x2B);
                 break;
-            case DROP_TUNIC_ZORA:
+            case ITEM00_TUNIC_ZORA:
                 func_800694A0(globalCtx, 0x3C);
                 break;
-            case DROP_TUNIC_GORON:
+            case ITEM00_TUNIC_GORON:
                 func_800694A0(globalCtx, 0x3B);
                 break;
-            case DROP_FLEXIBLE:
+            case ITEM00_FLEXIBLE:
                 break;
         }
     }
@@ -764,7 +764,7 @@ void En_Item00_Draw(ActorEnItem00* this, GlobalContext* globalCtx) {
 /**
  * Draw Function used for Rupee types of En_Item00.
  */
-void func_8001EF30(ActorEnItem00* this, GlobalContext* globalCtx) {
+void func_8001EF30(EnItem00* this, GlobalContext* globalCtx) {
     GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
     s32 iconNb;
     Gfx* dispRefs[5];
@@ -775,7 +775,7 @@ void func_8001EF30(ActorEnItem00* this, GlobalContext* globalCtx) {
     func_8002EBCC(&this->actor, globalCtx, 0);
 
     if (1) { // Necessary to match
-        if (this->actor.params <= DROP_RUPEE_RED) {
+        if (this->actor.params <= ITEM00_RUPEE_RED) {
             iconNb = this->actor.params;
         } else {
             iconNb = this->actor.params - 0x10;
@@ -795,7 +795,7 @@ void func_8001EF30(ActorEnItem00* this, GlobalContext* globalCtx) {
 /**
  * Draw Function used for most collectible types of En_Item00 (ammo, bombs, sticks, nuts, magic...).
  */
-void func_8001F080(ActorEnItem00* this, GlobalContext* globalCtx) {
+void func_8001F080(EnItem00* this, GlobalContext* globalCtx) {
     s32 iconNb;
     GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
     Gfx* dispRefs[4];
@@ -806,9 +806,9 @@ void func_8001F080(ActorEnItem00* this, GlobalContext* globalCtx) {
 
     gfxCtx->polyOpa.p = func_800BC8A0(globalCtx, gfxCtx->polyOpa.p);
 
-    if (this->actor.params == DROP_BOMBS_SPECIAL) {
+    if (this->actor.params == ITEM00_BOMBS_SPECIAL) {
         iconNb = 1;
-    } else if (this->actor.params >= DROP_ARROWS_SMALL) {
+    } else if (this->actor.params >= ITEM00_ARROWS_SMALL) {
         iconNb -= 3;
     }
 
@@ -826,7 +826,7 @@ void func_8001F080(ActorEnItem00* this, GlobalContext* globalCtx) {
 /**
  * Draw Function used for the Heart Container type of En_Item00.
  */
-void func_8001F1F4(ActorEnItem00* this, GlobalContext* globalCtx) {
+void func_8001F1F4(EnItem00* this, GlobalContext* globalCtx) {
     GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
     Gfx* dispRefs[5];
 
@@ -850,7 +850,7 @@ void func_8001F1F4(ActorEnItem00* this, GlobalContext* globalCtx) {
 /**
  * Draw Function used for the Piece of Heart type of En_Item00.
  */
-void func_8001F334(ActorEnItem00* this, GlobalContext* globalCtx) {
+void func_8001F334(EnItem00* this, GlobalContext* globalCtx) {
     GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
     Gfx* dispRefs[5];
 
@@ -871,29 +871,29 @@ void func_8001F334(ActorEnItem00* this, GlobalContext* globalCtx) {
  */
 s16 func_8001F404(s16 dropId) {
     if (LINK_IS_ADULT) {
-        if (dropId == DROP_SEEDS) {
-            dropId = DROP_ARROWS_SMALL;
-        } else if (dropId == DROP_STICK) {
-            dropId = DROP_RUPEE_GREEN;
+        if (dropId == ITEM00_SEEDS) {
+            dropId = ITEM00_ARROWS_SMALL;
+        } else if (dropId == ITEM00_STICK) {
+            dropId = ITEM00_RUPEE_GREEN;
         }
     } else {
-        if (dropId == DROP_ARROWS_SMALL || dropId == DROP_ARROWS_MEDIUM || dropId == DROP_ARROWS_LARGE) {
-            dropId = DROP_SEEDS;
+        if (dropId == ITEM00_ARROWS_SMALL || dropId == ITEM00_ARROWS_MEDIUM || dropId == ITEM00_ARROWS_LARGE) {
+            dropId = ITEM00_SEEDS;
         }
     }
 
     // This is convoluted but it seems like it must be a single condition to match
     // clang-format off
-    if (((dropId == DROP_BOMBS_A      || dropId == DROP_BOMBS_SPECIAL || dropId == DROP_BOMBS_B)      && INV_CONTENT(ITEM_BOMB) == ITEM_NONE) ||
-        ((dropId == DROP_ARROWS_SMALL || dropId == DROP_ARROWS_MEDIUM || dropId == DROP_ARROWS_LARGE) && INV_CONTENT(ITEM_BOW) == ITEM_NONE) ||
-        ((dropId == DROP_MAGIC_LARGE  || dropId == DROP_MAGIC_SMALL)                                  && gSaveContext.magicLevel == 0) ||
-        ((dropId == DROP_SEEDS)                                                                       && INV_CONTENT(ITEM_SLINGSHOT) == ITEM_NONE)) {
+    if (((dropId == ITEM00_BOMBS_A      || dropId == ITEM00_BOMBS_SPECIAL || dropId == ITEM00_BOMBS_B)      && INV_CONTENT(ITEM_BOMB) == ITEM_NONE) ||
+        ((dropId == ITEM00_ARROWS_SMALL || dropId == ITEM00_ARROWS_MEDIUM || dropId == ITEM00_ARROWS_LARGE) && INV_CONTENT(ITEM_BOW) == ITEM_NONE) ||
+        ((dropId == ITEM00_MAGIC_LARGE  || dropId == ITEM00_MAGIC_SMALL)                                    && gSaveContext.magicLevel == 0) ||
+        ((dropId == ITEM00_SEEDS)                                                                           && INV_CONTENT(ITEM_SLINGSHOT) == ITEM_NONE)) {
         return -1;
     }
     // clang-format on
 
-    if (dropId == DROP_HEART && gSaveContext.healthCapacity == gSaveContext.health) {
-        return DROP_RUPEE_GREEN;
+    if (dropId == ITEM00_HEART && gSaveContext.healthCapacity == gSaveContext.health) {
+        return ITEM00_RUPEE_GREEN;
     }
 
     return dropId;
@@ -903,17 +903,17 @@ s16 func_8001F404(s16 dropId) {
 
 Actor* Item_DropCollectible(GlobalContext* globalCtx, Vec3f* spawnPos, s16 params) {
     s32 pad[2];
-    ActorEnItem00* spawnedActor = NULL;
+    EnItem00* spawnedActor = NULL;
     s16 param4000 = params & 0x4000;
     s16 param8000 = params & 0x8000;
     s16 param3F00 = params & 0x3F00;
 
     params = params & 0x3FFF;
 
-    if (((params & 0x00FF) == DROP_FLEXIBLE) && !param4000) {
-        // TODO: Prevent the cast to ActorEnItem00 here since this is a different actor (En_Elf)
-        spawnedActor = (ActorEnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ELF, spawnPos->x,
-                                                   spawnPos->y + 40.0f, spawnPos->z, 0, 0, 0, 0x0002);
+    if (((params & 0x00FF) == ITEM00_FLEXIBLE) && !param4000) {
+        // TODO: Prevent the cast to EnItem00 here since this is a different actor (En_Elf)
+        spawnedActor = (EnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ELF, spawnPos->x,
+                                              spawnPos->y + 40.0f, spawnPos->z, 0, 0, 0, 0x0002);
         func_8002A9F4(globalCtx, spawnPos, 0x28E7, 1, 1, 0x28);
     } else {
         if (!param8000) {
@@ -921,20 +921,19 @@ Actor* Item_DropCollectible(GlobalContext* globalCtx, Vec3f* spawnPos, s16 param
         }
 
         if (params != -1) {
-            spawnedActor =
-                (ActorEnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ITEM00, spawnPos->x, spawnPos->y,
-                                            spawnPos->z, 0, 0, 0, params | param8000 | param3F00);
+            spawnedActor = (EnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ITEM00, spawnPos->x,
+                                                  spawnPos->y, spawnPos->z, 0, 0, 0, params | param8000 | param3F00);
             if ((spawnedActor != NULL) && !param8000) {
                 spawnedActor->actor.velocity.y = !param4000 ? 8.0f : -2.0f;
                 spawnedActor->actor.speedXZ = 2.0f;
                 spawnedActor->actor.gravity = -0.9f;
                 spawnedActor->actor.posRot.rot.y = Math_Rand_CenteredFloat(65536.0f);
                 Actor_SetScale(&spawnedActor->actor, 0.0f);
-                En_Item00_SetNewUpdate(spawnedActor, (ActorFunc)func_8001E304);
+                EnItem00_SetupAction(spawnedActor, (ActorFunc)func_8001E304);
                 spawnedActor->unk_15A = 220;
-                if ((spawnedActor->actor.params != DROP_SMALL_KEY) &&
-                    (spawnedActor->actor.params != DROP_HEART_PIECE) &&
-                    (spawnedActor->actor.params != DROP_HEART_CONTAINER)) {
+                if ((spawnedActor->actor.params != ITEM00_SMALL_KEY) &&
+                    (spawnedActor->actor.params != ITEM00_HEART_PIECE) &&
+                    (spawnedActor->actor.params != ITEM00_HEART_CONTAINER)) {
                     spawnedActor->actor.room = -1;
                 }
                 spawnedActor->actor.flags |= 0x0010;
@@ -946,7 +945,7 @@ Actor* Item_DropCollectible(GlobalContext* globalCtx, Vec3f* spawnPos, s16 param
 }
 
 Actor* Item_DropCollectible2(GlobalContext* globalCtx, Vec3f* spawnPos, s16 params) {
-    ActorEnItem00* spawnedActor = NULL;
+    EnItem00* spawnedActor = NULL;
     s32 pad;
     s16 param4000 = params & 0x4000;
     s16 param8000 = params & 0x8000;
@@ -954,17 +953,16 @@ Actor* Item_DropCollectible2(GlobalContext* globalCtx, Vec3f* spawnPos, s16 para
 
     params = params & 0x3FFF;
 
-    if (((params & 0x00FF) == DROP_FLEXIBLE) && !param4000) {
-        // TODO: Prevent the cast to ActorEnItem00 here since this is a different actor (En_Elf)
-        spawnedActor = (ActorEnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ELF, spawnPos->x,
-                                                   spawnPos->y + 40.0f, spawnPos->z, 0, 0, 0, 0x0002);
+    if (((params & 0x00FF) == ITEM00_FLEXIBLE) && !param4000) {
+        // TODO: Prevent the cast to EnItem00 here since this is a different actor (En_Elf)
+        spawnedActor = (EnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ELF, spawnPos->x,
+                                              spawnPos->y + 40.0f, spawnPos->z, 0, 0, 0, 0x0002);
         func_8002A9F4(globalCtx, spawnPos, 0x28E7, 1, 1, 0x28);
     } else {
         params = func_8001F404(params & 0x00FF);
         if (params != -1) {
-            spawnedActor =
-                (ActorEnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ITEM00, spawnPos->x, spawnPos->y,
-                                            spawnPos->z, 0, 0, 0, params | param8000 | param3F00);
+            spawnedActor = (EnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ITEM00, spawnPos->x,
+                                                  spawnPos->y, spawnPos->z, 0, 0, 0, params | param8000 | param3F00);
             if ((spawnedActor != NULL) && !param8000) {
                 spawnedActor->actor.velocity.y = 0.0f;
                 spawnedActor->actor.speedXZ = 0.0f;
@@ -980,7 +978,7 @@ Actor* Item_DropCollectible2(GlobalContext* globalCtx, Vec3f* spawnPos, s16 para
 
 void Item_DropCollectibleRandom(GlobalContext* globalCtx, Actor* fromActor, Vec3f* spawnPos, s16 params) {
     s32 pad;
-    ActorEnItem00* spawnedActor;
+    EnItem00* spawnedActor;
     s16 dropQuantity;
     s16 param8000;
     s16 dropTableIndex;
@@ -1016,7 +1014,7 @@ void Item_DropCollectibleRandom(GlobalContext* globalCtx, Actor* fromActor, Vec3
             }
         }
         if (fromActor->unk_116 & 0x20) {
-            dropId = DROP_RUPEE_PURPLE;
+            dropId = ITEM00_RUPEE_PURPLE;
         } else {
             dropId = D_80115574[params + dropTableIndex];
         }
@@ -1024,7 +1022,7 @@ void Item_DropCollectibleRandom(GlobalContext* globalCtx, Actor* fromActor, Vec3
         dropId = D_80115574[params + dropTableIndex];
     }
 
-    if (dropId == DROP_FLEXIBLE) {
+    if (dropId == ITEM00_FLEXIBLE) {
         if (gSaveContext.health <= 0x10) { // 1 heart or less
             Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ELF, spawnPos->x, spawnPos->y + 40.0f, spawnPos->z, 0,
                         0, 0, 0x0002);
@@ -1033,36 +1031,36 @@ void Item_DropCollectibleRandom(GlobalContext* globalCtx, Actor* fromActor, Vec3
         } else if (gSaveContext.health <= 0x30) { // 3 hearts or less
             params = 0xB * 0x10;
             dropTableIndex = 0x0;
-            dropId = DROP_HEART;
+            dropId = ITEM00_HEART;
         } else if (gSaveContext.health <= 0x50) { // 5 hearts or less
             params = 0xA * 0x10;
             dropTableIndex = 0x0;
-            dropId = DROP_HEART;
+            dropId = ITEM00_HEART;
         } else if ((gSaveContext.magicLevel != 0) && (gSaveContext.magic == 0)) { // Empty magic meter
             params = 0xA * 0x10;
             dropTableIndex = 0x0;
-            dropId = DROP_MAGIC_LARGE;
+            dropId = ITEM00_MAGIC_LARGE;
         } else if ((gSaveContext.magicLevel != 0) &&
                    (gSaveContext.magic <= (gSaveContext.magicLevel >> 1))) { // Half magic or less
             params = 0xA * 0x10;
             dropTableIndex = 0x0;
-            dropId = DROP_MAGIC_SMALL;
+            dropId = ITEM00_MAGIC_SMALL;
         } else if (LINK_IS_CHILD && (AMMO(ITEM_SLINGSHOT) < 6)) { // Child and less then 6 deku seeds
             params = 0xA * 0x10;
             dropTableIndex = 0x0;
-            dropId = DROP_SEEDS;
+            dropId = ITEM00_SEEDS;
         } else if (LINK_IS_ADULT && (AMMO(ITEM_BOW) < 6)) { // Adult and less than 6 arrows
             params = 0xA * 0x10;
             dropTableIndex = 0x0;
-            dropId = DROP_ARROWS_MEDIUM;
+            dropId = ITEM00_ARROWS_MEDIUM;
         } else if (AMMO(ITEM_BOMB) < 6) { // Less than 6 bombs
             params = 0xD * 0x10;
             dropTableIndex = 0x0;
-            dropId = DROP_BOMBS_A;
+            dropId = ITEM00_BOMBS_A;
         } else if (gSaveContext.rupees < 11) { // Less than 11 Rupees
             params = 0xA * 0x10;
             dropTableIndex = 0x0;
-            dropId = DROP_RUPEE_RED;
+            dropId = ITEM00_RUPEE_RED;
         } else {
             return;
         }
@@ -1074,19 +1072,19 @@ void Item_DropCollectibleRandom(GlobalContext* globalCtx, Actor* fromActor, Vec3
             if (!param8000) {
                 dropId = func_8001F404(dropId);
                 if (dropId != 0xFF) {
-                    spawnedActor = (ActorEnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ITEM00,
-                                                               spawnPos->x, spawnPos->y, spawnPos->z, 0, 0, 0, dropId);
+                    spawnedActor = (EnItem00*)Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_ITEM00, spawnPos->x,
+                                                          spawnPos->y, spawnPos->z, 0, 0, 0, dropId);
                     if ((spawnedActor != NULL) && (dropId != 0xFF)) {
                         spawnedActor->actor.velocity.y = 8.0f;
                         spawnedActor->actor.speedXZ = 2.0f;
                         spawnedActor->actor.gravity = -0.9f;
                         spawnedActor->actor.posRot.rot.y = Math_Rand_ZeroOne() * 40000.0f;
                         Actor_SetScale(&spawnedActor->actor, 0.0f);
-                        En_Item00_SetNewUpdate(spawnedActor, (ActorFunc)func_8001E304);
+                        EnItem00_SetupAction(spawnedActor, (ActorFunc)func_8001E304);
                         spawnedActor->actor.flags |= 0x0010;
-                        if ((spawnedActor->actor.params != DROP_SMALL_KEY) &&
-                            (spawnedActor->actor.params != DROP_HEART_PIECE) &&
-                            (spawnedActor->actor.params != DROP_HEART_CONTAINER)) {
+                        if ((spawnedActor->actor.params != ITEM00_SMALL_KEY) &&
+                            (spawnedActor->actor.params != ITEM00_HEART_PIECE) &&
+                            (spawnedActor->actor.params != ITEM00_HEART_CONTAINER)) {
                             spawnedActor->actor.room = -1;
                         }
                         spawnedActor->unk_15A = 220;

--- a/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
+++ b/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
@@ -6,7 +6,7 @@
 
 #include "z_arrow_fire.h"
 
-#include "../ovl_En_Arrow/z_en_arrow.h"
+#include "overlays/actors/ovl_En_Arrow/z_en_arrow.h"
 
 #define FLAGS 0x02000010
 

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
@@ -6,7 +6,7 @@
 
 #include "z_arrow_ice.h"
 
-#include "../ovl_En_Arrow/z_en_arrow.h"
+#include "overlays/actors/ovl_En_Arrow/z_en_arrow.h"
 
 #define FLAGS 0x02000010
 

--- a/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
+++ b/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
@@ -6,7 +6,7 @@
 
 #include "z_arrow_light.h"
 
-#include "../ovl_En_Arrow/z_en_arrow.h"
+#include "overlays/actors/ovl_En_Arrow/z_en_arrow.h"
 
 #define FLAGS 0x02000010
 

--- a/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.c
@@ -223,7 +223,7 @@ void func_8086D548(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D5C4(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086D5E0;
+    this->actionFunc = &func_8086D5E0;
     this->unk_1C8 = 1.0f;
 }
 
@@ -244,7 +244,7 @@ void func_8086D5E0(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D67C(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086D694;
+    this->actionFunc = &func_8086D694;
     this->unk_1DA = 0x64;
 }
 
@@ -261,7 +261,7 @@ void func_8086D694(BgBdanSwitch* this, GlobalContext* globalCtx) {
 
 void func_8086D730(BgBdanSwitch* this) {
     this->unk_1C8 = 0.1f;
-    this->updateFunc = &func_8086D754;
+    this->actionFunc = &func_8086D754;
     this->unk_1D8 = 6;
 }
 
@@ -285,7 +285,7 @@ void func_8086D754(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D7FC(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086D80C;
+    this->actionFunc = &func_8086D80C;
 }
 
 void func_8086D80C(BgBdanSwitch* this, GlobalContext* globalCtx) {
@@ -297,7 +297,7 @@ void func_8086D80C(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D86C(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086D888;
+    this->actionFunc = &func_8086D888;
     this->unk_1C8 = 1.0f;
 }
 
@@ -308,7 +308,7 @@ void func_8086D888(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D8BC(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086D8CC;
+    this->actionFunc = &func_8086D8CC;
 }
 
 void func_8086D8CC(BgBdanSwitch* this, GlobalContext* globalCtx) {
@@ -321,7 +321,7 @@ void func_8086D8CC(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D944(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086D95C;
+    this->actionFunc = &func_8086D95C;
     this->unk_1DA = 0x64;
 }
 
@@ -338,7 +338,7 @@ void func_8086D95C(BgBdanSwitch* this, GlobalContext* globalCtx) {
 
 void func_8086D9F8(BgBdanSwitch* this) {
     this->unk_1C8 = 0.6f;
-    this->updateFunc = &func_8086DA1C;
+    this->actionFunc = &func_8086DA1C;
     this->unk_1D8 = 6;
 }
 
@@ -362,7 +362,7 @@ void func_8086DA1C(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DAB4(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086DAC4;
+    this->actionFunc = &func_8086DAC4;
 }
 
 void func_8086DAC4(BgBdanSwitch* this, GlobalContext* globalCtx) {
@@ -375,14 +375,14 @@ void func_8086DAC4(BgBdanSwitch* this, GlobalContext* globalCtx) {
 
 void func_8086DB24(BgBdanSwitch* this) {
     this->unk_1C8 = 0.1f;
-    this->updateFunc = &func_8086DB40;
+    this->actionFunc = &func_8086DB40;
 }
 
 void func_8086DB40(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DB4C(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086DB68;
+    this->actionFunc = &func_8086DB68;
     this->unk_1C8 = 2.0f;
 }
 
@@ -407,7 +407,7 @@ void func_8086DB68(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DC30(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086DC48;
+    this->actionFunc = &func_8086DC48;
     this->unk_1DA = 0x64;
 }
 
@@ -422,7 +422,7 @@ void func_8086DC48(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DCCC(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086DCE8;
+    this->actionFunc = &func_8086DCE8;
     this->unk_1C8 = 1.0f;
 }
 
@@ -443,7 +443,7 @@ void func_8086DCE8(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DDA8(BgBdanSwitch* this) {
-    this->updateFunc = &func_8086DDC0;
+    this->actionFunc = &func_8086DDC0;
     this->unk_1DA = 0x64;
 }
 
@@ -466,7 +466,7 @@ void BgBdanSwitch_Update(BgBdanSwitch* this, GlobalContext* globalCtx) {
     if (this->unk_1DA > 0) {
         this->unk_1DA -= 1;
     }
-    this->updateFunc(this, globalCtx);
+    this->actionFunc(this, globalCtx);
     func_8086D0EC(this);
     type = this->actor.params & 0xFF;
     if (type != 3 && type != 4) {

--- a/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.h
+++ b/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.h
@@ -21,7 +21,7 @@ typedef struct {
     /* 0x0158 */ u32 unk_158;
     /* 0x015C */ u32 unk_15C;
     /* 0x0160 */ u8 unk_160;
-    /* 0x0164 */ ActorFunc updateFunc;
+    /* 0x0164 */ ActorFunc actionFunc;
     /* 0x0168 */ ColliderJntSph collider;
     /* 0x0188 */ ColliderJntSphItem colliderItems[1];
     /* 0x01C8 */ f32 unk_1C8;

--- a/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.c
+++ b/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.c
@@ -6,7 +6,7 @@
 
 #include "z_bg_bom_guard.h"
 
-#include "../ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h"
+#include "overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h"
 
 #include <vt.h>
 

--- a/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.c
+++ b/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.c
@@ -92,7 +92,7 @@ void BgGjyoBridge_SpawnBridge(BgGjyoBridge* this, GlobalContext* globalCtx) {
 }
 
 void BgGjyoBridge_Update(BgGjyoBridge* this, GlobalContext* globalCtx) {
-    this->actionFunc(&this->dyna.actor, globalCtx);
+    this->actionFunc(this, globalCtx);
 }
 
 void BgGjyoBridge_Draw(BgGjyoBridge* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.c
@@ -43,7 +43,7 @@ void BgHidanSyoku_Init(BgHidanSyoku* this, GlobalContext* globalCtx) {
     DynaPolyInfo_SetActorMove(&this->dyna.actor, 1);
     DynaPolyInfo_Alloc(&D_0600E568, &local_c);
     this->dyna.dynaPolyId = DynaPolyInfo_RegisterActor(globalCtx, &globalCtx->colCtx.dyna, &this->dyna.actor, local_c);
-    this->updateFunc = func_8088F4B8;
+    this->actionFunc = func_8088F4B8;
     this->dyna.actor.initPosRot.pos.y += 540.0f;
 }
 
@@ -54,13 +54,13 @@ void BgHidanSyoku_Destroy(BgHidanSyoku* this, GlobalContext* globalCtx) {
 void func_8088F47C(BgHidanSyoku* this) {
     this->unk_16A = 0x3C;
     Audio_PlayActorSound2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
-    this->updateFunc = func_8088F62C;
+    this->actionFunc = func_8088F62C;
 }
 
 void func_8088F4B8(BgHidanSyoku* this, GlobalContext* globalCtx) {
     if (Flags_GetClear(globalCtx, this->dyna.actor.room) && func_8004356C(&this->dyna.actor)) {
         this->unk_16A = 0x8C;
-        this->updateFunc = func_8088F514;
+        this->actionFunc = func_8088F514;
     }
 }
 
@@ -95,15 +95,15 @@ void func_8088F62C(BgHidanSyoku* this, GlobalContext* globalCtx) {
     if (this->unk_16A == 0) {
         this->unk_16A = 0x8c;
         if (this->dyna.actor.posRot.pos.y < this->dyna.actor.initPosRot.pos.y) {
-            this->updateFunc = func_8088F514;
+            this->actionFunc = func_8088F514;
         } else {
-            this->updateFunc = func_8088F5A0;
+            this->actionFunc = func_8088F5A0;
         }
     }
 }
 
 void BgHidanSyoku_Update(BgHidanSyoku* this, GlobalContext* globalCtx) {
-    this->updateFunc(this, globalCtx);
+    this->actionFunc(this, globalCtx);
     if (func_8004356C(&this->dyna.actor)) {
         if (this->unk_168 == 0) {
             this->unk_168 = 3;

--- a/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.h
@@ -6,7 +6,7 @@
 
 typedef struct {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc updateFunc;
+    /* 0x0164 */ ActorFunc actionFunc;
     /* 0x0168 */ s16 unk_168;
     /* 0x016A */ s16 unk_16A;
 } BgHidanSyoku; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.c
@@ -69,7 +69,7 @@ void BgJyaAmishutter_Destroy(BgJyaAmishutter* this, GlobalContext* globalCtx) {
 }
 
 void func_808933BC(BgJyaAmishutter* this) {
-    this->updateFunc = func_808933CC;
+    this->actionFunc = func_808933CC;
 }
 
 void func_808933CC(BgJyaAmishutter* this) {
@@ -81,7 +81,7 @@ void func_808933CC(BgJyaAmishutter* this) {
 }
 
 void func_80893428(BgJyaAmishutter* this) {
-    this->updateFunc = func_80893438;
+    this->actionFunc = func_80893438;
 }
 
 void func_80893438(BgJyaAmishutter* this) {
@@ -94,7 +94,7 @@ void func_80893438(BgJyaAmishutter* this) {
 }
 
 void func_808934B0(BgJyaAmishutter* this) {
-    this->updateFunc = func_808934C0;
+    this->actionFunc = func_808934C0;
 }
 
 void func_808934C0(BgJyaAmishutter* this) {
@@ -104,7 +104,7 @@ void func_808934C0(BgJyaAmishutter* this) {
 }
 
 void func_808934FC(BgJyaAmishutter* this) {
-    this->updateFunc = func_8089350C;
+    this->actionFunc = func_8089350C;
 }
 
 void func_8089350C(BgJyaAmishutter* this) {
@@ -117,7 +117,7 @@ void func_8089350C(BgJyaAmishutter* this) {
 }
 
 void BgJyaAmishutter_Update(BgJyaAmishutter* this, GlobalContext* globalCtx) {
-    this->updateFunc(this);
+    this->actionFunc(this);
 }
 
 void BgJyaAmishutter_Draw(BgJyaAmishutter* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.h
@@ -8,7 +8,7 @@ typedef struct {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x0150 */ char unk_150[0x14];
-    /* 0x0164 */ void (*updateFunc)(Actor*);
+    /* 0x0164 */ void (*actionFunc)(Actor*);
 } BgJyaAmishutter; // size = 0x0168
 
 extern const ActorInit Bg_Jya_Amishutter_InitVars;

--- a/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.c
@@ -71,7 +71,7 @@ void BgJyaKanaami_Destroy(BgJyaKanaami* this, GlobalContext* globalCtx) {
 }
 
 void func_80899880(BgJyaKanaami* this) {
-    this->updateFunc = func_80899894;
+    this->actionFunc = func_80899894;
     this->unk_16A = 0;
 }
 
@@ -88,7 +88,7 @@ void func_80899894(BgJyaKanaami* this, GlobalContext* globalCtx) {
 }
 
 void func_8089993C(BgJyaKanaami* this) {
-    this->updateFunc = func_80899950;
+    this->actionFunc = func_80899950;
     this->unk_168 = 0;
 }
 
@@ -107,13 +107,13 @@ void func_80899950(BgJyaKanaami* this, GlobalContext* globalCtx) {
 }
 
 void func_80899A08(BgJyaKanaami* this) {
-    this->updateFunc = 0;
+    this->actionFunc = 0;
     this->actor.posRot.rot.x = 0x4000;
 }
 
 void BgJyaKanaami_Update(BgJyaKanaami* this, GlobalContext* globalCtx) {
-    if (this->updateFunc) {
-        this->updateFunc(this, globalCtx);
+    if (this->actionFunc != NULL) {
+        this->actionFunc(this, globalCtx);
     }
     this->actor.shape.rot.x = this->actor.posRot.rot.x;
 }

--- a/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.h
@@ -8,7 +8,7 @@ typedef struct {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x014C */ char unk_150[0x14];
-    /* 0x0164 */ ActorFunc updateFunc;
+    /* 0x0164 */ ActorFunc actionFunc;
     /* 0x0168 */ s16 unk_168;
     /* 0x016A */ s16 unk_16A;
 } BgJyaKanaami; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -269,7 +269,7 @@ void func_808BB128(BgTokiSwd* this, GlobalContext* globalCtx) {
 }
 
 void BgTokiSwd_Update(BgTokiSwd* this, GlobalContext* globalCtx) {
-    this->actionFunc(&this->actor, globalCtx);
+    this->actionFunc(this, globalCtx);
     CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this->collider);
 }
 

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.h
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.h
@@ -6,7 +6,9 @@
 
 typedef struct {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ char unk_14C[0x5D0];
+    /* 0x014C */ char unk_14C[0x5CC];
+    /* 0x0718 */ s16 organFadeTimer;
+    /* 0x071A */ char unk_71A[0x2];
 } BossGanon; // size = 0x071C
 
 extern const ActorInit Boss_Ganon_InitVars;

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.c
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.c
@@ -4,28 +4,7 @@
  * Description: A brown bird. Tweet tweet.
  */
 
-#include <ultra64.h>
-#include <global.h>
-
-typedef struct {
-    /* 0x0000 */ Actor actor;
-    /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ ActorFunc updateFunc;
-    /* 0x0194 */ u32 unk_194;
-    /* 0x0198 */ s32 unk_198;
-    /* 0x019C */ s16 unk_19C;
-    /* 0x019E */ char unk_19E[0x2];
-    /* 0x01A0 */ f32 unk_1A0;
-    /* 0x01A4 */ f32 unk_1A4;
-    /* 0x01A8 */ f32 unk_1A8;
-    /* 0x01AC */ f32 unk_1AC;
-    /* 0x01B0 */ f32 unk_1B0;
-    /* 0x01B4 */ f32 unk_1B4;
-    /* 0x01B8 */ f32 unk_1B8;
-    /* 0x01BC */ f32 unk_1BC;
-    /* 0x01C0 */ s16 unk_1C0;
-    /* 0x01C2 */ char unk_1C2[0x1A];
-} EnBird; // size = 0x01C4
+#include "z_en_bird.h"
 
 #define FLAGS 0x00000000
 

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.c
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.c
@@ -14,7 +14,7 @@ void EnBird_Update(EnBird* this, GlobalContext* globalCtx);
 void EnBird_Draw(EnBird* this, GlobalContext* globalCtx);
 void func_809C1E00(EnBird* this, s16 params);
 void func_809C1E40(EnBird* this, GlobalContext* globalCtx);
-void EnBird_SetNewUpdate(EnBird* this, ActorFunc updateFunc);
+void EnBird_SetupAction(EnBird* this, ActorFunc actionFunc);
 void func_809C1D60(EnBird* this, GlobalContext* globalCtx);
 void func_809C1CAC(EnBird* this, s16 params);
 
@@ -37,8 +37,8 @@ static InitChainEntry initChain[] = {
 extern AnimationHeader D_0600006C;
 extern SkeletonHeader D_06002190;
 
-void EnBird_SetNewUpdate(EnBird* this, ActorFunc newUpdateFunc) {
-    this->updateFunc = newUpdateFunc;
+void EnBird_SetupAction(EnBird* this, ActorFunc actionFunc) {
+    this->actionFunc = actionFunc;
 }
 
 void EnBird_Init(EnBird* this, GlobalContext* globalCtx) {
@@ -70,7 +70,7 @@ void func_809C1CAC(EnBird* this, s16 params) {
 
     this->unk_198 = Math_Rand_S16Offset(5, 0x23);
     SkelAnime_ChangeAnim(&this->skelAnime, anim, playbackSpeed, 0.0f, frameCount, 0, 0.0f);
-    EnBird_SetNewUpdate(this, func_809C1D60);
+    EnBird_SetupAction(this, func_809C1D60);
 }
 
 void func_809C1D60(EnBird* this, GlobalContext* globalCtx) {
@@ -93,7 +93,7 @@ void func_809C1D60(EnBird* this, GlobalContext* globalCtx) {
 
 void func_809C1E00(EnBird* this, s16 params) {
     this->unk_198 = Math_Rand_S16Offset(0x14, 0x2D);
-    EnBird_SetNewUpdate(this, (ActorFunc)func_809C1E40);
+    EnBird_SetupAction(this, (ActorFunc)func_809C1E40);
 }
 
 void func_809C1E40(EnBird* this, GlobalContext* globalCtx) {
@@ -119,7 +119,7 @@ void func_809C1E40(EnBird* this, GlobalContext* globalCtx) {
 
 void EnBird_Update(EnBird* this, GlobalContext* globalCtx) {
     this->unk_1B4 += this->unk_1B8;
-    this->updateFunc(this, globalCtx);
+    this->actionFunc(this, globalCtx);
 }
 
 void EnBird_Draw(EnBird* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.h
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.h
@@ -7,7 +7,7 @@
 typedef struct {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ ActorFunc updateFunc;
+    /* 0x0190 */ ActorFunc actionFunc;
     /* 0x0194 */ u32 unk_194;
     /* 0x0198 */ s32 unk_198;
     /* 0x019C */ s16 unk_19C;

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.h
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.h
@@ -1,0 +1,29 @@
+#ifndef _Z_EN_BIRD_H_
+#define _Z_EN_BIRD_H_
+
+#include <ultra64.h>
+#include <global.h>
+
+typedef struct {
+    /* 0x0000 */ Actor actor;
+    /* 0x014C */ SkelAnime skelAnime;
+    /* 0x0190 */ ActorFunc updateFunc;
+    /* 0x0194 */ u32 unk_194;
+    /* 0x0198 */ s32 unk_198;
+    /* 0x019C */ s16 unk_19C;
+    /* 0x019E */ char unk_19E[0x2];
+    /* 0x01A0 */ f32 unk_1A0;
+    /* 0x01A4 */ f32 unk_1A4;
+    /* 0x01A8 */ f32 unk_1A8;
+    /* 0x01AC */ f32 unk_1AC;
+    /* 0x01B0 */ f32 unk_1B0;
+    /* 0x01B4 */ f32 unk_1B4;
+    /* 0x01B8 */ f32 unk_1B8;
+    /* 0x01BC */ f32 unk_1BC;
+    /* 0x01C0 */ s16 unk_1C0;
+    /* 0x01C2 */ char unk_1C2[0x1A];
+} EnBird; // size = 0x01DC
+
+extern const ActorInit En_Bird_InitVars;
+
+#endif

--- a/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.c
+++ b/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.c
@@ -6,6 +6,8 @@
 
 #include "z_en_ganon_organ.h"
 
+#include "overlays/actors/ovl_Boss_Ganon/z_boss_ganon.h"
+
 #define FLAGS 0x00000030
 
 void EnGanonOrgan_Init(EnGanonOrgan* this, GlobalContext* globalCtx);
@@ -24,14 +26,6 @@ const ActorInit En_Ganon_Organ_InitVars = {
     (ActorFunc)EnGanonOrgan_Update,
     (ActorFunc)EnGanonOrgan_Draw,
 };
-
-// temp local struct to represent ganondorf, remove when we can reference other overlays
-typedef struct {
-    /* 0x0000 */ Actor actor;
-    /* 0x014C */ char unk_14C[0x5CC];
-    /* 0x0718 */ s16 organFadeTimer;
-    /* 0x071A */ char unk_71A[0x2];
-} BossGanon; // size = 0x071C
 
 extern D_80A2CCA8; // remove when data is decompiled
 extern D_80A2EAB0; // remove when data is decompiled

--- a/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.c
+++ b/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.c
@@ -4,13 +4,7 @@
  * Description: The organ that Ganondorf plays in the cutscene before the fight. Includes carpet and scenery as well.
  */
 
-#include <ultra64.h>
-#include <global.h>
-
-typedef struct {
-    /* 0x0000 */ Actor actor;
-    /* 0x014C */ char unk_14C[0x4];
-} EnGanonOrgan; // size = 0x0150
+#include "z_en_ganon_organ.h"
 
 #define FLAGS 0x00000030
 

--- a/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.h
+++ b/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.h
@@ -1,0 +1,14 @@
+#ifndef _Z_EN_GANON_ORGAN_H_
+#define _Z_EN_GANON_ORGAN_H_
+
+#include <ultra64.h>
+#include <global.h>
+
+typedef struct {
+    /* 0x0000 */ Actor actor;
+    /* 0x014C */ char unk_14C[0x4];
+} EnGanonOrgan; // size = 0x0150
+
+extern const ActorInit En_Ganon_Organ_InitVars;
+
+#endif

--- a/src/overlays/actors/ovl_En_It/z_en_it.c
+++ b/src/overlays/actors/ovl_En_It/z_en_it.c
@@ -38,21 +38,21 @@ void EnIt_Init(EnIt* this, GlobalContext* globalCtx) {
     EnIt* it = this;
 
     it->actor.params = 0x0D05;
-    Collider_InitCylinder(globalCtx, &it->cylinderCollider);
-    Collider_SetCylinder(globalCtx, &it->cylinderCollider, &it->actor, &cylinderInitData);
+    Collider_InitCylinder(globalCtx, &it->collider);
+    Collider_SetCylinder(globalCtx, &it->collider, &it->actor, &cylinderInitData);
     func_80061EFC(&it->actor.colChkInfo, 0, &colChkInfoInit); // Init Damage Chart
 }
 
 void EnIt_Destroy(EnIt* this, GlobalContext* globalCtx) {
     EnIt* it = this;
 
-    Collider_DestroyCylinder(globalCtx, &it->cylinderCollider);
+    Collider_DestroyCylinder(globalCtx, &it->collider);
 }
 
 void EnIt_Update(EnIt* this, GlobalContext* globalCtx) {
     s32 pad;
     EnIt* it = this;
 
-    Collider_CylinderUpdate(&it->actor, &it->cylinderCollider);
-    CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &it->cylinderCollider);
+    Collider_CylinderUpdate(&it->actor, &it->collider);
+    CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &it->collider);
 }

--- a/src/overlays/actors/ovl_En_It/z_en_it.h
+++ b/src/overlays/actors/ovl_En_It/z_en_it.h
@@ -7,7 +7,7 @@
 typedef struct {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 unk_14C;
-    /* 0x0150 */ ColliderCylinder cylinderCollider;
+    /* 0x0150 */ ColliderCylinder collider;
 } EnIt; // size = 0x019C
 
 extern const ActorInit En_It_InitVars;

--- a/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.c
+++ b/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.c
@@ -40,23 +40,23 @@ void EnMFire1_Init(EnMFire1* this, GlobalContext* globalCtx) {
         Actor_ChangeType(globalCtx, &globalCtx->actorCtx, &thisLocal->actor, ACTORTYPE_ITEMACTION);
     }
 
-    Collider_InitCylinder(globalCtx, &thisLocal->capsule);
-    Collider_SetCylinder(globalCtx, &thisLocal->capsule, &thisLocal->actor, &cylinderInitData);
+    Collider_InitCylinder(globalCtx, &thisLocal->collider);
+    Collider_SetCylinder(globalCtx, &thisLocal->collider, &thisLocal->actor, &cylinderInitData);
 }
 
 void EnMFire1_Destroy(EnMFire1* this, GlobalContext* globalCtx) {
-    ColliderCylinder* capsule = &this->capsule;
-    Collider_DestroyCylinder(globalCtx, capsule);
+    ColliderCylinder* collider = &this->collider;
+    Collider_DestroyCylinder(globalCtx, collider);
 }
 
 void EnMFire1_Update(EnMFire1* this, GlobalContext* globalCtx) {
     s32 pad;
     EnMFire1* thisLocal = this;
 
-    if (Math_ApproxF(&thisLocal->unk_0198, 1.0, 0.2)) {
+    if (Math_ApproxF(&thisLocal->unk_198, 1.0f, 0.2f)) {
         Actor_Kill(&this->actor);
     } else {
-        Collider_CylinderUpdate(&thisLocal->actor, &thisLocal->capsule);
-        CollisionCheck_SetAT(globalCtx, &globalCtx->colChkCtx, &thisLocal->capsule);
+        Collider_CylinderUpdate(&thisLocal->actor, &thisLocal->collider);
+        CollisionCheck_SetAT(globalCtx, &globalCtx->colChkCtx, &thisLocal->collider);
     }
 }

--- a/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.h
+++ b/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.h
@@ -6,8 +6,8 @@
 
 typedef struct {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ColliderCylinder capsule;
-    /* 0x0198 */ f32 unk_0198;
+    /* 0x014C */ ColliderCylinder collider;
+    /* 0x0198 */ f32 unk_198;
 } EnMFire1; // size = 0x019C
 
 extern const ActorInit En_M_Fire1_InitVars;

--- a/src/overlays/actors/ovl_En_OE2/z_en_oe2.c
+++ b/src/overlays/actors/ovl_En_OE2/z_en_oe2.c
@@ -28,7 +28,7 @@ const ActorInit En_OE2_InitVars = {
 };
 
 void EnOE2_SetupAction(EnOE2* this, ActorFunc actionFunc) {
-    this->updateFunc = actionFunc;
+    this->actionFunc = actionFunc;
 }
 
 void EnOE2_Init(EnOE2* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_OE2/z_en_oe2.h
+++ b/src/overlays/actors/ovl_En_OE2/z_en_oe2.h
@@ -7,7 +7,7 @@
 typedef struct {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x44];
-    /* 0x0190 */ ActorFunc updateFunc;
+    /* 0x0190 */ ActorFunc actionFunc;
 } EnOE2; // size = 0x0194
 
 extern const ActorInit En_OE2_InitVars;

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -10,7 +10,7 @@
 
 #define FLAGS 0x02000010
 
-void EnOkarinaEffect_SetupAction(EnOkarinaEffect* this, ActorFunc* newActionFunc);
+void EnOkarinaEffect_SetupAction(EnOkarinaEffect* this, ActorFunc* actionFunc);
 void EnOkarinaEffect_Init(EnOkarinaEffect* this, GlobalContext* globalCtx);
 void EnOkarinaEffect_Destroy(EnOkarinaEffect* this, GlobalContext* globalCtx);
 void EnOkarinaEffect_TriggerStorm(EnOkarinaEffect* this, GlobalContext* globalCtx);
@@ -29,8 +29,8 @@ const ActorInit En_Okarina_Effect_InitVars = {
     NULL,
 };
 
-void EnOkarinaEffect_SetupAction(EnOkarinaEffect* this, ActorFunc* newActionFunc) {
-    this->actionFunc = newActionFunc;
+void EnOkarinaEffect_SetupAction(EnOkarinaEffect* this, ActorFunc* actionFunc) {
+    this->actionFunc = actionFunc;
 }
 
 void EnOkarinaEffect_Destroy(EnOkarinaEffect* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -4,16 +4,9 @@
  * Description: Manages the storm created when playing Song of Storms
  */
 
-#include <ultra64.h>
-#include <global.h>
+#include "z_en_okarina_effect.h"
 
 #include <vt.h>
-
-typedef struct {
-    /* 0x0000 */ Actor actor;
-    /* 0x014C */ u16 timer;
-    /* 0x0150 */ ActorFunc actionFunc;
-} EnOkarinaEffect; // size = 0x0154
 
 #define FLAGS 0x02000010
 

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.h
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.h
@@ -1,0 +1,15 @@
+#ifndef _Z_EN_OKARINA_EFFECT_H_
+#define _Z_EN_OKARINA_EFFECT_H_
+
+#include <ultra64.h>
+#include <global.h>
+
+typedef struct {
+    /* 0x0000 */ Actor actor;
+    /* 0x014C */ u16 timer;
+    /* 0x0150 */ ActorFunc actionFunc;
+} EnOkarinaEffect; // size = 0x0154
+
+extern const ActorInit En_Okarina_Effect_InitVars;
+
+#endif

--- a/src/overlays/actors/ovl_En_Part/z_en_part.h
+++ b/src/overlays/actors/ovl_En_Part/z_en_part.h
@@ -5,8 +5,12 @@
 #include <global.h>
 
 typedef struct {
-    /* 0x0000 */ Actor actor;
-    /* 0x014C */ char unk_14C[0x10];
+    /* 0x000 */ Actor actor;
+    /* 0x14C */ u8 unk_14C;
+    /* 0x14E */ s16 unk_14E;
+    /* 0x150 */ s32 unk_150;
+    /* 0x154 */ f32 unk_154;
+    /* 0x158 */ f32 unk_158;
 } EnPart; // size = 0x015C
 
 extern const ActorInit En_Part_InitVars;

--- a/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.c
+++ b/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.c
@@ -12,7 +12,7 @@ void EnSceneChange_Init(EnSceneChange* this, GlobalContext* globalCtx);
 void EnSceneChange_Destroy(EnSceneChange* this, GlobalContext* globalCtx);
 void EnSceneChange_Update(EnSceneChange* this, GlobalContext* globalCtx);
 void EnSceneChange_Draw(EnSceneChange* this, GlobalContext* globalCtx);
-void func_80AF8C70(EnSceneChange* this, ActorFunc updateFunc);
+void EnSceneChange_SetupAction(EnSceneChange* this, ActorFunc actionFunc);
 void func_80AF8CAC(EnSceneChange* this, GlobalContext* globalCtx);
 
 const ActorInit En_Scene_Change_InitVars = {
@@ -27,12 +27,12 @@ const ActorInit En_Scene_Change_InitVars = {
     (ActorFunc)EnSceneChange_Draw,
 };
 
-void func_80AF8C70(EnSceneChange* this, ActorFunc updateFunc) {
-    this->updateFunc = updateFunc;
+void EnSceneChange_SetupAction(EnSceneChange* this, ActorFunc actionFunc) {
+    this->actionFunc = actionFunc;
 }
 
 void EnSceneChange_Init(EnSceneChange* this, GlobalContext* globalCtx) {
-    func_80AF8C70(this, func_80AF8CAC);
+    EnSceneChange_SetupAction(this, func_80AF8CAC);
 }
 
 void EnSceneChange_Destroy(EnSceneChange* this, GlobalContext* globalCtx) {
@@ -42,7 +42,7 @@ void func_80AF8CAC(EnSceneChange* this, GlobalContext* globalCtx) {
 }
 
 void EnSceneChange_Update(EnSceneChange* this, GlobalContext* globalCtx) {
-    this->updateFunc(&this->actor, globalCtx);
+    this->actionFunc(this, globalCtx);
 }
 
 void EnSceneChange_Draw(EnSceneChange* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.c
+++ b/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.c
@@ -4,13 +4,7 @@
  * Description: Unknown (Broken Actor)
  */
 
-#include <ultra64.h>
-#include <global.h>
-
-typedef struct {
-    /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc updateFunc;
-} EnSceneChange; // size = 0x0150
+#include "z_en_scene_change.h"
 
 #define FLAGS 0x00000000
 

--- a/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.h
+++ b/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.h
@@ -6,7 +6,7 @@
 
 typedef struct {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc updateFunc;
+    /* 0x014C */ ActorFunc actionFunc;
 } EnSceneChange; // size = 0x0150
 
 extern const ActorInit En_Scene_Change_InitVars;

--- a/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.h
+++ b/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.h
@@ -1,0 +1,14 @@
+#ifndef _Z_ITEM_SCENE_CHANGE_H_
+#define _Z_ITEM_SCENE_CHANGE_H_
+
+#include <ultra64.h>
+#include <global.h>
+
+typedef struct {
+    /* 0x0000 */ Actor actor;
+    /* 0x014C */ ActorFunc updateFunc;
+} EnSceneChange; // size = 0x0150
+
+extern const ActorInit En_Scene_Change_InitVars;
+
+#endif

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -511,7 +511,7 @@ void EnWallmas_Update(EnWallmas* this, GlobalContext* globalCtx) {
     char pad[4];
 
     EnWallmas_ColUpdate(this2, globalCtx);
-    this2->actionFunc(&this->actor, globalCtx);
+    this2->actionFunc(this, globalCtx);
 
     if ((this2->actionFunc == (ActorFunc)&EnWallmas_WaitToDrop) ||
         (this2->actionFunc == (ActorFunc)&EnWallmas_WaitForProximity) ||

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -95,8 +95,8 @@ void EnWallmas_Init(EnWallmas* this, GlobalContext* globalCtx) {
     SkelAnime_InitSV(globalCtx, &this->skelAnime, &D_06008FB0, &D_06009DB0, &this->unkSkelAnimeStruct, &this->unk_22e,
                      0x19);
 
-    Collider_InitCylinder(globalCtx, &this->colCylinder);
-    Collider_SetCylinder(globalCtx, &this->colCylinder, &this->actor, &colCylinderInit);
+    Collider_InitCylinder(globalCtx, &this->collider);
+    Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &colCylinderInit);
     func_80061ED4(&this->actor.colChkInfo, &damageTable, &colChkInfoInit);
     this2->switchFlag = (u8)(this2->actor.params >> 0x8);
     this->actor.params = this->actor.params & 0xFF;
@@ -116,7 +116,7 @@ void EnWallmas_Init(EnWallmas* this, GlobalContext* globalCtx) {
 }
 
 void EnWallmas_Destroy(EnWallmas* this, GlobalContext* globalCtx) {
-    ColliderCylinder* col = &this->colCylinder;
+    ColliderCylinder* col = &this->collider;
     Collider_DestroyCylinder(globalCtx, col);
 }
 
@@ -192,10 +192,10 @@ void EnWallmas_ReturnToCeilingStart(EnWallmas* this) {
 
 void EnWallmas_TakeDamageStart(EnWallmas* this) {
     SkelAnime_ChangeAnimTransitionStop(&this->skelAnime, &D_06000590, -3.0f);
-    if ((this->colCylinder.body.acHitItem->toucher.flags & 0x1F824) != 0) {
-        this->actor.posRot.rot.y = this->colCylinder.base.ac->posRot.rot.y;
+    if ((this->collider.body.acHitItem->toucher.flags & 0x1F824) != 0) {
+        this->actor.posRot.rot.y = this->collider.base.ac->posRot.rot.y;
     } else {
-        this->actor.posRot.rot.y = func_8002DA78(&this->actor, this->colCylinder.base.ac) + 0x8000;
+        this->actor.posRot.rot.y = func_8002DA78(&this->actor, this->collider.base.ac) + 0x8000;
     }
 
     func_8003426C(&this->actor, 0x4000, 0xFF, 0, 0x14);
@@ -476,9 +476,9 @@ void EnWallmas_Stun(EnWallmas* this, GlobalContext* globalCtx) {
 }
 
 void EnWallmas_ColUpdate(EnWallmas* this, GlobalContext* globalCtx) {
-    if ((this->colCylinder.base.acFlags & 2) != 0) {
-        this->colCylinder.base.acFlags &= ~2;
-        func_80035650(&this->actor, &this->colCylinder.body, 1);
+    if ((this->collider.base.acFlags & 2) != 0) {
+        this->collider.base.acFlags &= ~2;
+        func_80035650(&this->actor, &this->collider.body, 1);
         if ((this->actor.colChkInfo.damageEffect != 0) || (this->actor.colChkInfo.damage != 0)) {
             if (Actor_ApplyDamage(&this->actor) == 0) {
                 func_80032C7C(globalCtx, &this->actor);
@@ -534,12 +534,12 @@ void EnWallmas_Update(EnWallmas* this, GlobalContext* globalCtx) {
     }
 
     if ((this2->actionFunc != (ActorFunc)&EnWallmas_Die) && (this2->actionFunc != (ActorFunc)&EnWallmas_Drop)) {
-        Collider_CylinderUpdate(&this2->actor, &this2->colCylinder);
-        CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this2->colCylinder);
+        Collider_CylinderUpdate(&this2->actor, &this2->collider);
+        CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this2->collider);
 
         if ((this2->actionFunc != (ActorFunc)&EnWallmas_TakeDamage) && (this2->actor.bgCheckFlags & 1) != 0 &&
             (this2->actor.freeze == 0)) {
-            CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this2->colCylinder);
+            CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this2->collider);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
@@ -21,7 +21,7 @@ typedef struct {
     /* 0x022E */ u16 unk_22e;
     /* 0x0230 */ char unk_230[0x94];
     /* 0x02C4 */ f32 unk_2c4;
-    /* 0x02C8 */ ColliderCylinder colCylinder;
+    /* 0x02C8 */ ColliderCylinder collider;
 } EnWallmas; // size = 0x0314
 
 extern const ActorInit En_Wallmas_InitVars;

--- a/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.c
+++ b/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.c
@@ -27,7 +27,7 @@ const ActorInit Item_Inbox_InitVars = {
 };
 
 void ItemInbox_Init(ItemInbox* this, GlobalContext* globalCtx) {
-    this->updateFunc = func_80B86020;
+    this->actionFunc = func_80B86020;
     Actor_SetScale(&this->actor, 0.2);
 }
 
@@ -41,7 +41,7 @@ void func_80B86020(ItemInbox* this, GlobalContext* globalCtx) {
 }
 
 void ItemInbox_Update(ItemInbox* this, GlobalContext* globalCtx) {
-    this->updateFunc(this, globalCtx);
+    this->actionFunc(this, globalCtx);
 }
 
 void ItemInbox_Draw(ItemInbox* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.h
+++ b/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.h
@@ -6,8 +6,8 @@
 
 typedef struct {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc updateFunc;
-} ItemInbox; // size = 0x0154
+    /* 0x014C */ ActorFunc actionFunc;
+} ItemInbox; // size = 0x0150
 
 extern const ActorInit Item_Inbox_InitVars;
 

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
@@ -176,7 +176,7 @@ void ObjComb_Wait(ObjComb* this, GlobalContext* globalCtx) {
 
 void ObjComb_Update(ObjComb* this, GlobalContext* globalCtx) {
     this->unk_1B2 += 12000;
-    this->actionFunc(&this->actor, globalCtx);
+    this->actionFunc(this, globalCtx);
     this->actor.shape.rot.x = Math_Sins(this->unk_1B2) * this->unk_1B0 + this->actor.initPosRot.rot.x;
 }
 

--- a/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
+++ b/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
@@ -61,5 +61,5 @@ void func_80B983D4(ObjMakekinsuta* this, GlobalContext* globalCtx) {
 }
 
 void ObjMakekinsuta_Update(ObjMakekinsuta* this, GlobalContext* globalCtx) {
-    this->actionFunc(&this->actor, globalCtx);
+    this->actionFunc(this, globalCtx);
 }

--- a/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
+++ b/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
@@ -41,7 +41,7 @@ void ObjRoomtimer_Init(ObjRoomtimer* this, GlobalContext* globalCtx) {
         }
     }
 
-    this->updateFunc = (ActorFunc)func_80B9D054;
+    this->actionFunc = (ActorFunc)func_80B9D054;
 }
 
 void ObjRoomtimer_Destroy(ObjRoomtimer* this, GlobalContext* globalCtx) {
@@ -58,7 +58,7 @@ void func_80B9D054(ObjRoomtimer* this, GlobalContext* globalCtx) {
     }
 
     Actor_ChangeType(globalCtx, &globalCtx->actorCtx, &this->actor, ACTORTYPE_PROP);
-    this->updateFunc = (ActorFunc)func_80B9D0B0;
+    this->actionFunc = (ActorFunc)func_80B9D0B0;
 }
 
 void func_80B9D0B0(ObjRoomtimer* this, GlobalContext* globalCtx) {
@@ -83,5 +83,5 @@ void func_80B9D0B0(ObjRoomtimer* this, GlobalContext* globalCtx) {
 }
 
 void ObjRoomtimer_Update(ObjRoomtimer* this, GlobalContext* globalCtx) {
-    this->updateFunc(this, globalCtx);
+    this->actionFunc(this, globalCtx);
 }

--- a/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.h
+++ b/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.h
@@ -7,7 +7,7 @@
 
 typedef struct {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc updateFunc;
+    /* 0x014C */ ActorFunc actionFunc;
     /* 0x0150 */ u32 switchFlag;
 } ObjRoomtimer; // size = 0x0154
 


### PR DESCRIPTION
This is my first set of remaining cleanups for actors.

Changes by commit:
- Fix naming and structs in z_en_item00.c and z_en_a_keep.c
- Decompile init vars in z_en_item00.c and z_en_a_keep.c
- Create missing .h files for the last few actors
- Fix old actors not properly using "actionFunc" / "SetupAction"
- Fix some collider member names in actor structs
- Remove some local temporary actor structs
- Fix some actor header includes to be absolute instead of relative

Next I'm going to work on changing all generic "main" functions and callbacks to take `Actor* thisx` as the argument, and remove casts accordingly.