### PR TITLE
Fix the rupee count in progress.py

### DIFF
--- a/progress.py
+++ b/progress.py
@@ -104,7 +104,7 @@ codePct = 100 * code / codeSize
 bootPct = 100 * boot / bootSize
 ovlPct = 100 * ovl / ovlSize
 
-bytesPerHeartPiece = total / 80
+bytesPerHeartPiece = int(total / 80)
 
 if args.format == 'csv':
     version = 1

--- a/progress.py
+++ b/progress.py
@@ -104,7 +104,7 @@ codePct = 100 * code / codeSize
 bootPct = 100 * boot / bootSize
 ovlPct = 100 * ovl / ovlSize
 
-bytesPerHeartPiece = int(total / 80)
+bytesPerHeartPiece = total // 80
 
 if args.format == 'csv':
     version = 1


### PR DESCRIPTION
Float issues are causing the rupee count to not always be 0 when the decompilable size lines up with a heart piece (eg. at 80 heart pieces). It should be fixed with this change.