### PR TITLE
Fix progress.py not counting libultra files

### DIFF
--- a/progress.py
+++ b/progress.py
@@ -60,12 +60,21 @@ def GetNonMatchingSize(path):
 
 
 mapFile = ReadAllLines("build/z64.map")
+curSegment = None
 src = 0
 code = 0
 boot = 0
 ovl = 0
 
 for line in mapFile:
+
+    if "_codeSegmentStart" in line:
+        curSegment = "code"
+    elif "_bootSegmentStart" in line:
+        curSegment = "boot"
+    elif "_codeSegmentEnd" in line or "_bootSegmentEnd" in line:
+        curSegment = None
+
     lineSplit =  list(filter(None, line.split(" ")))
 
     if (len(lineSplit) == 4 and lineSplit[0].startswith(".")):
@@ -77,9 +86,9 @@ for line in mapFile:
             if (objFile.startswith("build/src")):
                 src += size
 
-            if (objFile.startswith("build/src/code") or objFile.startswith("build/src/libultra_code")):
+            if (objFile.startswith("build/src/code") or (objFile.startswith("build/src/libultra/") and curSegment == "code")):
                 code += size
-            elif (objFile.startswith("build/src/boot") or objFile.startswith("build/src/libultra_boot")):
+            elif (objFile.startswith("build/src/boot") or (objFile.startswith("build/src/libultra/") and curSegment == "boot")):
                 boot += size
             elif (objFile.startswith("build/src/overlays")):
                 ovl += size


### PR DESCRIPTION
#1038 broke the assumption that progress.py made about libultra files being under `src/libultra_code` and `src/libultra_boot`. Those folders don't exist anymore and the boot/code files of libultra aren't even separated.

This made around 67% of boot and 2.6% of code vanish from the calculated progress (I should precise, it does not weigh much in the grand total)

----------

This fix works by looking for `_(code|boot)Segment(Start|End)` in the map file (progress.py already works off the map file), to tell if each libultra file is in code or boot

Another possibility is hardcoding the libultra files that go in code or boot:
https://github.com/Dragorn421/oot/commit/8a95918e29342fcc115c7a35da67f2acb5949c4a

Another possibility is reading the spec to tell if the libultra files are in code or boot:
https://github.com/Dragorn421/oot/commit/d9816fd04600245d58a2cc6261701d411034892b