### PR TITLE
Fix ichaindis.py always outputting an unsigned value

### DIFF
--- a/tools/ichaindis.py
+++ b/tools/ichaindis.py
@@ -92,6 +92,8 @@ def main():
         t = (entry >> 27) & 0xF
         offset = ((entry) >> 16) & 0x7FF
         value = (entry) & 0xFFFF
+        if value >= 0x8000 and not ICHAIN_MACROS[t].startswith('ICHAIN_U'):
+            value -= 0x10000
 
         var_name = '{0:X}'.format(offset)
 


### PR DESCRIPTION
See this from #425 :
https://github.com/zeldaret/oot/blob/61c529a5c1439a98249d3e9156a2d4fb49c4e08d/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c#L267
```c
static InitChainEntry sInitChains[][5] = {
    {
        ICHAIN_F32_DIV1000(gravity, 64336, ICHAIN_CONTINUE),
        ICHAIN_F32_DIV1000(minVelocityY, 45536, ICHAIN_CONTINUE),
        ICHAIN_F32(uncullZoneForward, 1200, ICHAIN_CONTINUE),
        ICHAIN_F32(uncullZoneScale, 150, ICHAIN_CONTINUE),
        ICHAIN_F32(uncullZoneDownward, 400, ICHAIN_STOP),
    },
    {
        ICHAIN_F32_DIV1000(gravity, 63036, ICHAIN_CONTINUE),
        ICHAIN_F32_DIV1000(minVelocityY, 45536, ICHAIN_CONTINUE),
        ICHAIN_F32(uncullZoneForward, 2000, ICHAIN_CONTINUE),
        ICHAIN_F32(uncullZoneScale, 250, ICHAIN_CONTINUE),
        ICHAIN_F32(uncullZoneDownward, 500, ICHAIN_STOP),
    },
};
```

Current `ichaindis.py` reads `InitChainEntry.value` as an unsigned value regardless of the type being signed (`ICHAIN_U8`, `ICHAIN_U16`, `ICHAIN_U32`) or not (s32, f32, f32/1000 ...)
This PR addresses this issue

With those changes the above init chains output become:
```c
$ ./tools/ichaindis.py zelda_ocarina_mq_dbg.z64 80A873B8
static InitChainEntry sInitChain[] = {
    ICHAIN_F32_DIV1000(unk_6C, -1200, ICHAIN_CONTINUE),
    ICHAIN_F32_DIV1000(unk_70, -20000, ICHAIN_CONTINUE),
    ICHAIN_F32(unk_F4, 1200, ICHAIN_CONTINUE),
    ICHAIN_F32(unk_F8, 150, ICHAIN_CONTINUE),
    ICHAIN_F32(unk_FC, 400, ICHAIN_STOP),
};

$ ./tools/ichaindis.py zelda_ocarina_mq_dbg.z64 80A873CC
static InitChainEntry sInitChain[] = {
    ICHAIN_F32_DIV1000(unk_6C, -2500, ICHAIN_CONTINUE),
    ICHAIN_F32_DIV1000(unk_70, -20000, ICHAIN_CONTINUE),
    ICHAIN_F32(unk_F4, 2000, ICHAIN_CONTINUE),
    ICHAIN_F32(unk_F8, 250, ICHAIN_CONTINUE),
    ICHAIN_F32(unk_FC, 500, ICHAIN_STOP),
};
```