### PR TITLE
Document Obj_Switch subtypes

### DIFF
--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -97,7 +97,7 @@ static ColliderTrisInit sRustyFloorTrisInit = {
         OC2_NONE,
         COLSHAPE_TRIS,
     },
-    2,
+    ARRAY_COUNT(D_80B9EC34),
     D_80B9EC34,
 };
 
@@ -135,7 +135,7 @@ static ColliderTrisInit trisColliderEye = {
         OC2_NONE,
         COLSHAPE_TRIS,
     },
-    2,
+    ARRAY_COUNT(D_80B9ECBC),
     D_80B9ECBC,
 };
 
@@ -162,7 +162,7 @@ static ColliderJntSphInit sCyrstalJntSphereInit = {
         OC2_TYPE_2,
         COLSHAPE_JNTSPH,
     },
-    1,
+    ARRAY_COUNT(D_80B9ED44),
     D_80B9ED44,
 };
 
@@ -382,25 +382,25 @@ void ObjSwitch_FloorUp(ObjSwitch* this, GlobalContext* globalCtx) {
         }
     } else {
         switch ((this->dyna.actor.params >> 4 & 7)) {
-            case OBJSWITCH_SUBTYPE_FLOOR_NORMAL:
+            case OBJSWITCH_SUBTYPE_DEFAULT:
                 if (func_8004356C(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_FLOOR_TOGGLE:
+            case OBJSWITCH_SUBTYPE_TOGGLE:
                 if ((this->dyna.unk_160 & 2) && !(this->unk_17F & 2)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_FLOOR_RESET_OFF:
+            case OBJSWITCH_SUBTYPE_RESET_OFF:
                 if (func_800435B4(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_FLOOR_RESET_ON:
+            case OBJSWITCH_SUBTYPE_RESET_ON:
                 if (func_800435B4(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOff(this, globalCtx);
@@ -416,7 +416,7 @@ void ObjSwitch_FloorPressInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_FloorPress(ObjSwitch* this, GlobalContext* globalCtx) {
-    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_FLOOR_RESET_ON || !this->cooldownOn ||
+    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_RESET_ON || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->dyna.actor.scale.y -= 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y <= 33.0f / 2000.0f) {
@@ -435,23 +435,23 @@ void ObjSwitch_FloorDownInit(ObjSwitch* this) {
 
 void ObjSwitch_FloorDown(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_FLOOR_NORMAL:
+        case OBJSWITCH_SUBTYPE_DEFAULT:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_FloorReleaseInit(this);
             }
             break;
-        case OBJSWITCH_SUBTYPE_FLOOR_TOGGLE:
+        case OBJSWITCH_SUBTYPE_TOGGLE:
             if ((this->dyna.unk_160 & 2) && !(this->unk_17F & 2)) {
                 ObjSwitch_FloorReleaseInit(this);
                 ObjSwitch_SetOff(this, globalCtx);
             }
             break;
-        case OBJSWITCH_SUBTYPE_FLOOR_RESET_OFF:
-        case OBJSWITCH_SUBTYPE_FLOOR_RESET_ON:
+        case OBJSWITCH_SUBTYPE_RESET_OFF:
+        case OBJSWITCH_SUBTYPE_RESET_ON:
             if (!func_800435B4(&this->dyna) && !Player_InCsMode(globalCtx)) {
                 if (this->releaseTimer <= 0) {
                     ObjSwitch_FloorReleaseInit(this);
-                    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_FLOOR_RESET_OFF) {
+                    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_RESET_OFF) {
                         ObjSwitch_SetOff(this, globalCtx);
                     } else {
                         ObjSwitch_SetOn(this, globalCtx);
@@ -472,13 +472,13 @@ void ObjSwitch_FloorReleaseInit(ObjSwitch* this) {
 void ObjSwitch_FloorRelease(ObjSwitch* this, GlobalContext* globalCtx) {
     s16 subType = (this->dyna.actor.params >> 4 & 7);
 
-    if (((subType != OBJSWITCH_SUBTYPE_FLOOR_TOGGLE) && (subType != OBJSWITCH_SUBTYPE_FLOOR_RESET_ON)) || !this->cooldownOn ||
+    if (((subType != OBJSWITCH_SUBTYPE_TOGGLE) && (subType != OBJSWITCH_SUBTYPE_RESET_ON)) || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->dyna.actor.scale.y += 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y >= 33.0f / 200.0f) {
             ObjSwitch_FloorUpInit(this);
             Audio_PlayActorSound2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
-            if (subType == OBJSWITCH_SUBTYPE_FLOOR_TOGGLE) {
+            if (subType == OBJSWITCH_SUBTYPE_TOGGLE) {
                 func_800AA000(this->dyna.actor.xyzDistToPlayerSq, 120, 20, 10);
             }
         }
@@ -548,13 +548,13 @@ void ObjSwitch_EyeClosedInit(ObjSwitch* this) {
 
 void ObjSwitch_EyeClosed(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_EYE_NORMAL:
+        case OBJSWITCH_SUBTYPE_DEFAULT:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_EyeOpeningInit(this);
                 this->dyna.actor.params &= ~0x80;
             }
             break;
-        case OBJSWITCH_SUBTYPE_EYE_TOGGLE:
+        case OBJSWITCH_SUBTYPE_TOGGLE:
             if (ObjSwitch_EyeIsHit(this) || (this->dyna.actor.params >> 7 & 1)) {
                 ObjSwitch_EyeOpeningInit(this);
                 ObjSwitch_SetOff(this, globalCtx);
@@ -570,7 +570,7 @@ void ObjSwitch_EyeOpeningInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_EyeOpening(ObjSwitch* this, GlobalContext* globalCtx) {
-    if ((this->dyna.actor.params >> 4 & 7) != OBJSWITCH_SUBTYPE_EYE_TOGGLE || !this->cooldownOn ||
+    if ((this->dyna.actor.params >> 4 & 7) != OBJSWITCH_SUBTYPE_TOGGLE || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->eyeTexIndex--;
         if (this->eyeTexIndex <= 0) {
@@ -590,14 +590,14 @@ void ObjSwitch_CrystalOffInit(ObjSwitch* this) {
 
 void ObjSwitch_CrystalOff(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_CRYSTAL_NORMAL:
+        case OBJSWITCH_SUBTYPE_DEFAULT:
             if ((this->jntSph.col.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 ObjSwitch_SetOn(this, globalCtx);
                 ObjSwitch_CrystalTurnOnInit(this);
             }
             break;
-        case OBJSWITCH_SUBTYPE_CRYSTAL_TIED:
+        case OBJSWITCH_SUBTYPE_SYNC:
             if (((this->jntSph.col.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) ||
                 Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 this->disableAcTimer = 10;
@@ -605,7 +605,7 @@ void ObjSwitch_CrystalOff(ObjSwitch* this, GlobalContext* globalCtx) {
                 ObjSwitch_CrystalTurnOnInit(this);
             }
             break;
-        case OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE:
+        case OBJSWITCH_SUBTYPE_TOGGLE:
             if ((this->jntSph.col.base.acFlags & AC_HIT) && !(this->unk_17F & 2) && this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 ObjSwitch_SetOn(this, globalCtx);
@@ -624,7 +624,7 @@ void ObjSwitch_CrystalTurnOnInit(ObjSwitch* this) {
 void ObjSwitch_CrystalTurnOn(ObjSwitch* this, GlobalContext* globalCtx) {
     if (!this->cooldownOn || func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         ObjSwitch_CrystalOnInit(this);
-        if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE) {
+        if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_TOGGLE) {
             ObjSwitch_UpdateTwoTexScrollXY(this);
         }
         Audio_PlayActorSound2(&this->dyna.actor, NA_SE_EV_DIAMOND_SWITCH);
@@ -641,13 +641,13 @@ void ObjSwitch_CrystalOnInit(ObjSwitch* this) {
 
 void ObjSwitch_CrystalOn(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_CRYSTAL_NORMAL:
-        case OBJSWITCH_SUBTYPE_CRYSTAL_TIED:
+        case OBJSWITCH_SUBTYPE_DEFAULT:
+        case OBJSWITCH_SUBTYPE_SYNC:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_CrystalTurnOffInit(this);
             }
             break;
-        case OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE:
+        case OBJSWITCH_SUBTYPE_TOGGLE:
             if ((this->jntSph.col.base.acFlags & AC_HIT) && !(this->unk_17F & 2) && this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 globalCtx = globalCtx;
@@ -665,7 +665,7 @@ void ObjSwitch_CrystalTurnOffInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_CrystalTurnOff(ObjSwitch* this, GlobalContext* globalCtx) {
-    if ((this->dyna.actor.params >> 4 & 7) != OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE || !this->cooldownOn ||
+    if ((this->dyna.actor.params >> 4 & 7) != OBJSWITCH_SUBTYPE_TOGGLE || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         ObjSwitch_CrystalOffInit(this);
         ObjSwitch_UpdateTwoTexScrollXY(this);
@@ -769,7 +769,7 @@ void ObjSwitch_DrawCrystal(ObjSwitch* this, GlobalContext* globalCtx) {
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_obj_switch.c", 1511),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-    if (subType == OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE) {
+    if (subType == OBJSWITCH_SUBTYPE_TOGGLE) {
         gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(this->crystalSubtype1texture));
     }
 

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -321,7 +321,10 @@ void ObjSwitch_Init(Actor* thisx, GlobalContext* globalCtx) {
 
     if (this->dyna.actor.params >> 7 & 1) {
         ObjSwitch_EyeFrozenInit(this);
-    } else if (type == OBJSWITCH_TYPE_FLOOR || type == OBJSWITCH_TYPE_FLOOR_RUSTY) {
+    } 
+    else if (type == OBJSWITCH_TYPE_FLOOR || type == OBJSWITCH_TYPE_FLOOR_RUSTY) {
+        //! @bug if the subtype is OBJSWITCH_SUBTYPE_RESET_INVERTED, the switch should be Down or Up according to
+        //! `!switchFlagSet` instead of `switchFlagSet`
         if (switchFlagSet) {
             ObjSwitch_FloorDownInit(this);
         } else {
@@ -394,13 +397,13 @@ void ObjSwitch_FloorUp(ObjSwitch* this, GlobalContext* globalCtx) {
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_RESET_OFF:
+            case OBJSWITCH_SUBTYPE_RESET:
                 if (func_800435B4(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_RESET_ON:
+            case OBJSWITCH_SUBTYPE_RESET_INVERTED:
                 if (func_800435B4(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOff(this, globalCtx);
@@ -416,7 +419,7 @@ void ObjSwitch_FloorPressInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_FloorPress(ObjSwitch* this, GlobalContext* globalCtx) {
-    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_RESET_ON || !this->cooldownOn ||
+    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_RESET_INVERTED || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->dyna.actor.scale.y -= 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y <= 33.0f / 2000.0f) {
@@ -446,12 +449,12 @@ void ObjSwitch_FloorDown(ObjSwitch* this, GlobalContext* globalCtx) {
                 ObjSwitch_SetOff(this, globalCtx);
             }
             break;
-        case OBJSWITCH_SUBTYPE_RESET_OFF:
-        case OBJSWITCH_SUBTYPE_RESET_ON:
+        case OBJSWITCH_SUBTYPE_RESET:
+        case OBJSWITCH_SUBTYPE_RESET_INVERTED:
             if (!func_800435B4(&this->dyna) && !Player_InCsMode(globalCtx)) {
                 if (this->releaseTimer <= 0) {
                     ObjSwitch_FloorReleaseInit(this);
-                    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_RESET_OFF) {
+                    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_RESET) {
                         ObjSwitch_SetOff(this, globalCtx);
                     } else {
                         ObjSwitch_SetOn(this, globalCtx);
@@ -472,7 +475,7 @@ void ObjSwitch_FloorReleaseInit(ObjSwitch* this) {
 void ObjSwitch_FloorRelease(ObjSwitch* this, GlobalContext* globalCtx) {
     s16 subType = (this->dyna.actor.params >> 4 & 7);
 
-    if (((subType != OBJSWITCH_SUBTYPE_TOGGLE) && (subType != OBJSWITCH_SUBTYPE_RESET_ON)) || !this->cooldownOn ||
+    if (((subType != OBJSWITCH_SUBTYPE_TOGGLE) && (subType != OBJSWITCH_SUBTYPE_RESET_INVERTED)) || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->dyna.actor.scale.y += 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y >= 33.0f / 200.0f) {

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -247,7 +247,7 @@ void ObjSwitch_SetOn(ObjSwitch* this, GlobalContext* globalCtx) {
         subType = (this->dyna.actor.params >> 4 & 7);
         Flags_SetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F));
 
-        if (subType == 0 || subType == 4) {
+        if (subType == OBJSWITCH_SUBTYPE_ONCE || subType == OBJSWITCH_SUBTYPE_SYNC) {
             OnePointCutscene_AttentionSetSfx(globalCtx, &this->dyna.actor, NA_SE_SY_CORRECT_CHIME);
         } else {
             OnePointCutscene_AttentionSetSfx(globalCtx, &this->dyna.actor, NA_SE_SY_TRE_BOX_APPEAR);
@@ -263,7 +263,7 @@ void ObjSwitch_SetOff(ObjSwitch* this, GlobalContext* globalCtx) {
     if (Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
         Flags_UnsetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F));
 
-        if ((this->dyna.actor.params >> 4 & 7) == 1) {
+        if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_TOGGLE) {
             OnePointCutscene_AttentionSetSfx(globalCtx, &this->dyna.actor, NA_SE_SY_TRE_BOX_APPEAR);
             this->cooldownOn = true;
         }
@@ -382,7 +382,7 @@ void ObjSwitch_FloorUp(ObjSwitch* this, GlobalContext* globalCtx) {
         }
     } else {
         switch ((this->dyna.actor.params >> 4 & 7)) {
-            case OBJSWITCH_SUBTYPE_DEFAULT:
+            case OBJSWITCH_SUBTYPE_ONCE:
                 if (func_8004356C(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOn(this, globalCtx);
@@ -435,7 +435,7 @@ void ObjSwitch_FloorDownInit(ObjSwitch* this) {
 
 void ObjSwitch_FloorDown(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_DEFAULT:
+        case OBJSWITCH_SUBTYPE_ONCE:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_FloorReleaseInit(this);
             }
@@ -548,7 +548,7 @@ void ObjSwitch_EyeClosedInit(ObjSwitch* this) {
 
 void ObjSwitch_EyeClosed(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_DEFAULT:
+        case OBJSWITCH_SUBTYPE_ONCE:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_EyeOpeningInit(this);
                 this->dyna.actor.params &= ~0x80;
@@ -590,7 +590,7 @@ void ObjSwitch_CrystalOffInit(ObjSwitch* this) {
 
 void ObjSwitch_CrystalOff(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_DEFAULT:
+        case OBJSWITCH_SUBTYPE_ONCE:
             if ((this->jntSph.col.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 ObjSwitch_SetOn(this, globalCtx);
@@ -641,7 +641,7 @@ void ObjSwitch_CrystalOnInit(ObjSwitch* this) {
 
 void ObjSwitch_CrystalOn(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_DEFAULT:
+        case OBJSWITCH_SUBTYPE_ONCE:
         case OBJSWITCH_SUBTYPE_SYNC:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_CrystalTurnOffInit(this);

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -322,8 +322,8 @@ void ObjSwitch_Init(Actor* thisx, GlobalContext* globalCtx) {
     if (this->dyna.actor.params >> 7 & 1) {
         ObjSwitch_EyeFrozenInit(this);
     } else if (type == OBJSWITCH_TYPE_FLOOR || type == OBJSWITCH_TYPE_FLOOR_RUSTY) {
-        //! @bug if the subtype is OBJSWITCH_SUBTYPE_HOLD_INVERTED, the switch should be Down or Up according to
-        //! `!switchFlagSet` instead of `switchFlagSet`
+        //! @bug This condition does not account for OBJSWITCH_SUBTYPE_HOLD_INVERTED which expects
+        //! the relationship between the switch position and the switch flag to be inverted
         if (switchFlagSet) {
             ObjSwitch_FloorDownInit(this);
         } else {

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -321,8 +321,7 @@ void ObjSwitch_Init(Actor* thisx, GlobalContext* globalCtx) {
 
     if (this->dyna.actor.params >> 7 & 1) {
         ObjSwitch_EyeFrozenInit(this);
-    } 
-    else if (type == OBJSWITCH_TYPE_FLOOR || type == OBJSWITCH_TYPE_FLOOR_RUSTY) {
+    } else if (type == OBJSWITCH_TYPE_FLOOR || type == OBJSWITCH_TYPE_FLOOR_RUSTY) {
         //! @bug if the subtype is OBJSWITCH_SUBTYPE_RESET_INVERTED, the switch should be Down or Up according to
         //! `!switchFlagSet` instead of `switchFlagSet`
         if (switchFlagSet) {

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -322,7 +322,7 @@ void ObjSwitch_Init(Actor* thisx, GlobalContext* globalCtx) {
     if (this->dyna.actor.params >> 7 & 1) {
         ObjSwitch_EyeFrozenInit(this);
     } else if (type == OBJSWITCH_TYPE_FLOOR || type == OBJSWITCH_TYPE_FLOOR_RUSTY) {
-        //! @bug if the subtype is OBJSWITCH_SUBTYPE_RESET_INVERTED, the switch should be Down or Up according to
+        //! @bug if the subtype is OBJSWITCH_SUBTYPE_HOLD_INVERTED, the switch should be Down or Up according to
         //! `!switchFlagSet` instead of `switchFlagSet`
         if (switchFlagSet) {
             ObjSwitch_FloorDownInit(this);
@@ -396,13 +396,13 @@ void ObjSwitch_FloorUp(ObjSwitch* this, GlobalContext* globalCtx) {
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_RESET:
+            case OBJSWITCH_SUBTYPE_HOLD:
                 if (func_800435B4(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_RESET_INVERTED:
+            case OBJSWITCH_SUBTYPE_HOLD_INVERTED:
                 if (func_800435B4(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOff(this, globalCtx);
@@ -418,7 +418,7 @@ void ObjSwitch_FloorPressInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_FloorPress(ObjSwitch* this, GlobalContext* globalCtx) {
-    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_RESET_INVERTED || !this->cooldownOn ||
+    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_HOLD_INVERTED || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->dyna.actor.scale.y -= 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y <= 33.0f / 2000.0f) {
@@ -448,12 +448,12 @@ void ObjSwitch_FloorDown(ObjSwitch* this, GlobalContext* globalCtx) {
                 ObjSwitch_SetOff(this, globalCtx);
             }
             break;
-        case OBJSWITCH_SUBTYPE_RESET:
-        case OBJSWITCH_SUBTYPE_RESET_INVERTED:
+        case OBJSWITCH_SUBTYPE_HOLD:
+        case OBJSWITCH_SUBTYPE_HOLD_INVERTED:
             if (!func_800435B4(&this->dyna) && !Player_InCsMode(globalCtx)) {
                 if (this->releaseTimer <= 0) {
                     ObjSwitch_FloorReleaseInit(this);
-                    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_RESET) {
+                    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_HOLD) {
                         ObjSwitch_SetOff(this, globalCtx);
                     } else {
                         ObjSwitch_SetOn(this, globalCtx);
@@ -474,7 +474,7 @@ void ObjSwitch_FloorReleaseInit(ObjSwitch* this) {
 void ObjSwitch_FloorRelease(ObjSwitch* this, GlobalContext* globalCtx) {
     s16 subType = (this->dyna.actor.params >> 4 & 7);
 
-    if (((subType != OBJSWITCH_SUBTYPE_TOGGLE) && (subType != OBJSWITCH_SUBTYPE_RESET_INVERTED)) || !this->cooldownOn ||
+    if (((subType != OBJSWITCH_SUBTYPE_TOGGLE) && (subType != OBJSWITCH_SUBTYPE_HOLD_INVERTED)) || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->dyna.actor.scale.y += 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y >= 33.0f / 200.0f) {

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -382,25 +382,25 @@ void ObjSwitch_FloorUp(ObjSwitch* this, GlobalContext* globalCtx) {
         }
     } else {
         switch ((this->dyna.actor.params >> 4 & 7)) {
-            case OBJSWITCH_SUBTYPE_FLOOR_0:
+            case OBJSWITCH_SUBTYPE_FLOOR_NORMAL:
                 if (func_8004356C(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_FLOOR_1:
+            case OBJSWITCH_SUBTYPE_FLOOR_TOGGLE:
                 if ((this->dyna.unk_160 & 2) && !(this->unk_17F & 2)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_FLOOR_2:
+            case OBJSWITCH_SUBTYPE_FLOOR_RESET_OFF:
                 if (func_800435B4(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOn(this, globalCtx);
                 }
                 break;
-            case OBJSWITCH_SUBTYPE_FLOOR_3:
+            case OBJSWITCH_SUBTYPE_FLOOR_RESET_ON:
                 if (func_800435B4(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
                     ObjSwitch_SetOff(this, globalCtx);
@@ -416,7 +416,7 @@ void ObjSwitch_FloorPressInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_FloorPress(ObjSwitch* this, GlobalContext* globalCtx) {
-    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_FLOOR_3 || !this->cooldownOn ||
+    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_FLOOR_RESET_ON || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->dyna.actor.scale.y -= 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y <= 33.0f / 2000.0f) {
@@ -435,23 +435,23 @@ void ObjSwitch_FloorDownInit(ObjSwitch* this) {
 
 void ObjSwitch_FloorDown(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_FLOOR_0:
+        case OBJSWITCH_SUBTYPE_FLOOR_NORMAL:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_FloorReleaseInit(this);
             }
             break;
-        case OBJSWITCH_SUBTYPE_FLOOR_1:
+        case OBJSWITCH_SUBTYPE_FLOOR_TOGGLE:
             if ((this->dyna.unk_160 & 2) && !(this->unk_17F & 2)) {
                 ObjSwitch_FloorReleaseInit(this);
                 ObjSwitch_SetOff(this, globalCtx);
             }
             break;
-        case OBJSWITCH_SUBTYPE_FLOOR_2:
-        case OBJSWITCH_SUBTYPE_FLOOR_3:
+        case OBJSWITCH_SUBTYPE_FLOOR_RESET_OFF:
+        case OBJSWITCH_SUBTYPE_FLOOR_RESET_ON:
             if (!func_800435B4(&this->dyna) && !Player_InCsMode(globalCtx)) {
                 if (this->releaseTimer <= 0) {
                     ObjSwitch_FloorReleaseInit(this);
-                    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_FLOOR_2) {
+                    if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_FLOOR_RESET_OFF) {
                         ObjSwitch_SetOff(this, globalCtx);
                     } else {
                         ObjSwitch_SetOn(this, globalCtx);
@@ -472,13 +472,13 @@ void ObjSwitch_FloorReleaseInit(ObjSwitch* this) {
 void ObjSwitch_FloorRelease(ObjSwitch* this, GlobalContext* globalCtx) {
     s16 subType = (this->dyna.actor.params >> 4 & 7);
 
-    if (((subType != OBJSWITCH_SUBTYPE_FLOOR_1) && (subType != OBJSWITCH_SUBTYPE_FLOOR_3)) || !this->cooldownOn ||
+    if (((subType != OBJSWITCH_SUBTYPE_FLOOR_TOGGLE) && (subType != OBJSWITCH_SUBTYPE_FLOOR_RESET_ON)) || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->dyna.actor.scale.y += 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y >= 33.0f / 200.0f) {
             ObjSwitch_FloorUpInit(this);
             Audio_PlayActorSound2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
-            if (subType == OBJSWITCH_SUBTYPE_FLOOR_1) {
+            if (subType == OBJSWITCH_SUBTYPE_FLOOR_TOGGLE) {
                 func_800AA000(this->dyna.actor.xyzDistToPlayerSq, 120, 20, 10);
             }
         }
@@ -548,13 +548,13 @@ void ObjSwitch_EyeClosedInit(ObjSwitch* this) {
 
 void ObjSwitch_EyeClosed(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_EYE_0:
+        case OBJSWITCH_SUBTYPE_EYE_NORMAL:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_EyeOpeningInit(this);
                 this->dyna.actor.params &= ~0x80;
             }
             break;
-        case OBJSWITCH_SUBTYPE_EYE_1:
+        case OBJSWITCH_SUBTYPE_EYE_TOGGLE:
             if (ObjSwitch_EyeIsHit(this) || (this->dyna.actor.params >> 7 & 1)) {
                 ObjSwitch_EyeOpeningInit(this);
                 ObjSwitch_SetOff(this, globalCtx);
@@ -570,7 +570,7 @@ void ObjSwitch_EyeOpeningInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_EyeOpening(ObjSwitch* this, GlobalContext* globalCtx) {
-    if ((this->dyna.actor.params >> 4 & 7) != OBJSWITCH_SUBTYPE_EYE_1 || !this->cooldownOn ||
+    if ((this->dyna.actor.params >> 4 & 7) != OBJSWITCH_SUBTYPE_EYE_TOGGLE || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         this->eyeTexIndex--;
         if (this->eyeTexIndex <= 0) {
@@ -590,14 +590,14 @@ void ObjSwitch_CrystalOffInit(ObjSwitch* this) {
 
 void ObjSwitch_CrystalOff(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_CRYSTAL_0:
+        case OBJSWITCH_SUBTYPE_CRYSTAL_NORMAL:
             if ((this->jntSph.col.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 ObjSwitch_SetOn(this, globalCtx);
                 ObjSwitch_CrystalTurnOnInit(this);
             }
             break;
-        case OBJSWITCH_SUBTYPE_CRYSTAL_4:
+        case OBJSWITCH_SUBTYPE_CRYSTAL_TIED:
             if (((this->jntSph.col.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) ||
                 Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 this->disableAcTimer = 10;
@@ -605,7 +605,7 @@ void ObjSwitch_CrystalOff(ObjSwitch* this, GlobalContext* globalCtx) {
                 ObjSwitch_CrystalTurnOnInit(this);
             }
             break;
-        case OBJSWITCH_SUBTYPE_CRYSTAL_1:
+        case OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE:
             if ((this->jntSph.col.base.acFlags & AC_HIT) && !(this->unk_17F & 2) && this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 ObjSwitch_SetOn(this, globalCtx);
@@ -624,7 +624,7 @@ void ObjSwitch_CrystalTurnOnInit(ObjSwitch* this) {
 void ObjSwitch_CrystalTurnOn(ObjSwitch* this, GlobalContext* globalCtx) {
     if (!this->cooldownOn || func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         ObjSwitch_CrystalOnInit(this);
-        if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_CRYSTAL_1) {
+        if ((this->dyna.actor.params >> 4 & 7) == OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE) {
             ObjSwitch_UpdateTwoTexScrollXY(this);
         }
         Audio_PlayActorSound2(&this->dyna.actor, NA_SE_EV_DIAMOND_SWITCH);
@@ -641,13 +641,13 @@ void ObjSwitch_CrystalOnInit(ObjSwitch* this) {
 
 void ObjSwitch_CrystalOn(ObjSwitch* this, GlobalContext* globalCtx) {
     switch ((this->dyna.actor.params >> 4 & 7)) {
-        case OBJSWITCH_SUBTYPE_CRYSTAL_0:
-        case OBJSWITCH_SUBTYPE_CRYSTAL_4:
+        case OBJSWITCH_SUBTYPE_CRYSTAL_NORMAL:
+        case OBJSWITCH_SUBTYPE_CRYSTAL_TIED:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_CrystalTurnOffInit(this);
             }
             break;
-        case OBJSWITCH_SUBTYPE_CRYSTAL_1:
+        case OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE:
             if ((this->jntSph.col.base.acFlags & AC_HIT) && !(this->unk_17F & 2) && this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 globalCtx = globalCtx;
@@ -665,7 +665,7 @@ void ObjSwitch_CrystalTurnOffInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_CrystalTurnOff(ObjSwitch* this, GlobalContext* globalCtx) {
-    if ((this->dyna.actor.params >> 4 & 7) != OBJSWITCH_SUBTYPE_CRYSTAL_1 || !this->cooldownOn ||
+    if ((this->dyna.actor.params >> 4 & 7) != OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE || !this->cooldownOn ||
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         ObjSwitch_CrystalOffInit(this);
         ObjSwitch_UpdateTwoTexScrollXY(this);
@@ -769,7 +769,7 @@ void ObjSwitch_DrawCrystal(ObjSwitch* this, GlobalContext* globalCtx) {
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_obj_switch.c", 1511),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-    if (subType == OBJSWITCH_SUBTYPE_CRYSTAL_1) {
+    if (subType == OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE) {
         gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(this->crystalSubtype1texture));
     }
 

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -17,10 +17,10 @@ typedef enum {
 } ObjSwitchType;
 
 typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_DEFAULT,      // Normal Yellow Switches
+    /* 0 */ OBJSWITCH_SUBTYPE_ONCE,         // Switches that can only be turned on
     /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,       // Switches that can be turned on and off
-    /* 2 */ OBJSWITCH_SUBTYPE_RESET_OFF,    // Floor Types only, reset itself when not stood on (off by default)
-    /* 3 */ OBJSWITCH_SUBTYPE_RESET_ON,     // Floor Types only, reset itself when not stood on (on by default)
+    /* 2 */ OBJSWITCH_SUBTYPE_RESET_OFF,    // Floor Types only, released when not stood on (state: off by default)
+    /* 3 */ OBJSWITCH_SUBTYPE_RESET_ON,     // Floor Types only, released when not stood on (state: on by default)
     /* 4 */ OBJSWITCH_SUBTYPE_SYNC          // Crystal Types only, syncs with the Switch Flag
 } ObjSwitchSubType;
 

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -17,16 +17,11 @@ typedef enum {
 } ObjSwitchType;
 
 typedef enum {
-            // Switches that can only be turned on (On -> Flag Set)
-    /* 0 */ OBJSWITCH_SUBTYPE_ONCE,
-            // Switches that can be turned on and off (On -> Flag Set, Off -> Flag Cleared)
-    /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,
-            // Floor Types only, released when not stood on (Down -> Flag Set, Up -> Flag Cleared)
-    /* 2 */ OBJSWITCH_SUBTYPE_RESET,
-            // Floor Types only, unused, inverted Switch Flag behavior (Down -> Flag Cleared, Up -> Flag Set)
-    /* 3 */ OBJSWITCH_SUBTYPE_RESET_INVERTED,
-            // Crystal Types only, syncs with the Switch Flag (On -> Flag Set, Off -> Flag Cleared)
-    /* 4 */ OBJSWITCH_SUBTYPE_SYNC
+    /* 0 */ OBJSWITCH_SUBTYPE_ONCE,             // Switches that can only be turned on (On -> Flag Set)
+    /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,           // Switches that can be turned on and off (On -> Flag Set, Off -> Flag Cleared)
+    /* 2 */ OBJSWITCH_SUBTYPE_HOLD,             // Floor Types only, released when not stood on (Down -> Flag Set, Up -> Flag Cleared)
+    /* 3 */ OBJSWITCH_SUBTYPE_HOLD_INVERTED,    // Floor Types only, unused, inverted Switch Flag behavior (Down -> Flag Cleared, Up -> Flag Set)
+    /* 4 */ OBJSWITCH_SUBTYPE_SYNC              // Crystal Types only, syncs with the Switch Flag (On -> Flag Set, Off -> Flag Cleared)
 } ObjSwitchSubType;
 
 typedef struct {

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -37,7 +37,7 @@ typedef struct {
 typedef struct ObjSwitch {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ ObjSwitchActionFunc actionFunc;
-    /* 0x0168 */ s16 releaseTimer; // used for SUBTYPE_RESET and SUBTYPE_RESET_INVERTED
+    /* 0x0168 */ s16 releaseTimer; // used for SUBTYPE_HOLD and SUBTYPE_HOLD_INVERTED
     /* 0x016A */ s16 disableAcTimer;
     /* 0x016C */ s16 cooldownTimer;
     /* 0x016E */ u8 cooldownOn;

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -37,7 +37,7 @@ typedef struct {
 typedef struct ObjSwitch {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ ObjSwitchActionFunc actionFunc;
-    /* 0x0168 */ s16 releaseTimer; // used for SUBTYPE_RESET_OFF and SUBTYPE_RESET_ON
+    /* 0x0168 */ s16 releaseTimer; // used for SUBTYPE_RESET and SUBTYPE_RESET_INVERTED
     /* 0x016A */ s16 disableAcTimer;
     /* 0x016C */ s16 cooldownTimer;
     /* 0x016E */ u8 cooldownOn;

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -17,21 +17,21 @@ typedef enum {
 } ObjSwitchType;
 
 typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_FLOOR_0,
-    /* 1 */ OBJSWITCH_SUBTYPE_FLOOR_1,
-    /* 2 */ OBJSWITCH_SUBTYPE_FLOOR_2,
-    /* 3 */ OBJSWITCH_SUBTYPE_FLOOR_3
+    /* 0 */ OBJSWITCH_SUBTYPE_FLOOR_NORMAL,     // Normal Yellow Switch
+    /* 1 */ OBJSWITCH_SUBTYPE_FLOOR_TOGGLE,     // On/Off Red Switch
+    /* 2 */ OBJSWITCH_SUBTYPE_FLOOR_RESET_OFF,  // Reset when not stood on, blue switch (default state: off)
+    /* 3 */ OBJSWITCH_SUBTYPE_FLOOR_RESET_ON    // Reset when not stood on, blue switch (default state: on)
 } ObjSwitchSubTypeFloor;
 
 typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_EYE_0,
-    /* 1 */ OBJSWITCH_SUBTYPE_EYE_1
+    /* 0 */ OBJSWITCH_SUBTYPE_EYE_NORMAL,       // Normal Yellow Eye
+    /* 1 */ OBJSWITCH_SUBTYPE_EYE_TOGGLE        // On/Off Grey Eye
 } ObjSwitchSubTypeEye;
 
 typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_CRYSTAL_0,
-    /* 1 */ OBJSWITCH_SUBTYPE_CRYSTAL_1,
-    /* 4 */ OBJSWITCH_SUBTYPE_CRYSTAL_4 = 4
+    /* 0 */ OBJSWITCH_SUBTYPE_CRYSTAL_NORMAL,   // Normal
+    /* 1 */ OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE,   // On/Off Blue/Red Crystal
+    /* 4 */ OBJSWITCH_SUBTYPE_CRYSTAL_TIED = 4  // Tied to Switch Flag's State
 } ObjSwitchSubTypeCrystal;
 
 typedef struct {
@@ -47,7 +47,7 @@ typedef struct {
 typedef struct ObjSwitch {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ ObjSwitchActionFunc actionFunc;
-    /* 0x0168 */ s16 releaseTimer; // used for SUBTYPE_FLOOR_2 and SUBTYPE_FLOOR_3
+    /* 0x0168 */ s16 releaseTimer; // used for SUBTYPE_FLOOR_RESET_OFF and SUBTYPE_FLOOR_RESET_ON
     /* 0x016A */ s16 disableAcTimer;
     /* 0x016C */ s16 cooldownTimer;
     /* 0x016E */ u8 cooldownOn;
@@ -58,7 +58,7 @@ typedef struct ObjSwitch {
     /* 0x017A */ u8 x2TexScroll;
     /* 0x017B */ u8 y2TexScroll;
     /* 0x017C */ Color_RGB8 crystalColor;
-    /* 0x017F */ u8 unk_17F; // used for different purposes between floor and eye switch
+    /* 0x017F */ u8 unk_17F; // seems to be used to check if a switch has been hit by an AC collider
     union {
         /* 0x0180 */ ObjSwitchJntSph jntSph;
         /* 0x0180 */ ObjSwitchTris tris;

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -17,11 +17,11 @@ typedef enum {
 } ObjSwitchType;
 
 typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_ONCE,         // Switches that can only be turned on
-    /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,       // Switches that can be turned on and off
-    /* 2 */ OBJSWITCH_SUBTYPE_RESET_OFF,    // Floor Types only, released when not stood on (state: off by default)
-    /* 3 */ OBJSWITCH_SUBTYPE_RESET_ON,     // Floor Types only, released when not stood on (state: on by default)
-    /* 4 */ OBJSWITCH_SUBTYPE_SYNC          // Crystal Types only, syncs with the Switch Flag
+    /* 0 */ OBJSWITCH_SUBTYPE_ONCE,             // Switches that can only be turned on
+    /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,           // Switches that can be turned on and off
+    /* 2 */ OBJSWITCH_SUBTYPE_RESET,            // Floor Types only, released when not stood on
+    /* 3 */ OBJSWITCH_SUBTYPE_RESET_INVERTED,   // Floor Types only, unused, inverted OBJSWITCH_SUBTYPE_RESET
+    /* 4 */ OBJSWITCH_SUBTYPE_SYNC              // Crystal Types only, syncs with the Switch Flag
 } ObjSwitchSubType;
 
 typedef struct {

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -17,11 +17,11 @@ typedef enum {
 } ObjSwitchType;
 
 typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_ONCE,             // Switches that can only be turned on
-    /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,           // Switches that can be turned on and off
-    /* 2 */ OBJSWITCH_SUBTYPE_RESET,            // Floor Types only, released when not stood on
-    /* 3 */ OBJSWITCH_SUBTYPE_RESET_INVERTED,   // Floor Types only, unused, inverted OBJSWITCH_SUBTYPE_RESET
-    /* 4 */ OBJSWITCH_SUBTYPE_SYNC              // Crystal Types only, syncs with the Switch Flag
+    /* 0 */ OBJSWITCH_SUBTYPE_ONCE,             // Switches that can only be turned on (On -> Flag Set)
+    /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,           // Switches that can be turned on and off (On -> Flag Set, Off -> Flag Cleared)
+    /* 2 */ OBJSWITCH_SUBTYPE_RESET,            // Floor Types only, released when not stood on (Down -> Flag Set, Up -> Flag Cleared)
+    /* 3 */ OBJSWITCH_SUBTYPE_RESET_INVERTED,   // Floor Types only, unused, inverted Switch Flag behavior (Down -> Flag Cleared, Up -> Flag Set)
+    /* 4 */ OBJSWITCH_SUBTYPE_SYNC              // Crystal Types only, syncs with the Switch Flag (On -> Flag Set, Off -> Flag Cleared)
 } ObjSwitchSubType;
 
 typedef struct {

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -58,7 +58,7 @@ typedef struct ObjSwitch {
     /* 0x017A */ u8 x2TexScroll;
     /* 0x017B */ u8 y2TexScroll;
     /* 0x017C */ Color_RGB8 crystalColor;
-    /* 0x017F */ u8 unk_17F; // seems to be used to check if a switch has been hit by an AC collider
+    /* 0x017F */ u8 unk_17F;
     union {
         /* 0x0180 */ ObjSwitchJntSph jntSph;
         /* 0x0180 */ ObjSwitchTris tris;

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -17,26 +17,16 @@ typedef enum {
 } ObjSwitchType;
 
 typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_FLOOR_NORMAL,     // Normal Yellow Switch
-    /* 1 */ OBJSWITCH_SUBTYPE_FLOOR_TOGGLE,     // On/Off Red Switch
-    /* 2 */ OBJSWITCH_SUBTYPE_FLOOR_RESET_OFF,  // Reset when not stood on, blue switch (default state: off)
-    /* 3 */ OBJSWITCH_SUBTYPE_FLOOR_RESET_ON    // Reset when not stood on, blue switch (default state: on)
-} ObjSwitchSubTypeFloor;
-
-typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_EYE_NORMAL,       // Normal Yellow Eye
-    /* 1 */ OBJSWITCH_SUBTYPE_EYE_TOGGLE        // On/Off Grey Eye
-} ObjSwitchSubTypeEye;
-
-typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_CRYSTAL_NORMAL,   // Normal
-    /* 1 */ OBJSWITCH_SUBTYPE_CRYSTAL_TOGGLE,   // On/Off Blue/Red Crystal
-    /* 4 */ OBJSWITCH_SUBTYPE_CRYSTAL_TIED = 4  // Tied to Switch Flag's State
-} ObjSwitchSubTypeCrystal;
+    /* 0 */ OBJSWITCH_SUBTYPE_DEFAULT,      // Normal Yellow Switches
+    /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,       // Switches that can be turned on and off
+    /* 2 */ OBJSWITCH_SUBTYPE_RESET_OFF,    // Floor Types only, reset itself when not stood on (off by default)
+    /* 3 */ OBJSWITCH_SUBTYPE_RESET_ON,     // Floor Types only, reset itself when not stood on (on by default)
+    /* 4 */ OBJSWITCH_SUBTYPE_SYNC          // Crystal Types only, syncs with the Switch Flag
+} ObjSwitchSubType;
 
 typedef struct {
     /* 0x00 */ ColliderJntSph col;
-    /* 0x20 */ ColliderJntSphElement items[2];
+    /* 0x20 */ ColliderJntSphElement items[1];
 } ObjSwitchJntSph;
 
 typedef struct {
@@ -47,7 +37,7 @@ typedef struct {
 typedef struct ObjSwitch {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ ObjSwitchActionFunc actionFunc;
-    /* 0x0168 */ s16 releaseTimer; // used for SUBTYPE_FLOOR_RESET_OFF and SUBTYPE_FLOOR_RESET_ON
+    /* 0x0168 */ s16 releaseTimer; // used for SUBTYPE_RESET_OFF and SUBTYPE_RESET_ON
     /* 0x016A */ s16 disableAcTimer;
     /* 0x016C */ s16 cooldownTimer;
     /* 0x016E */ u8 cooldownOn;

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -17,11 +17,16 @@ typedef enum {
 } ObjSwitchType;
 
 typedef enum {
-    /* 0 */ OBJSWITCH_SUBTYPE_ONCE,             // Switches that can only be turned on (On -> Flag Set)
-    /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,           // Switches that can be turned on and off (On -> Flag Set, Off -> Flag Cleared)
-    /* 2 */ OBJSWITCH_SUBTYPE_RESET,            // Floor Types only, released when not stood on (Down -> Flag Set, Up -> Flag Cleared)
-    /* 3 */ OBJSWITCH_SUBTYPE_RESET_INVERTED,   // Floor Types only, unused, inverted Switch Flag behavior (Down -> Flag Cleared, Up -> Flag Set)
-    /* 4 */ OBJSWITCH_SUBTYPE_SYNC              // Crystal Types only, syncs with the Switch Flag (On -> Flag Set, Off -> Flag Cleared)
+            // Switches that can only be turned on (On -> Flag Set)
+    /* 0 */ OBJSWITCH_SUBTYPE_ONCE,
+            // Switches that can be turned on and off (On -> Flag Set, Off -> Flag Cleared)
+    /* 1 */ OBJSWITCH_SUBTYPE_TOGGLE,
+            // Floor Types only, released when not stood on (Down -> Flag Set, Up -> Flag Cleared)
+    /* 2 */ OBJSWITCH_SUBTYPE_RESET,
+            // Floor Types only, unused, inverted Switch Flag behavior (Down -> Flag Cleared, Up -> Flag Set)
+    /* 3 */ OBJSWITCH_SUBTYPE_RESET_INVERTED,
+            // Crystal Types only, syncs with the Switch Flag (On -> Flag Set, Off -> Flag Cleared)
+    /* 4 */ OBJSWITCH_SUBTYPE_SYNC
 } ObjSwitchSubType;
 
 typedef struct {


### PR DESCRIPTION
- ~~Normal~~ ~~Default~~ Once = the default subtype of a type of switch, it's the yellow switches that doesn't do anything special
- Toggle = can be toggled on or off, without restrictions
- "~~Reset~~ Release when not stood on" = you have to stay on the switch in order to keep it activated
- ~~Tied~~ Sync (crystal only) = when you trigger another switch with the same switch flag it'll sync switches that have this subtype, ~~hence the name "tied" because it's tied to the switch flag (I wasn't sure how to name this one)~~
- There's a subtype called ``OBJSWITCH_SUBTYPE_RESET_INVERTED``, its behavior is inverted compared to the other reset subtype; when it's down it'll clear the switch flag, when it's up it'll set the switch flag

~~"Reset" subtype has two default states, subtype 2 is a blue switch being off by default meanwhile subtype 3 is on by default~~

~~Also I updated the comment for ``unk_17F``, it seems to be used to check if the player hit the switch, I didn't named it because I'm not 100% sure for this one so I'll leave it to AC experts~~

Regarding how I named the subtypes, for most of them I took a obj_switch parameter from the game and I did the maths using the code, I read more of the it too to make sure I wasn't going the wrong way (and I used the practice rom to try subtypes I had not figured out yet)

I'm not really good at naming things so, if you have any suggestions go on. ~~I'm not sure that keeping ``OBJSWITCH_`` is a good thing though, having ``SUBTYPE_FLOOR_NORMAL`` is enough in my opinion~~ (with every enums merged into one I'm ok with those names)