### PR TITLE
More actor cleanup Part 3

### DIFF
--- a/src/code/z_en_a_keep.c
+++ b/src/code/z_en_a_keep.c
@@ -16,9 +16,13 @@ typedef enum {
     /* 0x0B */ A_OBJ_KNOB
 } AObjType;
 
-typedef struct {
+struct EnAObj;
+
+typedef void (*EnAObjActionFunc)(struct EnAObj*, GlobalContext*);
+
+typedef struct EnAObj {
     /* 0x000 */ DynaPolyActor dyna;
-    /* 0x164 */ ActorFunc actionFunc;
+    /* 0x164 */ EnAObjActionFunc actionFunc;
     /* 0x168 */ s32 unk_168;
     /* 0x16C */ s16 textId;
     /* 0x16E */ s16 unk_16E;
@@ -66,7 +70,7 @@ extern ColliderCylinderInit D_80115440;
 extern u32 D_8011546C[];
 extern u32 D_80115484[];
 
-void EnAObj_SetupAction(EnAObj* this, ActorFunc actionFunc) {
+void EnAObj_SetupAction(EnAObj* this, EnAObjActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 
@@ -192,7 +196,7 @@ void func_8001D204(EnAObj* this, GlobalContext* globalCtx) {
 }
 
 void func_8001D234(EnAObj* this, s16 params) {
-    EnAObj_SetupAction(this, (ActorFunc)func_8001D25C);
+    EnAObj_SetupAction(this, func_8001D25C);
 }
 
 void func_8001D25C(EnAObj* this, GlobalContext* globalCtx) {
@@ -202,7 +206,7 @@ void func_8001D25C(EnAObj* this, GlobalContext* globalCtx) {
         var = this->dyna.actor.rotTowardsLinkY - this->dyna.actor.shape.rot.y;
         if ((ABS(var) < 0x2800) || ((this->dyna.actor.params == 0xA) && (ABS(var) > 0x5800))) {
             if (func_8002F194(&this->dyna.actor, globalCtx)) {
-                EnAObj_SetupAction(this, (ActorFunc)func_8001D204);
+                EnAObj_SetupAction(this, func_8001D204);
             } else {
                 func_8002F2F4(&this->dyna.actor, globalCtx);
             }
@@ -215,7 +219,7 @@ void func_8001D310(EnAObj* this, s16 params) {
     this->unk_168 = 10;
     this->dyna.actor.posRot.rot.y = 0;
     this->dyna.actor.shape.rot = this->dyna.actor.posRot.rot;
-    EnAObj_SetupAction(this, (ActorFunc)func_8001D360);
+    EnAObj_SetupAction(this, func_8001D360);
 }
 
 void func_8001D360(EnAObj* this, GlobalContext* globalCtx) {
@@ -258,7 +262,7 @@ void func_8001D360(EnAObj* this, GlobalContext* globalCtx) {
 }
 
 void func_8001D480(EnAObj* this, s16 params) {
-    EnAObj_SetupAction(this, (ActorFunc)func_8001D4A8);
+    EnAObj_SetupAction(this, func_8001D4A8);
 }
 
 void func_8001D4A8(EnAObj* this, GlobalContext* globalCtx) {
@@ -288,7 +292,7 @@ void func_8001D4A8(EnAObj* this, GlobalContext* globalCtx) {
 void func_8001D5C8(EnAObj* this, s16 params) {
     this->dyna.actor.unk_FC = 1200.0f;
     this->dyna.actor.unk_F8 = 720.0f;
-    EnAObj_SetupAction(this, (ActorFunc)func_8001D608);
+    EnAObj_SetupAction(this, func_8001D608);
 }
 
 void func_8001D608(EnAObj* this, GlobalContext* globalCtx) {

--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -30,9 +30,13 @@ typedef enum {
     /* 0x19 */ ITEM00_BOMBS_SPECIAL
 } Item00Type;
 
-typedef struct {
+struct EnItem00;
+
+typedef void (*EnItem00ActionFunc)(struct EnItem00*, GlobalContext*);
+
+typedef struct EnItem00 {
     /* 0x000 */ Actor actor;
-    /* 0x14C */ ActorFunc actionFunc;
+    /* 0x14C */ EnItem00ActionFunc actionFunc;
     /* 0x150 */ s16 collectibleFlag;
     /* 0x152 */ s16 unk_152;
     /* 0x154 */ s16 unk_154;
@@ -83,7 +87,7 @@ extern u8 D_80115664[];
 
 // Internal Actor Functions
 
-void EnItem00_SetupAction(EnItem00* this, ActorFunc actionFunc) {
+void EnItem00_SetupAction(EnItem00* this, EnItem00ActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 
@@ -228,7 +232,7 @@ void EnItem00_Init(Actor* thisx, GlobalContext* globalCtx) {
     this->unk_152 = 0;
 
     if (!spawnParam8000) {
-        EnItem00_SetupAction(this, (ActorFunc)func_8001DFC8);
+        EnItem00_SetupAction(this, func_8001DFC8);
         this->unk_15A = -1;
         return;
     }
@@ -310,7 +314,7 @@ void EnItem00_Init(Actor* thisx, GlobalContext* globalCtx) {
         func_8002F554(&this->actor, globalCtx, getItemId);
     }
 
-    EnItem00_SetupAction(this, (ActorFunc)func_8001E5C8);
+    EnItem00_SetupAction(this, func_8001E5C8);
     this->actionFunc(this, globalCtx);
 }
 
@@ -362,7 +366,7 @@ void func_8001DFC8(EnItem00* this, GlobalContext* globalCtx) {
     }
 
     if ((this->actor.gravity != 0.0f) && !(this->actor.bgCheckFlags & 0x0001)) {
-        EnItem00_SetupAction(this, (ActorFunc)func_8001E1C8);
+        EnItem00_SetupAction(this, func_8001E1C8);
     }
 }
 
@@ -384,7 +388,7 @@ void func_8001E1C8(EnItem00* this, GlobalContext* globalCtx) {
     if (this->actor.bgCheckFlags & 0x0003) {
         originalVelocity = this->actor.velocity.y;
         if (originalVelocity > -2.0f) {
-            EnItem00_SetupAction(this, (ActorFunc)func_8001DFC8);
+            EnItem00_SetupAction(this, func_8001DFC8);
             this->actor.velocity.y = 0.0f;
         } else {
             this->actor.velocity.y = originalVelocity * -0.8f;
@@ -440,7 +444,7 @@ void func_8001E304(EnItem00* this, GlobalContext* globalCtx) {
     }
 
     if (this->actor.bgCheckFlags & 0x0003) {
-        EnItem00_SetupAction(this, (ActorFunc)func_8001DFC8);
+        EnItem00_SetupAction(this, func_8001DFC8);
         this->actor.shape.rot.z = 0;
         this->actor.velocity.y = 0.0f;
         this->actor.speedXZ = 0.0f;
@@ -694,7 +698,7 @@ void EnItem00_Update(Actor* thisx, GlobalContext* globalCtx) {
     Actor_SetScale(&this->actor, this->unk_15C);
 
     this->unk_152 = 0;
-    EnItem00_SetupAction(this, (ActorFunc)func_8001E5C8);
+    EnItem00_SetupAction(this, func_8001E5C8);
 }
 
 // Draw Function prototypes (used in EnItem00_Draw)
@@ -939,7 +943,7 @@ Actor* Item_DropCollectible(GlobalContext* globalCtx, Vec3f* spawnPos, s16 param
                 spawnedActor->actor.gravity = -0.9f;
                 spawnedActor->actor.posRot.rot.y = Math_Rand_CenteredFloat(65536.0f);
                 Actor_SetScale(&spawnedActor->actor, 0.0f);
-                EnItem00_SetupAction(spawnedActor, (ActorFunc)func_8001E304);
+                EnItem00_SetupAction(spawnedActor, func_8001E304);
                 spawnedActor->unk_15A = 220;
                 if ((spawnedActor->actor.params != ITEM00_SMALL_KEY) &&
                     (spawnedActor->actor.params != ITEM00_HEART_PIECE) &&
@@ -1090,7 +1094,7 @@ void Item_DropCollectibleRandom(GlobalContext* globalCtx, Actor* fromActor, Vec3
                         spawnedActor->actor.gravity = -0.9f;
                         spawnedActor->actor.posRot.rot.y = Math_Rand_ZeroOne() * 40000.0f;
                         Actor_SetScale(&spawnedActor->actor, 0.0f);
-                        EnItem00_SetupAction(spawnedActor, (ActorFunc)func_8001E304);
+                        EnItem00_SetupAction(spawnedActor, func_8001E304);
                         spawnedActor->actor.flags |= 0x0010;
                         if ((spawnedActor->actor.params != ITEM00_SMALL_KEY) &&
                             (spawnedActor->actor.params != ITEM00_HEART_PIECE) &&

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -9,7 +9,6 @@ void ArmsHook_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void ArmsHook_Update(Actor* thisx, GlobalContext* globalCtx);
 void ArmsHook_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void ArmsHook_SetupAction(ArmsHook* this, ActorFunc actionFunc);
 void func_80864FC4(ArmsHook* this, GlobalContext* globalCtx);
 
 /*

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.h
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ArmsHook;
+
+typedef void (*ArmsHookActionFunc)(struct ArmsHook*, GlobalContext*);
+
+typedef struct ArmsHook {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC8];
-    /* 0x0214 */ ActorFunc actionFunc;
+    /* 0x0214 */ ArmsHookActionFunc actionFunc;
 } ArmsHook; // size = 0x0218
 
 extern const ActorInit Arms_Hook_InitVars;

--- a/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
+++ b/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
@@ -39,7 +39,7 @@ static InitChainEntry initChain[] = {
     ICHAIN_F32(unk_F4, 2000, ICHAIN_STOP),
 };
 
-void ArrowFire_SetupAction(ArrowFire* this, ActorFunc* actionFunc) {
+void ArrowFire_SetupAction(ArrowFire* this, ArrowFireActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.h
+++ b/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.h
@@ -4,12 +4,16 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ArrowFire;
+
+typedef void (*ArrowFireActionFunc)(struct ArrowFire*, GlobalContext*);
+
+typedef struct ArrowFire {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ Vec3f unkPos;
     /* 0x0158 */ f32 unk_158;
     /* 0x015C */ f32 unk_15C;
-    /* 0x0160 */ ActorFunc actionFunc;
+    /* 0x0160 */ ArrowFireActionFunc actionFunc;
     /* 0x0164 */ s16 radius;
     /* 0x0166 */ u16 timer;
     /* 0x0168 */ u8 alpha;

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
@@ -39,7 +39,7 @@ static InitChainEntry initChain[] = {
     ICHAIN_F32(unk_F4, 2000, ICHAIN_STOP),
 };
 
-void ArrowIce_SetupAction(ArrowIce* this, ActorFunc* actionFunc) {
+void ArrowIce_SetupAction(ArrowIce* this, ArrowIceActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.h
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.h
@@ -4,7 +4,11 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ArrowIce;
+
+typedef void (*ArrowIceActionFunc)(struct ArrowIce*, GlobalContext*);
+
+typedef struct ArrowIce {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ s16 radius;
     /* 0x014E */ u16 timer;
@@ -12,7 +16,7 @@ typedef struct {
     /* 0x0154 */ Vec3f unkPos;
     /* 0x0160 */ f32 unk_160;
     /* 0x0164 */ f32 unk_164;
-    /* 0x0168 */ ActorFunc actionFunc;
+    /* 0x0168 */ ArrowIceActionFunc actionFunc;
 } ArrowIce; // size = 0x016C
 
 extern const ActorInit Arrow_Ice_InitVars;

--- a/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
+++ b/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
@@ -39,7 +39,7 @@ static InitChainEntry initChain[] = {
     ICHAIN_F32(unk_F4, 2000, ICHAIN_STOP),
 };
 
-void ArrowLight_SetupAction(ArrowLight* this, ActorFunc* actionFunc) {
+void ArrowLight_SetupAction(ArrowLight* this, ArrowLightActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.h
+++ b/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.h
@@ -4,7 +4,11 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ArrowLight;
+
+typedef void (*ArrowLightActionFunc)(struct ArrowLight*, GlobalContext*);
+
+typedef struct ArrowLight {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ s16 radius;
     /* 0x014E */ u16 timer;
@@ -12,7 +16,7 @@ typedef struct {
     /* 0x0154 */ Vec3f unkPos;
     /* 0x0160 */ f32 unk_160;
     /* 0x0164 */ f32 unk_164;
-    /* 0x0168 */ ActorFunc actionFunc;
+    /* 0x0168 */ ArrowLightActionFunc actionFunc;
 } ArrowLight; // size = 0x016C
 
 extern const ActorInit Arrow_Light_InitVars;

--- a/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
@@ -108,7 +108,7 @@ void BgBdanObjects_Init(Actor* thisx, GlobalContext* globalCtx) {
     if (thisx->params == 2) {
         thisx->flags |= 0x30;
         globalCtx->colCtx.stat.colHeader->waterBoxes[7].unk_02 = thisx->posRot.pos.y;
-        this->actionFunc = (ActorFunc)func_8086C9A8;
+        this->actionFunc = func_8086C9A8;
         return;
     }
     if (thisx->params == 0) {
@@ -118,7 +118,7 @@ void BgBdanObjects_Init(Actor* thisx, GlobalContext* globalCtx) {
         thisx->posRot.pos.y = (f32)(thisx->posRot.pos.y + -79.0f);
         if (Flags_GetClear(globalCtx, thisx->room)) {
             Flags_SetSwitch(globalCtx, this->unk_168);
-            this->actionFunc = (ActorFunc)func_8086C6EC;
+            this->actionFunc = func_8086C6EC;
         } else {
             if (BgBdanObjects_GetContactRu1(this, 4)) {
                 if (Actor_SpawnAttached(&globalCtx->actorCtx, this, globalCtx, ACTOR_EN_BIGOKUTA,
@@ -127,12 +127,12 @@ void BgBdanObjects_Init(Actor* thisx, GlobalContext* globalCtx) {
                     thisx->attachedB->posRot.pos.z = thisx->attachedB->initPosRot.pos.z + 263.0f;
                 }
                 thisx->posRot.rot.y = 0;
-                this->actionFunc = (ActorFunc)func_8086C618;
+                this->actionFunc = func_8086C618;
                 thisx->posRot.pos.y = thisx->initPosRot.pos.y + -70.0f;
             } else {
                 Flags_SetSwitch(globalCtx, this->unk_168);
                 this->unk_16A = 0;
-                this->actionFunc = (ActorFunc)func_8086C054;
+                this->actionFunc = func_8086C054;
             }
         }
     } else {
@@ -140,14 +140,14 @@ void BgBdanObjects_Init(Actor* thisx, GlobalContext* globalCtx) {
             DynaPolyInfo_Alloc(&D_06005048, &localC);
             this->unk_16A = 0x200;
             this->unk_168 = 0;
-            this->actionFunc = (ActorFunc)func_8086C874;
+            this->actionFunc = func_8086C874;
         } else {
             DynaPolyInfo_Alloc(&D_06005580, &localC);
             if (Flags_GetSwitch(globalCtx, this->unk_168)) {
-                this->actionFunc = (ActorFunc)func_8086C868;
+                this->actionFunc = func_8086C868;
                 thisx->posRot.pos.y = thisx->initPosRot.pos.y - 400.0f;
             } else {
-                this->actionFunc = (ActorFunc)func_8086CB10;
+                this->actionFunc = func_8086CB10;
             }
         }
     }
@@ -182,7 +182,7 @@ void func_8086C054(BgBdanObjects* this, GlobalContext* globalCtx) {
                 this->unk_16A -= 1;
             }
             if (this->unk_16A == 0) {
-                this->actionFunc = (ActorFunc)func_8086C1A0;
+                this->actionFunc = func_8086C1A0;
             }
         }
     }
@@ -198,7 +198,7 @@ void func_8086C1A0(BgBdanObjects* this, GlobalContext* globalCtx) {
     if (Math_SmoothScaleMaxMinF(&this->dyna.actor.posRot.pos.y, this->dyna.actor.initPosRot.pos.y + 500.0f, 0.5f, 7.5f,
                                 1.0f) < 0.1f) {
         Audio_PlayActorSound2(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_A);
-        this->actionFunc = (ActorFunc)func_8086C29C;
+        this->actionFunc = func_8086C29C;
         this->unk_16A = 0x1E;
         BgBdanObjects_SetContactRu1(this, 2);
         func_800AA000(0.0f, 0xFF, 0x14, 0x96);
@@ -233,7 +233,7 @@ void func_8086C29C(BgBdanObjects* this, GlobalContext* globalCtx) {
                             this->dyna.actor.posRot.pos.z, 0, this->dyna.actor.shape.rot.y + 0x8000, 0, 0);
         BgBdanObjects_SetContactRu1(this, 4);
         this->unk_16A = 0xA;
-        this->actionFunc = (ActorFunc)func_8086C55C;
+        this->actionFunc = func_8086C55C;
         func_8005B1A4(globalCtx->cameraPtrs[globalCtx->activeCamera]);
     }
 }
@@ -248,7 +248,7 @@ void func_8086C3D8(BgBdanObjects* this, GlobalContext* globalCtx) {
         this->unk_16A = 0x3C;
         Audio_PlayActorSound2(&this->dyna.actor, 0x289F);
         this->dyna.actor.attachedB->posRot.pos.y = this->dyna.actor.posRot.pos.y + 140.0f;
-        this->actionFunc = (ActorFunc)func_8086C5BC;
+        this->actionFunc = func_8086C5BC;
         func_800800F8(globalCtx, 0xC08, -0x63, this->dyna.actor.attachedB, 0);
         player->actor.posRot.pos.x = -1130.0f;
         player->actor.posRot.pos.y = -1025.0f;
@@ -278,7 +278,7 @@ void func_8086C55C(BgBdanObjects* this, GlobalContext* globalCtx) {
         Flags_UnsetSwitch(globalCtx, this->unk_168);
     } else if (this->unk_16A == -0x28) {
         this->unk_16A = 0;
-        this->actionFunc = (ActorFunc)func_8086C3D8;
+        this->actionFunc = func_8086C3D8;
     }
 }
 
@@ -289,7 +289,7 @@ void func_8086C5BC(BgBdanObjects* this, GlobalContext* globalCtx) {
     if (this->unk_16A == 0) {
         if (this->dyna.actor.attachedB != NULL) {
             if (this->dyna.actor.attachedB->params == 2) {
-                this->actionFunc = (ActorFunc)func_8086C618;
+                this->actionFunc = func_8086C618;
             } else if (this->dyna.actor.attachedB->params == 0) {
                 this->dyna.actor.attachedB->params = 1;
             }
@@ -303,7 +303,7 @@ void func_8086C618(BgBdanObjects* this, GlobalContext* globalCtx) {
     if (Flags_GetClear(globalCtx, this->dyna.actor.room)) {
         Flags_SetSwitch(globalCtx, this->unk_168);
         this->dyna.actor.initPosRot.rot.y = (s16)(this->dyna.actor.shape.rot.y + 0x2000) & 0xC000;
-        this->actionFunc = (ActorFunc)func_8086C6EC;
+        this->actionFunc = func_8086C6EC;
     } else {
         this->dyna.actor.shape.rot.y += this->dyna.actor.posRot.rot.y;
         func_800F436C(&this->dyna.actor.unk_E4, 0x2063, ABS(this->dyna.actor.posRot.rot.y) / 512.0f);
@@ -314,7 +314,7 @@ void func_8086C6EC(BgBdanObjects* this, GlobalContext* globalCtx) {
     s32 cond = Math_ApproxUpdateScaledS(&this->dyna.actor.shape.rot.y, this->dyna.actor.initPosRot.rot.y, 0x200);
     if (Math_ApproxF(&this->dyna.actor.posRot.pos.y, this->dyna.actor.initPosRot.pos.y + -125.0f, 3.0f)) {
         if (cond) {
-            this->actionFunc = (ActorFunc)func_8086C76C;
+            this->actionFunc = func_8086C76C;
         }
     }
 }
@@ -322,7 +322,7 @@ void func_8086C6EC(BgBdanObjects* this, GlobalContext* globalCtx) {
 void func_8086C76C(BgBdanObjects* this, GlobalContext* globalCtx) {
     if (func_8004356C(&this->dyna.actor)) {
         if (this->dyna.actor.xzDistanceFromLink < 120.0f) {
-            this->actionFunc = (ActorFunc)func_8086C7D0;
+            this->actionFunc = func_8086C7D0;
             func_800800F8(globalCtx, 0xC12, -0x63, &this->dyna.actor, 0);
         }
     }
@@ -332,7 +332,7 @@ void func_8086C7D0(BgBdanObjects* this, GlobalContext* globalCtx) {
     if (Math_SmoothScaleMaxMinF(&this->dyna.actor.posRot.pos.y, this->dyna.actor.initPosRot.pos.y + 965.0f, 0.5f, 15.0f,
                                 0.2f) < 0.01f) {
         Audio_PlayActorSound2(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_A);
-        this->actionFunc = (ActorFunc)func_8086C868;
+        this->actionFunc = func_8086C868;
     } else {
         func_8002F974(&this->dyna.actor, 0x208F);
     }
@@ -376,7 +376,7 @@ void func_8086C874(BgBdanObjects* this, GlobalContext* globalCtx) {
 void func_8086C9A8(BgBdanObjects* this, GlobalContext* globalCtx) {
     if (Flags_GetSwitch(globalCtx, this->unk_168)) {
         this->unk_16A = 0x64;
-        this->actionFunc = (ActorFunc)func_8086C9F0;
+        this->actionFunc = func_8086C9F0;
     }
 }
 
@@ -384,12 +384,12 @@ void func_8086C9F0(BgBdanObjects* this, GlobalContext* globalCtx) {
     if (this->unk_16A == 0) {
         if (Math_ApproxF(&this->dyna.actor.posRot.pos.y, this->dyna.actor.initPosRot.pos.y, 0.5f)) {
             Flags_UnsetSwitch(globalCtx, this->unk_168);
-            this->actionFunc = (ActorFunc)func_8086C9A8;
+            this->actionFunc = func_8086C9A8;
         }
         func_8002F948(this, 0x205E);
     } else {
         if (Math_ApproxF(&this->dyna.actor.posRot.pos.y, this->dyna.actor.initPosRot.pos.y + 75.0f, 0.5f)) {
-            this->actionFunc = (ActorFunc)func_8086CABC;
+            this->actionFunc = func_8086CABC;
         }
         func_8002F948(this, 0x205E);
     }
@@ -402,7 +402,7 @@ void func_8086CABC(BgBdanObjects* this, GlobalContext* globalCtx) {
     }
     func_8002F994(&this->dyna.actor, this->unk_16A);
     if (this->unk_16A == 0) {
-        this->actionFunc = (ActorFunc)func_8086C9F0;
+        this->actionFunc = func_8086C9F0;
     }
 }
 
@@ -410,7 +410,7 @@ void func_8086CB10(BgBdanObjects* this, GlobalContext* globalCtx) {
     if (func_8004356C(&this->dyna.actor)) {
         Flags_SetSwitch(globalCtx, this->unk_168);
         this->unk_16A = 0x32;
-        this->actionFunc = (ActorFunc)func_8086CB8C;
+        this->actionFunc = func_8086CB8C;
         this->dyna.actor.initPosRot.pos.y -= 200.0f;
         func_800800F8(globalCtx, 0xC1C, 0x33, &this->dyna.actor, 0);
     }
@@ -423,7 +423,7 @@ void func_8086CB8C(BgBdanObjects* this, GlobalContext* globalCtx) {
     this->dyna.actor.posRot.pos.y = this->dyna.actor.initPosRot.pos.y - (cosf(this->unk_16A * (M_PI / 50.0f)) * 200.0f);
     if (this->unk_16A == 0) {
         Audio_PlayActorSound2(this, NA_SE_EV_BUYOSTAND_STOP_U);
-        this->actionFunc = (ActorFunc)func_8086C868;
+        this->actionFunc = func_8086C868;
         func_800C078C(globalCtx, 0, -1);
     } else {
         func_8002F974(&this->dyna.actor, 0x2090);
@@ -441,7 +441,7 @@ void BgBdanObjects_Draw(Actor* thisx, GlobalContext* globalCtx) {
     BgBdanObjects* this = THIS;
 
     if (thisx->params == 0) {
-        if (this->actionFunc == (ActorFunc)func_8086C054) {
+        if (this->actionFunc == func_8086C054) {
             if (((thisx->initPosRot.pos.y + -79.0f) - 5.0f) < thisx->posRot.pos.y) {
                 Matrix_Translate(0.0f, -50.0f, 0.0f, MTXMODE_APPLY);
             }

--- a/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.h
+++ b/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgBdanObjects;
+
+typedef void (*BgBdanObjectsActionFunc)(struct BgBdanObjects*, GlobalContext*);
+
+typedef struct BgBdanObjects {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgBdanObjectsActionFunc actionFunc;
     /* 0x0168 */ u8 unk_168;
     /* 0x016A */ s16 unk_16A;
     /* 0x016C */ ColliderCylinder collider;

--- a/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.c
@@ -229,7 +229,7 @@ void func_8086D548(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D5C4(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086D5E0;
+    this->actionFunc = func_8086D5E0;
     this->unk_1C8 = 1.0f;
 }
 
@@ -250,7 +250,7 @@ void func_8086D5E0(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D67C(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086D694;
+    this->actionFunc = func_8086D694;
     this->unk_1DA = 0x64;
 }
 
@@ -267,7 +267,7 @@ void func_8086D694(BgBdanSwitch* this, GlobalContext* globalCtx) {
 
 void func_8086D730(BgBdanSwitch* this) {
     this->unk_1C8 = 0.1f;
-    this->actionFunc = &func_8086D754;
+    this->actionFunc = func_8086D754;
     this->unk_1D8 = 6;
 }
 
@@ -291,7 +291,7 @@ void func_8086D754(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D7FC(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086D80C;
+    this->actionFunc = func_8086D80C;
 }
 
 void func_8086D80C(BgBdanSwitch* this, GlobalContext* globalCtx) {
@@ -303,7 +303,7 @@ void func_8086D80C(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D86C(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086D888;
+    this->actionFunc = func_8086D888;
     this->unk_1C8 = 1.0f;
 }
 
@@ -314,7 +314,7 @@ void func_8086D888(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D8BC(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086D8CC;
+    this->actionFunc = func_8086D8CC;
 }
 
 void func_8086D8CC(BgBdanSwitch* this, GlobalContext* globalCtx) {
@@ -327,7 +327,7 @@ void func_8086D8CC(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086D944(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086D95C;
+    this->actionFunc = func_8086D95C;
     this->unk_1DA = 0x64;
 }
 
@@ -344,7 +344,7 @@ void func_8086D95C(BgBdanSwitch* this, GlobalContext* globalCtx) {
 
 void func_8086D9F8(BgBdanSwitch* this) {
     this->unk_1C8 = 0.6f;
-    this->actionFunc = &func_8086DA1C;
+    this->actionFunc = func_8086DA1C;
     this->unk_1D8 = 6;
 }
 
@@ -368,7 +368,7 @@ void func_8086DA1C(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DAB4(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086DAC4;
+    this->actionFunc = func_8086DAC4;
 }
 
 void func_8086DAC4(BgBdanSwitch* this, GlobalContext* globalCtx) {
@@ -381,14 +381,14 @@ void func_8086DAC4(BgBdanSwitch* this, GlobalContext* globalCtx) {
 
 void func_8086DB24(BgBdanSwitch* this) {
     this->unk_1C8 = 0.1f;
-    this->actionFunc = &func_8086DB40;
+    this->actionFunc = func_8086DB40;
 }
 
 void func_8086DB40(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DB4C(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086DB68;
+    this->actionFunc = func_8086DB68;
     this->unk_1C8 = 2.0f;
 }
 
@@ -413,7 +413,7 @@ void func_8086DB68(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DC30(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086DC48;
+    this->actionFunc = func_8086DC48;
     this->unk_1DA = 0x64;
 }
 
@@ -428,7 +428,7 @@ void func_8086DC48(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DCCC(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086DCE8;
+    this->actionFunc = func_8086DCE8;
     this->unk_1C8 = 1.0f;
 }
 
@@ -449,7 +449,7 @@ void func_8086DCE8(BgBdanSwitch* this, GlobalContext* globalCtx) {
 }
 
 void func_8086DDA8(BgBdanSwitch* this) {
-    this->actionFunc = &func_8086DDC0;
+    this->actionFunc = func_8086DDC0;
     this->unk_1DA = 0x64;
 }
 

--- a/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.h
+++ b/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.h
@@ -13,7 +13,11 @@ typedef enum {
     /* 0x04 */ YELLOW_TALL_2
 } BgBdanSwitchType;
 
-typedef struct {
+struct BgBdanSwitch;
+
+typedef void (*BgBdanSwitchActionFunc)(struct BgBdanSwitch*, GlobalContext*);
+
+typedef struct BgBdanSwitch {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x0150 */ f32 unk_150;
@@ -21,7 +25,7 @@ typedef struct {
     /* 0x0158 */ u32 unk_158;
     /* 0x015C */ u32 unk_15C;
     /* 0x0160 */ u8 unk_160;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgBdanSwitchActionFunc actionFunc;
     /* 0x0168 */ ColliderJntSph collider;
     /* 0x0188 */ ColliderJntSphItem colliderItems[1];
     /* 0x01C8 */ f32 unk_1C8;

--- a/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.c
+++ b/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.c
@@ -34,7 +34,7 @@ const ActorInit Bg_Bom_Guard_InitVars = {
 
 extern u32 D_06001C40;
 
-void BgBomGuard_SetupAction(BgBomGuard* this, ActorFunc actionFunc) {
+void BgBomGuard_SetupAction(BgBomGuard* this, BgBomGuardActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.h
+++ b/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgBomGuard;
+
+typedef void (*BgBomGuardActionFunc)(struct BgBomGuard*, GlobalContext*);
+
+typedef struct BgBomGuard {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgBomGuardActionFunc actionFunc;
     /* 0x0168 */ u8 unk_168;
     /* 0x016C */ Vec3f unk_16C;
 } BgBomGuard; // size = 0x0178

--- a/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.h
+++ b/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgBombwall;
+
+typedef void (*BgBombwallActionFunc)(struct BgBombwall*, GlobalContext*);
+
+typedef struct BgBombwall {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x134];
-    /* 0x0298 */ ActorFunc actionFunc;
+    /* 0x0298 */ BgBombwallActionFunc actionFunc;
     /* 0x029C */ char unk_29C[0x8];
 } BgBombwall; // size = 0x02A4
 

--- a/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.h
+++ b/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgBowlWall;
+
+typedef void (*BgBowlWallActionFunc)(struct BgBowlWall*, GlobalContext*);
+
+typedef struct BgBowlWall {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgBowlWallActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x20];
 } BgBowlWall; // size = 0x0188
 

--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -14,7 +14,6 @@ void BgBreakwall_Init(Actor* thisx, GlobalContext* globalCtx);
 void BgBreakwall_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void BgBreakwall_Update(Actor* thisx, GlobalContext* globalCtx);
 
-void BgBreakwall_SetupAction(BgBreakwall* this, ActorFunc actionFunc);
 void func_80870290(BgBreakwall* this, GlobalContext* globalCtx);
 void func_80870394(BgBreakwall* this, GlobalContext* globalCtx);
 void func_80870564(BgBreakwall* this, GlobalContext* globalCtx);

--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.h
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgBreakwall;
+
+typedef void (*BgBreakwallActionFunc)(struct BgBreakwall*, GlobalContext*);
+
+typedef struct BgBreakwall {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x88];
-    /* 0x01EC */ ActorFunc actionFunc;
+    /* 0x01EC */ BgBreakwallActionFunc actionFunc;
 } BgBreakwall; // size = 0x01F0
 
 extern const ActorInit Bg_Breakwall_InitVars;

--- a/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.h
+++ b/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgDdanJd;
+
+typedef void (*BgDdanJdActionFunc)(struct BgDdanJd*, GlobalContext*);
+
+typedef struct BgDdanJd {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgDdanJdActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x8];
 } BgDdanJd; // size = 0x0170
 

--- a/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.c
+++ b/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.c
@@ -51,7 +51,7 @@ static f32 D_80871908[] = { 0.0f, -0.45f, 0.0f, 0.0f, 0.0f, 0.0f };
 extern UNK_TYPE D_06004F30;
 extern UNK_TYPE D_060048A8;
 
-void BgDdanKd_SetupAction(BgDdanKd* this, ActorFunc actionFunc) {
+void BgDdanKd_SetupAction(BgDdanKd* this, BgDdanKdActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 
@@ -71,10 +71,10 @@ void BgDdanKd_Init(Actor* thisx, GlobalContext* globalCtx) {
     this->dyna.dynaPolyId = DynaPolyInfo_RegisterActor(globalCtx, &globalCtx->colCtx.dyna, &this->dyna.actor, sp24);
 
     if (Flags_GetSwitch(globalCtx, this->dyna.actor.params) == 0) {
-        BgDdanKd_SetupAction(this, &BgDdanKd_CheckForExplosions);
+        BgDdanKd_SetupAction(this, BgDdanKd_CheckForExplosions);
     } else {
         this->dyna.actor.posRot.pos.y = this->dyna.actor.initPosRot.pos.y - 200.0f - 20.0f;
-        BgDdanKd_SetupAction(this, &func_80871838);
+        BgDdanKd_SetupAction(this, func_80871838);
     }
 }
 
@@ -96,7 +96,7 @@ void BgDdanKd_CheckForExplosions(BgDdanKd* this, GlobalContext* globalCtx) {
     if ((currentCollidingExplosion != NULL) && (this->previousCollidingExplosion != NULL) &&
         (currentCollidingExplosion != this->previousCollidingExplosion) &&
         (Math_Vec3f_DistXZ(&this->previousCollidingExplosionPos, &currentCollidingExplosion->posRot.pos) > 80.0f)) {
-        BgDdanKd_SetupAction(this, &BgDdanKd_LowerStairs);
+        BgDdanKd_SetupAction(this, BgDdanKd_LowerStairs);
         func_800800F8(globalCtx, 0xBEA, 0x3E7, this, 0);
     } else {
         if (this->timer != 0) {
@@ -124,7 +124,7 @@ void BgDdanKd_LowerStairs(BgDdanKd* this, GlobalContext* globalCtx) {
     if (Math_SmoothScaleMaxMinF(&this->dyna.actor.posRot.pos.y, (this->dyna.actor.initPosRot.pos.y - 200.0f) - 20.0f,
                                 0.075f, this->dyna.actor.speedXZ, 0.0075f) == 0.0f) {
         Flags_SetSwitch(globalCtx, this->dyna.actor.params);
-        BgDdanKd_SetupAction(this, &func_80871838);
+        BgDdanKd_SetupAction(this, func_80871838);
     } else {
         sp4C = (this->dyna.actor.pos4.y - this->dyna.actor.posRot.pos.y) + (this->dyna.actor.speedXZ * 0.25f);
 

--- a/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.h
+++ b/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.h
@@ -4,13 +4,17 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgDdanKd;
+
+typedef void (*BgDdanKdActionFunc)(struct BgDdanKd*, GlobalContext*);
+
+typedef struct BgDdanKd {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ Actor* previousCollidingExplosion;
     /* 0x0168 */ s16 timer;
     /* 0x016C */ Vec3f previousCollidingExplosionPos;
     /* 0x0178 */ ColliderCylinder collider;
-    /* 0x01C4 */ ActorFunc actionFunc;
+    /* 0x01C4 */ BgDdanKdActionFunc actionFunc;
 } BgDdanKd; // size = 0x01C8
 
 extern const ActorInit Bg_Ddan_Kd_InitVars;

--- a/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
+++ b/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
@@ -15,7 +15,6 @@ void BgDodoago_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void BgDodoago_Update(Actor* thisx, GlobalContext* globalCtx);
 void BgDodoago_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void BgDodoago_SetupAction(BgDodoago* this, ActorFunc actionFunc);
 // void func_80871A08(Vec3f* vec, GlobalContext* globalCtx); // Not 100% sure
 void func_80871CF4(BgDodoago* this, GlobalContext* globalCtx);
 void func_80871FB8(BgDodoago* this, GlobalContext* globalCtx);

--- a/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.h
+++ b/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgDodoago;
+
+typedef void (*BgDodoagoActionFunc)(struct BgDodoago*, GlobalContext*);
+
+typedef struct BgDodoago {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0xE8];
-    /* 0x024C */ ActorFunc actionFunc;
+    /* 0x024C */ BgDodoagoActionFunc actionFunc;
 } BgDodoago; // size = 0x0250
 
 extern const ActorInit Bg_Dodoago_InitVars;

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgDyYoseizo;
+
+typedef void (*BgDyYoseizoActionFunc)(struct BgDyYoseizo*, GlobalContext*);
+
+typedef struct BgDyYoseizo {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ BgDyYoseizoActionFunc actionFunc;
     /* 0x0150 */ SkelAnime skelAnime;
     /* 0x0194 */ char unk_194[0x3720];
 } BgDyYoseizo; // size = 0x38B4

--- a/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.h
+++ b/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgGanonOtyuka;
+
+typedef void (*BgGanonOtyukaActionFunc)(struct BgGanonOtyuka*, GlobalContext*);
+
+typedef struct BgGanonOtyuka {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgGanonOtyukaActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x24];
 } BgGanonOtyuka; // size = 0x018C
 

--- a/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.c
@@ -59,7 +59,7 @@ void BgGateShutter_Init(Actor* thisx, GlobalContext* globalCtx) {
     thisx->scale.z = 1.0f;
     osSyncPrintf("\n\n");
     osSyncPrintf(VT_FGCOL(GREEN) " ☆☆☆☆☆ 柵でたなぁ ☆☆☆☆☆ \n" VT_RST);
-    this->actionFunc = (ActorFunc)func_8087828C;
+    this->actionFunc = func_8087828C;
 }
 
 void BgGateShutter_Destroy(Actor* thisx, GlobalContext* globalCtx) {
@@ -71,13 +71,13 @@ void BgGateShutter_Destroy(Actor* thisx, GlobalContext* globalCtx) {
 void func_8087828C(BgGateShutter* this, GlobalContext* globalCtx) {
     if (this->unk_168 == 1 && !(gSaveContext.infTable[7] & 0x40)) {
         this->unk_178 = 2;
-        this->actionFunc = (ActorFunc)func_80878300;
+        this->actionFunc = func_80878300;
     } else if (this->unk_168 == 2) {
         this->unk_178 = 2;
-        this->actionFunc = (ActorFunc)func_80878300;
+        this->actionFunc = func_80878300;
     } else if (this->unk_168 < 0) {
         this->unk_178 = 2;
-        this->actionFunc = (ActorFunc)func_808783D4;
+        this->actionFunc = func_808783D4;
     }
 }
 
@@ -91,7 +91,7 @@ void func_80878300(BgGateShutter* this, GlobalContext* globalCtx) {
         if (thisx->posRot.pos.x < -89.0f) {
             Audio_PlayActorSound2(thisx, NA_SE_EV_BRIDGE_OPEN_STOP);
             this->unk_178 = 0x1E;
-            this->actionFunc = (ActorFunc)func_808783AC;
+            this->actionFunc = func_808783AC;
         }
     }
 }
@@ -99,7 +99,7 @@ void func_80878300(BgGateShutter* this, GlobalContext* globalCtx) {
 void func_808783AC(BgGateShutter* this, GlobalContext* globalCtx) {
     if (this->unk_178 == 0) {
         this->unk_168 = 0;
-        this->actionFunc = (ActorFunc)func_8087828C;
+        this->actionFunc = func_8087828C;
     }
 }
 
@@ -114,7 +114,7 @@ void func_808783D4(BgGateShutter* this, GlobalContext* globalCtx) {
             thisx->posRot.pos.x = 91.0f;
             Audio_PlayActorSound2(thisx, NA_SE_EV_BRIDGE_OPEN_STOP);
             this->unk_178 = 30;
-            this->actionFunc = (ActorFunc)func_808783AC;
+            this->actionFunc = func_808783AC;
         }
     }
 }

--- a/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgGateShutter;
+
+typedef void (*BgGateShutterActionFunc)(struct BgGateShutter*, GlobalContext*);
+
+typedef struct BgGateShutter {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgGateShutterActionFunc actionFunc;
     /* 0x0168 */ s16 unk_168;
     /* 0x016C */ f32 somePosX;
     /* 0x0170 */ f32 somePosY;

--- a/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.h
+++ b/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgGjyoBridge;
+
+typedef void (*BgGjyoBridgeActionFunc)(struct BgGjyoBridge*, GlobalContext*);
+
+typedef struct BgGjyoBridge {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgGjyoBridgeActionFunc actionFunc;
 } BgGjyoBridge; // size = 0x0168
 
 extern const ActorInit Bg_Gjyo_Bridge_InitVars;

--- a/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgGndDarkmeiro;
+
+typedef void (*BgGndDarkmeiroActionFunc)(struct BgGndDarkmeiro*, GlobalContext*);
+
+typedef struct BgGndDarkmeiro {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x8];
-    /* 0x016C */ ActorFunc actionFunc;
+    /* 0x016C */ BgGndDarkmeiroActionFunc actionFunc;
 } BgGndDarkmeiro; // size = 0x0170
 
 extern const ActorInit Bg_Gnd_Darkmeiro_InitVars;

--- a/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.h
@@ -4,11 +4,15 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgGndFiremeiro;
+
+typedef void (*BgGndFiremeiroActionFunc)(struct BgGndFiremeiro*, GlobalContext*);
+
+typedef struct BgGndFiremeiro {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ Vec3f unk_164;
     /* 0x0170 */ char unk_170[0x4];
-    /* 0x0174 */ ActorFunc actionFunc;
+    /* 0x0174 */ BgGndFiremeiroActionFunc actionFunc;
 } BgGndFiremeiro; // size = 0x0178
 
 extern const ActorInit Bg_Gnd_Firemeiro_InitVars;

--- a/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgGndIceblock;
+
+typedef void (*BgGndIceblockActionFunc)(struct BgGndIceblock*, GlobalContext*);
+
+typedef struct BgGndIceblock {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgGndIceblockActionFunc actionFunc;
     /* 0x0168 */ Vec3f unk_168;
 } BgGndIceblock; // size = 0x0174
 

--- a/src/overlays/actors/ovl_Bg_Gnd_Nisekabe/z_bg_gnd_nisekabe.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Nisekabe/z_bg_gnd_nisekabe.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgGndNisekabe;
+
+typedef struct BgGndNisekabe {
     /* 0x0000 */ Actor actor;
 } BgGndNisekabe; // size = 0x014C
 

--- a/src/overlays/actors/ovl_Bg_Gnd_Soulmeiro/z_bg_gnd_soulmeiro.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Soulmeiro/z_bg_gnd_soulmeiro.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgGndSoulmeiro;
+
+typedef void (*BgGndSoulmeiroActionFunc)(struct BgGndSoulmeiro*, GlobalContext*);
+
+typedef struct BgGndSoulmeiro {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x50];
-    /* 0x019C */ ActorFunc actionFunc;
+    /* 0x019C */ BgGndSoulmeiroActionFunc actionFunc;
 } BgGndSoulmeiro; // size = 0x01A0
 
 extern const ActorInit Bg_Gnd_Soulmeiro_InitVars;

--- a/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.h
+++ b/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHaka;
+
+typedef void (*BgHakaActionFunc)(struct BgHaka*, GlobalContext*);
+
+typedef struct BgHaka {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHakaActionFunc actionFunc;
 } BgHaka; // size = 0x0168
 
 extern const ActorInit Bg_Haka_InitVars;

--- a/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaGate;
+
+typedef void (*BgHakaGateActionFunc)(struct BgHakaGate*, GlobalContext*);
+
+typedef struct BgHakaGate {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHakaGateActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0xC];
 } BgHakaGate; // size = 0x0174
 

--- a/src/overlays/actors/ovl_Bg_Haka_Huta/z_bg_haka_huta.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Huta/z_bg_haka_huta.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaHuta;
+
+typedef void (*BgHakaHutaActionFunc)(struct BgHakaHuta*, GlobalContext*);
+
+typedef struct BgHakaHuta {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHakaHutaActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x4];
 } BgHakaHuta; // size = 0x016C
 

--- a/src/overlays/actors/ovl_Bg_Haka_Megane/z_bg_haka_megane.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Megane/z_bg_haka_megane.c
@@ -62,7 +62,7 @@ void BgHakaMegane_Init(Actor* thisx, GlobalContext* globalCtx) {
     if (this->objBankIndex < 0) {
         Actor_Kill(thisx);
     } else {
-        this->actionFunc = (ActorFunc)func_8087DB24;
+        this->actionFunc = func_8087DB24;
     }
 }
 
@@ -81,7 +81,7 @@ void func_8087DB24(BgHakaMegane* this, GlobalContext* globalCtx) {
         this->dyna.actor.draw = BgHakaMegane_Draw;
         Actor_SetObjectDependency(globalCtx, &this->dyna.actor);
         if (globalCtx->roomCtx.curRoom.showInvisActors) {
-            this->actionFunc = (ActorFunc)func_8087DBF0;
+            this->actionFunc = func_8087DBF0;
             collision = collisions[this->dyna.actor.params];
             if (collision != 0) {
                 DynaPolyInfo_Alloc(collision, &localC);
@@ -89,7 +89,7 @@ void func_8087DB24(BgHakaMegane* this, GlobalContext* globalCtx) {
                     DynaPolyInfo_RegisterActor(globalCtx, &globalCtx->colCtx.dyna, &this->dyna.actor, localC);
             }
         } else {
-            this->actionFunc = (ActorFunc)func_8087DC64;
+            this->actionFunc = func_8087DC64;
         }
     }
 }

--- a/src/overlays/actors/ovl_Bg_Haka_Megane/z_bg_haka_megane.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Megane/z_bg_haka_megane.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaMegane;
+
+typedef void (*BgHakaMeganeActionFunc)(struct BgHakaMegane*, GlobalContext*);
+
+typedef struct BgHakaMegane {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHakaMeganeActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x1];
     /* 0x0169 */ s8 objBankIndex;
     /* 0x016A */ char unk_16A[0x2];

--- a/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.h
+++ b/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaMeganeBG;
+
+typedef void (*BgHakaMeganeBGActionFunc)(struct BgHakaMeganeBG*, GlobalContext*);
+
+typedef struct BgHakaMeganeBG {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHakaMeganeBGActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x1];
     /* 0x0169 */ s8 unk_169; // objBankIndex ?
     /* 0x016A */ char unk_16A[0x2];

--- a/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaSgami;
+
+typedef void (*BgHakaSgamiActionFunc)(struct BgHakaSgami*, GlobalContext*);
+
+typedef struct BgHakaSgami {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ BgHakaSgamiActionFunc actionFunc;
     /* 0x0150 */ char unk_150[0x1E8];
 } BgHakaSgami; // size = 0x0338
 

--- a/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaShip;
+
+typedef void (*BgHakaShipActionFunc)(struct BgHakaShip*, GlobalContext*);
+
+typedef struct BgHakaShip {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHakaShipActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x2];
     /* 0x016A */ char unk_16A[0x2];
     /* 0x016C */ Vec3f unk_16C;

--- a/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaTrap;
+
+typedef void (*BgHakaTrapActionFunc)(struct BgHakaTrap*, GlobalContext*);
+
+typedef struct BgHakaTrap {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHakaTrapActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x134];
 } BgHakaTrap; // size = 0x029C
 

--- a/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaTubo;
+
+typedef void (*BgHakaTuboActionFunc)(struct BgHakaTubo*, GlobalContext*);
+
+typedef struct BgHakaTubo {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHakaTuboActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x9C];
 } BgHakaTubo; // size = 0x0204
 

--- a/src/overlays/actors/ovl_Bg_Haka_Water/z_bg_haka_water.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Water/z_bg_haka_water.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaWater;
+
+typedef void (*BgHakaWaterActionFunc)(struct BgHakaWater*, GlobalContext*);
+
+typedef struct BgHakaWater {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ BgHakaWaterActionFunc actionFunc;
     /* 0x0150 */ char unk_150[0x4];
 } BgHakaWater; // size = 0x0154
 

--- a/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHakaZou;
+
+typedef struct BgHakaZou {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x6C];
 } BgHakaZou; // size = 0x01B8

--- a/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.h
+++ b/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHeavyBlock;
+
+typedef struct BgHeavyBlock {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2C];
 } BgHeavyBlock; // size = 0x0178

--- a/src/overlays/actors/ovl_Bg_Hidan_Curtain/z_bg_hidan_curtain.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Curtain/z_bg_hidan_curtain.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanCurtain;
+
+typedef struct BgHidanCurtain {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x58];
 } BgHidanCurtain; // size = 0x01A4

--- a/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanDalm;
+
+typedef struct BgHidanDalm {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1B0];
 } BgHidanDalm; // size = 0x02FC

--- a/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
@@ -69,7 +69,7 @@ void BgHidanFirewall_Init(Actor* thisx, GlobalContext* globalCtx) {
 
     func_80061ED4(&this->actor.colChkInfo, NULL, &colChkInfoInit);
 
-    this->actionFunc = (ActorFunc)BgHidanFirewall_Wait;
+    this->actionFunc = BgHidanFirewall_Wait;
 }
 
 void BgHidanFirewall_Destroy(Actor* thisx, GlobalContext* globalCtx) {
@@ -95,7 +95,7 @@ void BgHidanFirewall_Wait(BgHidanFirewall* this, GlobalContext* globalCtx) {
     if (BgHidanFirewall_CheckProximity(this, globalCtx) != 0) {
         this->actor.draw = BgHidanFirewall_Draw;
         this->actor.params = 5;
-        this->actionFunc = (ActorFunc)BgHidanFirewall_Countdown;
+        this->actionFunc = BgHidanFirewall_Countdown;
     }
 }
 
@@ -105,7 +105,7 @@ void BgHidanFirewall_Countdown(BgHidanFirewall* this, GlobalContext* globalCtx) 
         this->actor.params--;
     }
     if (this->actor.params == 0) {
-        this->actionFunc = (ActorFunc)BgHidanFirewall_Erupt;
+        this->actionFunc = BgHidanFirewall_Erupt;
     }
 }
 
@@ -115,7 +115,7 @@ void BgHidanFirewall_Erupt(BgHidanFirewall* this, GlobalContext* globalCtx) {
     } else {
         if (Math_ApproxF(&this->actor.scale.y, 0.01f, 0.01f) != 0) {
             this->actor.draw = NULL;
-            this->actionFunc = (ActorFunc)BgHidanFirewall_Wait;
+            this->actionFunc = BgHidanFirewall_Wait;
         } else {
             this->actor.params = 0;
         }
@@ -182,7 +182,7 @@ void BgHidanFirewall_Update(Actor* thisx, GlobalContext* globalCtx) {
     }
 
     this->actionFunc(this, globalCtx);
-    if (this->actionFunc == (ActorFunc)BgHidanFirewall_Erupt) {
+    if (this->actionFunc == BgHidanFirewall_Erupt) {
         BgHidanFirewall_ColliderFollowPlayer(this, globalCtx);
         CollisionCheck_SetAT(globalCtx, &globalCtx->colChkCtx, &this->collider);
         CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this->collider);

--- a/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.h
@@ -4,11 +4,15 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
-    /* 0x0000 */ Actor                 actor;
-    /* 0x014C */ ActorFunc             actionFunc;
-    /* 0x0150 */ s16                   unk_150;
-    /* 0x0154 */ ColliderCylinder      collider;
+struct BgHidanFirewall;
+
+typedef void (*BgHidanFirewallActionFunc)(struct BgHidanFirewall*, GlobalContext*);
+
+typedef struct BgHidanFirewall {
+    /* 0x0000 */ Actor actor;
+    /* 0x014C */ BgHidanFirewallActionFunc actionFunc;
+    /* 0x0150 */ s16 unk_150;
+    /* 0x0154 */ ColliderCylinder collider;
 } BgHidanFirewall; // size = 0x01A0
 
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanFslift;
+
+typedef void (*BgHidanFsliftActionFunc)(struct BgHidanFslift*, GlobalContext*);
+
+typedef struct BgHidanFslift {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHidanFsliftActionFunc actionFunc;
     /* 0x0168 */ s16 unk_168;
     /* 0x016A */ s16 unk_16A;
 } BgHidanFslift; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Hidan_Fwbig/z_bg_hidan_fwbig.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Fwbig/z_bg_hidan_fwbig.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanFwbig;
+
+typedef struct BgHidanFwbig {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x54];
 } BgHidanFwbig; // size = 0x01A0

--- a/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanHamstep;
+
+typedef struct BgHidanHamstep {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xFC];
 } BgHidanHamstep; // size = 0x0248

--- a/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanHrock;
+
+typedef struct BgHidanHrock {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xF8];
 } BgHidanHrock; // size = 0x0244

--- a/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanKousi;
+
+typedef struct BgHidanKousi {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } BgHidanKousi; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanKowarerukabe;
+
+typedef struct BgHidanKowarerukabe {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x78];
 } BgHidanKowarerukabe; // size = 0x01C4

--- a/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanRock;
+
+typedef struct BgHidanRock {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x7C];
 } BgHidanRock; // size = 0x01C8

--- a/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanRsekizou;
+
+typedef struct BgHidanRsekizou {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1BC];
 } BgHidanRsekizou; // size = 0x0308

--- a/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanSekizou;
+
+typedef struct BgHidanSekizou {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C8];
 } BgHidanSekizou; // size = 0x0314

--- a/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanSima;
+
+typedef struct BgHidanSima {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC0];
 } BgHidanSima; // size = 0x020C

--- a/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgHidanSyoku;
+
+typedef void (*BgHidanSyokuActionFunc)(struct BgHidanSyoku*, GlobalContext*);
+
+typedef struct BgHidanSyoku {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgHidanSyokuActionFunc actionFunc;
     /* 0x0168 */ s16 unk_168;
     /* 0x016A */ s16 unk_16A;
 } BgHidanSyoku; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.h
+++ b/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgIceObjects;
+
+typedef struct BgIceObjects {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x28];
 } BgIceObjects; // size = 0x0174

--- a/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.h
+++ b/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgIceShelter;
+
+typedef struct BgIceShelter {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xB8];
 } BgIceShelter; // size = 0x0204

--- a/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgIceShutter;
+
+typedef void (*BgIceShutterActionFunc)(struct BgIceShutter*, GlobalContext*);
+
+typedef struct BgIceShutter {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgIceShutterActionFunc actionFunc;
 } BgIceShutter; // size = 0x0168
 
 extern const ActorInit Bg_Ice_Shutter_InitVars;

--- a/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.h
+++ b/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgIceTurara;
+
+typedef struct BgIceTurara {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x6C];
 } BgIceTurara; // size = 0x01B8

--- a/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
+++ b/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
@@ -15,7 +15,6 @@ void BgIngate_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void BgIngate_Update(Actor* thisx, GlobalContext* globalCtx);
 void BgIngate_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void BgIngate_SetupAction(BgIngate* this, ActorFunc actionFunc);
 void func_80892890(BgIngate* this, GlobalContext* globalCtx);
 void func_80892990(BgIngate* this, GlobalContext* globalCtx);
 

--- a/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.h
+++ b/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgIngate;
+
+typedef void (*BgIngateActionFunc)(struct BgIngate*, GlobalContext*);
+
+typedef struct BgIngate {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgIngateActionFunc actionFunc;
 } BgIngate; // size = 0x0168
 
 extern const ActorInit Bg_Ingate_InitVars;

--- a/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.h
+++ b/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJya1flift;
+
+typedef struct BgJya1flift {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x70];
 } BgJya1flift; // size = 0x01BC

--- a/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.h
@@ -4,11 +4,15 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaAmishutter;
+
+typedef void (*BgJyaAmishutterActionFunc)(struct BgJyaAmishutter*);
+
+typedef struct BgJyaAmishutter {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x0150 */ char unk_150[0x14];
-    /* 0x0164 */ void (*actionFunc)(Actor*);
+    /* 0x0164 */ BgJyaAmishutterActionFunc actionFunc;
 } BgJyaAmishutter; // size = 0x0168
 
 extern const ActorInit Bg_Jya_Amishutter_InitVars;

--- a/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaBigmirror;
+
+typedef struct BgJyaBigmirror {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x28];
 } BgJyaBigmirror; // size = 0x0174

--- a/src/overlays/actors/ovl_Bg_Jya_Block/z_bg_jya_block.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Block/z_bg_jya_block.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaBlock;
+
+typedef struct BgJyaBlock {
     /* 0x0000 */ DynaPolyActor dyna;
 } BgJyaBlock; // size = 0x0164
 

--- a/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaBombchuiwa;
+
+typedef struct BgJyaBombchuiwa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x6C];
 } BgJyaBombchuiwa; // size = 0x01B8

--- a/src/overlays/actors/ovl_Bg_Jya_Bombiwa/z_bg_jya_bombiwa.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombiwa/z_bg_jya_bombiwa.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaBombiwa;
+
+typedef struct BgJyaBombiwa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x7C];
 } BgJyaBombiwa; // size = 0x01C8

--- a/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaCobra;
+
+typedef struct BgJyaCobra {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1058];
 } BgJyaCobra; // size = 0x11A4

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaGoroiwa;
+
+typedef struct BgJyaGoroiwa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x70];
 } BgJyaGoroiwa; // size = 0x01BC

--- a/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaHaheniron;
+
+typedef struct BgJyaHaheniron {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x68];
 } BgJyaHaheniron; // size = 0x01B4

--- a/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaIronobj;
+
+typedef struct BgJyaIronobj {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x68];
 } BgJyaIronobj; // size = 0x01B4

--- a/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.h
@@ -4,11 +4,15 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaKanaami;
+
+typedef void (*BgJyaKanaamiActionFunc)(struct BgJyaKanaami*, GlobalContext*);
+
+typedef struct BgJyaKanaami {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x014C */ char unk_150[0x14];
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgJyaKanaamiActionFunc actionFunc;
     /* 0x0168 */ s16 unk_168;
     /* 0x016A */ s16 unk_16A;
 } BgJyaKanaami; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaLift;
+
+typedef struct BgJyaLift {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } BgJyaLift; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaMegami;
+
+typedef struct BgJyaMegami {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1F0];
 } BgJyaMegami; // size = 0x033C

--- a/src/overlays/actors/ovl_Bg_Jya_Zurerukabe/z_bg_jya_zurerukabe.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Zurerukabe/z_bg_jya_zurerukabe.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgJyaZurerukabe;
+
+typedef struct BgJyaZurerukabe {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x24];
 } BgJyaZurerukabe; // size = 0x0170

--- a/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.h
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMenkuriEye;
+
+typedef struct BgMenkuriEye {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4];
     /* 0x0150 */ Collider collider;

--- a/src/overlays/actors/ovl_Bg_Menkuri_Kaiten/z_bg_menkuri_kaiten.h
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Kaiten/z_bg_menkuri_kaiten.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMenkuriKaiten;
+
+typedef struct BgMenkuriKaiten {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x0150 */ char unk_150[0x14];

--- a/src/overlays/actors/ovl_Bg_Menkuri_Nisekabe/z_bg_menkuri_nisekabe.h
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Nisekabe/z_bg_menkuri_nisekabe.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMenkuriNisekabe;
+
+typedef struct BgMenkuriNisekabe {
     /* 0x0000 */ Actor actor;
 } BgMenkuriNisekabe; // size = 0x014C
 

--- a/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMizuBwall;
+
+typedef struct BgMizuBwall {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x170];
 } BgMizuBwall; // size = 0x02BC

--- a/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMizuMovebg;
+
+typedef struct BgMizuMovebg {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x3C];
 } BgMizuMovebg; // size = 0x0188

--- a/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMizuShutter;
+
+typedef struct BgMizuShutter {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x44];
 } BgMizuShutter; // size = 0x0190

--- a/src/overlays/actors/ovl_Bg_Mizu_Uzu/z_bg_mizu_uzu.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Uzu/z_bg_mizu_uzu.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMizuUzu;
+
+typedef void (*BgMizuUzuActionFunc)(struct BgMizuUzu*, GlobalContext*);
+
+typedef struct BgMizuUzu {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgMizuUzuActionFunc actionFunc;
 } BgMizuUzu; // size = 0x0168
 
 extern const ActorInit Bg_Mizu_Uzu_InitVars;

--- a/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMizuWater;
+
+typedef struct BgMizuWater {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x14];
 } BgMizuWater; // size = 0x0160

--- a/src/overlays/actors/ovl_Bg_Mjin/z_bg_mjin.c
+++ b/src/overlays/actors/ovl_Bg_Mjin/z_bg_mjin.c
@@ -15,7 +15,6 @@ void BgMjin_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void BgMjin_Update(Actor* thisx, GlobalContext* globalCtx);
 void BgMjin_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void BgMjin_SetupAction(BgMjin* this, ActorFunc actionFunc);
 void func_808A0850(BgMjin* this, GlobalContext* globalCtx);
 void func_808A0920(BgMjin* this, GlobalContext* globalCtx);
 
@@ -46,7 +45,7 @@ static InitChainEntry initChain[] = {
 static s16 objectTbl[] = { OBJECT_MJIN_FLASH, OBJECT_MJIN_DARK, OBJECT_MJIN_FLAME,
                            OBJECT_MJIN_ICE,   OBJECT_MJIN_SOUL, OBJECT_MJIN_WIND };
 
-void BgMjin_SetupAction(BgMjin* this, ActorFunc actionFunc) {
+void BgMjin_SetupAction(BgMjin* this, BgMjinActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 
@@ -60,7 +59,7 @@ void BgMjin_Init(Actor* thisx, GlobalContext* globalCtx) {
     if (objBankIndex < 0) {
         Actor_Kill(thisx);
     } else {
-        BgMjin_SetupAction(this, &func_808A0850);
+        BgMjin_SetupAction(this, func_808A0850);
     }
 }
 
@@ -84,7 +83,7 @@ void func_808A0850(BgMjin* this, GlobalContext* globalCtx) {
         DynaPolyInfo_Alloc(collision, &local_c);
         this->dyna.dynaPolyId =
             DynaPolyInfo_RegisterActor(globalCtx, &globalCtx->colCtx.dyna, &this->dyna.actor, local_c);
-        BgMjin_SetupAction(this, &func_808A0920);
+        BgMjin_SetupAction(this, func_808A0920);
         this->dyna.actor.draw = BgMjin_Draw;
     }
 }

--- a/src/overlays/actors/ovl_Bg_Mjin/z_bg_mjin.h
+++ b/src/overlays/actors/ovl_Bg_Mjin/z_bg_mjin.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMjin;
+
+typedef void (*BgMjinActionFunc)(struct BgMjin*, GlobalContext*);
+
+typedef struct BgMjin {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ s8 objBankIndex;
-    /* 0x0168 */ ActorFunc actionFunc;
+    /* 0x0168 */ BgMjinActionFunc actionFunc;
 } BgMjin; // size = 0x016C
 
 extern const ActorInit Bg_Mjin_InitVars;

--- a/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMoriBigst;
+
+typedef struct BgMoriBigst {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } BgMoriBigst; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMoriElevator;
+
+typedef struct BgMoriElevator {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x28];
 } BgMoriElevator; // size = 0x0174

--- a/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMoriHashigo;
+
+typedef struct BgMoriHashigo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x84];
 } BgMoriHashigo; // size = 0x01D0

--- a/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMoriHashira4;
+
+typedef struct BgMoriHashira4 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } BgMoriHashira4; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Mori_Hineri/z_bg_mori_hineri.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Hineri/z_bg_mori_hineri.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMoriHineri;
+
+typedef struct BgMoriHineri {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } BgMoriHineri; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Mori_Idomizu/z_bg_mori_idomizu.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Idomizu/z_bg_mori_idomizu.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMoriIdomizu;
+
+typedef struct BgMoriIdomizu {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x14];
 } BgMoriIdomizu; // size = 0x0160

--- a/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMoriKaitenkabe;
+
+typedef struct BgMoriKaitenkabe {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x3C];
 } BgMoriKaitenkabe; // size = 0x0188

--- a/src/overlays/actors/ovl_Bg_Mori_Rakkatenjo/z_bg_mori_rakkatenjo.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Rakkatenjo/z_bg_mori_rakkatenjo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgMoriRakkatenjo;
+
+typedef struct BgMoriRakkatenjo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2C];
 } BgMoriRakkatenjo; // size = 0x0178

--- a/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.h
+++ b/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgPoEvent;
+
+typedef struct BgPoEvent {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xFC];
 } BgPoEvent; // size = 0x0248

--- a/src/overlays/actors/ovl_Bg_Po_Syokudai/z_bg_po_syokudai.h
+++ b/src/overlays/actors/ovl_Bg_Po_Syokudai/z_bg_po_syokudai.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgPoSyokudai;
+
+typedef struct BgPoSyokudai {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x64];
 } BgPoSyokudai; // size = 0x01B0

--- a/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
+++ b/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
@@ -15,7 +15,6 @@ void BgPushbox_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void BgPushbox_Update(Actor* thisx, GlobalContext* globalCtx);
 void BgPushbox_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void func_808A8AE0(BgPushbox* this, ActorFunc actionFunc);
 void func_808A8BAC(BgPushbox* this, GlobalContext* globalCtx);
 
 const ActorInit Bg_Pushbox_InitVars = {
@@ -37,7 +36,7 @@ static InitChainEntry initChain[] = {
     ICHAIN_F32_DIV1000(gravity, -2000, ICHAIN_STOP),
 };
 
-void func_808A8AE0(BgPushbox* this, ActorFunc actionFunc) {
+void BgPushbox_SetupAction(BgPushbox* this, BgPushboxActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 
@@ -52,7 +51,7 @@ void BgPushbox_Init(Actor* thisx, GlobalContext* globalCtx) {
     DynaPolyInfo_Alloc(&D_06000350, &local_c);
     this->dyna.dynaPolyId = DynaPolyInfo_RegisterActor(globalCtx, &globalCtx->colCtx.dyna, thisx, local_c);
     ActorShape_Init(&thisx->shape, 0.0f, NULL, 0.0f);
-    func_808A8AE0(this, &func_808A8BAC);
+    BgPushbox_SetupAction(this, func_808A8BAC);
 }
 
 void BgPushbox_Destroy(Actor* thisx, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.h
+++ b/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgPushbox;
+
+typedef void (*BgPushboxActionFunc)(struct BgPushbox*, GlobalContext*);
+
+typedef struct BgPushbox {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgPushboxActionFunc actionFunc;
 } BgPushbox; // size = 0x0168
 
 extern const ActorInit Bg_Pushbox_InitVars;

--- a/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.h
+++ b/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgRelayObjects;
+
+typedef struct BgRelayObjects {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } BgRelayObjects; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Spot00_Break/z_bg_spot00_break.h
+++ b/src/overlays/actors/ovl_Bg_Spot00_Break/z_bg_spot00_break.h
@@ -5,7 +5,9 @@
 #include <global.h>
 
 
-typedef struct {
+struct BgSpot00Break;
+
+typedef struct BgSpot00Break {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x0150 */ char unk_150[0x14];

--- a/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.h
+++ b/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot00Hanebasi;
+
+typedef struct BgSpot00Hanebasi {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x1C];
 } BgSpot00Hanebasi; // size = 0x0180

--- a/src/overlays/actors/ovl_Bg_Spot01_Fusya/z_bg_spot01_fusya.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Fusya/z_bg_spot01_fusya.c
@@ -38,7 +38,7 @@ static InitChainEntry initChain[] = {
 
 extern u32 D_06000100;
 
-void BgSpot01Fusya_SetupAction(BgSpot01Fusya* this, ActorFunc actionFunc) {
+void BgSpot01Fusya_SetupAction(BgSpot01Fusya* this, BgSpot01FusyaActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_Bg_Spot01_Fusya/z_bg_spot01_fusya.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Fusya/z_bg_spot01_fusya.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot01Fusya;
+
+typedef void (*BgSpot01FusyaActionFunc)(struct BgSpot01Fusya*, GlobalContext*);
+
+typedef struct BgSpot01Fusya {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ BgSpot01FusyaActionFunc actionFunc;
     /* 0x0150 */ char unk_150[0x4];
     /* 0x0154 */ f32 unk_154;
     /* 0x0158 */ f32 unk_158;

--- a/src/overlays/actors/ovl_Bg_Spot01_Idohashira/z_bg_spot01_idohashira.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idohashira/z_bg_spot01_idohashira.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot01Idohashira;
+
+typedef struct BgSpot01Idohashira {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x28];
 } BgSpot01Idohashira; // size = 0x0174

--- a/src/overlays/actors/ovl_Bg_Spot01_Idomizu/z_bg_spot01_idomizu.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idomizu/z_bg_spot01_idomizu.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot01Idomizu;
+
+typedef void (*BgSpot01IdomizuActionFunc)(struct BgSpot01Idomizu*, GlobalContext*);
+
+typedef struct BgSpot01Idomizu {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ BgSpot01IdomizuActionFunc actionFunc;
     /* 0x0150 */ f32 unk_150;
     /* 0x0154 */ char unk_154[0x4];
 } BgSpot01Idomizu; // size = 0x0158

--- a/src/overlays/actors/ovl_Bg_Spot01_Idosoko/z_bg_spot01_idosoko.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idosoko/z_bg_spot01_idosoko.c
@@ -35,7 +35,7 @@ static InitChainEntry initChain[] = {
 
 extern u32 D_06003C64;
 
-void BgSpot01Idosoko_SetupAction(BgSpot01Idosoko* this, ActorFunc actionFunc) {
+void BgSpot01Idosoko_SetupAction(BgSpot01Idosoko* this, BgSpot01IdosokoActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_Bg_Spot01_Idosoko/z_bg_spot01_idosoko.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idosoko/z_bg_spot01_idosoko.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot01Idosoko;
+
+typedef void (*BgSpot01IdosokoActionFunc)(struct BgSpot01Idosoko*, GlobalContext*);
+
+typedef struct BgSpot01Idosoko {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgSpot01IdosokoActionFunc actionFunc;
 } BgSpot01Idosoko; // size = 0x0168
 
 extern const ActorInit Bg_Spot01_Idosoko_InitVars;

--- a/src/overlays/actors/ovl_Bg_Spot01_Objects2/z_bg_spot01_objects2.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Objects2/z_bg_spot01_objects2.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot01Objects2;
+
+typedef void (*BgSpot01Objects2ActionFunc)(struct BgSpot01Objects2*, GlobalContext*);
+
+typedef struct BgSpot01Objects2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x18];
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgSpot01Objects2ActionFunc actionFunc;
     /* 0x0168 */ char unk_168[0x10];
     /* 0x0178 */ s32 objectId;
     /* 0x0179 */ char unk_179[0x4];

--- a/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.h
+++ b/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot02Objects;
+
+typedef struct BgSpot02Objects {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x28];
 } BgSpot02Objects; // size = 0x0174

--- a/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.h
+++ b/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot03Taki;
+
+typedef struct BgSpot03Taki {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2C];
 } BgSpot03Taki; // size = 0x0178

--- a/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.h
+++ b/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot05Soko;
+
+typedef void (*BgSpot05SokoActionFunc)(struct BgSpot05Soko*, GlobalContext*);
+
+typedef struct BgSpot05Soko {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgSpot05SokoActionFunc actionFunc;
     /* 0x0168 */ s32 switchFlag;
 } BgSpot05Soko; // size = 0x016C
 

--- a/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.h
+++ b/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot06Objects;
+
+typedef struct BgSpot06Objects {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x84];
 } BgSpot06Objects; // size = 0x01D0

--- a/src/overlays/actors/ovl_Bg_Spot07_Taki/z_bg_spot07_taki.h
+++ b/src/overlays/actors/ovl_Bg_Spot07_Taki/z_bg_spot07_taki.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot07Taki;
+
+typedef struct BgSpot07Taki {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C];
 } BgSpot07Taki; // size = 0x0168

--- a/src/overlays/actors/ovl_Bg_Spot08_Bakudankabe/z_bg_spot08_bakudankabe.h
+++ b/src/overlays/actors/ovl_Bg_Spot08_Bakudankabe/z_bg_spot08_bakudankabe.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot08Bakudankabe;
+
+typedef struct BgSpot08Bakudankabe {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xF8];
 } BgSpot08Bakudankabe; // size = 0x0244

--- a/src/overlays/actors/ovl_Bg_Spot08_Iceblock/z_bg_spot08_iceblock.h
+++ b/src/overlays/actors/ovl_Bg_Spot08_Iceblock/z_bg_spot08_iceblock.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot08Iceblock;
+
+typedef struct BgSpot08Iceblock {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x50];
 } BgSpot08Iceblock; // size = 0x019C

--- a/src/overlays/actors/ovl_Bg_Spot09_Obj/z_bg_spot09_obj.h
+++ b/src/overlays/actors/ovl_Bg_Spot09_Obj/z_bg_spot09_obj.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot09Obj;
+
+typedef struct BgSpot09Obj {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x04];
 } BgSpot09Obj; // size = 0x0168

--- a/src/overlays/actors/ovl_Bg_Spot11_Bakudankabe/z_bg_spot11_bakudankabe.h
+++ b/src/overlays/actors/ovl_Bg_Spot11_Bakudankabe/z_bg_spot11_bakudankabe.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot11Bakudankabe;
+
+typedef struct BgSpot11Bakudankabe {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x64];
 } BgSpot11Bakudankabe; // size = 0x01B0

--- a/src/overlays/actors/ovl_Bg_Spot11_Oasis/z_bg_spot11_oasis.h
+++ b/src/overlays/actors/ovl_Bg_Spot11_Oasis/z_bg_spot11_oasis.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot11Oasis;
+
+typedef struct BgSpot11Oasis {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8];
 } BgSpot11Oasis; // size = 0x0154

--- a/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.c
+++ b/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.c
@@ -82,7 +82,7 @@ void BgSpot12Gate_Destroy(Actor* thisx, GlobalContext* globalCtx) {
 void func_808B30C0(BgSpot12Gate* this) {
     Actor* thisx = &this->dyna.actor;
 
-    this->actionFunc = (ActorFunc)func_808B30D8;
+    this->actionFunc = func_808B30D8;
     thisx->posRot.pos.y = thisx->initPosRot.pos.y;
 }
 
@@ -96,7 +96,7 @@ void func_808B30D8(BgSpot12Gate* this, GlobalContext* globalCtx) {
 }
 
 void func_808B3134(BgSpot12Gate* this) {
-    this->actionFunc = (ActorFunc)func_808B314C;
+    this->actionFunc = func_808B314C;
     this->unk_168 = 0x28;
 }
 
@@ -107,7 +107,7 @@ void func_808B314C(BgSpot12Gate* this, GlobalContext* globalCtx) {
 }
 
 void func_808B317C(BgSpot12Gate* this) {
-    this->actionFunc = (ActorFunc)func_808B318C;
+    this->actionFunc = func_808B318C;
 }
 
 void func_808B318C(BgSpot12Gate* this, GlobalContext* globalCtx) {
@@ -130,7 +130,7 @@ void func_808B318C(BgSpot12Gate* this, GlobalContext* globalCtx) {
 void func_808B3274(BgSpot12Gate* this) {
     Actor* thisx = &this->dyna.actor;
 
-    this->actionFunc = (ActorFunc)func_808B3298;
+    this->actionFunc = func_808B3298;
     thisx->posRot.pos.y = thisx->initPosRot.pos.y + 200.0f;
 }
 

--- a/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.h
+++ b/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot12Gate;
+
+typedef void (*BgSpot12GateActionFunc)(struct BgSpot12Gate*, GlobalContext*);
+
+typedef struct BgSpot12Gate {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgSpot12GateActionFunc actionFunc;
     /* 0x0168 */ s16 unk_168;
 } BgSpot12Gate; // size = 0x016C
 

--- a/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.h
+++ b/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot12Saku;
+
+typedef void (*BgSpot12SakuActionFunc)(struct BgSpot12Saku*, GlobalContext*);
+
+typedef struct BgSpot12Saku {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgSpot12SakuActionFunc actionFunc;
     /* 0x0168 */ s16 unk_168;
 } BgSpot12Saku; // size = 0x016C
 

--- a/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.h
+++ b/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot15Rrbox;
+
+typedef struct BgSpot15Rrbox {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x38];
 } BgSpot15Rrbox; // size = 0x0184

--- a/src/overlays/actors/ovl_Bg_Spot15_Saku/z_bg_spot15_saku.h
+++ b/src/overlays/actors/ovl_Bg_Spot15_Saku/z_bg_spot15_saku.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot15Saku;
+
+typedef void (*BgSpot15SakuActionFunc)(struct BgSpot15Saku*, GlobalContext*);
+
+typedef struct BgSpot15Saku {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ BgSpot15SakuActionFunc actionFunc;
     /* 0x0168 */ u64 unk_168;
     /* 0x0170 */ f32 unk_170;
     /* 0x0174 */ f32 unk_174;

--- a/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.h
+++ b/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot16Bombstone;
+
+typedef struct BgSpot16Bombstone {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xCC];
 } BgSpot16Bombstone; // size = 0x0218

--- a/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.h
+++ b/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot16Doughnut;
+
+typedef struct BgSpot16Doughnut {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8];
 } BgSpot16Doughnut; // size = 0x0154

--- a/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.h
+++ b/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot17Bakudankabe;
+
+typedef struct BgSpot17Bakudankabe {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x18];
 } BgSpot17Bakudankabe; // size = 0x0164

--- a/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.h
+++ b/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot17Funen;
+
+typedef struct BgSpot17Funen {
     /* 0x0000 */ Actor actor;
 } BgSpot17Funen; // size = 0x014C
 

--- a/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.h
+++ b/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot18Basket;
+
+typedef struct BgSpot18Basket {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xD0];
 } BgSpot18Basket; // size = 0x021C

--- a/src/overlays/actors/ovl_Bg_Spot18_Futa/z_bg_spot18_futa.h
+++ b/src/overlays/actors/ovl_Bg_Spot18_Futa/z_bg_spot18_futa.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot18Futa;
+
+typedef struct BgSpot18Futa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x0150 */ u32 unk_150[0x5];

--- a/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.h
+++ b/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot18Obj;
+
+typedef struct BgSpot18Obj {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } BgSpot18Obj; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSpot18Shutter;
+
+typedef struct BgSpot18Shutter {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C];
 } BgSpot18Shutter; // size = 0x0168

--- a/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.h
+++ b/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgSstFloor;
+
+typedef struct BgSstFloor {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } BgSstFloor; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.h
+++ b/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgTokiHikari;
+
+typedef struct BgTokiHikari {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8];
 } BgTokiHikari; // size = 0x0154

--- a/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -15,7 +15,6 @@ void BgTokiSwd_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void BgTokiSwd_Update(Actor* thisx, GlobalContext* globalCtx);
 void BgTokiSwd_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void BgTokiSwd_SetupAction(BgTokiSwd* this, ActorFunc actionFunc);
 void func_808BAF40(BgTokiSwd* this, GlobalContext* globalCtx);
 void func_808BB0AC(BgTokiSwd* this, GlobalContext* globalCtx);
 void func_808BB128(BgTokiSwd* this, GlobalContext* globalCtx);
@@ -181,7 +180,7 @@ static InitChainEntry initChain[] = {
     ICHAIN_VEC3F_DIV1000(scale, 0x19, ICHAIN_STOP),
 };
 
-void BgTokiSwd_SetupAction(BgTokiSwd* this, ActorFunc actionFunc) {
+void BgTokiSwd_SetupAction(BgTokiSwd* this, BgTokiSwdActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.h
+++ b/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgTokiSwd;
+
+typedef void (*BgTokiSwdActionFunc)(struct BgTokiSwd*, GlobalContext*);
+
+typedef struct BgTokiSwd {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ BgTokiSwdActionFunc actionFunc;
     /* 0x0150 */ ColliderCylinder collider;
 } BgTokiSwd; // size = 0x019C
 

--- a/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.h
+++ b/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgTreemouth;
+
+typedef struct BgTreemouth {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x24];
 } BgTreemouth; // size = 0x0170

--- a/src/overlays/actors/ovl_Bg_Umajump/z_bg_umajump.h
+++ b/src/overlays/actors/ovl_Bg_Umajump/z_bg_umajump.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgUmaJump;
+
+typedef struct BgUmaJump {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x0150 */ char unk_150[0x14];

--- a/src/overlays/actors/ovl_Bg_Vb_Sima/z_bg_vb_sima.h
+++ b/src/overlays/actors/ovl_Bg_Vb_Sima/z_bg_vb_sima.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgVbSima;
+
+typedef struct BgVbSima {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x30];
 } BgVbSima; // size = 0x017C

--- a/src/overlays/actors/ovl_Bg_Ydan_Hasi/z_bg_ydan_hasi.h
+++ b/src/overlays/actors/ovl_Bg_Ydan_Hasi/z_bg_ydan_hasi.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgYdanHasi;
+
+typedef struct BgYdanHasi {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } BgYdanHasi; // size = 0x016C

--- a/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.h
+++ b/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgYdanMaruta;
+
+typedef struct BgYdanMaruta {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xF8];
 } BgYdanMaruta; // size = 0x0244

--- a/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.h
+++ b/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgYdanSp;
+
+typedef struct BgYdanSp {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xFC];
 } BgYdanSp; // size = 0x0248

--- a/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
+++ b/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
@@ -24,17 +24,17 @@ void func_808C0CD4(BgZg* this, GlobalContext* globalCtx);
 void func_808C0D08(BgZg* this, GlobalContext* globalCtx);
 void func_808C0EEC(BgZg* this, GlobalContext* globalCtx);
 
-static const ActorFunc actionFuncs[] = {
-    (ActorFunc)func_808C0CD4,
-    (ActorFunc)func_808C0D08,
+static const BgZgActionFunc actionFuncs[] = {
+    func_808C0CD4,
+    func_808C0D08,
 };
 
 static InitChainEntry initChain[] = {
     ICHAIN_VEC3F_DIV1000(scale, 1000, ICHAIN_STOP),
 };
 
-static const ActorFunc drawFuncs[] = {
-    (ActorFunc)func_808C0EEC,
+static const BgZgDrawFunc drawFuncs[] = {
+    func_808C0EEC,
 };
 
 const ActorInit Bg_Zg_InitVars = {

--- a/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.h
+++ b/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.h
@@ -4,7 +4,12 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BgZg;
+
+typedef void (*BgZgActionFunc)(struct BgZg*, GlobalContext*);
+typedef void (*BgZgDrawFunc)(struct BgZg*, GlobalContext*);
+
+typedef struct BgZg {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ s32 action;
     /* 0x0168 */ s32 drawConfig;

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.h
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossDodongo;
+
+typedef struct BossDodongo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x16D4];
 } BossDodongo; // size = 0x1820

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.h
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossFd;
+
+typedef struct BossFd {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4254];
 } BossFd; // size = 0x43A0

--- a/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.h
+++ b/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossFd2;
+
+typedef struct BossFd2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1530];
 } BossFd2; // size = 0x167C

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.h
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossGanon;
+
+typedef struct BossGanon {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x5CC];
     /* 0x0718 */ s16 organFadeTimer;

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.h
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossGanon2;
+
+typedef struct BossGanon2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x798];
 } BossGanon2; // size = 0x08E4

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossGanondrof;
+
+typedef struct BossGanondrof {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x42C];
 } BossGanondrof; // size = 0x0578

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.h
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossGoma;
+
+typedef struct BossGoma {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x9D0];
 } BossGoma; // size = 0x0B1C

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.h
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossMo;
+
+typedef struct BossMo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1440];
 } BossMo; // size = 0x158C

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossSst;
+
+typedef struct BossSst {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x94C];
 } BossSst; // size = 0x0A98

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.h
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossTw;
+
+typedef struct BossTw {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x568];
 } BossTw; // size = 0x06B4

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct BossVa;
+
+typedef struct BossVa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x26C];
 } BossVa; // size = 0x03B8

--- a/src/overlays/actors/ovl_Demo_6K/z_demo_6k.h
+++ b/src/overlays/actors/ovl_Demo_6K/z_demo_6k.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct Demo6K;
+
+typedef struct Demo6K {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x148];
 } Demo6K; // size = 0x0294

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.h
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoDu;
+
+typedef struct DemoDu {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x68];
 } DemoDu; // size = 0x01B4

--- a/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.h
+++ b/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoEc;
+
+typedef struct DemoEc {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x5C];
 } DemoEc; // size = 0x01A8

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.h
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoEffect;
+
+typedef struct DemoEffect {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x54];
 } DemoEffect; // size = 0x01A0

--- a/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.h
+++ b/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoExt;
+
+typedef struct DemoExt {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x38];
 } DemoExt; // size = 0x0184

--- a/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.c
+++ b/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.c
@@ -29,18 +29,19 @@ s16 objectIds[] = {
     OBJECT_GEFF, OBJECT_GEFF, OBJECT_GEFF, OBJECT_GEFF, OBJECT_GEFF, OBJECT_GEFF, OBJECT_GEFF, OBJECT_GEFF, OBJECT_GEFF,
 };
 
-ActorFunc scaleFuncs[] = {
-    (ActorFunc)func_80978030, (ActorFunc)func_80978030, (ActorFunc)func_80978030,
-    (ActorFunc)func_80978030, (ActorFunc)func_80978030, (ActorFunc)func_80978030,
-    (ActorFunc)func_80978030, (ActorFunc)func_80978030, (ActorFunc)func_80978030,
+DemoGeffInitFunc initFuncs[] = {
+    func_80978030, func_80978030, func_80978030, func_80978030, func_80978030,
+    func_80978030, func_80978030, func_80978030, func_80978030,
 };
-ActorFunc actionFuncs[] = {
-    (ActorFunc)func_809783D4,
-    (ActorFunc)func_80978308,
+
+DemoGeffActionFunc actionFuncs[] = {
+    func_809783D4,
+    func_80978308,
 };
-ActorFunc drawFuncs[] = {
-    (ActorFunc)func_809784D4,
-    (ActorFunc)func_80978344,
+
+DemoGeffDrawFunc drawFuncs[] = {
+    func_809784D4,
+    func_80978344,
 };
 
 const ActorInit Demo_Geff_InitVars = {
@@ -178,13 +179,13 @@ void func_80978344(DemoGeff* this, GlobalContext* globalCtx) {
 
 void func_80978370(DemoGeff* this, GlobalContext* globalCtx) {
     s16 params = this->actor.params;
-    ActorFunc actorFunc = scaleFuncs[params];
-    if (actorFunc == NULL) {
+    DemoGeffInitFunc initFunc = initFuncs[params];
+    if (initFunc == NULL) {
         osSyncPrintf(VT_FGCOL(RED) " Demo_Geff_main_init:初期化処理がおかしいarg_data = %d!\n" VT_RST, params);
         Actor_Kill(&this->actor);
         return;
     }
-    actorFunc(this, globalCtx);
+    initFunc(this, globalCtx);
 }
 
 void func_809783D4(DemoGeff* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.h
+++ b/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.h
@@ -6,7 +6,13 @@
 
 #include "../ovl_Demo_Gt/z_demo_gt.h"
 
-typedef struct {
+struct DemoGeff;
+
+typedef void (*DemoGeffInitFunc)(struct DemoGeff*, GlobalContext*);
+typedef void (*DemoGeffActionFunc)(struct DemoGeff*, GlobalContext*);
+typedef void (*DemoGeffDrawFunc)(struct DemoGeff*, GlobalContext*);
+
+typedef struct DemoGeff {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ s32 action;
     /* 0x0150 */ s32 drawConfig;

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.h
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoGj;
+
+typedef struct DemoGj {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x12C];
 } DemoGj; // size = 0x0278

--- a/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
+++ b/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
@@ -30,11 +30,11 @@ void func_8097D29C(DemoGo* this, GlobalContext* globalCtx);
 
 UNK_PTR D_8097D440[] = { 0x0600CE80, 0x0600D280, 0x0600D680 };
 
-ActorFunc D_8097D44C[] = {
+DemoGoActionFunc D_8097D44C[] = {
     func_8097CFDC, func_8097CFFC, func_8097D01C, func_8097D058, func_8097D088, func_8097D0D0, func_8097D130,
 };
 
-ActorFunc D_8097D468[] = {
+DemoGoDrawFunc D_8097D468[] = {
     func_8097D290,
     func_8097D29C,
 };

--- a/src/overlays/actors/ovl_Demo_Go/z_demo_go.h
+++ b/src/overlays/actors/ovl_Demo_Go/z_demo_go.h
@@ -4,7 +4,12 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoGo;
+
+typedef void (*DemoGoActionFunc)(struct DemoGo*, GlobalContext*);
+typedef void (*DemoGoDrawFunc)(struct DemoGo*, GlobalContext*);
+
+typedef struct DemoGo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ s16 unk_190;

--- a/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.h
+++ b/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoGt;
+
+typedef struct DemoGt {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x5C];
 } DemoGt; // size = 0x01A8

--- a/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.h
+++ b/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoIk;
+
+typedef struct DemoIk {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x68];
 } DemoIk; // size = 0x01B4

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.h
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoIm;
+
+typedef struct DemoIm {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1B0];
 } DemoIm; // size = 0x02FC

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.h
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoKankyo;
+
+typedef struct DemoKankyo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4B8];
 } DemoKankyo; // size = 0x0604

--- a/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.h
+++ b/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoKekkai;
+
+typedef struct DemoKekkai {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xB0];
 } DemoKekkai; // size = 0x01FC

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.h
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoSa;
+
+typedef struct DemoSa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x68];
 } DemoSa; // size = 0x01B4

--- a/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
+++ b/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
@@ -15,7 +15,6 @@ void DemoShd_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void DemoShd_Update(Actor* thisx, GlobalContext* globalCtx);
 void DemoShd_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void DemoShd_SetupAction(DemoShd* this, ActorFunc actionFunc);
 void func_80991298(DemoShd* this, GlobalContext* globalCtx);
 
 /*

--- a/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.h
+++ b/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.h
@@ -4,11 +4,15 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoShd;
+
+typedef void (*DemoShdActionFunc)(struct DemoShd*, GlobalContext*);
+
+typedef struct DemoShd {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ s16 unk_14C;
     /* 0x014E */ s16 unk_14E;
-    /* 0x0150 */ ActorFunc actionFunc;
+    /* 0x0150 */ DemoShdActionFunc actionFunc;
 } DemoShd; // size = 0x0154
 
 extern const ActorInit Demo_Shd_InitVars;

--- a/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.h
+++ b/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DemoTreLgt;
+
+typedef struct DemoTreLgt {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x30];
 } DemoTreLgt; // size = 0x017C

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -15,8 +15,6 @@ void DoorAna_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void DoorAna_Update(Actor* thisx, GlobalContext* globalCtx);
 void DoorAna_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void DoorAna_SetupAction(DoorAna* this, ActorFunc func);
-
 void DoorAna_Update_Hidden(DoorAna* this, GlobalContext* globalCtx);
 void DoorAna_Update_Open(DoorAna* this, GlobalContext* globalCtx);
 void DoorAna_Update_Entering(DoorAna* this, GlobalContext* globalCtx);
@@ -49,9 +47,8 @@ static s16 entrances[] = {
 // display list
 extern Gfx D_05001390[];
 
-// sets current actionFunc to be ran on next update call
-void DoorAna_SetupAction(DoorAna* this, ActorFunc func) {
-    this->actionFunc = func;
+void DoorAna_SetupAction(DoorAna* this, DoorAnaActionFunc actionFunc) {
+    this->actionFunc = actionFunc;
 }
 
 void DoorAna_Init(Actor* thisx, GlobalContext* globalCtx) {
@@ -69,9 +66,9 @@ void DoorAna_Init(Actor* thisx, GlobalContext* globalCtx) {
             this->actor.flags |= 0x10;
         }
         Actor_SetScale(&this->actor, 0);
-        DoorAna_SetupAction(this, (ActorFunc)&DoorAna_Update_Hidden);
+        DoorAna_SetupAction(this, DoorAna_Update_Hidden);
     } else {
-        DoorAna_SetupAction(this, (ActorFunc)&DoorAna_Update_Open);
+        DoorAna_SetupAction(this, DoorAna_Update_Open);
     }
     this->actor.unk_1F = 0;
 }
@@ -107,7 +104,7 @@ void DoorAna_Update_Hidden(DoorAna* this, GlobalContext* globalCtx) {
     // open the grotto
     if (openGrotto) {
         this->actor.params &= ~0x0300;
-        DoorAna_SetupAction(this, (ActorFunc)&DoorAna_Update_Open);
+        DoorAna_SetupAction(this, DoorAna_Update_Open);
         Audio_PlaySoundGeneral(NA_SE_SY_CORRECT_CHIME, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
     }
     func_8002F5F0(&this->actor, globalCtx);
@@ -131,7 +128,7 @@ void DoorAna_Update_Open(DoorAna* this, GlobalContext* globalCtx) {
                 destinationIdx = this->actor.initPosRot.rot.z + 1;
             }
             globalCtx->nextEntranceIndex = entrances[destinationIdx];
-            DoorAna_SetupAction(this, (ActorFunc)&DoorAna_Update_Entering);
+            DoorAna_SetupAction(this, DoorAna_Update_Entering);
         } else {
             if (!func_8008E988(globalCtx) && !(player->stateFlags1 & 0x8800000) &&
                 this->actor.xzDistanceFromLink <= 15.0f && -50.0f <= this->actor.yDistanceFromLink &&

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.h
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DoorAna;
+
+typedef void (*DoorAnaActionFunc)(struct DoorAna*, GlobalContext*);
+
+typedef struct DoorAna {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ ColliderCylinder collider;
-    /* 0x0198 */ ActorFunc actionFunc;
+    /* 0x0198 */ DoorAnaActionFunc actionFunc;
 } DoorAna; // size = 0x019C
 
 extern const ActorInit Door_Ana_InitVars;

--- a/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.h
+++ b/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DoorGerudo;
+
+typedef struct DoorGerudo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } DoorGerudo; // size = 0x016C

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.h
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DoorKiller;
+
+typedef struct DoorKiller {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x138];
 } DoorKiller; // size = 0x0284

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.h
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DoorShutter;
+
+typedef struct DoorShutter {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2C];
 } DoorShutter; // size = 0x0178

--- a/src/overlays/actors/ovl_Door_Toki/z_door_toki.h
+++ b/src/overlays/actors/ovl_Door_Toki/z_door_toki.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DoorToki;
+
+typedef struct DoorToki {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 dynaPolyId;
     /* 0x0150 */ u8 unk_150[0x18];

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.h
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct DoorWarp1;
+
+typedef struct DoorWarp1 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xA0];
     /* 0x01EC */ s32 unk_1EC;

--- a/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.h
+++ b/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EfcErupc;
+
+typedef struct EfcErupc {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1780];
 } EfcErupc; // size = 0x18CC

--- a/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.h
+++ b/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EffDust;
+
+typedef struct EffDust {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x41C];
 } EffDust; // size = 0x0568

--- a/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.h
+++ b/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ElfMsg;
+
+typedef struct ElfMsg {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4];
 } ElfMsg; // size = 0x0150

--- a/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.h
+++ b/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ElfMsg2;
+
+typedef struct ElfMsg2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4];
 } ElfMsg2; // size = 0x0150

--- a/src/overlays/actors/ovl_En_Am/z_en_am.h
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnAm;
+
+typedef struct EnAm {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x240];
 } EnAm; // size = 0x038C

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -15,7 +15,6 @@ void EnAni_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void EnAni_Update(Actor* thisx, GlobalContext* globalCtx);
 void EnAni_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void EnAni_SetupAction(EnAni* this, ActorFunc actionFunc);
 s32 EnAni_SetText(EnAni* this, GlobalContext* globalCtx, u16 textId);
 void func_809B04F0(EnAni* this, GlobalContext* globalCtx);
 void func_809B0524(EnAni* this, GlobalContext* globalCtx);
@@ -64,7 +63,7 @@ UNK_PTR D_809B0F80[] = {
     0x06001D18,
 };
 
-void EnAni_SetupAction(EnAni* this, ActorFunc actionFunc) {
+void EnAni_SetupAction(EnAni* this, EnAniActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.h
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.h
@@ -4,7 +4,11 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnAni;
+
+typedef void (*EnAniActionFunc)(struct EnAni*, GlobalContext*);
+
+typedef struct EnAni {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ ColliderCylinder collider;
     /* 0x0198 */ SkelAnime skelAnime;
@@ -16,7 +20,7 @@ typedef struct {
     /* 0x02AA */ u16 unk_2AA;
     /* 0x02AC */ s16 unk_2AC;
     /* 0x02AE */ s16 unk_2AE;
-    /* 0x02B0 */ ActorFunc actionFunc;
+    /* 0x02B0 */ EnAniActionFunc actionFunc;
 } EnAni; // size = 0x02B4
 
 extern const ActorInit En_Ani_InitVars;

--- a/src/overlays/actors/ovl_En_Anubice/z_en_anubice.h
+++ b/src/overlays/actors/ovl_En_Anubice/z_en_anubice.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnAnubice;
+
+typedef struct EnAnubice {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x10E];
     /* 0x025A */ s16 unk_25A;

--- a/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.h
+++ b/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnAnubiceFire;
+
+typedef struct EnAnubiceFire {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xA8];
 } EnAnubiceFire; // size = 0x01F4

--- a/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
+++ b/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
@@ -45,7 +45,7 @@ void EnAnubiceTag_Init(Actor* thisx, GlobalContext* globalCtx) {
     if (this->actor.params != 0) {
         this->triggerRange = this->actor.params * 40.0f;
     }
-    this->actionFunc = &EnAnubiceTag_SpawnAnubis;
+    this->actionFunc = EnAnubiceTag_SpawnAnubis;
 }
 
 void EnAnubiceTag_Destroy(Actor* thisx, GlobalContext* globalCtx) {
@@ -57,7 +57,7 @@ void EnAnubiceTag_SpawnAnubis(EnAnubiceTag* this, GlobalContext* globalCtx) {
                             this->actor.posRot.pos.y, this->actor.posRot.pos.z, 0, this->actor.rotTowardsLinkY, 0, 0);
 
     if (this->anubis != NULL) {
-        this->actionFunc = &EnAnubiceTag_ManageAnubis;
+        this->actionFunc = EnAnubiceTag_ManageAnubis;
     }
 }
 

--- a/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.h
+++ b/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.h
@@ -6,9 +6,13 @@
 
 #include "../ovl_En_Anubice/z_en_anubice.h"
 
-typedef struct {
+struct EnAnubiceTag;
+
+typedef void (*EnAnubiceTagActionFunc)(struct EnAnubiceTag*, GlobalContext*);
+
+typedef struct EnAnubiceTag {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ EnAnubiceTagActionFunc actionFunc;
     /* 0x0150 */ EnAnubice* anubis;
     /* 0x0154 */ f32 triggerRange;
 } EnAnubiceTag; // size = 0x0158

--- a/src/overlays/actors/ovl_En_Arow_Trap/z_en_arow_trap.h
+++ b/src/overlays/actors/ovl_En_Arow_Trap/z_en_arow_trap.h
@@ -5,7 +5,9 @@
 #include <global.h>
 #include <z64.h>
 
-typedef struct {
+struct EnArowTrap;
+
+typedef struct EnArowTrap {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 unk_14C;
     /* 0x0150 */ u32 attackTimer;

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.h
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnArrow;
+
+typedef struct EnArrow {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xFC];
     /* 0x0248 */ u8 timer; // used for dissapearing when flying or hitting a wall

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.h
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnAttackNiw;
+
+typedef struct EnAttackNiw {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x19C];
 } EnAttackNiw; // size = 0x02E8

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.h
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBa;
+
+typedef struct EnBa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x274];
 } EnBa; // size = 0x03C0

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.h
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBb;
+
+typedef struct EnBb {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1DC];
 } EnBb; // size = 0x0328

--- a/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.h
+++ b/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBdfire;
+
+typedef struct EnBdfire {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x98];
 } EnBdfire; // size = 0x01E4

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBigokuta;
+
+typedef struct EnBigokuta {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x238];
 } EnBigokuta; // size = 0x0384

--- a/src/overlays/actors/ovl_En_Bili/z_en_bili.h
+++ b/src/overlays/actors/ovl_En_Bili/z_en_bili.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBili;
+
+typedef struct EnBili {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xD4];
 } EnBili; // size = 0x0220

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.c
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.c
@@ -17,7 +17,6 @@ void EnBird_Draw(Actor* thisx, GlobalContext* globalCtx);
 
 void func_809C1E00(EnBird* this, s16 params);
 void func_809C1E40(EnBird* this, GlobalContext* globalCtx);
-void EnBird_SetupAction(EnBird* this, ActorFunc actionFunc);
 void func_809C1D60(EnBird* this, GlobalContext* globalCtx);
 void func_809C1CAC(EnBird* this, s16 params);
 
@@ -40,7 +39,7 @@ static InitChainEntry initChain[] = {
 extern AnimationHeader D_0600006C;
 extern SkeletonHeader D_06002190;
 
-void EnBird_SetupAction(EnBird* this, ActorFunc actionFunc) {
+void EnBird_SetupAction(EnBird* this, EnBirdActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 
@@ -98,7 +97,7 @@ void func_809C1D60(EnBird* this, GlobalContext* globalCtx) {
 
 void func_809C1E00(EnBird* this, s16 params) {
     this->unk_198 = Math_Rand_S16Offset(0x14, 0x2D);
-    EnBird_SetupAction(this, (ActorFunc)func_809C1E40);
+    EnBird_SetupAction(this, func_809C1E40);
 }
 
 void func_809C1E40(EnBird* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.h
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBird;
+
+typedef void (*EnBirdActionFunc)(struct EnBird*, GlobalContext*);
+
+typedef struct EnBird {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ ActorFunc actionFunc;
+    /* 0x0190 */ EnBirdActionFunc actionFunc;
     /* 0x0194 */ u32 unk_194;
     /* 0x0198 */ s32 unk_198;
     /* 0x019C */ s16 unk_19C;

--- a/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.h
+++ b/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBlkobj;
+
+typedef struct EnBlkobj {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } EnBlkobj; // size = 0x016C

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.h
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBom;
+
+typedef struct EnBom {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xBC];
 } EnBom; // size = 0x0208

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBomBowlMan;
+
+typedef struct EnBomBowlMan {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x10C];
     /* 0x0258 */ u8 unk_258;

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.h
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBomBowlPit;
+
+typedef struct EnBomBowlPit {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x35B8];
 } EnBomBowlPit; // size = 0x3704

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.h
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBomChu;
+
+typedef struct EnBomChu {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x98];
 } EnBomChu; // size = 0x01E4

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.h
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBombf;
+
+typedef struct EnBombf {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC4];
 } EnBombf; // size = 0x0210

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -15,7 +15,6 @@ void EnBoom_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void EnBoom_Update(Actor* thisx, GlobalContext* globalCtx);
 void EnBoom_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void EnBoom_SetupAction(EnBoom* this, ActorFunc* actionFunc);
 void EnBoom_Fly(EnBoom* this, GlobalContext* globalCtx);
 
 const ActorInit En_Boom_InitVars = {
@@ -46,7 +45,7 @@ static Vec3f mtxSrc2 = { 960.0f, 0.0f, 0.0f };
 
 extern D_0400C808;
 
-void EnBoom_SetupAction(EnBoom* this, ActorFunc* actionFunc) {
+void EnBoom_SetupAction(EnBoom* this, EnBoomActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 
@@ -87,7 +86,7 @@ void EnBoom_Init(Actor* thisx, GlobalContext* globalCtx) {
     Collider_InitQuad(globalCtx, &this->collider);
     Collider_SetQuad(globalCtx, &this->collider, this, &col);
 
-    EnBoom_SetupAction(this, &EnBoom_Fly);
+    EnBoom_SetupAction(this, EnBoom_Fly);
 }
 
 void EnBoom_Destroy(Actor* thisx, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.h
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.h
@@ -4,16 +4,20 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
-    /* 0x0000 */ Actor          actor;
-    /* 0x014C */ ColliderQuad   collider;
-    /* 0x01CC */ Actor*         moveTo;      // actor boomerang moves toward
-    /* 0x01D0 */ Actor*         grabbed;     // actor grabbed by the boomerang
-    /* 0x01D4 */ u8             returnTimer; // returns to Link when 0
-    /* 0x01D5 */ u8             activeTimer; // increments once every update
-    /* 0x01D8 */ u32            effect;      // set by Effect_Add
-    /* 0x01DC */ u32            unk_1DC[0x7];
-    /* 0x01F8 */ ActorFunc      actionFunc;
+struct EnBoom;
+
+typedef void (*EnBoomActionFunc)(struct EnBoom*, GlobalContext*);
+
+typedef struct EnBoom {
+    /* 0x0000 */ Actor              actor;
+    /* 0x014C */ ColliderQuad       collider;
+    /* 0x01CC */ Actor*             moveTo;      // actor boomerang moves toward
+    /* 0x01D0 */ Actor*             grabbed;     // actor grabbed by the boomerang
+    /* 0x01D4 */ u8                 returnTimer; // returns to Link when 0
+    /* 0x01D5 */ u8                 activeTimer; // increments once every update
+    /* 0x01D8 */ u32                effect;      // set by Effect_Add
+    /* 0x01DC */ u32                unk_1DC[0x7];
+    /* 0x01F8 */ EnBoomActionFunc   actionFunc;
 } EnBoom; // size = 0x01FC
 
 extern const ActorInit En_Boom_InitVars;

--- a/src/overlays/actors/ovl_En_Box/z_en_box.h
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBox;
+
+typedef struct EnBox {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xB0];
 } EnBox; // size = 0x01FC

--- a/src/overlays/actors/ovl_En_Brob/z_en_brob.h
+++ b/src/overlays/actors/ovl_En_Brob/z_en_brob.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBrob;
+
+typedef struct EnBrob {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x174];
 } EnBrob; // size = 0x02C0

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.h
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBubble;
+
+typedef struct EnBubble {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x114];
 } EnBubble; // size = 0x0260

--- a/src/overlays/actors/ovl_En_Butte/z_en_butte.h
+++ b/src/overlays/actors/ovl_En_Butte/z_en_butte.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnButte;
+
+typedef struct EnButte {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x11C];
 } EnButte; // size = 0x0268

--- a/src/overlays/actors/ovl_En_Bw/z_en_bw.h
+++ b/src/overlays/actors/ovl_En_Bw/z_en_bw.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBw;
+
+typedef struct EnBw {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1E0];
 } EnBw; // size = 0x032C

--- a/src/overlays/actors/ovl_En_Bx/z_en_bx.h
+++ b/src/overlays/actors/ovl_En_Bx/z_en_bx.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnBx;
+
+typedef struct EnBx {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x14C];
 } EnBx; // size = 0x0298

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.h
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnChanger;
+
+typedef struct EnChanger {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } EnChanger; // size = 0x016C

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnClearTag;
+
+typedef struct EnClearTag {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xB8];
 } EnClearTag; // size = 0x0204

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -116,7 +116,7 @@ void EnCow_Init(Actor* thisx, GlobalContext* globalCtx) {
             Collider_InitCylinder(globalCtx, &this->colliders[1]);
             Collider_SetCylinder(globalCtx, &this->colliders[1], &this->actor, &cylinderInit);
             func_809DEE9C(this);
-            this->actionFunc = (ActorFunc)func_809DF96C;
+            this->actionFunc = func_809DF96C;
             if (globalCtx->sceneNum == SCENE_LINK_HOME) {
                 if (gSaveContext.linkAge != 0) {
                     Actor_Kill(&this->actor);
@@ -140,7 +140,7 @@ void EnCow_Init(Actor* thisx, GlobalContext* globalCtx) {
             SkelAnime_ChangeAnimDefaultRepeat(&this->skelAnime, &D_06004348);
             this->actor.update = func_809DFE98;
             this->actor.draw = func_809E0070;
-            this->actionFunc = (ActorFunc)func_809DFA84;
+            this->actionFunc = func_809DFA84;
             func_809DEF94(this);
             this->actor.flags &= ~0x1;
             this->unk_278 = ((u32)(Math_Rand_ZeroFloat(1000.0f)) & 0xFFFF) + 40.0f;
@@ -199,21 +199,21 @@ void func_809DF6BC(EnCow* this, GlobalContext* globalCtx) {
     if ((func_8010BDBC(&globalCtx->msgCtx) == 5) && (func_80106BC8(globalCtx) != 0)) {
         this->actor.flags &= ~0x10000;
         func_80106CCC(globalCtx);
-        this->actionFunc = (ActorFunc)func_809DF96C;
+        this->actionFunc = func_809DF96C;
     }
 }
 
 void func_809DF730(EnCow* this, GlobalContext* globalCtx) {
     if (func_8002F334(&this->actor, globalCtx)) {
         this->actor.flags &= ~0x10000;
-        this->actionFunc = (ActorFunc)func_809DF96C;
+        this->actionFunc = func_809DF96C;
     }
 }
 
 void func_809DF778(EnCow* this, GlobalContext* globalCtx) {
     if (func_8002F410(&this->actor, globalCtx)) {
         this->actor.attachedA = NULL;
-        this->actionFunc = (ActorFunc)func_809DF730;
+        this->actionFunc = func_809DF730;
     } else {
         func_8002F434(&this->actor, globalCtx, GI_MILK, 10000.0f, 100.0f);
     }
@@ -223,7 +223,7 @@ void func_809DF7D8(EnCow* this, GlobalContext* globalCtx) {
     if ((func_8010BDBC(&globalCtx->msgCtx) == 5) && (func_80106BC8(globalCtx) != 0)) {
         this->actor.flags &= ~0x10000;
         func_80106CCC(globalCtx);
-        this->actionFunc = (ActorFunc)func_809DF778;
+        this->actionFunc = func_809DF778;
         func_8002F434(&this->actor, globalCtx, GI_MILK, 10000.0f, 100.0f);
     }
 }
@@ -232,17 +232,17 @@ void func_809DF870(EnCow* this, GlobalContext* globalCtx) {
     if ((func_8010BDBC(&globalCtx->msgCtx) == 5) && (func_80106BC8(globalCtx) != 0)) {
         if (Inventory_HasEmptyBottle()) {
             func_8010B720(globalCtx, 0x2007);
-            this->actionFunc = (ActorFunc)func_809DF7D8;
+            this->actionFunc = func_809DF7D8;
         } else {
             func_8010B720(globalCtx, 0x2013);
-            this->actionFunc = (ActorFunc)func_809DF6BC;
+            this->actionFunc = func_809DF6BC;
         }
     }
 }
 
 void func_809DF8FC(EnCow* this, GlobalContext* globalCtx) {
     if (func_8002F194(&this->actor, globalCtx)) {
-        this->actionFunc = (ActorFunc)func_809DF870;
+        this->actionFunc = func_809DF870;
     } else {
         this->actor.flags |= 0x10000;
         func_8002F2CC(&this->actor, globalCtx, 170.0f);
@@ -261,7 +261,7 @@ void func_809DF96C(EnCow* this, GlobalContext* globalCtx) {
                 if ((this->actor.xzDistanceFromLink < 150.0f) &&
                     (ABS((s16)(this->actor.rotTowardsLinkY - this->actor.shape.rot.y)) < 0x61A8)) {
                     DREG(53) = 0;
-                    this->actionFunc = (ActorFunc)func_809DF8FC;
+                    this->actionFunc = func_809DF8FC;
                     this->actor.flags |= 0x10000;
                     func_8002F2CC(&this->actor, globalCtx, 170.0f);
                     this->actor.textId = 0x2006;

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.h
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.h
@@ -4,7 +4,11 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnCow;
+
+typedef void (*EnCowActionFunc)(struct EnCow*, GlobalContext*);
+
+typedef struct EnCow {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ ColliderCylinder colliders[2];
     /* 0x01E4 */ SkelAnime skelAnime;
@@ -14,7 +18,7 @@ typedef struct {
     /* 0x0276 */ u16 unk_276;
     /* 0x0278 */ u16 unk_278;
     /* 0x027A */ u16 unk_27A;
-    /* 0x027C */ ActorFunc actionFunc;
+    /* 0x027C */ EnCowActionFunc actionFunc;
 } EnCow; // size = 0x0280
 
 extern const ActorInit En_Cow_InitVars;

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.h
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnCrow;
+
+typedef struct EnCrow {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x14C];
 } EnCrow; // size = 0x0298

--- a/src/overlays/actors/ovl_En_Cs/z_en_cs.h
+++ b/src/overlays/actors/ovl_En_Cs/z_en_cs.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnCs;
+
+typedef struct EnCs {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1F8];
 } EnCs; // size = 0x0344

--- a/src/overlays/actors/ovl_En_Daiku/z_en_daiku.h
+++ b/src/overlays/actors/ovl_En_Daiku/z_en_daiku.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDaiku;
+
+typedef struct EnDaiku {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x200];
 } EnDaiku; // size = 0x034C

--- a/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.h
+++ b/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDaikuKakariko;
+
+typedef struct EnDaikuKakariko {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1BC];
 } EnDaikuKakariko; // size = 0x0308

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.h
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDekubaba;
+
+typedef struct EnDekubaba {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2CC];
 } EnDekubaba; // size = 0x0418

--- a/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.h
+++ b/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDekunuts;
+
+typedef struct EnDekunuts {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C8];
 } EnDekunuts; // size = 0x0314

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.h
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDh;
+
+typedef struct EnDh {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1D8];
 } EnDh; // size = 0x0324

--- a/src/overlays/actors/ovl_En_Dha/z_en_dha.h
+++ b/src/overlays/actors/ovl_En_Dha/z_en_dha.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDha;
+
+typedef struct EnDha {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x214];
 } EnDha; // size = 0x0360

--- a/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.h
+++ b/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDivingGame;
+
+typedef struct EnDivingGame {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x24C];
 } EnDivingGame; // size = 0x0398

--- a/src/overlays/actors/ovl_En_Dns/z_en_dns.h
+++ b/src/overlays/actors/ovl_En_Dns/z_en_dns.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDns;
+
+typedef struct EnDns {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x17C];
 } EnDns; // size = 0x02C8

--- a/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h
+++ b/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDntDemo;
+
+typedef struct EnDntDemo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xB4];
 } EnDntDemo; // size = 0x0200

