### PR TITLE
Fix the format of some overlay textures

### DIFF
--- a/assets/xml/overlays/ovl_Arrow_Fire.xml
+++ b/assets/xml/overlays/ovl_Arrow_Fire.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="ovl_Arrow_Fire" BaseAddress="0x80865d10" RangeStart="0x9D0" RangeEnd="0x1DF0">
-        <Texture Name="s1Tex" OutName="fire_tex_1" Format="ia8" Width="32" Height="64" Offset="0x9D0" Static="On"/>
-        <Texture Name="s2Tex" OutName="fire_tex_2" Format="ia8" Width="32" Height="64" Offset="0x11D0" Static="On"/>
+        <Texture Name="s1Tex" OutName="fire_tex_1" Format="i8" Width="32" Height="64" Offset="0x9D0" Static="On"/>
+        <Texture Name="s2Tex" OutName="fire_tex_2" Format="i8" Width="32" Height="64" Offset="0x11D0" Static="On"/>
         <Array Name="sVtx" Count="43" Offset="0x19D0" Static="On">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_Arrow_Ice.xml
+++ b/assets/xml/overlays/ovl_Arrow_Ice.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="ovl_Arrow_Ice" BaseAddress="0x80867cd0" RangeStart="0x9F0" RangeEnd="0x1E10">
-        <Texture Name="s1Tex" OutName="ice_tex_1" Format="ia8" Width="32" Height="64" Offset="0x9F0" Static="On"/>
-        <Texture Name="s2Tex" OutName="ice_tex_2" Format="ia8" Width="32" Height="64" Offset="0x11F0" Static="On"/>
+        <Texture Name="s1Tex" OutName="ice_tex_1" Format="i8" Width="32" Height="64" Offset="0x9F0" Static="On"/>
+        <Texture Name="s2Tex" OutName="ice_tex_2" Format="i8" Width="32" Height="64" Offset="0x11F0" Static="On"/>
         <Array Name="sVtx" Count="43" Offset="0x19F0" Static="On">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_Arrow_Light.xml
+++ b/assets/xml/overlays/ovl_Arrow_Light.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="ovl_Arrow_Light" BaseAddress="0x80869cb0" RangeStart="0xA00" RangeEnd="0x1E20">
-        <Texture Name="s1Tex" OutName="light_tex_1" Format="ia8" Width="32" Height="64" Offset="0xA00" Static="On"/>
-        <Texture Name="s2Tex" OutName="light_tex_2" Format="ia8" Width="32" Height="64" Offset="0x1200" Static="On"/>
+        <Texture Name="s1Tex" OutName="light_tex_1" Format="i8" Width="32" Height="64" Offset="0xA00" Static="On"/>
+        <Texture Name="s2Tex" OutName="light_tex_2" Format="i8" Width="32" Height="64" Offset="0x1200" Static="On"/>
         <Array Name="sVtx" Count="43" Offset="0x1A00" Static="On">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_Bg_Ganon_Otyuka.xml
+++ b/assets/xml/overlays/ovl_Bg_Ganon_Otyuka.xml
@@ -18,7 +18,7 @@
         </Array>
         <DList Name="sPlatformSideDL" Offset="0x1B40"/>
 
-        <Texture Name="sFlashTex" Format="ia8" OutName="flash_tex" Width="32" Height="64" Offset="0x1B58"/>
+        <Texture Name="sFlashTex" Format="i8" OutName="flash_tex" Width="32" Height="64" Offset="0x1B58"/>
         <Array Name="sFlashVtx" Count="8" Offset="0x2358">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_Magic_Fire.xml
+++ b/assets/xml/overlays/ovl_Magic_Fire.xml
@@ -1,6 +1,6 @@
 <Root>
     <File Name="ovl_Magic_Fire" BaseAddress="0x80B88D70" RangeStart="0xB90" RangeEnd="0x21E0">
-        <Texture Name="sTex" OutName="dins_fire" Format="ia8" Width="64" Height="64" Offset="0xB90"/>
+        <Texture Name="sTex" OutName="dins_fire" Format="i8" Width="64" Height="64" Offset="0xB90"/>
         <Array Name="sSphereVtx" Count="76" Offset="0x1B90">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_Magic_Wind.xml
+++ b/assets/xml/overlays/ovl_Magic_Wind.xml
@@ -8,7 +8,7 @@
         <Array Name="sCylinderVtx" Count="36" Offset="0x780">
             <Vtx/>
         </Array>
-        <Texture Name="sTex" OutName="magic_wind" Format="ia8" Width="64" Height="64" Offset="0x9C0"/>
+        <Texture Name="sTex" OutName="magic_wind" Format="i8" Width="64" Height="64" Offset="0x9C0"/>
         <DList Name="sInnerCylinderDL" Offset="0x19C0"/>
         <DList Name="sOuterCylinderDL" Offset="0x1AC8"/>
     </File>

