### PR TITLE
fix UB in DemoSa_FrameUpdateMatrix.

### DIFF
--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
@@ -156,7 +156,7 @@ void func_8098E5C8(DemoSa* this, GlobalContext* globalCtx) {
 }
 
 s32 DemoSa_FrameUpdateMatrix(DemoSa* this) {
-    SkelAnime_Update(&this->skelAnime);
+    return SkelAnime_Update(&this->skelAnime);
 }
 
 CsCmdActorAction* DemoSa_GetNpcAction(GlobalContext* globalCtx, s32 idx) {


### PR DESCRIPTION
This UB was responsible for the disappearence of medallion objects in Chamber of Sages cutscenes on GCC builds. This change still produces a matching ROM so it was likely just a small decomp mistake.