--- a/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.h
+++ b/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDntJiji;
+
+typedef struct EnDntJiji {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x15C];
 } EnDntJiji; // size = 0x02A8

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.h
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDntNomal;
+
+typedef struct EnDntNomal {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x214];
 } EnDntNomal; // size = 0x0360

--- a/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.h
+++ b/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDodojr;
+
+typedef struct EnDodojr {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x174];
 } EnDodojr; // size = 0x02C0

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.h
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDodongo;
+
+typedef struct EnDodongo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x5DC];
 } EnDodongo; // size = 0x0728

--- a/src/overlays/actors/ovl_En_Dog/z_en_dog.h
+++ b/src/overlays/actors/ovl_En_Dog/z_en_dog.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDog;
+
+typedef void (*EnDogActionFunc)(struct EnDog*, GlobalContext*);
+
+typedef struct EnDog {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ ActorFunc actionFunc;
+    /* 0x0190 */ EnDogActionFunc actionFunc;
     /* 0x0194 */ ColliderCylinder collider;
     /* 0x01E0 */ Path* path;
     /* 0x01E4 */ u8 reverse;

--- a/src/overlays/actors/ovl_En_Door/z_en_door.h
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDoor;
+
+typedef struct EnDoor {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8C];
 } EnDoor; // size = 0x01D8

