### PR TITLE
Add struct `LegacyLimb` and rename `AnimationHeader2` for `object_human`

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1209,9 +1209,10 @@ void SkelAnime_DrawFlexOpa(GlobalContext* globalCtx, void** skeleton, Vec3s* joi
                            OverrideLimbDrawOpa overrideLimbDraw, PostLimbDrawOpa postLimbDraw, void* arg);
 s16 Animation_GetLength(void* animation);
 s16 Animation_GetLastFrame(void* animation);
-s16 Animation_GetLimbCount2(AnimationHeader2* animation);
-s16 Animation_GetLength2(AnimationHeader2* animation);
-s16 Animation_GetLastFrame2(AnimationHeader2* animation);
+s32 SkelAnime_GetFrameDataLegacy(LegacyAnimationHeader* animation, s32 frame, Vec3s* frameTable);
+s16 Animation_GetLimbCountLegacy(LegacyAnimationHeader* animation);
+s16 Animation_GetLengthLegacy(LegacyAnimationHeader* animation);
+s16 Animation_GetLastFrameLegacy(LegacyAnimationHeader* animation);
 Gfx* SkelAnime_Draw(GlobalContext* globalCtx, void** skeleton, Vec3s* jointTable, OverrideLimbDraw overrideLimbDraw,
                     PostLimbDraw postLimbDraw, void* arg, Gfx* gfx);
 Gfx* SkelAnime_DrawFlex(GlobalContext* globalCtx, void** skeleton, Vec3s* jointTable, s32 dListCount,

--- a/include/z64animation.h
+++ b/include/z64animation.h
@@ -96,8 +96,8 @@ typedef struct {
     /* 0x04 */ s16 yMax;
     /* 0x06 */ s16 y;
     /* 0x08 */ s16 zMax;
-    /* 0x10 */ s16 z;
-} JointKey; // size = 0x12
+    /* 0x0A */ s16 z;
+} JointKey; // size = 0x0C
 
 // Unused
 typedef struct {
@@ -105,7 +105,7 @@ typedef struct {
     /* 0x02 */ s16 limbCount;
     /* 0x04 */ s16* frameData;
     /* 0x08 */ JointKey* jointKey;
-} AnimationHeader2; // size = 0xC
+} LegacyAnimationHeader; // size = 0xC
 
 typedef s32 (*OverrideLimbDrawOpa)(struct GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot,
                                    void*);
