### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_size = 4
+indent_style = tab


### PR DESCRIPTION
After reading [a comment on another PR](https://github.com/zeldaret/oot/pull/255/files#r455288401) I thought we'd need an editor-agnostic configuration file to avoid these kind of hard to catch mistakes.

See https://editorconfig.org/ for details.