--- a/src/overlays/actors/ovl_En_Ds/z_en_ds.h
+++ b/src/overlays/actors/ovl_En_Ds/z_en_ds.h
@@ -4,7 +4,11 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDs;
+
+typedef void (*EnDsActionFunc)(struct EnDs*, GlobalContext*);
+
+typedef struct EnDs {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ Vec3s limbDrawTable;
@@ -16,7 +20,7 @@ typedef struct {
     /* 0x01E4 */ float unk_1E4;
     /* 0x01E8 */ u16 unk_1E8;
     /* 0x01EA */ u16 brewTimer;
-    /* 0x01EC */ ActorFunc actionFunc;
+    /* 0x01EC */ EnDsActionFunc actionFunc;
 } EnDs; // size = 0x01F0
 
 extern const ActorInit En_Ds_InitVars;

--- a/src/overlays/actors/ovl_En_Du/z_en_du.h
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDu;
+
+typedef struct EnDu {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xD0];
 } EnDu; // size = 0x021C

--- a/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.h
+++ b/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnDyExtra;
+
+typedef struct EnDyExtra {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x28];
 } EnDyExtra; // size = 0x0174

--- a/src/overlays/actors/ovl_En_Eg/z_en_eg.c
+++ b/src/overlays/actors/ovl_En_Eg/z_en_eg.c
@@ -20,8 +20,8 @@ void EnEg_Draw(Actor* thisx, GlobalContext* globalCtx);
 void func_809FFDC8(EnEg* this, GlobalContext* globalCtx);
 
 static bool hasVoidedOut = false;