@@ -312,5 +312,13 @@ typedef struct {
 
 typedef void (*SkinCallback)(struct Actor*, struct GlobalContext*, PSkinAwb*);
 typedef s32 (*SkinCallback2)(struct Actor*, struct GlobalContext*, s32, PSkinAwb*);
+
+typedef struct LegacyLimb {
+    /* 0x000 */ Gfx* dList;
+    /* 0x004 */ Vec3f trans;
+    /* 0x010 */ Vec3s rot;
+    /* 0x018 */ struct LegacyLimb* sibling;
+    /* 0x01C */ struct LegacyLimb* child;
+} LegacyLimb; // size = 0x20
 
 #endif

--- a/include/z64animation.h
+++ b/include/z64animation.h
@@ -54,6 +54,14 @@ typedef struct {
     /* 0x0C */ void* segment; // Segment address of data. Currently unclear what.
 } SkinLimb; // size = 0x10
 
+typedef struct LegacyLimb {
+    /* 0x000 */ Gfx* dList;
+    /* 0x004 */ Vec3f trans;
+    /* 0x010 */ Vec3s rot;
+    /* 0x018 */ struct LegacyLimb* sibling;
+    /* 0x01C */ struct LegacyLimb* child;
+} LegacyLimb; // size = 0x20
+
 // Model has limbs with only rigid meshes
 typedef struct {
     /* 0x00 */ void** segment;
@@ -312,13 +320,5 @@ typedef struct {
 
 typedef void (*SkinCallback)(struct Actor*, struct GlobalContext*, PSkinAwb*);
 typedef s32 (*SkinCallback2)(struct Actor*, struct GlobalContext*, s32, PSkinAwb*);
-
-typedef struct LegacyLimb {
-    /* 0x000 */ Gfx* dList;
-    /* 0x004 */ Vec3f trans;
-    /* 0x010 */ Vec3s rot;
-    /* 0x018 */ struct LegacyLimb* sibling;
-    /* 0x01C */ struct LegacyLimb* child;
-} LegacyLimb; // size = 0x20
 
 #endif

--- a/include/z64animation.h
+++ b/include/z64animation.h
@@ -205,13 +205,13 @@ typedef struct {
     /* 0x0008 */ s16* copyValues;
     /* 0x000C */ s16 unk_0C;
     /* 0x000E */ s16 unk_10;
-} TransformUpdateIndex; // size 0x10
+} TransformUpdateIndex; // size = 0x10
 
 typedef struct {
     /* 0x0000 */ u8 firstChildIdx;
     /* 0x0001 */ u8 nextLimbIdx;
     /* 0x0004 */ Gfx* dList[2];
-} SkelCurveLimb; // size >= 0x8
+} SkelCurveLimb; // size = 0xC
 
 typedef struct {
     /* 0x0000 */ SkelCurveLimb** limbs;
@@ -295,7 +295,7 @@ typedef struct {
     /* 0x002 */ u16 unk_2;
     /* 0x004 */ Struct_800A598C* unk_4;
     /* 0x008 */ Gfx* unk_8;
-} Struct_800A5E28;
+} Struct_800A5E28; // size = 0xC
 
 typedef struct {
     /* 0x000 */ u8 unk_0;

--- a/src/code/z_skelanime.c
+++ b/src/code/z_skelanime.c
@@ -732,53 +732,19 @@ s32 SkelAnime_GetFrameDataLegacy(LegacyAnimationHeader* animation, s32 frame, Ve
     s16* dynamicData = &frameData[frame];
     s32 i;
 
-    /**
-     *Equivalent to the following, but the compiler optimizes the loop in a way I can't replicate
-     */
-
-    // for(i = 0, frameTable++, key++; i < limbCount + 1; i++, key++, frameTable++) {
-    //     frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
-    //     frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
-    //     frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
-    // }
-
     frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
     frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
     frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
 
-    i = 1;
     frameTable++;
     key++;
 
-    if (limbCount & 1) {}
-
-    if (limbCount > 0) {
-        if (limbCount & 1) {
-            i++;
-            frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
-            frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
-            frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
-            key++;
-            frameTable++;
-            if (limbCount + 1 == i) {
-                goto ret;
-            }
-        }
-        do {
-            i += 2;
-            frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
-            frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
-            frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
-            key++;
-            frameTable++;
-            frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
-            frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
-            frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
-            key++;
-            frameTable++;
-        } while (i != limbCount + 1);
+    for(i = 1; i <= limbCount; i++, key++, frameTable++) {
+        frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
+        frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
+        frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
     }
-ret:
+
     return limbCount;
 }
 

--- a/src/code/z_skelanime.c
+++ b/src/code/z_skelanime.c
@@ -739,7 +739,7 @@ s32 SkelAnime_GetFrameDataLegacy(LegacyAnimationHeader* animation, s32 frame, Ve
     frameTable++;
     key++;
 
-    for(i = 1; i <= limbCount; i++, key++, frameTable++) {
+    for (i = 1; i <= limbCount; i++, key++, frameTable++) {
         frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
         frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
         frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];

--- a/src/code/z_skelanime.c
+++ b/src/code/z_skelanime.c
@@ -723,8 +723,8 @@ Gfx* SkelAnime_DrawFlex(GlobalContext* globalCtx, void** skeleton, Vec3s* jointT
  * Unpacks frame data for the animation at the given frame into frameTable
  * Used by the legacy animation format
  */
-s32 SkelAnime_GetFrameData2(AnimationHeader2* animation, s32 frame, Vec3s* frameTable) {
-    AnimationHeader2* animHeader = SEGMENTED_TO_VIRTUAL(animation);
+s32 SkelAnime_GetFrameDataLegacy(LegacyAnimationHeader* animation, s32 frame, Vec3s* frameTable) {
+    LegacyAnimationHeader* animHeader = SEGMENTED_TO_VIRTUAL(animation);
     s32 limbCount = animHeader->limbCount;
     JointKey* key = SEGMENTED_TO_VIRTUAL(animHeader->jointKey);
     s16* frameData = SEGMENTED_TO_VIRTUAL(animHeader->frameData);
@@ -785,8 +785,8 @@ ret:
 /**
  * Used by legacy animation format
  */
-s16 Animation_GetLimbCount2(AnimationHeader2* animation) {
-    AnimationHeader2* animHeader = SEGMENTED_TO_VIRTUAL(animation);
+s16 Animation_GetLimbCountLegacy(LegacyAnimationHeader* animation) {
+    LegacyAnimationHeader* animHeader = SEGMENTED_TO_VIRTUAL(animation);
 
     return animHeader->limbCount;
 }
@@ -794,8 +794,8 @@ s16 Animation_GetLimbCount2(AnimationHeader2* animation) {
 /**
  * Used by legacy animation format
  */
-s16 Animation_GetLength2(AnimationHeader2* animation) {
-    AnimationHeader2* animHeader = SEGMENTED_TO_VIRTUAL(animation);
+s16 Animation_GetLengthLegacy(LegacyAnimationHeader* animation) {
+    LegacyAnimationHeader* animHeader = SEGMENTED_TO_VIRTUAL(animation);
 
     return animHeader->frameCount;
 }
@@ -803,8 +803,8 @@ s16 Animation_GetLength2(AnimationHeader2* animation) {
 /**
  * Used by legacy animation format
  */
-s16 Animation_GetLastFrame2(AnimationHeader2* animation) {
-    AnimationHeader2* animHeader = SEGMENTED_TO_VIRTUAL(animation);
+s16 Animation_GetLastFrameLegacy(LegacyAnimationHeader* animation) {
+    LegacyAnimationHeader* animHeader = SEGMENTED_TO_VIRTUAL(animation);
 
     return animHeader->frameCount - 1;
 }


### PR DESCRIPTION
Since soon ZAPD will be able to extract `object_human` completely ([PR 152](https://github.com/zeldaret/ZAPD/pull/152)), we are going to have the struct for its specific limb structure.
I also decided to rename `AnimationHeader2` to `LegacyAnimationHeader` for consistency with the limb name. I renamed the functions that use this struct accordingly.
Finally, I rewrote `SkelAnime_GetFrameDataLegacy`to match in a cleaner way.

If somebody don't like the name `LegacyLimb` or `LegacyAnimationHeader` I'm open to suggestions.