### PR TITLE
Remove InitVars declarations from actor headers

### DIFF
--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.h
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.h
@@ -20,6 +20,4 @@ typedef struct ArmsHook {
     /* 0x0214 */ ArmsHookActionFunc actionFunc;
 } ArmsHook; // size = 0x0218
 
-extern const ActorInit Arms_Hook_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.h
+++ b/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.h
@@ -19,6 +19,4 @@ typedef struct ArrowFire {
     /* 0x0168 */ u8 alpha;
 } ArrowFire; // size = 0x016C
 
-extern const ActorInit Arrow_Fire_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.h
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.h
@@ -19,6 +19,4 @@ typedef struct ArrowIce {
     /* 0x0168 */ ArrowIceActionFunc actionFunc;
 } ArrowIce; // size = 0x016C
 
-extern const ActorInit Arrow_Ice_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.h
+++ b/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.h
@@ -19,6 +19,4 @@ typedef struct ArrowLight {
     /* 0x0168 */ ArrowLightActionFunc actionFunc;
 } ArrowLight; // size = 0x016C
 
-extern const ActorInit Arrow_Light_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.h
+++ b/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.h
@@ -17,6 +17,4 @@ typedef struct BgBdanObjects {
     /* 0x01B8 */ s32 cameraSetting;
 } BgBdanObjects; // size = 0x01BC
 
-extern const ActorInit Bg_Bdan_Objects_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.h
+++ b/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.h
@@ -33,6 +33,4 @@ typedef struct BgBdanSwitch {
     /* 0x01DD */ char unk_1DD[0x3];
 } BgBdanSwitch; // size = 0x01E0
 
-extern const ActorInit Bg_Bdan_Switch_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.h
+++ b/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.h
@@ -15,6 +15,4 @@ typedef struct BgBomGuard {
     /* 0x016C */ Vec3f unk_16C;
 } BgBomGuard; // size = 0x0178
 
-extern const ActorInit Bg_Bom_Guard_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.h
+++ b/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.h
@@ -19,6 +19,4 @@ typedef struct BgBombwall {
     /* 0x02A3 */ u8 unk_2A3;
 } BgBombwall; // size = 0x02A4
 
-extern const ActorInit Bg_Bombwall_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.h
+++ b/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.h
@@ -19,6 +19,4 @@ typedef struct BgBowlWall {
     /* 0x0184 */ EnBomBowlMan* chuGirl;
 } BgBowlWall; // size = 0x0188
 
-extern const ActorInit Bg_Bowl_Wall_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.h
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.h
@@ -24,6 +24,4 @@ typedef enum {
     /* 3 */ BWALL_KD_LAVA_COVER // Spawned after the KD fight in order to cover the lava floor to disable damage
 } BombableWallType;
 
-extern const ActorInit Bg_Breakwall_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.h
+++ b/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.h
@@ -17,6 +17,4 @@ typedef struct BgDdanJd {
     /* 0x016C */ f32 targetY;
 } BgDdanJd; // size = 0x0170
 
-extern const ActorInit Bg_Ddan_Jd_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.h
+++ b/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.h
@@ -17,6 +17,4 @@ typedef struct BgDdanKd {
     /* 0x01C4 */ BgDdanKdActionFunc actionFunc;
 } BgDdanKd; // size = 0x01C8
 
-extern const ActorInit Bg_Ddan_Kd_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.h
+++ b/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.h
@@ -15,6 +15,4 @@ typedef struct BgDodoago {
     /* 0x024C */ BgDodoagoActionFunc actionFunc;
 } BgDodoago; // size = 0x0250
 
-extern const ActorInit Bg_Dodoago_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
@@ -70,6 +70,4 @@ typedef struct BgDyYoseizo {
     /* 0x0394 */ BgDyYoseizoParticle particles[200];
 } BgDyYoseizo; // size = 0x38B4
 
-extern const ActorInit Bg_Dy_Yoseizo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.h
+++ b/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.h
@@ -32,6 +32,4 @@ typedef struct BgGanonOtyuka {
     /* 0x0188 */ f32 flashEnvColorB;
 } BgGanonOtyuka; // size = 0x018C
 
-extern const ActorInit Bg_Ganon_Otyuka_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.h
@@ -16,6 +16,4 @@ typedef struct BgGateShutter {
     /* 0x0178 */ s16 unk_178;
 } BgGateShutter; // size = 0x017C
 
-extern const ActorInit Bg_Gate_Shutter_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.h
+++ b/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.h
@@ -13,6 +13,4 @@ typedef struct BgGjyoBridge {
     /* 0x0164 */ BgGjyoBridgeActionFunc actionFunc;
 } BgGjyoBridge; // size = 0x0168
 
-extern const ActorInit Bg_Gjyo_Bridge_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.h
@@ -29,6 +29,4 @@ typedef enum {
                                            and the timer sets flag N if either timer is above 64 frames. */
 } DarkmeiroType;
 
-extern const ActorInit Bg_Gnd_Darkmeiro_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.h
@@ -15,6 +15,4 @@ typedef struct BgGndFiremeiro {
     /* 0x0174 */ BgGndFiremeiroActionFunc actionFunc;
 } BgGndFiremeiro; // size = 0x0178
 
-extern const ActorInit Bg_Gnd_Firemeiro_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.h
@@ -14,6 +14,4 @@ typedef struct BgGndIceblock {
     /* 0x0168 */ Vec3f targetPos;
 } BgGndIceblock; // size = 0x0174
 
-extern const ActorInit Bg_Gnd_Iceblock_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Gnd_Nisekabe/z_bg_gnd_nisekabe.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Nisekabe/z_bg_gnd_nisekabe.h
@@ -10,6 +10,4 @@ typedef struct BgGndNisekabe {
     /* 0x0000 */ Actor actor;
 } BgGndNisekabe; // size = 0x014C
 
-extern const ActorInit Bg_Gnd_Nisekabe_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Gnd_Soulmeiro/z_bg_gnd_soulmeiro.h
+++ b/src/overlays/actors/ovl_Bg_Gnd_Soulmeiro/z_bg_gnd_soulmeiro.h
@@ -15,6 +15,4 @@ typedef struct BgGndSoulmeiro {
     /* 0x019C */ BgGndSoulmeiroActionFunc actionFunc;
 } BgGndSoulmeiro; // size = 0x01A0
 
-extern const ActorInit Bg_Gnd_Soulmeiro_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.h
+++ b/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.h
@@ -13,6 +13,4 @@ typedef struct BgHaka {
     /* 0x0164 */ BgHakaActionFunc actionFunc;
 } BgHaka; // size = 0x0168
 
-extern const ActorInit Bg_Haka_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.h
@@ -26,6 +26,4 @@ typedef enum {
     BGHAKAGATE_SKULL
 } BgHakaGateType;
 
-extern const ActorInit Bg_Haka_Gate_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_Huta/z_bg_haka_huta.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Huta/z_bg_haka_huta.h
@@ -15,6 +15,4 @@ typedef struct BgHakaHuta {
     /* 0x016A */ s16 unk_16A;
 } BgHakaHuta; // size = 0x016C
 
-extern const ActorInit Bg_Haka_Huta_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_Megane/z_bg_haka_megane.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Megane/z_bg_haka_megane.h
@@ -16,6 +16,4 @@ typedef struct BgHakaMegane {
     /* 0x016A */ char unk_16A[0x2];
 } BgHakaMegane; // size = 0x016C
 
-extern const ActorInit Bg_Haka_Megane_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.h
+++ b/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.h
@@ -15,6 +15,4 @@ typedef struct BgHakaMeganeBG {
     /* 0x016A */ s16 unk_16A;
 } BgHakaMeganeBG; // size = 0x016C
 
-extern const ActorInit Bg_Haka_Meganebg_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.h
@@ -20,6 +20,4 @@ typedef struct BgHakaSgami {
     /* 0x01C8 */ ColliderTrisElement colliderScytheItems[4];
 } BgHakaSgami; // size = 0x0338
 
-extern const ActorInit Bg_Haka_Sgami_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.h
@@ -17,6 +17,4 @@ typedef struct BgHakaShip {
     /* 0x016C */ Vec3f bellSoundPos;
 } BgHakaShip; // size = 0x0178
 
-extern const ActorInit Bg_Haka_Ship_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.h
@@ -29,6 +29,4 @@ typedef struct BgHakaTrap {
     /* 0x01E4 */ ColliderTrisElement colliderSpikesItem[2];
 } BgHakaTrap; // size = 0x029C
 
-extern const ActorInit Bg_Haka_Trap_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.h
@@ -17,6 +17,4 @@ typedef struct BgHakaTubo {
     /* 0x01B8 */ ColliderCylinder flamesCollider;
 } BgHakaTubo; // size = 0x0204
 
-extern const ActorInit Bg_Haka_Tubo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_Water/z_bg_haka_water.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Water/z_bg_haka_water.h
@@ -14,6 +14,4 @@ typedef struct BgHakaWater {
     /* 0x0150 */ u8 isLowered;
 } BgHakaWater; // size = 0x0154
 
-extern const ActorInit Bg_Haka_Water_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.h
@@ -17,6 +17,4 @@ typedef struct BgHakaZou {
     /* 0x016C */ ColliderCylinder collider;
 } BgHakaZou; // size = 0x01B8
 
-extern const ActorInit Bg_Haka_Zou_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.h
+++ b/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.h
@@ -24,6 +24,4 @@ typedef enum {
     /* 0x04 */ HEAVYBLOCK_UNBREAKABLE_OUTSIDE_CASTLE
 } HeavyBlockType;
 
-extern const ActorInit Bg_Heavy_Block_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Curtain/z_bg_hidan_curtain.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Curtain/z_bg_hidan_curtain.h
@@ -20,6 +20,4 @@ typedef struct BgHidanCurtain {
     /* 0x0158 */ ColliderCylinder collider;
 } BgHidanCurtain; // size = 0x01A4
 
-extern const ActorInit Bg_Hidan_Curtain_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.h
@@ -16,6 +16,4 @@ typedef struct BgHidanDalm {
     /* 0x018C */ ColliderTrisElement colliderItems[4];
 } BgHidanDalm; // size = 0x02FC
 
-extern const ActorInit Bg_Hidan_Dalm_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.h
@@ -15,6 +15,4 @@ typedef struct BgHidanFslift {
     /* 0x016A */ s16 unk_16A;
 } BgHidanFslift; // size = 0x016C
 
-extern const ActorInit Bg_Hidan_Fslift_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Fwbig/z_bg_hidan_fwbig.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Fwbig/z_bg_hidan_fwbig.h
@@ -17,6 +17,4 @@ typedef struct BgHidanFwbig {
     /* 0x0154 */ ColliderCylinder collider;
 } BgHidanFwbig; // size = 0x01A0
 
-extern const ActorInit Bg_Hidan_Fwbig_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.h
@@ -17,6 +17,4 @@ typedef struct BgHidanHamstep {
     /* 0x0244 */ s32 unk_244;
 } BgHidanHamstep; // size = 0x0248
 
-extern const ActorInit Bg_Hidan_Hamstep_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.h
@@ -17,6 +17,4 @@ typedef struct BgHidanHrock {
     /* 0x018C */ ColliderTrisElement colliderItems[2];
 } BgHidanHrock; // size = 0x0244
 
-extern const ActorInit Bg_Hidan_Hrock_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.h
@@ -14,6 +14,4 @@ typedef struct BgHidanKousi {
     /* 0x0168 */ s16 unk_168;
 } BgHidanKousi; // size = 0x016C
 
-extern const ActorInit Bg_Hidan_Kousi_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.h
@@ -12,6 +12,4 @@ typedef struct BgHidanKowarerukabe {
     /* 0x0184 */ ColliderJntSphElement colliderItems[1];
 } BgHidanKowarerukabe; // size = 0x01C4
 
-extern const ActorInit Bg_Hidan_Kowarerukabe_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.h
@@ -19,6 +19,4 @@ typedef struct BgHidanRock {
     /* 0x017C */ ColliderCylinder collider;
 } BgHidanRock; // size = 0x01C8
 
-extern const ActorInit Bg_Hidan_Rock_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.h
@@ -14,6 +14,4 @@ typedef struct BgHidanRsekizou {
     /* 0x0188 */ ColliderJntSphElement colliderItems[6];
 } BgHidanRsekizou; // size = 0x0308
 
-extern const ActorInit Bg_Hidan_Rsekizou_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.h
@@ -11,6 +11,4 @@ typedef struct BgHidanSekizou {
     /* 0x014C */ char unk_14C[0x1C8];
 } BgHidanSekizou; // size = 0x0314
 
-extern const ActorInit Bg_Hidan_Sekizou_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.h
@@ -16,6 +16,4 @@ typedef struct BgHidanSima {
     /* 0x018C */ ColliderJntSphElement elements[2];
 } BgHidanSima; // size = 0x020C
 
-extern const ActorInit Bg_Hidan_Sima_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.h
+++ b/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.h
@@ -15,6 +15,4 @@ typedef struct BgHidanSyoku {
     /* 0x016A */ s16 timer;
 } BgHidanSyoku; // size = 0x016C
 
-extern const ActorInit Bg_Hidan_Syoku_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.h
+++ b/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.h
@@ -14,6 +14,4 @@ typedef struct BgIceObjects {
     /* 0x0168 */ Vec3f targetPos;
 } BgIceObjects; // size = 0x0174
 
-extern const ActorInit Bg_Ice_Objects_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.h
+++ b/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.h
@@ -16,6 +16,4 @@ typedef struct BgIceShelter {
     /* 0x0200 */ s16 alpha;
 } BgIceShelter; // size = 0x0204
 
-extern const ActorInit Bg_Ice_Shelter_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.h
@@ -13,6 +13,4 @@ typedef struct BgIceShutter {
     /* 0x0164 */ BgIceShutterActionFunc actionFunc;
 } BgIceShutter; // size = 0x0168
 
-extern const ActorInit Bg_Ice_Shutter_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.h
+++ b/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.h
@@ -21,6 +21,4 @@ typedef struct BgIceTurara {
     /* 0x016C */ ColliderCylinder collider;
 } BgIceTurara; // size = 0x01B8
 
-extern const ActorInit Bg_Ice_Turara_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.h
+++ b/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.h
@@ -13,6 +13,4 @@ typedef struct BgInGate {
     /* 0x0164 */ BgInGateActionFunc actionFunc;
 } BgInGate; // size = 0x0168
 
-extern const ActorInit Bg_Ingate_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.h
+++ b/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.h
@@ -18,6 +18,4 @@ typedef struct BgJya1flift {
     /* 0x01B8 */ u8 isLinkRiding;
 } BgJya1flift; // size = 0x01BC
 
-extern const ActorInit Bg_Jya_1flift_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.h
@@ -13,6 +13,4 @@ typedef struct BgJyaAmishutter {
     /* 0x0164 */ BgJyaAmishutterActionFunc actionFunc;
 } BgJyaAmishutter; // size = 0x0168
 
-extern const ActorInit Bg_Jya_Amishutter_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.h
@@ -29,6 +29,4 @@ typedef struct BgJyaBigmirror {
     /* 0x0170 */ f32 liftHeight;
 } BgJyaBigmirror; // size = 0x0174
 
