### PR TITLE
More minor assets fixes

### DIFF
--- a/assets/xml/scenes/dungeons/ice_doukutu.xml
+++ b/assets/xml/scenes/dungeons/ice_doukutu.xml
@@ -1,6 +1,8 @@
 <Root>
     <File Name="ice_doukutu_scene" Segment="2">
-        <Scene Name="ice_doukutu_scene"/>
+        <Cutscene Name="gIceCavernSerenadeCs" Offset="0x330"/>
+
+        <Scene Name="ice_doukutu_scene" Offset="0x0"/>
     </File>
     <File Name="ice_doukutu_room_0" Segment="3">
         <Room Name="ice_doukutu_room_0" Offset="0x0"/>

--- a/assets/xml/scenes/overworld/spot12.xml
+++ b/assets/xml/scenes/overworld/spot12.xml
@@ -1,6 +1,7 @@
 <Root>
     <File Name="spot12_scene" Segment="2">
-        <Cutscene  Offset="0x6490"/>
+        <Cutscene Name="gSpot12Cs_006490" Offset="0x6490"/>
+
         <Scene Name="spot12_scene" Offset="0x0"/>
     </File>
     <File Name="spot12_room_0" Segment="3">

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -431,7 +431,7 @@ typedef enum {
     /* 0x06 */ SCENE_CMD_ID_ENTRANCE_LIST,
     /* 0x07 */ SCENE_CMD_ID_SPECIAL_FILES,
     /* 0x08 */ SCENE_CMD_ID_ROOM_BEHAVIOR,
-    /* 0x09 */ SCENE_CMD_ID_UNUSED_09,
+    /* 0x09 */ SCENE_CMD_ID_UNK_09,
     /* 0x0A */ SCENE_CMD_ID_MESH,
     /* 0x0B */ SCENE_CMD_ID_OBJECT_LIST,
     /* 0x0C */ SCENE_CMD_ID_LIGHT_LIST,
@@ -477,6 +477,9 @@ typedef enum {
 #define SCENE_CMD_ROOM_BEHAVIOR(curRoomUnk3, curRoomUnk2, showInvisActors, disableWarpSongs) \
     { SCENE_CMD_ID_ROOM_BEHAVIOR, curRoomUnk3, \
         curRoomUnk2 | _SHIFTL(showInvisActors, 8, 1) | _SHIFTL(disableWarpSongs, 10, 1) }
+
+#define SCENE_CMD_UNK_09() \
+    { SCENE_CMD_ID_UNK_09, 0, CMD_W(0) }
 
 #define SCENE_CMD_MESH(meshHeader) \
     { SCENE_CMD_ID_MESH, 0, CMD_PTR(meshHeader) }

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -347,7 +347,7 @@ s32 EnXc_SerenadeCS(EnXc* this, GlobalContext* globalCtx) {
         s32 stateFlags = player->stateFlags1;
         if (CHECK_OWNED_EQUIP(EQUIP_BOOTS, 1) && !(gSaveContext.eventChkInf[5] & 4) && !(stateFlags & 0x20000000) &&
             !Gameplay_InCsMode(globalCtx)) {
-            Cutscene_SetSegment(globalCtx, &ice_doukutu_sceneCutsceneData0x000330);
+            Cutscene_SetSegment(globalCtx, &gIceCavernSerenadeCs);
             gSaveContext.cutsceneTrigger = 1;
             gSaveContext.eventChkInf[5] |= 4; // Learned Serenade of Water Flag
             Item_Give(globalCtx, ITEM_SONG_SERENADE);


### PR DESCRIPTION
Just some minor fixes:
- Add a missing cutscene name in `spot12` (my bad).
- `EnXc` was using an autogenerated cutscene name. Change it to a proper name.
- Add `SCENE_CMD_UNK_09` scene macro.

Those fixes are needed for ZAPD PRs [126](https://github.com/zeldaret/ZAPD/pull/126) and [140](https://github.com/zeldaret/ZAPD/pull/140)

Originally, this change was part of #811, but I decided to make it an standalone PR. This way, the mentioned PRs could be merged to ZAPD, and #811 could include them.