### PR TITLE
Add do whiles to all remaining gbi macros

### DIFF
--- a/include/ultra64/gbi.h
+++ b/include/ultra64/gbi.h
@@ -1618,12 +1618,12 @@ typedef union {
  * DMA macros
  */
 #define gDma0p(pkt, c, s, l)                        \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL((c), 24, 8) | _SHIFTL((l), 0, 24);   \
     _g->words.w1 = (unsigned int)(s);               \
-}
+})
 
 #define gsDma0p(c, s, l)                        \
 {                                   \
@@ -1742,11 +1742,11 @@ _DW({                                   \
  * RSP short command (no DMA required) macros
  */
 #define gImmp0(pkt, c)                          \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL((c), 24, 8);             \
-}
+})
 
 #define gsImmp0(c)                          \
 {                                   \
@@ -1767,12 +1767,12 @@ _DW({                                   \
 }
 
 #define gImmp2(pkt, c, p0, p1)                      \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL((c), 24, 8);             \
     _g->words.w1 = _SHIFTL((p0), 16, 16) | _SHIFTL((p1), 8, 8); \
-}
+})
 
 #define gsImmp2(c, p0, p1)                      \
 {                                   \
@@ -1780,13 +1780,13 @@ _DW({                                   \
 }
 
 #define gImmp3(pkt, c, p0, p1, p2)                  \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL((c), 24, 8);             \
     _g->words.w1 = (_SHIFTL((p0), 16, 16) | _SHIFTL((p1), 8, 8) |   \
             _SHIFTL((p2), 0, 8));               \
-}
+})
 
 #define gsImmp3(c, p0, p1, p2)                      \
 {                                   \
@@ -1824,7 +1824,7 @@ _DW({                                   \
 /* Sprite immediate macros, there is also a sprite dma macro above */
 
 #define gSPSprite2DScaleFlip(pkt, sx, sy, fx, fy)                       \
-{                                                                       \
+_DW({                                                                       \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = (_SHIFTL(G_SPRITE2D_SCALEFLIP, 24, 8) |          \
@@ -1832,7 +1832,7 @@ _DW({                                   \
             _SHIFTL((fy), 0, 8));                           \
     _g->words.w1 = (_SHIFTL((sx), 16, 16) |                         \
             _SHIFTL((sy),  0, 16));                         \
-}
+})
 
 #define gsSPSprite2DScaleFlip(sx, sy, fx, fy)                           \
 {                                                                       \
@@ -1844,13 +1844,13 @@ _DW({                                   \
 }
 
 #define gSPSprite2DDraw(pkt, px, py)                                    \
-{                                                                       \
+_DW({                                                                       \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = (_SHIFTL(G_SPRITE2D_DRAW, 24, 8));               \
     _g->words.w1 = (_SHIFTL((px), 16, 16) |                         \
             _SHIFTL((py),  0, 16));                         \
-}
+})
 
 #define gsSPSprite2DDraw(px, py)                                        \
 {                                                                       \
@@ -1917,13 +1917,13 @@ _DW({                                   \
  ***  Line
  ***/
 #define gSPLine3D(pkt, v0, v1, flag)                    \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL(G_LINE3D, 24, 8)|            \
             __gsSPLine3D_w1f(v0, v1, 0, flag);      \
     _g->words.w1 = 0;                       \
-}
+})
 #define gsSPLine3D(v0, v1, flag)                    \
 {                                   \
     _SHIFTL(G_LINE3D, 24, 8)|__gsSPLine3D_w1f(v0, v1, 0, flag), \
@@ -1940,13 +1940,13 @@ _DW({                                   \
  * a 2.0 pixels wide line.
  */
 #define gSPLineW3D(pkt, v0, v1, wd, flag)               \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL(G_LINE3D, 24, 8)|            \
             __gsSPLine3D_w1f(v0, v1, wd, flag);     \
     _g->words.w1 = 0;                       \
-}
+})
 #define gsSPLineW3D(v0, v1, wd, flag)                   \
 {                                   \
     _SHIFTL(G_LINE3D, 24, 8)|__gsSPLine3D_w1f(v0, v1, wd, flag),    \
@@ -2071,13 +2071,13 @@ _DW({                                   \
 
 #if (defined(F3DEX_GBI)||defined(F3DLP_GBI))
 #define gSPCullDisplayList(pkt,vstart,vend)             \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL(G_CULLDL, 24, 8) |           \
             _SHIFTL((vstart)*2, 0, 16);         \
     _g->words.w1 = _SHIFTL((vend)*2, 0, 16);            \
-}
+})
 
 #define gsSPCullDisplayList(vstart,vend)                \
 {                                   \
@@ -2126,12 +2126,12 @@ _DW({                                   \
  * r should be one of: FRUSTRATIO_1, FRUSTRATIO_2, FRUSTRATIO_3, ... FRUSTRATIO_6
  */
 #define gSPClipRatio(pkt, r)                        \
-{                                   \
+_DW({                                   \
     gMoveWd(pkt, G_MW_CLIP, G_MWO_CLIP_RNX, FR_NEG_##r);        \
     gMoveWd(pkt, G_MW_CLIP, G_MWO_CLIP_RNY, FR_NEG_##r);        \
     gMoveWd(pkt, G_MW_CLIP, G_MWO_CLIP_RPX, FR_POS_##r);        \
     gMoveWd(pkt, G_MW_CLIP, G_MWO_CLIP_RPY, FR_POS_##r);        \
-}
+})
 
 #define gsSPClipRatio(r)                        \
     gsMoveWd(G_MW_CLIP, G_MWO_CLIP_RNX, FR_NEG_##r),        \
@@ -2165,9 +2165,10 @@ _DW({                                   \
  */
 #ifdef  F3DEX_GBI_2
 #define gSPForceMatrix(pkt, mptr)                   \
-{   gDma2p((pkt),G_MOVEMEM,(mptr),sizeof(Mtx),G_MV_MATRIX,0);   \
+_DW({  \
+    gDma2p((pkt),G_MOVEMEM,(mptr),sizeof(Mtx),G_MV_MATRIX,0);   \
     gMoveWd((pkt), G_MW_FORCEMTX,0,0x00010000);         \
-}
+})
 #define gsSPForceMatrix(mptr)                       \
     gsDma2p(G_MOVEMEM,(mptr),sizeof(Mtx),G_MV_MATRIX,0),        \
     gsMoveWd(G_MW_FORCEMTX,0,0x00010000)
@@ -2196,12 +2197,12 @@ _DW({                                   \
  */
 #if (defined(F3DEX_GBI)||defined(F3DLP_GBI))
 # define gSPModifyVertex(pkt, vtx, where, val)              \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
     _g->words.w0 = (_SHIFTL(G_MODIFYVTX,24,8)|          \
                 _SHIFTL((where),16,8)|_SHIFTL((vtx)*2,0,16));   \
     _g->words.w1 = (unsigned int)(val);             \
-}
+})
 # define gsSPModifyVertex(vtx, where, val)              \
 {                                   \
     _SHIFTL(G_MODIFYVTX,24,8)|                  \
@@ -2242,7 +2243,7 @@ _DW({                                   \
     G_DEPTOZSrg(zval, near, far, flag, 0, G_MAXZ)
 
 #define gSPBranchLessZrg(pkt, dl, vtx, zval, near, far, flag, zmin, zmax) \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
     _g->words.w0 = _SHIFTL(G_RDPHALF_1,24,8);           \
     _g->words.w1 = (unsigned int)(dl);              \
@@ -2250,7 +2251,7 @@ _DW({                                   \
     _g->words.w0 = (_SHIFTL(G_BRANCH_Z,24,8)|           \
                 _SHIFTL((vtx)*5,12,12)|_SHIFTL((vtx)*2,0,12));  \
     _g->words.w1 = G_DEPTOZSrg(zval, near, far, flag, zmin, zmax);  \
-}
+})
 
 #define gsSPBranchLessZrg(dl, vtx, zval, near, far, flag, zmin, zmax)         \
 {   _SHIFTL(G_RDPHALF_1,24,8),                        \
@@ -2271,7 +2272,7 @@ _DW({                                   \
  *  zval = Raw value of screen depth
  */
 #define gSPBranchLessZraw(pkt, dl, vtx, zval)               \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
     _g->words.w0 = _SHIFTL(G_RDPHALF_1,24,8);           \
     _g->words.w1 = (unsigned int)(dl);              \
@@ -2279,7 +2280,7 @@ _DW({                                   \
     _g->words.w0 = (_SHIFTL(G_BRANCH_Z,24,8)|           \
                 _SHIFTL((vtx)*5,12,12)|_SHIFTL((vtx)*2,0,12));  \
     _g->words.w1 = (unsigned int)(zval);                \
-}
+})
 
 #define gsSPBranchLessZraw(dl, vtx, zval)               \
 {   _SHIFTL(G_RDPHALF_1,24,8),                        \
@@ -2329,12 +2330,12 @@ _DW({                                   \
  * gSPDma_io  DMA to/from DMEM/IMEM for DEBUG.
  */
 #define gSPDma_io(pkt, flag, dmem, dram, size)              \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
     _g->words.w0 = _SHIFTL(G_DMA_IO,24,8)|_SHIFTL((flag),23,1)| \
       _SHIFTL((dmem)/8,13,10)|_SHIFTL((size)-1,0,12);       \
     _g->words.w1 = (unsigned int)(dram);                \
-}
+})
 
 #define gsSPDma_io(flag, dmem, dram, size)              \
 {                                   \
@@ -2409,10 +2410,10 @@ _DW({                                   \
  * n should be one of LIGHT_1, LIGHT_2, ..., LIGHT_8
  */
 #define gSPLightColor(pkt, n, col)                  \
-{                                   \
+_DW({                                   \
     gMoveWd(pkt, G_MW_LIGHTCOL, G_MWO_a##n, col);           \
     gMoveWd(pkt, G_MW_LIGHTCOL, G_MWO_b##n, col);           \
-}
+})
 #define gsSPLightColor(n, col)                      \
     gsMoveWd(G_MW_LIGHTCOL, G_MWO_a##n, col),           \
     gsMoveWd(G_MW_LIGHTCOL, G_MWO_b##n, col)
@@ -2420,34 +2421,34 @@ _DW({                                   \
 /* These macros use a structure "name" which is init'd with the gdSPDefLights macros*/
 
 #define gSPSetLights0(pkt,name)                     \
-{                                   \
+_DW({                                   \
     gSPNumLights(pkt,NUMLIGHTS_0);                  \
     gSPLight(pkt,&name.l[0],1);                 \
     gSPLight(pkt,&name.a,2);                    \
-}
+})
 #define gsSPSetLights0(name)                        \
     gsSPNumLights(NUMLIGHTS_0),                 \
     gsSPLight(&name.l[0],1),                    \
     gsSPLight(&name.a,2)
 
 #define gSPSetLights1(pkt,name)                     \
-{                                   \
+_DW({                                   \
     gSPNumLights(pkt,NUMLIGHTS_1);                  \
     gSPLight(pkt,&name.l[0],1);                 \
     gSPLight(pkt,&name.a,2);                    \
-}
+})
 #define gsSPSetLights1(name)                        \
     gsSPNumLights(NUMLIGHTS_1),                 \
     gsSPLight(&name.l[0],1),                    \
     gsSPLight(&name.a,2)
 
 #define gSPSetLights2(pkt,name)                     \
-{                                   \
+_DW({                                   \
     gSPNumLights(pkt,NUMLIGHTS_2);                  \
     gSPLight(pkt,&name.l[0],1);                 \
     gSPLight(pkt,&name.l[1],2);                 \
     gSPLight(pkt,&name.a,3);                    \
-}
+})
 #define gsSPSetLights2(name)                        \
     gsSPNumLights(NUMLIGHTS_2),                 \
     gsSPLight(&name.l[0],1),                    \
@@ -2455,13 +2456,13 @@ _DW({                                   \
     gsSPLight(&name.a,3)
 
 #define gSPSetLights3(pkt,name)                     \
-{                                   \
+_DW({                                   \
     gSPNumLights(pkt,NUMLIGHTS_3);                  \
     gSPLight(pkt,&name.l[0],1);                 \
     gSPLight(pkt,&name.l[1],2);                 \
     gSPLight(pkt,&name.l[2],3);                 \
     gSPLight(pkt,&name.a,4);                    \
-}
+})
 #define gsSPSetLights3(name)                        \
     gsSPNumLights(NUMLIGHTS_3),                 \
     gsSPLight(&name.l[0],1),                    \
@@ -2470,14 +2471,14 @@ _DW({                                   \
     gsSPLight(&name.a,4)
 
 #define gSPSetLights4(pkt,name)                     \
-{                                   \
+_DW({                                   \
     gSPNumLights(pkt,NUMLIGHTS_4);                  \
     gSPLight(pkt,&name.l[0],1);                 \
     gSPLight(pkt,&name.l[1],2);                 \
     gSPLight(pkt,&name.l[2],3);                 \
     gSPLight(pkt,&name.l[3],4);                 \
     gSPLight(pkt,&name.a,5);                    \
-}
+})
 #define gsSPSetLights4(name)                        \
     gsSPNumLights(NUMLIGHTS_4),                 \
     gsSPLight(&name.l[0],1),                    \
@@ -2487,7 +2488,7 @@ _DW({                                   \
     gsSPLight(&name.a,5)
 
 #define gSPSetLights5(pkt,name)                     \
-{                                   \
+_DW({                                   \
     gSPNumLights(pkt,NUMLIGHTS_5);                  \
     gSPLight(pkt,&name.l[0],1);                 \
     gSPLight(pkt,&name.l[1],2);                 \
@@ -2495,7 +2496,7 @@ _DW({                                   \
     gSPLight(pkt,&name.l[3],4);                 \
     gSPLight(pkt,&name.l[4],5);                 \
     gSPLight(pkt,&name.a,6);                    \
-}
+})
 
 #define gsSPSetLights5(name)                        \
     gsSPNumLights(NUMLIGHTS_5),                 \
@@ -2507,7 +2508,7 @@ _DW({                                   \
     gsSPLight(&name.a,6)
 
 #define gSPSetLights6(pkt,name)                     \
-{                                   \
+_DW({                                   \
     gSPNumLights(pkt,NUMLIGHTS_6);                  \
     gSPLight(pkt,&name.l[0],1);                 \
     gSPLight(pkt,&name.l[1],2);                 \
@@ -2516,7 +2517,7 @@ _DW({                                   \
     gSPLight(pkt,&name.l[4],5);                 \
     gSPLight(pkt,&name.l[5],6);                 \
     gSPLight(pkt,&name.a,7);                    \
-}
+})
 
 #define gsSPSetLights6(name)                        \
     gsSPNumLights(NUMLIGHTS_6),                 \
@@ -2529,7 +2530,7 @@ _DW({                                   \
     gsSPLight(&name.a,7)
 
 #define gSPSetLights7(pkt,name)                     \
-{                                   \
+_DW({                                   \
     gSPNumLights(pkt,NUMLIGHTS_7);                  \
     gSPLight(pkt,&name.l[0],1);                 \
     gSPLight(pkt,&name.l[1],2);                 \
@@ -2539,7 +2540,7 @@ _DW({                                   \
     gSPLight(pkt,&name.l[5],6);                 \
     gSPLight(pkt,&name.l[6],7);                 \
     gSPLight(pkt,&name.a,8);                    \
-}
+})
 
 #define gsSPSetLights7(name)                        \
     gsSPNumLights(NUMLIGHTS_7),                 \
@@ -2654,7 +2655,7 @@ _DW({                                   \
  * which is currently reserved in the microcode.
  */
 # define gSPTextureL(pkt, s, t, level, xparam, tile, on)        \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = (_SHIFTL(G_TEXTURE,24,8) |           \
@@ -2662,7 +2663,7 @@ _DW({                                   \
             _SHIFTL((level),11,3) | _SHIFTL((tile),8,3) |   \
             _SHIFTL((on),1,7));             \
     _g->words.w1 = (_SHIFTL((s),16,16) | _SHIFTL((t),0,16));    \
-}
+})
 # define gsSPTextureL(s, t, level, xparam, tile, on)            \
 {                                   \
     (_SHIFTL(G_TEXTURE,24,8) | _SHIFTL((xparam),16,8) |     \
@@ -2947,12 +2948,12 @@ _DW({                                   \
  */
 
 #define gDPSetCombine(pkt, muxs0, muxs1)                \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL(G_SETCOMBINE, 24, 8) | _SHIFTL(muxs0, 0, 24);\
     _g->words.w1 = (unsigned int)(muxs1);               \
-}
+})
 
 #define gsDPSetCombine(muxs0, muxs1)                    \
 {                                   \
@@ -3287,7 +3288,7 @@ _DW({                                   \
 
 #define gDPLoadTextureBlock(pkt, timg, fmt, siz, width, height,     \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, siz##_LOAD_BLOCK, 1, timg);    \
     gDPSetTile(pkt, fmt, siz##_LOAD_BLOCK, 0, 0, G_TX_LOADTILE,     \
         0 , cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3303,11 +3304,11 @@ _DW({                                   \
     gDPSetTileSize(pkt, G_TX_RENDERTILE, 0, 0,          \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 #define gDPLoadTextureBlockYuv(pkt, timg, fmt, siz, width, height,  \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, siz##_LOAD_BLOCK, 1, timg);    \
     gDPSetTile(pkt, fmt, siz##_LOAD_BLOCK, 0, 0, G_TX_LOADTILE,     \
         0 , cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3323,14 +3324,14 @@ _DW({                                   \
     gDPSetTileSize(pkt, G_TX_RENDERTILE, 0, 0,          \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 /* Load fix rww 27jun95 */
 /* The S at the end means odd lines are already word Swapped */
 
 #define gDPLoadTextureBlockS(pkt, timg, fmt, siz, width, height,    \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, siz##_LOAD_BLOCK, 1, timg);    \
     gDPSetTile(pkt, fmt, siz##_LOAD_BLOCK, 0, 0, G_TX_LOADTILE,     \
         0 , cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3345,7 +3346,7 @@ _DW({                                   \
     gDPSetTileSize(pkt, G_TX_RENDERTILE, 0, 0,          \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 /*
  *  Allow tmem address and render tile to be specified.
@@ -3353,7 +3354,7 @@ _DW({                                   \
  */
 #define gDPLoadMultiBlockS(pkt, timg, tmem, rtile, fmt, siz, width,     \
            height, pal, cms, cmt, masks, maskt, shifts, shiftt) \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, siz##_LOAD_BLOCK, 1, timg);    \
     gDPSetTile(pkt, fmt, siz##_LOAD_BLOCK, 0, tmem, G_TX_LOADTILE,  \
         0 , cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3368,12 +3369,12 @@ _DW({                                   \
     gDPSetTileSize(pkt, rtile, 0, 0,                \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 
 #define gDPLoadTextureBlockYuvS(pkt, timg, fmt, siz, width, height, \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, siz##_LOAD_BLOCK, 1, timg);    \
     gDPSetTile(pkt, fmt, siz##_LOAD_BLOCK, 0, 0, G_TX_LOADTILE,     \
         0 , cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3388,14 +3389,14 @@ _DW({                                   \
     gDPSetTileSize(pkt, G_TX_RENDERTILE, 0, 0,          \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 /*
  *  allows tmem address to be specified
  */
 #define _gDPLoadTextureBlock(pkt, timg, tmem, fmt, siz, width, height,  \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, siz##_LOAD_BLOCK, 1, timg);    \
     gDPSetTile(pkt, fmt, siz##_LOAD_BLOCK, 0, tmem, G_TX_LOADTILE,  \
         0, cmt, maskt, shiftt, cms, masks, shifts);     \
@@ -3410,14 +3411,14 @@ _DW({                                   \
     gDPSetTileSize(pkt, G_TX_RENDERTILE, 0, 0,          \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 /*
  *  allows tmem address and render tile to be specified
  */
 #define _gDPLoadTextureBlockTile(pkt, timg, tmem, rtile, fmt, siz, width,  \
         height, pal, cms, cmt, masks, maskt, shifts, shiftt)    \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, siz##_LOAD_BLOCK, 1, timg);    \
     gDPSetTile(pkt, fmt, siz##_LOAD_BLOCK, 0, tmem, G_TX_LOADTILE, 0,\
         cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3432,14 +3433,14 @@ _DW({                                   \
     gDPSetTileSize(pkt, rtile, 0, 0,                \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 /*
  *  allows tmem address and render tile to be specified
  */
 #define gDPLoadMultiBlock(pkt, timg, tmem, rtile, fmt, siz, width,      \
         height, pal, cms, cmt, masks, maskt, shifts, shiftt)    \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, siz##_LOAD_BLOCK, 1, timg);    \
     gDPSetTile(pkt, fmt, siz##_LOAD_BLOCK, 0, tmem, G_TX_LOADTILE, 0,\
         cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3454,7 +3455,7 @@ _DW({                                   \
     gDPSetTileSize(pkt, rtile, 0, 0,                \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 #define gsDPLoadTextureBlock(timg, fmt, siz, width, height,     \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
@@ -3594,7 +3595,7 @@ _DW({                                   \
 
 #define gDPLoadTextureBlock_4b(pkt, timg, fmt, width, height,       \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, G_IM_SIZ_16b, 1, timg);        \
     gDPSetTile(pkt, fmt, G_IM_SIZ_16b, 0, 0, G_TX_LOADTILE, 0,  \
         cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3609,14 +3610,14 @@ _DW({                                   \
     gDPSetTileSize(pkt, G_TX_RENDERTILE, 0, 0,          \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 /* Load fix rww 27jun95 */
 /* The S at the end means odd lines are already word Swapped */
 
 #define gDPLoadTextureBlock_4bS(pkt, timg, fmt, width, height,      \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, G_IM_SIZ_16b, 1, timg);        \
     gDPSetTile(pkt, fmt, G_IM_SIZ_16b, 0, 0, G_TX_LOADTILE, 0,  \
         cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3630,14 +3631,14 @@ _DW({                                   \
     gDPSetTileSize(pkt, G_TX_RENDERTILE, 0, 0,          \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 /*
  *  4-bit load block.  Useful when loading multiple tiles
  */
 #define gDPLoadMultiBlock_4b(pkt, timg, tmem, rtile, fmt, width, height,\
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, G_IM_SIZ_16b, 1, timg);        \
     gDPSetTile(pkt, fmt, G_IM_SIZ_16b, 0, tmem, G_TX_LOADTILE, 0,   \
         cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3652,7 +3653,7 @@ _DW({                                   \
     gDPSetTileSize(pkt, rtile, 0, 0,                \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 /*
  *  4-bit load block.  Allows tmem and render tile to be specified.  Useful when
@@ -3660,7 +3661,7 @@ _DW({                                   \
  */
 #define gDPLoadMultiBlock_4bS(pkt, timg, tmem, rtile, fmt, width, height,\
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, G_IM_SIZ_16b, 1, timg);        \
     gDPSetTile(pkt, fmt, G_IM_SIZ_16b, 0, tmem, G_TX_LOADTILE, 0,   \
         cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3674,12 +3675,12 @@ _DW({                                   \
     gDPSetTileSize(pkt, rtile, 0, 0,                \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 
 #define _gDPLoadTextureBlock_4b(pkt, timg, tmem, fmt, width, height,    \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, G_IM_SIZ_16b, 1, timg);        \
     gDPSetTile(pkt, fmt, G_IM_SIZ_16b, 0, tmem, G_TX_LOADTILE, 0,   \
         cmt, maskt, shiftt, cms, masks, shifts);        \
@@ -3694,7 +3695,7 @@ _DW({                                   \
     gDPSetTileSize(pkt, G_TX_RENDERTILE, 0, 0,          \
         ((width)-1) << G_TEXTURE_IMAGE_FRAC,            \
         ((height)-1) << G_TEXTURE_IMAGE_FRAC);          \
-}
+})
 
 #define gsDPLoadTextureBlock_4b(timg, fmt, width, height,       \
         pal, cms, cmt, masks, maskt, shifts, shiftt)        \
@@ -3931,7 +3932,7 @@ _DW({                                   \
 #define gDPLoadTextureTile_4b(pkt, timg, fmt, width, height,        \
         uls, ult, lrs, lrt, pal,                \
         cms, cmt, masks, maskt, shifts, shiftt)         \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, G_IM_SIZ_8b, ((width)>>1), timg);  \
     gDPSetTile(pkt, fmt, G_IM_SIZ_8b,               \
            (((((lrs)-(uls)+1)>>1)+7)>>3), 0,            \
@@ -3953,7 +3954,7 @@ _DW({                                   \
             (ult)<<G_TEXTURE_IMAGE_FRAC,            \
             (lrs)<<G_TEXTURE_IMAGE_FRAC,            \
             (lrt)<<G_TEXTURE_IMAGE_FRAC);           \
-}
+})
 
 /*
  *  Load texture tile.  Allows tmem address and render tile to be specified.
@@ -3962,7 +3963,7 @@ _DW({                                   \
 #define gDPLoadMultiTile_4b(pkt, timg, tmem, rtile, fmt, width, height, \
         uls, ult, lrs, lrt, pal,                \
         cms, cmt, masks, maskt, shifts, shiftt)         \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, fmt, G_IM_SIZ_8b, ((width)>>1), timg);  \
     gDPSetTile(pkt, fmt, G_IM_SIZ_8b,                   \
            (((((lrs)-(uls)+1)>>1)+7)>>3), tmem,         \
@@ -3984,7 +3985,7 @@ _DW({                                   \
             (ult)<<G_TEXTURE_IMAGE_FRAC,            \
             (lrs)<<G_TEXTURE_IMAGE_FRAC,            \
             (lrt)<<G_TEXTURE_IMAGE_FRAC);           \
-}
+})
 
 #define gsDPLoadTextureTile_4b(timg, fmt, width, height,        \
         uls, ult, lrs, lrt, pal,                \
@@ -4045,7 +4046,7 @@ _DW({                                   \
 #ifndef _HW_VERSION_1
 
 #define gDPLoadTLUT_pal16(pkt, pal, dram)               \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, dram);  \
     gDPTileSync(pkt);                       \
     gDPSetTile(pkt, 0, 0, 0, (256+(((pal)&0xf)*16)),        \
@@ -4053,7 +4054,7 @@ _DW({                                   \
     gDPLoadSync(pkt);                       \
     gDPLoadTLUTCmd(pkt, G_TX_LOADTILE, 15);             \
     gDPPipeSync(pkt);                       \
-}
+})
 
 #else /* **** WORKAROUND hardware 1 load_tlut bug ****** */
 
@@ -4099,7 +4100,7 @@ _DW({                                   \
 #ifndef _HW_VERSION_1
 
 #define gDPLoadTLUT_pal256(pkt, dram)                   \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, dram);  \
     gDPTileSync(pkt);                       \
     gDPSetTile(pkt, 0, 0, 0, 256,                   \
@@ -4107,7 +4108,7 @@ _DW({                                   \
     gDPLoadSync(pkt);                       \
     gDPLoadTLUTCmd(pkt, G_TX_LOADTILE, 255);            \
     gDPPipeSync(pkt);                       \
-}
+})
 
 #else /* **** WORKAROUND hardware 1 load_tlut bug ****** */
 
@@ -4147,7 +4148,7 @@ _DW({                                   \
 #ifndef _HW_VERSION_1
 
 #define gDPLoadTLUT(pkt, count, tmemaddr, dram)             \
-{                                   \
+_DW({                                   \
     gDPSetTextureImage(pkt, G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, dram);  \
     gDPTileSync(pkt);                       \
     gDPSetTile(pkt, 0, 0, 0, tmemaddr,              \
@@ -4155,7 +4156,7 @@ _DW({                                   \
     gDPLoadSync(pkt);                       \
     gDPLoadTLUTCmd(pkt, G_TX_LOADTILE, ((count)-1));        \
     gDPPipeSync(pkt);                       \
-}
+})
 
 #else /* **** WORKAROUND hardware 1 load_tlut bug ****** */
 
@@ -4253,7 +4254,7 @@ _DW({                                   \
 
 /* like gDPFillRectangle but accepts negative arguments */
 #define gDPScisFillRectangle(pkt, ulx, uly, lrx, lry)           \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = (_SHIFTL(G_FILLRECT, 24, 8) |            \
@@ -4261,10 +4262,10 @@ _DW({                                   \
             _SHIFTL(MAX((lry),0), 2, 10));          \
     _g->words.w1 = (_SHIFTL(MAX((ulx),0), 14, 10) |         \
             _SHIFTL(MAX((uly),0), 2, 10));          \
-}
+})
 
 #define gDPSetConvert(pkt, k0, k1, k2, k3, k4, k5)          \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = (_SHIFTL(G_SETCONVERT, 24, 8) |          \
@@ -4272,7 +4273,7 @@ _DW({                                   \
             _SHIFTR(k2, 5, 4));             \
     _g->words.w1 = (_SHIFTL(k2, 27, 5) | _SHIFTL(k3, 18, 9) |   \
             _SHIFTL(k4, 9, 9) | _SHIFTL(k5, 0, 9));     \
-}
+})
 
 #define gsDPSetConvert(k0, k1, k2, k3, k4, k5)              \
 {                                   \
@@ -4283,13 +4284,13 @@ _DW({                                   \
 }
 
 #define gDPSetKeyR(pkt, cR, sR, wR)                 \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL(G_SETKEYR, 24, 8);           \
     _g->words.w1 = (_SHIFTL(wR, 16, 12) | _SHIFTL(cR, 8, 8) |   \
             _SHIFTL(sR, 0, 8));             \
-}
+})
 
 #define gsDPSetKeyR(cR, sR, wR)                     \
 {                                   \
@@ -4298,14 +4299,14 @@ _DW({                                   \
 }
 
 #define gDPSetKeyGB(pkt, cG, sG, wG, cB, sB, wB)            \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = (_SHIFTL(G_SETKEYGB, 24, 8) |            \
             _SHIFTL(wG, 12, 12) | _SHIFTL(wB, 0, 12));  \
     _g->words.w1 = (_SHIFTL(cG, 24, 8) | _SHIFTL(sG, 16, 8) |   \
              _SHIFTL(cB, 8, 8) | _SHIFTL(sB, 0, 8));    \
-}
+})
 
 #define gsDPSetKeyGB(cG, sG, wG, cB, sB, wB)                \
 {                                   \
@@ -4329,12 +4330,12 @@ _DW({                                   \
 }
 
 #define gDPParam(pkt, cmd, param)                   \
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
                                     \
     _g->words.w0 = _SHIFTL(cmd, 24, 8);             \
     _g->words.w1 = (param);                     \
-}
+})
 
 #define gsDPParam(cmd, param)                       \
 {                                   \
@@ -4358,7 +4359,7 @@ _DW({                                   \
 }
 
 #define gDPTextureRectangle(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy)\
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
     if (pkt);                               \
     _g->words.w0 = (_SHIFTL(G_TEXRECT, 24, 8) | _SHIFTL(xh, 12, 12) |   \
@@ -4368,7 +4369,7 @@ _DW({                                   \
     _g ++;                              \
     _g->words.w0 = (_SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16));        \
     _g->words.w1 = (_SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16));  \
-}
+})
 
 #define gsDPTextureRectangleFlip(xl, yl, xh, yh, tile, s, t, dsdx, dtdy) \
 {                                   \
@@ -4382,7 +4383,7 @@ _DW({                                   \
 }
 
 #define gDPTextureRectangleFlip(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy)\
-{                                   \
+_DW({                                   \
     Gfx *_g = (Gfx *)(pkt);                     \
     if (pkt);                               \
     _g->words.w0 = (_SHIFTL(G_TEXRECTFLIP, 24, 8) | _SHIFTL(xh, 12, 12) | \
@@ -4392,7 +4393,7 @@ _DW({                                   \
     _g ++;                              \
     _g->words.w0 = (_SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16));        \
     _g->words.w1 = (_SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16));  \
-}
+})
 
 #define gsSPTextureRectangle(xl, yl, xh, yh, tile, s, t, dsdx, dtdy)    \
     (_SHIFTL(G_TEXRECT, 24, 8) | _SHIFTL(xh, 12, 12) | _SHIFTL(yh, 0, 12)),\
@@ -4414,7 +4415,7 @@ _DW({                                   \
 
 /* like gSPTextureRectangle but accepts negative position arguments */
 #define gSPScisTextureRectangle(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy) \
-{                                                                            \
+_DW({                                                                            \
     Gfx *_g = (Gfx *)(pkt);                                                  \
                                                                              \
     _g->words.w0 = (_SHIFTL(G_TEXRECT, 24, 8) |                              \
@@ -4438,7 +4439,7 @@ _DW({                                   \
              0, 16)));                                           \
     gImmp1(pkt, G_RDPHALF_2, (_SHIFTL((dsdx), 16, 16) |                      \
                               _SHIFTL((dtdy), 0, 16)));                      \
-}
+})
 
 #define gsSPTextureRectangleFlip(xl, yl, xh, yh, tile, s, t, dsdx, dtdy) \
     (_SHIFTL(G_TEXRECTFLIP, 24, 8) | _SHIFTL(xh, 12, 12) |      \
@@ -4448,7 +4449,7 @@ _DW({                                   \
     gsImmp1(G_RDPHALF_2, (_SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16)))
 
 #define gSPTextureRectangleFlip(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy) \
-{                                       \
+_DW({                                       \
     Gfx *_g = (Gfx *)(pkt);                         \
                                      \
     _g->words.w0 = (_SHIFTL(G_TEXRECTFLIP, 24, 8) | _SHIFTL(xh, 12, 12) |\
@@ -4457,19 +4458,19 @@ _DW({                                   \
             _SHIFTL(yl, 0, 12));                \
     gImmp1(pkt, G_RDPHALF_1, (_SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16))); \
     gImmp1(pkt, G_RDPHALF_2, (_SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16))); \
-}
+})
 
 #define gsDPWord(wordhi, wordlo)            \
     gsImmp1(G_RDPHALF_1, (unsigned int)(wordhi)),   \
     gsImmp1(G_RDPHALF_2, (unsigned int)(wordlo))
 
 #define gDPWord(pkt, wordhi, wordlo)            \
-{                           \
+_DW({                           \
     Gfx *_g = (Gfx *)(pkt);             \
                             \
     gImmp1(pkt, G_RDPHALF_1, (unsigned int)(wordhi));   \
     gImmp1(pkt, G_RDPHALF_2, (unsigned int)(wordlo));   \
-}
+})
 
 #define gDPFullSync(pkt)    gDPNoParam(pkt, G_RDPFULLSYNC)
 #define gsDPFullSync()      gsDPNoParam(G_RDPFULLSYNC)

--- a/src/code/code_800FC620.c
+++ b/src/code/code_800FC620.c
@@ -157,10 +157,9 @@ void func_800FCA18(void* blk, u32 nBlk, u32 blkSize, arg3_800FCA18 arg3, s32 arg
         if (masked_arg2) {}
 
         while (pos > end) {
-            do {
-                pos -= masked_arg2;
-                arg3((void*)pos, 2);
-            } while (0);
+            pos -= masked_arg2;
+            arg3((void*)pos, 2);
+            if (1) {}
         }
 
         if (!masked_arg2) {}

--- a/src/code/gfxprint.c
+++ b/src/code/gfxprint.c
@@ -128,16 +128,7 @@ u8 sGfxPrintFontData[(16 * 256) / 2] = {
     0x00, 0xC1, 0xC2, 0x11, 0x00, 0x45, 0x0E, 0x27, 0x00, 0xD9, 0xC3, 0x00, 0x10, 0x07, 0xF8, 0x8D, 0x20, 0x01, 0x30,
     0x00, 0x10, 0xAC, 0x02, 0x25, 0xA0, 0x01, 0x22, 0x00, 0x10, 0x44, 0x20, 0x16, 0xA0, 0x13, 0x02, 0x00, 0x30, 0x04,
     0x1B, 0xAA, 0x40, 0x21, 0x00, 0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-
 };
-
-#define gDPSetPrimColorMod(pkt, m, l, rgba)                                                    \
-    {                                                                                          \
-        Gfx* _g = (Gfx*)(pkt);                                                                 \
-                                                                                               \
-        _g->words.w0 = (_SHIFTL(G_SETPRIMCOLOR, 24, 8) | _SHIFTL(m, 8, 8) | _SHIFTL(l, 0, 8)); \
-        _g->words.w1 = (rgba);                                                                 \
-    }
 
 void GfxPrint_InitDlist(GfxPrint* this) {
     s32 width = 16;
@@ -160,7 +151,7 @@ void GfxPrint_InitDlist(GfxPrint* this) {
         gDPSetTileSize(this->dlist++, i * 2, 0, 0, 60, 1020);
     }
 
-    gDPSetPrimColorMod(this->dlist++, 0, 0, this->color.rgba);
+    gDPSetColor(this->dlist++, G_SETPRIMCOLOR, this->color.rgba);
 
     gDPLoadMultiTile_4b(this->dlist++, sGfxPrintUnkData, 0, 1, G_IM_FMT_CI, 2, 8, 0, 0, 1, 7, 4,
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, 1, 3, G_TX_NOLOD, G_TX_NOLOD);
@@ -180,7 +171,7 @@ void GfxPrint_SetColor(GfxPrint* this, u32 r, u32 g, u32 b, u32 a) {
     this->color.b = b;
     this->color.a = a;
     gDPPipeSync(this->dlist++);
-    gDPSetPrimColorMod(this->dlist++, 0, 0, this->color.rgba);
+    gDPSetColor(this->dlist++, G_SETPRIMCOLOR, this->color.rgba);
 }
 
 void GfxPrint_SetPosPx(GfxPrint* this, s32 x, s32 y) {
@@ -218,7 +209,7 @@ void GfxPrint_PrintCharImpl(GfxPrint* this, u8 c) {
     }
 
     if (this->flag & GFXPRINT_FLAG4) {
-        gDPSetPrimColorMod(this->dlist++, 0, 0, 0);
+        gDPSetColor(this->dlist++, G_SETPRIMCOLOR, 0);
 
         if (this->flag & GFXPRINT_FLAG64) {
             gSPTextureRectangle(this->dlist++, (this->posX + 4) << 1, (this->posY + 4) << 1, (this->posX + 4 + 32) << 1,
@@ -229,7 +220,7 @@ void GfxPrint_PrintCharImpl(GfxPrint* this, u8 c) {
                                 tile, (u16)(c & 4) * 64, (u16)(c >> 3) * 256, 1 << 10, 1 << 10);
         }
 
-        gDPSetPrimColorMod(this->dlist++, 0, 0, this->color.rgba);
+        gDPSetColor(this->dlist++, G_SETPRIMCOLOR, this->color.rgba);
     }
 
     if (this->flag & GFXPRINT_FLAG64) {

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -731,8 +731,6 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
         spC8 = (spCC * spC8 > 0x1000) ? 0x1000 / spCC : spC8;
         spB4 = spB8 + (spC8 * 4);
 
-        if (1) {} // Necessary to match
-
         OVERLAY_DISP = func_80093808(OVERLAY_DISP);
 
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, (u8)titleCtx->intensity, (u8)titleCtx->intensity, (u8)titleCtx->intensity,

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -6648,8 +6648,8 @@ s32 Camera_Special9(Camera* camera) {
     sCameraInterfaceFlags = params->interfaceFlags;
 
     switch (camera->animState) {
-        do {
-        } while (0);
+        if (1) {}
+
         case 0:
             camera->unk_14C &= ~(0x4 | 0x2);
             camera->animState++;

--- a/src/code/z_eff_shield_particle.c
+++ b/src/code/z_eff_shield_particle.c
@@ -166,8 +166,6 @@ void EffectShieldParticle_Draw(void* thisx, GraphicsContext* gfxCtx) {
         gDPLoadTextureBlock(POLY_XLU_DISP++, gUnknownCircle6Tex, G_IM_FMT_I, G_IM_SIZ_8b, 32, 32, 0,
                             G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, 5, 5, G_TX_NOLOD, G_TX_NOLOD);
 
-        if (1) {} // Necessary to match
-
         gDPSetCombineLERP(POLY_XLU_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, PRIMITIVE, 0, TEXEL0, 0, 0, 0,
                           0, COMBINED, 0, 0, 0, COMBINED);
         gDPSetRenderMode(POLY_XLU_DISP++, G_RM_PASS, G_RM_ZB_CLD_SURF2);

--- a/src/code/z_eff_spark.c
+++ b/src/code/z_eff_spark.c
@@ -152,8 +152,6 @@ void EffectSpark_Draw(void* thisx, GraphicsContext* gfxCtx) {
     u8 sp1C4;
     f32 ratio;
 
-    if (1) {}
-
     OPEN_DISPS(gfxCtx, "../z_eff_spark.c", 293);
 
     if (this != NULL) {

--- a/src/code/z_effect.c
+++ b/src/code/z_effect.c
@@ -166,12 +166,11 @@ void Effect_DrawAll(GraphicsContext* gfxCtx) {
     }
 
     for (i = 0; i < BLURE_COUNT; i++) {
-        do {
-            if (1) {} // Necessary to match
-            if (sEffectContext.blures[i].status.active) {
-                sEffectInfoTable[EFFECT_BLURE1].draw(&sEffectContext.blures[i].effect, gfxCtx);
-            }
-        } while (0); // Necessary to match
+        if (sEffectContext.blures[i].status.active) {
+            sEffectInfoTable[EFFECT_BLURE1].draw(&sEffectContext.blures[i].effect, gfxCtx);
+        }
+        if (1) {} // Necessary to match
+        if (1) {}
     }
 
     for (i = 0; i < SHIELD_PARTICLE_COUNT; i++) {

--- a/src/code/z_fcurve_data_skelanime.c
+++ b/src/code/z_fcurve_data_skelanime.c
@@ -22,9 +22,7 @@ s32 SkelCurve_Init(GlobalContext* globalCtx, SkelAnimeCurve* skelCurve, SkelCurv
     skelCurve->transforms = ZeldaArena_MallocDebug(sizeof(*skelCurve->transforms) * skelCurve->limbCount,
                                                    "../z_fcurve_data_skelanime.c", 125);
     ASSERT(skelCurve->transforms != NULL, "this->now_joint != NULL", "../z_fcurve_data_skelanime.c", 127);
-    do {
-        skelCurve->animCurFrame = 0.0f;
-    } while (0);
+    skelCurve->animCurFrame = 0.0f;
     return 1;
 }
 

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -2860,8 +2860,6 @@ void Interface_DrawActionButton(GlobalContext* globalCtx) {
     Matrix_Scale(1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
     Matrix_RotateX(interfaceCtx->unk_1F4 / 10000.0f, MTXMODE_APPLY);
 
-    if (1) {} // Necessary to match
-
     gSPMatrix(OVERLAY_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_parameter.c", 3177),
               G_MTX_MODELVIEW | G_MTX_LOAD);
     gSPVertex(OVERLAY_DISP++, &interfaceCtx->actionVtx[0], 4, 0);
@@ -3183,7 +3181,6 @@ void Interface_Draw(GlobalContext* globalCtx) {
         if (gSaveContext.equips.buttonItems[1] < 0xF0) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->cLeftAlpha);
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
-            if (1) {}
             Interface_DrawItemIconTexture(globalCtx, interfaceCtx->iconItemSegment + 0x1000, 1);
             gDPPipeSync(OVERLAY_DISP++);
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
@@ -3197,7 +3194,6 @@ void Interface_Draw(GlobalContext* globalCtx) {
         if (gSaveContext.equips.buttonItems[2] < 0xF0) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->cDownAlpha);
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
-            if (1) {}
             Interface_DrawItemIconTexture(globalCtx, interfaceCtx->iconItemSegment + 0x2000, 2);
             gDPPipeSync(OVERLAY_DISP++);
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
@@ -3211,7 +3207,6 @@ void Interface_Draw(GlobalContext* globalCtx) {
         if (gSaveContext.equips.buttonItems[3] < 0xF0) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->cRightAlpha);
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
-            if (1) {}
             Interface_DrawItemIconTexture(globalCtx, interfaceCtx->iconItemSegment + 0x3000, 3);
             gDPPipeSync(OVERLAY_DISP++);
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,

--- a/src/code/z_room.c
+++ b/src/code/z_room.c
@@ -297,7 +297,6 @@ void func_8009638C(Gfx** displayList, u32 source, u32 tlut, u16 width, u16 heigh
         bg->s.scaleW = 1024;
         bg->s.scaleH = 1024;
         bg->s.imageYorig = bg->b.imageY;
-        if (1) {}
         gDPSetOtherMode(displayListHead++,
                         mode0 | G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_NONE |
                             G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE,

--- a/src/code/z_view.c
+++ b/src/code/z_view.c
@@ -402,8 +402,6 @@ s32 func_800AB2C4(View* view) {
     Mtx* projection;
     GraphicsContext* gfxCtx;
 
-    if (1) {} // Necessary to match
-
     gfxCtx = view->gfxCtx;
 
     OPEN_DISPS(gfxCtx, "../z_view.c", 777);

--- a/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
@@ -367,8 +367,7 @@ void func_8086C874(BgBdanObjects* this, GlobalContext* globalCtx) {
             }
         }
         if (this->switchFlag == 0) {
-            do {
-            } while (0);
+            if (1) {}
             Camera_ChangeSetting(globalCtx->cameraPtrs[MAIN_CAM], this->cameraSetting);
             func_8005ACFC(globalCtx->cameraPtrs[MAIN_CAM], 4);
         }

--- a/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.c
@@ -582,8 +582,6 @@ void BgJyaCobra_DrawShadow(BgJyaCobra* this, GlobalContext* globalCtx) {
     Vec3f sp64;
     Vec3s* phi_a3;
 
-    if (1) {}
-
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_bg_jya_cobra.c", 966);
 
     func_80094044(globalCtx->state.gfxCtx);

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1098,11 +1098,11 @@ void DemoEffect_UpdateLightEffect(DemoEffect* this, GlobalContext* globalCtx) {
         }
 
         if (globalCtx->sceneNum == SCENE_TOKINOMA && gSaveContext.sceneSetupIndex == 14) {
-            do {
-                if (globalCtx->csCtx.npcActions[this->csActionId]->action == 2) {
-                    Audio_PlayActorSound2(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
-                }
-            } while (0);
+            if (1) {}
+
+            if (globalCtx->csCtx.npcActions[this->csActionId]->action == 2) {
+                Audio_PlayActorSound2(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
+            }
         }
 
         if (globalCtx->sceneNum == SCENE_DAIYOUSEI_IZUMI || globalCtx->sceneNum == SCENE_YOUSEI_IZUMI_YOKO) {

--- a/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.c
+++ b/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.c
@@ -66,9 +66,8 @@ Gfx* func_80A280BC(GraphicsContext* gfxCtx, BossGanon* dorf) {
     displayList = Graph_Alloc(gfxCtx, 4 * sizeof(Gfx));
     displayListHead = displayList;
     gDPPipeSync(displayListHead++);
-    do {
-        if (1) {}
-    } while (0);
+    if (1) {}
+    if (1) {}
     gDPSetEnvColor(displayListHead++, 25, 20, 0, dorf->organFadeTimer);
     gDPSetRenderMode(displayListHead++, G_RM_FOG_SHADE_A, G_RM_AA_ZB_XLU_SURF2);
     gSPEndDisplayList(displayListHead);
@@ -83,9 +82,8 @@ Gfx* func_80A28148(GraphicsContext* gfxCtx, BossGanon* dorf) {
     displayListHead = displayList;
 
     gDPPipeSync(displayListHead++);
-    do {
-        if (1) {}
-    } while (0);
+    if (1) {}
+    if (1) {}
     gDPSetEnvColor(displayListHead++, 0, 0, 0, dorf->organFadeTimer);
     gDPSetRenderMode(displayListHead++, G_RM_FOG_SHADE_A, G_RM_AA_ZB_XLU_SURF2);
     gSPEndDisplayList(displayListHead);

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -284,8 +284,6 @@ void EnMag_DrawEffectTextures(Gfx** gfxp, void* maskTex, void* effectTex, s16 ma
     gDPLoadMultiBlock_4b(gfx++, maskTex, 0x0000, 0, G_IM_FMT_I, maskWidth, maskHeight, 0, G_TX_NOMIRROR | G_TX_WRAP,
                          G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-    if (1) {}
-
     if (!flag) {
         gDPLoadMultiBlock(gfx++, effectTex, 0x0100, 1, G_IM_FMT_I, G_IM_SIZ_8b, effectWidth, effectHeight, 0,
                           G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, 5, shifts, shiftt);

--- a/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -2251,10 +2251,8 @@ void EnOssan_DrawCursor(GlobalContext* globalCtx, EnOssan* this, f32 x, f32 y, f
         func_80094520(globalCtx->state.gfxCtx);
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, this->cursorColorR, this->cursorColorG, this->cursorColorB,
                         this->cursorColorA);
-        do {
-            gDPLoadTextureBlock_4b(OVERLAY_DISP++, &gSelectionCursorTex, G_IM_FMT_IA, 16, 16, 0,
-                                   G_TX_MIRROR | G_TX_WRAP, G_TX_MIRROR | G_TX_WRAP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
-        } while (0);
+        gDPLoadTextureBlock_4b(OVERLAY_DISP++, gSelectionCursorTex, G_IM_FMT_IA, 16, 16, 0, G_TX_MIRROR | G_TX_WRAP,
+                               G_TX_MIRROR | G_TX_WRAP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
         w = 16.0f * z;
         ulx = (x - w) * 4.0f;
         uly = (y - w) * 4.0f;
@@ -2299,15 +2297,9 @@ void EnOssan_DrawStickDirectionPrompts(GlobalContext* globalCtx, EnOssan* this) 
     if (drawStickLeftPrompt || drawStickRightPrompt) {
         func_80094520(globalCtx->state.gfxCtx);
         gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
-        gDPSetTextureImage(OVERLAY_DISP++, G_IM_FMT_IA, G_IM_SIZ_16b, 1, &gArrowCursorTex);
-        gDPSetTile(OVERLAY_DISP++, G_IM_FMT_IA, G_IM_SIZ_16b, 0, 0x0000, G_TX_LOADTILE, 0, G_TX_NOMIRROR | G_TX_WRAP,
-                   G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, 4, G_TX_NOLOD);
-        gDPLoadSync(OVERLAY_DISP++);
-        gDPLoadBlock(OVERLAY_DISP++, G_TX_LOADTILE, 0, 0, 191, 1024);
-        gDPPipeSync(OVERLAY_DISP++);
-        gDPSetTile(OVERLAY_DISP++, G_IM_FMT_IA, G_IM_SIZ_8b, 2, 0x0000, G_TX_RENDERTILE, 0, G_TX_NOMIRROR | G_TX_WRAP,
-                   G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, 4, G_TX_NOLOD);
-        gDPSetTileSize(OVERLAY_DISP++, G_TX_RENDERTILE, 0, 0, 15 * 4, 23 * 4);
+        gDPLoadTextureBlock(OVERLAY_DISP++, gArrowCursorTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 24, 0,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, 4, G_TX_NOMASK, G_TX_NOLOD,
+                            G_TX_NOLOD);
         if (drawStickLeftPrompt) {
             EnOssan_DrawTextRec(globalCtx, this->stickLeftPrompt.arrowColorR, this->stickLeftPrompt.arrowColorG,
                                 this->stickLeftPrompt.arrowColorB, this->stickLeftPrompt.arrowColorA,
@@ -2320,15 +2312,9 @@ void EnOssan_DrawStickDirectionPrompts(GlobalContext* globalCtx, EnOssan* this) 
                                 this->stickRightPrompt.arrowTexX, this->stickRightPrompt.arrowTexY,
                                 this->stickRightPrompt.z, 0, 0, 1.0f, 1.0f);
         }
-        gDPSetTextureImage(OVERLAY_DISP++, G_IM_FMT_IA, G_IM_SIZ_16b, 1, &gControlStickTex);
-        gDPSetTile(OVERLAY_DISP++, G_IM_FMT_IA, G_IM_SIZ_16b, 0, 0x0000, G_TX_LOADTILE, 0, G_TX_NOMIRROR | G_TX_WRAP,
-                   G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, 4, G_TX_NOLOD);
-        gDPLoadSync(OVERLAY_DISP++);
-        gDPLoadBlock(OVERLAY_DISP++, G_TX_LOADTILE, 0, 0, 127, 1024);
-        gDPPipeSync(OVERLAY_DISP++);
-        gDPSetTile(OVERLAY_DISP++, G_IM_FMT_IA, G_IM_SIZ_8b, 2, 0x0000, G_TX_RENDERTILE, 0, G_TX_NOMIRROR | G_TX_WRAP,
-                   G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, 4, G_TX_NOLOD);
-        gDPSetTileSize(OVERLAY_DISP++, G_TX_RENDERTILE, 0, 0, 15 * 4, 15 * 4);
+        gDPLoadTextureBlock(OVERLAY_DISP++, gControlStickTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, 0,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, 4, G_TX_NOMASK, G_TX_NOLOD,
+                            G_TX_NOLOD);
         if (drawStickLeftPrompt) {
             EnOssan_DrawTextRec(globalCtx, this->stickLeftPrompt.stickColorR, this->stickLeftPrompt.stickColorG,
                                 this->stickLeftPrompt.stickColorB, this->stickLeftPrompt.stickColorA,

--- a/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -367,8 +367,6 @@ void func_80AF9C70(u8* shadowTexture, Player* player, GlobalContext* globalCtx) 
 
     OPEN_DISPS(gfxCtx, "../z_en_sda.c", 826);
 
-    if (1) {}
-
     osSyncPrintf("SDA D 1\n");
     func_80094044(globalCtx->state.gfxCtx);
     gDPSetPrimColor(POLY_XLU_DISP++, 0x00, 0x00, 0, 0, 0, (BREG(52) + 50));

--- a/src/overlays/actors/ovl_kaleido_scope/z_kaleido_collect.c
+++ b/src/overlays/actors/ovl_kaleido_scope/z_kaleido_collect.c
@@ -350,7 +350,6 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
 
     gDPLoadTextureBlock(POLY_OPA_DISP++, gSongNoteTex, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 24, 0, G_TX_NOMIRROR | G_TX_WRAP,
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-    if (1) {}
 
     for (sp218 = 0; sp218 < 12; sp218++, sp21A += 4) {
         if (CHECK_QUEST_ITEM(sp218 + 6)) {
@@ -511,7 +510,6 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                     gDPLoadTextureBlock(POLY_OPA_DISP++, D_8082A130[D_8082A124[sp218]], G_IM_FMT_IA, G_IM_SIZ_8b, 16,
                                         16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                         G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-                    if (1) {}
 
                     gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
                 }
@@ -548,7 +546,6 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                 gDPLoadTextureBlock(POLY_OPA_DISP++, D_8082A130[gOcarinaSongNotes[phi_a2].notesIdx[phi_s3]],
                                     G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                     G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-                if (1) {}
 
                 gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
             }
@@ -598,7 +595,6 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                     gDPLoadTextureBlock(POLY_OPA_DISP++, D_8082A130[D_8082A124[phi_s3]], G_IM_FMT_IA, G_IM_SIZ_8b, 16,
                                         16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                         G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-                    if (1) {}
 
                     gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
                 }
@@ -657,7 +653,6 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                     gDPLoadTextureBlock(POLY_OPA_DISP++, ((u8*)gCounterDigit0Tex + (8 * 16 * sp208[sp218])), G_IM_FMT_I,
                                         G_IM_SIZ_8b, 8, 16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                         G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-                    if (1) {}
 
                     gSP1Quadrangle(POLY_OPA_DISP++, sp21A, sp21A + 2, sp21A + 3, sp21A + 1, 0);
 

--- a/src/overlays/actors/ovl_kaleido_scope/z_kaleido_map_PAL.c
+++ b/src/overlays/actors/ovl_kaleido_scope/z_kaleido_map_PAL.c
@@ -502,8 +502,6 @@ void KaleidoScope_DrawWorldMap(GlobalContext* globalCtx, GraphicsContext* gfxCtx
                                 G_TX_NOLOD, G_TX_NOLOD);
 
             gSP1Quadrangle(POLY_OPA_DISP++, j, j + 2, j + 3, j + 1, 0);
-
-            if (1) {}
         }
 
         gSPVertex(POLY_OPA_DISP++, &pauseCtx->mapPageVtx[220], 28, 0);
@@ -563,8 +561,6 @@ void KaleidoScope_DrawWorldMap(GlobalContext* globalCtx, GraphicsContext* gfxCtx
                                            G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
                     gSP1Quadrangle(POLY_OPA_DISP++, j, j + 2, j + 3, j + 1, 0);
-
-                    if (1) {}
                 }
             }
         }

--- a/src/overlays/actors/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/src/overlays/actors/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -478,8 +478,6 @@ Gfx* KaleidoScope_DrawPageSections(Gfx* gfx, Vtx* vertices, void** textures) {
                             G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(gfx++, j, j + 2, j + 3, j + 1, 0);
 
-        if (1) {}
-
         j += 4;
         i++;
     }
@@ -492,8 +490,6 @@ Gfx* KaleidoScope_DrawPageSections(Gfx* gfx, Vtx* vertices, void** textures) {
         gDPLoadTextureBlock(gfx++, textures[i], G_IM_FMT_IA, G_IM_SIZ_8b, 80, 32, 0, G_TX_NOMIRROR | G_TX_WRAP,
                             G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(gfx++, j, j + 2, j + 3, j + 1, 0);
-
-        if (1) {}
 
         j += 4;
         i++;


### PR DESCRIPTION
I noticed `if (1)`s were often necessary near macros like `gDPLoadTextureBlock`, which are among the ones we didn't wrap in `do {} while (0)` yet, because we weren't sure if they should be. So I tried to wrap every single gbi macro, and it seems to work just fine since everything still matches after removing a bunch of `if (1)`.

I also cleaned up a few `do while (0)`s I found while going through the repo, either by removing them when possible, or changing them into `if (1)` which we generally prefer. And I removed a custom macro in `gfxprint.c` because using `gDPSetColor` works and it's what we've used in other places.