### PR TITLE
Correctly align program stacks

### DIFF
--- a/include/z64.h
+++ b/include/z64.h
@@ -49,8 +49,10 @@
 #define Z_PRIORITY_DMAMGR      16
 #define Z_PRIORITY_IRQMGR      17
 
+#define ALIGN8(val) (((val) + 7) & ~7)
+
 #define STACK(stack, size) \
-    u64 stack[((size + (sizeof(u64) - 1)) & ~(sizeof(u64) - 1)) / sizeof(u64)]
+    u64 stack[ALIGN8(size) / sizeof(u64)]
 
 #define STACK_TOP(stack) \
     ((u8*)(stack) + sizeof(stack))

--- a/include/z64.h
+++ b/include/z64.h
@@ -49,6 +49,12 @@
 #define Z_PRIORITY_DMAMGR      16
 #define Z_PRIORITY_IRQMGR      17
 
+#define STACK(stack, size) \
+    u64 stack[size / sizeof(u64)]
+
+#define STACK_END(stack) \
+    ((u8*)(stack) + sizeof(stack))
+
 // NOTE: Once we start supporting other builds, this can be changed with an ifdef
 #define REGION_NATIVE REGION_EU
 

--- a/include/z64.h
+++ b/include/z64.h
@@ -50,9 +50,9 @@
 #define Z_PRIORITY_IRQMGR      17
 
 #define STACK(stack, size) \
-    u64 stack[size / sizeof(u64)]
+    u64 stack[((size + 7) & ~7) / sizeof(u64)]
 
-#define STACK_END(stack) \
+#define STACK_TOP(stack) \
     ((u8*)(stack) + sizeof(stack))
 
 // NOTE: Once we start supporting other builds, this can be changed with an ifdef

--- a/include/z64.h
+++ b/include/z64.h
@@ -50,7 +50,7 @@
 #define Z_PRIORITY_IRQMGR      17
 
 #define STACK(stack, size) \
-    u64 stack[((size + 7) & ~7) / sizeof(u64)]
+    u64 stack[((size + (sizeof(u64) - 1)) & ~(sizeof(u64) - 1)) / sizeof(u64)]
 
 #define STACK_TOP(stack) \
     ((u8*)(stack) + sizeof(stack))

