### PR TITLE
Add needed rules for prerenders extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ tools/*dSYM/
 *.ia16.png
 *.ci4.png
 *.ci8.png
+*.jpg
 *.mdli
 *.anmi
 *.obj

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ TEXTURE_FILES_GRAYA8 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ia8.
 TEXTURE_FILES_GRAYA16 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ia16.png))
 TEXTURE_FILES_CI4 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ci4.png))
 TEXTURE_FILES_CI8 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ci8.png))
-TEXTURE_FILES_JFIF := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.jfif))
+TEXTURE_FILES_JPG := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.jpg))
 TEXTURE_FILES_OUT := $(foreach f,$(TEXTURE_FILES_RGBA32:.rgba32.png=.rgba32.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_RGBA16:.rgb5a1.png=.rgb5a1.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_GRAY4:.i4.png=.i4.inc.c),build/$f) \
@@ -129,7 +129,7 @@ TEXTURE_FILES_OUT := $(foreach f,$(TEXTURE_FILES_RGBA32:.rgba32.png=.rgba32.inc.
 					 $(foreach f,$(TEXTURE_FILES_GRAYA16:.ia16.png=.ia16.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_CI4:.ci4.png=.ci4.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_CI8:.ci8.png=.ci8.inc.c),build/$f) \
-					 $(foreach f,$(TEXTURE_FILES_JFIF:.jfif=.jfif.inc.c),build/$f) \
+					 $(foreach f,$(TEXTURE_FILES_JPG:.jpg=.jpg.inc.c),build/$f) \
 
 # create build directories
 $(shell mkdir -p build/baserom $(foreach dir,$(SRC_DIRS) $(ASM_DIRS) $(ASSET_BIN_DIRS),build/$(dir)))
@@ -282,5 +282,5 @@ build/%.ci8.inc.c: %.ci8.png
 build/assets/%.bin.inc.c: assets/%.bin
 	$(ZAPD) bblb -i $< -o $@
 
-build/assets/%.jfif.inc.c: assets/%.jfif
+build/assets/%.jpg.inc.c: assets/%.jpg
 	$(ZAPD) bren -i $< -o $@ -eh

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ TEXTURE_FILES_GRAYA8 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ia8.
 TEXTURE_FILES_GRAYA16 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ia16.png))
 TEXTURE_FILES_CI4 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ci4.png))
 TEXTURE_FILES_CI8 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.ci8.png))
+TEXTURE_FILES_JFIF := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.jfif))
 TEXTURE_FILES_OUT := $(foreach f,$(TEXTURE_FILES_RGBA32:.rgba32.png=.rgba32.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_RGBA16:.rgb5a1.png=.rgb5a1.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_GRAY4:.i4.png=.i4.inc.c),build/$f) \
@@ -128,6 +129,7 @@ TEXTURE_FILES_OUT := $(foreach f,$(TEXTURE_FILES_RGBA32:.rgba32.png=.rgba32.inc.
 					 $(foreach f,$(TEXTURE_FILES_GRAYA16:.ia16.png=.ia16.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_CI4:.ci4.png=.ci4.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_CI8:.ci8.png=.ci8.inc.c),build/$f) \
+					 $(foreach f,$(TEXTURE_FILES_JFIF:.jfif=.jfif.inc.c),build/$f) \
 
 # create build directories
 $(shell mkdir -p build/baserom $(foreach dir,$(SRC_DIRS) $(ASM_DIRS) $(ASSET_BIN_DIRS),build/$(dir)))
@@ -279,3 +281,6 @@ build/%.ci8.inc.c: %.ci8.png
 
 build/assets/%.bin.inc.c: assets/%.bin
 	$(ZAPD) bblb -i $< -o $@
+
+build/assets/%.jfif.inc.c: assets/%.jfif
+	$(ZAPD) bren -i $< -o $@ -eh


### PR DESCRIPTION
These rules are needed to be able to recompile the jpg prerenders back into C code.
This PR is made in preparation of this [PR](https://github.com/zeldaret/ZAPD/pull/106) in ZAPD (Also jenkins is failing in that repo because this rules are needed here).