-static const ActorFunc funcTbl[] = {
-    (ActorFunc)func_809FFDC8,
+static const EnEgActionFunc actionFuncs[] = {
+    func_809FFDC8,
 };
 
 const ActorInit En_Eg_InitVars = {
@@ -46,7 +46,7 @@ void EnEg_Destroy(Actor* thisx, GlobalContext* globalCtx) {
 void EnEg_Init(Actor* thisx, GlobalContext* globalCtx) {
     EnEg* this = THIS;
 
-    this->funcIndex = 0;
+    this->action = 0;
 }
 
 void func_809FFDC8(EnEg* this, GlobalContext* globalCtx) {
@@ -63,13 +63,13 @@ void func_809FFDC8(EnEg* this, GlobalContext* globalCtx) {
 
 void EnEg_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnEg* this = THIS;
-    s32 funcIndex = this->funcIndex;
+    s32 action = this->action;
 
-    if (((funcIndex < 0) || (0 < funcIndex)) || (funcTbl[funcIndex] == NULL)) {
+    if (((action < 0) || (0 < action)) || (actionFuncs[action] == NULL)) {
         // Translates to: "Main Mode is wrong!!!!!!!!!!!!!!!!!!!!!!!!!"
         osSyncPrintf(VT_FGCOL(RED) "メインモードがおかしい!!!!!!!!!!!!!!!!!!!!!!!!!\n" VT_RST);
     } else {
-        funcTbl[funcIndex](this, globalCtx);
+        actionFuncs[action](this, globalCtx);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Eg/z_en_eg.h
+++ b/src/overlays/actors/ovl_En_Eg/z_en_eg.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnEg;
+
+typedef void (*EnEgActionFunc)(struct EnEg*, GlobalContext*);
+
+typedef struct EnEg {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ s32 funcIndex;
+    /* 0x014C */ s32 action;
 } EnEg; // size = 0x0154
 
 extern const ActorInit En_Eg_InitVars;

--- a/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.h
+++ b/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnEiyer;
+
+typedef struct EnEiyer {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x188];
 } EnEiyer; // size = 0x02D4

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.h
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnElf;
+
+typedef struct EnElf {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x184];
 } EnElf; // size = 0x02D0

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.h
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnEncount1;
+
+typedef struct EnEncount1 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x24];
 } EnEncount1; // size = 0x0170

--- a/src/overlays/actors/ovl_En_Encount2/z_en_encount2.h
+++ b/src/overlays/actors/ovl_En_Encount2/z_en_encount2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnEncount2;
+
+typedef struct EnEncount2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8D4];
 } EnEncount2; // size = 0x0A20

--- a/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.h
+++ b/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnExItem;
+
+typedef struct EnExItem {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x38];
 } EnExItem; // size = 0x0184

