### PR TITLE
Hotfix: `extract_assets.py` compatibility

### DIFF
--- a/extract_assets.py
+++ b/extract_assets.py
@@ -52,12 +52,12 @@ def ExtractFunc(fullPath):
     if not globalForce:
         if fullPath in globalExtractedAssetsTracker:
             timestamp = globalExtractedAssetsTracker[fullPath]["timestamp"]
-            modificationTime = int(os.path.getmtime(fullPath) * (10**9))
+            modificationTime = int(os.path.getmtime(fullPath))
             if modificationTime < timestamp:
                 # XML has not been modified since last extraction.
                 return
 
-    currentTimeStamp = time.time_ns()
+    currentTimeStamp = int(time.time())
 
     if isScene:
         ExtractScene(fullPath, outPath, outSourcePath)


### PR DESCRIPTION
[`time_ns()`](https://docs.python.org/3/library/time.html#time.time_ns) is a function introduced to Python in version 3.7, so it was causing issues in some users using Python 3.6.

