### PR TITLE
Use `__builtin_offsetof` for non IDO builds

### DIFF
--- a/include/ichain.h
+++ b/include/ichain.h
@@ -1,6 +1,8 @@
 #ifndef ICHAIN_H
 #define ICHAIN_H
 
+#include "libc/stddef.h"
+
 typedef struct {
     u32 cont:   1;
     u32 type:   4;
@@ -36,7 +38,7 @@ typedef enum {
  * * cont ----- ICHAIN_CONTINUE (or ICHAIN_STOP) to continue (or stop) parsing
  */
 #define ICHAIN(type, member, value, cont)      \
-        { cont, type, OFFSETOF(Actor, member), value }
+        { cont, type, offsetof(Actor, member), value }
 
 #define ICHAIN_U8(member, val, cont)            ICHAIN(ICHAINTYPE_U8, member, val, cont)
 #define ICHAIN_S8(member, val, cont)            ICHAIN(ICHAINTYPE_S8, member, val, cont)

--- a/include/libc/stddef.h
+++ b/include/libc/stddef.h
@@ -7,4 +7,10 @@ typedef unsigned long size_t;
 
 typedef unsigned int uintptr_t;
 
+#ifdef __GNUC__
+#define offsetof(structure, member) __builtin_offsetof (structure, member)
+#else
+#define offsetof(structure, member) ((size_t)&(((structure*)0)->member))
+#endif
+
 #endif

--- a/include/macros.h
+++ b/include/macros.h
@@ -8,8 +8,6 @@
 #define VIRTUAL_TO_PHYSICAL(addr) (u32)((u8*)(addr) - 0x80000000)
 #define SEGMENTED_TO_VIRTUAL(addr) PHYSICAL_TO_VIRTUAL(gSegments[SEGMENT_NUMBER(addr)] + SEGMENT_OFFSET(addr))
 
-#define OFFSETOF(structure, member) ((size_t)&(((structure*)0)->member))
-
 #define SQ(x) ((x)*(x))
 #define ABS(x) ((x) >= 0 ? (x) : -(x))
 #define DECR(x) ((x) == 0 ? 0 : --(x))

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -74,13 +74,13 @@ typedef struct {
 #define SLOT_SIZE (sizeof(SaveContext) + 0x28)
 #define CHECKSUM_SIZE (sizeof(Save) / 2)
 
-#define DEATHS OFFSETOF(SaveContext, deaths)
-#define NAME OFFSETOF(SaveContext, playerName)
-#define N64DD OFFSETOF(SaveContext, n64ddFlag)
-#define HEALTH_CAP OFFSETOF(SaveContext, healthCapacity)
-#define QUEST OFFSETOF(SaveContext, inventory.questItems)
-#define DEFENSE OFFSETOF(SaveContext, inventory.defenseHearts)
-#define HEALTH OFFSETOF(SaveContext, health)
+#define DEATHS offsetof(SaveContext, deaths)
+#define NAME offsetof(SaveContext, playerName)
+#define N64DD offsetof(SaveContext, n64ddFlag)
+#define HEALTH_CAP offsetof(SaveContext, healthCapacity)
+#define QUEST offsetof(SaveContext, inventory.questItems)
+#define DEFENSE offsetof(SaveContext, inventory.defenseHearts)
+#define HEALTH offsetof(SaveContext, health)
 
 #define SLOT_OFFSET(index) (SRAM_HEADER_SIZE + 0x10 + (index * SLOT_SIZE))
 

--- a/src/overlays/gamestates/ovl_file_choose/file_choose.h
+++ b/src/overlays/gamestates/ovl_file_choose/file_choose.h
@@ -1,12 +1,13 @@
 #ifndef _FILE_CHOOSE_H_
 #define _FILE_CHOOSE_H_
 
+#include "libc/stddef.h"
 #include "ultra64.h"
 #include "global.h"
 #include "vt.h"
 
 
-#define GET_NEWF(sramCtx, slotNum, index) (sramCtx->readBuff[gSramSlotOffsets[slotNum] + OFFSETOF(SaveContext, newf[index])])
+#define GET_NEWF(sramCtx, slotNum, index) (sramCtx->readBuff[gSramSlotOffsets[slotNum] + offsetof(SaveContext, newf[index])])
 
 #define SLOT_OCCUPIED(sramCtx, slotNum) \
     ((GET_NEWF(sramCtx, slotNum, 0) == 'Z') || \


### PR DESCRIPTION
The current way this repo handles `OFFSETOF` can be considered as UB. 
We already know it works fine with both IDO and GCC,  but some future version of GCC may change its behavior. So this PR changes the macro to use `__builtin_offsetof` on GCC builds.
I also renamed the macro to `offsetof`, because that is the name of this macro in the C89 standard, and it works exactly the same as the standard says.