--- a/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.h
+++ b/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnExRuppy;
+
+typedef struct EnExRuppy {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x18];
 } EnExRuppy; // size = 0x0164

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.h
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFd;
+
+typedef struct EnFd {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x3094];
 } EnFd; // size = 0x31E0

--- a/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.h
+++ b/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFdFire;
+
+typedef struct EnFdFire {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x60];
 } EnFdFire; // size = 0x01AC

--- a/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.h
+++ b/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFhgFire;
+
+typedef struct EnFhgFire {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xB8];
 } EnFhgFire; // size = 0x0204

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.h
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFireRock;
+
+typedef struct EnFireRock {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x94];
 } EnFireRock; // size = 0x01E0

--- a/src/overlays/actors/ovl_En_Firefly/z_en_firefly.h
+++ b/src/overlays/actors/ovl_En_Firefly/z_en_firefly.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFirefly;
+
+typedef struct EnFirefly {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x228];
 } EnFirefly; // size = 0x0374

--- a/src/overlays/actors/ovl_En_Fish/z_en_fish.h
+++ b/src/overlays/actors/ovl_En_Fish/z_en_fish.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFish;
+
+typedef struct EnFish {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x108];
 } EnFish; // size = 0x0254

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.h
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFloormas;
+
+typedef struct EnFloormas {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C8];
 } EnFloormas; // size = 0x0314

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.h
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFr;
+
+typedef struct EnFr {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x278];
 } EnFr; // size = 0x03C4

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.h
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFu;
+
+typedef struct EnFu {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x164];
 } EnFu; // size = 0x02B0

--- a/src/overlays/actors/ovl_En_Fw/z_en_fw.h
+++ b/src/overlays/actors/ovl_En_Fw/z_en_fw.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFw;
+
+typedef struct EnFw {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x5B4];
 } EnFw; // size = 0x0700

--- a/src/overlays/actors/ovl_En_Fz/z_en_fz.h
+++ b/src/overlays/actors/ovl_En_Fz/z_en_fz.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnFz;
+
+typedef struct EnFz {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xA88];
 } EnFz; // size = 0x0BD4

--- a/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.h
+++ b/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGSwitch;
+
+typedef struct EnGSwitch {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x11AC];
 } EnGSwitch; // size = 0x12F8

--- a/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.h
+++ b/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGanonMant;
+
+typedef struct EnGanonMant {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x15BC];
 } EnGanonMant; // size = 0x1708

--- a/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.h
+++ b/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGanonOrgan;
+
+typedef struct EnGanonOrgan {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4];
 } EnGanonOrgan; // size = 0x0150

--- a/src/overlays/actors/ovl_En_Gb/z_en_gb.h
+++ b/src/overlays/actors/ovl_En_Gb/z_en_gb.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGb;
+
+typedef struct EnGb {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2EC];
 } EnGb; // size = 0x0438

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.h
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGe1;
+
+typedef struct EnGe1 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x170];
 } EnGe1; // size = 0x02BC

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.h
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGe2;
+
+typedef struct EnGe2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C0];
 } EnGe2; // size = 0x030C

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.h
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGe3;
+
+typedef struct EnGe3 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C8];
 } EnGe3; // size = 0x0314

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.h
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGeldB;
+
+typedef struct EnGeldB {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x398];
 } EnGeldB; // size = 0x04E4

--- a/src/overlays/actors/ovl_En_GirlA/z_en_girla.h
+++ b/src/overlays/actors/ovl_En_GirlA/z_en_girla.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGirlA;
+
+typedef struct EnGirlA {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x88];
 } EnGirlA; // size = 0x01D4

--- a/src/overlays/actors/ovl_En_Gm/z_en_gm.h
+++ b/src/overlays/actors/ovl_En_Gm/z_en_gm.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGm;
+
+typedef struct EnGm {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x184];
 } EnGm; // size = 0x02D0

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGo;
+
+typedef struct EnGo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x57C];
 } EnGo; // size = 0x06C8

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGo2;
+
+typedef struct EnGo2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x454];
 } EnGo2; // size = 0x05A0

--- a/src/overlays/actors/ovl_En_Goma/z_en_goma.h
+++ b/src/overlays/actors/ovl_En_Goma/z_en_goma.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGoma;
+
+typedef struct EnGoma {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x258];
 } EnGoma; // size = 0x03A4

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.h
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGoroiwa;
+
+typedef struct EnGoroiwa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x88];
 } EnGoroiwa; // size = 0x01D4

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.h
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGs;
+
+typedef struct EnGs {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xBC];
 } EnGs; // size = 0x0208

--- a/src/overlays/actors/ovl_En_Guest/z_en_guest.h
+++ b/src/overlays/actors/ovl_En_Guest/z_en_guest.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnGuest;
+
+typedef struct EnGuest {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C4];
 } EnGuest; // size = 0x0310

--- a/src/overlays/actors/ovl_En_Hata/z_en_hata.h
+++ b/src/overlays/actors/ovl_En_Hata/z_en_hata.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHata;
+
+typedef struct EnHata {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x130];
 } EnHata; // size = 0x027C

--- a/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.h
+++ b/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHeishi1;
+
+typedef struct EnHeishi1 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x160];
 } EnHeishi1; // size = 0x02AC

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.h
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHeishi2;
+
+typedef struct EnHeishi2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x298];
 } EnHeishi2; // size = 0x03E4

--- a/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.h
+++ b/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHeishi3;
+
+typedef struct EnHeishi3 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x17C];
 } EnHeishi3; // size = 0x02C8

--- a/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.h
+++ b/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHeishi4;
+
+typedef struct EnHeishi4 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1BC];
 } EnHeishi4; // size = 0x0308

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.h
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHintnuts;
+
+typedef struct EnHintnuts {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x114];
 } EnHintnuts; // size = 0x0260

--- a/src/overlays/actors/ovl_En_Holl/z_en_holl.h
+++ b/src/overlays/actors/ovl_En_Holl/z_en_holl.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHoll;
+
+typedef struct EnHoll {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8];
 } EnHoll; // size = 0x0154

--- a/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.h
+++ b/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHonotrap;
+
+typedef struct EnHonotrap {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xF8];
 } EnHonotrap; // size = 0x0244

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.h
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHorse;
+
+typedef struct EnHorse {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2B0];
 } EnHorse; // size = 0x03FC

--- a/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.h
+++ b/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHorseGameCheck;
+
+typedef struct EnHorseGameCheck {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x58];
 } EnHorseGameCheck; // size = 0x01A4

--- a/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
+++ b/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
@@ -87,7 +87,7 @@ static InitChainEntry initChain[] = {
     ICHAIN_F32(unk_F8, 1200, ICHAIN_STOP),
 };
 
-static void (*actionFuncs[])(EnHorseGanon*, GlobalContext*) = { func_80A68AF0, func_80A68DB0, NULL };
+static EnHorseGanonActionFunc actionFuncs[] = { func_80A68AF0, func_80A68DB0, NULL };
 
 const f32 D_80A692D0 = 10430.3779f;
 

--- a/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.h
+++ b/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct unk_D_80A69248;
+
+typedef struct unk_D_80A69248 {
     /* 0x0 */ Vec3s unk_0;
     /* 0x6 */ u8 unk_6;
 } unk_D_80A69248; // size = 0x8

--- a/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.h
+++ b/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.h
@@ -9,7 +9,11 @@ typedef struct {
     /* 0x6 */ u8 unk_6;
 } unk_D_80A69248; // size = 0x8
 
-typedef struct {
+struct EnHorseGanon;
+
+typedef void (*EnHorseGanonActionFunc)(struct EnHorseGanon*, GlobalContext*);
+
+typedef struct EnHorseGanon {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ s32 action;
     /* 0x0150 */ s32 currentAnimation;

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.h
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHorseLinkChild;
+
+typedef struct EnHorseLinkChild {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x158];
 } EnHorseLinkChild; // size = 0x02A4

--- a/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.h
+++ b/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHorseNormal;
+
+typedef struct EnHorseNormal {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1DC];
 } EnHorseNormal; // size = 0x0328

--- a/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.h
+++ b/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHorseZelda;
+
+typedef struct EnHorseZelda {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x15C];
 } EnHorseZelda; // size = 0x02A8

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.h
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHs;
+
+typedef struct EnHs {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x164];
 } EnHs; // size = 0x02B0

