### PR TITLE
Fix name of function in z_player_lib

### DIFF
--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -245,7 +245,7 @@ void func_8008EEAC(GlobalContext* globalCtx, Actor* arg1) {
     func_8005A444(Gameplay_GetCamera(globalCtx, 0), 2);
 }
 
-s32 func_8008EF40(GlobalContext* globalCtx) {
+s32 func_8008EF30(GlobalContext* globalCtx) {
     Player* player = PLAYER;
     return player->stateFlags1 & 0x800000;
 }


### PR DESCRIPTION
Renamed func_8008EF40 to func_8008EF30 in z_player_lib.c, because the function is actually at address 0x8008EF30.