### PR TITLE
Add decompme.compilers to permuter_settings.toml

### DIFF
--- a/tools/permuter_settings.toml
+++ b/tools/permuter_settings.toml
@@ -11,3 +11,11 @@ CLOSE_DISPS = "void"
 ABS = "int"
 SQ = "int"
 CLAMP = "int"
+
+[decompme.compilers]
+"tools/ido_recomp/linux/7.1/cc" = "ido7.1"
+"tools/ido_recomp/macos/7.1/cc" = "ido7.1"
+"tools/ido_recomp/windows/7.1/cc" = "ido7.1"
+"tools/ido_recomp/linux/5.3/cc" = "ido5.3"
+"tools/ido_recomp/macos/5.3/cc" = "ido5.3"
+"tools/ido_recomp/windows/5.3/cc" = "ido5.3"


### PR DESCRIPTION
This enables permuter ./import.py --decompme to work with the oot repo.