--- a/src/overlays/actors/ovl_En_Hs2/z_en_hs2.h
+++ b/src/overlays/actors/ovl_En_Hs2/z_en_hs2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHs2;
+
+typedef struct EnHs2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x164];
 } EnHs2; // size = 0x02B0

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.h
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnHy;
+
+typedef struct EnHy {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1E8];
 } EnHy; // size = 0x0334

--- a/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.h
+++ b/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnIceHono;
+
+typedef struct EnIceHono {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x70];
 } EnIceHono; // size = 0x01BC

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.h
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnIk;
+
+typedef struct EnIk {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x390];
 } EnIk; // size = 0x04DC

--- a/src/overlays/actors/ovl_En_In/z_en_in.h
+++ b/src/overlays/actors/ovl_En_In/z_en_in.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnIn;
+
+typedef struct EnIn {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x25C];
 } EnIn; // size = 0x03A8

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.h
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnInsect;
+
+typedef struct EnInsect {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1E0];
 } EnInsect; // size = 0x032C

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.h
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnIshi;
+
+typedef struct EnIshi {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x50];
 } EnIshi; // size = 0x019C

--- a/src/overlays/actors/ovl_En_It/z_en_it.h
+++ b/src/overlays/actors/ovl_En_It/z_en_it.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnIt;
+
+typedef struct EnIt {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u32 unk_14C;
     /* 0x0150 */ ColliderCylinder collider;

--- a/src/overlays/actors/ovl_En_Jj/z_en_jj.h
+++ b/src/overlays/actors/ovl_En_Jj/z_en_jj.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnJj;
+
+typedef struct EnJj {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C8];
 } EnJj; // size = 0x0314

--- a/src/overlays/actors/ovl_En_Js/z_en_js.h
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnJs;
+
+typedef struct EnJs {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x144];
 } EnJs; // size = 0x0290

--- a/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.h
+++ b/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnJsjutan;
+
+typedef struct EnJsjutan {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2C];
 } EnJsjutan; // size = 0x0178

--- a/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.h
+++ b/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnKakasi;
+
+typedef struct EnKakasi {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC0];
 } EnKakasi; // size = 0x020C

--- a/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.h
+++ b/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnKakasi2;
+
+typedef struct EnKakasi2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xAC];
 } EnKakasi2; // size = 0x01F8

--- a/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.h
+++ b/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnKakasi3;
+
+typedef struct EnKakasi3 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC0];
 } EnKakasi3; // size = 0x020C

--- a/src/overlays/actors/ovl_En_Kanban/z_en_kanban.h
+++ b/src/overlays/actors/ovl_En_Kanban/z_en_kanban.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnKanban;
+
+typedef struct EnKanban {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xA0];
 } EnKanban; // size = 0x01EC

--- a/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.h
+++ b/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnKarebaba;
+
+typedef struct EnKarebaba {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x144];
 } EnKarebaba; // size = 0x0290

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.h
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnKo;
+
+typedef struct EnKo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1D8];
 } EnKo; // size = 0x0324

--- a/src/overlays/actors/ovl_En_Kusa/z_en_kusa.h
+++ b/src/overlays/actors/ovl_En_Kusa/z_en_kusa.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnKusa;
+
+typedef struct EnKusa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x54];
 } EnKusa; // size = 0x01A0

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.h
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnKz;
+
+typedef struct EnKz {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x18C];
 } EnKz; // size = 0x02D8

--- a/src/overlays/actors/ovl_En_Light/z_en_light.h
+++ b/src/overlays/actors/ovl_En_Light/z_en_light.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnLight;
+
+typedef struct EnLight {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x18];
 } EnLight; // size = 0x0164

--- a/src/overlays/actors/ovl_En_Lightbox/z_en_lightbox.h
+++ b/src/overlays/actors/ovl_En_Lightbox/z_en_lightbox.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnLightbox;
+
+typedef struct EnLightbox {
     /* 0x0000 */ DynaPolyActor dyna;
 } EnLightbox; // size = 0x0164
 

--- a/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.h
+++ b/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMFire1;
+
+typedef struct EnMFire1 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ ColliderCylinder collider;
     /* 0x0198 */ f32 unk_198;

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.h
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMThunder;
+
+typedef struct EnMThunder {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x80];
 } EnMThunder; // size = 0x01CC

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -265,10 +265,10 @@ void EnMa1_Init(Actor* thisx, GlobalContext* globalCtx) {
     this->unk_1E8.unk_00 = 0;
 
     if ((!(gSaveContext.eventChkInf[1] & 0x10)) || (CHECK_QUEST_ITEM(QUEST_SONG_EPONA))) {
-        this->actionFunc = (ActorFunc)func_80AA0D88;
+        this->actionFunc = func_80AA0D88;
         func_80AA0A84(this, 2);
     } else {
-        this->actionFunc = (ActorFunc)func_80AA0F44;
+        this->actionFunc = func_80AA0F44;
         func_80AA0A84(this, 2);
     }
 }
@@ -295,7 +295,7 @@ void func_80AA0D88(EnMa1* this, GlobalContext* globalCtx) {
         Actor_Kill(&this->actor);
     } else if ((!(gSaveContext.eventChkInf[1] & 0x10)) || (CHECK_QUEST_ITEM(QUEST_SONG_EPONA))) {
         if (this->unk_1E8.unk_00 == 2) {
-            this->actionFunc = (ActorFunc)func_80AA0EA0;
+            this->actionFunc = func_80AA0EA0;
             globalCtx->msgCtx.unk_E3E7 = 4;
             globalCtx->msgCtx.msgMode = 0x36;
         }
@@ -305,7 +305,7 @@ void func_80AA0D88(EnMa1* this, GlobalContext* globalCtx) {
 void func_80AA0EA0(EnMa1* this, GlobalContext* globalCtx) {
     if (func_8002F410(&this->actor, globalCtx)) {
         this->actor.attachedA = NULL;
-        this->actionFunc = (ActorFunc)func_80AA0EFC;
+        this->actionFunc = func_80AA0EFC;
     } else {
         func_8002F434(&this->actor, globalCtx, GI_WEIRD_EGG, 120.0f, 10.0f);
     }
@@ -314,7 +314,7 @@ void func_80AA0EA0(EnMa1* this, GlobalContext* globalCtx) {
 void func_80AA0EFC(EnMa1* this, GlobalContext* globalCtx) {
     if (this->unk_1E8.unk_00 == 3) {
         this->unk_1E8.unk_00 = 0;
-        this->actionFunc = (ActorFunc)func_80AA0D88;
+        this->actionFunc = func_80AA0D88;
         gSaveContext.eventChkInf[1] |= 4;
         globalCtx->msgCtx.msgMode = 0x36;
     }
@@ -341,7 +341,7 @@ void func_80AA0F44(EnMa1* this, GlobalContext* globalCtx) {
             func_8010B680(globalCtx, this->actor.textId, 0);
             this->unk_1E8.unk_00 = 1;
             this->actor.flags |= 0x10000;
-            this->actionFunc = (ActorFunc)func_80AA106C;
+            this->actionFunc = func_80AA106C;
         } else if (this->actor.xzDistanceFromLink < 30.0f + (f32)this->collider.dim.radius) {
             player->stateFlags2 |= 0x800000;
         }
@@ -354,7 +354,7 @@ void func_80AA106C(EnMa1* this, GlobalContext* globalCtx) {
         func_800ED858(2);
         func_8010BD58(globalCtx, 9);
         this->actor.flags &= ~0x10000;
-        this->actionFunc = (ActorFunc)func_80AA10EC;
+        this->actionFunc = func_80AA10EC;
     }
 }
 
@@ -362,7 +362,7 @@ void func_80AA10EC(EnMa1* this, GlobalContext* globalCtx) {
     PLAYER->stateFlags2 |= 0x800000;
     if (func_8010BDBC(&globalCtx->msgCtx) == 7) {
         func_8010BD58(globalCtx, 0x16);
-        this->actionFunc = (ActorFunc)func_80AA1150;
+        this->actionFunc = func_80AA1150;
     }
 }
 
@@ -373,7 +373,7 @@ void func_80AA1150(EnMa1* this, GlobalContext* globalCtx) {
         gSaveContext.nextCutsceneIndex = 0xFFF1;
         globalCtx->fadeTransition = 42;
         globalCtx->sceneLoadFlag = 0x14;
-        this->actionFunc = (ActorFunc)func_80AA11C8;
+        this->actionFunc = func_80AA11C8;
     }
 }
 
@@ -389,7 +389,7 @@ void EnMa1_Update(Actor* thisx, GlobalContext* globalCtx) {
     SkelAnime_FrameUpdateMatrix(&this->skelAnime);
     func_80AA0A0C(this);
     this->actionFunc(this, globalCtx);
-    if (this->actionFunc != (ActorFunc)func_80AA11C8) {
+    if (this->actionFunc != func_80AA11C8) {
         func_800343CC(globalCtx, &this->actor, &this->unk_1E8.unk_00, (f32)this->collider.dim.radius + 30.0f,
                       EnMa1_GetText, func_80AA0778);
     }

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.h
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMa1;
+
+typedef void (*EnMa1ActionFunc)(struct EnMa1*, GlobalContext*);
+
+typedef struct EnMa1 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ ActorFunc actionFunc;
+    /* 0x0190 */ EnMa1ActionFunc actionFunc;
     /* 0x0194 */ ColliderCylinder collider;
     /* 0x01E0 */ s16 unk_1E0;
     /* 0x01E2 */ s16 unk_1E2;

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
@@ -247,11 +247,11 @@ void EnMa2_Init(Actor* thisx, GlobalContext* globalCtx) {
     switch (func_80AA1B58(this, globalCtx)) {
         case 1:
             func_80AA1D44(this, 2);
-            this->actionFunc = (ActorFunc)func_80AA2018;
+            this->actionFunc = func_80AA2018;
             break;
         case 2:
             func_80AA1D44(this, 3);
-            this->actionFunc = (ActorFunc)func_80AA204C;
+            this->actionFunc = func_80AA204C;
             break;
         case 3:
             if (gSaveContext.infTable[8] & 0x2000) {
@@ -259,7 +259,7 @@ void EnMa2_Init(Actor* thisx, GlobalContext* globalCtx) {
             } else {
                 func_80AA1D44(this, 3);
             }
-            this->actionFunc = (ActorFunc)func_80AA2018;
+            this->actionFunc = func_80AA2018;
             break;
         case 0:
             Actor_Kill(&this->actor);
@@ -293,7 +293,7 @@ void func_80AA204C(EnMa2* this, GlobalContext* globalCtx) {
         player->unk_6A8 = &this->actor;
         player->stateFlags2 |= 0x2000000;
         func_8010BD58(globalCtx, 0x23);
-        this->actionFunc = (ActorFunc)func_80AA20E4;
+        this->actionFunc = func_80AA20E4;
     } else if (this->actor.xzDistanceFromLink < 30.0f + (f32)this->collider.dim.radius) {
         player->stateFlags2 |= 0x800000;
     }
@@ -303,13 +303,13 @@ void func_80AA20E4(EnMa2* this, GlobalContext* globalCtx) {
     Player* player = PLAYER;
 
     if (globalCtx->msgCtx.unk_E3EE >= 4) {
-        this->actionFunc = (ActorFunc)func_80AA204C;
+        this->actionFunc = func_80AA204C;
         globalCtx->msgCtx.unk_E3EE = 4;
     } else if (globalCtx->msgCtx.unk_E3EE == 3) {
         Audio_PlaySoundGeneral(NA_SE_SY_CORRECT_CHIME, &D_801333D4, 4, &D_801333E0, &D_801333E0, &D_801333E8);
         this->unk_208 = 0x1E;
         gSaveContext.infTable[8] |= 0x4000;
-        this->actionFunc = (ActorFunc)func_80AA21C8;
+        this->actionFunc = func_80AA21C8;
         globalCtx->msgCtx.unk_E3EE = 4;
     } else {
         player->stateFlags2 |= 0x800000;
@@ -327,7 +327,7 @@ void func_80AA21C8(EnMa2* this, GlobalContext* globalCtx) {
             func_80106CCC(globalCtx);
         } else {
             this->actor.flags &= ~0x10000;
-            this->actionFunc = (ActorFunc)func_80AA2018;
+            this->actionFunc = func_80AA2018;
         }
     }
 }
@@ -343,7 +343,7 @@ void EnMa2_Update(Actor* thisx, GlobalContext* globalCtx) {
     this->actionFunc(this, globalCtx);
     func_80AA1DB4(this, globalCtx);
     func_80AA1AE4(this, globalCtx);
-    if (this->actionFunc != (ActorFunc)func_80AA20E4) {
+    if (this->actionFunc != func_80AA20E4) {
         func_800343CC(globalCtx, &this->actor, &this->unk_1E0.unk_00, (f32)this->collider.dim.radius + 30.0f,
                       func_80AA19A0, func_80AA1A38);
     }

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.h
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMa2;
+
+typedef void (*EnMa2ActionFunc)(struct EnMa2*, GlobalContext*);
+
+typedef struct EnMa2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ ActorFunc actionFunc;
+    /* 0x0190 */ EnMa2ActionFunc actionFunc;
     /* 0x0194 */ ColliderCylinder collider;
     /* 0x01E0 */ struct_80034A14_arg1 unk_1E0;
     /* 0x0208 */ s16 unk_208;

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -277,11 +277,11 @@ void EnMa3_Init(Actor* thisx, GlobalContext* globalCtx) {
     switch (func_80AA2EC8(this, globalCtx)) {
         case 0:
             func_80AA3004(this, 0);
-            this->actionFunc = (ActorFunc)func_80AA3200;
+            this->actionFunc = func_80AA3200;
             break;
         case 1:
             func_80AA3004(this, 0);
-            this->actionFunc = (ActorFunc)func_80AA3200;
+            this->actionFunc = func_80AA3200;
             break;
         case 2:
             Actor_Kill(&this->actor);

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.h
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMa3;
+
+typedef void (*EnMa3ActionFunc)(struct EnMa3*, GlobalContext*);
+
+typedef struct EnMa3 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ ActorFunc actionFunc;
+    /* 0x0190 */ EnMa3ActionFunc actionFunc;
     /* 0x0194 */ ColliderCylinder collider;
     /* 0x01E0 */ struct_80034A14_arg1 unk_1E0;
     /* 0x0208 */ s16 unk_208;

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.h
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMag;
+
+typedef struct EnMag {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xE1DC];
 } EnMag; // size = 0xE328

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.h
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMb;
+
+typedef struct EnMb {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x3C0];
 } EnMb; // size = 0x050C

--- a/src/overlays/actors/ovl_En_Md/z_en_md.h
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMd;
+
+typedef struct EnMd {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1D8];
 } EnMd; // size = 0x0324

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.h
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMk;
+
+typedef struct EnMk {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x13C];
 } EnMk; // size = 0x0288

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.h
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMm;
+
+typedef struct EnMm {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1D4];
 } EnMm; // size = 0x0320

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.h
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMm2;
+
+typedef struct EnMm2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x170];
 } EnMm2; // size = 0x02BC

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -104,7 +104,7 @@ void EnMs_Wait(EnMs* this, GlobalContext* globalCtx) {
     unkAngle = this->actor.rotTowardsLinkY - this->actor.shape.rot.y;
     EnMs_SetOfferText(&this->actor, globalCtx);
     if (func_8002F194(&this->actor, globalCtx) != 0) { // if talk is initiated
-        this->actionFunc = &EnMs_Talk;
+        this->actionFunc = EnMs_Talk;
         return;
     }
 
@@ -119,7 +119,7 @@ void EnMs_Talk(EnMs* this, GlobalContext* globalCtx) {
     dialogState = func_8010BDBC(&globalCtx->msgCtx);
     if (dialogState != 4) {
         if ((dialogState == 6) && (func_80106BC8(globalCtx) != 0)) { // advanced final textbox
-            this->actionFunc = &EnMs_Wait;
+            this->actionFunc = EnMs_Wait;
         }
     } else {
         if (func_80106BC8(globalCtx) != 0) {
@@ -130,7 +130,7 @@ void EnMs_Talk(EnMs* this, GlobalContext* globalCtx) {
                         return;
                     }
                     func_8002F434(&this->actor, globalCtx, GI_BEAN, 90.0f, 10.0f);
-                    this->actionFunc = &EnMs_Sell;
+                    this->actionFunc = EnMs_Sell;
                     return;
                 case 1: // no
                     func_8010B720(globalCtx, 0x4068);
@@ -145,7 +145,7 @@ void EnMs_Sell(EnMs* this, GlobalContext* globalCtx) {
     if (func_8002F410(&this->actor, globalCtx) != 0) { // if attached is set
         Rupees_ChangeBy(-prices[BEANS_BOUGHT]);
         this->actor.attachedA = NULL;
-        this->actionFunc = &EnMs_TalkAfterBuy;
+        this->actionFunc = EnMs_TalkAfterBuy;
         return;
     }
     func_8002F434(&this->actor, globalCtx, GI_BEAN, 90.0f, 10.0f);
@@ -155,7 +155,7 @@ void EnMs_TalkAfterBuy(EnMs* this, GlobalContext* globalCtx) {
     // if dialog state is 6 and player responded to textbox
     if ((func_8010BDBC(&globalCtx->msgCtx)) == 6 && (func_80106BC8(globalCtx) != 0)) {
         func_8010B720(globalCtx, 0x406C);
-        this->actionFunc = &EnMs_Talk;
+        this->actionFunc = EnMs_Talk;
     }
 }
 

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.h
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.h
@@ -4,14 +4,18 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMs;
+
+typedef void (*EnMsActionFunc)(struct EnMs*, GlobalContext*);
+
+typedef struct EnMs {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ UNK_PTR unkSkelAnimeStruct;
     /* 0x0194 */ char unk_194[0x32];
     /* 0x01C6 */ s16 unk_1C6;
     /* 0x01C8 */ char unk_1C8[0x34];
-    /* 0x01FC */ ActorFunc actionFunc;
+    /* 0x01FC */ EnMsActionFunc actionFunc;
     /* 0x0200 */ ColliderCylinder collider;
     /* 0x024C */ s16 activeTimer;
 } EnMs; // size = 0x0250

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.h
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnMu;
+
+typedef struct EnMu {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x100];
 } EnMu; // size = 0x024C

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.h
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnNb;
+
+typedef struct EnNb {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1DC];
 } EnNb; // size = 0x0328

--- a/src/overlays/actors/ovl_En_Niw/z_en_niw.h
+++ b/src/overlays/actors/ovl_En_Niw/z_en_niw.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnNiw;
+
+typedef struct EnNiw {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x66C];
 } EnNiw; // size = 0x07B8

--- a/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.h
+++ b/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnNiwGirl;
+
+typedef struct EnNiwGirl {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1B0];
 } EnNiwGirl; // size = 0x02FC

--- a/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.h
+++ b/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnNiwLady;
+
+typedef struct EnNiwLady {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1B0];
 } EnNiwLady; // size = 0x02FC

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
@@ -51,7 +51,7 @@ void EnNutsball_Init(Actor* thisx, GlobalContext* globalCtx) {
     if (this->objBankIndex < 0) {
         Actor_Kill(&this->actor);
     } else {
-        this->actionFunc = (ActorFunc)func_80ABBB34;
+        this->actionFunc = func_80ABBB34;
     }
 }
 
@@ -67,7 +67,7 @@ void func_80ABBB34(EnNutsball* this, GlobalContext* globalCtx) {
         this->actor.draw = EnNutsball_Draw;
         this->actor.shape.rot.y = 0;
         this->timer = 30;
-        this->actionFunc = (ActorFunc)func_80ABBBA8;
+        this->actionFunc = func_80ABBBA8;
         this->actor.speedXZ = 10.0f;
     }
 }
@@ -122,7 +122,7 @@ void EnNutsball_Update(Actor* thisx, GlobalContext* globalCtx) {
     Player* player = PLAYER;
     s32 pad;
 
-    if (!(player->stateFlags1 & 0x300000C0) || (this->actionFunc == (ActorFunc)func_80ABBB34)) {
+    if (!(player->stateFlags1 & 0x300000C0) || (this->actionFunc == func_80ABBB34)) {
         this->actionFunc(this, globalCtx);
 
         Actor_MoveForward(&this->actor);

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.h
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.h
@@ -4,11 +4,15 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
-    /* 0x0000 */ Actor     actor;
-    /* 0x014C */ ActorFunc actionFunc;
-    /* 0x0150 */ s8        objBankIndex;
-    /* 0x0152 */ s16       timer;
+struct EnNutsball;
+
+typedef void (*EnNutsballActionFunc)(struct EnNutsball*, GlobalContext*);
+
+typedef struct EnNutsball {
+    /* 0x0000 */ Actor actor;
+    /* 0x014C */ EnNutsballActionFunc actionFunc;
+    /* 0x0150 */ s8 objBankIndex;
+    /* 0x0152 */ s16 timer;
     /* 0x0154 */ ColliderCylinder collider;
 } EnNutsball; // size = 0x01A0
 

--- a/src/overlays/actors/ovl_En_Nwc/z_en_nwc.h
+++ b/src/overlays/actors/ovl_En_Nwc/z_en_nwc.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnNwc;
+
+typedef struct EnNwc {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x5E8];
 } EnNwc; // size = 0x0734

--- a/src/overlays/actors/ovl_En_Ny/z_en_ny.h
+++ b/src/overlays/actors/ovl_En_Ny/z_en_ny.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnNy;
+
+typedef struct EnNy {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x16C];
 } EnNy; // size = 0x02B8

--- a/src/overlays/actors/ovl_En_OE2/z_en_oe2.c
+++ b/src/overlays/actors/ovl_En_OE2/z_en_oe2.c
@@ -15,7 +15,6 @@ void EnOE2_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void EnOE2_Update(Actor* thisx, GlobalContext* globalCtx);
 void EnOE2_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void func_80ABE6A0(EnOE2* this, ActorFunc func);
 void func_80ABE6DC(EnOE2* this, GlobalContext* globalCtx);
 
 const ActorInit En_OE2_InitVars = {
@@ -30,7 +29,7 @@ const ActorInit En_OE2_InitVars = {
     (ActorFunc)EnOE2_Draw,
 };
 
-void EnOE2_SetupAction(EnOE2* this, ActorFunc actionFunc) {
+void EnOE2_SetupAction(EnOE2* this, EnOE2ActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_En_OE2/z_en_oe2.h
+++ b/src/overlays/actors/ovl_En_OE2/z_en_oe2.h
@@ -4,11 +4,16 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnOE2;
+
+typedef void (*EnOE2ActionFunc)(struct EnOE2*, GlobalContext*);
+
+typedef struct EnOE2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x44];
-    /* 0x0190 */ ActorFunc actionFunc;
+    /* 0x0190 */ EnOE2ActionFunc actionFunc;
 } EnOE2; // size = 0x0194
 
 extern const ActorInit En_OE2_InitVars;
+
 #endif

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -16,7 +16,6 @@ void EnOkarinaEffect_Init(Actor* thisx, GlobalContext* globalCtx);
 void EnOkarinaEffect_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void EnOkarinaEffect_Update(Actor* thisx, GlobalContext* globalCtx);
 
-void EnOkarinaEffect_SetupAction(EnOkarinaEffect* this, ActorFunc* actionFunc);
 void EnOkarinaEffect_TriggerStorm(EnOkarinaEffect* this, GlobalContext* globalCtx);
 void EnOkarinaEffect_ManageStorm(EnOkarinaEffect* this, GlobalContext* globalCtx);
 
@@ -32,7 +31,7 @@ const ActorInit En_Okarina_Effect_InitVars = {
     NULL,
 };
 
-void EnOkarinaEffect_SetupAction(EnOkarinaEffect* this, ActorFunc* actionFunc) {
+void EnOkarinaEffect_SetupAction(EnOkarinaEffect* this, EnOkarinaEffectActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 
@@ -57,7 +56,7 @@ void EnOkarinaEffect_Init(Actor* thisx, GlobalContext* globalCtx) {
     if (globalCtx->envCtx.unk_EE[1] != 0) {
         Actor_Kill(&this->actor); // kill if an instance is already spawned
     }
-    EnOkarinaEffect_SetupAction(this, &EnOkarinaEffect_TriggerStorm);
+    EnOkarinaEffect_SetupAction(this, EnOkarinaEffect_TriggerStorm);
 }
 
 void EnOkarinaEffect_TriggerStorm(EnOkarinaEffect* this, GlobalContext* globalCtx) {
@@ -69,7 +68,7 @@ void EnOkarinaEffect_TriggerStorm(EnOkarinaEffect* this, GlobalContext* globalCt
     }
     globalCtx->envCtx.lightning = 1; // start lightning
     func_80077624(globalCtx);
-    EnOkarinaEffect_SetupAction(this, &EnOkarinaEffect_ManageStorm);
+    EnOkarinaEffect_SetupAction(this, EnOkarinaEffect_ManageStorm);
 }
 
 void EnOkarinaEffect_ManageStorm(EnOkarinaEffect* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.h
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnOkarinaEffect;
+
+typedef void (*EnOkarinaEffectActionFunc)(struct EnOkarinaEffect*, GlobalContext*);
+
+typedef struct EnOkarinaEffect {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ u16 timer;
-    /* 0x0150 */ ActorFunc actionFunc;
+    /* 0x0150 */ EnOkarinaEffectActionFunc actionFunc;
 } EnOkarinaEffect; // size = 0x0154
 
 extern const ActorInit En_Okarina_Effect_InitVars;

--- a/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.h
+++ b/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnOkarinaTag;
+
+typedef struct EnOkarinaTag {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x14];
 } EnOkarinaTag; // size = 0x0160

--- a/src/overlays/actors/ovl_En_Okuta/z_en_okuta.h
+++ b/src/overlays/actors/ovl_En_Okuta/z_en_okuta.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnOkuta;
+
+typedef struct EnOkuta {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x270];
 } EnOkuta; // size = 0x03BC

--- a/src/overlays/actors/ovl_En_Ossan/z_en_ossan.h
+++ b/src/overlays/actors/ovl_En_Ossan/z_en_ossan.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnOssan;
+
+typedef struct EnOssan {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x18C];
 } EnOssan; // size = 0x02D8

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.h
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnOwl;
+
+typedef struct EnOwl {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2C8];
 } EnOwl; // size = 0x0414

--- a/src/overlays/actors/ovl_En_Part/z_en_part.h
+++ b/src/overlays/actors/ovl_En_Part/z_en_part.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnPart;
+
+typedef struct EnPart {
     /* 0x000 */ Actor actor;
     /* 0x14C */ u8 unk_14C;
     /* 0x14E */ s16 unk_14E;

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnPeehat;
+
+typedef struct EnPeehat {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2E0];
 } EnPeehat; // size = 0x042C

--- a/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.h
+++ b/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnPoDesert;
+
+typedef struct EnPoDesert {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x138];
 } EnPoDesert; // size = 0x0284

--- a/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.h
+++ b/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnPoField;
+
+typedef struct EnPoField {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x190];
 } EnPoField; // size = 0x02DC

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.h
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnPoRelay;
+
+typedef struct EnPoRelay {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x190];
 } EnPoRelay; // size = 0x02DC

--- a/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h
+++ b/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnPoSisters;
+
+typedef struct EnPoSisters {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1EC];
 } EnPoSisters; // size = 0x0338

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.h
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnPoh;
+
+typedef struct EnPoh {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x25C];
 } EnPoh; // size = 0x03A8

