### PR TITLE
Force required alignment on DMA related stuff

### DIFF
--- a/include/alignment.h
+++ b/include/alignment.h
@@ -1,0 +1,16 @@
+#ifndef ALIGNMENT_H
+#define ALIGNMENT_H
+
+#define ALIGN8(val) (((val) + 7) & ~7)
+#define ALIGN16(val) (((val) + 0xF) & ~0xF)
+#define ALIGN32(val) (((val) + 0x1F) & ~0x1F)
+#define ALIGN64(val) (((val) + 0x3F) & ~0x3F)
+#define ALIGN256(val) (((val) + 0xFF) & ~0xFF)
+
+#ifdef __GNUC__
+#define ALIGNED8 __attribute__ ((aligned (8)))
+#else
+#define ALIGNED8
+#endif
+
+#endif

--- a/include/macros.h
+++ b/include/macros.h
@@ -8,11 +8,6 @@
 #define VIRTUAL_TO_PHYSICAL(addr) (u32)((u8*)(addr) - 0x80000000)
 #define SEGMENTED_TO_VIRTUAL(addr) PHYSICAL_TO_VIRTUAL(gSegments[SEGMENT_NUMBER(addr)] + SEGMENT_OFFSET(addr))
 
-#define ALIGN16(val) (((val) + 0xF) & ~0xF)
-#define ALIGN32(val) (((val) + 0x1F) & ~0x1F)
-#define ALIGN64(val) (((val) + 0x3F) & ~0x3F)
-#define ALIGN256(val) (((val) + 0xFF) & ~0xFF)
-
 #define OFFSETOF(structure, member) ((size_t)&(((structure*)0)->member))
 
 #define SQ(x) ((x)*(x))
@@ -167,11 +162,5 @@ extern GraphicsContext* __gfxCtx;
         gDPSetTileSize(pkt, G_TX_RENDERTILE, 0, 0, ((width)-1) << G_TEXTURE_IMAGE_FRAC,                                \
                        ((height)-1) << G_TEXTURE_IMAGE_FRAC);                                                          \
     } while (0)
-
-#ifdef __GNUC__
-#define ALIGNED8 __attribute__ ((aligned (8)))
-#else
-#define ALIGNED8
-#endif
 
 #endif

--- a/include/ultra64/controller.h
+++ b/include/ultra64/controller.h
@@ -96,9 +96,12 @@
 #define BTN_B           0x4000
 #define BTN_A           0x8000
 
