### PR TITLE
Speed up `extract_assets.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ graphs/
 *.mtl
 *.fbx
 !*_custom*
-.extracted-assets.json
+.extracted-assets-v2.json
 
 # Per-user configuration
 .python-version

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ graphs/
 *.mtl
 *.fbx
 !*_custom*
+.extracted-assets.json
 .extracted-assets-v2.json
 
 # Per-user configuration

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -76,15 +76,10 @@ def main():
     manager = Manager()
     signal.signal(signal.SIGINT, SignalHandler)
 
-    startTimePerf = time.time()
-
     extractedAssetsTracker = manager.dict()
     if os.path.exists(EXTRACTED_ASSETS_NAMEFILE) and not args.force:
         with open(EXTRACTED_ASSETS_NAMEFILE, encoding='utf-8') as f:
             extractedAssetsTracker.update(json.load(f))
-
-    endTimePerf = time.time()
-    print("read", endTimePerf - startTimePerf)
 
     asset_path = args.single
     if asset_path is not None:
@@ -119,19 +114,11 @@ def main():
             for singlePath in xmlFiles:
                 ExtractFunc(singlePath)
 
-    startTimePerf = time.time()
-
     with open(EXTRACTED_ASSETS_NAMEFILE, 'w', encoding='utf-8') as f:
         json.dump(dict(extractedAssetsTracker), f, ensure_ascii=False, indent=4)
-
-    endTimePerf = time.time()
-    print("write", endTimePerf - startTimePerf)
 
     if mainAbort.is_set():
         exit(1)
 
 if __name__ == "__main__":
-    startTimePerf = time.time()
     main()
-    endTimePerf = time.time()
-    print("main()", endTimePerf - startTimePerf)

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -78,10 +78,15 @@ def main():
     manager = Manager()
     signal.signal(signal.SIGINT, SignalHandler)
 
+    startTimePerf = time.time()
+
     extractedAssetsTracker = manager.dict()
     if os.path.exists(EXTRACTED_ASSETS_NAMEFILE) and not args.force:
         with open(EXTRACTED_ASSETS_NAMEFILE, encoding='utf-8') as f:
             extractedAssetsTracker.update(json.load(f, object_hook=manager.dict))
+
+    endTimePerf = time.time()
+    print("read", endTimePerf - startTimePerf)
 
     asset_path = args.single
     if asset_path is not None:
@@ -116,14 +121,22 @@ def main():
             for singlePath in xmlFiles:
                 ExtractFunc(singlePath)
 
+    startTimePerf = time.time()
+
     with open(EXTRACTED_ASSETS_NAMEFILE, 'w', encoding='utf-8') as f:
         serializableDict = dict()
         for xml, data in extractedAssetsTracker.items():
             serializableDict[xml] = dict(data)
         json.dump(dict(serializableDict), f, ensure_ascii=False, indent=4)
 
+    endTimePerf = time.time()
+    print("write", endTimePerf - startTimePerf)
+
     if mainAbort.is_set():
         exit(1)
 
 if __name__ == "__main__":
+    startTimePerf = time.time()
     main()
+    endTimePerf = time.time()
+    print("main()", endTimePerf - startTimePerf)


### PR DESCRIPTION
## Why `extract_assets.py` is slow

Currently in `extract_assets.py` the last-extracted-time of assets is stored in a file `.extracted-assets.json` to avoid extracting assets again when xmls didn't change
**Reading takes around 1.5 seconds, writing around 1 second.**
An empty run (when no assets are extracted, all of them are up-to-date) takes 3.5 seconds (and extracting a few assets doesn't take much longer)

So basically when few assets are extracted `.extracted-assets.json`-related IO takes 70% of the script execution time

My first instinct was to replace json by something more efficient like pickle (I did it [here](https://github.com/Dragorn421/oot/blob/fix_extract_assets_slow/extract_assets.py)), but it turns out **the true bottleneck is using `multiprocessing.Manager.dict`**. (I'm not familiar with `multiprocessing` I assume it's needed for synchronization or something like that)

## A fix

So I got rid of 99.8% of the `multiprocessing.Manager.dict` calls by changing the json structure from
```json
{
    "assets/xml/objects/object_gi_soldout.xml": {
        "timestamp": 1632918073
    },
```
to
```json
{
    "assets/xml/objects/object_gi_soldout.xml": 1632918073,
```

and **now reading takes around 10 milliseconds, writing around 100 milliseconds.** So, consequent speedup