### PR TITLE
Change all instances of "palette" in object symbols/OutNames to "tlut"

### DIFF
--- a/assets/xml/objects/gameplay_field_keep.xml
+++ b/assets/xml/objects/gameplay_field_keep.xml
@@ -23,7 +23,7 @@
         <Texture Name="gButterflyWingTex" OutName="butterfly_wing" Format="rgba16" Width="32" Height="64" Offset="0x2680"/>
         <Skeleton Name="gButterflySkel" Type="Normal" LimbType="Standard" Offset="0x36F0"/>
         <Animation Name="gButterflyAnim" Offset="0x2470"/>
-        <Texture Name="gBgBombwallTLUT" OutName="bombwall_palette" Format="rgba16" Width="4" Height="4" Offset="0x3700"/>
+        <Texture Name="gBgBombwallTLUT" OutName="bombwall_tlut" Format="rgba16" Width="4" Height="4" Offset="0x3700"/>
         <Texture Name="gBgBombwallNormalTex" OutName="bombwall_normal" Format="ci4" Width="32" Height="64" Offset="0x3720" TlutOffset="0x3700"/>
         <Texture Name="gBgBombWallBrokenTex" OutName="bombwall_broken" Format="ci4" Width="32" Height="64" Offset="0x3B20" TlutOffset="0x3700"/>
         <DList Name="gFieldDoorDL_004720" Offset="0x4720"/>
@@ -52,7 +52,7 @@
         <Texture Name="gFieldBeehiveTex" OutName="beehive" Format="rgba16" Width="32" Height="32" Offset="0x8900"/>
         <Texture Name="gFieldBeehiveFragmentTex" OutName="beehive_fragment" Format="rgba16" Width="16" Height="16" Offset="0x9710"/>
         <Texture Name="gFieldSilverRockTex" OutName="silver_rock" Format="ci4" Width="64" Height="64" Offset="0x99F8" TlutOffset="0x99D0"/>
-        <Texture Name="gFieldSilverRockTLUT" OutName="silver_rock_palette" Format="rgba16" Width="4" Height="4" Offset="0x99D0"/>
+        <Texture Name="gFieldSilverRockTLUT" OutName="silver_rock_tlut" Format="rgba16" Width="4" Height="4" Offset="0x99D0"/>
 
         <Texture Name="gFieldSandstorm1Tex" OutName="sandstorm_1" Format="i8" Width="64" Height="32" Offset="0xBA70"/>
         <Texture Name="gFieldSandstorm2Tex" OutName="sandstorm_2" Format="ia8" Width="64" Height="32" Offset="0xC270"/>

--- a/assets/xml/objects/object_gnd.xml
+++ b/assets/xml/objects/object_gnd.xml
@@ -66,8 +66,8 @@
         <DList Name="gPhantomGanonFaceDL" Offset="0x4EC0"/>
 
         <!-- Face textures-->
-        <Texture Name="gPhantomGanonEyeTLUT" OutName="phantom_ganon_eye_palette" Format="rgba16" Width="16" Height="5" Offset="0x3CC0"/>
-        <Texture Name="gPhantomGanonMouthTLUT" OutName="phantom_ganon_mouth_palette" Format="rgba16" Width="8" Height="5" Offset="0x3D60"/>
+        <Texture Name="gPhantomGanonEyeTLUT" OutName="phantom_ganon_eye_tlut" Format="rgba16" Width="16" Height="5" Offset="0x3CC0"/>
+        <Texture Name="gPhantomGanonMouthTLUT" OutName="phantom_ganon_mouth_tlut" Format="rgba16" Width="8" Height="5" Offset="0x3D60"/>
         <Texture Name="gPhantomGanonEyeTex" OutName="phantom_ganon_eye_tex" Format="ci8" Width="32" Height="16" Offset="0x3DB0" TlutOffset="0x3CC0"/>
         <Texture Name="gPhantomGanonSmileTex" OutName="phantom_ganon_smile_tex" Format="ci8" Width="16" Height="16" Offset="0x3FB0" TlutOffset="0x3D60"/> 
         <Texture Name="gPhantomGanonMouthTex" OutName="phantom_ganon_mouth_tex" Format="ci8" Width="16" Height="16" Offset="0x40B0" TlutOffset="0x3D60"/>

