### PR TITLE
Fix non equivalence in Audio_SequenceChannelProcessScript.

### DIFF
--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -1044,8 +1044,8 @@ void Audio_SequenceChannelProcessScript(SequenceChannel* channel) {
 
                         if (player->defaultBank != 0xFF) {
                             offset = ((u16*)gAudioContext.unk_283C)[player->seqId];
-                            lowBits = gAudioContext.unk_283C[offset];
-                            command = gAudioContext.unk_283C[offset + lowBits - result];
+                            lowBits = gAudioContext.unk_283Cb[offset];
+                            command = gAudioContext.unk_283Cb[offset + lowBits - result];
                         }
 
                         if (func_800DF074(1, 2, command)) {
@@ -1155,8 +1155,8 @@ void Audio_SequenceChannelProcessScript(SequenceChannel* channel) {
 
                         if (player->defaultBank != 0xFF) {
                             offset = ((u16*)gAudioContext.unk_283C)[player->seqId];
-                            lowBits = gAudioContext.unk_283C[offset];
-                            command = gAudioContext.unk_283C[offset + lowBits - result];
+                            lowBits = gAudioContext.unk_283Cb[offset];
+                            command = gAudioContext.unk_283Cb[offset + lowBits - result];
                         }
 
                         if (func_800DF074(1, 2, command)) {


### PR DESCRIPTION
When compiling Audio_SequenceChannelProcessScript's available code, it turns out some entities such as the Deku Baba played the incorrect sound effect. This was due to incorrect array accesses; the following changes access the char/u8 array instead of the u16 array. This also makes the diff just a bit better: the function seems to be mostly regalloc differences now.