-typedef struct {
+typedef union {
+    struct {
     /* 0x00 */ u32 ram[15];
     /* 0x3C */ u32 status;
+    };
+    u64 force_structure_alignment;
 } OSPifRam; // size = 0x40
 
 typedef struct {

--- a/include/z64.h
+++ b/include/z64.h
@@ -24,6 +24,7 @@
 #include "z64skin.h"
 #include "z64transition.h"
 #include "z64interface.h"
+#include "alignment.h"
 #include "sequence.h"
 #include "sfx.h"
 #include "color.h"
@@ -48,8 +49,6 @@
 #define Z_PRIORITY_SCHED       15
 #define Z_PRIORITY_DMAMGR      16
 #define Z_PRIORITY_IRQMGR      17
-
-#define ALIGN8(val) (((val) + 7) & ~7)
 
 #define STACK(stack, size) \
     u64 stack[ALIGN8(size) / sizeof(u64)]

--- a/include/z64.h
+++ b/include/z64.h
@@ -521,12 +521,22 @@ typedef enum {
 typedef struct {
     /* 0x0000 */ u32    msgOffset;
     /* 0x0004 */ u32    msgLength;
+    union {
     /* 0x0008 */ u8     charTexBuf[FONT_CHAR_TEX_SIZE * 120];
+    /* 0x0008 */ u64    force_structure_alignment_charTex;
+    };
+    union {
     /* 0x3C08 */ u8     iconBuf[FONT_CHAR_TEX_SIZE];
+    /* 0x3C08 */ u64    force_structure_alignment_icon;
+    };
+    union {
     /* 0x3C88 */ u8     fontBuf[FONT_CHAR_TEX_SIZE * 320];
+    /* 0x3C88 */ u64    force_structure_alignment_font;
+    };
     union {
     /* 0xDC88 */ char   msgBuf[1280];
     /* 0xDC88 */ u16    msgBufWide[640];
+    /* 0xDC88 */ u64    force_structure_alignment_msg;
     };
 } Font; // size = 0xE188
 

--- a/include/z64player.h
+++ b/include/z64player.h
@@ -2,6 +2,7 @@
 #define Z64PLAYER_H
 
 #include "z64actor.h"
+#include "alignment.h"
 
 struct Player;
 
@@ -158,7 +159,7 @@ typedef enum {
 } PlayerDoorType;
 
 
-#define PLAYER_LIMB_BUF_COUNT PLAYER_LIMB_MAX + 2 // 2 extra entries in limb buffers?
+#define PLAYER_LIMB_BUF_COUNT ALIGN8(PLAYER_LIMB_MAX)
 
 typedef struct {
     /* 0x00 */ f32 unk_00;

--- a/include/z64player.h
+++ b/include/z64player.h
@@ -159,7 +159,7 @@ typedef enum {
 } PlayerDoorType;
 
 
-#define PLAYER_LIMB_BUF_COUNT ALIGN8(PLAYER_LIMB_MAX)
+#define LIMB_BUF_COUNT(limbCount) ((ALIGN16((limbCount) * sizeof(Vec3s)) + sizeof(Vec3s) - 1) / sizeof(Vec3s))
 
 typedef struct {
     /* 0x00 */ f32 unk_00;
@@ -312,9 +312,9 @@ typedef struct Player {
     /* 0x01AC */ OSMesg     giObjectLoadMsg;
     /* 0x01B0 */ void*      giObjectSegment; // also used for title card textures
     /* 0x01B4 */ SkelAnime  skelAnime;
-    /* 0x01F8 */ Vec3s      jointTable[PLAYER_LIMB_BUF_COUNT];
-    /* 0x0288 */ Vec3s      morphTable[PLAYER_LIMB_BUF_COUNT];
-    /* 0x0318 */ Vec3s      blendTable[PLAYER_LIMB_BUF_COUNT];
+    /* 0x01F8 */ Vec3s      jointTable[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
+    /* 0x0288 */ Vec3s      morphTable[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
+    /* 0x0318 */ Vec3s      blendTable[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
     /* 0x03A8 */ s16        unk_3A8[2];
     /* 0x03AC */ Actor*     heldActor;
     /* 0x03B0 */ Vec3f      leftHandPos;
@@ -381,8 +381,8 @@ typedef struct Player {
     /* 0x06C2 */ s16        unk_6C2;
     /* 0x06C4 */ f32        unk_6C4;
     /* 0x06C8 */ SkelAnime  skelAnime2;
-    /* 0x070C */ Vec3s      jointTable2[PLAYER_LIMB_BUF_COUNT];
-    /* 0x079C */ Vec3s      morphTable2[PLAYER_LIMB_BUF_COUNT];
+    /* 0x070C */ Vec3s      jointTable2[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
+    /* 0x079C */ Vec3s      morphTable2[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
     /* 0x082C */ PlayerFunc82C func_82C;
     /* 0x0830 */ f32        unk_830;
     /* 0x0834 */ s16        unk_834;

--- a/include/z64player.h
+++ b/include/z64player.h
@@ -160,6 +160,7 @@ typedef enum {
 
 
 #define LIMB_BUF_COUNT(limbCount) ((ALIGN16((limbCount) * sizeof(Vec3s)) + sizeof(Vec3s) - 1) / sizeof(Vec3s))
+#define PLAYER_LIMB_BUF_COUNT LIMB_BUF_COUNT(PLAYER_LIMB_MAX)
 
 typedef struct {
     /* 0x00 */ f32 unk_00;
@@ -312,9 +313,9 @@ typedef struct Player {
     /* 0x01AC */ OSMesg     giObjectLoadMsg;
     /* 0x01B0 */ void*      giObjectSegment; // also used for title card textures
     /* 0x01B4 */ SkelAnime  skelAnime;
-    /* 0x01F8 */ Vec3s      jointTable[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
-    /* 0x0288 */ Vec3s      morphTable[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
-    /* 0x0318 */ Vec3s      blendTable[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
+    /* 0x01F8 */ Vec3s      jointTable[PLAYER_LIMB_BUF_COUNT];
+    /* 0x0288 */ Vec3s      morphTable[PLAYER_LIMB_BUF_COUNT];
+    /* 0x0318 */ Vec3s      blendTable[PLAYER_LIMB_BUF_COUNT];
     /* 0x03A8 */ s16        unk_3A8[2];
     /* 0x03AC */ Actor*     heldActor;
     /* 0x03B0 */ Vec3f      leftHandPos;
@@ -381,8 +382,8 @@ typedef struct Player {
     /* 0x06C2 */ s16        unk_6C2;
     /* 0x06C4 */ f32        unk_6C4;
     /* 0x06C8 */ SkelAnime  skelAnime2;
-    /* 0x070C */ Vec3s      jointTable2[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
-    /* 0x079C */ Vec3s      morphTable2[LIMB_BUF_COUNT(PLAYER_LIMB_MAX)];
+    /* 0x070C */ Vec3s      jointTable2[PLAYER_LIMB_BUF_COUNT];
+    /* 0x079C */ Vec3s      morphTable2[PLAYER_LIMB_BUF_COUNT];
     /* 0x082C */ PlayerFunc82C func_82C;
     /* 0x0830 */ f32        unk_830;
     /* 0x0834 */ s16        unk_834;

--- a/src/code/z_common_data.c
+++ b/src/code/z_common_data.c
@@ -1,5 +1,6 @@
 #include "global.h"
 
+// The use of ALIGNED8 here is just a temporary solution until the SaveContext is re-structured
 ALIGNED8 SaveContext gSaveContext;
 u32 D_8015FA88;
 u32 D_8015FA8C;

--- a/src/code/z_common_data.c
+++ b/src/code/z_common_data.c
@@ -1,6 +1,6 @@
 #include "global.h"
 
-SaveContext gSaveContext;
+ALIGNED8 SaveContext gSaveContext;
 u32 D_8015FA88;
 u32 D_8015FA8C;
 


### PR DESCRIPTION
The address of any variable that's going to be DMA'd requires dword alignment (8 byte boundaries).

- Converts `OSPifRam` to an union and adds a `u64 force_structure_alignment;`.
- Add a `u64 force_structure_alignment` member to every buffer in `Font`.
- Add `ALIGNED8` to `gSaveContext` as a temporary fix until the main struct gets re-estructured.
- Use `ALIGN8(PLAYER_LIMB_MAX)` for `PLAYER_LIMB_BUF_COUNT`.
- Creates an `alignment.h` header and moves all the alignment related macros there.