-extern const ActorInit Bg_Jya_Bigmirror_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Block/z_bg_jya_block.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Block/z_bg_jya_block.h
@@ -10,6 +10,4 @@ typedef struct BgJyaBlock {
     /* 0x0000 */ DynaPolyActor dyna;
 } BgJyaBlock; // size = 0x0164
 
-extern const ActorInit Bg_Jya_Block_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h
@@ -18,6 +18,4 @@ typedef struct BgJyaBombchuiwa {
     /* 0x01B6 */ u8 drawFlags; // Used to determine how the actor is drawn.
 } BgJyaBombchuiwa; // size = 0x01B8
 
-extern const ActorInit Bg_Jya_Bombchuiwa_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Bombiwa/z_bg_jya_bombiwa.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombiwa/z_bg_jya_bombiwa.h
@@ -14,6 +14,4 @@ typedef struct BgJyaBombiwa {
     /* 0x0188 */ ColliderJntSphElement colliderItems[1];
 } BgJyaBombiwa; // size = 0x01C8
 
-extern const ActorInit Bg_Jya_Bombiwa_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.h
@@ -24,6 +24,4 @@ typedef struct BgJyaCobra {
     /* 0x0194 */ u8 shadowTexture[0x1010];
 } BgJyaCobra; // size = 0x11A4
 
-extern const ActorInit Bg_Jya_Cobra_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.h
@@ -19,6 +19,4 @@ typedef struct BgJyaGoroiwa {
     /* 0x01B8 */ f32 yOffsetSpeed;
 } BgJyaGoroiwa; // size = 0x01BC
 
-extern const ActorInit Bg_Jya_Goroiwa_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.h
@@ -16,6 +16,4 @@ typedef struct BgJyaHaheniron {
     /* 0x01B0 */ s16 timer;
 } BgJyaHaheniron; // size = 0x01B4
 
-extern const ActorInit Bg_Jya_Haheniron_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.h
@@ -14,6 +14,4 @@ typedef struct BgJyaIronobj {
     /* 0x0168 */ ColliderCylinder colCylinder;
 } BgJyaIronobj; // size = 0x01B4
 
-extern const ActorInit Bg_Jya_Ironobj_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.h
@@ -15,6 +15,4 @@ typedef struct BgJyaLift {
     /* 0x16B */ u8 unk_16B;
 } BgJyaLift; // size = 0x016C
 
-extern const ActorInit Bg_Jya_Lift_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.h
@@ -26,6 +26,4 @@ typedef struct BgJyaMegami {
     /* 0x01D0 */ BgJyaMegamiPiece pieces[13];
 } BgJyaMegami; // size = 0x033C
 
-extern const ActorInit Bg_Jya_Megami_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Jya_Zurerukabe/z_bg_jya_zurerukabe.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Zurerukabe/z_bg_jya_zurerukabe.h
@@ -17,6 +17,4 @@ typedef struct BgJyaZurerukabe {
     /* 0x016E */ s16 unk_16E;
 } BgJyaZurerukabe; // size = 0x0170
 
-extern const ActorInit Bg_Jya_Zurerukabe_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.h
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.h
@@ -13,6 +13,4 @@ typedef struct BgMenkuriEye {
     /* 0x0170 */ ColliderJntSphElement colliderItems[1];
 } BgMenkuriEye; // size = 0x01B0
 
-extern const ActorInit Bg_Menkuri_Eye_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Menkuri_Kaiten/z_bg_menkuri_kaiten.h
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Kaiten/z_bg_menkuri_kaiten.h
@@ -10,6 +10,4 @@ typedef struct BgMenkuriKaiten {
     /* 0x0000 */ DynaPolyActor dyna;
 } BgMenkuriKaiten; // size = 0x0164
 
-extern const ActorInit Bg_Menkuri_Kaiten_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.h
@@ -31,6 +31,4 @@ typedef enum {
     MIZUBWALL_STINGER_ROOM_2
 } BgMizuBwallType;
 
-extern const ActorInit Bg_Mizu_Bwall_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.h
@@ -21,6 +21,4 @@ typedef struct BgMizuMovebg {
     /* 0x0184 */ s32 waypointId;
 } BgMizuMovebg; // size = 0x0188
 
-extern const ActorInit Bg_Mizu_Movebg_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.h
@@ -26,6 +26,4 @@ typedef enum BgMizuShutterSize {
     BGMIZUSHUTTER_LARGE
 } BgMizuShutterSize;
 
-extern const ActorInit Bg_Mizu_Shutter_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mizu_Uzu/z_bg_mizu_uzu.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Uzu/z_bg_mizu_uzu.h
@@ -13,6 +13,4 @@ typedef struct BgMizuUzu {
     /* 0x0164 */ BgMizuUzuActionFunc actionFunc;
 } BgMizuUzu; // size = 0x0168
 
-extern const ActorInit Bg_Mizu_Uzu_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.h
@@ -17,8 +17,6 @@ typedef struct BgMizuWater {
     /* 0x015C */ s32 switchFlag; // only used for types 2-4
 } BgMizuWater; // size = 0x0160
 
-extern const ActorInit Bg_Mizu_Water_InitVars;
-
 #define WATER_TEMPLE_WATER_F3_Y 765.0f
 #define WATER_TEMPLE_WATER_F2_Y 445.0f
 #define WATER_TEMPLE_WATER_F1_Y -15.0f

--- a/src/overlays/actors/ovl_Bg_Mjin/z_bg_mjin.h
+++ b/src/overlays/actors/ovl_Bg_Mjin/z_bg_mjin.h
@@ -14,6 +14,4 @@ typedef struct BgMjin {
     /* 0x0168 */ BgMjinActionFunc actionFunc;
 } BgMjin; // size = 0x016C
 
-extern const ActorInit Bg_Mjin_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.h
@@ -15,6 +15,4 @@ typedef struct BgMoriBigst {
     /* 0x016A */ s8 moriTexObjIndex;
 } BgMoriBigst; // size = 0x016C
 
-extern const ActorInit Bg_Mori_Bigst_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.h
@@ -18,6 +18,4 @@ typedef struct BgMoriElevator {
     /* 0x0172 */ s16 unk_172;
 } BgMoriElevator; // size = 0x0174
 
-extern const ActorInit Bg_Mori_Elevator_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.h
@@ -23,6 +23,4 @@ typedef enum {
     /*  0  */ HASHIGO_LADDER
 } HasigoType;
 
-extern const ActorInit Bg_Mori_Hashigo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.h
@@ -16,6 +16,4 @@ typedef struct BgMoriHashira4 {
     /* 0x016A */ s16 gateTimer;
 } BgMoriHashira4; // size = 0x016C
 
-extern const ActorInit Bg_Mori_Hashira4_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mori_Hineri/z_bg_mori_hineri.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Hineri/z_bg_mori_hineri.h
@@ -17,6 +17,4 @@ typedef struct BgMoriHineri {
     /* 0x016B */ s8 switchFlag;
 } BgMoriHineri; // size = 0x016C
 
-extern const ActorInit Bg_Mori_Hineri_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mori_Idomizu/z_bg_mori_idomizu.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Idomizu/z_bg_mori_idomizu.h
@@ -18,6 +18,4 @@ typedef struct BgMoriIdomizu {
     /* 0x015C */ s8 moriTexObjIndex;
 } BgMoriIdomizu; // size = 0x0160
 
-extern const ActorInit Bg_Mori_Idomizu_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.h
@@ -19,6 +19,4 @@ typedef struct BgMoriKaitenkabe {
     /* 0x0184 */ s8 moriTexObjIndex;
 } BgMoriKaitenkabe; // size = 0x0188
 
-extern const ActorInit Bg_Mori_Kaitenkabe_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Mori_Rakkatenjo/z_bg_mori_rakkatenjo.h
+++ b/src/overlays/actors/ovl_Bg_Mori_Rakkatenjo/z_bg_mori_rakkatenjo.h
@@ -17,6 +17,4 @@ typedef struct BgMoriRakkatenjo {
     /* 0x0174 */ s8 moriTexObjIndex;
 } BgMoriRakkatenjo; // size = 0x0178
 
-extern const ActorInit Bg_Mori_Rakkatenjo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.h
+++ b/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.h
@@ -19,6 +19,4 @@ typedef struct BgPoEvent {
     /* 0x0190 */ ColliderTrisElement colliderItems[2];
 } BgPoEvent; // size = 0x0248
 
-extern const ActorInit Bg_Po_Event_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Po_Syokudai/z_bg_po_syokudai.h
+++ b/src/overlays/actors/ovl_Bg_Po_Syokudai/z_bg_po_syokudai.h
@@ -15,6 +15,4 @@ typedef struct BgPoSyokudai {
     /* 0x0164 */ ColliderCylinder collider;
 } BgPoSyokudai; // size = 0x01B0
 
-extern const ActorInit Bg_Po_Syokudai_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.h
+++ b/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.h
@@ -13,6 +13,4 @@ typedef struct BgPushbox {
     /* 0x0164 */ BgPushboxActionFunc actionFunc;
 } BgPushbox; // size = 0x0168
 
-extern const ActorInit Bg_Pushbox_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.h
+++ b/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.h
@@ -16,6 +16,4 @@ typedef struct BgRelayObjects {
     /* 0x016A */ s16 timer;
 } BgRelayObjects; // size = 0x016C
 
-extern const ActorInit Bg_Relay_Objects_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.h
+++ b/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.h
@@ -16,6 +16,4 @@ typedef struct BgSpot00Hanebasi {
     /* 0x0170 */ LightInfo lightInfo;
 } BgSpot00Hanebasi; // size = 0x0180
 
-extern const ActorInit Bg_Spot00_Hanebasi_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot01_Fusya/z_bg_spot01_fusya.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Fusya/z_bg_spot01_fusya.h
@@ -17,6 +17,4 @@ typedef struct BgSpot01Fusya {
     /* 0x015C */ f32 unk_15C;
 } BgSpot01Fusya; // size = 0x0160
 
-extern const ActorInit Bg_Spot01_Fusya_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot01_Idohashira/z_bg_spot01_idohashira.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idohashira/z_bg_spot01_idohashira.h
@@ -17,6 +17,4 @@ typedef struct BgSpot01Idohashira {
     /* 0x0170 */ s32 unk_170;
 } BgSpot01Idohashira; // size = 0x0174
 
-extern const ActorInit Bg_Spot01_Idohashira_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot01_Idomizu/z_bg_spot01_idomizu.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idomizu/z_bg_spot01_idomizu.h
@@ -15,6 +15,4 @@ typedef struct BgSpot01Idomizu {
     /* 0x0154 */ char unk_154[0x4];
 } BgSpot01Idomizu; // size = 0x0158
 
-extern const ActorInit Bg_Spot01_Idomizu_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot01_Idosoko/z_bg_spot01_idosoko.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idosoko/z_bg_spot01_idosoko.h
@@ -13,6 +13,4 @@ typedef struct BgSpot01Idosoko {
     /* 0x0164 */ BgSpot01IdosokoActionFunc actionFunc;
 } BgSpot01Idosoko; // size = 0x0168
 
-extern const ActorInit Bg_Spot01_Idosoko_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot01_Objects2/z_bg_spot01_objects2.h
+++ b/src/overlays/actors/ovl_Bg_Spot01_Objects2/z_bg_spot01_objects2.h
@@ -16,6 +16,4 @@ typedef struct BgSpot01Objects2 {
     /* 0x017C */ s8 objBankIndex;
 } BgSpot01Objects2; // size = 0x0180
 
-extern const ActorInit Bg_Spot01_Objects2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.h
+++ b/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.h
@@ -19,6 +19,4 @@ typedef struct BgSpot02Objects {
     /* 0x0172 */ u16 unk_172;
 } BgSpot02Objects; // size = 0x0174
 
-extern const ActorInit Bg_Spot02_Objects_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.h
+++ b/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.h
@@ -26,6 +26,4 @@ typedef struct BgSpot03Taki {
     /* 0x0174 */ u8 bufferIndex;
 } BgSpot03Taki; // size = 0x0178
 
-extern const ActorInit Bg_Spot03_Taki_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.h
+++ b/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.h
@@ -14,6 +14,4 @@ typedef struct BgSpot05Soko {
     /* 0x0168 */ s32 switchFlag;
 } BgSpot05Soko; // size = 0x016C
 
-extern const ActorInit Bg_Spot05_Soko_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.h
+++ b/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.h
@@ -18,6 +18,4 @@ typedef struct BgSpot06Objects {
     /* 0x0190 */ ColliderJntSphElement colliderItem[1];
 } BgSpot06Objects; // size = 0x01D0
 
-extern const ActorInit Bg_Spot06_Objects_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot07_Taki/z_bg_spot07_taki.h
+++ b/src/overlays/actors/ovl_Bg_Spot07_Taki/z_bg_spot07_taki.h
@@ -13,6 +13,4 @@ typedef struct BgSpot07Taki {
     /* 0x0164 */ BgSpot07TakiActionFunc  actionFunc;
 } BgSpot07Taki; // size = 0x0168
 
-extern const ActorInit Bg_Spot07_Taki_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot08_Bakudankabe/z_bg_spot08_bakudankabe.h
+++ b/src/overlays/actors/ovl_Bg_Spot08_Bakudankabe/z_bg_spot08_bakudankabe.h
@@ -12,6 +12,4 @@ typedef struct BgSpot08Bakudankabe {
     /* 0x0184 */ ColliderJntSphElement colliderItems[3];
 } BgSpot08Bakudankabe; // size = 0x0244
 
-extern const ActorInit Bg_Spot08_Bakudankabe_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot08_Iceblock/z_bg_spot08_iceblock.h
+++ b/src/overlays/actors/ovl_Bg_Spot08_Iceblock/z_bg_spot08_iceblock.h
@@ -22,8 +22,6 @@ typedef struct BgSpot08Iceblock {
     /* 0x0198 */ f32 bobOffset;
 } BgSpot08Iceblock; // size = 0x019C
 
-extern const ActorInit Bg_Spot08_Iceblock_InitVars;
-
 // Params
 /**
  * 0x200: Shape

--- a/src/overlays/actors/ovl_Bg_Spot09_Obj/z_bg_spot09_obj.h
+++ b/src/overlays/actors/ovl_Bg_Spot09_Obj/z_bg_spot09_obj.h
@@ -11,6 +11,4 @@ typedef struct BgSpot09Obj {
     /* 0x0164 */ char unk_164[0x04];
 } BgSpot09Obj; // size = 0x0168
 
-extern const ActorInit Bg_Spot09_Obj_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot11_Bakudankabe/z_bg_spot11_bakudankabe.h
+++ b/src/overlays/actors/ovl_Bg_Spot11_Bakudankabe/z_bg_spot11_bakudankabe.h
@@ -11,6 +11,4 @@ typedef struct BgSpot11Bakudankabe {
     /* 0x0164 */ ColliderCylinder collider;
 } BgSpot11Bakudankabe; // size = 0x01B0
 
