### PR TITLE
Add distclean rule to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,12 +195,9 @@ clean:
 	$(RM) -r $(ROM) $(ELF) build
 
 distclean: clean
-	$(RM) -r $(TEXTURE_BIN_DIRS)
+	$(RM) -r $(ASSET_BIN_DIRS)
 	$(RM) -r baserom/
 	$(MAKE) -C tools distclean
-
-nuke: distclean
-	@echo "Nuked."
 
 setup:
 	$(MAKE) -C tools -j
@@ -212,7 +209,7 @@ resources: $(ASSET_FILES_OUT)
 test: $(ROM)
 	$(EMULATOR) $(EMU_FLAGS) $<
 
-.PHONY: all clean setup test distclean nuke
+.PHONY: all clean setup test distclean
 
 #### Various Recipes ####
 

--- a/Makefile
+++ b/Makefile
@@ -194,12 +194,12 @@ build/undefined_syms.txt: undefined_syms.txt
 clean:
 	$(RM) -r $(ROM) $(ELF) build
 
-clean_everything: clean
+distclean: clean
 	$(RM) -r $(TEXTURE_BIN_DIRS)
 	$(RM) -r baserom/
-	$(MAKE) -C tools clean_everything
+	$(MAKE) -C tools distclean
 
-nuke: clean_everything
+nuke: distclean
 	@echo "Nuked."
 
 setup:
@@ -212,7 +212,7 @@ resources: $(ASSET_FILES_OUT)
 test: $(ROM)
 	$(EMULATOR) $(EMU_FLAGS) $<
 
-.PHONY: all clean setup test clean_everything nuke
+.PHONY: all clean setup test distclean nuke
 
 #### Various Recipes ####
 

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,14 @@ build/undefined_syms.txt: undefined_syms.txt
 clean:
 	$(RM) -r $(ROM) $(ELF) build
 
+clean_everything: clean
+	$(RM) -r $(TEXTURE_BIN_DIRS)
+	$(RM) -r baserom/
+	$(MAKE) -C tools clean_everything
+
+nuke: clean_everything
+	@echo "Nuked."
+
 setup:
 	$(MAKE) -C tools -j
 	python3 fixbaserom.py
@@ -204,7 +212,7 @@ resources: $(ASSET_FILES_OUT)
 test: $(ROM)
 	$(EMULATOR) $(EMU_FLAGS) $<
 
-.PHONY: all clean setup test
+.PHONY: all clean setup test clean_everything nuke
 
 #### Various Recipes ####
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,6 @@ SPEC := spec
 
 SRC_DIRS := $(shell find src -type d)
 ASM_DIRS := $(shell find asm -type d -not -path "asm/non_matchings*") $(shell find data -type d)
