### PR TITLE
Delete `-j` from `make setup` and document use of `-jN` and `-j` in readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,18 @@ CPPFLAGS += -P
 
 ifeq ($(OS),Windows_NT)
     DETECTED_OS=windows
+    NUM_CORES=$(NUMBER_OF_PROCESSORS)
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S),Linux)
         DETECTED_OS=linux
+        NUM_CORES=$(shell nproc)
     endif
     ifeq ($(UNAME_S),Darwin)
         DETECTED_OS=macos
         MAKE=gmake
         CPPFLAGS += -xc++
+        NUM_CORES=$(shell sysctl -n hw.logicalcpu)
     endif
 endif
 
@@ -203,7 +206,7 @@ distclean: clean
 	$(MAKE) -C tools distclean
 
 setup:
-	$(MAKE) -C tools -j`nproc`
+	$(MAKE) -C tools -j $(NUM_CORES)
 	python3 fixbaserom.py
 	python3 extract_baserom.py
 	python3 extract_assets.py

--- a/Makefile
+++ b/Makefile
@@ -22,18 +22,15 @@ CPPFLAGS += -P
 
 ifeq ($(OS),Windows_NT)
     DETECTED_OS=windows
-    NUM_CORES=$(NUMBER_OF_PROCESSORS)
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S),Linux)
         DETECTED_OS=linux
-        NUM_CORES=$(shell nproc)
     endif
     ifeq ($(UNAME_S),Darwin)
         DETECTED_OS=macos
         MAKE=gmake
         CPPFLAGS += -xc++
-        NUM_CORES=$(shell sysctl -n hw.logicalcpu)
     endif
 endif
 
@@ -206,7 +203,7 @@ distclean: clean
 	$(MAKE) -C tools distclean
 
 setup:
-	$(MAKE) -C tools -j $(NUM_CORES)
+	$(MAKE) -C tools
 	python3 fixbaserom.py
 	python3 extract_baserom.py
 	python3 extract_assets.py

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ distclean: clean
 	$(MAKE) -C tools distclean
 
 setup:
-	$(MAKE) -C tools -j
+	$(MAKE) -C tools -j`nproc`
 	python3 fixbaserom.py
 	python3 extract_baserom.py
 	python3 extract_assets.py

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ md5sum: WARNING: 1 computed checksum did NOT match
 
 This means that the built ROM isn't the same as the base one, so something went wrong or some part of the code doesn't match.
 
+**NOTE:** to speed up the build, you can either:
+* pass `-jN` to `make setup` and `make`, where N is the number of threads to use in the build. The generally-accepted wisdom is to use the number of virtual cores your computer has.
+* pass `-j` to `make setup` and `make`, to use as many threads as possible, but beware that this can use too much memory on lower-end systems.
+
+Both of these have the disadvantage that the ordering of the terminal output is scrambled, so for debugging it is best to stick to one.
+
+
 ### Cygwin
 
 If you want to use Cygwin, you will need to:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This means that the built ROM isn't the same as the base one, so something went 
 * pass `-jN` to `make setup` and `make`, where N is the number of threads to use in the build. The generally-accepted wisdom is to use the number of virtual cores your computer has.
 * pass `-j` to `make setup` and `make`, to use as many threads as possible, but beware that this can use too much memory on lower-end systems.
 
-Both of these have the disadvantage that the ordering of the terminal output is scrambled, so for debugging it is best to stick to one.
+Both of these have the disadvantage that the ordering of the terminal output is scrambled, so for debugging it is best to stick to one thread (i.e. not pass `-j` or `-jN`).
 
 
 ### Cygwin


### PR DESCRIPTION
~~I was having serious memory issues building the newest version of ZAPD during `make setup`, which were fixed by replacing `-j` in the Makefile by ``-j`nproc` ``, which uses the number of available threads.~~

Remove `-j` from `make setup` for tools. This addresses #597 ~~: although afaik there is no way to pass in the argument of `j` from the original argument of `make`, this is a far better default that what we currently have, at least for lower-end machines.~~