### PR TITLE
fix `Math_GetAtan2Tbl`

### DIFF
--- a/src/code/sys_math_atan.c
+++ b/src/code/sys_math_atan.c
@@ -78,16 +78,20 @@ static u16 sATan2Tbl[] = {
 };
 
 u16 Math_GetAtan2Tbl(f32 x, f32 y) {
-    s32 tblIdx = ((x / y) * 1024.0f) + 0.5f;
     u16 ret;
 
     if (y == 0.0f) {
         ret = sATan2Tbl[0];
-    } else if (tblIdx >= ARRAY_COUNT(sATan2Tbl)) {
-        ret = sATan2Tbl[0];
     } else {
-        ret = sATan2Tbl[tblIdx];
+        s32 tblIdx = ((x / y) * 1024.0f) + 0.5f;
+
+        if (tblIdx >= ARRAY_COUNT(sATan2Tbl)) {
+            ret = sATan2Tbl[0];
+        } else {
+            ret = sATan2Tbl[tblIdx];
+        }
     }
+
     return ret;
 }
 


### PR DESCRIPTION
This was found through gcc research. 
O2 on ido happens to reorder that index calculation below the 0 check, but gcc Os did not