### PR TITLE
Add COMPARE and NON_MATCHING build options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .SUFFIXES:
 
-# Build options can either be changed by modifying the makefile, or by building with 'make SETTING=value'.
+# Build options can either be changed by modifying the makefile, or by building with 'make SETTING=value'
 
 # If COMPARE is 1, check the output md5sum after building
 COMPARE ?= 1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
 .SUFFIXES:
 
+# Build options can either be changed by modifying the makefile, or by building with 'make SETTING=value'.
+
+# If COMPARE is 1, check the output md5sum after building
+COMPARE ?= 1
+# If NON_MATCHING is 1, define the NON_MATCHING C flag when building
+NON_MATCHING ?= 0
+
+ifeq ($(NON_MATCHING),1)
+  CFLAGS := -DNON_MATCHING
+  COMPARE := 0
+endif
+
 PROJECT_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 #### Tools ####
@@ -38,7 +50,7 @@ ASFLAGS := -march=vr4300 -32 -Iinclude
 MIPS_VERSION := -mips2
 
 # we support Microsoft extensions such as anonymous structs, which the compiler does support but warns for their usage. Surpress the warnings with -woff.
-CFLAGS  := -G 0 -non_shared -Xfullwarn -Xcpluscomm -Iinclude -Isrc -Wab,-r4300_mul -woff 649,838
+CFLAGS += -G 0 -non_shared -Xfullwarn -Xcpluscomm -Iinclude -Isrc -Wab,-r4300_mul -woff 649,838
 
 ifeq ($(shell getconf LONG_BIT), 32)
   # Work around memory allocation bug in QEMU
@@ -128,9 +140,11 @@ build/src/overlays/gamestates/%.o: CC := python3 tools/asm_processor/build.py $(
 
 #### Main Targets ###
 
-compare: $(ROM)
+all: $(ROM)
+ifeq ($(COMPARE),1)
 	@md5sum $(ROM)
 	@md5sum -c checksum.md5
+endif
 
 $(ROM): $(ELF)
 	$(ELF2ROM) -cic 6105 $< $@

--- a/first_diff.py
+++ b/first_diff.py
@@ -24,9 +24,15 @@ parser.add_argument(
     const="prompt",
     help="run diff.py on the result with the provided arguments"
 )
+parser.add_argument(
+    "-m", "--make", help="run make before finding difference(s)", action="store_true"
+)
 args = parser.parse_args()
 
 diff_count = args.count
+
+if args.make:
+    check_call(["make", "-j4", "COMPARE=0"])
 
 baseimg = f"baserom.z64"
 basemap = f"expected/build/z64.map"
@@ -228,6 +234,10 @@ if diffs > 100:
         print(f"No ROM shift{' (!?)' if definite_shift else ''}")
 
 if args.diff_args:
+    if len(found_instr_diff) < 1:
+        print(f"No instruction difference to run diff.py on")
+        exit()
+
     diff_sym = search_rom_address(found_instr_diff[0]).split()[0]
     if args.diff_args == "prompt":
         diff_args = input("Call diff.py with which arguments? ") or "--"

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -1636,7 +1636,7 @@ s32 func_800C05E4(GlobalContext* globalCtx, s16 camId, Vec3f* arg2, Vec3f* arg3,
     ret *= 2;
     ret |= Camera_SetParam(camera, 4, arg4);
 
-    camera->dist = func_800CB678(arg2, arg3);
+    camera->dist = Math3D_Vec3f_DistXYZ(arg2, arg3);
 
     player = camera->player;
     if (player != NULL) {


### PR DESCRIPTION
Also fixed a function name in a `z_play.c` non matching and improved the `first_diff.py` script with a new `-m`/`--make` option to run `make -j4 COMPARE=0` before finding differences.