--- a/assets/xml/objects/object_horse_link_child.xml
+++ b/assets/xml/objects/object_horse_link_child.xml
@@ -13,7 +13,7 @@
         <!-- Running. -->
         <Animation Name="gChildEponaGallopingAnim" Offset="0x2F98"/>
 
-        <Texture Name="gChildEponaEyePal" OutName="child_epona_eye_pal" Format="rgba16" Width="16" Height="16" Offset="0x1728"/>
+        <Texture Name="gChildEponaEyeTLUT" OutName="child_epona_eye_tlut" Format="rgba16" Width="16" Height="16" Offset="0x1728"/>
         <Texture Name="gChildEponaEyeOpenTex" OutName="child_epona_eye_open" Format="ci8" Width="32" Height="16" Offset="0x1D28"  TlutOffset="0x1728"/>
         <Texture Name="gChildEponaEyeHalfTex" OutName="child_epona_eye_half" Format="ci8" Width="32" Height="16" Offset="0x1928"  TlutOffset="0x1728"/>
         <Texture Name="gChildEponaEyeCloseTex" OutName="child_epona_eye_close" Format="ci8" Width="32" Height="16" Offset="0x1B28"  TlutOffset="0x1728"/>

--- a/assets/xml/objects/object_human.xml
+++ b/assets/xml/objects/object_human.xml
@@ -44,7 +44,7 @@
         <Texture Name="object_human_Tex_007200" OutName="object_human_Tex_007200" Format="ci8" Width="32" Height="32" Offset="0x7200" TlutOffset="0x7A00"/>
         <Texture Name="object_human_Tex_007600" OutName="object_human_Tex_007600" Format="ci8" Width="32" Height="32" Offset="0x7600" TlutOffset="0x7A00"/>
 
-        <Texture Name="gHumanTLUT" OutName="face_palette" Format="rgba16" Width="16" Height="16" Offset="0x7A00"/>
+        <Texture Name="gHumanTLUT" OutName="face_tlut" Format="rgba16" Width="16" Height="16" Offset="0x7A00"/>
 
         <LegacyAnimation Name="gHumanLookingBackAnim" Offset="0x8354"/>
         <LegacyAnimation Name="gHumanLookingBackStartsAnim" Offset="0x8784"/>

--- a/assets/xml/objects/object_jya_obj.xml
+++ b/assets/xml/objects/object_jya_obj.xml
@@ -55,15 +55,15 @@
         <DList Name="gMegamiPiece11DL" Offset="0xA7E0"/>
         <DList Name="gMegamiPiece12DL" Offset="0xA978"/>
         <DList Name="gMegamiPiece13DL" Offset="0xAAC8"/>
-        <Texture Name="gMegami1TLUT" OutName="megami_palette_1" Format="rgba16" Width="4" Height="4" Offset="0x5C80"/>
+        <Texture Name="gMegami1TLUT" OutName="megami_tlut_1" Format="rgba16" Width="4" Height="4" Offset="0x5C80"/>
         <Texture Name="gMegami1Tex" OutName="megami_tex_1" Format="ci4" Width="64" Height="64" Offset="0x5CE8" TlutOffset="0x5C80"/>
-        <Texture Name="gMegami2TLUT" OutName="megami_palette_2" Format="rgba16" Width="4" Height="4" Offset="0xAC50"/>
+        <Texture Name="gMegami2TLUT" OutName="megami_tlut_2" Format="rgba16" Width="4" Height="4" Offset="0xAC50"/>
         <Texture Name="gMegami2Tex" OutName="megami_tex_2" Format="ci4" Width="64" Height="64" Offset="0xACB8" TlutOffset="0xAC50"/>
-        <Texture Name="gMegami3TLUT" OutName="megami_palette_3" Format="rgba16" Width="4" Height="64" Offset="0x6CE8"/>
+        <Texture Name="gMegami3TLUT" OutName="megami_tlut_3" Format="rgba16" Width="4" Height="64" Offset="0x6CE8"/>
         <Texture Name="gMegami3Tex" OutName="megami_tex_3" Format="ci4" Width="64" Height="64" Offset="0x64E8" TlutOffset="0x5C80"/>
