### PR TITLE
z_en_a_keep documentation and cleanup

### DIFF
--- a/assets/xml/objects/gameplay_keep.xml
+++ b/assets/xml/objects/gameplay_keep.xml
@@ -855,20 +855,23 @@
         <Texture Name="gMoonTex" OutName="moon" Format="ia8" Width="64" Height="64" Offset="0x37F00"/>
         <DList Name="gMoonDL" Offset="0x38F00"/>
         <Texture Name="gUnknownCircle6Tex" OutName="unknown_circle_6" Format="i8" Width="32" Height="32" Offset="0x38FB0"/>
-        <Collision Name="gUnknown1Col" Offset="0x394B0"/>
+        <Collision Name="gLargerCubeCol" Offset="0x394B0"/> <!-- unused in game -->
         <DList Name="gLiftableRockDL" Offset="0x39660"/>
+
+        <!-- unused in game -->
         <DList Name="gUnusedRockRectangularPrism1DL" Offset="0x39890"/>
-        <Collision Name="gUnknown2Col" Offset="0x39A48"/>
-        <DList Name="gUnusedRockRectangularPrism2DL" Offset="0x39C00"/>
-        <Collision Name="gUnknown3Col" Offset="0x39DC0"/>
+        <Collision Name="gWideTallBlockCol" Offset="0x39A48"/>
+        <DList Name="gFlatBlockDL" Offset="0x39C00"/>
+        <Collision Name="gTallBlockCol" Offset="0x39DC0"/>
         <DList Name="gUnusedRockRectangularPrism3DL" Offset="0x39F70"/>
-        <Collision Name="gUnknown4Col" Offset="0x3A120"/>
-        <DList Name="gUnusedRockRectangularPrism4DL" Offset="0x3A2D0"/>
-        <Collision Name="gUnknown5Col" Offset="0x3A480"/>
-        <DList Name="gUnusedRockRectangularPrism5DL" Offset="0x3A630"/>
-        <Collision Name="gUnknown6Col" Offset="0x3A7F0"/>
-        <DList Name="gUnusedTreeStumpDL" Offset="0x3A9B0"/>
-        <DList Name="gUnusedGrassBladesDL" Offset="0x3AB80"/>
+        <Collision Name="gSmallerFlatBlockCol" Offset="0x3A120"/>
+        <DList Name="gFlatRotBlockDL" Offset="0x3A2D0"/>
+        <Collision Name="gLargerFlatBlockCol" Offset="0x3A480"/>
+        <DList Name="gSmallCubeDL" Offset="0x3A630"/>
+        <Collision Name="gSmallerCubeCol" Offset="0x3A7F0"/>
+        <DList Name="gTreeStumpDL" Offset="0x3A9B0"/>
+        <DList Name="gGrassBladesDL" Offset="0x3AB80"/>
+
         <Texture Name="gHeartShapeTex" OutName="heart_shape" Format="i8" Width="16" Height="16" Offset="0x3AC30"/>
         <DList Name="gHeartPieceInteriorDL" Offset="0x3B030"/>
         <DList Name="gHeartPieceExteriorDL" Offset="0x3BBA0"/>

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -259,6 +259,7 @@ typedef struct EnItem00 {
     /* 0x160 */ ColliderCylinder collider;
 } EnItem00; // size = 0x1AC
 
+// Only A_OBJ_SIGNPOST_OBLONG and A_OBJ_SIGNPOST_ARROW are used in room files.
 typedef enum {
     /* 0x00 */ A_OBJ_BLOCK_SMALL,
     /* 0x01 */ A_OBJ_BLOCK_LARGE,
@@ -271,7 +272,8 @@ typedef enum {
     /* 0x08 */ A_OBJ_TREE_STUMP,
     /* 0x09 */ A_OBJ_SIGNPOST_OBLONG,
     /* 0x0A */ A_OBJ_SIGNPOST_ARROW,
-    /* 0x0B */ A_OBJ_KNOB
+    /* 0x0B */ A_OBJ_BOULDER_FRAGMENT,
+    /* 0x0C */ A_OBJ_MAX
 } AObjType;
 
 struct EnAObj;
@@ -281,13 +283,13 @@ typedef void (*EnAObjActionFunc)(struct EnAObj*, struct GlobalContext*);
 typedef struct EnAObj {
     /* 0x000 */ DynaPolyActor dyna;
     /* 0x164 */ EnAObjActionFunc actionFunc;
-    /* 0x168 */ s32 unk_168;
+    /* 0x168 */ s32 rotateWaitTimer;
     /* 0x16C */ s16 textId;
-    /* 0x16E */ s16 unk_16E;
-    /* 0x170 */ s16 unk_170;
-    /* 0x172 */ s16 unk_172;
-    /* 0x174 */ s16 unk_174;
-    /* 0x178 */ f32 unk_178;
+    /* 0x16E */ s16 rotateState;
+    /* 0x170 */ s16 rotateForTimer;
+    /* 0x172 */ s16 rotSpeedY;
+    /* 0x174 */ s16 rotSpeedX;
+    /* 0x178 */ f32 focusYoffset;
     /* 0x17C */ ColliderCylinder collider;
 } EnAObj; // size = 0x1C8
 


### PR DESCRIPTION
This is sketchy to document, apart from the sign posts most of this code and data is unused and sometimes flawed

<details>

collision (scale 1/100 from object) ![](https://421.es/doyu/24gqa5)
collision front view ![](https://421.es/doyu/24gq9m)

</details>