-ASSET_DIRS := assets/objects assets/textures assets/scenes assets/overlays
 ASSET_BIN_DIRS := $(shell find assets/* -type d -not -path "assets/xml*")
 ASSET_FILES_XML := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.xml))
 ASSET_FILES_BIN := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.bin))
@@ -113,17 +112,15 @@ O_FILES       := $(foreach f,$(S_FILES:.s=.o),build/$f) \
                  $(foreach f,$(C_FILES:.c=.o),build/$f) \
                  $(foreach f,$(wildcard baserom/*),build/$f.o)
 
-TEXTURE_BIN_DIRS := $(shell find assets/objects/* assets/textures/* assets/scenes/* assets/overlays/* -type d)
-
-TEXTURE_FILES_RGBA32 := $(foreach dir,$(TEXTURE_BIN_DIRS),$(wildcard $(dir)/*.rgba32.png))
-TEXTURE_FILES_RGBA16 := $(foreach dir,$(TEXTURE_BIN_DIRS),$(wildcard $(dir)/*.rgb5a1.png))
-TEXTURE_FILES_GRAY4 := $(foreach dir,$(TEXTURE_BIN_DIRS),$(wildcard $(dir)/*.i4.png))
-TEXTURE_FILES_GRAY8 := $(foreach dir,$(TEXTURE_BIN_DIRS),$(wildcard $(dir)/*.i8.png))
-TEXTURE_FILES_GRAYA4 := $(foreach dir,$(TEXTURE_BIN_DIRS),$(wildcard $(dir)/*.ia4.png))
-TEXTURE_FILES_GRAYA8 := $(foreach dir,$(TEXTURE_BIN_DIRS),$(wildcard $(dir)/*.ia8.png))
-TEXTURE_FILES_GRAYA16 := $(foreach dir,$(TEXTURE_BIN_DIRS),$(wildcard $(dir)/*.ia16.png))
-TEXTURE_FILES_CI4 := $(foreach dir,$(TEXTURE_BIN_DIRS),$(wildcard $(dir)/*.ci4.png))
-TEXTURE_FILES_CI8 := $(foreach dir,$(TEXTURE_BIN_DIRS),$(wildcard $(dir)/*.ci8.png))
+TEXTURE_FILES_RGBA32 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.rgba32.png))
+TEXTURE_FILES_RGBA16 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.rgb5a1.png))
+TEXTURE_FILES_GRAY4 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.i4.png))
+TEXTURE_FILES_GRAY8 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.i8.png))
+TEXTURE_FILES_GRAYA4 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ia4.png))
+TEXTURE_FILES_GRAYA8 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ia8.png))
+TEXTURE_FILES_GRAYA16 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ia16.png))
+TEXTURE_FILES_CI4 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ci4.png))
+TEXTURE_FILES_CI8 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ci8.png))
 TEXTURE_FILES_OUT := $(foreach f,$(TEXTURE_FILES_RGBA32:.rgba32.png=.rgba32.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_RGBA16:.rgb5a1.png=.rgb5a1.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_GRAY4:.i4.png=.i4.inc.c),build/$f) \
@@ -135,7 +132,7 @@ TEXTURE_FILES_OUT := $(foreach f,$(TEXTURE_FILES_RGBA32:.rgba32.png=.rgba32.inc.
 					 $(foreach f,$(TEXTURE_FILES_CI8:.ci8.png=.ci8.inc.c),build/$f) \
 
 # create build directories
-$(shell mkdir -p build/baserom $(foreach dir,$(SRC_DIRS) $(ASM_DIRS) $(TEXTURE_DIRS) $(ASSET_BIN_DIRS),build/$(dir)))
+$(shell mkdir -p build/baserom $(foreach dir,$(SRC_DIRS) $(ASM_DIRS) $(ASSET_BIN_DIRS),build/$(dir)))
 
 build/src/libultra_boot_O1/%.o: OPTFLAGS := -O1
 build/src/libultra_boot_O2/%.o: OPTFLAGS := -O2

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,6 @@ ASSET_FILES_BIN := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.bin))
 ASSET_FILES_OUT := $(foreach f,$(ASSET_FILES_XML:.xml=.c),$f) \
 				   $(foreach f,$(ASSET_FILES_BIN:.bin=.bin.inc.c),build/$f)
 
-TEXTURE_DIRS := assets/textures assets/scenes assets/objects assets/overlays
-
 # source files
 C_FILES       := $(foreach dir,$(SRC_DIRS) $(ASSET_BIN_DIRS),$(wildcard $(dir)/*.c))
 S_FILES       := $(foreach dir,$(ASM_DIRS),$(wildcard $(dir)/*.s))

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -11,6 +11,11 @@ clean:
 	$(RM) ZAPD/ZAPD.out
 # Need to clean the above line later...
 
+clean_everything: clean
+	$(MAKE) -C ZAPD clean
+
+.PHONY: all clean clean_everything
+
 mkldscript_SOURCES := mkldscript.c util.c
 elf2rom_SOURCES    := elf2rom.c elf32.c n64chksum.c util.c
 yaz0_SOURCES       := yaz0tool.c yaz0.c util.c

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -11,10 +11,10 @@ clean:
 	$(RM) ZAPD/ZAPD.out
 # Need to clean the above line later...
 
-clean_everything: clean
+distclean: clean
 	$(MAKE) -C ZAPD clean
 
-.PHONY: all clean clean_everything
+.PHONY: all clean distclean
 
 mkldscript_SOURCES := mkldscript.c util.c
 elf2rom_SOURCES    := elf2rom.c elf32.c n64chksum.c util.c


### PR DESCRIPTION
Adds a ~`clean_everything`~ `distclean` that aims to clean all generated files not deleted by `clean`.

It does:
- Delete every file that `make clean` deletes.
- Delete every extracted asset in `assets/`. It doesn't deletes the `assets/xml/` folder.
- Delete `baserom/`
- Delete the generated/compiled tools and files in `tools/`. It only invokes the ~`clean_everything`~ `distclean` rule of the tool's makefile.
  - This will also delete every file generated when compiling ZAPD.

I did this because sometimes your local copy can break because of an residual file or something, and just running `make clean && make setup -j && make -j` will not fix the issue, but erasing every generated file may fix it.

Let me know if I forgot any generated file.

~PS: For comedic purposes, the rule `nuke` was also added and it does the same as ~`clean_everything`~ `distclean`, so you can do `make nuke` instead if you prefer.~