-        <Texture Name="gMegami4TLUT" OutName="megami_palette_4" Format="rgba16" Width="4" Height="4" Offset="0x5CA0"/>
-        <Texture Name="gMegami5TLUT" OutName="megami_palette_5" Format="rgba16" Width="4" Height="4" Offset="0xAC70"/>
-        <Texture Name="gMegamiCrumbleTLUT" OutName="megami_crumble_palette" Format="rgba16" Width="4" Height="4" Offset="0x4E0"/>
+        <Texture Name="gMegami4TLUT" OutName="megami_tlut_4" Format="rgba16" Width="4" Height="4" Offset="0x5CA0"/>
+        <Texture Name="gMegami5TLUT" OutName="megami_tlut_5" Format="rgba16" Width="4" Height="4" Offset="0xAC70"/>
+        <Texture Name="gMegamiCrumbleTLUT" OutName="megami_crumble_tlut" Format="rgba16" Width="4" Height="4" Offset="0x4E0"/>
         <Texture Name="gMegamiRightCrumble1Tex" OutName="megami_right_crumble_1" Format="ci4" Width="64" Height="64" Offset="0xD00" TlutOffset="0x4E0"/>
         <Texture Name="gMegamiRightCrumble2Tex" OutName="megami_right_crumble_2" Format="ci4" Width="64" Height="64" Offset="0x1D00" TlutOffset="0x4E0"/>
         <Texture Name="gMegamiRightCrumble3Tex" OutName="megami_right_crumble_3" Format="ci4" Width="64" Height="64" Offset="0x2500" TlutOffset="0x4E0"/>

--- a/assets/xml/objects/object_mori_objects.xml
+++ b/assets/xml/objects/object_mori_objects.xml
@@ -1,8 +1,8 @@
 <Root>
     <File Name="object_mori_objects" Segment="6">
-        <Texture Name="gMoriHashiraTLUT" OutName="hashira_palette" Format="rgba16" Width="112" Height="1" Offset="0x0000"/>
+        <Texture Name="gMoriHashiraTLUT" OutName="hashira_tlut" Format="rgba16" Width="112" Height="1" Offset="0x0000"/>
         <Texture Name="gMoriHashiraTex" OutName="hashira" Format="ci8" Width="32" Height="32" Offset="0x00E0" TlutOffset="0x0000"/>
-        <Texture Name="gMoriHashigoClaspTLUT" OutName="hashigo_clasp_palette" Format="rgba16" Width="112" Height="1" Offset="0x3810"/>
+        <Texture Name="gMoriHashigoClaspTLUT" OutName="hashigo_clasp_tlut" Format="rgba16" Width="112" Height="1" Offset="0x3810"/>
         <Texture Name="gMoriHashigoClaspTex" OutName="hashigo_clasp" Format="ci8" Width="32" Height="32" Offset="0x38F0" TlutOffset="0x3810"/>
         <Collision Name="gMoriBigstCol" Offset="0x221C"/>
         <DList Name="gMoriBigstDL" Offset="0x1E50"/>

--- a/assets/xml/objects/object_ossan.xml
+++ b/assets/xml/objects/object_ossan.xml
@@ -1,8 +1,8 @@
 <Root>
     <File Name="object_ossan" Segment="6">
         <Animation Name="gObjectOssanAnim_000338" Offset="0x338"/>
-        <Texture Name="gOssanEyesTLUT" OutName="ossan_eyes_palette" Format="rgba16" Width="63" Height="4" Offset="0x4530"/>
-        <Texture Name="gOssanTLUT" OutName="ossan_palette" Format="rgba16" Width="168" Height="1" Offset="0x4728"/>
+        <Texture Name="gOssanEyesTLUT" OutName="ossan_eyes_tlut" Format="rgba16" Width="63" Height="4" Offset="0x4530"/>
+        <Texture Name="gOssanTLUT" OutName="ossan_tlut" Format="rgba16" Width="168" Height="1" Offset="0x4728"/>
         <Texture Name="gOssanEyeOpenTex" OutName="eye_open" Format="ci8" Width="32" Height="32" Offset="0x4878" TlutOffset="0x4530"/>
         <Texture Name="gOssanBeardTex" OutName="beard" Format="ci8" Width="32" Height="32" Offset="0x4C78" TlutOffset="0x4728"/>
         <Texture Name="gOssanEyeHalfTex" OutName="eye_half" Format="ci8" Width="32" Height="32" Offset="0x52B8" TlutOffset="0x4530"/>

