### PR TITLE
Fixing mkldscript.c for MacOS

### DIFF
--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -194,10 +194,15 @@ static void parse_rom_spec(char *spec)
     while (line[0] != 0)
     {
         char *nextLine = line_split(line);
+        char* stmtName;
 
         if (line[0] != 0)
         {
-            char *stmtName = skip_whitespace(line);
+            stmtName = skip_whitespace(line);
+        }
+
+        if (line[0] != 0 && stmtName[0] != 0)
+        {
             char *args = token_split(stmtName);
             unsigned int stmt;
 


### PR DESCRIPTION
The way we use the clang cpp on mac causes empty lines to be put into the spec. This is causing an issue with mkldscript, since it wasn't designed to handle empty lines (with spaces). I modified it a tiny bit so it skips over lines with spaces.