### PR TITLE
General object cleanup

### DIFF
--- a/assets/xml/objects/object_fd.xml
+++ b/assets/xml/objects/object_fd.xml
@@ -4,9 +4,9 @@
         <Texture Name="gVolvagiaBossTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
 
         <!-- Skeletons -->
-        <Skeleton Name="gVolvagiaLeftArmSkel" Type="Standard" LimbType="Standard" Offset="0x114E0"/>
-        <Skeleton Name="gVolvagiaRightArmSkel" Type="Standard" LimbType="Standard" Offset="0x115A0"/>
-        <Skeleton Name="gVolvagiaHeadSkel" Type="Standard" LimbType="Standard" Offset="0x11660"/>
+        <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x114E0"/>
+        <Skeleton Name="gVolvagiaRightArmSkel" Type="Normal" LimbType="Standard" Offset="0x115A0"/>
+        <Skeleton Name="gVolvagiaHeadSkel" Type="Normal" LimbType="Standard" Offset="0x11660"/>
 
         <!-- Animations -->
         <Animation Name="gVolvagiaLeftArmEmergeAnim" Offset="0x11464"/>

--- a/assets/xml/objects/object_goma.xml
+++ b/assets/xml/objects/object_goma.xml
@@ -28,16 +28,16 @@
         <Animation Name="gGohmaAnim_0039D0" Offset="0x39D0"/> <!-- unused attack animation -->
 
         <!-- Limb textures -->
-        <Texture Name="gGohmaTex_0183A8" Outname="gohma_tex_0183A8" Format="rgb5a1" Width="16" Height="16" Offset="0x183A8"/>
-        <Texture Name="gGohmaTex_0185A8" Outname="gohma_tex_0185A8" Format="rgb5a1" Width="16" Height="16" Offset="0x185A8"/>
-        <Texture Name="gGohmaTex_0187A8" Outname="gohma_tex_0187A8" Format="rgb5a1" Width="16" Height="16" Offset="0x187A8"/>
-        <Texture Name="gGohmaTex_0189A8" Outname="gohma_tex_0189A8" Format="rgb5a1" Width="32" Height="32" Offset="0x189A8"/>
-        <Texture Name="gGohmaTex_0191A8" Outname="gohma_tex_0191A8" Format="rgb5a1" Width="16" Height="16" Offset="0x191A8"/>
-        <Texture Name="gGohmaTex_0193A8" Outname="gohma_tex_0193A8" Format="rgb5a1" Width="32" Height="32" Offset="0x193A8"/>
-        
+        <Texture Name="gGohmaTex_0183A8" OutName="gohma_tex_0183A8" Format="rgb5a1" Width="16" Height="16" Offset="0x183A8"/>
+        <Texture Name="gGohmaTex_0185A8" OutName="gohma_tex_0185A8" Format="rgb5a1" Width="16" Height="16" Offset="0x185A8"/>
+        <Texture Name="gGohmaTex_0187A8" OutName="gohma_tex_0187A8" Format="rgb5a1" Width="16" Height="16" Offset="0x187A8"/>
+        <Texture Name="gGohmaTex_0189A8" OutName="gohma_tex_0189A8" Format="rgb5a1" Width="32" Height="32" Offset="0x189A8"/>
+        <Texture Name="gGohmaTex_0191A8" OutName="gohma_tex_0191A8" Format="rgb5a1" Width="16" Height="16" Offset="0x191A8"/>
+        <Texture Name="gGohmaTex_0193A8" OutName="gohma_tex_0193A8" Format="rgb5a1" Width="32" Height="32" Offset="0x193A8"/>
+
         <!-- Boss title card -->
         <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
-        
+
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1EC20"/>
         <Collision Name="gGohmaDoorCol" Offset="0x1EDD0"/>

--- a/assets/xml/objects/object_mm.xml
+++ b/assets/xml/objects/object_mm.xml
@@ -7,7 +7,7 @@
         <Animation Name="gRunningManSprintAnim" Offset="0x0468"/>
         <Animation Name="gRunningManExcitedAnim" Offset="0x73A0"/>
         <Animation Name="gRunningManHappyAnim" Offset="0x8060"/>
-        <Texture Name="gRunningManMouthClosedTex" Outname="running_man_mouth_closed" Format="ci8" Width="32" Height="16" Offset="0xE30"/>
-        <Texture Name="gRunningManMouthOpenTex" Outname="running_man_mouth_closed" Format="ci8" Width="32" Height="16" Offset="0xC30"/>
+        <Texture Name="gRunningManMouthClosedTex" OutName="running_man_mouth_open" Format="ci8" Width="32" Height="16" Offset="0xE30"/>
+        <Texture Name="gRunningManMouthOpenTex" OutName="running_man_mouth_closed" Format="ci8" Width="32" Height="16" Offset="0xC30"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_mm.xml
+++ b/assets/xml/objects/object_mm.xml
@@ -1,13 +1,16 @@
 <Root>
     <File Name="object_mm" Segment="6">
         <Skeleton Name="gRunningManSkel" Type="Flex" LimbType="Standard" Offset="0x5E18"/>
+
         <Animation Name="gRunningManRunAnim" Offset="0x0718"/>
         <Animation Name="gRunningManSitStandAnim" Offset="0x6940"/>
         <Animation Name="gRunningManSitWaitAnim" Offset="0x6C50"/>
         <Animation Name="gRunningManSprintAnim" Offset="0x0468"/>
         <Animation Name="gRunningManExcitedAnim" Offset="0x73A0"/>
         <Animation Name="gRunningManHappyAnim" Offset="0x8060"/>