--- a/assets/xml/objects/object_spot17_obj.xml
+++ b/assets/xml/objects/object_spot17_obj.xml
@@ -1,6 +1,6 @@
 <Root>
     <File Name="object_spot17_obj" Segment="6">
-        <Texture Name="gCraterRockPaletteTex" OutName="crater_rock_palette" Format="rgba16" Width="4" Height="4" Offset="0x00"/>
+        <Texture Name="gCraterRockTLUT" OutName="crater_rock_tlut" Format="rgba16" Width="4" Height="4" Offset="0x00"/>
         <Texture Name="gCraterRockTex" OutName="crater_rock" Format="ci4" Width="64" Height="64" Offset="0x20" TlutOffset="0x00"/>
         <DList Name="gCraterBombableWallDL" Offset="0x8A0"/>
         <DList Name="gCraterBombableWallCracksDL" Offset="0x960"/>

--- a/assets/xml/objects/object_ydan_objects.xml
+++ b/assets/xml/objects/object_ydan_objects.xml
@@ -6,15 +6,15 @@
         <Texture Name="gYdanHasiFloatingBlockSideTex" OutName="floating_block_side" Format="rgba16" Width="32" Height="32" Offset="0x0"/>
         <Texture Name="gYdanHasiFloatingBlockBottomTex" OutName="floating_block_bottom" Format="rgba16" Width="32" Height="32" Offset="0x800"/>
         <Texture Name="gYdanUnused1Tex" OutName="unused_1" Format="ci8" Width="32" Height="64" Offset="0x6BC8" TlutOffset="0x69C0"/>
-        <Texture Name="gYdanHasi2TLUT" OutName="palette_2" Format="rgba16" Width="16" Height="16" Offset="0x69C0"/>
+        <Texture Name="gYdanHasi2TLUT" OutName="tlut_2" Format="rgba16" Width="16" Height="16" Offset="0x69C0"/>
         <Texture Name="gYdanHasi3BlocksTopTex" OutName="three_blocks_top" Format="ci8" Width="32" Height="64" Offset="0x3AF8" TlutOffset="0x38F0"/>
-        <Texture Name="gYdanTLUT_38F0" OutName="palette_3" Format="rgba16" Width="16" Height="16" Offset="0x38F0"/> <!--3Blocks Palette?-->
+        <Texture Name="gYdanTLUT_38F0" OutName="tlut_3" Format="rgba16" Width="16" Height="16" Offset="0x38F0"/> <!--3Blocks Palette?-->
         <Texture Name="gYdanHasi3BlocksSideTex" OutName="three_blocks_side" Format="ci8" Width="32" Height="64" Offset="0x42F8" TlutOffset="0x38F0"/>
         <Texture Name="gYdanHasiWaterTex" OutName="water_tex" Format="ci8" Width="32" Height="32" Offset="0x5950" TlutOffset="0x57B0"/>
-        <Texture Name="gYdanHasiWaterTLUT" OutName="water_palette" Format="rgba16" Width="208" Height="1" Offset="0x57B0"/>
+        <Texture Name="gYdanHasiWaterTLUT" OutName="water_tlut" Format="rgba16" Width="208" Height="1" Offset="0x57B0"/>
         <Texture Name="gYdanMarutaUnused1Tex" OutName="maruta_unused_1" Format="rgba16" Width="32" Height="32" Offset="0x2000"/>
         <Texture Name="gYdanMarutaUnused2Tex" OutName="maruta_unused_2" Format="ci8" Width="32" Height="64" Offset="0x79D8" TlutOffset="0x77D0"/>
-        <Texture Name="gYdanMaruta1TLUT" OutName="maruta_palette" Format="rgba16" Width="16" Height="16" Offset="0x77D0"/>
+        <Texture Name="gYdanMaruta1TLUT" OutName="maruta_tlut" Format="rgba16" Width="16" Height="16" Offset="0x77D0"/>
         <DList Name="gDTUnknownWebDL" Offset="0x3850"/>
         <DList Name="gDTRisingPlatformsDL" Offset="0x5018"/>
         <DList Name="gDTWaterPlaneDL" Offset="0x5DE0"/>


### PR DESCRIPTION
I heard from Fig that OoT standardized on naming texture look up tables "tlut" in object files a while back, but there are still some uses of "palette" or "pal" in the codebase. All this PR does is change these to use "tlut" instead; that's it.