### PR TITLE
Track XML extraction time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ graphs/
 *.mtl
 *.fbx
 !*_custom*
+.extracted-assets.json
 
 # Per-user configuration
 .python-version

--- a/Makefile
+++ b/Makefile
@@ -184,9 +184,10 @@ clean:
 assetclean:
 	$(RM) -r $(ASSET_BIN_DIRS)
 	$(RM) -r build/assets
+	$(RM) -r .extracted-assets.json
 
 distclean: clean assetclean
-	$(RM) -r baserom/ .extracted-assets.json
+	$(RM) -r baserom/
 	$(MAKE) -C tools distclean
 
 setup:

--- a/Makefile
+++ b/Makefile
@@ -183,10 +183,10 @@ clean:
 
 assetclean:
 	$(RM) -r $(ASSET_BIN_DIRS)
-	$(RM) -r build/assets	
+	$(RM) -r build/assets
 
 distclean: clean assetclean
-	$(RM) -r baserom/
+	$(RM) -r baserom/ .extracted-assets.json
 	$(MAKE) -C tools distclean
 
 setup:


### PR DESCRIPTION
As requested by @Roman971, I modified `extract_assets.py` so now it would track the timestamp of the last time when each XML was extracted to prevent the unnecessary re-extraction of it (opposed to the current "check the existing C file" method). So, only files which are missing on this file or have a newer modification time than the stored will be extracted.
To do this, a `.extracted-assets.json` file will be automatically generated by `extract_assets.py` It looks like this:
```json
{
    "assets/xml/textures/icon_item_field_static.xml": {
        "timestamp": 1621964754871166317
    },
    "assets/xml/scenes/indoors/bowling.xml": {
        "timestamp": 1621964754871644009
    },
    "assets/xml/scenes/shops/drag.xml": {
        "timestamp": 1621964754873410688
    },
}
```
The stored `"timestamp"` value is the UNIX timestamp for the moment that XML was extracted, in nanoseconds.
I decided to use the json format because it would make easier to add more metadata if we wanted in the future.
The `.extracted-assets.json` file will always be updated at the end of the script.
Running `make distclean` or `make assetclean` will automatically delete this file.

I also added a `SIGINT` handler, so the script should be able to stop gracefully (while properly updating the `.extracted-assets.json`) in case somebody wants to stop the execution with `CTRL-C`