### PR TITLE
Update asm-processor and add make dependencies for global asm and early includes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,10 @@ O_FILES       := $(foreach f,$(S_FILES:.s=.o),build/$f) \
                  $(foreach f,$(C_FILES:.c=.o),build/$f) \
                  $(foreach f,$(wildcard baserom/*),build/$f.o)
 
+# Automatic dependency files
+# (Only asm_processor dependencies are handled for now)
+DEP_FILES := $(O_FILES:.o=.asmproc.d)
+
 TEXTURE_FILES_RGBA32 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.rgba32.png))
 TEXTURE_FILES_RGBA16 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.rgb5a1.png))
 TEXTURE_FILES_GRAY4 := $(foreach dir,$(ASSET_BIN_DIRS),$(wildcard $(dir)/*.i4.png))
@@ -216,36 +220,36 @@ build/baserom/%.o: baserom/%
 	$(OBJCOPY) -I binary -O elf32-big $< $@
 
 build/asm/%.o: asm/%.s
-	$(AS) $(ASFLAGS) $^ -o $@
+	$(AS) $(ASFLAGS) $< -o $@
 
 build/data/%.o: data/%.s
-	iconv --from UTF-8 --to EUC-JP $^ | $(AS) $(ASFLAGS) -o $@
+	iconv --from UTF-8 --to EUC-JP $< | $(AS) $(ASFLAGS) -o $@
 
 build/assets/%.o: assets/%.c
-	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $^
+	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
 	$(OBJCOPY) -O binary $@ $@.bin
 
 build/src/overlays/%.o: src/overlays/%.c
-	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $^
-	$(CC_CHECK) $^
-	$(ZAPD) bovl -i $@ -cfg $^ --outputpath $(@D)/$(notdir $(@D))_reloc.s
+	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
+	$(CC_CHECK) $<
+	$(ZAPD) bovl -i $@ -cfg $< --outputpath $(@D)/$(notdir $(@D))_reloc.s
 	-test -f $(@D)/$(notdir $(@D))_reloc.s && $(AS) $(ASFLAGS) $(@D)/$(notdir $(@D))_reloc.s -o $(@D)/$(notdir $(@D))_reloc.o
 	@$(OBJDUMP) -d $@ > $(@:.o=.s)
 
 build/src/%.o: src/%.c
-	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $^
-	$(CC_CHECK) $^
+	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
+	$(CC_CHECK) $<
 	@$(OBJDUMP) -d $@ > $(@:.o=.s)
 
 build/src/libultra_boot_O1/ll.o: src/libultra_boot_O1/ll.c
-	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $^
-	$(CC_CHECK) $^
+	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
+	$(CC_CHECK) $<
 	python3 tools/set_o32abi_bit.py $@
 	@$(OBJDUMP) -d $@ > $(@:.o=.s)
 
 build/src/libultra_code_O1/llcvt.o: src/libultra_code_O1/llcvt.c
-	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $^
-	$(CC_CHECK) $^
+	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
+	$(CC_CHECK) $<
 	python3 tools/set_o32abi_bit.py $@
 	@$(OBJDUMP) -d $@ > $(@:.o=.s)
 
@@ -286,3 +290,5 @@ build/assets/%.bin.inc.c: assets/%.bin
 
 build/assets/%.jpg.inc.c: assets/%.jpg
 	$(ZAPD) bren -i $< -o $@ -eh
+
+-include $(DEP_FILES)

--- a/tools/asm_processor/asm_processor.py
+++ b/tools/asm_processor/asm_processor.py
@@ -722,7 +722,7 @@ float_regexpr = re.compile(r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?f")
 def repl_float_hex(m):
     return str(struct.unpack(">I", struct.pack(">f", float(m.group(0).strip().rstrip("f"))))[0])
 
-def parse_source(f, opt, framepointer, input_enc, output_enc, print_source=None):
+def parse_source(f, opt, framepointer, input_enc, output_enc, out_dependencies, print_source=None):
     if opt in ['O2', 'O1']:
         if framepointer:
             min_instr_count = 6
@@ -786,6 +786,7 @@ def parse_source(f, opt, framepointer, input_enc, output_enc, print_source=None)
             elif ((line.startswith('GLOBAL_ASM("') or line.startswith('#pragma GLOBAL_ASM("'))
                     and line.endswith('")')):
                 fname = line[line.index('(') + 2 : -2]
+                out_dependencies.append(fname)
                 global_asm = GlobalAsmBlock(fname)
                 with open(fname, encoding=input_enc) as f:
                     for line2 in f:
@@ -798,10 +799,11 @@ def parse_source(f, opt, framepointer, input_enc, output_enc, print_source=None)
                 # C includes qualified with EARLY (i.e. #include "file.c" EARLY) will be
                 # processed recursively when encountered
                 fpath = os.path.dirname(f.name)
-                fname = line[line.index(' ') + 2 : -7]
+                fname = os.path.join(fpath, line[line.index(' ') + 2 : -7])
+                out_dependencies.append(fname)
                 include_src = StringIO()
-                with open(fpath + os.path.sep + fname, encoding=input_enc) as include_file:
-                    parse_source(include_file, opt, framepointer, input_enc, output_enc, include_src)
+                with open(fname, encoding=input_enc) as include_file:
+                    parse_source(include_file, opt, framepointer, input_enc, output_enc, out_dependencies, include_src)
                 include_src.write('#line ' + str(line_no + 1) + ' "' + f.name + '"')
                 output_lines[-1] = include_src.getvalue()
                 include_src.close()
@@ -1191,13 +1193,15 @@ def run_wrapped(argv, outfile, functions):
 
     if args.objfile is None:
         with open(args.filename, encoding=args.input_enc) as f:
-            return parse_source(f, opt=opt, framepointer=args.framepointer, input_enc=args.input_enc, output_enc=args.output_enc, print_source=outfile)
+            deps = []
+            functions = parse_source(f, opt=opt, framepointer=args.framepointer, input_enc=args.input_enc, output_enc=args.output_enc, out_dependencies=deps, print_source=outfile)
+            return functions, deps
     else:
         if args.assembler is None:
             raise Failure("must pass assembler command")
         if functions is None:
             with open(args.filename, encoding=args.input_enc) as f:
-                functions = parse_source(f, opt=opt, framepointer=args.framepointer, input_enc=args.input_enc, output_enc=args.output_enc)
+                functions = parse_source(f, opt=opt, framepointer=args.framepointer, input_enc=args.input_enc, out_dependencies=[], output_enc=args.output_enc)
         if not functions:
             return
         asm_prelude = b''

--- a/tools/asm_processor/asm_processor.py
+++ b/tools/asm_processor/asm_processor.py
@@ -1080,7 +1080,7 @@ def fixup_objfile(objfile_name, functions, asm_prelude, assembler, output_enc):
                         assert symbol_name_offset_end != -1
                         symbol_name = objfile.data[symbol_name_offset : symbol_name_offset_end + 1]
                         symbol_name_str = symbol_name[:-1].decode('latin1')
-                        section_name = ['', '.text', '.data', '.bss'][sc]
+                        section_name = {1: '.text', 2: '.data', 3: '.bss', 15: '.rodata'}[sc]
                         section = objfile.find_section(section_name)
                         symtype = STT_FUNC if sc == 1 else STT_OBJECT
                         sym = Symbol.from_parts(

--- a/tools/asm_processor/build.py
+++ b/tools/asm_processor/build.py
@@ -35,7 +35,7 @@ try:
     asmproc_flags = opt_flags + [in_file, '--input-enc', 'utf-8', '--output-enc', 'euc-jp']
     compile_cmdline = compiler + compile_args + ['-I', in_dir, '-o', out_file, preprocessed_file.name]
 
-    functions = asm_processor.run(asmproc_flags, outfile=preprocessed_file)
+    functions, deps = asm_processor.run(asmproc_flags, outfile=preprocessed_file)
     try:
         subprocess.check_call(compile_cmdline)
     except subprocess.CalledProcessError as e:

--- a/tools/asm_processor/build.py
+++ b/tools/asm_processor/build.py
@@ -48,5 +48,17 @@ try:
         # os._exit(1)
 
     asm_processor.run(asmproc_flags + ['--post-process', out_file, '--assembler', assembler_sh, '--asm-prelude', prelude], functions=functions)
+
+    deps_file = out_file[:-2] + ".asmproc.d"
+    if deps:
+        with open(deps_file, "w") as f:
+            f.write(out_file + ": " + " \\\n    ".join(deps) + "\n")
+            for dep in deps:
+                f.write("\n" + dep + ":\n")
+    else:
+        try:
+            os.remove(deps_file)
+        except OSError:
+            pass
 finally:
     os.remove(preprocessed_file.name)


### PR DESCRIPTION
Updated the asm-processor to latest master and made some changes to the `Makefile` and `build.py` regarding dependency handling. This uses a new feature in the asm-processor to keep track of files `GLOBAL_ASM`'d or included with the `EARLY` tag, so `make` automatically rebuilds the file that includes them when they are touched. (see the discussion in the tools-other channel in discord for more detail)

For instance, this ensures all necessary files are rebuilt when we rename symbols in asm files, so we no longer have to run `make clean` or manually touch C files when doing mass renames, or when pulling from master.

Note that headers and other files included by the compiler are still not treated as dependencies because we're waiting until headers are split, but these changes also include most of the groundwork for that.