### PR TITLE
object_pu_box-related doc

### DIFF
--- a/assets/xml/objects/object_pu_box.xml
+++ b/assets/xml/objects/object_pu_box.xml
@@ -1,13 +1,13 @@
 <Root>
     <File Name="object_pu_box" Segment="6">
-        <DList Name="gUnknownUnusedBox1DL" Offset="0x0"/>
-        <Collision Name="gUnknownUnusedBox1Col" Offset="0x350"/>
-        <DList Name="gUnknownUnusedBox2DL" Offset="0x380"/>
-        <Collision Name="gUnknownUnusedBox2Col" Offset="0x6D0"/>
-        <DList Name="gUnknownUnusedBox3DL" Offset="0x700"/>
-        <Collision Name="gUnknownUnusedBox3Col" Offset="0xA50"/>
-        <DList Name="gUnknownUnusedBox4DL" Offset="0xA80"/>
-        <Collision Name="gUnknownUnusedBox4Col" Offset="0x15D0"/>
-        <Texture Name="gUnknownUnusedBoxTex" OutName="unknown_unused_box" Format="rgba16" Width="32" Height="32" Offset="0xCC8"/>
+        <DList Name="gBlockSmallDL" Offset="0x0"/>
+        <Collision Name="gBlockSmallCol" Offset="0x350"/>
+        <DList Name="gBlockMediumDL" Offset="0x380"/>
+        <Collision Name="gBlockMediumCol" Offset="0x6D0"/>
+        <DList Name="gBlockTallDL" Offset="0x700"/>
+        <Collision Name="gBlockTallCol" Offset="0xA50"/>
+        <DList Name="gBlockTallestDL" Offset="0xA80"/>
+        <Collision Name="gBlockTallestCol" Offset="0x15D0"/>
+        <Texture Name="gBlockTex" OutName="block" Format="rgba16" Width="32" Height="32" Offset="0xCC8"/>
     </File>
 </Root>

--- a/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
+++ b/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
@@ -1,10 +1,11 @@
 /*
  * File: z_bg_pushbox.c
  * Overlay: ovl_Bg_Pushbox
- * Description:
+ * Description: Unused (and non functional) pushable block
  */
 
 #include "z_bg_pushbox.h"
+#include "objects/object_pu_box/object_pu_box.h"
 
 #define FLAGS 0x00000000
 
@@ -15,12 +16,13 @@ void BgPushbox_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void BgPushbox_Update(Actor* thisx, GlobalContext* globalCtx);
 void BgPushbox_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-void func_808A8BAC(BgPushbox* this, GlobalContext* globalCtx);
+void BgPushbox_UpdateImpl(BgPushbox* this, GlobalContext* globalCtx);
 
 const ActorInit Bg_Pushbox_InitVars = {
     ACTOR_BG_PUSHBOX,
     ACTORCAT_BG,
     FLAGS,
+    //! @bug fixing this actor would involve using OBJECT_PU_BOX
     OBJECT_GAMEPLAY_DANGEON_KEEP,
     sizeof(BgPushbox),
     (ActorFunc)BgPushbox_Init,
@@ -28,9 +30,6 @@ const ActorInit Bg_Pushbox_InitVars = {
     (ActorFunc)BgPushbox_Update,
     (ActorFunc)BgPushbox_Draw,
 };
-
-extern Gfx D_06000000[];
-extern CollisionHeader D_06000350;
 
 static InitChainEntry sInitChain[] = {
     ICHAIN_F32_DIV1000(gravity, -2000, ICHAIN_STOP),
@@ -48,10 +47,10 @@ void BgPushbox_Init(Actor* thisx, GlobalContext* globalCtx) {
 
     Actor_ProcessInitChain(&this->dyna.actor, sInitChain);
     DynaPolyActor_Init(&this->dyna, DPM_UNK);
-    CollisionHeader_GetVirtual(&D_06000350, &colHeader);
+    CollisionHeader_GetVirtual(&gBlockSmallCol, &colHeader);
     this->dyna.bgId = DynaPoly_SetBgActor(globalCtx, &globalCtx->colCtx.dyna, &this->dyna.actor, colHeader);
     ActorShape_Init(&this->dyna.actor.shape, 0.0f, NULL, 0.0f);
-    BgPushbox_SetupAction(this, func_808A8BAC);
+    BgPushbox_SetupAction(this, BgPushbox_UpdateImpl);
 }
 
 void BgPushbox_Destroy(Actor* thisx, GlobalContext* globalCtx) {
@@ -60,7 +59,7 @@ void BgPushbox_Destroy(Actor* thisx, GlobalContext* globalCtx) {
     DynaPoly_DeleteBgActor(globalCtx, &globalCtx->colCtx.dyna, this->dyna.bgId);
 }
 
-void func_808A8BAC(BgPushbox* this, GlobalContext* globalCtx) {
+void BgPushbox_UpdateImpl(BgPushbox* this, GlobalContext* globalCtx) {
     this->dyna.actor.speedXZ += this->dyna.unk_150 * 0.2f;
     this->dyna.actor.speedXZ = (this->dyna.actor.speedXZ < -1.0f)
                                    ? -1.0f
@@ -86,7 +85,7 @@ void BgPushbox_Draw(Actor* thisx, GlobalContext* globalCtx) {
     func_80093D18(globalCtx->state.gfxCtx);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_bg_pushbox.c", 269),
               G_MTX_NOPUSH | G_MTX_MODELVIEW | G_MTX_LOAD);
-    gSPDisplayList(POLY_OPA_DISP++, &D_06000000);
+    gSPDisplayList(POLY_OPA_DISP++, &gBlockSmallDL);
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_bg_pushbox.c", 272);
 }

--- a/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.c
+++ b/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.c
@@ -57,7 +57,7 @@ void EnPubox_Init(Actor* thisx, GlobalContext* globalCtx) {
     this->dyna.unk_15C = DPM_UNK;
     thisx->targetMode = 1;
     thisx->gravity = -2.0f;
-    CollisionHeader_GetVirtual(&gUnknownUnusedBox2Col, &colHeader);
+    CollisionHeader_GetVirtual(&gBlockMediumCol, &colHeader);
     this->dyna.bgId = DynaPoly_SetBgActor(globalCtx, &globalCtx->colCtx.dyna, thisx, colHeader);
 }
 
@@ -87,5 +87,5 @@ void EnPubox_Update(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void EnPubox_Draw(Actor* thisx, GlobalContext* globalCtx) {
-    Gfx_DrawDListOpa(globalCtx, gUnknownUnusedBox2DL);
+    Gfx_DrawDListOpa(globalCtx, gBlockMediumDL);
 }


### PR DESCRIPTION
Small documentation on these unused actors and object

I assume `z_bg_pushbox` used `object_pu_box` at some point in development, even though its init vars say it "now" uses the dungeon keep object

<details>

<summary>click to show dlists and collision</summary>

(I spaced the four dlists/collision models apart so they can be seen better)

dlists (z64utils is too accurate to display them since they have errors):
![dlists imported into blender](https://421.es/doyu/24gpa1)

collision:
![collision models importer into blender](https://421.es/doyu/24gpah)

the collision has no special properties apart from setting the no_grab flag (can't grab ledges)

</details>