### PR TITLE
Remove fake match in EnInsect

### DIFF
--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -590,8 +590,6 @@ void func_80A7D460(EnInsect* this, GlobalContext* globalCtx) {
         sp40 = 40.0f;
     }
 
-    if (!this->soilActor->actor.params) {}
-
     D_80A7DEB0 += 0.99999994f / 300.0f;
     if (D_80A7DEB0 > 1.0f) {
         D_80A7DEB0 = 1.0f;


### PR DESCRIPTION
This fake match did not change IDO code gen but was causing a GCC build to crash if the player dropped bugs far away from a soft soil spot.