### PR TITLE
Added information about reg. 8011D3F0

### DIFF
--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -6851,7 +6851,7 @@ void Camera_Init(Camera* camera, View* view, CollisionContext* colCtx, GlobalCon
     camera->atLERPStepScale = 1;
     sCameraInterfaceFlags = 0xFF00;
     sDbgModeIdx = -1;
-    D_8011D3F0 = 3;
+    sCameraVBorderTimerCountdown = 3;
     osSyncPrintf(VT_FGCOL(BLUE) "camera: initialize --- " VT_RST " UID %d\n", camera->uid);
 }
 
@@ -7419,8 +7419,8 @@ Vec3s Camera_Update(Camera* camera) {
         if ((gSaveContext.gameMode != 0) && (gSaveContext.gameMode != 3)) {
             sCameraInterfaceFlags = 0;
             Camera_UpdateInterface(sCameraInterfaceFlags);
-        } else if ((D_8011D3F0 != 0) && (camera->thisIdx == MAIN_CAM)) {
-            D_8011D3F0--;
+        } else if ((sCameraVBorderTimerCountdown != 0) && (camera->thisIdx == MAIN_CAM)) {
+            sCameraVBorderTimerCountdown--;
             sCameraInterfaceFlags = 0x3200;
             Camera_UpdateInterface(sCameraInterfaceFlags);
         } else if (camera->globalCtx->transitionMode != 0) {

--- a/src/code/z_camera_data.c
+++ b/src/code/z_camera_data.c
@@ -3410,7 +3410,11 @@ s16 D_8011D3CC[] = {
 
 s32 sUpdateCameraDirection = 0;
 s32 D_8011D3EC = 0;
-s32 D_8011D3F0 = 0;
+/**
+ * If 8011D3F0 is greater than 0, it counts back to 0 with 10ms interval
+ * vertical camera borders are visible & HUD elements are hidden when 8011D3F0 > 0
+ */
+s32 sCameraVBorderTimerCountdown = 0;
 
 s32 sDemo5PrevAction12Frame = -16;
 


### PR DESCRIPTION
This PR documents information about register 8011D3F0.
If 8011D3F0 is greater than 0, it counts back to 0 with 10ms interval
Vertical camera borders are visible & HUD elements are hidden when 8011D3F0 is greater than 0.

![OOTDC-8011D3F0](https://user-images.githubusercontent.com/11473832/144921244-0098ed40-4655-4a1d-9623-b9585972f645.gif)