### PR TITLE
Fix sym_info.py and first_diff.py map lookup issues

### DIFF
--- a/first_diff.py
+++ b/first_diff.py
@@ -93,7 +93,7 @@ def search_rom_address(target_addr):
             rom = ram - ram_offset 
             sym = line.split()[-1]
     
-            if "0x" in sym:
+            if sym.startswith("0x"):
                 ram_offset = None
                 continue
             if "/" in sym:
@@ -139,7 +139,7 @@ def parse_map(map_fname):
             rom = ram - ram_offset
             sym = line.split()[-1]
 
-            if "0x" in sym:
+            if sym.startswith("0x"):
                 ram_offset = None
                 continue
             elif "/" in sym:

--- a/sym_info.py
+++ b/sym_info.py
@@ -64,8 +64,8 @@ def search_address(target_addr):
             ram = int(line[16 : 16 + 18], 0)
             rom = ram - ram_offset 
             sym = line.split()[-1]
-    
-            if "0x" in sym:
+
+            if sym.startswith("0x"):
                 ram_offset = None
                 continue
             if "/" in sym:
@@ -112,7 +112,7 @@ def search_symbol(target_sym):
             rom = ram - ram_offset
             sym = line.split()[-1]
 
-            if "0x" in sym:
+            if sym.startswith("0x"):
                 ram_offset = None
                 continue
             elif "/" in sym:


### PR DESCRIPTION
Symbol names like `qNaN0x3FFFFF` were detected as new sections in the map since they contain "0x", which broke lookups for some sections of the ROM.

Noticed this while trying to find some .data symbols (eg. `./sym_info.py 0x8014B300` failed to find `sTextboxSkipped`)