--- a/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.h
+++ b/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnPubox;
+
+typedef struct EnPubox {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ u32 unk_164;
 } EnPubox; // size = 0x0168

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.h
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnRd;
+
+typedef struct EnRd {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x220];
 } EnRd; // size = 0x036C

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.h
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnReeba;
+
+typedef struct EnReeba {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x190];
 } EnReeba; // size = 0x02DC

--- a/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.h
+++ b/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnRiverSound;
+
+typedef struct EnRiverSound {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4];
 } EnRiverSound; // size = 0x0150

--- a/src/overlays/actors/ovl_En_Rl/z_en_rl.h
+++ b/src/overlays/actors/ovl_En_Rl/z_en_rl.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnRl;
+
+typedef struct EnRl {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x60];
 } EnRl; // size = 0x01AC

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.h
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnRr;
+
+typedef struct EnRr {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2278];
 } EnRr; // size = 0x23C4

--- a/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
+++ b/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
@@ -98,31 +98,31 @@ s32 D_80AF087C = 0;
 
 u32 D_80AF1938 = 0;
 
-ActorFunc D_80AF193C[] = {
-    (ActorFunc)func_80AEC0B4, (ActorFunc)func_80AEC100, (ActorFunc)func_80AEC130, (ActorFunc)func_80AEC17C,
-    (ActorFunc)func_80AEC1D4, (ActorFunc)func_80AEC244, (ActorFunc)func_80AEC2C0, (ActorFunc)func_80AECA94,
-    (ActorFunc)func_80AECAB4, (ActorFunc)func_80AECAD4, (ActorFunc)func_80AECB18, (ActorFunc)func_80AECB60,
-    (ActorFunc)func_80AECBB8, (ActorFunc)func_80AECC1C, (ActorFunc)func_80AECC84, (ActorFunc)func_80AED304,
-    (ActorFunc)func_80AED324, (ActorFunc)func_80AED344, (ActorFunc)func_80AED374, (ActorFunc)func_80AED3A4,
-    (ActorFunc)func_80AED3E0, (ActorFunc)func_80AED414, (ActorFunc)func_80AEF29C, (ActorFunc)func_80AEF2AC,
-    (ActorFunc)func_80AEF2D0, (ActorFunc)func_80AEF354, (ActorFunc)func_80AEF3A8, (ActorFunc)func_80AEEBD4,
-    (ActorFunc)func_80AEEC5C, (ActorFunc)func_80AEECF0, (ActorFunc)func_80AEED58, (ActorFunc)func_80AEEDCC,
-    (ActorFunc)func_80AEEE34, (ActorFunc)func_80AEEE9C, (ActorFunc)func_80AEEF08, (ActorFunc)func_80AEEF5C,
-    (ActorFunc)func_80AEF9D8, (ActorFunc)func_80AEFA2C, (ActorFunc)func_80AEFAAC, (ActorFunc)func_80AEFB04,
-    (ActorFunc)func_80AEFB68, (ActorFunc)func_80AEFCE8, (ActorFunc)func_80AEFBC8, (ActorFunc)func_80AEFC24,
-    (ActorFunc)func_80AEFECC, (ActorFunc)func_80AEFF40,
+EnRu1ActionFunc D_80AF193C[] = {
+    func_80AEC0B4, func_80AEC100, func_80AEC130, func_80AEC17C,
+    func_80AEC1D4, func_80AEC244, func_80AEC2C0, func_80AECA94,
+    func_80AECAB4, func_80AECAD4, func_80AECB18, func_80AECB60,
+    func_80AECBB8, func_80AECC1C, func_80AECC84, func_80AED304,
+    func_80AED324, func_80AED344, func_80AED374, func_80AED3A4,
+    func_80AED3E0, func_80AED414, func_80AEF29C, func_80AEF2AC,
+    func_80AEF2D0, func_80AEF354, func_80AEF3A8, func_80AEEBD4,
+    func_80AEEC5C, func_80AEECF0, func_80AEED58, func_80AEEDCC,
+    func_80AEEE34, func_80AEEE9C, func_80AEEF08, func_80AEEF5C,
+    func_80AEF9D8, func_80AEFA2C, func_80AEFAAC, func_80AEFB04,
+    func_80AEFB68, func_80AEFCE8, func_80AEFBC8, func_80AEFC24,
+    func_80AEFECC, func_80AEFF40,
 };
 
-void (*D_80AF19F4[])(EnRu1* this, GlobalContext* globalCtx, s32 limbIndex, Vec3s* rot) = {
+EnRu1PreLimbDrawFunc D_80AF19F4[]= {
     func_80AF0278,
 };
 
 Vec3f D_80AF19F8 = { 0.0f, 10.0f, 0.0f };
 
-ActorFunc D_80AF1A04[] = {
-    (ActorFunc)func_80AF03F4,
-    (ActorFunc)func_80AF0400,
-    (ActorFunc)func_80AF05D4,
+EnRu1DrawFunc D_80AF1A04[] = {
+    func_80AF03F4,
+    func_80AF0400,
+    func_80AF05D4,
 };
 
 const ActorInit En_Ru1_InitVars = {

--- a/src/overlays/actors/ovl_En_Ru1/z_en_ru1.h
+++ b/src/overlays/actors/ovl_En_Ru1/z_en_ru1.h
@@ -7,7 +7,13 @@
 #include <overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.h>
 #include <overlays/actors/ovl_Door_Warp1/z_door_warp1.h>
 
-typedef struct {
+struct EnRu1;
+
+typedef void (*EnRu1ActionFunc)(struct EnRu1*, GlobalContext*);
+typedef void (*EnRu1DrawFunc)(struct EnRu1*, GlobalContext*);
+typedef void (*EnRu1PreLimbDrawFunc)(struct EnRu1*, GlobalContext*, s32, Vec3s*);
+
+typedef struct EnRu1 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ Vec3s limbDrawTable[17];

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -60,18 +60,18 @@ static u32 D_80AF4118 = 0;
 
 #include "z_en_ru2_cutscene_data.c"
 
-static ActorFunc D_80AF50BC[] = {
-    (ActorFunc)func_80AF2CB4, (ActorFunc)func_80AF2CD4, (ActorFunc)func_80AF2CF4, (ActorFunc)func_80AF2D2C,
-    (ActorFunc)func_80AF2D6C, (ActorFunc)func_80AF2DAC, (ActorFunc)func_80AF2DEC, (ActorFunc)func_80AF3144,
-    (ActorFunc)func_80AF3174, (ActorFunc)func_80AF31C8, (ActorFunc)func_80AF3604, (ActorFunc)func_80AF3624,
-    (ActorFunc)func_80AF366C, (ActorFunc)func_80AF36AC, (ActorFunc)func_80AF3BC8, (ActorFunc)func_80AF3C04,
-    (ActorFunc)func_80AF3C64, (ActorFunc)func_80AF3CB8, (ActorFunc)func_80AF3D0C, (ActorFunc)func_80AF3D60,
+static EnRu2ActionFunc D_80AF50BC[] = {
+    func_80AF2CB4, func_80AF2CD4, func_80AF2CF4, func_80AF2D2C,
+    func_80AF2D6C, func_80AF2DAC, func_80AF2DEC, func_80AF3144,
+    func_80AF3174, func_80AF31C8, func_80AF3604, func_80AF3624,
+    func_80AF366C, func_80AF36AC, func_80AF3BC8, func_80AF3C04,
+    func_80AF3C64, func_80AF3CB8, func_80AF3D0C, func_80AF3D60,
 };
 
-static ActorFunc D_80AF510C[] = {
-    (ActorFunc)func_80AF3F14,
-    (ActorFunc)func_80AF3F20,
-    (ActorFunc)func_80AF321C,
+static EnRu2DrawFunc D_80AF510C[] = {
+    func_80AF3F14,
+    func_80AF3F20,
+    func_80AF321C,
 };
 
 const ActorInit En_Ru2_InitVars = {

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.h
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.h
@@ -4,7 +4,12 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnRu2;
+
+typedef void (*EnRu2ActionFunc)(struct EnRu2*, GlobalContext*);
+typedef void (*EnRu2DrawFunc)(struct EnRu2*, GlobalContext*);
+
+typedef struct EnRu2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ Vec3s limbDrawTable[23];

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.h
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSa;
+
+typedef struct EnSa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1A0];
 } EnSa; // size = 0x02EC

--- a/src/overlays/actors/ovl_En_Sb/z_en_sb.h
+++ b/src/overlays/actors/ovl_En_Sb/z_en_sb.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSb;
+
+typedef struct EnSb {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xBC];
 } EnSb; // size = 0x0208

--- a/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.c
+++ b/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.c
@@ -15,7 +15,6 @@ void EnSceneChange_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void EnSceneChange_Update(Actor* thisx, GlobalContext* globalCtx);
 void EnSceneChange_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void EnSceneChange_SetupAction(EnSceneChange* this, ActorFunc actionFunc);
 void func_80AF8CAC(EnSceneChange* this, GlobalContext* globalCtx);
 
 const ActorInit En_Scene_Change_InitVars = {
@@ -30,7 +29,7 @@ const ActorInit En_Scene_Change_InitVars = {
     (ActorFunc)EnSceneChange_Draw,
 };
 
-void EnSceneChange_SetupAction(EnSceneChange* this, ActorFunc actionFunc) {
+void EnSceneChange_SetupAction(EnSceneChange* this, EnSceneChangeActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.h
+++ b/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSceneChange;
+
+typedef void (*EnSceneChangeActionFunc)(struct EnSceneChange*, GlobalContext*);
+
+typedef struct EnSceneChange {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ EnSceneChangeActionFunc actionFunc;
 } EnSceneChange; // size = 0x0150
 
 extern const ActorInit En_Scene_Change_InitVars;

--- a/src/overlays/actors/ovl_En_Sda/z_en_sda.h
+++ b/src/overlays/actors/ovl_En_Sda/z_en_sda.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSda;
+
+typedef struct EnSda {
     /* 0x0000 */ Actor actor;
 } EnSda; // size = 0x014C
 

--- a/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.h
+++ b/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnShopnuts;
+
+typedef struct EnShopnuts {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x170];
 } EnShopnuts; // size = 0x02BC

--- a/src/overlays/actors/ovl_En_Si/z_en_si.h
+++ b/src/overlays/actors/ovl_En_Si/z_en_si.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSi;
+
+typedef void (*EnSiActionFunc)(struct EnSi*, GlobalContext*);
+
+typedef struct EnSi {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ EnSiActionFunc actionFunc;
     /* 0x0150 */ char unk_150[0x50];
 } EnSi; // size = 0x01A0
 

--- a/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.h
+++ b/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSiofuki;
+
+typedef struct EnSiofuki {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x54];
 } EnSiofuki; // size = 0x01A0

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.h
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSkb;
+
+typedef struct EnSkb {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1F8];
 } EnSkb; // size = 0x0344

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.h
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSkj;
+
+typedef struct EnSkj {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1B4];
 } EnSkj; // size = 0x0300

--- a/src/overlays/actors/ovl_En_Skjneedle/z_en_skjneedle.h
+++ b/src/overlays/actors/ovl_En_Skjneedle/z_en_skjneedle.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSkjneedle;
+
+typedef struct EnSkjneedle {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x9C];
 } EnSkjneedle; // size = 0x01E8

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSsh;
+
+typedef struct EnSsh {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x488];
 } EnSsh; // size = 0x05D4

--- a/src/overlays/actors/ovl_En_St/z_en_st.h
+++ b/src/overlays/actors/ovl_En_St/z_en_st.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSt;
+
+typedef struct EnSt {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x430];
 } EnSt; // size = 0x057C

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.h
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSth;
+
+typedef struct EnSth {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x170];
 } EnSth; // size = 0x02BC

--- a/src/overlays/actors/ovl_En_Stream/z_en_stream.h
+++ b/src/overlays/actors/ovl_En_Stream/z_en_stream.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnStream;
+
+typedef struct EnStream {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC];
 } EnStream; // size = 0x0158

--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.h
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSw;
+
+typedef struct EnSw {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x38C];
 } EnSw; // size = 0x04D8

--- a/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.h
+++ b/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSyatekiItm;
+
+typedef struct EnSyatekiItm {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8C];
 } EnSyatekiItm; // size = 0x01D8

--- a/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.h
+++ b/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSyatekiMan;
+
+typedef struct EnSyatekiMan {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xE0];
 } EnSyatekiMan; // size = 0x022C

--- a/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.h
+++ b/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnSyatekiNiw;
+
+typedef struct EnSyatekiNiw {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x314];
 } EnSyatekiNiw; // size = 0x0460

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.h
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTa;
+
+typedef struct EnTa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x19C];
 } EnTa; // size = 0x02E8

--- a/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.h
+++ b/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTakaraMan;
+
+typedef struct EnTakaraMan {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xEC];
 } EnTakaraMan; // size = 0x0238

--- a/src/overlays/actors/ovl_En_Tana/z_en_tana.h
+++ b/src/overlays/actors/ovl_En_Tana/z_en_tana.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTana;
+
+typedef struct EnTana {
     /* 0x0000 */ Actor actor;
 } EnTana; // size = 0x014C
 

--- a/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -14,7 +14,7 @@ void EnTest_Init(Actor* thisx, GlobalContext* globalCtx);
 void EnTest_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void EnTest_Update(Actor* thisx, GlobalContext* globalCtx);
 void EnTest_Draw(Actor* thisx, GlobalContext* globalCtx);
-void EnTest_SetupAction(EnTest* this, ActorFunc actionFunc);
+
 void func_8085F938(EnTest* this, GlobalContext* globalCtx);
 void func_8085FAB0(EnTest* this, GlobalContext* globalCtx);
 void func_8085FE48(EnTest* this, GlobalContext* globalCtx);
@@ -42,8 +42,6 @@ void func_80862E6C(EnTest* this, GlobalContext* globalCtx);
 void func_80863044(EnTest* this, GlobalContext* globalCtx);
 void func_8086318C(EnTest* this, GlobalContext* globalCtx);
 void func_80863294(EnTest* this, GlobalContext* globalCtx);
-s32 func_80863AB8(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, EnTest* this);
-void func_80863CC4(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Vec3s* rot, EnTest* this);
 
 /*
 const ActorInit En_Test_InitVars = {

--- a/src/overlays/actors/ovl_En_Test/z_en_test.h
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTest;
+
+typedef struct EnTest {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x03C];
     /* 0x0188 */ SkelAnime skelAnime_188;

--- a/src/overlays/actors/ovl_En_Tg/z_en_tg.h
+++ b/src/overlays/actors/ovl_En_Tg/z_en_tg.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTg;
+
+typedef struct EnTg {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC0];
 } EnTg; // size = 0x020C

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.h
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTite;
+
+typedef struct EnTite {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x22C];
 } EnTite; // size = 0x0378

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.h
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.h
@@ -5,7 +5,9 @@
 #include <global.h>
 
 /* Dirt particle effect */
-typedef struct {
+struct EnTkEff;
+
+typedef struct EnTkEff {
     /* 0x0000 */ u8         active;
     /* 0x0001 */ u8         timeLeft;
     /* 0x0002 */ u8         timeTotal;

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.h
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.h
@@ -17,14 +17,14 @@ typedef struct {
     /* 0x002C */ Vec3f      accel;
 } EnTkEff; // size = 0x0038
 
-typedef struct EnTk EnTk;
+struct EnTk;
 
-typedef void EnTkFunc(EnTk* this, GlobalContext* globalCtx);
+typedef void (*EnTkActionFunc)(struct EnTk*, GlobalContext*);
 
-struct EnTk {
+typedef struct EnTk {
     /* 0x0000 */ Actor      actor;
     /* 0x014C */ SkelAnime  skelAnim;
-    /* 0x0190 */ EnTkFunc*  actionFunc;
+    /* 0x0190 */ EnTkActionFunc actionFunc;
     /* 0x0194 */ ColliderCylinder collider;
     /* 0x01E0 */ s16        h_1E0;
     /* 0x01E2 */ char       unk_1E2[0x26];
@@ -45,7 +45,7 @@ struct EnTk {
     /* 0x022A */ u16        hz_296[55];
     /* 0x0304 */ Vec3f      v3f_304;
     /* 0x0310 */ EnTkEff    eff[20];
-}; // size = 0x0770
+} EnTk; // size = 0x0770
 
 extern const ActorInit En_Tk_InitVars;
 

--- a/src/overlays/actors/ovl_En_Torch/z_en_torch.h
+++ b/src/overlays/actors/ovl_En_Torch/z_en_torch.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTorch;
+
+typedef struct EnTorch {
     /* 0x0000 */ Actor actor;
 } EnTorch; // size = 0x014C
 

--- a/src/overlays/actors/ovl_En_Torch2/z_en_torch2.h
+++ b/src/overlays/actors/ovl_En_Torch2/z_en_torch2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTorch2;
+
+typedef struct EnTorch2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x948];
 } EnTorch2; // size = 0x0A94

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.h
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnToryo;
+
+typedef struct EnToryo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x194];
 } EnToryo; // size = 0x02E0

--- a/src/overlays/actors/ovl_En_Tp/z_en_tp.h
+++ b/src/overlays/actors/ovl_En_Tp/z_en_tp.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTp;
+
+typedef struct EnTp {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8C];
 } EnTp; // size = 0x01D8

--- a/src/overlays/actors/ovl_En_Tr/z_en_tr.h
+++ b/src/overlays/actors/ovl_En_Tr/z_en_tr.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTr;
+
+typedef struct EnTr {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x19C];
 } EnTr; // size = 0x02E8

--- a/src/overlays/actors/ovl_En_Trap/z_en_trap.h
+++ b/src/overlays/actors/ovl_En_Trap/z_en_trap.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTrap;
+
+typedef struct EnTrap {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xA0];
 } EnTrap; // size = 0x01EC

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
@@ -51,7 +51,7 @@ void EnTuboTrap_Init(Actor* thisx, GlobalContext* globalCtx) {
     Collider_InitCylinder(globalCtx, &this->collider);
     Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &cylinderInitData);
     Actor_SetScale(&this->actor, 0.1f);
-    this->actionFunc = (ActorFunc)EnTuboTrap_WaitForProximity;
+    this->actionFunc = EnTuboTrap_WaitForProximity;
 }
 
 void EnTuboTrap_Destroy(Actor* thisx, GlobalContext* globalCtx) {
@@ -251,7 +251,7 @@ void EnTuboTrap_WaitForProximity(EnTuboTrap* this, GlobalContext* globalCtx) {
 
         this->originPos = this->actor.posRot.pos;
         Audio_PlayActorSound2(this, NA_SE_EV_POT_MOVE_START);
-        this->actionFunc = (ActorFunc)EnTuboTrap_Levitate;
+        this->actionFunc = EnTuboTrap_Levitate;
     }
 }
 
@@ -262,7 +262,7 @@ void EnTuboTrap_Levitate(EnTuboTrap* this, GlobalContext* globalCtx) {
     if (fabsf(this->actor.posRot.pos.y - this->targetY) < 10.0f) {
         this->actor.speedXZ = 10.0f;
         this->actor.posRot.rot.y = this->actor.rotTowardsLinkY;
-        this->actionFunc = (ActorFunc)EnTuboTrap_Fly;
+        this->actionFunc = EnTuboTrap_Fly;
     }
 }
 

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.h
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnTuboTrap;
+
+typedef void (*EnTuboTrapActionFunc)(struct EnTuboTrap*, GlobalContext*);
+
+typedef struct EnTuboTrap {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ EnTuboTrapActionFunc actionFunc;
     /* 0x0150 */ f32 targetY;
     /* 0x0154 */ Vec3f originPos;
     /* 0x0160 */ ColliderCylinder collider;

--- a/src/overlays/actors/ovl_En_Vali/z_en_vali.h
+++ b/src/overlays/actors/ovl_En_Vali/z_en_vali.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnVali;
+
+typedef struct EnVali {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2FC];
 } EnVali; // size = 0x0448

--- a/src/overlays/actors/ovl_En_Vase/z_en_vase.h
+++ b/src/overlays/actors/ovl_En_Vase/z_en_vase.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnVase;
+
+typedef struct EnVase {
     /* 0x0000 */ Actor actor;
 } EnVase; // size = 0x014C
 

--- a/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.h
+++ b/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnVbBall;
+
+typedef struct EnVbBall {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x68];
 } EnVbBall; // size = 0x01B4

--- a/src/overlays/actors/ovl_En_Viewer/z_en_viewer.h
+++ b/src/overlays/actors/ovl_En_Viewer/z_en_viewer.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnViewer;
+
+typedef struct EnViewer {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4AC];
 } EnViewer; // size = 0x05F8

--- a/src/overlays/actors/ovl_En_Vm/z_en_vm.h
+++ b/src/overlays/actors/ovl_En_Vm/z_en_vm.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnVm;
+
+typedef struct EnVm {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x268];
 } EnVm; // size = 0x03B4

