### PR TITLE
Expose MIPS_BINUTILS_PREFIX for building on alternative platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ NON_MATCHING ?= 0
 # If ORIG_COMPILER is 1, compile with QEMU_IRIX and the original compiler
 ORIG_COMPILER ?= 0
 
-# Set prefix to mips binutils binaries (mips-linux-gnu-ld => 'mips-linux-gnu') - Change at your own risk!
+# Set prefix to mips binutils binaries (mips-linux-gnu-ld => 'mips-linux-gnu-') - Change at your own risk!
 # In nearly all cases, not having 'mips-linux-gnu-*' binaries on the PATH is indicative of missing dependencies
 MIPS_BINUTILS_PREFIX ?= mips-linux-gnu
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ else
 endif
 
 #### Tools ####
-ifneq ($(shell type $(MIPS_BINUTILS_PREFIX)-ld >/dev/null 2>/dev/null; echo $$?), 0)
+ifneq ($(shell type $(MIPS_BINUTILS_PREFIX)ld >/dev/null 2>/dev/null; echo $$?), 0)
   $(error Please install or build $(MIPS_BINUTILS_PREFIX))
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,8 @@ else
 endif
 
 #### Tools ####
-ifeq ($(shell type mips-linux-gnu-ld >/dev/null 2>/dev/null; echo $$?), 0)
-  MIPS_BINUTILS_PREFIX := mips-linux-gnu-
-else
+MIPS_BINUTILS_PREFIX ?= mips-linux-gnu
+ifneq ($(shell type $(MIPS_BINUTILS_PREFIX)-ld >/dev/null 2>/dev/null; echo $$?), 0)
   $(error Please install or build mips-linux-gnu)
 endif
 
@@ -56,10 +55,10 @@ ifeq ($(ORIG_COMPILER),1)
   CC_OLD    = $(QEMU_IRIX) -L tools/ido5.3_compiler tools/ido5.3_compiler/usr/bin/cc
 endif
 
-AS         := $(MIPS_BINUTILS_PREFIX)as
-LD         := $(MIPS_BINUTILS_PREFIX)ld
-OBJCOPY    := $(MIPS_BINUTILS_PREFIX)objcopy
-OBJDUMP    := $(MIPS_BINUTILS_PREFIX)objdump
+AS         := $(MIPS_BINUTILS_PREFIX)-as
+LD         := $(MIPS_BINUTILS_PREFIX)-ld
+OBJCOPY    := $(MIPS_BINUTILS_PREFIX)-objcopy
+OBJDUMP    := $(MIPS_BINUTILS_PREFIX)-objdump
 EMULATOR = mupen64plus
 EMU_FLAGS = --noosd
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ORIG_COMPILER ?= 0
 
 # Set prefix to mips binutils binaries (mips-linux-gnu-ld => 'mips-linux-gnu-') - Change at your own risk!
 # In nearly all cases, not having 'mips-linux-gnu-*' binaries on the PATH is indicative of missing dependencies
-MIPS_BINUTILS_PREFIX ?= mips-linux-gnu
+MIPS_BINUTILS_PREFIX ?= mips-linux-gnu-
 
 ifeq ($(NON_MATCHING),1)
   CFLAGS := -DNON_MATCHING

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ ORIG_COMPILER ?= 0
 
 # Set prefix to mips binutils binaries (mips-linux-gnu-ld => 'mips-linux-gnu') - Change at your own risk!
 # In nearly all cases, not having 'mips-linux-gnu-*' binaries on the PATH is indicative of missing dependencies
-# This project is not maintained or tested on platforms that require changing this (like gentoo)
 MIPS_BINUTILS_PREFIX ?= mips-linux-gnu
 
 ifeq ($(NON_MATCHING),1)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 #### Tools ####
 MIPS_BINUTILS_PREFIX ?= mips-linux-gnu
 ifneq ($(shell type $(MIPS_BINUTILS_PREFIX)-ld >/dev/null 2>/dev/null; echo $$?), 0)
-  $(error Please install or build mips-linux-gnu)
+  $(error Please install or build $(MIPS_BINUTILS_PREFIX))
 endif
 
 CC       := tools/ido_recomp/$(DETECTED_OS)/7.1/cc

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ NON_MATCHING ?= 0
 # If ORIG_COMPILER is 1, compile with QEMU_IRIX and the original compiler
 ORIG_COMPILER ?= 0
 
-# Set mips binutils prefix  - Change at your own risk!
+# Set prefix to mips binutils binaries (mips-linux-gnu-ld => 'mips-linux-gnu') - Change at your own risk!
 # In nearly all cases, not having 'mips-linux-gnu-*' binaries on the PATH is indicative of missing dependencies
 # This project is not maintained or tested on platforms that require changing this (like gentoo)
 MIPS_BINUTILS_PREFIX ?= mips-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,10 @@ ifeq ($(ORIG_COMPILER),1)
   CC_OLD    = $(QEMU_IRIX) -L tools/ido5.3_compiler tools/ido5.3_compiler/usr/bin/cc
 endif
 
-AS         := $(MIPS_BINUTILS_PREFIX)-as
-LD         := $(MIPS_BINUTILS_PREFIX)-ld
-OBJCOPY    := $(MIPS_BINUTILS_PREFIX)-objcopy
-OBJDUMP    := $(MIPS_BINUTILS_PREFIX)-objdump
+AS         := $(MIPS_BINUTILS_PREFIX)as
+LD         := $(MIPS_BINUTILS_PREFIX)ld
+OBJCOPY    := $(MIPS_BINUTILS_PREFIX)objcopy
+OBJDUMP    := $(MIPS_BINUTILS_PREFIX)objdump
 EMULATOR = mupen64plus
 EMU_FLAGS = --noosd
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ NON_MATCHING ?= 0
 # If ORIG_COMPILER is 1, compile with QEMU_IRIX and the original compiler
 ORIG_COMPILER ?= 0
 
+# Set mips binutils prefix  - Change at your own risk!
+# In nearly all cases, not having 'mips-linux-gnu-*' binaries on the PATH is indicative of missing dependencies
+# This project is not maintained or tested on platforms that require changing this (like gentoo)
+MIPS_BINUTILS_PREFIX ?= mips-linux-gnu
+
 ifeq ($(NON_MATCHING),1)
   CFLAGS := -DNON_MATCHING
   CPPFLAGS := -DNON_MATCHING
@@ -35,7 +40,6 @@ else
 endif
 
 #### Tools ####
-MIPS_BINUTILS_PREFIX ?= mips-linux-gnu
 ifneq ($(shell type $(MIPS_BINUTILS_PREFIX)-ld >/dev/null 2>/dev/null; echo $$?), 0)
   $(error Please install or build $(MIPS_BINUTILS_PREFIX))
 endif


### PR DESCRIPTION
crossdev on gentoo will build mips-gentoo-linux-gnu-* binaries