### PR TITLE
Add colorization to Makefile w/ Verbose toggle (brought over from sm64).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,5 +316,3 @@ build/assets/%.jpg.inc.c: assets/%.jpg
 	$(V)$(ZAPD) bren -eh -i $< -o $@ $(ZAPD_QUIET)
 
 -include $(DEP_FILES)
-
-print-% : ; $(info $* is a $(flavor $*) variable set to [$($*)]) @true


### PR DESCRIPTION
I'm opening this as a draft PR. Originally, I had planned to implement a simple version switch (only 1 version is valid at this time mq_dbg) as well in order to redo how oot's Makefile handles colorization but I have decided that is out of scope and thus there is no version switch and it simply hardcodes the version.

If this is still too much I will remove the build option print at the start but this was only done to match what other n64 decomps are doing.

At this time, only the main build process has been colorized: make setup will not be colorized at this time due to intrusive edits being required for that like surpressing python prints.