### PR TITLE
"Fix" the map not showing the right value for RomStart/RomEnd symbols

### DIFF
--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -328,8 +328,9 @@ static void write_ld_script(void)
         //if (seg->fields & (1 << STMT_increment))
             //fprintf(fout, "    . += 0x%08X;\n", seg->increment);
 
-        fprintf(fout, "    _%sSegmentRomStart = _RomSize;\n"
-                  "    ..%s ", seg->name, seg->name);
+        fprintf(fout, "    _%sSegmentRomStartTemp = _RomSize;\n"
+                  "    _%sSegmentRomStart = _%sSegmentRomStartTemp;\n"
+                  "    ..%s ", seg->name, seg->name, seg->name, seg->name);
 
         if (seg->fields & (1 << STMT_after))
             fprintf(fout, "_%sSegmentEnd ", seg->after);
@@ -410,7 +411,9 @@ static void write_ld_script(void)
         //fprintf(fout, "    _RomSize += ( _%sSegmentDataEnd - _%sSegmentTextStart );\n", seg->name, seg->name);
         fprintf(fout, "    _RomSize += ( _%sSegmentOvlEnd - _%sSegmentTextStart );\n", seg->name, seg->name);
 
-        fprintf(fout, "    _%sSegmentRomEnd = _RomSize;\n\n", seg->name);
+        fprintf(fout, "    _%sSegmentRomEndTemp = _RomSize;\n"
+                  "_%sSegmentRomEnd = _%sSegmentRomEndTemp;\n\n",
+                  seg->name, seg->name, seg->name);
 
         // algn end of ROM segment
         if (seg->fields & (1 << STMT_romalign))


### PR DESCRIPTION
* Currently in `build/z64.map`:
```
                0x00000000035df000                _dmadataSegmentRomStart = _RomSize
```
```
                0x00000000035df000                _dmadataSegmentRomEnd = _RomSize
```
in the currently built map file the RomStart/RomEnd values are always the last _RomSize value for some reason.

* With this PR adding a temp symbol:
```
                0x00000000035cf000                _dmadataSegmentRomStartTemp = _RomSize
                0x0000000000012f70                _dmadataSegmentRomStart = _dmadataSegmentRomStartTemp
```
```
                0x00000000035cf000                _dmadataSegmentRomEndTemp = _RomSize
                0x0000000000019030                _dmadataSegmentRomEnd = _dmadataSegmentRomEndTemp
```
somehow it "fixes" it.

This doesn't add information (current tools get the ROM address from the `load address` part in `..dmadata       0x0000000080016d60     0x6130 load address 0x0000000000012f30`), but imo makes it easier to read the map file/find what you're looking for. I had a need for this for modding purposes

* Impact on build time: literally none

People didn't seem to care about this on Discord so I guess there's no opposition to merging. Time to speak up!