### PR TITLE
Add 64-byte alignment requirement to the buffers segment

### DIFF
--- a/spec
+++ b/spec
@@ -536,6 +536,7 @@ endseg
 
 beginseg
     name "buffers"
+    align 0x40
     include "build/src/buffers/zbuffer.o"
     include "build/src/buffers/gfxbuffers.o"
     include "build/src/buffers/heaps.o"


### PR DESCRIPTION
This fixes a hardware crash that occurs when modifications shift the z-buffer to an address that has only the default 16-byte segment alignment, where as the RDP requires a 64-byte alignment for the depth and color buffers.