### PR TITLE
fix rodata order inconsistency bug in mkldscript (required for GCC support)

### DIFF
--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -377,7 +377,20 @@ static void write_ld_script(void)
         fprintf(fout, "        _%sSegmentRoDataStart = .;\n", seg->name);
 
         for (j = 0; j < seg->includesCount; j++)
+        {
             fprintf(fout, "            %s (.rodata)\n", seg->includes[j]);
+            // In other compilers such as GCC, they produce different sections such as
+            // the ones named directly below. These sections do not contain values that
+            // need relocating, but we need to ensure that the base .rodata section
+            // always comes first. The reason this is important is due to relocs assuming
+            // the base of .rodata being the offset for the relocs and thus needs to remain
+            // the beginning of the entire rodata area in order to remain consistent.
+            // Inconsistencies will lead to various .rodata reloc crashes as a result of
+            // either missing relocs or wrong relocs.
+            fprintf(fout, "            %s (.rodata.str1.4)\n", seg->includes[j]);
+            fprintf(fout, "            %s (.rodata.cst4)\n", seg->includes[j]);
+            fprintf(fout, "            %s (.rodata.cst8)\n", seg->includes[j]);
+        }
 
          //fprintf(fout, "        . = ALIGN(0x10);\n");
 

--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -379,7 +379,7 @@ static void write_ld_script(void)
         for (j = 0; j < seg->includesCount; j++)
         {
             fprintf(fout, "            %s (.rodata)\n", seg->includes[j]);
-            // In other compilers such as GCC, they produce different sections such as
+            // Compilers other than IDO, such as GCC, produce different sections such as
             // the ones named directly below. These sections do not contain values that
             // need relocating, but we need to ensure that the base .rodata section
             // always comes first. The reason this is important is due to relocs assuming


### PR DESCRIPTION
Currently, mkldscript assumes a single .rodata section. This is fine for IDO, but for GCC there are multiple sections which require rodata to be linked. A wildcard would also technically link, but you cannot do this because of the possibility that .rodata gets linked after the other cst4 and other sub-rodata sections. Ensuring it is first is required for relocs to be applied correctly since the other sub-rodata sections do not need relocs applied.