### PR TITLE
Changed progress.py csv output to be compatible with new website

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,9 +39,9 @@ pipeline {
             }
             steps {
                 sh 'mkdir reports'
-                sh 'python3 progress.py csv >> reports/progress.csv'
-                sh 'python3 progress.py csv -m >> reports/progress_matching.csv'
-                sh 'python3 progress.py shield-json > reports/progress_shield.json'
+                sh 'python3 progress.py csv >> reports/progress-oot-nonmatching.csv'
+                sh 'python3 progress.py csv -m >> reports/progress-oot-matching.csv'
+                sh 'python3 progress.py shield-json > reports/progress-oot-shield.json'
                 stash includes: 'reports/*', name: 'reports'
             }
         }
@@ -54,9 +54,9 @@ pipeline {
             }
             steps {
                 unstash 'reports'
-                sh 'cat reports/progress.csv >> /var/www/html/reports/progress.csv'
-                sh 'cat reports/progress_matching.csv >> /var/www/html/reports/progress_matching.csv'
-                sh 'cat reports/progress_shield.json > /var/www/html/reports/progress_shield.json'
+                sh 'cat reports/progress-oot-nonmatching.csv >> /var/www/zelda64.dev/assets/csv/progress-oot-nonmatching.csv'
+                sh 'cat reports/progress-oot-matching.csv >> /var/www/zelda64.dev/assets/csv/progress-matching.csv'
+                sh 'cat reports/progress-oot-shield.json > /var/www/zelda64.dev/assets/csv/progress-oot-shield.json'
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [jenkins]: https://jenkins.deco.mp/job/OOT/job/master
 [jenkins-badge]: https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.deco.mp%2Fjob%2FOOT%2Fjob%2Fmaster
 
-[progress]: https://zelda64.dev/progress.html
-[progress-badge]: https://img.shields.io/endpoint?url=https://zelda64.dev/reports/progress_shield.json
+[progress]: https://zelda64.dev/games/oot
+[progress-badge]: https://img.shields.io/endpoint?url=https://zelda64.dev/assets/csv/progress-oot-shield.json
 
 [contributors]: https://github.com/zeldaret/oot/graphs/contributors
 [contributors-badge]: https://img.shields.io/github/contributors/zeldaret/oot

--- a/progress.py
+++ b/progress.py
@@ -120,7 +120,7 @@ if args.format == 'csv':
     git_object = git.Repo().head.object
     timestamp = str(git_object.committed_date)
     git_hash = git_object.hexsha
-    csv_list = [str(version), timestamp, git_hash, str(code), str(codeSize), str(boot), str(bootSize), str(ovl), str(ovlSize), str(src), str(nonMatchingASM), str(len(nonMatchingFunctions))]
+    csv_list = [str(version), timestamp, git_hash, str(src), str(total), str(code), str(codeSize), str(boot), str(bootSize), str(ovl), str(ovlSize), str(nonMatchingASM), str(len(nonMatchingFunctions))]
     print(",".join(csv_list))
 elif args.format == 'shield-json':
     # https://shields.io/endpoint

--- a/progress.py
+++ b/progress.py
@@ -116,11 +116,11 @@ ovlPct = 100 * ovl / ovlSize
 bytesPerHeartPiece = total // 80
 
 if args.format == 'csv':
-    version = 1
+    csv_version = 2
     git_object = git.Repo().head.object
     timestamp = str(git_object.committed_date)
     git_hash = git_object.hexsha
-    csv_list = [str(version), timestamp, git_hash, str(src), str(total), str(code), str(codeSize), str(boot), str(bootSize), str(ovl), str(ovlSize), str(nonMatchingASM), str(len(nonMatchingFunctions))]
+    csv_list = [str(csv_version), timestamp, git_hash, str(src), str(total), str(code), str(codeSize), str(boot), str(bootSize), str(ovl), str(ovlSize), str(nonMatchingASM), str(len(nonMatchingFunctions))]
     print(",".join(csv_list))
 elif args.format == 'shield-json':
     # https://shields.io/endpoint


### PR DESCRIPTION
For the new website, we want project progress csvs to be in the same format as far as possible, with pairs of columns indicating current decompiled total and current decompilable total in each category tracked. For OoT the change is very minor: just add `src` and `total` after the hash.

PR marked as draft for now since the csv itself will need to be changed, which will be done in sync with deploying the new site.