--- a/assets/xml/overlays/ovl_Oceff_Spot.xml
+++ b/assets/xml/overlays/ovl_Oceff_Spot.xml
@@ -1,6 +1,6 @@
 <Root>
     <File Name="ovl_Oceff_Spot" BaseAddress="0x80BA6070" RangeStart="0x7F0" RangeEnd="0xEC8">
-        <Texture Name="sTex" OutName="sun_song_effect" Format="ia8" Width="32" Height="32" Offset="0x7F0"/>
+        <Texture Name="sTex" OutName="sun_song_effect" Format="i8" Width="32" Height="32" Offset="0x7F0"/>
         <Array Name="sCylinderVtx" Count="27" Offset="0xBF0">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_Oceff_Storm.xml
+++ b/assets/xml/overlays/ovl_Oceff_Storm.xml
@@ -1,6 +1,6 @@
 <Root>
     <File Name="ovl_Oceff_Storm" BaseAddress="0x80BA70E0" RangeStart="0x7B0" RangeEnd="0x1B40">
-        <Texture Name="sTex" OutName="song_of_storms_effect" Format="ia8" Width="64" Height="64" Offset="0x7B0"/>
+        <Texture Name="sTex" OutName="song_of_storms_effect" Format="i8" Width="64" Height="64" Offset="0x7B0"/>
         <DList Name="sMaterialDL" Offset="0x17B0"/>
         <Array Name="sCylinderVtx" Count="27" Offset="0x1858">
             <Vtx/>

--- a/assets/xml/overlays/ovl_Oceff_Wipe.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe.xml
@@ -1,6 +1,6 @@
 <Root>
     <File Name="ovl_Oceff_Wipe" BaseAddress="0x80BA8D90" RangeStart="0x550" RangeEnd="0xD10">
-        <Texture Name="sTex" OutName="oceff" Format="ia8" Width="32" Height="32" Offset="0x550"/>
+        <Texture Name="sTex" OutName="oceff" Format="i8" Width="32" Height="32" Offset="0x550"/>
         <Array Name="sFrustumVtx" Count="40" Offset="0x950">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_Oceff_Wipe2.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe2.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="ovl_Oceff_Wipe2" BaseAddress="0x80BA9BB0" RangeStart="0x480" RangeEnd="0x16E8">
-        <Texture Name="s1Tex" OutName="eponas_song_effect_1" Format="ia4" Width="64" Height="64" Offset="0x480"/>
-        <Texture Name="s2Tex" OutName="eponas_song_effect_2" Format="ia4" Width="64" Height="64" Offset="0xC80"/>
+        <Texture Name="s1Tex" OutName="eponas_song_effect_1" Format="i4" Width="64" Height="64" Offset="0x480"/>
+        <Texture Name="s2Tex" OutName="eponas_song_effect_2" Format="i4" Width="64" Height="64" Offset="0xC80"/>
         <Array Name="sFrustumVtx" Count="22" Offset="0x1480">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_Oceff_Wipe3.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe3.xml
@@ -1,6 +1,6 @@
 <Root>
     <File Name="ovl_Oceff_Wipe3" BaseAddress="0x80BAB3F0" RangeStart="0x480" RangeEnd="0x16C8">
-        <Texture Name="sTex" OutName="saria_song_effect" Format="ia8" Width="64" Height="64" Offset="0x480"/>
+        <Texture Name="sTex" OutName="saria_song_effect" Format="i8" Width="64" Height="64" Offset="0x480"/>
         <Array Name="sFrustumVtx" Count="22" Offset="0x1480">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_Oceff_Wipe4.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe4.xml
@@ -1,6 +1,6 @@
 <Root>
     <File Name="ovl_Oceff_Wipe4" BaseAddress="0x80BACC10" RangeStart="0x460" RangeEnd="0xF48">
-        <Texture Name="sTex" OutName="scarecrow_song_effect" Format="ia8" Width="32" Height="64" Offset="0x460"/>
+        <Texture Name="sTex" OutName="scarecrow_song_effect" Format="i8" Width="32" Height="64" Offset="0x460"/>
         <Array Name="sFrustumVtx" Count="22" Offset="0xC60">
             <Vtx/>
         </Array>


### PR DESCRIPTION
Noticed some textures looked off and it turns out a bunch of textures from overlays were described as `ia8` instead of `i8`, so I fixed them. I looked over the rest of the overlay textures and this should be all of them, tho there might be more hidden in objects.

Note: I wonder if we could have a way to run ZAPD in a "validation" mode, for example to check that texture formats and widths/heights match display lists, which would catch most of these (except cases where the texture is rendered through code ofc)