### PR TITLE
Remove hardcoded sizes for a few data tables

### DIFF
--- a/include/variables.h
+++ b/include/variables.h
@@ -173,9 +173,9 @@ extern u8 D_80114930[];
 //extern ? D_801159A8;
 //extern ? D_801159A9;
 //extern ? D_801159AA;
-extern EffectSsOverlay gEffectSsOverlayTable[37];
+extern EffectSsOverlay gEffectSsOverlayTable[EFFECT_SS_TYPE_MAX];
 extern Gfx D_80116280[];
-extern ActorOverlay gActorOverlayTable[471]; // original name: "actor_dlftbls" 801162A0
+extern ActorOverlay gActorOverlayTable[ACTOR_ID_MAX]; // original name: "actor_dlftbls" 801162A0
 extern s32 gMaxActorId; // original name: "MaxProfile"
 //extern ? D_80119E2C;
 //extern ? D_80119E52;
@@ -397,9 +397,9 @@ extern u8 gItemSlots[56];
 extern void (*gSceneCmdHandlers[26])(GlobalContext*, SceneCmd*);
 extern s16 gLinkObjectIds[2];
 extern u32 gObjectTableSize;
-extern RomFile gObjectTable[402];
+extern RomFile gObjectTable[OBJECT_ID_MAX];
 extern EntranceInfo gEntranceTable[1556];
-extern Scene gSceneTable[110];
+extern Scene gSceneTable[SCENE_ID_MAX];
 //extern ? D_8012A4A0;
 extern u16 gSramSlotOffsets[2][3];
 //extern ? D_8012A690;

--- a/include/z64object.h
+++ b/include/z64object.h
@@ -405,7 +405,8 @@ typedef enum {
     /* 0x018E */ OBJECT_DOOR_KILLER,
     /* 0x018F */ OBJECT_OUKE_HAKA,
     /* 0x0190 */ OBJECT_TIMEBLOCK,
-    /* 0x0191 */ OBJECT_ZL4
+    /* 0x0191 */ OBJECT_ZL4,
+    /* 0x0192 */ OBJECT_ID_MAX
 } ObjectID;
 
 #endif

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -413,7 +413,8 @@ typedef enum {
     /* 0x6A */ SCENE_SUTARU,
     /* 0x6B */ SCENE_HAIRAL_NIWA2,
     /* 0x6C */ SCENE_SASATEST,
-    /* 0x6D */ SCENE_TESTROOM
+    /* 0x6D */ SCENE_TESTROOM,
+    /* 0x6E */ SCENE_ID_MAX
 } SceneID;
 
 #endif

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -527,7 +527,7 @@ RomFile sNaviMsgFiles[] = {
 
 s16 gLinkObjectIds[] = { OBJECT_LINK_BOY, OBJECT_LINK_CHILD };
 
-u32 gObjectTableSize = 402;
+u32 gObjectTableSize = ARRAY_COUNT(gObjectTable);
 
 RomFile gObjectTable[] = {
     ROM_FILE_UNSET,


### PR DESCRIPTION
`gActorOverlayTable`, `gEffectSsOverlayTable`, `gObjectTable` and `gSceneTable` now change size if new IDs are added to the appropriate enum associated with each. It should ideally also be made so that new entries for new IDs are added automatically as well, but that seems like something for the future as it will involve a lot of preprocessor messing.
