### PR TITLE
Label a bug in Door_Shutter

### DIFF
--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -678,7 +678,7 @@ void DoorShutter_Draw(Actor* thisx, GlobalContext* globalCtx) {
     DoorShutter* this = THIS;
 
     //! @bug This actor is not fully initialized until the required object dependency is loaded.
-    //! In  most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor
+    //! In most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor
     //! from drawing until initialization is complete. However when the required object is 
     //! gameplay_keep, this check will pass no matter what.
     //! This only matters in very specific scenarios, when the door is unculled on the first possible frame after

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -677,17 +677,17 @@ s32 func_80997A34(DoorShutter* this, GlobalContext* globalCtx) {
 void DoorShutter_Draw(Actor* thisx, GlobalContext* globalCtx) {
     DoorShutter* this = THIS;
 
-//! @bug This actor is not fully initialized until the required object dependency is loaded.
-//! In most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor
-//! from drawing until initialization is complete. However if the required object is the same as the
-//! object dependency listed in init vars (gameplay_keep in this case), the check will pass even though
-//! initialization has not completed. When this happens, it will try to draw the display list of the 
-//! first entry in `D_80998134`, which will likely crash the game.
-//! This only matters in very specific scenarios, when the door is unculled on the first possible frame
-//! after spawning. It will try to draw without having run update yet.
-//!
-//! The best way to fix this issue (and what was done in Majora's Mask) is to null out the draw function in
-//! the init vars for the actor, and only set draw after initialization is complete.
+    //! @bug This actor is not fully initialized until the required object dependency is loaded.
+    //! In most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor
+    //! from drawing until initialization is complete. However if the required object is the same as the
+    //! object dependency listed in init vars (gameplay_keep in this case), the check will pass even though
+    //! initialization has not completed. When this happens, it will try to draw the display list of the
+    //! first entry in `D_80998134`, which will likely crash the game.
+    //! This only matters in very specific scenarios, when the door is unculled on the first possible frame
+    //! after spawning. It will try to draw without having run update yet.
+    //!
+    //! The best way to fix this issue (and what was done in Majora's Mask) is to null out the draw function in
+    //! the init vars for the actor, and only set draw after initialization is complete.
 
     if (this->dyna.actor.objBankIndex == this->requiredObjBankIndex &&
         (this->unk_16B == 0 || func_80997A34(this, globalCtx) != 0)) {

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -677,20 +677,27 @@ s32 func_80997A34(DoorShutter* this, GlobalContext* globalCtx) {
 void DoorShutter_Draw(Actor* thisx, GlobalContext* globalCtx) {
     DoorShutter* this = THIS;
 
+    //! @bug This actor is not fully initialized until the required object dependency is loaded.
+    //! In  most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor  the
+    //! from drawing until initialization is complete. However when the required object is 
+    //! gameplay_keep, this check will pass no matter what.
+    //! This only matters in very specific scenarios, when the door is unculled on the first possible frame after
+    //! spawning. It will try to draw on the first possible frame without having run update yet.
+    //! If the required object is gameplay_keep, the check will pass even though initialization has not completed
+    //! yet, and will try to draw the display list of the first entry in `D_80998134`, which will likely crash the game.
+    //!
+    //! The best way to fix this issue (and what was done in Majora's Mask) is to null out draw in the init vars
+    //! for the actor, and only set draw after initialization is complete.
+
     if (this->dyna.actor.objBankIndex == this->requiredObjBankIndex &&
         (this->unk_16B == 0 || func_80997A34(this, globalCtx) != 0)) {
         s32 pad[2];
         ShutterInfo* sp70 = &D_80998134[this->unk_16C];
 
-        //! @bug In very niche scenarios, depending on the placement of other doors when a new room is loading,
-        //! it is possible that a newly spawned door will try to draw after init, without having run it's first update.
-        //! In this case, `DoorShutter_SetupDoor` will not have run yet, so unk_16C is not initialized.
-        //! When this occurs, it will try to draw the display list of the first entry in `D_80998134`.
-        //! This bug can be avoided either by initialized 16C in init, or by checking 
-        //! to make sure the setup has complete before allowing it to draw.
-
         OPEN_DISPS(globalCtx->state.gfxCtx, "../z_door_shutter.c", 2048);
+
         func_80093D18(globalCtx->state.gfxCtx);
+        
         if (this->unk_16C == 3) {
             POLY_OPA_DISP = func_80997838(globalCtx, this, POLY_OPA_DISP);
             if (this->unk_170 != 0.0f) {
@@ -732,11 +739,13 @@ void DoorShutter_Draw(Actor* thisx, GlobalContext* globalCtx) {
                 gSPDisplayList(POLY_OPA_DISP++, sp70->b);
             }
         }
+
         if (this->unk_16E != 0) {
             Matrix_Scale(0.01f, 0.01f, 0.025f, MTXMODE_APPLY);
             Actor_DrawDoorLock(globalCtx, this->unk_16E,
                                (this->doorType == SHUTTER_BOSS) ? 1 : ((this->unk_16C == 6) ? 2 : 0));
         }
+
         CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_door_shutter.c", 2135);
     }
 }

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -677,18 +677,17 @@ s32 func_80997A34(DoorShutter* this, GlobalContext* globalCtx) {
 void DoorShutter_Draw(Actor* thisx, GlobalContext* globalCtx) {
     DoorShutter* this = THIS;
 
-    //! @bug This actor is not fully initialized until the required object dependency is loaded.
-    //! In most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor
-    //! from drawing until initialization is complete. However if the required object is the same as the
-    //! object dependency listed in init vars, this check will pass no matter what.
-    //! This only matters in very specific scenarios, when the door is unculled on the first possible frame
-    //! after spawning. It will try to draw without having run update yet.
-    //! If the required object is the same as the init vars requirement (gameplay_keep in this case), the check will
-    //! pass even though initialization has not completed. When this happens, it will try to draw the display list
-    //! of the first entry in `D_80998134`, which will likely crash the game.
-    //!
-    //! The best way to fix this issue (and what was done in Majora's Mask) is to null out the draw function in
-    //! the init vars for the actor, and only set draw after initialization is complete.
+//! @bug This actor is not fully initialized until the required object dependency is loaded.
+//! In most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor
+//! from drawing until initialization is complete. However if the required object is the same as the
+//! object dependency listed in init vars (gameplay_keep in this case), the check will pass even though
+//! initialization has not completed. When this happens, it will try to draw the display list of the 
+//! first entry in `D_80998134`, which will likely crash the game.
+//! This only matters in very specific scenarios, when the door is unculled on the first possible frame
+//! after spawning. It will try to draw without having run update yet.
+//!
+//! The best way to fix this issue (and what was done in Majora's Mask) is to null out the draw function in
+//! the init vars for the actor, and only set draw after initialization is complete.
 
     if (this->dyna.actor.objBankIndex == this->requiredObjBankIndex &&
         (this->unk_16B == 0 || func_80997A34(this, globalCtx) != 0)) {

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -682,6 +682,13 @@ void DoorShutter_Draw(Actor* thisx, GlobalContext* globalCtx) {
         s32 pad[2];
         ShutterInfo* sp70 = &D_80998134[this->unk_16C];
 
+        //! @bug In very niche scenarios, depending on the placement of other doors when a new room is loading,
+        //! it is possible that a newly spawned door will try to draw after init, without having run it's first update.
+        //! In this case, `DoorShutter_SetupDoor` will not have run yet, so unk_16C is not initialized.
+        //! When this occurs, it will try to draw the display list of the first entry in `D_80998134`.
+        //! This bug can be avoided either by initialized 16C in init, or by checking 
+        //! to make sure the setup has complete before allowing it to draw.
+
         OPEN_DISPS(globalCtx->state.gfxCtx, "../z_door_shutter.c", 2048);
         func_80093D18(globalCtx->state.gfxCtx);
         if (this->unk_16C == 3) {

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -682,7 +682,7 @@ void DoorShutter_Draw(Actor* thisx, GlobalContext* globalCtx) {
     //! from drawing until initialization is complete. However when the required object is 
     //! gameplay_keep, this check will pass no matter what.
     //! This only matters in very specific scenarios, when the door is unculled on the first possible frame after
-    //! spawning. It will try to draw on the first possible frame without having run update yet.
+    //! spawning. It will try to draw without having run update yet.
     //! If the required object is gameplay_keep, the check will pass even though initialization has not completed
     //! yet, and will try to draw the display list of the first entry in `D_80998134`, which will likely crash the game.
     //!

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -678,7 +678,7 @@ void DoorShutter_Draw(Actor* thisx, GlobalContext* globalCtx) {
     DoorShutter* this = THIS;
 
     //! @bug This actor is not fully initialized until the required object dependency is loaded.
-    //! In  most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor  the
+    //! In  most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor
     //! from drawing until initialization is complete. However when the required object is 
     //! gameplay_keep, this check will pass no matter what.
     //! This only matters in very specific scenarios, when the door is unculled on the first possible frame after

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -679,15 +679,16 @@ void DoorShutter_Draw(Actor* thisx, GlobalContext* globalCtx) {
 
     //! @bug This actor is not fully initialized until the required object dependency is loaded.
     //! In most cases, the check for objBankIndex to equal requiredObjBankIndex prevents the actor
-    //! from drawing until initialization is complete. However when the required object is 
-    //! gameplay_keep, this check will pass no matter what.
-    //! This only matters in very specific scenarios, when the door is unculled on the first possible frame after
-    //! spawning. It will try to draw without having run update yet.
-    //! If the required object is gameplay_keep, the check will pass even though initialization has not completed
-    //! yet, and will try to draw the display list of the first entry in `D_80998134`, which will likely crash the game.
+    //! from drawing until initialization is complete. However if the required object is the same as the
+    //! object dependency listed in init vars, this check will pass no matter what.
+    //! This only matters in very specific scenarios, when the door is unculled on the first possible frame
+    //! after spawning. It will try to draw without having run update yet.
+    //! If the required object is the same as the init vars requirement (gameplay_keep in this case), the check will
+    //! pass even though initialization has not completed. When this happens, it will try to draw the display list
+    //! of the first entry in `D_80998134`, which will likely crash the game.
     //!
-    //! The best way to fix this issue (and what was done in Majora's Mask) is to null out draw in the init vars
-    //! for the actor, and only set draw after initialization is complete.
+    //! The best way to fix this issue (and what was done in Majora's Mask) is to null out the draw function in
+    //! the init vars for the actor, and only set draw after initialization is complete.
 
     if (this->dyna.actor.objBankIndex == this->requiredObjBankIndex &&
         (this->unk_16B == 0 || func_80997A34(this, globalCtx) != 0)) {


### PR DESCRIPTION
This one took like 3 days to figure out cause rcp crash with no helpful debug screen :)))

This was found while working on a separate project with custom maps. Its a miracle this bug never shows itself in the original game.
Thanks to tharo for helping me debug this as well, was quite an adventure

Below is debug printf output showing the order of events, if anyone is curious.

```
FAR DOOR INIT START
Next action set: DoorShutter_SetupType
FAR DOOR INIT END

FAR DOOR DRAW START
this->unk_16C: 0
sp70->b: 060067A0 (gohmas door display list, not the right one)
FAR DOOR DRAW END

FAR DOOR UPDATE START
DoorShutter_SetupType is starting
Required object index: 0
Is the object loaded?.. Yes
continuing setup
Starting DoorShutter_SetupDoor
16C set in DoorShutter_SetupDoor: 8
FAR DOOR UPDATE END

FAR DOOR DRAW START
this->unk_16C: 8
sp70->b: 0404B0D0 (gDungeonDoorDL)
FAR DOOR DRAW END
```