### PR TITLE
fix m2ctx incompatibility on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Cache files
 __pycache__/
 .pyc
+.DS_Store
 
 # Text editor remnants
 .vscode/

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -25,7 +25,7 @@ def get_c_file(directory):
 
 def import_c_file(in_file):
     in_file = os.path.relpath(in_file, root_dir)
-    cpp_command = ["cpp", "-P", "-Iinclude", "-Isrc", "-undef", "-D__sgi", "-D_LANGUAGE_C",
+    cpp_command = ["gcc", "-E", "-P", "-Iinclude", "-Isrc", "-undef", "-D__sgi", "-D_LANGUAGE_C",
                    "-DNON_MATCHING", "-D_Static_assert(x, y)=", "-D__attribute__(x)=", in_file]
     try:
         return subprocess.check_output(cpp_command, cwd=root_dir, encoding="utf-8")


### PR DESCRIPTION
A version of `cpp` that is installed with the standard command line tools for MacOS is somehow unable to parse comments that begin with `//`. Switching the preprocessor to `gcc` alleviates this issue.