-extern const ActorInit Bg_Spot11_Bakudankabe_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot11_Oasis/z_bg_spot11_oasis.h
+++ b/src/overlays/actors/ovl_Bg_Spot11_Oasis/z_bg_spot11_oasis.h
@@ -15,6 +15,4 @@ typedef struct BgSpot11Oasis {
     /* 0x0151 */ u8 unk_151;
 } BgSpot11Oasis; // size = 0x0154
 
-extern const ActorInit Bg_Spot11_Oasis_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.h
+++ b/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.h
@@ -14,6 +14,4 @@ typedef struct BgSpot12Gate {
     /* 0x0168 */ s16 unk_168;
 } BgSpot12Gate; // size = 0x016C
 
-extern const ActorInit Bg_Spot12_Gate_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.h
+++ b/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.h
@@ -14,6 +14,4 @@ typedef struct BgSpot12Saku {
     /* 0x0168 */ s16 timer;
 } BgSpot12Saku; // size = 0x016C
 
-extern const ActorInit Bg_Spot12_Saku_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.h
+++ b/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.h
@@ -20,6 +20,4 @@ typedef struct BgSpot15Rrbox {
     /* 0x0180 */ s32 bgId; // Id of BgActor beneath the box
 } BgSpot15Rrbox; // size = 0x0184
 
-extern const ActorInit Bg_Spot15_Rrbox_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot15_Saku/z_bg_spot15_saku.h
+++ b/src/overlays/actors/ovl_Bg_Spot15_Saku/z_bg_spot15_saku.h
@@ -16,6 +16,4 @@ typedef struct BgSpot15Saku {
     /* 0x017C */ s16 timer;
 } BgSpot15Saku; // size = 0x0180
 
-extern const ActorInit Bg_Spot15_Saku_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.h
+++ b/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.h
@@ -25,6 +25,4 @@ typedef struct BgSpot16Bombstone {
     /* 0x0214 */ s8 bombiwaBankIndex;
 } BgSpot16Bombstone; // size = 0x0218
 
-extern const ActorInit Bg_Spot16_Bombstone_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.h
+++ b/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.h
@@ -13,6 +13,4 @@ typedef struct BgSpot16Doughnut {
     /* 0x0150 */ u8 envColorAlpha;
 } BgSpot16Doughnut; // size = 0x0154
 
-extern const ActorInit Bg_Spot16_Doughnut_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.h
+++ b/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.h
@@ -10,6 +10,4 @@ typedef struct BgSpot17Bakudankabe {
     /* 0x0000 */ DynaPolyActor dyna;
 } BgSpot17Bakudankabe; // size = 0x0164
 
-extern const ActorInit Bg_Spot17_Bakudankabe_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.h
+++ b/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.h
@@ -10,6 +10,4 @@ typedef struct BgSpot17Funen {
     /* 0x0000 */ Actor actor;
 } BgSpot17Funen; // size = 0x014C
 
-extern const ActorInit Bg_Spot17_Funen_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.h
+++ b/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.h
@@ -25,7 +25,5 @@ typedef struct BgSpot18Basket {
     /* 0x021B */ u8 unk_21B;
 } BgSpot18Basket; // size = 0x021C
 
-extern const ActorInit Bg_Spot18_Basket_InitVars;
-
 #endif
 

--- a/src/overlays/actors/ovl_Bg_Spot18_Futa/z_bg_spot18_futa.h
+++ b/src/overlays/actors/ovl_Bg_Spot18_Futa/z_bg_spot18_futa.h
@@ -9,6 +9,4 @@ struct BgSpot18Futa;
 typedef struct BgSpot18Futa {
     /* 0x0000 */ DynaPolyActor dyna;
 } BgSpot18Futa; // size = 0x0164
-
-extern const ActorInit Bg_Spot18_Futa_InitVars;
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.h
+++ b/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.h
@@ -15,6 +15,4 @@ typedef struct BgSpot18Obj {
     /* 0x0168 */ s16 unk_168;
 } BgSpot18Obj; // size = 0x016C
 
-extern const ActorInit Bg_Spot18_Obj_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.h
@@ -13,6 +13,4 @@ typedef struct BgSpot18Shutter {
     /* 0x0164 */ BgSpot18ShutterActionFunc actionFunc;
 } BgSpot18Shutter; // size = 0x0168
 
-extern const ActorInit Bg_Spot18_Shutter_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.h
+++ b/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.h
@@ -18,6 +18,4 @@ typedef enum {
     /* 1 */ BONGOFLOOR_HIT
 } BgSstFloorParams;
 
-extern const ActorInit Bg_Sst_Floor_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.h
+++ b/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.h
@@ -14,6 +14,4 @@ typedef struct BgTokiHikari {
     /* 0x0150 */ BgTokiHikariActionFunc actionFunc; 
 } BgTokiHikari; // size = 0x0154
 
-extern const ActorInit Bg_Toki_Hikari_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.h
+++ b/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.h
@@ -14,6 +14,4 @@ typedef struct BgTokiSwd {
     /* 0x0150 */ ColliderCylinder collider;
 } BgTokiSwd; // size = 0x019C
 
-extern const ActorInit Bg_Toki_Swd_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.h
+++ b/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.h
@@ -15,6 +15,4 @@ typedef struct BgTreemouth {
     /* 0x016C */ BgTreemouthActionFunc actionFunc;
 } BgTreemouth; // size = 0x0170
 
-extern const ActorInit Bg_Treemouth_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Umajump/z_bg_umajump.h
+++ b/src/overlays/actors/ovl_Bg_Umajump/z_bg_umajump.h
@@ -10,6 +10,4 @@ typedef struct BgUmaJump {
     /* 0x0000 */ DynaPolyActor dyna;
 } BgUmaJump; // size = 0x0164
 
-extern const ActorInit Bg_Uma_Jump_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Vb_Sima/z_bg_vb_sima.h
+++ b/src/overlays/actors/ovl_Bg_Vb_Sima/z_bg_vb_sima.h
@@ -19,6 +19,4 @@ typedef struct BgVbSima {
     /* 0x0176 */ char unk_176[6];
 } BgVbSima; // size = 0x017C
 
-extern const ActorInit Bg_Vb_Sima_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ydan_Hasi/z_bg_ydan_hasi.h
+++ b/src/overlays/actors/ovl_Bg_Ydan_Hasi/z_bg_ydan_hasi.h
@@ -21,6 +21,4 @@ typedef enum {
     /* 2 */ HASI_THREE_BLOCKS
 } HasiType;
 
-extern const ActorInit Bg_Ydan_Hasi_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.h
+++ b/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.h
@@ -17,6 +17,4 @@ typedef struct BgYdanMaruta {
     /* 0x018C */ ColliderTrisElement elements[2];
 } BgYdanMaruta; // size = 0x0244
 
-extern const ActorInit Bg_Ydan_Maruta_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.h
+++ b/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.h
@@ -19,6 +19,4 @@ typedef struct BgYdanSp {
     /* 0x0190 */ ColliderTrisElement trisColliderItems[2];
 } BgYdanSp; // size = 0x0248
 
-extern const ActorInit Bg_Ydan_Sp_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.h
+++ b/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.h
@@ -15,6 +15,4 @@ typedef struct BgZg {
     /* 0x0168 */ s32 drawConfig;
 } BgZg; // size = 0x016C
 
-extern const ActorInit Bg_Zg_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.h
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.h
@@ -98,6 +98,4 @@ typedef struct BossDodongo {
     /* 0x0920 */ BossDodongoEffect effects[80];
 } BossDodongo; // size = 0x1820
 
-extern const ActorInit Boss_Dodongo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.h
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.h
@@ -182,6 +182,4 @@ typedef struct BossFd {
     /* 0x1970 */ BossFdEffect effects[180];
 } BossFd; // size = 0x43A0
 
-extern const ActorInit Boss_Fd_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.h
+++ b/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.h
@@ -89,6 +89,4 @@ typedef struct BossFd2 {
     /* 0x143C */ ColliderJntSphElement elements[9];
 } BossFd2; // size = 0x167C
 
-extern const ActorInit Boss_Fd2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.h
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.h
@@ -17,6 +17,4 @@ typedef struct BossGanon {
     /* 0x071A */ char unk_71A[0x2];
 } BossGanon; // size = 0x071C
 
-extern const ActorInit Boss_Ganon_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.h
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.h
@@ -94,6 +94,4 @@ typedef struct BossGanon2 {
     /* 0x0864 */ ColliderJntSphElement unk_864[2];
 } BossGanon2; // size = 0x08E4
 
-extern const ActorInit Boss_Ganon2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
@@ -101,6 +101,4 @@ typedef struct BossGanondrof {
     /* 0x052C */ ColliderCylinder colliderSpear;
 } BossGanondrof; // size = 0x0578
 
-extern const ActorInit Boss_Ganondrof_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.h
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.h
@@ -153,6 +153,4 @@ typedef struct BossGoma {
     /* 0x07DC */ ColliderJntSphElement colliderItems[13];
 } BossGoma; // size = 0x0B1C
 
