### PR TITLE
Fix colliderinit.py to run from project root

### DIFF
--- a/tools/csdis.py
+++ b/tools/csdis.py
@@ -2,8 +2,7 @@
 
 from overlayhelpers import filemap
 
-import argparse
-import struct
+import argparse, os, struct
 
 """
 Enumerations
@@ -472,8 +471,9 @@ def main():
     print(file_result)
     print()
 
+    script_dir = os.path.dirname(os.path.realpath(__file__))
     cs_data = None
-    with open("baserom/" + file_result.name, "rb") as ovl_file:
+    with open(script_dir + "/../baserom/" + file_result.name, "rb") as ovl_file:
         ovl_file.seek(file_result.offset)
         cs_data = [i[0] for i in struct.iter_unpack(">I",  bytearray(ovl_file.read()))]
     if cs_data is not None:

--- a/tools/overlayhelpers/colliderinit.py
+++ b/tools/overlayhelpers/colliderinit.py
@@ -223,7 +223,7 @@ else:
     print("ItemInit type must specify number of elements")
     exit()
 
-ovlFile = open("../../baserom/" + fileResult.name, "rb")
+ovlFile = open("baserom/" + fileResult.name, "rb")
 ovlData = bytearray(ovlFile.read())
 ovlFile.close()
 

--- a/tools/overlayhelpers/colliderinit.py
+++ b/tools/overlayhelpers/colliderinit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import struct
 import argparse
 from filemap import FileResult, GetFromVRam, GetFromRom
@@ -223,7 +224,9 @@ else:
     print("ItemInit type must specify number of elements")
     exit()
 
-ovlFile = open("baserom/" + fileResult.name, "rb")
+script_dir = os.path.dirname(os.path.realpath(__file__))
+
+ovlFile = open(script_dir + "/../../baserom/" + fileResult.name, "rb")
 ovlData = bytearray(ovlFile.read())
 ovlFile.close()
 


### PR DESCRIPTION
filemap.py was already fixed in #235  to work from anywhere when the cutscene disassembler script was added so the fix was simple. Downside is it no longer works when cd'd to but I don't really see that as an issue since running it from root should be preferred anyway.