### PR TITLE
Highscores array

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -45,7 +45,7 @@
 #define CHECK_QUEST_ITEM(item) (gBitFlags[item] & gSaveContext.inventory.questItems)
 #define CHECK_DUNGEON_ITEM(item, dungeonIndex) (gSaveContext.inventory.dungeonItems[dungeonIndex] & gBitFlags[item])
 
-#define HIGHSCORE(score) (gSaveContext.highscores[score])
+#define HIGH_SCORE(score) (gSaveContext.highScores[score])
 
 #define B_BTN_ITEM ((gSaveContext.buttonStatus[0] == ITEM_NONE)                    \
                         ? ITEM_NONE                                                \

--- a/include/macros.h
+++ b/include/macros.h
@@ -45,6 +45,8 @@
 #define CHECK_QUEST_ITEM(item) (gBitFlags[item] & gSaveContext.inventory.questItems)
 #define CHECK_DUNGEON_ITEM(item, dungeonIndex) (gSaveContext.inventory.dungeonItems[dungeonIndex] & gBitFlags[item])
 
+#define HIGHSCORE(score) (gSaveContext.highscores[score])
+
 #define B_BTN_ITEM ((gSaveContext.buttonStatus[0] == ITEM_NONE)                    \
                         ? ITEM_NONE                                                \
                         : (gSaveContext.equips.buttonItems[0] == ITEM_SWORD_KNIFE) \

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -97,7 +97,7 @@ typedef struct {
     /* 0x0E8C */ char unk_E8C[0x10];
     /* 0x0E9C */ s32 gsFlags[6];
     /* 0x0EB4 */ char unk_EB4[0x4];
-    /* 0x0EB8 */ s32 highscores[7];
+    /* 0x0EB8 */ s32 highScores[7];
     /* 0x0ED4 */ u16 eventChkInf[14]; // "event_chk_inf"
     /* 0x0EF0 */ u16 itemGetInf[4]; // "item_get_inf"
     /* 0x0EF8 */ u16 infTable[30]; // "inf_table"
@@ -187,13 +187,13 @@ typedef enum {
 } ButtonStatus;
 
 typedef enum {
-    /* 0x00 */ HIGHSCORE_HORSE_ARCHERY,
-    /* 0x01 */ HIGHSCORE_POE_POINTS,
-    /* 0x02 */ HIGHSCORE_LARGEST_FISH,
-    /* 0x03 */ HIGHSCORE_HORSE_RACE,
-    /* 0x04 */ HIGHSCORE_MARATHON,
-    /* 0x05 */ HIGHSCORE_UNK_05,
-    /* 0x06 */ HIGHSCORE_DAMPE_RACE
-} Highscores;
+    /* 0x00 */ HS_HBA,          // horseback archery
+    /* 0x01 */ HS_POE_POINTS,
+    /* 0x02 */ HS_FISHING,
+    /* 0x03 */ HS_HORSE_RACE,
+    /* 0x04 */ HS_MARATHON,
+    /* 0x05 */ HS_UNK_05,
+    /* 0x06 */ HS_DAMPE_RACE
+} HighScores;
 
 #endif

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -96,11 +96,8 @@ typedef struct {
     /* 0x0E64 */ FaroresWindData fw;
     /* 0x0E8C */ char unk_E8C[0x10];
     /* 0x0E9C */ s32 gsFlags[6];
-    /* 0x0EB4 */ char unk_EB4[0xC];
-    /* 0x0EC0 */ s32 unk_EC0;
-    /* 0x0EC4 */ s32 horseRaceRecord;
-    /* 0x0EC8 */ char unk_EC8[0x08];
-    /* 0x0ED0 */ s32 dampeRaceTime;
+    /* 0x0EB4 */ char unk_EB4[0x4];
+    /* 0x0EB8 */ s32 highscores[7];
     /* 0x0ED4 */ u16 eventChkInf[14]; // "event_chk_inf"
     /* 0x0EF0 */ u16 itemGetInf[4]; // "item_get_inf"
     /* 0x0EF8 */ u16 infTable[30]; // "inf_table"
@@ -188,5 +185,15 @@ typedef enum {
     /* 0x00 */ BTN_ENABLED,
     /* 0xFF */ BTN_DISABLED = 0xFF
 } ButtonStatus;
+
+typedef enum {
+    /* 0x00 */ HIGHSCORE_HORSE_ARCHERY,
+    /* 0x01 */ HIGHSCORE_POE_POINTS,
+    /* 0x02 */ HIGHSCORE_LARGEST_FISH,
+    /* 0x03 */ HIGHSCORE_HORSE_RACE,
+    /* 0x04 */ HIGHSCORE_MARATHON,
+    /* 0x05 */ HIGHSCORE_UNK_05,
+    /* 0x06 */ HIGHSCORE_DAMPE_RACE
+} Highscores;
 
 #endif

--- a/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
+++ b/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
@@ -1052,7 +1052,7 @@ void DemoEc_FishingManPostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx*
                                    Gfx** gfx) {
     DemoEc* this = THIS;
 
-    if ((limbIndex == 8) && !(gSaveContext.unk_EC0 & 0x1000)) {
+    if ((limbIndex == 8) && !(HIGHSCORE(HIGHSCORE_LARGEST_FISH) & 0x1000)) {
         gSPDisplayList((*gfx)++, SEGMENTED_TO_VIRTUAL(D_060074C8));
     }
 }

--- a/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
+++ b/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
@@ -1052,7 +1052,7 @@ void DemoEc_FishingManPostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx*
                                    Gfx** gfx) {
     DemoEc* this = THIS;
 
-    if ((limbIndex == 8) && !(HIGHSCORE(HIGHSCORE_LARGEST_FISH) & 0x1000)) {
+    if ((limbIndex == 8) && !(HIGH_SCORE(HS_FISHING) & 0x1000)) {
         gSPDisplayList((*gfx)++, SEGMENTED_TO_VIRTUAL(D_060074C8));
     }
 }

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -83,13 +83,13 @@ u16 func_80AA2AA0(GlobalContext* globalCtx, Actor* thisx) {
         if (gSaveContext.timer1Value >= 0xD3) {
             return 0x208E;
         }
-        if ((gSaveContext.horseRaceRecord == 0) || (gSaveContext.horseRaceRecord >= 0xB4)) {
-            gSaveContext.horseRaceRecord = 0xB4;
+        if ((HIGHSCORE(HIGHSCORE_HORSE_RACE) == 0) || (HIGHSCORE(HIGHSCORE_HORSE_RACE) >= 0xB4)) {
+            HIGHSCORE(HIGHSCORE_HORSE_RACE) = 0xB4;
             gSaveContext.timer1Value = *timer1ValuePtr;
         }
         if (!(gSaveContext.eventChkInf[1] & 0x4000) && (gSaveContext.timer1Value < 0x32)) {
             return 0x208F;
-        } else if (gSaveContext.timer1Value < gSaveContext.horseRaceRecord) {
+        } else if (gSaveContext.timer1Value < HIGHSCORE(HIGHSCORE_HORSE_RACE)) {
             return 0x2012;
         } else {
             return 0x2004;
@@ -126,7 +126,7 @@ s16 func_80AA2BD4(GlobalContext* globalCtx, Actor* thisx) {
                 if (globalCtx->msgCtx.choiceIndex == 0) {
                     if (gSaveContext.eventChkInf[1] & 0x4000) {
                         func_8010B720(globalCtx, 0x2091);
-                    } else if (gSaveContext.horseRaceRecord == 0) {
+                    } else if (HIGHSCORE(HIGHSCORE_HORSE_RACE) == 0) {
                         func_8010B720(globalCtx, 0x2092);
                     } else {
                         func_8010B720(globalCtx, 0x2090);
@@ -144,8 +144,8 @@ s16 func_80AA2BD4(GlobalContext* globalCtx, Actor* thisx) {
                     gSaveContext.eventChkInf[1] |= 0x4000;
                 case 0x2004:
                 case 0x2012:
-                    if (gSaveContext.horseRaceRecord > gSaveContext.timer1Value) {
-                        gSaveContext.horseRaceRecord = gSaveContext.timer1Value;
+                    if (HIGHSCORE(HIGHSCORE_HORSE_RACE) > gSaveContext.timer1Value) {
+                        HIGHSCORE(HIGHSCORE_HORSE_RACE) = gSaveContext.timer1Value;
                     }
                 case 0x208E:
                     gSaveContext.eventInf[0] &= ~0x400;

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -83,13 +83,13 @@ u16 func_80AA2AA0(GlobalContext* globalCtx, Actor* thisx) {
         if (gSaveContext.timer1Value >= 0xD3) {
             return 0x208E;
         }
-        if ((HIGHSCORE(HIGHSCORE_HORSE_RACE) == 0) || (HIGHSCORE(HIGHSCORE_HORSE_RACE) >= 0xB4)) {
-            HIGHSCORE(HIGHSCORE_HORSE_RACE) = 0xB4;
+        if ((HIGH_SCORE(HS_HORSE_RACE) == 0) || (HIGH_SCORE(HS_HORSE_RACE) >= 0xB4)) {
+            HIGH_SCORE(HS_HORSE_RACE) = 0xB4;
             gSaveContext.timer1Value = *timer1ValuePtr;
         }
         if (!(gSaveContext.eventChkInf[1] & 0x4000) && (gSaveContext.timer1Value < 0x32)) {
             return 0x208F;
-        } else if (gSaveContext.timer1Value < HIGHSCORE(HIGHSCORE_HORSE_RACE)) {
+        } else if (gSaveContext.timer1Value < HIGH_SCORE(HS_HORSE_RACE)) {
             return 0x2012;
         } else {
             return 0x2004;
@@ -126,7 +126,7 @@ s16 func_80AA2BD4(GlobalContext* globalCtx, Actor* thisx) {
                 if (globalCtx->msgCtx.choiceIndex == 0) {
                     if (gSaveContext.eventChkInf[1] & 0x4000) {
                         func_8010B720(globalCtx, 0x2091);
-                    } else if (HIGHSCORE(HIGHSCORE_HORSE_RACE) == 0) {
+                    } else if (HIGH_SCORE(HS_HORSE_RACE) == 0) {
                         func_8010B720(globalCtx, 0x2092);
                     } else {
                         func_8010B720(globalCtx, 0x2090);
@@ -144,8 +144,8 @@ s16 func_80AA2BD4(GlobalContext* globalCtx, Actor* thisx) {
                     gSaveContext.eventChkInf[1] |= 0x4000;
                 case 0x2004:
                 case 0x2012:
-                    if (HIGHSCORE(HIGHSCORE_HORSE_RACE) > gSaveContext.timer1Value) {
-                        HIGHSCORE(HIGHSCORE_HORSE_RACE) = gSaveContext.timer1Value;
+                    if (HIGH_SCORE(HS_HORSE_RACE) > gSaveContext.timer1Value) {
+                        HIGH_SCORE(HS_HORSE_RACE) = gSaveContext.timer1Value;
                     }
                 case 0x208E:
                     gSaveContext.eventInf[0] &= ~0x400;

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -316,8 +316,8 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, GlobalContext* globalCtx) {
             sp60.x = this->actor.posRot.pos.x;
             sp60.y = this->actor.groundY;
             sp60.z = this->actor.posRot.pos.z;
-            if (gSaveContext.timer1Value < gSaveContext.dampeRaceTime) {
-                gSaveContext.dampeRaceTime = gSaveContext.timer1Value;
+            if (gSaveContext.timer1Value < HIGHSCORE(HIGHSCORE_DAMPE_RACE)) {
+                HIGHSCORE(HIGHSCORE_DAMPE_RACE) = gSaveContext.timer1Value;
             }
             if (Flags_GetCollectible(globalCtx, this->actor.params) == 0 && gSaveContext.timer1Value <= 60) {
                 Item_DropCollectible2(globalCtx, &sp60, (this->actor.params << 8) + (0x4000 | ITEM00_HEART_PIECE));
@@ -326,7 +326,7 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, GlobalContext* globalCtx) {
             }
         } else {
             Flags_SetTempClear(globalCtx, 4);
-            gSaveContext.dampeRaceTime = gSaveContext.timer1Value;
+            HIGHSCORE(HIGHSCORE_DAMPE_RACE) = gSaveContext.timer1Value;
         }
         Actor_Kill(&this->actor);
     }

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -316,8 +316,8 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, GlobalContext* globalCtx) {
             sp60.x = this->actor.posRot.pos.x;
             sp60.y = this->actor.groundY;
             sp60.z = this->actor.posRot.pos.z;
-            if (gSaveContext.timer1Value < HIGHSCORE(HIGHSCORE_DAMPE_RACE)) {
-                HIGHSCORE(HIGHSCORE_DAMPE_RACE) = gSaveContext.timer1Value;
+            if (gSaveContext.timer1Value < HIGH_SCORE(HS_DAMPE_RACE)) {
+                HIGH_SCORE(HS_DAMPE_RACE) = gSaveContext.timer1Value;
             }
             if (Flags_GetCollectible(globalCtx, this->actor.params) == 0 && gSaveContext.timer1Value <= 60) {
                 Item_DropCollectible2(globalCtx, &sp60, (this->actor.params << 8) + (0x4000 | ITEM00_HEART_PIECE));
@@ -326,7 +326,7 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, GlobalContext* globalCtx) {
             }
         } else {
             Flags_SetTempClear(globalCtx, 4);
-            HIGHSCORE(HIGHSCORE_DAMPE_RACE) = gSaveContext.timer1Value;
+            HIGH_SCORE(HS_DAMPE_RACE) = gSaveContext.timer1Value;
         }
         Actor_Kill(&this->actor);
     }


### PR DESCRIPTION
From progress on z_message_PAL, highscores are actually an array.
- Created the highscores array, replacing necessary fields
- Added an enum for use as an index into this array
- Added a macro, one definitely existed in the original codebase as seen in debug strings
- Replaced previous highscores accesses with the new accesses

This came up as something that can affect matching in some cases, so is useful to have now rather than later.