-extern const ActorInit Boss_Goma_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.h
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.h
@@ -132,6 +132,4 @@ typedef struct BossMo {
 #define BOSSMO_CORE -1
 #define BOSSMO_TENTACLE 100
 
-extern const ActorInit Boss_Mo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
@@ -59,6 +59,4 @@ typedef enum {
     /*  1 */ BONGO_RIGHT_HAND
 } BossSstType;
 
-extern const ActorInit Boss_Sst_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.h
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.h
@@ -135,6 +135,4 @@ typedef struct BossTw {
     /* 0x06B0 */ f32 subCamYawStep;
 } BossTw; // size = 0x06B4
 
-extern const ActorInit Boss_Tw_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
@@ -71,6 +71,4 @@ typedef enum {
     /* 19 */ BOSSVA_DOOR
 } BossVaParam;
 
-extern const ActorInit Boss_Va_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_6K/z_demo_6k.h
+++ b/src/overlays/actors/ovl_Demo_6K/z_demo_6k.h
@@ -31,6 +31,4 @@ typedef struct Demo6K {
     /* 0x0293 */ u8 unk_293;
 } Demo6K; // size = 0x0294
 
-extern const ActorInit Demo_6k_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.h
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.h
@@ -21,8 +21,6 @@ typedef struct DemoDu {
     /* 0x01B0 */ s32 lastAction;
 } DemoDu; // size = 0x01B4
 
-extern const ActorInit Demo_Du_InitVars;
-
 // This is the parameter of this actor,
 typedef enum DemoDu_Cutscene {
     /* 0x00 */ DEMO_DU_CS_FIREMEDALLION, // default

--- a/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.h
+++ b/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.h
@@ -22,6 +22,4 @@ typedef struct DemoEc {
     /* 0x01A4 */ s32 animObjBankIndex;
 } DemoEc; // size = 0x01A8
 
-extern const ActorInit Demo_Ec_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.h
+++ b/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.h
@@ -23,6 +23,4 @@ typedef struct DemoExt {
     /* 0x0178 */ Vec3f scale;
 } DemoExt; // size = 0x0184
 
-extern const ActorInit Demo_Ext_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.h
+++ b/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.h
@@ -23,6 +23,4 @@ typedef struct DemoGeff {
     /* 0x0164 */ f32 deltaPosZ;
 } DemoGeff; // size = 0x0168
 
-extern const ActorInit Demo_Geff_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.h
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.h
@@ -22,8 +22,6 @@ typedef struct DemoGj {
     /* 0x026C */ Vec3f unk_26C; // This actor never sets this. Specifies which direction will this actor explode when killed using `killFlag`.
 } DemoGj; // size = 0x0278
 
-extern const ActorInit Demo_Gj_InitVars;
-
 /**
  * The format of this actor's params is the following:
  * bits 11-15: The collectible that will be dropped when killed.

--- a/src/overlays/actors/ovl_Demo_Go/z_demo_go.h
+++ b/src/overlays/actors/ovl_Demo_Go/z_demo_go.h
@@ -19,6 +19,4 @@ typedef struct DemoGo {
     /* 0x019C */ f32 unk_19C;
 } DemoGo; // size = 0x01A0
 
-extern const ActorInit Demo_Go_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.h
+++ b/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.h
@@ -21,6 +21,4 @@ typedef struct DemoGt {
     /* 0x0198 */ s32 unk_198[4];
 } DemoGt; // size = 0x01A8
 
-extern const ActorInit Demo_Gt_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.h
+++ b/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.h
@@ -19,6 +19,4 @@ typedef struct DemoIk {
     /* 0x01B0 */ s32 csAction;
 } DemoIk; // size = 0x01B4
 
-extern const ActorInit Demo_Ik_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.h
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.h
@@ -30,6 +30,4 @@ typedef struct DemoIm {
     /* 0x02D4 */ struct_80034A14_arg1 unk_2D4;
 } DemoIm; // size = 0x02FC
 
-extern const ActorInit Demo_Im_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.h
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.h
@@ -49,6 +49,4 @@ typedef struct DemoKankyo {
     /* 0x0600 */ DemoKankyoActionFunc actionFunc;
 } DemoKankyo; // size = 0x0604
 
-extern const ActorInit Demo_Kankyo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.h
+++ b/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.h
@@ -21,8 +21,6 @@ typedef struct DemoKekkai {
     /* 0x01F8 */ DemoKekkaiUpdateFunc updateFunc;
 } DemoKekkai; // size = 0x01FC
 
-extern const ActorInit Demo_Kekkai_InitVars;
-
 typedef enum {
     /* 0 */ KEKKAI_TOWER,
     /* 1 */ KEKKAI_WATER,

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.h
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.h
@@ -24,6 +24,4 @@ typedef struct DemoSa {
     /* 0x01B0 */ s32 unk_1B0;
 } DemoSa; // size = 0x01B4
 
-extern const ActorInit Demo_Sa_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.h
+++ b/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.h
@@ -15,6 +15,4 @@ typedef struct DemoShd {
     /* 0x0150 */ DemoShdActionFunc actionFunc;
 } DemoShd; // size = 0x0154
 
-extern const ActorInit Demo_Shd_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.h
+++ b/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.h
@@ -22,6 +22,4 @@ typedef enum {
     /* 0x01 */ DEMO_TRE_LGT_ACTION_ANIMATE
 } DemoTreLgtAction;
 
-extern const ActorInit Demo_Tre_Lgt_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.h
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.h
@@ -14,6 +14,4 @@ typedef struct DoorAna {
     /* 0x0198 */ DoorAnaActionFunc actionFunc;
 } DoorAna; // size = 0x019C
 
-extern const ActorInit Door_Ana_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.h
+++ b/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.h
@@ -15,6 +15,4 @@ typedef struct DoorGerudo {
     /* 0x0168 */ DoorGerudoActionFunc actionFunc;
 } DoorGerudo; // size = 0x016C
 
-extern const ActorInit Door_Gerudo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.h
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.h
@@ -35,6 +35,4 @@ typedef struct DoorKiller {
     /* 0x0280 */ DoorKillerActionFunc actionFunc;
 } DoorKiller; // size = 0x0284
 
-extern const ActorInit Door_Killer_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.h
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.h
@@ -58,6 +58,4 @@ typedef struct DoorShutter {
     /* 0x0174 */ DoorShutterActionFunc actionFunc;
 } DoorShutter; // size = 0x0178
 
-extern const ActorInit Door_Shutter_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Door_Toki/z_door_toki.h
+++ b/src/overlays/actors/ovl_Door_Toki/z_door_toki.h
@@ -11,6 +11,4 @@ typedef struct DoorToki {
     /* 0x0164 */ char unk_164[0x4];
 } DoorToki; // size = 0x0168
 
-extern const ActorInit Door_Toki_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.h
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.h
@@ -14,6 +14,4 @@ typedef struct DoorWarp1 {
     /* 0x01EC */ s32 unk_1EC;
 } DoorWarp1; // size = 0x01F0
 
-extern const ActorInit Door_Warp1_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.h
+++ b/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.h
@@ -34,6 +34,4 @@ typedef struct EfcErupc {
     /* 0x18C8 */ EfcErupcActionFunc actionFunc;
 } EfcErupc; // size = 0x18CC
 
-extern const ActorInit Efc_Erupc_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.h
+++ b/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.h
@@ -31,6 +31,4 @@ typedef enum {
     /* 0x04 */ EFF_DUST_TYPE_4
 } EffDustType;
 
-extern const ActorInit Eff_Dust_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.h
+++ b/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.h
@@ -13,6 +13,4 @@ typedef struct ElfMsg {
     /* 0x014C */ ElfMsgActionFunc actionFunc;
 } ElfMsg; // size = 0x0150
 
-extern const ActorInit Elf_Msg_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.h
+++ b/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.h
@@ -13,6 +13,4 @@ typedef struct ElfMsg2 {
     /* 0x014C */ ElfMsg2ActionFunc  actionFunc;
 } ElfMsg2; // size = 0x0150
 
-extern const ActorInit Elf_Msg2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Am/z_en_am.h
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.h
@@ -35,6 +35,4 @@ typedef enum {
     /* 1 */ ARMOS_ENEMY
 } ArmosType;
 
-extern const ActorInit En_Am_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.h
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.h
@@ -23,6 +23,4 @@ typedef struct EnAni {
     /* 0x02B0 */ EnAniActionFunc actionFunc;
 } EnAni; // size = 0x02B4
 
-extern const ActorInit En_Ani_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Anubice/z_en_anubice.h
+++ b/src/overlays/actors/ovl_En_Anubice/z_en_anubice.h
@@ -39,6 +39,4 @@ typedef struct EnAnubice {
     /* 0x02C8 */ ColliderCylinder col;
 } EnAnubice; // size = 0x0314
 
-extern const ActorInit En_Anubice_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.h
+++ b/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.h
@@ -21,6 +21,4 @@ typedef struct EnAnubiceFire {
     /* 0x01A8 */ ColliderCylinder cylinder;
 } EnAnubiceFire; // size = 0x01F4
 
-extern const ActorInit En_Anubice_Fire_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.h
+++ b/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.h
@@ -16,6 +16,4 @@ typedef struct EnAnubiceTag {
     /* 0x0154 */ f32 triggerRange;
 } EnAnubiceTag; // size = 0x0158
 
-extern const ActorInit En_Anubice_Tag_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Arow_Trap/z_en_arow_trap.h
+++ b/src/overlays/actors/ovl_En_Arow_Trap/z_en_arow_trap.h
@@ -13,6 +13,4 @@ typedef struct EnArowTrap {
     /* 0x0150 */ u32 attackTimer;
 } EnArowTrap; // size = 0x0154
 
-extern const ActorInit En_Arow_Trap_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.h
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.h
@@ -41,6 +41,4 @@ typedef enum {
     /*  10 */ ARROW_NUT
 } ArrowType;
 
-extern const ActorInit En_Arrow_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.h
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.h
@@ -51,6 +51,4 @@ typedef struct EnAttackNiw {
     /* 0x02E4 */ f32 unk_2E4;
 } EnAttackNiw; // size = 0x02E8
 
-extern const ActorInit En_Attack_Niw_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.h
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.h
@@ -34,6 +34,4 @@ typedef struct EnBa {
     /* 0x0340 */ ColliderJntSphElement colliderItems[2];
 } EnBa; // size = 0x03C0
 
-extern const ActorInit En_Ba_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.h
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.h
@@ -56,6 +56,4 @@ typedef enum {
     ENBB_KILL_TRAIL = 11
 } EnBbType;
 
-extern const ActorInit En_Bb_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.h
+++ b/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.h
@@ -27,6 +27,4 @@ typedef struct EnBdfire {
     /* 0x01D4 */ LightInfo lightInfoNoGlow;
 } EnBdfire; // size = 0x01E4
 
-extern const ActorInit En_Bdfire_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
@@ -24,6 +24,4 @@ typedef struct EnBigokuta {
     /* 0x02EC */ ColliderCylinder cylinder[2];
 } EnBigokuta; // size = 0x0384
 
-extern const ActorInit En_Bigokuta_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bili/z_en_bili.h
+++ b/src/overlays/actors/ovl_En_Bili/z_en_bili.h
@@ -29,8 +29,6 @@ typedef struct EnBili {
     /* 0x01D4 */ ColliderCylinder collider;
 } EnBili; // size = 0x0220
 
-extern const ActorInit En_Bili_InitVars;
-
 typedef enum {
     /* -1 */ EN_BILI_TYPE_NORMAL = -1,
     /*  0 */ EN_BILI_TYPE_VALI_SPAWNED,

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.h
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.h
@@ -28,6 +28,4 @@ typedef struct EnBird {
     /* 0x01C2 */ char unk_1C2[0x1A];
 } EnBird; // size = 0x01DC
 
-extern const ActorInit En_Bird_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.h
+++ b/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.h
@@ -15,6 +15,4 @@ typedef struct EnBlkobj {
     /* 0x0168 */ EnBlkobjActionFunc actionFunc;
 } EnBlkobj; // size = 0x016C
 
-extern const ActorInit En_Blkobj_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.h
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.h
@@ -25,6 +25,4 @@ typedef enum {
     /* 0x01 */ BOMB_EXPLOSION
 } EnBomType;
 
-extern const ActorInit En_Bom_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
@@ -39,6 +39,4 @@ typedef struct EnBomBowlMan {
     /* 0x0260 */ EnExItem* exItem;
 } EnBomBowlMan; // size = 0x0264
 
-extern const ActorInit En_Bom_Bowl_Man_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.h
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.h
@@ -35,6 +35,4 @@ typedef struct EnBomBowlPit {
     /* 0x01E4 */ char unk_1E4[0x3520];
 } EnBomBowlPit; // size = 0x3704
 
-extern const ActorInit En_Bom_Bowl_Pit_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.h
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.h
@@ -22,6 +22,4 @@ typedef struct EnBomChu {
     /* 0x01A4 */ ColliderJntSphElement colliderElements[1];
 } EnBomChu; // size = 0x01E4
 
-extern const ActorInit En_Bom_Chu_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.h
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.h
@@ -28,6 +28,4 @@ typedef enum {
     /* 0x0001 */ BOMBFLOWER_EXPLOSION
 } EnBombfType;
 
-extern const ActorInit En_Bombf_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.h
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.h
@@ -20,6 +20,4 @@ typedef struct EnBoom {
     /* 0x01F8 */ EnBoomActionFunc actionFunc;
 } EnBoom; // size = 0x01FC
 
-extern const ActorInit En_Boom_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Box/z_en_box.h
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.h
@@ -47,6 +47,4 @@ typedef struct EnBox {
     /* 0x01FB */ u8 unk_1FB;
 } EnBox; // size = 0x01FC
 
-extern const ActorInit En_Box_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Brob/z_en_brob.h
+++ b/src/overlays/actors/ovl_En_Brob/z_en_brob.h
@@ -19,6 +19,4 @@ typedef struct EnBrob {
     /* 0x0228 */ ColliderCylinder colliders[2];
 } EnBrob; // size = 0x02C0
 
-extern const ActorInit En_Brob_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Butte/z_en_butte.h
+++ b/src/overlays/actors/ovl_En_Butte/z_en_butte.h
@@ -27,6 +27,4 @@ typedef struct EnButte {
     /* 0x0264 */ f32 posYTarget;
 } EnButte; // size = 0x0268
 
-extern const ActorInit En_Butte_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bw/z_en_bw.h
+++ b/src/overlays/actors/ovl_En_Bw/z_en_bw.h
@@ -44,6 +44,4 @@ typedef struct EnBw {
     /* 0x02E0 */ ColliderCylinder collider2;
 } EnBw; // size = 0x032C
 
-extern const ActorInit En_Bw_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Bx/z_en_bx.h
+++ b/src/overlays/actors/ovl_En_Bx/z_en_bx.h
@@ -18,6 +18,4 @@ typedef struct EnBx {
     /* 0x0218 */ ColliderQuad colliderQuad;
 } EnBx; // size = 0x0298
 
-extern const ActorInit En_Bx_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.h
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.h
@@ -24,6 +24,4 @@ typedef struct EnChanger {
     /* 0x0168 */ s16 roomChestsOpened;
 } EnChanger; // size = 0x016C
 
-extern const ActorInit En_Changer_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h
@@ -92,6 +92,4 @@ typedef struct EnClearTagEffect {
 
 #define CLEAR_TAG_EFFECT_MAX_COUNT 100
 
-extern const ActorInit En_Clear_Tag_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.h
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.h
@@ -21,6 +21,4 @@ typedef struct EnCow {
     /* 0x027C */ EnCowActionFunc actionFunc;
 } EnCow; // size = 0x0280
 
-extern const ActorInit En_Cow_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.h
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.h
@@ -22,6 +22,4 @@ typedef struct EnCrow {
     /* 0x0258 */ ColliderJntSphElement colliderItems[1];
 } EnCrow; // size = 0x0298
 
-extern const ActorInit En_Crow_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Cs/z_en_cs.h
+++ b/src/overlays/actors/ovl_En_Cs/z_en_cs.h
@@ -34,6 +34,4 @@ typedef struct EnCs {
     /* 0x02E4 */ Vec3s morphTable[16];
 } EnCs; // size = 0x0344
 
-extern const ActorInit En_Cs_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Daiku/z_en_daiku.h
+++ b/src/overlays/actors/ovl_En_Daiku/z_en_daiku.h
@@ -37,6 +37,4 @@ typedef struct EnDaiku {
     /* 0x0340 */ Vec3f initPos;
 } EnDaiku; // size = 0x034C
 
-extern const ActorInit En_Daiku_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.h
+++ b/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.h
@@ -30,6 +30,4 @@ typedef struct EnDaikuKakariko {
     /* 0x0302 */ Vec3s neckAngleTarget;
 } EnDaikuKakariko; // size = 0x0308
 
-extern const ActorInit En_Daiku_Kakariko_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.h
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.h
@@ -30,6 +30,4 @@ typedef struct EnDekubaba {
     /* 0x0258 */ ColliderJntSphElement colliderElements[7];
 } EnDekubaba; // size = 0x0418
 
-extern const ActorInit En_Dekubaba_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.h
+++ b/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.h
@@ -22,6 +22,4 @@ typedef struct EnDekunuts {
     /* 0x02C8 */ ColliderCylinder collider;
 } EnDekunuts; // size = 0x0314
 
-extern const ActorInit En_Dekunuts_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.h
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.h
@@ -32,8 +32,6 @@ typedef struct EnDh {
     /* 0x0320 */ f32 dirtWaveAlpha;
 } EnDh; // size = 0x0324
 
-extern const ActorInit En_Dh_InitVars;
-
 typedef enum {
     ENDH_HANDS_KILLED_4 = -4,
     ENDH_HANDS_KILLED_3,

--- a/src/overlays/actors/ovl_En_Dha/z_en_dha.h
+++ b/src/overlays/actors/ovl_En_Dha/z_en_dha.h
@@ -27,6 +27,4 @@ typedef struct EnDha {
     /* 0x0220 */ ColliderJntSphElement colliderItem[5];
 } EnDha; // size = 0x0360
 
-extern const ActorInit En_Dha_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.h
+++ b/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.h
@@ -49,8 +49,6 @@ typedef struct EnDivingGame {
     /* 0x034C */ ColliderCylinder collider;
 } EnDivingGame; // size = 0x0398
 
-extern const ActorInit En_Diving_Game_InitVars;
-
 typedef enum {
     /* 0 */ ENDIVINGGAME_PHASE_ENDED,
     /* 1 */ ENDIVINGGAME_PHASE_1, // Player has not received the scale.

--- a/src/overlays/actors/ovl_En_Dns/z_en_dns.h
+++ b/src/overlays/actors/ovl_En_Dns/z_en_dns.h
@@ -34,6 +34,4 @@ typedef struct EnDns {
     /* 0x02C4 */ f32 yInitPos;
 } EnDns; // size = 0x02C8
 
-extern const ActorInit En_Dns_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h
+++ b/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.h
@@ -64,6 +64,4 @@ typedef enum {
     /* 5 */ DNT_ACTION_PRIZE
 } EnDntAction;
 
-extern const ActorInit En_Dnt_Demo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.h
+++ b/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.h
@@ -32,6 +32,4 @@ typedef struct EnDntJiji {
     /* 0x025C */ ColliderCylinder collider;
 } EnDntJiji; // size = 0x02A8
 
-extern const ActorInit En_Dnt_Jiji_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.h
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.h
@@ -45,6 +45,4 @@ typedef struct EnDntNomal {
 #define ENDNTNOMAL_TARGET 0
 #define ENDNTNOMAL_STAGE 1
 
-extern const ActorInit En_Dnt_Nomal_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.h
+++ b/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.h
@@ -26,6 +26,4 @@ typedef struct EnDodojr {
     /* 0x0266 */ Vec3s morphTable[15];
 } EnDodojr; // size = 0x02C0
 
-extern const ActorInit En_Dodojr_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.h
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.h
@@ -44,6 +44,4 @@ typedef enum {
     EN_DODONGO_SMOKE_DEATH
 } EnDodongoParam;
 
-extern const ActorInit En_Dodongo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dog/z_en_dog.h
+++ b/src/overlays/actors/ovl_En_Dog/z_en_dog.h
@@ -26,6 +26,4 @@ typedef struct EnDog {
     /* 0x0242 */ Vec3s morphTable[13];
 } EnDog; // size = 0x0290
 
-extern const ActorInit En_Dog_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Door/z_en_door.h
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.h
@@ -57,6 +57,4 @@ typedef struct EnDoor {
     /* 0x01D4 */ EnDoorActionFunc actionFunc;
 } EnDoor; // size = 0x01D8
 
-extern const ActorInit En_Door_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ds/z_en_ds.h
+++ b/src/overlays/actors/ovl_En_Ds/z_en_ds.h
@@ -21,6 +21,4 @@ typedef struct EnDs {
     /* 0x01EC */ EnDsActionFunc actionFunc;
 } EnDs; // size = 0x01F0
 
-extern const ActorInit En_Ds_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Du/z_en_du.h
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.h
@@ -29,6 +29,4 @@ typedef struct EnDu {
     /* 0x01F4 */ struct_80034A14_arg1 unk_1F4;
 } EnDu; // size = 0x021C
 
-extern const ActorInit En_Du_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.h
+++ b/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.h
@@ -19,6 +19,4 @@ typedef struct EnDyExtra {
     /* 0x0168 */ Vec3f unk_168; // Set and not used
 } EnDyExtra; // size = 0x0174
 
-extern const ActorInit En_Dy_Extra_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Eg/z_en_eg.h
+++ b/src/overlays/actors/ovl_En_Eg/z_en_eg.h
@@ -12,6 +12,4 @@ typedef struct EnEg {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ s32 action;
 } EnEg; // size = 0x0154
-
-extern const ActorInit En_Eg_InitVars;
 #endif

--- a/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.h
+++ b/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.h
@@ -20,6 +20,4 @@ typedef struct EnEiyer {
     /* 0x0288 */ ColliderCylinder collider;
 } EnEiyer; // size = 0x02D4
 
-extern const ActorInit En_Eiyer_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.h
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.h
@@ -55,6 +55,4 @@ typedef enum {
     /* 0x07 */ FAIRY_HEAL_BIG
 } FairyType;
 
-extern const ActorInit En_Elf_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.h
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.h
@@ -37,6 +37,4 @@ typedef enum {
     /* 3 */ SPAWNER_WOLFOS
 } EnEncount1type;
 
-extern const ActorInit En_Encount1_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Encount2/z_en_encount2.h
+++ b/src/overlays/actors/ovl_En_Encount2/z_en_encount2.h
@@ -38,6 +38,4 @@ typedef struct EnEncount2 {
     /* 0x0188 */ EnEncount2Particle particles[50];
 } EnEncount2; // size = 0x0A20
 
-extern const ActorInit En_Encount2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.h
+++ b/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.h
@@ -29,8 +29,6 @@ typedef struct EnExItem {
     /* 0x0180 */ EnExItemLightFunc unk_180;
 } EnExItem; // size = 0x0184
 
-extern const ActorInit En_Ex_Item_InitVars;
-
 typedef enum {
     /*  0 */ EXITEM_BOMB_BAG_BOWLING,
     /*  1 */ EXITEM_HEART_PIECE_BOWLING,

--- a/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.h
+++ b/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.h
@@ -21,6 +21,4 @@ typedef struct EnExRuppy {
     /* 0x0160 */ f32 unk_160;
 } EnExRuppy; // size = 0x0164
 
-extern const ActorInit En_Ex_Ruppy_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.h
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.h
@@ -50,6 +50,4 @@ typedef struct EnFd {
     /* 0x0620 */ EnFdEffect effects[200];
 } EnFd; // size = 0x31E0
 
-extern const ActorInit En_Fd_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.h
+++ b/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.h
@@ -19,6 +19,4 @@ typedef struct EnFdFire {
     /* 0x01A8 */ s16 tile2Y;
 } EnFdFire; // size = 0x01AC
 
-extern const ActorInit En_Fd_Fire_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.h
+++ b/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.h
@@ -66,6 +66,4 @@ typedef struct EnFhgFire {
     /* 0x0200 */ f32 lensFlareScale;
 } EnFhgFire; // size = 0x0204
 
-extern const ActorInit En_Fhg_Fire_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.h
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.h
@@ -36,6 +36,4 @@ typedef struct EnFireRock {
     /* 0x0194 */ ColliderCylinder collider;
 } EnFireRock; // size = 0x01E0
 
-extern const ActorInit En_Fire_Rock_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Firefly/z_en_firefly.h
+++ b/src/overlays/actors/ovl_En_Firefly/z_en_firefly.h
@@ -32,6 +32,4 @@ typedef enum {
     /* 4 */ KEESE_ICE_FLY
 } KeeseType;
 
-extern const ActorInit En_Firefly_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Fish/z_en_fish.h
+++ b/src/overlays/actors/ovl_En_Fish/z_en_fish.h
@@ -29,6 +29,4 @@ typedef enum {
     /*  1 */ FISH_SWIMMING_UNIQUE // Used in grottos
 } EnFishType;
 
-extern const ActorInit En_Fish_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.h
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.h
@@ -21,6 +21,4 @@ struct EnFloormas{
     /* 0x02C8 */ ColliderCylinder collider;
 }; // size = 0x0314
 
-extern const ActorInit En_Floormas_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.h
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.h
@@ -69,6 +69,4 @@ typedef struct EnFr {
     /* 0x03B8 */ Vec3f posButterflyLight; // Used in Lights_PointNoGlowSetInfo()
 } EnFr; // size = 0x03C4
 
-extern const ActorInit En_Fr_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.h
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.h
@@ -41,6 +41,4 @@ typedef struct EnFu {
     /* 0x02AC */ EnFuActionFunc actionFunc;
 } EnFu; // size = 0x02B0
 
-extern const ActorInit En_Fu_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Fw/z_en_fw.h
+++ b/src/overlays/actors/ovl_En_Fw/z_en_fw.h
@@ -45,6 +45,4 @@ typedef struct EnFw {
     /* 0x02A0 */ EnFwEffect effects[20];
 } EnFw; // size = 0x0700
 
-extern const ActorInit En_Fw_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Fz/z_en_fz.h
+++ b/src/overlays/actors/ovl_En_Fz/z_en_fz.h
@@ -52,6 +52,4 @@ typedef struct EnFz {
     /* 0x0274 */ EnFzEffectSsIceSmoke iceSmoke[40];
 } EnFz; // size = 0x0BD4
 
-extern const ActorInit En_Fz_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.h
+++ b/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.h
@@ -57,6 +57,4 @@ typedef struct EnGSwitch {
     /* 0x01C8 */ EnGSwitchEffect effects[100];
 } EnGSwitch; // size = 0x12F8
 
-extern const ActorInit En_G_Switch_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.h
+++ b/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.h
@@ -39,6 +39,4 @@ typedef struct EnGanonMant {
     /* 0x1706 */ u8 frameTimer;
 } EnGanonMant; // size = 0x1708
 
-extern const ActorInit En_Ganon_Mant_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.h
+++ b/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.h
@@ -11,6 +11,4 @@ typedef struct EnGanonOrgan {
     /* 0x014C */ char unk_14C[0x4];
 } EnGanonOrgan; // size = 0x0150
 
-extern const ActorInit En_Ganon_Organ_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Gb/z_en_gb.h
+++ b/src/overlays/actors/ovl_En_Gb/z_en_gb.h
@@ -46,6 +46,4 @@ typedef struct EnGb {
     /* 0x0388 */ EnGbCagedSoul cagedSouls[4];
 } EnGb; // size = 0x0438
 
-extern const ActorInit En_Gb_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.h
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.h
@@ -56,6 +56,4 @@ typedef struct EnGe1 {
     /* 0x02B8 */ EnGe1AnimFunc animFunc;
 } EnGe1; // size = 0x02BC
 
-extern const ActorInit En_Ge1_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.h
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.h
@@ -30,6 +30,4 @@ typedef struct EnGe2 {
     /* 0x0308 */ EnGe2ActionFunc actionFunc;
 } EnGe2; // size = 0x030C
 
-extern const ActorInit En_Ge2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.h
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.h
@@ -23,6 +23,4 @@ typedef struct EnGe3 {
     /* 0x0310 */ EnGe3ActionFunc actionFunc;
 } EnGe3; // size = 0x0314
 
-extern const ActorInit En_Ge3_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.h
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.h
@@ -69,6 +69,4 @@ typedef struct EnGeldB {
     /* 0x04DC */ Vec3s headRot;
 } EnGeldB; // size = 0x04E4
 
-extern const ActorInit En_Geldb_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_GirlA/z_en_girla.h
+++ b/src/overlays/actors/ovl_En_GirlA/z_en_girla.h
@@ -35,8 +35,6 @@ typedef struct EnGirlA {
     /* 0x01D0 */ EnGirlA3Func hiliteFunc;
 } EnGirlA; // size = 0x01D4
 
-extern const ActorInit En_GirlA_InitVars;
-
 typedef enum {
     /* 0x00 */ SI_DEKU_NUTS_5,
     /* 0x01 */ SI_ARROWS_30,

--- a/src/overlays/actors/ovl_En_Gm/z_en_gm.h
+++ b/src/overlays/actors/ovl_En_Gm/z_en_gm.h
@@ -24,6 +24,4 @@ typedef struct EnGm {
     /* 0x02C4 */ Vec3f talkPos;
 } EnGm; // size = 0x02D0
 
-extern const ActorInit En_Gm_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -58,6 +58,4 @@ typedef struct EnGo {
     /* 0x0268 */ EnGoEffect dustEffects[20];
 } EnGo; // size = 0x06C8
 
-extern const ActorInit En_Go_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -106,6 +106,4 @@ typedef struct EnGo2 {
     /* 0x059C */ s16 unk_59C;
 } EnGo2; // size = 0x05A0
 
-extern const ActorInit En_Go2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Goma/z_en_goma.h
+++ b/src/overlays/actors/ovl_En_Goma/z_en_goma.h
@@ -77,6 +77,4 @@ typedef struct EnGoma {
     /* 0x358 */ ColliderCylinder colCyl2;
 } EnGoma; // size = 0x03A4
 
-extern const ActorInit En_Goma_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.h
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.h
@@ -27,6 +27,4 @@ typedef struct EnGoroiwa {
     /* 0x01D3 */ u8 stateFlags;
 } EnGoroiwa; // size = 0x01D4
 
-extern const ActorInit En_Goroiwa_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.h
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.h
@@ -31,6 +31,4 @@ typedef struct EnGs {
     /* 0x0202 */ char unk_202[0x6];
 } EnGs; // size = 0x0208
 
-extern const ActorInit En_Gs_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Guest/z_en_guest.h
+++ b/src/overlays/actors/ovl_En_Guest/z_en_guest.h
@@ -25,6 +25,4 @@ typedef struct EnGuest {
     /* 0x030E */ u8 unk_30E;
 } EnGuest; // size = 0x0310
 
-extern const ActorInit En_Guest_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Hata/z_en_hata.h
+++ b/src/overlays/actors/ovl_En_Hata/z_en_hata.h
@@ -41,6 +41,4 @@ typedef struct {
     /* 0x0278 */ s16 unk_278;
 } EnHata; // size = 0x027C
 
-extern const ActorInit En_Hata_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.h
+++ b/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.h
@@ -52,6 +52,4 @@ typedef struct EnHeishi1 {
     /* 0x02AA */ s16 waypoint;
 } EnHeishi1; // size = 0x02AC
 
-extern const ActorInit En_Heishi1_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.h
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.h
@@ -50,6 +50,4 @@ typedef struct EnHeishi2 {
     /* 0x0398 */ ColliderCylinder collider;
 } EnHeishi2; // size = 0x03E4
 
-extern const ActorInit En_Heishi2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.h
+++ b/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.h
@@ -28,6 +28,4 @@ typedef struct EnHeishi3 {
     /* 0x027C */ ColliderCylinder collider;
 } EnHeishi3; // size = 0x02C8
 
-extern const ActorInit En_Heishi3_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.h
+++ b/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.h
@@ -37,6 +37,4 @@ typedef struct EnHeishi4 {
     /* 0x02BC */ ColliderCylinder collider;
 } EnHeishi4; // size = 0x0308
 
-extern const ActorInit En_Heishi4_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.h
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.h
@@ -20,6 +20,4 @@ typedef struct EnHintnuts {
     /* 0x0214 */ ColliderCylinder collider;
 } EnHintnuts; // size = 0x0260
 
-extern const ActorInit En_Hintnuts_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Holl/z_en_holl.h
+++ b/src/overlays/actors/ovl_En_Holl/z_en_holl.h
@@ -16,6 +16,4 @@ typedef struct EnHoll {
     /* 0x0150 */ EnHollActionFunc actionFunc;
 } EnHoll; // size = 0x0154
 
-extern const ActorInit En_Holl_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.h
+++ b/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.h
@@ -35,6 +35,4 @@ typedef enum {
     HONOTRAP_FLAME_DROP
 } EnHonotrapType;
 
-extern const ActorInit En_Honotrap_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.h
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.h
@@ -188,6 +188,4 @@ typedef struct EnHorse {
         ? true                       \
         : false)
 
-extern const ActorInit En_Horse_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.h
+++ b/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.h
@@ -62,6 +62,4 @@ typedef enum {
     /* 4 */ HORSEGAME_MALON_RACE
 } EnHorseGameCheckType;
 
-extern const ActorInit En_Horse_Game_Check_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.h
+++ b/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.h
@@ -24,6 +24,4 @@ typedef struct EnHorseGanon {
     /* 0x0268 */ ColliderJntSphElement headElements[1];
 } EnHorseGanon; // size = 0x02A8
 
-extern const ActorInit En_Horse_Ganon_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.h
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.h
@@ -23,6 +23,4 @@ typedef struct EnHorseLinkChild {
     /* 0x02A0 */ s32 unk_2A0;
 } EnHorseLinkChild; // size = 0x02A4
 
-extern const ActorInit En_Horse_Link_Child_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.h
+++ b/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.h
@@ -32,6 +32,4 @@ typedef struct EnHorseNormal {
     /* 0x0324 */ s32 waypoint;
 } EnHorseNormal; // size = 0x0328
 
-extern const ActorInit En_Horse_Normal_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.h
+++ b/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.h
@@ -23,6 +23,4 @@ typedef struct EnHorseZelda {
     /* 0x0268 */ ColliderJntSphElement colliderSphereItem;
 } EnHorseZelda; // size = 0x02A8
 
-extern const ActorInit En_Horse_Zelda_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.h
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.h
@@ -21,6 +21,4 @@ typedef struct EnHs {
     /* 0x02AC */ EnHsActionFunc actionFunc;
 } EnHs; // size = 0x02B0
 
-extern const ActorInit En_Hs_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Hs2/z_en_hs2.h
+++ b/src/overlays/actors/ovl_En_Hs2/z_en_hs2.h
@@ -20,6 +20,4 @@ typedef struct EnHs2 {
     /* 0x02AC */ EnHs2ActionFunc actionFunc;
 } EnHs2; // size = 0x02B0
 
-extern const ActorInit En_Hs2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.h
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.h
@@ -36,6 +36,4 @@ typedef struct EnHy {
     /* 0x0330 */ u16 unk_330;
 } EnHy; // size = 0x0334
 
-extern const ActorInit En_Hy_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.h
+++ b/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.h
@@ -21,6 +21,4 @@ typedef struct EnIceHono {
     /* 0x01AC */ LightInfo lightInfo;
 } EnIceHono; // size = 0x01BC
 
-extern const ActorInit En_Ice_Hono_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.h
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.h
@@ -37,6 +37,4 @@ typedef struct EnIk {
     /* 0x04D8 */ char unk_4D8[0x04];
 } EnIk; // size = 0x04DC
 
-extern const ActorInit En_Ik_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_In/z_en_in.h
+++ b/src/overlays/actors/ovl_En_In/z_en_in.h
@@ -38,6 +38,4 @@ typedef struct EnIn {
     /* 0x0330 */ Vec3s unk_330[20];
 } EnIn; // size = 0x03A8
 
-extern const ActorInit En_In_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.h
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.h
@@ -29,6 +29,4 @@ typedef struct EnInsect {
     /* 0x032A */ u8 unk_32A;
 } EnInsect; // size = 0x032C
 
-extern const ActorInit En_Insect_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.h
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.h
@@ -21,6 +21,4 @@ typedef struct EnIshi {
     /* 0x0150 */ ColliderCylinder collider;
 } EnIshi; // size = 0x019C
 
-extern const ActorInit En_Ishi_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_It/z_en_it.h
+++ b/src/overlays/actors/ovl_En_It/z_en_it.h
@@ -12,6 +12,4 @@ typedef struct EnIt {
     /* 0x0150 */ ColliderCylinder collider;
 } EnIt; // size = 0x019C
 
-extern const ActorInit En_It_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Jj/z_en_jj.h
+++ b/src/overlays/actors/ovl_En_Jj/z_en_jj.h
@@ -33,6 +33,4 @@ typedef enum {
 } EnJjType;
 
 
-extern const ActorInit En_Jj_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Js/z_en_js.h
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.h
@@ -22,6 +22,4 @@ typedef struct EnJs {
     /* 0x028C */ EnJsActionFunc actionFunc;
 } EnJs; // size = 0x0290
 
-extern const ActorInit En_Js_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.h
+++ b/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.h
@@ -21,6 +21,4 @@ typedef enum {
     /* 1 */ ENJSJUTAN_TYPE_01
 } EnJsjutanType;
 
-extern const ActorInit En_Jsjutan_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.h
+++ b/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.h
@@ -29,6 +29,4 @@ typedef struct EnKakasi {
     /* 0x0208 */ s16 camId;
 } EnKakasi; // size = 0x020C
 
-extern const ActorInit En_Kakasi_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.h
+++ b/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.h
@@ -20,6 +20,4 @@ typedef struct EnKakasi2 {
     /* 0x01AC */ ColliderCylinder collider;
 } EnKakasi2; // size = 0x01F8
 
-extern const ActorInit En_Kakasi2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.h
+++ b/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.h
@@ -30,6 +30,4 @@ typedef struct EnKakasi3 {
     /* 0x0208 */ s16 camId;
 } EnKakasi3; // size = 0x020C
 
-extern const ActorInit En_Kakasi3_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Kanban/z_en_kanban.h
+++ b/src/overlays/actors/ovl_En_Kanban/z_en_kanban.h
@@ -41,6 +41,4 @@ typedef struct EnKanban {
 #define ENKANBAN_PIECE ((s16)0xFFDD)
 #define ENKANBAN_FISHING 0x300
 
-extern const ActorInit En_Kanban_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.h
+++ b/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.h
@@ -4,8 +4,6 @@
 #include "ultra64.h"
 #include "global.h"
 
-extern const ActorInit En_Karebaba_InitVars;
-
 struct EnKarebaba;
 
 typedef void (*EnKarebabaActionFunc)(struct EnKarebaba*, GlobalContext*);

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.h
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.h
@@ -32,8 +32,6 @@ typedef struct EnKo {
     /* 0x0304 */ s16 unk_304[16];
 } EnKo; // size = 0x0324
 
-extern const ActorInit En_Ko_InitVars;
-
 typedef enum {
     ENKO_TYPE_CHILD_0,
     ENKO_TYPE_CHILD_1,

--- a/src/overlays/actors/ovl_En_Kusa/z_en_kusa.h
+++ b/src/overlays/actors/ovl_En_Kusa/z_en_kusa.h
@@ -16,6 +16,4 @@ typedef struct EnKusa {
     /* 0x019E */ s8 kusaTexObjIndex;
 } EnKusa; // size = 0x01A0
 
-extern const ActorInit En_Kusa_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.h
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.h
@@ -28,6 +28,4 @@ typedef struct EnKz {
     /* 0x02BE */ s16 unk_2BE[12];
 } EnKz; // size = 0x02D8
 
-extern const ActorInit En_Kz_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Light/z_en_light.h
+++ b/src/overlays/actors/ovl_En_Light/z_en_light.h
@@ -13,6 +13,4 @@ typedef struct EnLight {
     /* 0x0154 */ LightInfo lightInfo;
 } EnLight; // size = 0x0164
 
-extern const ActorInit En_Light_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Lightbox/z_en_lightbox.h
+++ b/src/overlays/actors/ovl_En_Lightbox/z_en_lightbox.h
@@ -10,6 +10,4 @@ typedef struct EnLightbox {
     /* 0x0000 */ DynaPolyActor dyna;
 } EnLightbox; // size = 0x0164
 
-extern const ActorInit En_Lightbox_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.h
+++ b/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.h
@@ -12,6 +12,4 @@ typedef struct EnMFire1 {
     /* 0x0198 */ f32 timer;
 } EnMFire1; // size = 0x019C
 
-extern const ActorInit En_M_Fire1_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.h
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.h
@@ -27,6 +27,4 @@ typedef struct EnMThunder {
     /* 0x01CA */ u8 unk_1CA;
 } EnMThunder; // size = 0x01CC
 
-extern const ActorInit En_M_Thunder_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.h
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.h
@@ -20,6 +20,4 @@ typedef struct EnMa1 {
     /* 0x01E8 */ struct_80034A14_arg1 unk_1E8;
 } EnMa1; // size = 0x0210
 
-extern const ActorInit En_Ma1_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.h
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.h
@@ -22,6 +22,4 @@ typedef struct EnMa2 {
     /* 0x0212 */ Vec3s unk_212[0x13];
 } EnMa2; // size = 0x0284
 
-extern const ActorInit En_Ma2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.h
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.h
@@ -22,6 +22,4 @@ typedef struct EnMa3 {
     /* 0x0212 */ Vec3s unk_212[0x13];
 } EnMa3; // size = 0x0284
 
-extern const ActorInit En_Ma3_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.h
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.h
@@ -32,8 +32,6 @@ typedef struct EnMag {
     /* 0xE324 */ char unk_E324[0x0004];
 } EnMag; // size = 0xE328
 
-extern const ActorInit En_Mag_InitVars;
-
 typedef enum {
     /* 0x00 */ MAG_STATE_INITIAL,
     /* 0x01 */ MAG_STATE_FADE_IN,

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.h
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.h
@@ -50,6 +50,4 @@ typedef struct EnMb {
     /* 0x0454 */ ColliderTrisElement frontShieldingTris[2];
 } EnMb; // size = 0x050C
 
-extern const ActorInit En_Mb_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Md/z_en_md.h
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.h
@@ -28,6 +28,4 @@ typedef struct EnMd {
     /* 0x02BE */ Vec3s morphTable[17];
 } EnMd; // size = 0x0324
 
-extern const ActorInit En_Md_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.h
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.h
@@ -21,6 +21,4 @@ typedef struct EnMk {
     /* 0x0284 */ EnMkActionFunc actionFunc;
 } EnMk; // size = 0x0288
 
-extern const ActorInit En_Mk_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.h
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.h
@@ -33,6 +33,4 @@ typedef struct EnMm {
     /* 0x02C0 */ Vec3s morphTable[16];
 } EnMm; // size = 0x0320
 
-extern const ActorInit En_Mm_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.h
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.h
@@ -24,6 +24,4 @@ typedef struct EnMm2 {
     /* 0x025C */ Vec3s morphTable[16];
 } EnMm2; // size = 0x02BC
 
-extern const ActorInit En_Mm2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ms/dlists.c
+++ b/src/overlays/actors/ovl_En_Ms/dlists.c
@@ -1,1 +1,0 @@
-#include "dlists.h"

--- a/src/overlays/actors/ovl_En_Ms/dlists.h
+++ b/src/overlays/actors/ovl_En_Ms/dlists.h
@@ -1,7 +1,0 @@
-#ifndef _DLISTS_H_
-#define _DLISTS_H_
-
-#include "ultra64.h"
-#include "global.h"
-
-#endif

--- a/src/overlays/actors/ovl_En_Ms/dlists.h
+++ b/src/overlays/actors/ovl_En_Ms/dlists.h
@@ -4,6 +4,4 @@
 #include "ultra64.h"
 #include "global.h"
 
-extern const ActorInit InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.h
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.h
@@ -18,5 +18,4 @@ typedef struct EnMs {
     /* 0x024C */ s16 activeTimer;
 } EnMs; // size = 0x0250
 
-
 #endif

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.h
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.h
@@ -19,6 +19,4 @@ typedef struct EnMs {
 } EnMs; // size = 0x0250
 
 
-extern const ActorInit En_Ms_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.h
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.h
@@ -19,6 +19,4 @@ typedef struct EnMu {
     /* 0x022A */ s16 unk_22A[17];
 } EnMu; // size = 0x024C
 
-extern const ActorInit En_Mu_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.h
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.h
@@ -63,6 +63,4 @@ typedef enum {
     /* 0x06 */ NB_TYPE_CRAWLSPACE
 } EnNbType;
 
-extern const ActorInit En_Nb_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Niw/z_en_niw.h
+++ b/src/overlays/actors/ovl_En_Niw/z_en_niw.h
@@ -76,6 +76,4 @@ typedef struct EnNiw {
     /* 0x0358 */ EnNiwFeather feathers[20];
 } EnNiw; // size = 0x07B8
 
-extern const ActorInit En_Niw_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.h
+++ b/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.h
@@ -32,6 +32,4 @@ typedef struct EnNiwGirl {
     /* 0x02D4 */ struct_80034A14_arg1 unk_2D4;
 } EnNiwGirl; // size = 0x02FC
 
-extern const ActorInit En_Niw_Girl_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.h
+++ b/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.h
@@ -42,6 +42,4 @@ typedef struct EnNiwLady {
     /* 0x02B0 */ ColliderCylinder collider;
 } EnNiwLady; // size = 0x02FC
 
-extern const ActorInit En_Niw_Lady_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.h
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.h
@@ -16,6 +16,4 @@ typedef struct EnNutsball {
     /* 0x0154 */ ColliderCylinder collider;
 } EnNutsball; // size = 0x01A0
 
-extern const ActorInit En_Nutsball_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Nwc/z_en_nwc.h
+++ b/src/overlays/actors/ovl_En_Nwc/z_en_nwc.h
@@ -33,6 +33,4 @@ typedef struct EnNwc {
     /* 0x0730 */ EnNwcUpdateFunc updateFunc;
 } EnNwc; // size = 0x0734
 
-extern const ActorInit En_Nwc_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ny/z_en_ny.h
+++ b/src/overlays/actors/ovl_En_Ny/z_en_ny.h
@@ -32,6 +32,4 @@ typedef struct EnNy {
     /* 0x01F8 */ Vec3f unk_1F8[16];
 } EnNy; // size = 0x02B8
 
-extern const ActorInit En_Ny_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_OE2/z_en_oe2.h
+++ b/src/overlays/actors/ovl_En_OE2/z_en_oe2.h
@@ -14,6 +14,4 @@ typedef struct EnOE2 {
     /* 0x0190 */ EnOE2ActionFunc actionFunc;
 } EnOE2; // size = 0x0194
 
-extern const ActorInit En_OE2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.h
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.h
@@ -14,6 +14,4 @@ typedef struct EnOkarinaEffect {
     /* 0x0150 */ EnOkarinaEffectActionFunc actionFunc;
 } EnOkarinaEffect; // size = 0x0154
 
-extern const ActorInit En_Okarina_Effect_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.h
+++ b/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.h
@@ -20,6 +20,4 @@ typedef struct EnOkarinaTag {
     /* 0x015C */ f32 unk_15C;
 } EnOkarinaTag; // size = 0x0160
 
-extern const ActorInit En_Okarina_Tag_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Okuta/z_en_okuta.h
+++ b/src/overlays/actors/ovl_En_Okuta/z_en_okuta.h
@@ -21,6 +21,4 @@ typedef struct EnOkuta {
     /* 0x0370 */ ColliderCylinder collider;
 } EnOkuta; // size = 0x03BC
 
-extern const ActorInit En_Okuta_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ossan/z_en_ossan.h
+++ b/src/overlays/actors/ovl_En_Ossan/z_en_ossan.h
@@ -83,8 +83,6 @@ typedef struct EnOssan {
     /* 0x02D4 */ f32 cameraFaceAngle; // stored in degrees
 } EnOssan; // size = 0x02D8
 
-extern const ActorInit En_Ossan_InitVars;
-
 typedef enum {
     /* 00 */ OSSAN_TYPE_KOKIRI,
     /* 01 */ OSSAN_TYPE_KAKARIKO_POTION,

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.h
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.h
@@ -43,6 +43,4 @@ typedef struct EnOwl {
     /* 0x0410 */ OwlFunc unk_410;
 } EnOwl; // size = 0x0414
 
-extern const ActorInit En_Owl_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Part/z_en_part.h
+++ b/src/overlays/actors/ovl_En_Part/z_en_part.h
@@ -17,6 +17,4 @@ typedef struct EnPart {
     /* 0x158 */ f32 rotZSpeed;
 } EnPart; // size = 0x015C
 
-extern const ActorInit En_Part_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
@@ -44,6 +44,4 @@ typedef struct EnPeehat {
     /* 0x03AC */ ColliderQuad colQuad;
 } EnPeehat; // size = 0x042C
 
-extern const ActorInit En_Peehat_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.h
+++ b/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.h
@@ -26,6 +26,4 @@ typedef struct EnPoDesert {
     /* 0x0238 */ ColliderCylinder collider;
 } EnPoDesert; // size = 0x0284
 
-extern const ActorInit En_Po_Desert_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.h
+++ b/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.h
@@ -43,6 +43,4 @@ typedef struct EnPoField {
     /* 0x0290 */ ColliderCylinder flameCollider;
 } EnPoField; // size = 0x02DC
 
-extern const ActorInit En_Po_Field_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.h
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.h
@@ -27,6 +27,4 @@ typedef struct EnPoRelay {
     /* 0x0290 */ ColliderCylinder collider;
 } EnPoRelay; // size = 0x02DC
 
-extern const ActorInit En_Po_Relay_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h
+++ b/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h
@@ -31,6 +31,4 @@ typedef struct EnPoSisters {
     /* 0x02F8 */ MtxF unk_2F8;
 } EnPoSisters; // size = 0x0338
 
-extern const ActorInit En_Po_Sisters_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.h
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.h
@@ -59,6 +59,4 @@ typedef struct EnPoh {
     /* 0x0368 */ MtxF unk_368;
 } EnPoh; // size = 0x03A8
 
-extern const ActorInit En_Poh_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.h
+++ b/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.h
@@ -11,6 +11,4 @@ typedef struct EnPubox {
     /* 0x0164 */ u32 unk_164;
 } EnPubox; // size = 0x0168
 
-extern const ActorInit En_Pu_Box_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.h
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.h
@@ -34,6 +34,4 @@ typedef struct EnRd {
     /* 0x0320 */ ColliderCylinder collider;
 } EnRd; // size = 0x036C
 
-extern const ActorInit En_Rd_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.h
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.h
@@ -35,6 +35,4 @@ typedef enum {
     /* 1 */ LEEVER_BIG
 } LeeverParam;
 
-extern const ActorInit En_Reeba_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.h
+++ b/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.h
@@ -40,6 +40,4 @@ typedef enum {
     /* 0xF8 */ RS_MAX
 } RiverSoundType;
 
-extern const ActorInit En_River_Sound_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Rl/z_en_rl.h
+++ b/src/overlays/actors/ovl_En_Rl/z_en_rl.h
@@ -22,6 +22,4 @@ typedef struct EnRl {
     /* 0x01A8 */ s32 lightMedallionGiven;
 } EnRl; // size = 0x01AC
 
-extern const ActorInit En_Rl_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.h
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.h
@@ -59,6 +59,4 @@ typedef struct EnRr {
     /* 0x03C4 */ char unk_3C4[0x2000]; //! @bug This is a huge amount of wasted memory.
 } EnRr; // size = 0x23C4
 
-extern const ActorInit En_Rr_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ru1/z_en_ru1.h
+++ b/src/overlays/actors/ovl_En_Ru1/z_en_ru1.h
@@ -76,6 +76,4 @@ typedef enum {
     /* 15 */ RUTO_CHILD_TORSO
 } RutoLimb;
 
-extern const ActorInit En_Ru1_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.h
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.h
@@ -29,6 +29,4 @@ typedef struct EnRu2 {
     /* 0x02C8 */ ColliderCylinder collider;
 } EnRu2; // size = 0x0314
 
-extern const ActorInit En_Ru2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.h
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.h
@@ -30,6 +30,4 @@ typedef struct EnSa {
     /* 0x0286 */ Vec3s morphTable[17];
 } EnSa; // size = 0x02EC
 
-extern const ActorInit En_Sa_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Sb/z_en_sb.h
+++ b/src/overlays/actors/ovl_En_Sb/z_en_sb.h
@@ -23,6 +23,4 @@ typedef struct EnSb {
     /* 0x0204 */ u8 hitByWindArrow;
 } EnSb; // size = 0x0208
 
-extern const ActorInit En_Sb_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.h
+++ b/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.h
@@ -13,6 +13,4 @@ typedef struct EnSceneChange {
     /* 0x014C */ EnSceneChangeActionFunc actionFunc;
 } EnSceneChange; // size = 0x0150
 
-extern const ActorInit En_Scene_Change_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Sda/z_en_sda.h
+++ b/src/overlays/actors/ovl_En_Sda/z_en_sda.h
@@ -10,6 +10,4 @@ typedef struct EnSda {
     /* 0x0000 */ Actor actor;
 } EnSda; // size = 0x014C
 
-extern const ActorInit En_Sda_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.h
+++ b/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.h
@@ -18,6 +18,4 @@ typedef struct EnShopnuts {
     /* 0x0270 */ ColliderCylinder collider;
 } EnShopnuts; // size = 0x02BC
 
-extern const ActorInit En_Shopnuts_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Si/z_en_si.h
+++ b/src/overlays/actors/ovl_En_Si/z_en_si.h
@@ -15,6 +15,4 @@ typedef struct EnSi {
     /* 0x019C */ u8 unk_19C;
 } EnSi; // size = 0x01A0
 
-extern const ActorInit En_Si_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.h
+++ b/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.h
@@ -33,6 +33,4 @@ typedef struct EnSiofuki {
     /* 0x019C */ u8 sfxFlags;
 } EnSiofuki; // size = 0x01A0
 
-extern const ActorInit En_Siofuki_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.h
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.h
@@ -24,6 +24,4 @@ typedef struct EnSkb {
     /* 0x02C4 */ ColliderJntSphElement colliderItem[2];
 } EnSkb; // size = 0x0344
 
-extern const ActorInit En_Skb_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.h
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.h
@@ -37,6 +37,4 @@ typedef struct EnSkj {
     /* 0x02F4 */ Vec3f posCopy;
 } EnSkj; // size = 0x0300
 
-extern const ActorInit En_Skj_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Skjneedle/z_en_skjneedle.h
+++ b/src/overlays/actors/ovl_En_Skjneedle/z_en_skjneedle.h
@@ -15,6 +15,4 @@ typedef struct EnSkjneedle {
     /* 0x01E4 */ char unk_1E4[4];
 } EnSkjneedle; // size = 0x01E8
 
-extern const ActorInit En_Skjneedle_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
@@ -39,8 +39,6 @@ typedef struct EnSsh {
     /* 0x05D0 */ s16 blinkTimer;
 } EnSsh; // size = 0x05D4
 
-extern const ActorInit En_Ssh_InitVars;
-
 #define ENSSH_FATHER 0
 
 #endif

--- a/src/overlays/actors/ovl_En_St/z_en_st.h
+++ b/src/overlays/actors/ovl_En_St/z_en_st.h
@@ -47,6 +47,4 @@ typedef struct EnSt {
     /* 0x04C6 */ Vec3s morphTable[30];
 } EnSt; // size = 0x057C
 
-extern const ActorInit En_St_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.h
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.h
@@ -25,6 +25,4 @@ typedef struct EnSth {
     /* 0x02B8 */ EnSthActionFunc actionFunc;
 } EnSth; // size = 0x02BC
 
-extern const ActorInit En_Sth_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Stream/z_en_stream.h
+++ b/src/overlays/actors/ovl_En_Stream/z_en_stream.h
@@ -15,6 +15,4 @@ typedef struct EnStream {
     /* 0x0154 */ char unk_154[0x4];
 } EnStream; // size = 0x0158
 
-extern const ActorInit En_Stream_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.h
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.h
@@ -49,6 +49,4 @@ typedef struct EnSw {
     /* 0x0490 */ char unk_490[0x48];
 } EnSw; // size = 0x04D8
 
-extern const ActorInit En_Sw_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.h
+++ b/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.h
@@ -40,6 +40,4 @@ typedef struct EnSyatekiItm {
     /* 0x01D0 */ struct EnExRuppy* curMarkers[2]; // marker rupees for the current round
 } EnSyatekiItm; // size = 0x01D8
 
-extern const ActorInit En_Syateki_Itm_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.h
+++ b/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.h
@@ -30,6 +30,4 @@ typedef struct EnSyatekiMan {
     /* 0x0228 */ s16 csCam;
 } EnSyatekiMan; // size = 0x022C
 
-extern const ActorInit En_Syateki_Man_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.h
+++ b/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.h
@@ -68,6 +68,4 @@ typedef struct EnSyatekiNiw {
     /* 0x0348 */ EnSyatekiNiw_1 unk_348[5];
 } EnSyatekiNiw; // size = 0x0460
 
-extern const ActorInit En_Syateki_Niw_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.h
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.h
@@ -36,6 +36,4 @@ typedef struct EnTa {
     /* 0x02E4 */ AnimationHeader* unk_2E4;
 } EnTa; // size = 0x02E8
 
-extern const ActorInit En_Ta_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.h
+++ b/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.h
@@ -28,6 +28,4 @@ typedef struct EnTakaraMan {
     /* 0x0232 */ Vec3s unk_232;
 } EnTakaraMan; // size = 0x0238
 
-extern const ActorInit En_Takara_Man_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Tana/z_en_tana.h
+++ b/src/overlays/actors/ovl_En_Tana/z_en_tana.h
@@ -10,6 +10,4 @@ typedef struct EnTana {
     /* 0x0000 */ Actor actor;
 } EnTana; // size = 0x014C
 
-extern const ActorInit En_Tana_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Test/z_en_test.h
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.h
@@ -111,6 +111,4 @@ typedef enum {
     /* 5 */ STALFOS_TYPE_5
 } StalfosType;
 
-extern const ActorInit En_Test_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Tg/z_en_tg.h
+++ b/src/overlays/actors/ovl_En_Tg/z_en_tg.h
@@ -18,6 +18,4 @@ typedef struct EnTg {
     /* 0x0208 */ u8 nextDialogue;
 } EnTg; // size = 0x020C
 
-extern const ActorInit En_Tg_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.h
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.h
@@ -35,6 +35,4 @@ typedef struct EnTite {
     /* 0x036C */ Vec3f backLeftFootPos;
 } EnTite; // size = 0x0378
 
-extern const ActorInit En_Tite_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.h
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.h
@@ -49,6 +49,4 @@ typedef struct EnTk {
     /* 0x0310 */ EnTkEff    eff[20];
 } EnTk; // size = 0x0770
 
-extern const ActorInit En_Tk_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Torch/z_en_torch.h
+++ b/src/overlays/actors/ovl_En_Torch/z_en_torch.h
@@ -10,6 +10,4 @@ typedef struct EnTorch {
     /* 0x0000 */ Actor actor;
 } EnTorch; // size = 0x014C
 
-extern const ActorInit En_Torch_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Torch2/z_en_torch2.h
+++ b/src/overlays/actors/ovl_En_Torch2/z_en_torch2.h
@@ -6,6 +6,4 @@
 
 // Uses the Player struct (from z64player.h)
 
-extern const ActorInit En_Torch2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.h
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.h
@@ -22,6 +22,4 @@ typedef struct EnToryo {
     /* 0x027A */ Vec3s morphTable[17];
 } EnToryo; // size = 0x02E0
 
-extern const ActorInit En_Toryo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Tp/z_en_tp.h
+++ b/src/overlays/actors/ovl_En_Tp/z_en_tp.h
@@ -36,6 +36,4 @@ typedef enum {
     /* 12 */ TAILPASARAN_HEAD_DYING
 } EnTpType;
 
-extern const ActorInit En_Tp_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Tr/z_en_tr.h
+++ b/src/overlays/actors/ovl_En_Tr/z_en_tr.h
@@ -22,8 +22,6 @@ typedef struct EnTr {
     /* 0x02E4 */ AnimationHeader* animation;
 } EnTr; // size = 0x02E8
 
-extern const ActorInit En_Tr_InitVars;
-
 typedef enum {
     /* 0 */ TR_KOUME,
     /* 1 */ TR_KOTAKE

--- a/src/overlays/actors/ovl_En_Trap/z_en_trap.h
+++ b/src/overlays/actors/ovl_En_Trap/z_en_trap.h
@@ -32,6 +32,4 @@ typedef struct EnTrap {
     /* 0x01A0 */ ColliderCylinder collider;
 } EnTrap; // size = 0x01EC
 
-extern const ActorInit En_Trap_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.h
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.h
@@ -16,6 +16,4 @@ typedef struct EnTuboTrap {
     /* 0x0160 */ ColliderCylinder collider;
 } EnTuboTrap; // size = 0x01AC
 
-extern const ActorInit En_Tubo_Trap_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Vali/z_en_vali.h
+++ b/src/overlays/actors/ovl_En_Vali/z_en_vali.h
@@ -57,8 +57,6 @@ typedef struct EnVali {
     /* 0x03FC */ ColliderCylinder bodyCollider;
 } EnVali; // size = 0x0448
 
-extern const ActorInit En_Vali_InitVars;
-
 typedef enum {
     /* 0 */ BARI_TYPE_NORMAL,
     /* 1 */ BARI_TYPE_SWORD_DAMAGE

--- a/src/overlays/actors/ovl_En_Vase/z_en_vase.h
+++ b/src/overlays/actors/ovl_En_Vase/z_en_vase.h
@@ -10,6 +10,4 @@ typedef struct EnVase {
     /* 0x0000 */ Actor actor;
 } EnVase; // size = 0x014C
 
-extern const ActorInit En_Vase_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.h
+++ b/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.h
@@ -19,6 +19,4 @@ typedef struct EnVbBall {
     /* 0x0168 */ ColliderCylinder collider;
 } EnVbBall; // size = 0x01B4
 
-extern const ActorInit En_Vb_Ball_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Viewer/z_en_viewer.h
+++ b/src/overlays/actors/ovl_En_Viewer/z_en_viewer.h
@@ -43,6 +43,4 @@ typedef struct EnViewer {
     /* 0x01E8 */ EnViewerUnkStruct unk_1E8[20];
 } EnViewer; // size = 0x05F8
 
-extern const ActorInit En_Viewer_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Vm/z_en_vm.h
+++ b/src/overlays/actors/ovl_En_Vm/z_en_vm.h
@@ -37,6 +37,4 @@ typedef enum {
     /* 0x01 */ BEAMOS_SMALL
 } BeamosType;
 
-extern const ActorInit En_Vm_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.h
+++ b/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.h
@@ -18,6 +18,4 @@ typedef struct EnWallTubo {
     /* 0x0164 */ Vec3f unk_164;
 } EnWallTubo; // size = 0x0170
 
-extern const ActorInit En_Wall_Tubo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
@@ -26,6 +26,4 @@ typedef struct EnWallmas {
     /* 0x02C8 */ ColliderCylinder collider;
 } EnWallmas; // size = 0x0314
 
-extern const ActorInit En_Wallmas_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.h
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.h
@@ -14,8 +14,6 @@ typedef struct EnWeatherTag {
     /* 0x0150 */ char unk_150[0x04];
 } EnWeatherTag; // size = 0x0154
 
-extern const ActorInit En_Weather_Tag_InitVars;
-
 typedef enum {
     /* 0x00 */ EN_WEATHER_TAG_TYPE_CLOUDY_MARKET,
     /* 0x01 */ EN_WEATHER_TAG_TYPE_CLOUDY_LON_LON_RANCH,

--- a/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.h
+++ b/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.h
@@ -21,6 +21,4 @@ typedef struct EnWeiyer {
     /* 0x0284 */ ColliderCylinder collider;
 } EnWeiyer; // size = 0x02D0
 
-extern const ActorInit En_Weiyer_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.h
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.h
@@ -11,6 +11,4 @@ typedef struct EnWf {
     /* 0x014C */ char unk_14C[0x390];
 } EnWf; // size = 0x04DC
 
-extern const ActorInit En_Wf_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.h
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.h
@@ -58,6 +58,4 @@ typedef enum {
     /* C */ WONDERITEM_DROP_RANDOM
 } EnWonderItemDrop;
 
-extern const ActorInit En_Wonder_Item_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.h
+++ b/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.h
@@ -22,6 +22,4 @@ typedef struct EnWonderTalk {
     /* 0x0164 */ u8  unk_164;
 } EnWonderTalk; // size = 0x0168
 
-extern const ActorInit En_Wonder_Talk_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.h
+++ b/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.h
@@ -23,6 +23,4 @@ typedef struct EnWonderTalk2 {
     /* 0x0164 */ Vec3f initPos;
 } EnWonderTalk2; // size = 0x0170
 
-extern const ActorInit En_Wonder_Talk2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.h
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.h
@@ -15,8 +15,6 @@ typedef struct EnWood02 {
     /* 0x0158 */ ColliderCylinder collider;
 } EnWood02; // size = 0x01A4
 
-extern const ActorInit En_Wood02_InitVars;
-
 // Types with SPAWNED in the name are those that can be managed by a spawner, however the actor allows you to spawn them
 // on their own without a spawner as well.
 typedef enum {

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.h
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.h
@@ -142,6 +142,4 @@ typedef struct EnXc {
     /* 0x0314 */ struct_80034A14_arg1 npcInfo;
 } EnXc; // size = 0x033C
 
-extern const ActorInit En_Xc_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.h
+++ b/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.h
@@ -21,6 +21,4 @@ typedef struct EnYabusameMark {
     /* 0x0190 */ ColliderQuad collider;
 } EnYabusameMark; // size = 0x0210
 
-extern const ActorInit En_Yabusame_Mark_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.h
+++ b/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.h
@@ -16,6 +16,4 @@ typedef struct EnYukabyun {
     /* 0x0154 */ ColliderCylinder collider;
 } EnYukabyun; // size = 0x01A0
 
-extern const ActorInit En_Yukabyun_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Zf/z_en_zf.h
+++ b/src/overlays/actors/ovl_En_Zf/z_en_zf.h
@@ -11,6 +11,4 @@ typedef struct EnZf {
     /* 0x014C */ char unk_14C[0x41C];
 } EnZf; // size = 0x0568
 
-extern const ActorInit En_Zf_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Zl1/z_en_zl1.h
+++ b/src/overlays/actors/ovl_En_Zl1/z_en_zl1.h
@@ -30,6 +30,4 @@ typedef struct EnZl1 {
     /* 0x0206 */ Vec3s unk_206;
 } EnZl1; // size = 0x020C
 
-extern const ActorInit En_Zl1_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Zl2/z_en_zl2.h
+++ b/src/overlays/actors/ovl_En_Zl2/z_en_zl2.h
@@ -40,6 +40,4 @@ typedef struct EnZl2 {
     /* 0x027C */ f32 unk_27C;
 } EnZl2; // size = 0x0280
 
-extern const ActorInit En_Zl2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Zl3/z_en_zl3.h
+++ b/src/overlays/actors/ovl_En_Zl3/z_en_zl3.h
@@ -68,6 +68,4 @@ typedef struct EnZl3 {
     /* 0x03F8 */ struct_80034A14_arg1 unk_3F8;
 } EnZl3; // size = 0x0420
 
-extern const ActorInit En_Zl3_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.h
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.h
@@ -31,6 +31,4 @@ typedef struct EnZl4 {
     /* 0x0284 */ Vec3s morphTable[18];
 } EnZl4; // size = 0x02F0
 
-extern const ActorInit En_Zl4_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.h
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.h
@@ -40,6 +40,4 @@ typedef struct EnZo {
     /* 0x067E */ s16 unk_67E[20];
 } EnZo; // size = 0x06A8
 
-extern const ActorInit En_Zo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_En_fHG/z_en_fhg.h
+++ b/src/overlays/actors/ovl_En_fHG/z_en_fhg.h
@@ -61,6 +61,4 @@ typedef struct EnfHG {
     /* 0x0204 */ PSkinAwb skin;
 } EnfHG; // size = 0x0294
 
-extern const ActorInit En_Fhg_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_End_Title/z_end_title.h
+++ b/src/overlays/actors/ovl_End_Title/z_end_title.h
@@ -13,6 +13,4 @@ typedef struct EndTitle {
     /* 0x014E */ u8 ootAlpha;
 } EndTitle; // size = 0x0150
 
-extern const ActorInit End_Title_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Fishing/z_fishing.h
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.h
@@ -60,6 +60,4 @@ typedef struct Fishing {
     /* 0x0250 */ ColliderJntSphElement colliderElements[12];
 } Fishing; // size = 0x0550
 
-extern const ActorInit Fishing_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.h
+++ b/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.h
@@ -15,6 +15,4 @@ typedef struct ItemBHeart {
     /* 0x0166 */ char unk_166[0x6];
 } ItemBHeart; // size = 0x016C
 
-extern const ActorInit Item_B_Heart_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.h
+++ b/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.h
@@ -35,6 +35,4 @@ typedef enum {
     /* 0x0D */ ITEM_ETC_KEY_SMALL_CHEST_GAME
 } ItemEtceteraType;
 
-extern const ActorInit Item_Etcetera_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.h
+++ b/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.h
@@ -13,6 +13,4 @@ typedef struct ItemInbox {
     /* 0x014C */ ItemInboxActionFunc actionFunc;
 } ItemInbox; // size = 0x0150
 
-extern const ActorInit Item_Inbox_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.h
+++ b/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.h
@@ -14,6 +14,4 @@ typedef struct ItemOcarina {
     /* 0x0150 */ s16 spinRotOffset;
 } ItemOcarina; // size = 0x0154
 
-extern const ActorInit Item_Ocarina_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Item_Shield/z_item_shield.h
+++ b/src/overlays/actors/ovl_Item_Shield/z_item_shield.h
@@ -19,6 +19,4 @@ typedef struct ItemShield {
     /* 0x0208 */ ItemShieldActionFunc actionFunc;
 } ItemShield; // size = 0x020C
 
-extern const ActorInit Item_Shield_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.h
+++ b/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.h
@@ -15,6 +15,4 @@ typedef struct MagicDark {
     /* 0x0160 */ char unk_160[0x4];
 } MagicDark; // size = 0x0164
 
-extern const ActorInit Magic_Dark_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.h
+++ b/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.h
@@ -18,6 +18,4 @@ typedef struct MagicFire {
     /* 0x01AA */ s16 screenTintBehaviourTimer;
 } MagicFire; // size = 0x01AC
 
-extern const ActorInit Magic_Fire_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.h
+++ b/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.h
@@ -15,6 +15,4 @@ typedef struct MagicWind {
     /* 0x0170 */ MagicWindFunc actionFunc;
 } MagicWind; // size = 0x0174
 
-extern const ActorInit Magic_Wind_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.h
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.h
@@ -44,6 +44,4 @@ typedef struct MirRay {
     /* 0x02AE */ u8 unLit; // Conditioned on. set in Cobra?
 } MirRay; // size = 0x02B0
 
-extern const ActorInit Mir_Ray_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.h
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.h
@@ -38,6 +38,4 @@ typedef struct ObjBean {
     /* 0x01F7 */ u8 stateFlags;
 } ObjBean; // size = 0x01F8
 
-extern const ActorInit Obj_Bean_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.h
+++ b/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.h
@@ -10,6 +10,4 @@ typedef struct ObjBlockstop {
     /* 0x0000 */ Actor actor;
 } ObjBlockstop; // size = 0x014C
 
-extern const ActorInit ObjBlockstop_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.h
+++ b/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.h
@@ -11,6 +11,4 @@ typedef struct ObjBombiwa {
     /* 0x014C */ ColliderCylinder collider;
 } ObjBombiwa; // size = 0x0198
 
-extern const ActorInit Obj_Bombiwa_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.h
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.h
@@ -17,6 +17,4 @@ typedef struct ObjComb {
     /* 0x01B2 */ s16 unk_1B2;
 } ObjComb; // size = 0x01B4
 
-extern const ActorInit Obj_Comb_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.h
+++ b/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.h
@@ -16,6 +16,4 @@ typedef struct ObjDekujr {
     /* 0x01A0 */ s32 unk_1A0;
 } ObjDekujr; // size = 0x01A4
 
-extern const ActorInit Obj_Dekujr_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.h
+++ b/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.h
@@ -16,6 +16,4 @@ typedef struct ObjElevator {
     /* 0x0170 */ u8 unk_170;
 } ObjElevator; // size = 0x0174
 
-extern const ActorInit Obj_Elevator_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.h
+++ b/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.h
@@ -17,6 +17,4 @@ typedef struct ObjHamishi {
     /* 0x01A6 */ s16 hitCount;
 } ObjHamishi; // size = 0x01A8
 
-extern const ActorInit Obj_Hamishi_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Hana/z_obj_hana.h
+++ b/src/overlays/actors/ovl_Obj_Hana/z_obj_hana.h
@@ -11,6 +11,4 @@ typedef struct ObjHana {
     /* 0x014C */ ColliderCylinder collider;
 } ObjHana; // size = 0x0198
 
-extern const ActorInit Obj_Hana_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.h
+++ b/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.h
@@ -13,6 +13,4 @@ typedef struct ObjHsblock {
     /* 0x0164 */ ObjHsblockActionFunc actionFunc;
 } ObjHsblock; // size = 0x0168
 
-extern const ActorInit Obj_Hsblock_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.h
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.h
@@ -18,6 +18,4 @@ typedef struct ObjIcePoly {
     /* 0x01A0 */ ColliderCylinder colliderHard;
 } ObjIcePoly; // size = 0x01EC
 
-extern const ActorInit Obj_Ice_Poly_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.h
+++ b/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.h
@@ -14,6 +14,4 @@ typedef struct ObjKibako {
     /* 0x0150 */ ColliderCylinder collider;
 } ObjKibako; // size = 0x019C
 
-extern const ActorInit Obj_Kibako_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.h
+++ b/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.h
@@ -15,6 +15,4 @@ typedef struct ObjKibako2 {
     /* 0x01B4 */ s16 collectibleFlag;
 } ObjKibako2; // size = 0x01B8
 
-extern const ActorInit Obj_Kibako2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.h
+++ b/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.h
@@ -15,6 +15,4 @@ typedef struct ObjLift {
     /* 0x016E */ s16 timer;
 } ObjLift; // size = 0x0170
 
-extern const ActorInit Obj_Lift_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.h
+++ b/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.h
@@ -30,6 +30,4 @@ typedef struct ObjLightswitch {
     /* 0x01C2 */ u8 prevFrameACflags;
 } ObjLightswitch; // size = 0x01C4
 
-extern const ActorInit Obj_Lightswitch_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.h
+++ b/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.h
@@ -15,6 +15,4 @@ typedef struct ObjMakekinsuta {
     /* 0x152  */ s16 unk_152;
 } ObjMakekinsuta; // size = 0x0154
 
-extern const ActorInit Obj_Makekinsuta_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Makeoshihiki/z_obj_makeoshihiki.h
+++ b/src/overlays/actors/ovl_Obj_Makeoshihiki/z_obj_makeoshihiki.h
@@ -10,6 +10,4 @@ typedef struct ObjMakeoshihiki {
     /* 0x0000 */ Actor actor;
 } ObjMakeoshihiki; // size = 0x014C
 
-extern const ActorInit Obj_Makeoshihiki_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.h
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.h
@@ -24,6 +24,4 @@ typedef struct ObjMure {
     /* 0x01A8 */ s16 unk_1A8;
 } ObjMure; // size = 0x01AC
 
-extern const ActorInit Obj_Mure_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.h
+++ b/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.h
@@ -16,6 +16,4 @@ typedef struct ObjMure2 {
     /* 0x0184 */ f32 unk_184; // some sort of distance
 } ObjMure2; // size = 0x0188
 
-extern const ActorInit Obj_Mure2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.h
+++ b/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.h
@@ -16,6 +16,4 @@ typedef struct ObjMure3 {
     /* 0x016C */ u16 unk_16C;
 } ObjMure3; // size = 0x0170
 
-extern const ActorInit Obj_Mure3_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.h
+++ b/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.h
@@ -51,6 +51,4 @@ typedef struct ObjOshihiki {
     /* 0x01D0 */ Color_RGB8 color;
 } ObjOshihiki; // size = 0x01D4
 
-extern const ActorInit Obj_Oshihiki_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.h
+++ b/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.h
@@ -15,6 +15,4 @@ typedef struct ObjRoomtimer {
     /* 0x0150 */ u32 switchFlag;
 } ObjRoomtimer; // size = 0x0154
 
-extern const ActorInit Obj_Roomtimer_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -65,6 +65,4 @@ typedef struct ObjSwitch {
     };
 } ObjSwitch; // size = 0x0258
 
-extern const ActorInit Obj_Switch_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h
+++ b/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h
@@ -16,6 +16,4 @@ typedef struct ObjSyokudai {
     /* 0x01EC */ LightInfo lightInfo;
 } ObjSyokudai; // size = 0x01FC
 
-extern const ActorInit Obj_Syokudai_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.h
+++ b/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.h
@@ -24,6 +24,4 @@ typedef struct ObjTimeblock {
     /* 0x0178 */ u8 isVisible;
 } ObjTimeblock; // size = 0x017C
 
-extern const ActorInit Obj_Timeblock_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.h
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.h
@@ -15,7 +15,5 @@ typedef struct ObjTsubo {
     /* 0x019C */ s8 objTsuboBankIndex;
 } ObjTsubo; // size = 0x01A0
 
-extern const ActorInit Obj_Tsubo_InitVars;
-
 #endif
 

--- a/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.h
+++ b/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.h
@@ -20,6 +20,4 @@ typedef struct ObjWarp2block {
     /* 0x0174 */ s16 unk_174;
 } ObjWarp2block; // size = 0x0178
 
-extern const ActorInit Obj_Warp2block_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.h
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.h
@@ -14,6 +14,4 @@ typedef struct ObjectKankyo {
     /* 0x165C */ ObjectKankyoActionFunc actionFunc;
 } ObjectKankyo; // size = 0x1660
 
-extern const ActorInit Object_Kankyo_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.h
+++ b/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.h
@@ -19,6 +19,4 @@ typedef struct OceffSpot {
     /* 0x017C */ OceffSpotActionFunc actionFunc;
 } OceffSpot; // size = 0x0180
 
-extern const ActorInit Oceff_Spot_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.h
+++ b/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.h
@@ -18,6 +18,4 @@ typedef struct OceffStorm {
     /* 0x0154 */ OceffStormActionFunc actionFunc;
 } OceffStorm; // size = 0x0158
 
-extern const ActorInit Oceff_Storm_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.h
+++ b/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.h
@@ -16,6 +16,4 @@ typedef struct OceffWipe {
     /* 0x014C */ s16 counter;
 } OceffWipe; // size = 0x0150
 
-extern const ActorInit Oceff_Wipe_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.h
+++ b/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.h
@@ -11,6 +11,4 @@ typedef struct OceffWipe2 {
     /* 0x014C */ s16 counter;
 } OceffWipe2; // size = 0x0150
 
-extern const ActorInit Oceff_Wipe2_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.h
+++ b/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.h
@@ -11,6 +11,4 @@ typedef struct OceffWipe3 {
     /* 0x014C */ s16 counter;
 } OceffWipe3; // size = 0x0150
 
-extern const ActorInit Oceff_Wipe3_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.h
+++ b/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.h
@@ -16,6 +16,4 @@ typedef struct OceffWipe4 {
     /* 0x014C */ s16 counter;
 } OceffWipe4; // size = 0x0150
 
-extern const ActorInit Oceff_Wipe4_InitVars;
-
 #endif

--- a/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.h
+++ b/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.h
@@ -17,6 +17,4 @@ typedef struct ShotSun {
     /* 0x01A4 */ u8 unk_1A4;
 } ShotSun; // size = 0x01A8
 
-extern const ActorInit Shot_Sun_InitVars;
-
 #endif


### PR DESCRIPTION
These declarations were meant for future-proofing, but in the end they aren't used at all, so I think we can remove them.

For context, the only place we need to reference InitVars is `z_actor_dlftbls.c` aka. the actor overlay table, and we don't need manual externs there since we automatically generate the declarations from the actor name. I also can't think of a reason to reference InitVars directly in a modding scenario, so that's not really a concern either.