--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -11,7 +11,7 @@ void cleararena(void) {
 }
 
 void bootproc(void) {
-    StackCheck_Init(&sBootThreadInfo, sBootThreadStack, STACK_END(sBootThreadStack), 0, -1, "boot");
+    StackCheck_Init(&sBootThreadInfo, sBootThreadStack, STACK_TOP(sBootThreadStack), 0, -1, "boot");
 
     osMemSize = osGetMemSize();
     cleararena();
@@ -23,8 +23,8 @@ void bootproc(void) {
     isPrintfInit();
     Locale_Init();
 
-    StackCheck_Init(&sIdleThreadInfo, sIdleThreadStack, STACK_END(sIdleThreadStack), 0, 256, "idle");
-    osCreateThread(&sIdleThread, 1, Idle_ThreadEntry, NULL, STACK_END(sIdleThreadStack),
+    StackCheck_Init(&sIdleThreadInfo, sIdleThreadStack, STACK_TOP(sIdleThreadStack), 0, 256, "idle");
+    osCreateThread(&sIdleThread, 1, Idle_ThreadEntry, NULL, STACK_TOP(sIdleThreadStack),
                    Z_PRIORITY_MAIN);
     osStartThread(&sIdleThread);
 }

--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -2,16 +2,16 @@
 
 StackEntry sBootThreadInfo;
 OSThread sIdleThread;
-u8 sIdleThreadStack[0x400];
+STACK(sIdleThreadStack, 0x400);
 StackEntry sIdleThreadInfo;
-u8 sBootThreadStack[0x400];
+STACK(sBootThreadStack, 0x400);
 
 void cleararena(void) {
     bzero(_dmadataSegmentStart, osMemSize - OS_K0_TO_PHYSICAL(_dmadataSegmentStart));
 }
 
 void bootproc(void) {
-    StackCheck_Init(&sBootThreadInfo, sBootThreadStack, sBootThreadStack + sizeof(sBootThreadStack), 0, -1, "boot");
+    StackCheck_Init(&sBootThreadInfo, sBootThreadStack, STACK_END(sBootThreadStack), 0, -1, "boot");
 
     osMemSize = osGetMemSize();
     cleararena();
@@ -23,8 +23,8 @@ void bootproc(void) {
     isPrintfInit();
     Locale_Init();
 
-    StackCheck_Init(&sIdleThreadInfo, sIdleThreadStack, sIdleThreadStack + sizeof(sIdleThreadStack), 0, 256, "idle");
-    osCreateThread(&sIdleThread, 1, Idle_ThreadEntry, NULL, sIdleThreadStack + sizeof(sIdleThreadStack),
+    StackCheck_Init(&sIdleThreadInfo, sIdleThreadStack, STACK_END(sIdleThreadStack), 0, 256, "idle");
+    osCreateThread(&sIdleThread, 1, Idle_ThreadEntry, NULL, STACK_END(sIdleThreadStack),
                    Z_PRIORITY_MAIN);
     osStartThread(&sIdleThread);
 }

--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -2,7 +2,7 @@
 #include "vt.h"
 
 OSThread gMainThread;
-u8 sMainStack[0x900];
+STACK(sMainStack, 0x900);
 StackEntry sMainStackInfo;
 OSMesg sPiMgrCmdBuff[50];
 OSMesgQueue gPiMgrCmdQ;
@@ -79,8 +79,8 @@ void Idle_ThreadEntry(void* arg) {
     osViBlack(1);
     osViSwapBuffer(0x803DA80); //! @bug Invalid vram address (probably intended to be 0x803DA800)
     osCreatePiManager(OS_PRIORITY_PIMGR, &gPiMgrCmdQ, sPiMgrCmdBuff, 50);
-    StackCheck_Init(&sMainStackInfo, sMainStack, sMainStack + sizeof(sMainStack), 0, 0x400, "main");
-    osCreateThread(&gMainThread, 3, Main_ThreadEntry, arg, sMainStack + sizeof(sMainStack), Z_PRIORITY_MAIN);
+    StackCheck_Init(&sMainStackInfo, sMainStack, STACK_END(sMainStack), 0, 0x400, "main");
+    osCreateThread(&gMainThread, 3, Main_ThreadEntry, arg, STACK_END(sMainStack), Z_PRIORITY_MAIN);
     osStartThread(&gMainThread);
     osSetThreadPri(NULL, OS_PRIORITY_IDLE);
 

--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -79,8 +79,8 @@ void Idle_ThreadEntry(void* arg) {
     osViBlack(1);
     osViSwapBuffer(0x803DA80); //! @bug Invalid vram address (probably intended to be 0x803DA800)
     osCreatePiManager(OS_PRIORITY_PIMGR, &gPiMgrCmdQ, sPiMgrCmdBuff, 50);
-    StackCheck_Init(&sMainStackInfo, sMainStack, STACK_END(sMainStack), 0, 0x400, "main");
-    osCreateThread(&gMainThread, 3, Main_ThreadEntry, arg, STACK_END(sMainStack), Z_PRIORITY_MAIN);
+    StackCheck_Init(&sMainStackInfo, sMainStack, STACK_TOP(sMainStack), 0, 0x400, "main");
+    osCreateThread(&gMainThread, 3, Main_ThreadEntry, arg, STACK_TOP(sMainStack), Z_PRIORITY_MAIN);
     osStartThread(&gMainThread);
     osSetThreadPri(NULL, OS_PRIORITY_IDLE);
 

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -419,8 +419,8 @@ void DmaMgr_Init(void) {
     }
 
     osCreateMesgQueue(&sDmaMgrMsgQueue, sDmaMgrMsgs, ARRAY_COUNT(sDmaMgrMsgs));
-    StackCheck_Init(&sDmaMgrStackInfo, sDmaMgrStack, STACK_END(sDmaMgrStack), 0, 0x100, "dmamgr");
-    osCreateThread(&sDmaMgrThread, 0x12, DmaMgr_ThreadEntry, 0, STACK_END(sDmaMgrStack), Z_PRIORITY_DMAMGR);
+    StackCheck_Init(&sDmaMgrStackInfo, sDmaMgrStack, STACK_TOP(sDmaMgrStack), 0, 0x100, "dmamgr");
+    osCreateThread(&sDmaMgrThread, 0x12, DmaMgr_ThreadEntry, 0, STACK_TOP(sDmaMgrStack), Z_PRIORITY_DMAMGR);
     osStartThread(&sDmaMgrThread);
 }
 

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -5,7 +5,7 @@ StackEntry sDmaMgrStackInfo;
 OSMesgQueue sDmaMgrMsgQueue;
 OSMesg sDmaMgrMsgs[0x20];
 OSThread sDmaMgrThread;
-u8 sDmaMgrStack[0x500];
+STACK(sDmaMgrStack, 0x500);
 const char* sDmaMgrCurFileName;
 s32 sDmaMgrCurFileLine;
 
@@ -419,8 +419,8 @@ void DmaMgr_Init(void) {
     }
 
     osCreateMesgQueue(&sDmaMgrMsgQueue, sDmaMgrMsgs, ARRAY_COUNT(sDmaMgrMsgs));
-    StackCheck_Init(&sDmaMgrStackInfo, sDmaMgrStack, sDmaMgrStack + sizeof(sDmaMgrStack), 0, 0x100, "dmamgr");
-    osCreateThread(&sDmaMgrThread, 0x12, DmaMgr_ThreadEntry, 0, sDmaMgrStack + sizeof(sDmaMgrStack), Z_PRIORITY_DMAMGR);
+    StackCheck_Init(&sDmaMgrStackInfo, sDmaMgrStack, STACK_END(sDmaMgrStack), 0, 0x100, "dmamgr");
+    osCreateThread(&sDmaMgrThread, 0x12, DmaMgr_ThreadEntry, 0, STACK_END(sDmaMgrStack), Z_PRIORITY_DMAMGR);
     osStartThread(&sDmaMgrThread);
 }
 

--- a/src/code/fault.c
+++ b/src/code/fault.c
@@ -79,7 +79,7 @@ const char* sFpExceptionNames[] = {
 // TODO: import .bss (has reordering issues)
 extern FaultMgr* sFaultInstance;
 extern u8 sFaultAwaitingInput;
-extern char sFaultStack[0x600];
+extern STACK(sFaultStack, 0x600);
 extern StackEntry sFaultThreadInfo;
 extern FaultMgr gFaultMgr;
 
@@ -1264,8 +1264,8 @@ void Fault_Init(void) {
     sFaultInstance->autoScroll = false;
     gFaultMgr.faultHandlerEnabled = true;
     osCreateMesgQueue(&sFaultInstance->queue, &sFaultInstance->msg, 1);
-    StackCheck_Init(&sFaultThreadInfo, &sFaultStack, sFaultStack + sizeof(sFaultStack), 0, 0x100, "fault");
-    osCreateThread(&sFaultInstance->thread, 2, Fault_ThreadEntry, 0, sFaultStack + sizeof(sFaultStack),
+    StackCheck_Init(&sFaultThreadInfo, &sFaultStack, STACK_END(sFaultStack), 0, 0x100, "fault");
+    osCreateThread(&sFaultInstance->thread, 2, Fault_ThreadEntry, 0, STACK_END(sFaultStack),
                    OS_PRIORITY_APPMAX);
     osStartThread(&sFaultInstance->thread);
 }

--- a/src/code/fault.c
+++ b/src/code/fault.c
@@ -1264,8 +1264,8 @@ void Fault_Init(void) {
     sFaultInstance->autoScroll = false;
     gFaultMgr.faultHandlerEnabled = true;
     osCreateMesgQueue(&sFaultInstance->queue, &sFaultInstance->msg, 1);
-    StackCheck_Init(&sFaultThreadInfo, &sFaultStack, STACK_END(sFaultStack), 0, 0x100, "fault");
-    osCreateThread(&sFaultInstance->thread, 2, Fault_ThreadEntry, 0, STACK_END(sFaultStack),
+    StackCheck_Init(&sFaultThreadInfo, &sFaultStack, STACK_TOP(sFaultStack), 0, 0x100, "fault");
+    osCreateThread(&sFaultInstance->thread, 2, Fault_ThreadEntry, 0, STACK_TOP(sFaultStack),
                    OS_PRIORITY_APPMAX);
     osStartThread(&sFaultInstance->thread);
 }

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -75,25 +75,25 @@ void Main(void* arg) {
     Main_LogSystemHeap();
 
     osCreateMesgQueue(&irqMgrMsgQ, irqMgrMsgBuf, 0x3C);
-    StackCheck_Init(&sIrqMgrStackInfo, sIrqMgrStack, STACK_END(sIrqMgrStack), 0, 0x100, "irqmgr");
+    StackCheck_Init(&sIrqMgrStackInfo, sIrqMgrStack, STACK_TOP(sIrqMgrStack), 0, 0x100, "irqmgr");
     IrqMgr_Init(&gIrqMgr, &sGraphStackInfo, Z_PRIORITY_IRQMGR, 1);
 
     osSyncPrintf("タスクスケジューラの初期化\n"); // "Initialize the task scheduler"
-    StackCheck_Init(&sSchedStackInfo, sSchedStack, STACK_END(sSchedStack), 0, 0x100, "sched");
+    StackCheck_Init(&sSchedStackInfo, sSchedStack, STACK_TOP(sSchedStack), 0, 0x100, "sched");
     Sched_Init(&gSchedContext, &sAudioStack, Z_PRIORITY_SCHED, D_80013960, 1, &gIrqMgr);
 
     IrqMgr_AddClient(&gIrqMgr, &irqClient, &irqMgrMsgQ);
 
-    StackCheck_Init(&sAudioStackInfo, sAudioStack, STACK_END(sAudioStack), 0, 0x100, "audio");
-    AudioMgr_Init(&gAudioMgr, STACK_END(sAudioStack), Z_PRIORITY_AUDIOMGR, 0xA, &gSchedContext, &gIrqMgr);
+    StackCheck_Init(&sAudioStackInfo, sAudioStack, STACK_TOP(sAudioStack), 0, 0x100, "audio");
+    AudioMgr_Init(&gAudioMgr, STACK_TOP(sAudioStack), Z_PRIORITY_AUDIOMGR, 0xA, &gSchedContext, &gIrqMgr);
 
-    StackCheck_Init(&sPadMgrStackInfo, sPadMgrStack, STACK_END(sPadMgrStack), 0, 0x100, "padmgr");
+    StackCheck_Init(&sPadMgrStackInfo, sPadMgrStack, STACK_TOP(sPadMgrStack), 0, 0x100, "padmgr");
     PadMgr_Init(&gPadMgr, &sSiIntMsgQ, &gIrqMgr, 7, Z_PRIORITY_PADMGR, &sIrqMgrStack);
 
     AudioMgr_Unlock(&gAudioMgr);
 
-    StackCheck_Init(&sGraphStackInfo, sGraphStack, STACK_END(sGraphStack), 0, 0x100, "graph");
-    osCreateThread(&sGraphThread, 4, Graph_ThreadEntry, arg, STACK_END(sGraphStack), Z_PRIORITY_GRAPH);
+    StackCheck_Init(&sGraphStackInfo, sGraphStack, STACK_TOP(sGraphStack), 0, 0x100, "graph");
+    osCreateThread(&sGraphThread, 4, Graph_ThreadEntry, arg, STACK_TOP(sGraphStack), Z_PRIORITY_GRAPH);
     osStartThread(&sGraphThread);
     osSetThreadPri(0, Z_PRIORITY_SCHED);
 

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -11,11 +11,11 @@ PadMgr gPadMgr;
 IrqMgr gIrqMgr;
 u32 gSegments[NUM_SEGMENTS];
 OSThread sGraphThread;
-u8 sGraphStack[0x1800];
-u8 sSchedStack[0x600];
-u8 sAudioStack[0x800];
-u8 sPadMgrStack[0x500];
-u8 sIrqMgrStack[0x500];
+STACK(sGraphStack, 0x1800);
+STACK(sSchedStack, 0x600);
+STACK(sAudioStack, 0x800);
+STACK(sPadMgrStack, 0x500);
+STACK(sIrqMgrStack, 0x500);
 StackEntry sGraphStackInfo;
 StackEntry sSchedStackInfo;
 StackEntry sAudioStackInfo;
@@ -75,25 +75,25 @@ void Main(void* arg) {
     Main_LogSystemHeap();
 
     osCreateMesgQueue(&irqMgrMsgQ, irqMgrMsgBuf, 0x3C);
-    StackCheck_Init(&sIrqMgrStackInfo, sIrqMgrStack, sIrqMgrStack + sizeof(sIrqMgrStack), 0, 0x100, "irqmgr");
+    StackCheck_Init(&sIrqMgrStackInfo, sIrqMgrStack, STACK_END(sIrqMgrStack), 0, 0x100, "irqmgr");
     IrqMgr_Init(&gIrqMgr, &sGraphStackInfo, Z_PRIORITY_IRQMGR, 1);
 
     osSyncPrintf("タスクスケジューラの初期化\n"); // "Initialize the task scheduler"
-    StackCheck_Init(&sSchedStackInfo, sSchedStack, sSchedStack + sizeof(sSchedStack), 0, 0x100, "sched");
+    StackCheck_Init(&sSchedStackInfo, sSchedStack, STACK_END(sSchedStack), 0, 0x100, "sched");
     Sched_Init(&gSchedContext, &sAudioStack, Z_PRIORITY_SCHED, D_80013960, 1, &gIrqMgr);
 
     IrqMgr_AddClient(&gIrqMgr, &irqClient, &irqMgrMsgQ);
 
-    StackCheck_Init(&sAudioStackInfo, sAudioStack, sAudioStack + sizeof(sAudioStack), 0, 0x100, "audio");
-    AudioMgr_Init(&gAudioMgr, sAudioStack + sizeof(sAudioStack), Z_PRIORITY_AUDIOMGR, 0xA, &gSchedContext, &gIrqMgr);
+    StackCheck_Init(&sAudioStackInfo, sAudioStack, STACK_END(sAudioStack), 0, 0x100, "audio");
+    AudioMgr_Init(&gAudioMgr, STACK_END(sAudioStack), Z_PRIORITY_AUDIOMGR, 0xA, &gSchedContext, &gIrqMgr);
 
-    StackCheck_Init(&sPadMgrStackInfo, sPadMgrStack, sPadMgrStack + sizeof(sPadMgrStack), 0, 0x100, "padmgr");
+    StackCheck_Init(&sPadMgrStackInfo, sPadMgrStack, STACK_END(sPadMgrStack), 0, 0x100, "padmgr");
     PadMgr_Init(&gPadMgr, &sSiIntMsgQ, &gIrqMgr, 7, Z_PRIORITY_PADMGR, &sIrqMgrStack);
 
     AudioMgr_Unlock(&gAudioMgr);
 
-    StackCheck_Init(&sGraphStackInfo, sGraphStack, sGraphStack + sizeof(sGraphStack), 0, 0x100, "graph");
-    osCreateThread(&sGraphThread, 4, Graph_ThreadEntry, arg, sGraphStack + sizeof(sGraphStack), Z_PRIORITY_GRAPH);
+    StackCheck_Init(&sGraphStackInfo, sGraphStack, STACK_END(sGraphStack), 0, 0x100, "graph");
+    osCreateThread(&sGraphThread, 4, Graph_ThreadEntry, arg, STACK_END(sGraphStack), Z_PRIORITY_GRAPH);
     osStartThread(&sGraphThread);
     osSetThreadPri(0, Z_PRIORITY_SCHED);
 

--- a/src/libultra/io/pimgr.c
+++ b/src/libultra/io/pimgr.c
@@ -6,7 +6,7 @@ OSMgrArgs __osPiDevMgr = { 0 };
 OSPiHandle __Dom1SpeedParam;
 OSPiHandle __Dom2SpeedParam;
 OSThread piThread;
-u8 piStackThread[0x1000];
+STACK(piStackThread, 0x1000);
 OSMesgQueue piEventQueue;
 OSMesg piEventBuf[2];
 OSThread __osThreadSave;
@@ -46,7 +46,7 @@ void osCreatePiManager(OSPri pri, OSMesgQueue* cmdQ, OSMesg* cmdBuf, s32 cmdMsgC
         __osPiDevMgr.piDmaCallback = __osPiRawStartDma;
         __osPiDevMgr.epiDmaCallback = __osEPiRawStartDma;
 
-        osCreateThread(&piThread, 0, __osDevMgrMain, (void*)&__osPiDevMgr, piStackThread + sizeof(piStackThread), pri);
+        osCreateThread(&piThread, 0, __osDevMgrMain, (void*)&__osPiDevMgr, STACK_END(piStackThread), pri);
         osStartThread(&piThread);
 
         __osRestoreInt(prevInt);

--- a/src/libultra/io/pimgr.c
+++ b/src/libultra/io/pimgr.c
@@ -46,7 +46,7 @@ void osCreatePiManager(OSPri pri, OSMesgQueue* cmdQ, OSMesg* cmdBuf, s32 cmdMsgC
         __osPiDevMgr.piDmaCallback = __osPiRawStartDma;
         __osPiDevMgr.epiDmaCallback = __osEPiRawStartDma;
 
-        osCreateThread(&piThread, 0, __osDevMgrMain, (void*)&__osPiDevMgr, STACK_END(piStackThread), pri);
+        osCreateThread(&piThread, 0, __osDevMgrMain, (void*)&__osPiDevMgr, STACK_TOP(piStackThread), pri);
         osStartThread(&piThread);
 
         __osRestoreInt(prevInt);

--- a/src/libultra/io/vimgr.c
+++ b/src/libultra/io/vimgr.c
@@ -45,7 +45,7 @@ void osCreateViManager(OSPri pri) {
         __osViDevMgr.piDmaCallback = NULL;
         __osViDevMgr.epiDmaCallback = NULL;
 
-        osCreateThread(&viThread, 0, &viMgrMain, &__osViDevMgr, STACK_END(viThreadStack), pri);
+        osCreateThread(&viThread, 0, &viMgrMain, &__osViDevMgr, STACK_TOP(viThreadStack), pri);
         __osViInit();
         osStartThread(&viThread);
         __osRestoreInt(prevInt);

--- a/src/libultra/io/vimgr.c
+++ b/src/libultra/io/vimgr.c
@@ -2,7 +2,7 @@
 #include "ultra64/internal.h"
 
 OSThread viThread;
-u8 viThreadStack[0x1000];
+STACK(viThreadStack, 0x1000);
 OSMesgQueue viEventQueue;
 OSMesg viEventBuf[6];
 OSIoMesg viRetraceMsg;
@@ -45,7 +45,7 @@ void osCreateViManager(OSPri pri) {
         __osViDevMgr.piDmaCallback = NULL;
         __osViDevMgr.epiDmaCallback = NULL;
 
-        osCreateThread(&viThread, 0, &viMgrMain, &__osViDevMgr, viThreadStack + sizeof(viThreadStack), pri);
+        osCreateThread(&viThread, 0, &viMgrMain, &__osViDevMgr, STACK_END(viThreadStack), pri);
         __osViInit();
         osStartThread(&viThread);
         __osRestoreInt(prevInt);


### PR DESCRIPTION
On MIPS o32, program stacks must be aligned to at least 8 byte boundaries and their size must also be a multiple of 8, otherwise 64-bit types stored on the stack may cause unaligned accesses.