### PR TITLE
m2ctx.py fixes

### DIFF
--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import subprocess
+import argparse
 from pathlib import Path
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
@@ -23,9 +24,10 @@ def get_c_file(directory):
             if file.endswith(".c") and "data" not in file:
                 return file
 
+
 def import_c_file(in_file):
     in_file = os.path.relpath(in_file, root_dir)
-    cpp_command = ["gcc", "-E", "-P", "-Iinclude", "-Isrc", "-undef", "-D__sgi", "-D_LANGUAGE_C",
+    cpp_command = ["gcc", "-E", "-P", "-Iinclude", "-Iassets", "-Isrc", "-undef", "-D__sgi", "-D_LANGUAGE_C",
                    "-DNON_MATCHING", "-D_Static_assert(x, y)=", "-D__attribute__(x)=", in_file]
     try:
         return subprocess.check_output(cpp_command, cwd=root_dir, encoding="utf-8")
@@ -34,25 +36,30 @@ def import_c_file(in_file):
             "Failed to preprocess input file, when running command:\n"
             + cpp_command,
             file=sys.stderr,
-            )
+        )
         sys.exit(1)
 
+
 def main():
-    if len(sys.argv) > 1:
-        arg = sys.argv[1]
-        if arg == "-h" or arg == "--help":
-            sys.exit("Usage: ./m2ctx.py path/to/file.c\n" \
-            "or ./m2ctx.py (from an actor or gamestate's asm dir)\n" \
-            "Output will be saved in oot/ctx.c")
-        c_file_path = Path.cwd() / sys.argv[1]
+    parser = argparse.ArgumentParser(usage="./m2ctx.py path/to/file.c or ./m2ctx.py (from an actor or gamestate's asm dir)",
+                                     description="Creates ctx.c for mips2c. "
+                                     "Output will be saved as oot/ctx.c")
+
+    parser.add_argument('filepath', help="path to c file to be processed")
+
+    args = parser.parse_args()
+
+    if args.file:
+        c_file_path = args.filepath
     else:
         this_dir = Path.cwd()
         c_dir_path = get_c_dir(this_dir.name)
         if c_dir_path is None:
-            sys.exit("Cannot find appropriate c file dir. In argumentless mode, run this script from the c file's corresponding asm dir.")
+            sys.exit(
+                "Cannot find appropriate c file dir. In argumentless mode, run this script from the c file's corresponding asm dir.")
         c_file = get_c_file(c_dir_path)
         c_file_path = os.path.join(c_dir_path, c_file)
-    
+
     output = import_c_file(c_file_path)
 
     with open(os.path.join(root_dir, "ctx.c"), "w", encoding="UTF-8") as f:

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -42,15 +42,14 @@ def import_c_file(in_file):
 
 def main():
     parser = argparse.ArgumentParser(usage="./m2ctx.py path/to/file.c or ./m2ctx.py (from an actor or gamestate's asm dir)",
-                                     description="Creates ctx.c for mips2c. "
+                                     description="Creates a ctx.c file for mips2c. "
                                      "Output will be saved as oot/ctx.c")
-
-    parser.add_argument('filepath', help="path to c file to be processed")
-
+    parser.add_argument('filepath', help="path of c file to be processed")
     args = parser.parse_args()
 
-    if args.file:
+    if args.filepath:
         c_file_path = args.filepath
+        print("Using file: {}".format(c_file_path))
     else:
         this_dir = Path.cwd()
         c_dir_path = get_c_dir(this_dir.name)
@@ -59,6 +58,7 @@ def main():
                 "Cannot find appropriate c file dir. In argumentless mode, run this script from the c file's corresponding asm dir.")
         c_file = get_c_file(c_dir_path)
         c_file_path = os.path.join(c_dir_path, c_file)
+        print("Using file: {}".format(c_file_path))
 
     output = import_c_file(c_file_path)
 


### PR DESCRIPTION
Fixes an error when running m2ctx.py would be unable to find `#include "objects/gameplay_keep/gameplay_keep.h"`

I also changed it to use argparse since other tools we use argparse and it could make updating the arguments in the future easier. There are also some print statements to let the user know which file path was used to make the ctx.c file.