### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,22 @@
-FROM ubuntu:18.04 as build
+FROM ubuntu:21.10 as build
+ENV TZ=UTC
 
-RUN apt-get update && \
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    apt-get update && \
     apt-get install -y \
         binutils-mips-linux-gnu \
         build-essential \
         pkg-config \
         python3 \
         python3-pip \
-        wget \
         git \
+        wget \
         unzip \
         clang-tidy \
         clang-format \
-        clang-format-11 \
-        nano \
-        vbindiff \
-        libpng-dev
+        libpng-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install --user colorama ansiwrap attrs watchdog python-Levenshtein
 RUN python3 -m pip install --upgrade attrs pycparser
@@ -24,3 +25,6 @@ ENV LANG C.UTF-8
 
 RUN mkdir /oot
 WORKDIR /oot
+
+CMD ["/bin/sh", "-c", \
+    "echo 'usage:\n  docker run --rm --mount type=bind,source=\"$(pwd)\",destination=/oot oot make -j$(nproc) setup\n  docker run --rm --mount type=bind,source=\"$(pwd)\",destination=/oot oot make -j$(nproc)'"]


### PR DESCRIPTION
- Moved to ubuntu 21.10 as base image to be able to make use of GCC 11.2 and LLVM 13
- Cleaned up necessary packages a little
- Added simple instructions to the Dockerfile for easier usage