--- a/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.h
+++ b/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnWallTubo;
+
+typedef struct EnWallTubo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x24];
 } EnWallTubo; // size = 0x0170

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -134,7 +134,7 @@ void EnWallmas_TimerInit(EnWallmas* this, GlobalContext* globalCtx) {
     this->actor.posRot.pos.y = player->actor.posRot.pos.y;
     this->actor.unk_80 = player->actor.unk_80;
     this->actor.draw = EnWallmas_Draw;
-    this->actionFunc = (ActorFunc)&EnWallmas_WaitToDrop;
+    this->actionFunc = EnWallmas_WaitToDrop;
 }
 
 void EnWallmas_DropStart(EnWallmas* this, GlobalContext* globalCtx) {
@@ -150,7 +150,7 @@ void EnWallmas_DropStart(EnWallmas* this, GlobalContext* globalCtx) {
     this->actor.unk_80 = player->actor.unk_80;
     this->actor.flags |= 1;
     this->actor.flags &= ~0x20;
-    this->actionFunc = (ActorFunc)&EnWallmas_Drop;
+    this->actionFunc = EnWallmas_Drop;
 }
 
 void EnWallmas_LandStart(EnWallmas* this, GlobalContext* globalCtx) {
@@ -162,23 +162,23 @@ void EnWallmas_LandStart(EnWallmas* this, GlobalContext* globalCtx) {
 
     func_80033260(globalCtx, &this->actor, &this->actor.posRot.pos, 15.0f, 6, 20.0f, 0x12C, 0x64, 1);
     Audio_PlayActorSound2(&this->actor, NA_SE_EN_FALL_LAND);
-    this->actionFunc = (ActorFunc)&EnWallmas_Land;
+    this->actionFunc = EnWallmas_Land;
 }
 
 void EnWallmas_StandStart(EnWallmas* this) {
     SkelAnime_ChangeAnimDefaultStop(&this->skelAnime, &D_0600A054);
-    this->actionFunc = (ActorFunc)&EnWallmas_Stand;
+    this->actionFunc = EnWallmas_Stand;
 }
 
 void EnWallmas_WalkStart(EnWallmas* this) {
     SkelAnime_ChangeAnimPlaybackStop(&this->skelAnime, &D_060041F4, 3.0f);
-    this->actionFunc = (ActorFunc)&EnWallmas_Walk;
+    this->actionFunc = EnWallmas_Walk;
     this->actor.speedXZ = 3.0f;
 }
 
 void EnWallmas_JumpToCeilingStart(EnWallmas* this) {
     SkelAnime_ChangeAnimDefaultStop(&this->skelAnime, &D_06009244);
-    this->actionFunc = (ActorFunc)&EnWallmas_JumpToCeiling;
+    this->actionFunc = EnWallmas_JumpToCeiling;
     this->actor.speedXZ = 0.0f;
 }
 void EnWallmas_ReturnToCeilingStart(EnWallmas* this) {
@@ -191,7 +191,7 @@ void EnWallmas_ReturnToCeilingStart(EnWallmas* this) {
     SkelAnime_ChangeAnim(&this->skelAnime, objSegChangeAnime, 3.0f, 0.0f,
                          (f32)SkelAnime_GetFrameCount(objSegFrameCount), 2, -3.0f);
 
-    this->actionFunc = (ActorFunc)&EnWallmas_ReturnToCeiling;
+    this->actionFunc = EnWallmas_ReturnToCeiling;
 }
 
 void EnWallmas_TakeDamageStart(EnWallmas* this) {
@@ -203,7 +203,7 @@ void EnWallmas_TakeDamageStart(EnWallmas* this) {
     }
 
     func_8003426C(&this->actor, 0x4000, 0xFF, 0, 0x14);
-    this->actionFunc = (ActorFunc)&EnWallmas_TakeDamage;
+    this->actionFunc = EnWallmas_TakeDamage;
     this->actor.speedXZ = 5.0f;
     this->actor.velocity.y = 10.0f;
 }
@@ -213,7 +213,7 @@ void EnWallmas_DamageCoolDownStart(EnWallmas* this) {
     this->actor.speedXZ = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.posRot.rot.y = this->actor.shape.rot.y;
-    this->actionFunc = (ActorFunc)&EnWallmas_DamageCoolDown;
+    this->actionFunc = EnWallmas_DamageCoolDown;
 }
 
 void EnWallMas_DieBegin(EnWallmas* this, GlobalContext* globalCtx) {
@@ -224,13 +224,13 @@ void EnWallMas_DieBegin(EnWallmas* this, GlobalContext* globalCtx) {
                   0, 0xFF, 1, 9, 1);
 
     Item_DropCollectibleRandom(globalCtx, &this->actor, &this->actor.posRot.pos, 0xC0);
-    this->actionFunc = (ActorFunc)&EnWallmas_Die;
+    this->actionFunc = EnWallmas_Die;
 }
 
 void EnWallmas_TakePlayerBegin(EnWallmas* this, GlobalContext* globalCtx) {
     SkelAnime_ChangeAnimTransitionStop(&this->skelAnime, &D_06009520, -5.0f);
     this->timer = -0x1e;
-    this->actionFunc = (ActorFunc)&EnWallmas_TakePlayer;
+    this->actionFunc = EnWallmas_TakePlayer;
     this->actor.speedXZ = 0.0f;
     this->actor.velocity.y = 0.0f;
 
@@ -244,9 +244,9 @@ void EnWallmas_ProximityOrSwitchInit(EnWallmas* this) {
     this->actor.draw = NULL;
     this->actor.flags = this->actor.flags & ~1;
     if (this->actor.params == WMT_PROXIMITY) {
-        this->actionFunc = (ActorFunc)&EnWallmas_WaitForProximity;
+        this->actionFunc = EnWallmas_WaitForProximity;
     } else {
-        this->actionFunc = (ActorFunc)&EnWallmas_WaitForSwitchFlag;
+        this->actionFunc = EnWallmas_WaitForSwitchFlag;
     }
 }
 
@@ -262,7 +262,7 @@ void EnWallmas_StunBegin(EnWallmas* this) {
     }
 
     this->timer = 0x50;
-    this->actionFunc = (ActorFunc)&EnWallmas_Stun;
+    this->actionFunc = EnWallmas_Stun;
 }
 
 void EnWallmas_WaitToDrop(EnWallmas* this, GlobalContext* globalCtx) {
@@ -496,7 +496,7 @@ void EnWallmas_ColUpdate(EnWallmas* this, GlobalContext* globalCtx) {
 
             if ((this->actor.colChkInfo.damageEffect == DAMAGE_EFFECT_STUN_WHITE) ||
                 (this->actor.colChkInfo.damageEffect == DAMAGE_EFFECT_STUN_BLUE)) {
-                if (this->actionFunc != (ActorFunc)&EnWallmas_Stun) {
+                if (this->actionFunc != EnWallmas_Stun) {
                     EnWallmas_StunBegin(this);
                 }
             } else {
@@ -517,19 +517,19 @@ void EnWallmas_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnWallmas_ColUpdate(this, globalCtx);
     this->actionFunc(this, globalCtx);
 
-    if ((this->actionFunc == (ActorFunc)&EnWallmas_WaitToDrop) ||
-        (this->actionFunc == (ActorFunc)&EnWallmas_WaitForProximity) ||
-        (this->actionFunc == (ActorFunc)&EnWallmas_TakePlayer) ||
-        (this->actionFunc == (ActorFunc)&EnWallmas_WaitForSwitchFlag)) {
+    if ((this->actionFunc == EnWallmas_WaitToDrop) ||
+        (this->actionFunc == EnWallmas_WaitForProximity) ||
+        (this->actionFunc == EnWallmas_TakePlayer) ||
+        (this->actionFunc == EnWallmas_WaitForSwitchFlag)) {
         return;
     }
 
-    if ((this->actionFunc != (ActorFunc)&EnWallmas_ReturnToCeiling) &&
-        (this->actionFunc != (ActorFunc)&EnWallmas_TakePlayer)) {
+    if ((this->actionFunc != EnWallmas_ReturnToCeiling) &&
+        (this->actionFunc != EnWallmas_TakePlayer)) {
         Actor_MoveForward(&this->actor);
     }
 
-    if (this->actionFunc != (ActorFunc)&EnWallmas_Drop) {
+    if (this->actionFunc != EnWallmas_Drop) {
         func_8002E4B4(globalCtx, &this->actor, 20.0f, 25.0f, 0.0f, 0x1D);
     } else if (this->actor.posRot.pos.y <= this->unk_2c4) {
         this->actor.posRot.pos.y = this->unk_2c4;
@@ -537,11 +537,11 @@ void EnWallmas_Update(Actor* thisx, GlobalContext* globalCtx) {
         EnWallmas_LandStart(this, globalCtx);
     }
 
-    if ((this->actionFunc != (ActorFunc)&EnWallmas_Die) && (this->actionFunc != (ActorFunc)&EnWallmas_Drop)) {
+    if ((this->actionFunc != EnWallmas_Die) && (this->actionFunc != EnWallmas_Drop)) {
         Collider_CylinderUpdate(&this->actor, &this->collider);
         CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this->collider);
 
-        if ((this->actionFunc != (ActorFunc)&EnWallmas_TakeDamage) && (this->actor.bgCheckFlags & 1) != 0 &&
+        if ((this->actionFunc != EnWallmas_TakeDamage) && (this->actor.bgCheckFlags & 1) != 0 &&
             (this->actor.freeze == 0)) {
             CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->collider);
         }
@@ -549,7 +549,7 @@ void EnWallmas_Update(Actor* thisx, GlobalContext* globalCtx) {
 
     Actor_SetHeight(&this->actor, 25.0f);
 
-    if (this->actionFunc == (ActorFunc)&EnWallmas_TakeDamage) {
+    if (this->actionFunc == EnWallmas_TakeDamage) {
         return;
     }
 
@@ -564,7 +564,7 @@ void EnWallmas_DrawXlu(EnWallmas* this, GlobalContext* globalCtx) {
     Gfx* dispRefs[3];
 
     if ((this->actor.floorPoly == NULL) ||
-        ((this->timer >= 0x51) && (this->actionFunc != (ActorFunc)&EnWallmas_Stun))) {
+        ((this->timer >= 0x51) && (this->actionFunc != EnWallmas_Stun))) {
         return;
     }
 
@@ -578,10 +578,10 @@ void EnWallmas_DrawXlu(EnWallmas* this, GlobalContext* globalCtx) {
     func_80038A28(this->actor.floorPoly, this->actor.posRot.pos.x, this->actor.unk_80, this->actor.posRot.pos.z, &mf);
     Matrix_Mult(&mf, MTXMODE_NEW);
 
-    if ((this->actionFunc != (ActorFunc)EnWallmas_WaitToDrop) &&
-        (this->actionFunc != (ActorFunc)EnWallmas_ReturnToCeiling) &&
-        (this->actionFunc != (ActorFunc)EnWallmas_TakePlayer) &&
-        (this->actionFunc != (ActorFunc)EnWallmas_WaitForSwitchFlag)) {
+    if ((this->actionFunc != EnWallmas_WaitToDrop) &&
+        (this->actionFunc != EnWallmas_ReturnToCeiling) &&
+        (this->actionFunc != EnWallmas_TakePlayer) &&
+        (this->actionFunc != EnWallmas_WaitForSwitchFlag)) {
         xzScale = this->actor.scale.x * 50.0f;
     } else {
         xzScale = ((0x50 - this->timer) >= 0x51 ? 0x50 : (0x50 - this->timer)) * TIMER_SCALE;
@@ -598,7 +598,7 @@ s32 EnWallMas_OverrideLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dL
     EnWallmas* this = THIS;
 
     if (limbIndex == 1) {
-        if (this->actionFunc != (ActorFunc)EnWallmas_TakePlayer) {
+        if (this->actionFunc != EnWallmas_TakePlayer) {
             pos->z -= 1600.0f;
         } else {
             pos->z -= ((1600.0f * (this->skelAnime.animFrameCount - this->skelAnime.animCurrentFrame)) /
@@ -633,7 +633,7 @@ void EnWallMas_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList
 void EnWallmas_Draw(Actor* thisx, GlobalContext* globalCtx) {
     EnWallmas* this = THIS;
 
-    if (this->actionFunc != (ActorFunc)&EnWallmas_WaitToDrop) {
+    if (this->actionFunc != EnWallmas_WaitToDrop) {
         func_80093D18(globalCtx->state.gfxCtx);
         SkelAnime_DrawSV(globalCtx, this->skelAnime.skeleton, this->skelAnime.limbDrawTbl, this->skelAnime.dListCount,
                          EnWallMas_OverrideLimbDraw, EnWallMas_PostLimbDraw, &this->actor);

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
@@ -10,10 +10,14 @@ typedef enum {
     /* 0x02 */ WMT_FLAG
 } WallmasType;
 
-typedef struct {
+struct EnWallmas;
+
+typedef void (*EnWallmasActionFunc)(struct EnWallmas*, GlobalContext*);
+
+typedef struct EnWallmas {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ ActorFunc actionFunc;
+    /* 0x0190 */ EnWallmasActionFunc actionFunc;
     /* 0x0194 */ s16 timer;
     /* 0x0196 */ s16 switchFlag;
     /* 0x0198 */ UNK_PTR unkSkelAnimeStruct;

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.h
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnWeatherTag;
+
+typedef struct EnWeatherTag {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8];
 } EnWeatherTag; // size = 0x0154

--- a/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.h
+++ b/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnWeiyer;
+
+typedef struct EnWeiyer {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x184];
 } EnWeiyer; // size = 0x02D0

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.h
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnWf;
+
+typedef struct EnWf {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x390];
 } EnWf; // size = 0x04DC

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.h
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnWonderItem;
+
+typedef struct EnWonderItem {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x84];
 } EnWonderItem; // size = 0x01D0

--- a/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.h
+++ b/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnWonderTalk;
+
+typedef struct EnWonderTalk {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1C];
 } EnWonderTalk; // size = 0x0168

--- a/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.h
+++ b/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnWonderTalk2;
+
+typedef struct EnWonderTalk2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x24];
 } EnWonderTalk2; // size = 0x0170

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.h
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnWood02;
+
+typedef struct EnWood02 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x58];
 } EnWood02; // size = 0x01A4

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.h
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnXc;
+
+typedef struct EnXc {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1F0];
 } EnXc; // size = 0x033C

--- a/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.h
+++ b/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnYabusameMark;
+
+typedef struct EnYabusameMark {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC4];
 } EnYabusameMark; // size = 0x0210

--- a/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.h
+++ b/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnYukabyun;
+
+typedef struct EnYukabyun {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x54];
 } EnYukabyun; // size = 0x01A0

--- a/src/overlays/actors/ovl_En_Zf/z_en_zf.h
+++ b/src/overlays/actors/ovl_En_Zf/z_en_zf.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnZf;
+
+typedef struct EnZf {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x41C];
 } EnZf; // size = 0x0568

--- a/src/overlays/actors/ovl_En_Zl1/z_en_zl1.h
+++ b/src/overlays/actors/ovl_En_Zl1/z_en_zl1.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnZl1;
+
+typedef struct EnZl1 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC0];
 } EnZl1; // size = 0x020C

--- a/src/overlays/actors/ovl_En_Zl2/z_en_zl2.h
+++ b/src/overlays/actors/ovl_En_Zl2/z_en_zl2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnZl2;
+
+typedef struct EnZl2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x134];
 } EnZl2; // size = 0x0280

--- a/src/overlays/actors/ovl_En_Zl3/z_en_zl3.h
+++ b/src/overlays/actors/ovl_En_Zl3/z_en_zl3.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnZl3;
+
+typedef struct EnZl3 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x2D4];
 } EnZl3; // size = 0x0420

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.h
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnZl4;
+
+typedef struct EnZl4 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1A4];
 } EnZl4; // size = 0x02F0

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.h
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnZo;
+
+typedef struct EnZo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x55C];
 } EnZo; // size = 0x06A8

--- a/src/overlays/actors/ovl_En_fHG/z_en_fhg.h
+++ b/src/overlays/actors/ovl_En_fHG/z_en_fhg.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EnfHG;
+
+typedef struct EnfHG {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x148];
 } EnfHG; // size = 0x0294

--- a/src/overlays/actors/ovl_End_Title/z_end_title.h
+++ b/src/overlays/actors/ovl_End_Title/z_end_title.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct EndTitle;
+
+typedef struct EndTitle {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4];
 } EndTitle; // size = 0x0150

--- a/src/overlays/actors/ovl_Fishing/z_fishing.h
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct Fishing;
+
+typedef struct Fishing {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x404];
 } Fishing; // size = 0x0550

--- a/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.h
+++ b/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ItemBHeart;
+
+typedef struct ItemBHeart {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x20];
 } ItemBHeart; // size = 0x016C

--- a/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.h
+++ b/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ItemEtcetera;
+
+typedef struct ItemEtcetera {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x14];
 } ItemEtcetera; // size = 0x0160

--- a/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.h
+++ b/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ItemInbox;
+
+typedef void (*ItemInboxActionFunc)(struct ItemInbox*, GlobalContext*);
+
+typedef struct ItemInbox {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ ItemInboxActionFunc actionFunc;
 } ItemInbox; // size = 0x0150
 
 extern const ActorInit Item_Inbox_InitVars;

--- a/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.h
+++ b/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ItemOcarina;
+
+typedef struct ItemOcarina {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x8];
 } ItemOcarina; // size = 0x0154

--- a/src/overlays/actors/ovl_Item_Shield/z_item_shield.h
+++ b/src/overlays/actors/ovl_Item_Shield/z_item_shield.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ItemShield;
+
+typedef struct ItemShield {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC0];
 } ItemShield; // size = 0x020C

--- a/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.h
+++ b/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct MagicDark;
+
+typedef struct MagicDark {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x18];
 } MagicDark; // size = 0x0164

--- a/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.h
+++ b/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct MagicFire;
+
+typedef struct MagicFire {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x60];
 } MagicFire; // size = 0x01AC

--- a/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.h
+++ b/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct MagicWind;
+
+typedef struct MagicWind {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x28];
 } MagicWind; // size = 0x0174

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.h
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct MirRay;
+
+typedef struct MirRay {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x164];
 } MirRay; // size = 0x02B0

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.h
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjBean;
+
+typedef struct ObjBean {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x94];
 } ObjBean; // size = 0x01F8

--- a/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.h
+++ b/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjBlockstop;
+
+typedef struct ObjBlockstop {
     /* 0x0000 */ Actor actor;
 } ObjBlockstop; // size = 0x014C
 

--- a/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.h
+++ b/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjBombiwa;
+
+typedef struct ObjBombiwa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ ColliderCylinder collider;
 } ObjBombiwa; // size = 0x0198

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.h
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjComb;
+
+typedef void (*ObjCombActionFunc)(struct ObjComb*, GlobalContext*);
+
+typedef struct ObjComb {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ ObjCombActionFunc actionFunc;
     /* 0x0150 */ ColliderJntSph collider;
     /* 0x0170 */ ColliderJntSphItem colliderItems[1];
     /* 0x01B0 */ s16 unk_1B0;

--- a/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.h
+++ b/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjDekujr;
+
+typedef struct ObjDekujr {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x58];
 } ObjDekujr; // size = 0x01A4

--- a/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.c
+++ b/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.c
@@ -43,7 +43,7 @@ static f32 sizes[] = { 0.1f, 0.05f };
 extern u32 D_06000180;
 extern u32 D_06000360;
 
-void ObjElevator_SetupAction(ObjElevator* this, ActorFunc actionFunc) {
+void ObjElevator_SetupAction(ObjElevator* this, ObjElevatorActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
 

--- a/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.h
+++ b/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjElevator;
+
+typedef void (*ObjElevatorActionFunc)(struct ObjElevator*, GlobalContext*);
+
+typedef struct ObjElevator {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc;
+    /* 0x0164 */ ObjElevatorActionFunc actionFunc;
     /* 0x0168 */ f32 unk_168;
     /* 0x016C */ f32 unk_16C;
     /* 0x0170 */ u8 unk_170;

--- a/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.h
+++ b/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjHamishi;
+
+typedef struct ObjHamishi {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x5C];
 } ObjHamishi; // size = 0x01A8

--- a/src/overlays/actors/ovl_Obj_Hana/z_obj_hana.h
+++ b/src/overlays/actors/ovl_Obj_Hana/z_obj_hana.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjHana;
+
+typedef struct ObjHana {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4C];
 } ObjHana; // size = 0x0198

--- a/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.h
+++ b/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjHsblock;
+
+typedef struct ObjHsblock {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x4];
 } ObjHsblock; // size = 0x0168

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.h
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjIcePoly;
+
+typedef struct ObjIcePoly {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xA0];
 } ObjIcePoly; // size = 0x01EC

--- a/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.h
+++ b/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjKibako;
+
+typedef struct ObjKibako {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x50];
 } ObjKibako; // size = 0x019C

--- a/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.h
+++ b/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjKibako2;
+
+typedef struct ObjKibako2 {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x54];
 } ObjKibako2; // size = 0x01B8

--- a/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.h
+++ b/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjLift;
+
+typedef struct ObjLift {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0xC];
 } ObjLift; // size = 0x0170

--- a/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.h
+++ b/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjLightswitch;
+
+typedef struct ObjLightswitch {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x78];
 } ObjLightswitch; // size = 0x01C4

--- a/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
+++ b/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
@@ -53,7 +53,7 @@ void func_80B98320(ObjMakekinsuta* this, GlobalContext* globalCtx) {
             Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_SW, this->actor.posRot.pos.x,
                         this->actor.posRot.pos.y, this->actor.posRot.pos.z, 0, this->actor.shape.rot.y, 0,
                         (this->actor.params | 0x8000));
-            this->actionFunc = &func_80B983D4;
+            this->actionFunc = func_80B983D4;
             return;
         }
         this->unk_150 = this->unk_150 + 1;

--- a/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.h
+++ b/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjMakekinsuta;
+
+typedef void (*ObjMakekinsutaActionFunc)(struct ObjMakekinsuta*, GlobalContext*);
+
+typedef struct ObjMakekinsuta {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ ObjMakekinsutaActionFunc actionFunc;
     /* 0x150  */ s16 unk_150;
     /* 0x152  */ s16 unk_152;
 } ObjMakekinsuta; // size = 0x0154

--- a/src/overlays/actors/ovl_Obj_Makeoshihiki/z_obj_makeoshihiki.h
+++ b/src/overlays/actors/ovl_Obj_Makeoshihiki/z_obj_makeoshihiki.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjMakeoshihiki;
+
+typedef struct ObjMakeoshihiki {
     /* 0x0000 */ Actor actor;
 } ObjMakeoshihiki; // size = 0x014C
 

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.h
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjMure;
+
+typedef struct ObjMure {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x60];
 } ObjMure; // size = 0x01AC

--- a/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.h
+++ b/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjMure2;
+
+typedef struct ObjMure2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x3C];
 } ObjMure2; // size = 0x0188

--- a/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.h
+++ b/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjMure3;
+
+typedef struct ObjMure3 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x24];
 } ObjMure3; // size = 0x0170

--- a/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.h
+++ b/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjOshihiki;
+
+typedef struct ObjOshihiki {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x70];
 } ObjOshihiki; // size = 0x01D4

--- a/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
+++ b/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
@@ -45,7 +45,7 @@ void ObjRoomtimer_Init(Actor* thisx, GlobalContext* globalCtx) {
         }
     }
 
-    this->actionFunc = (ActorFunc)func_80B9D054;
+    this->actionFunc = func_80B9D054;
 }
 
 void ObjRoomtimer_Destroy(Actor* thisx, GlobalContext* globalCtx) {
@@ -64,7 +64,7 @@ void func_80B9D054(ObjRoomtimer* this, GlobalContext* globalCtx) {
     }
 
     Actor_ChangeType(globalCtx, &globalCtx->actorCtx, &this->actor, ACTORTYPE_PROP);
-    this->actionFunc = (ActorFunc)func_80B9D0B0;
+    this->actionFunc = func_80B9D0B0;
 }
 
 void func_80B9D0B0(ObjRoomtimer* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.h
+++ b/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.h
@@ -5,9 +5,13 @@
 #include <global.h>
 #include <z64.h>
 
-typedef struct {
+struct ObjRoomtimer;
+
+typedef void (*ObjRoomtimerActionFunc)(struct ObjRoomtimer*, GlobalContext*);
+
+typedef struct ObjRoomtimer {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ ObjRoomtimerActionFunc actionFunc;
     /* 0x0150 */ u32 switchFlag;
 } ObjRoomtimer; // size = 0x0154
 

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjSwitch;
+
+typedef struct ObjSwitch {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0xF4];
 } ObjSwitch; // size = 0x0258

--- a/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h
+++ b/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjSyokudai;
+
+typedef struct ObjSyokudai {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xB0];
 } ObjSyokudai; // size = 0x01FC

--- a/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.h
+++ b/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjTimeblock;
+
+typedef void (*ObjTimeblockActionFunc)(struct ObjTimeblock*, GlobalContext*);
+
+typedef struct ObjTimeblock {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ char unk_164[0x4];
-    /* 0x0168 */ ActorFunc actionFunc;
+    /* 0x0168 */ ObjTimeblockActionFunc actionFunc;
     /* 0x016C */ char unk_16C[0x10];
 } ObjTimeblock; // size = 0x017C
 

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.h
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.h
@@ -4,9 +4,13 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjTsubo;
+
+typedef void (*ObjTsuboActionFunc)(struct ObjTsubo*, GlobalContext*);
+
+typedef struct ObjTsubo {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ActorFunc actionFunc;
+    /* 0x014C */ ObjTsuboActionFunc actionFunc;
     /* 0x0150 */ char unk_150[0x50];
 } ObjTsubo; // size = 0x01A0
 

--- a/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.h
+++ b/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjWarp2block;
+
+typedef void (*ObjWarp2blockActionFunc)(struct ObjWarp2block*, GlobalContext*);
+
+typedef struct ObjWarp2block {
     /* 0x0000 */ DynaPolyActor dyna;
-    /* 0x0164 */ ActorFunc actionFunc_164;
-    /* 0x0168 */ ActorFunc actionFunc_168;
+    /* 0x0164 */ ObjWarp2blockActionFunc actionFunc_164;
+    /* 0x0168 */ ObjWarp2blockActionFunc actionFunc_168;
     /* 0x016C */ char unk_16C[0xC];
 } ObjWarp2block; // size = 0x0178
 

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -14,7 +14,6 @@ void ObjectKankyo_Init(Actor* thisx, GlobalContext* globalCtx);
 void ObjectKankyo_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void ObjectKankyo_Update(Actor* thisx, GlobalContext* globalCtx);
 void ObjectKankyo_Draw(Actor* thisx, GlobalContext* globalCtx);
-void ObjectKankyo_SetupAction(ObjectKankyo* this, ActorFunc actionFunc);
 
 /*
 const ActorInit Object_Kankyo_InitVars = {

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.h
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ObjectKankyo;
+
+typedef void (*ObjectKankyoActionFunc)(struct ObjectKankyo*, GlobalContext*);
+
+typedef struct ObjectKankyo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x1510];
-    /* 0x165C */ ActorFunc actionFunc;
+    /* 0x165C */ ObjectKankyoActionFunc actionFunc;
 } ObjectKankyo; // size = 0x1660
 
 extern const ActorInit Object_Kankyo_InitVars;

--- a/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.h
+++ b/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct OceffSpot;
+
+typedef struct OceffSpot {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x34];
 } OceffSpot; // size = 0x0180

--- a/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.h
+++ b/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct OceffStorm;
+
+typedef struct OceffStorm {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0xC];
 } OceffStorm; // size = 0x0158

--- a/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.h
+++ b/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct OceffWipe;
+
+typedef struct OceffWipe {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4];
 } OceffWipe; // size = 0x0150

--- a/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.h
+++ b/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct OceffWipe2;
+
+typedef struct OceffWipe2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ s16 unk_14C;
     /* 0x014E */ s16 unk_14E;

--- a/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.h
+++ b/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct OceffWipe3;
+
+typedef struct OceffWipe3 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ s16 unk_14C;
     /* 0x014E */ s16 unk_14E;

--- a/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.h
+++ b/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.h
@@ -4,7 +4,9 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct OceffWipe4;
+
+typedef struct OceffWipe4 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ s16 unk_14C;
     /* 0x014E */ char unk_14E[0x2];

--- a/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.h
+++ b/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.h
@@ -4,10 +4,14 @@
 #include <ultra64.h>
 #include <global.h>
 
-typedef struct {
+struct ShotSun;
+
+typedef void (*ShotSunActionFunc)(struct ShotSun*, GlobalContext*);
+
+typedef struct ShotSun {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ char unk_14C[0x4C];
-    /* 0x0198 */ ActorFunc actionFunc;
+    /* 0x0198 */ ShotSunActionFunc actionFunc;
     /* 0x019C */ char unk_19C[0xC];
 } ShotSun; // size = 0x01A8
 


### PR DESCRIPTION
Pointers to specific functions inside actors should now all use dedicated types, and I also added a forward struct declaration to all actors, so it's consistent and easy to add types like these when needed.

ActorFunc should no longer be used except for the 4 main generic functions (init, destroy, update, draw).

