### PR TITLE
Fix progress.py to not include files in asm/

### DIFF
--- a/progress.py
+++ b/progress.py
@@ -64,7 +64,6 @@ src = 0
 code = 0
 boot = 0
 ovl = 0
-asm = 0
 
 for line in mapFile:
     lineSplit =  list(filter(None, line.split(" ")))
@@ -77,8 +76,6 @@ for line in mapFile:
         if (section == ".text"):
             if (objFile.startswith("build/src")):
                 src += size
-            elif (objFile.startswith("build/asm")):
-                asm += size
 
             if (objFile.startswith("build/src/code") or objFile.startswith("build/src/libultra_code")):
                 code += size
@@ -89,37 +86,32 @@ for line in mapFile:
 
 nonMatchingASM = GetNonMatchingSize("asm/non_matchings")
 nonMatchingASMBoot = GetNonMatchingSize("asm/non_matchings/boot")
-nonMatchingASMCode = GetNonMatchingSize("asm/non_matchings/code") + GetNonMatchingSize("asm/non_matchings/libultra_code")
+nonMatchingASMCode = GetNonMatchingSize("asm/non_matchings/code")
 nonMatchingASMOvl = GetNonMatchingSize("asm/non_matchings/overlays")
 
 src -= nonMatchingASM
 code -= nonMatchingASMCode
 boot -= nonMatchingASMBoot
 ovl -= nonMatchingASMOvl
-asm += nonMatchingASM
 
 bootSize = 31408 # decompilable code only
-codeSize = 1004128 # .text section except rsp bins (1.00mb)
+codeSize = 1000000 # decompilable code only (1.00mb)
 ovlSize = 2812000 # .text sections
-handwritten = 5840 # boot only
 
-asm -= handwritten
-
-total = src + asm
+total = src + nonMatchingASM
 srcPct = 100 * src / total
-asmPct = 100 * asm / total
 codePct = 100 * code / codeSize
 bootPct = 100 * boot / bootSize
 ovlPct = 100 * ovl / ovlSize
-compiled_bytes = total
-bytesPerHeartPiece = compiled_bytes / 80
+
+bytesPerHeartPiece = total / 80
 
 if args.format == 'csv':
     version = 1
     git_object = git.Repo().head.object
     timestamp = str(git_object.committed_date)
     git_hash = git_object.hexsha
-    csv_list = [str(version), timestamp, git_hash, str(code), str(codeSize), str(boot), str(bootSize), str(ovl), str(ovlSize), str(src), str(asm), str(len(nonMatchingFunctions))]
+    csv_list = [str(version), timestamp, git_hash, str(code), str(codeSize), str(boot), str(bootSize), str(ovl), str(ovlSize), str(src), str(nonMatchingASM), str(len(nonMatchingFunctions))]
     print(",".join(csv_list))
 elif args.format == 'shield-json':
     # https://shields.io/endpoint


### PR DESCRIPTION
Turns out the progress script has been tracking files in asm/ and only accounting some of them as handwritten, so the total decompilable count was slightly higher than it should have been. This includes files like ipl3 and dmadata which is apparently linked as .text, so it amounts for ~33000 bytes which is almost 1% overall. See the discussion in #oot-decomp for more details.

I changed the script to not include files in asm/ at all in the count, since at this point every decompilable file should have a C file and should be linked from src/ instead of asm/. I also adjusted the hardcoded decompilable code size to properly account for handwritten asm, but that difference is pretty minor.

For reference, here is the new output in the current repo:
```
3843408 total bytes of decompilable code

3520624 bytes decompiled in src 91.60162022871368%

31408/31408 bytes decompiled in boot 100.0%

871344/1000000 bytes decompiled in code 87.1344%

2617872/2812000 bytes decompiled in overlays 93.09644381223329%

------------------------------------

You have 73/80 heart pieces and 28 rupee(s).
```

Note: We should probably rectify the csv retroactively to fix progress tracking on the website, but this will have to be done separately and we still need to figure out the exact way we're going to do it.