### PR TITLE
Add `va_end` and returns to variadic functions

### DIFF
--- a/src/boot/is_debug.c
+++ b/src/boot/is_debug.c
@@ -17,6 +17,8 @@ void osSyncPrintfUnused(const char* fmt, ...) {
     va_start(args, fmt);
 
     _Printf(is_proutSyncPrintf, NULL, fmt, args);
+
+    va_end(args);
 }
 
 void osSyncPrintf(const char* fmt, ...) {
@@ -24,6 +26,8 @@ void osSyncPrintf(const char* fmt, ...) {
     va_start(args, fmt);
 
     _Printf(is_proutSyncPrintf, NULL, fmt, args);
+    
+    va_end(args);
 }
 
 // assumption
@@ -32,6 +36,8 @@ void rmonPrintf(const char* fmt, ...) {
     va_start(args, fmt);
 
     _Printf(is_proutSyncPrintf, NULL, fmt, args);
+    
+    va_end(args);
 }
 
 void* is_proutSyncPrintf(void* arg, const char* str, u32 count) {

--- a/src/code/fault_drawer.c
+++ b/src/code/fault_drawer.c
@@ -272,6 +272,8 @@ void FaultDrawer_Printf(const char* fmt, ...) {
     va_start(args, fmt);
 
     FaultDrawer_VPrintf(fmt, args);
+
+    va_end(args);
 }
 
 void FaultDrawer_DrawText(s32 x, s32 y, const char* fmt, ...) {
@@ -280,6 +282,8 @@ void FaultDrawer_DrawText(s32 x, s32 y, const char* fmt, ...) {
 
     FaultDrawer_SetCursor(x, y);
     FaultDrawer_VPrintf(fmt, args);
+    
+    va_end(args);
 }
 
 void FaultDrawer_SetDrawerFB(void* fb, u16 w, u16 h) {

--- a/src/code/gfxprint.c
+++ b/src/code/gfxprint.c
@@ -357,8 +357,13 @@ s32 GfxPrint_VPrintf(GfxPrint* this, const char* fmt, va_list args) {
 }
 
 s32 GfxPrint_Printf(GfxPrint* this, const char* fmt, ...) {
+    s32 ret;
     va_list args;
     va_start(args, fmt);
 
-    return GfxPrint_VPrintf(this, fmt, args);
+    ret = GfxPrint_VPrintf(this, fmt, args);
+
+    va_end(args);
+
+    return ret;
 }

--- a/src/code/printutils.c
+++ b/src/code/printutils.c
@@ -5,8 +5,13 @@ s32 PrintUtils_VPrintf(PrintCallback* pfn, const char* fmt, va_list args) {
 }
 
 s32 PrintUtils_Printf(PrintCallback* pfn, const char* fmt, ...) {
+    s32 ret;
     va_list args;
     va_start(args, fmt);
 
-    return PrintUtils_VPrintf(pfn, fmt, args);
+    ret = PrintUtils_VPrintf(pfn, fmt, args);
+
+    va_end(args);
+
+    return ret;
 }

--- a/src/libultra_boot_O2/sprintf.c
+++ b/src/libultra_boot_O2/sprintf.c
@@ -21,5 +21,8 @@ s32 sprintf(char* dst, const char* fmt, ...) {
     if (ret > -1) {
         dst[ret] = 0;
     }
+
+    va_end(args);
+
     return ret;
 }


### PR DESCRIPTION
This fixes some UB. It thankfully doesn't affect matching since the `va_end` macro is empty, but more modern compilers will likely have issues without. Also added some missing returns that I saw at the same time.