### PR TITLE
Remove link_animetion related undefined sym

### DIFF
--- a/include/segment_symbols.h
+++ b/include/segment_symbols.h
@@ -28,7 +28,10 @@ DECLARE_ROM_SEGMENT(dmadata)
 DECLARE_ROM_SEGMENT(Audiobank)
 DECLARE_ROM_SEGMENT(Audioseq)
 DECLARE_ROM_SEGMENT(Audiotable)
+
+DECLARE_SEGMENT(link_animetion)
 DECLARE_ROM_SEGMENT(link_animetion)
+
 DECLARE_ROM_SEGMENT(icon_item_static)
 DECLARE_ROM_SEGMENT(icon_item_24_static)
 DECLARE_ROM_SEGMENT(icon_item_field_static)

--- a/include/z64animation.h
+++ b/include/z64animation.h
@@ -5,13 +5,12 @@
 #include "z64dma.h"
 #include "z64math.h"
 
-extern u32 link_animetion_segment;
 struct GlobalContext;
 struct Actor;
 struct SkelAnime;
 
 #define LINK_ANIMATION_OFFSET(addr, offset) \
-    (((u32)&_link_animetionSegmentRomStart) + ((u32)addr) - ((u32)&link_animetion_segment) + ((u32)offset))
+    (((u32)_link_animetionSegmentRomStart) + ((u32)addr) - ((u32)_link_animetionSegmentStart) + ((u32)offset))
 #define LIMB_DONE 0xFF
 #define ANIMATION_ENTRY_MAX 50
 #define ANIM_FLAG_UPDATEY (1 << 1)

--- a/undefined_syms.txt
+++ b/undefined_syms.txt
@@ -68,9 +68,6 @@ D_060257B8 = 0x060257B8;
 D_0602A738 = 0x0602A738;
 D_0602CB48 = 0x0602CB48;
 
-// z_skelanime
-link_animetion_segment = 0x07000000;
-
 // z_kankyo, z_demo_kankyo, z_en_viewer, z_object_kankyo, z_eff_ss_dead_dd
 D_01000000 = 0x01000000;
 


### PR DESCRIPTION
Little thing I noticed earlier, now that link_animetion is set to segment 7 we can remove this undefined sym.