-        <Texture Name="gRunningManMouthClosedTex" OutName="running_man_mouth_open" Format="ci8" Width="32" Height="16" Offset="0xE30"/>
-        <Texture Name="gRunningManMouthOpenTex" OutName="running_man_mouth_closed" Format="ci8" Width="32" Height="16" Offset="0xC30"/>
+
+        <Texture Name="gRunningManTLUT" OutName="running_man_tlut" Format="rgb5a1" Width="16" Height="16" Offset="0x730"/>
+        <Texture Name="gRunningManMouthOpenTex" OutName="running_man_mouth_open" Format="ci8" Width="32" Height="16" Offset="0xE30"/>
+        <Texture Name="gRunningManMouthClosedTex" OutName="running_man_mouth_closed" Format="ci8" Width="32" Height="16" Offset="0xC30"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_po_field.xml
+++ b/assets/xml/objects/object_po_field.xml
@@ -15,6 +15,6 @@
         <DList Name="gBigPoeFaceDL" Offset="0x5900"/>
         <DList Name="gBigPoeBodyDL" Offset="0x59F0"/>
         <DList Name="gPoeFieldBurnDL" Offset="0x66D0"/>
-        <Skeleton Name="gPoeFieldSkel" Type="Standard" LimbType="Standard" Offset="0x6A30"/>
+        <Skeleton Name="gPoeFieldSkel" Type="Normal" LimbType="Standard" Offset="0x6A30"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_po_sisters.xml
+++ b/assets/xml/objects/object_po_sisters.xml
@@ -17,7 +17,7 @@
         <DList Name="gPoeSistersAmyBodyDL" Offset="0x3DC8"/>
         <DList Name="gPoSistersAmyFaceDL" Offset="0x4020"/>
         <DList Name="gPoSistersBurnDL" Offset="0x46E0"/>
-        <Skeleton Name="gPoeSistersSkel" Type="Standard" LimbType="Standard" Offset="0x65C8"/>
+        <Skeleton Name="gPoeSistersSkel" Type="Normal" LimbType="Standard" Offset="0x65C8"/>
         <DList Name="gPoSistersJoellePaintingDL" Offset="0x6830"/> 
         <DList Name="gPoSistersBethPaintingDL" Offset="0x6D60"/> 
         <DList Name="gPoSistersAmyPaintingDL" Offset="0x7230"/> 

--- a/assets/xml/objects/object_poh.xml
+++ b/assets/xml/objects/object_poh.xml
@@ -9,6 +9,6 @@
         <DList Name="gPoeBurnDL" Offset="0x2608"/>
         <DList Name="gPoeLanternDL" Offset="0x2D28"/>
         <DList Name="gPoeSoulDL" Offset="0x3850"/>
-        <Skeleton Name="gPoeSkel" Type="Standard" LimbType="Standard" Offset="0x50D0"/>
+        <Skeleton Name="gPoeSkel" Type="Normal" LimbType="Standard" Offset="0x50D0"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_spot09_obj.xml
+++ b/assets/xml/objects/object_spot09_obj.xml
@@ -6,9 +6,9 @@
         <DList Name="gCarpentersTentDL" Offset="0x7D40"/>
         <DList Name="gValleyRepairedBridgeDL" Offset="0x6210"/>
         <DList Name="gCarpentersTentEntranceDL" Offset="0x8010"/>
-        <Collision Name="gValleyObjects1Col" Offset="0x5520" Size="0x30"/>
-        <Collision Name="gValleyObjects2Col" Offset="0x283C" Size="0x30"/>
-        <Collision Name="gValleyObjects3Col" Offset="0x8458" Size="0x30"/>
-        <Collision Name="gValleyObjects4Col" Offset="0x7580" Size="0x30"/>
+        <Collision Name="gValleyObjects1Col" Offset="0x5520"/>
+        <Collision Name="gValleyObjects2Col" Offset="0x283C"/>
+        <Collision Name="gValleyObjects3Col" Offset="0x8458"/>
+        <Collision Name="gValleyObjects4Col" Offset="0x7580"/>
     </File>
 </Root>

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -522,7 +522,7 @@ void EnMm_Update(Actor* thisx, GlobalContext* globalCtx) {
 extern Gfx D_0602CA38[]; // bunny hood dlist from object_link_child. replace with proper symbol later
 
 void EnMm_Draw(Actor* thisx, GlobalContext* globalCtx) {
-    static u64* mouthTextures[] = { gRunningManMouthClosedTex, gRunningManMouthOpenTex };
+    static u64* mouthTextures[] = { gRunningManMouthOpenTex, gRunningManMouthClosedTex };
     s32 pad;
     EnMm* this = THIS;
 

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
@@ -318,7 +318,7 @@ void EnMm2_Update(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void EnMm2_Draw(Actor* thisx, GlobalContext* globalCtx) {
-    static u64* mouthTextures[] = { gRunningManMouthClosedTex, gRunningManMouthOpenTex };
+    static u64* mouthTextures[] = { gRunningManMouthOpenTex, gRunningManMouthClosedTex };
     EnMm2* this = THIS;
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_en_mm2.c", 634);


### PR DESCRIPTION
Fixes some typos, warnings and invalid attributes.

This change will be needed by the future attribute's checker of ZAPD ([PR 126](https://github.com/zeldaret/ZAPD/pull/126)).
