### PR TITLE
Angle cleanup - miscellaneous

### DIFF
--- a/include/z64math.h
+++ b/include/z64math.h
@@ -103,6 +103,7 @@ typedef struct {
 #define BINANG_TO_DEGF(binang) ((f32)(binang) * (360.0001525f / 65535.0f))
 #define BINANG_TO_RAD(binang) ((f32)(binang) * (M_PI / 0x8000))
 #define BINANG_TO_RAD_ALT(binang) (((f32)(binang) / (f32)0x8000) * M_PI)
+#define BINANG_TO_RAD_ALT2(binang) (((f32)(binang) * M_PI) / 0x8000)
 
 // Vector macros
 #define SQXZ(vec) ((vec.x) * (vec.x) + (vec.z) * (vec.z))

--- a/src/code/db_camera.c
+++ b/src/code/db_camera.c
@@ -1090,9 +1090,9 @@ void DbCamera_Update(DbCamera* dbCamera, Camera* cam) {
                     dbCamera->unk_3C = false;
                     if (dbCamera->sub.mode != 1) {
                         func_8006376C(0xD, 0x18, 3, !D_80161144 ? D_8012CF04 : D_8012CF08);
-                        DbCamera_SetTextValue(sp104.pitch * 0.00549325f, &D_8012D0E4[11], 4);
+                        DbCamera_SetTextValue(BINANG_TO_DEGF(sp104.pitch), &D_8012D0E4[11], 4);
                         func_8006376C(0xF, 0x17, 3, D_8012D0E4);
-                        DbCamera_SetTextValue(sp104.yaw * 0.00549325f, &D_8012D0F8[11], 4);
+                        DbCamera_SetTextValue(BINANG_TO_DEGF(sp104.yaw), &D_8012D0F8[11], 4);
                         func_8006376C(0xF, 0x18, 3, D_8012D0F8);
                         DbCamera_SetTextValue(sp104.r, &D_8012D0D4[8], 6);
                         func_8006376C(0xF, 0x19, 3, D_8012D0D4);
@@ -1363,9 +1363,9 @@ void DbCamera_Update(DbCamera* dbCamera, Camera* cam) {
                               : !D_80161144                                                               ? 4
                                                                                                           : 3,
                               D_8012CF30);
-                DbCamera_SetTextValue(spFC.pitch * 0.00549325f, &D_8012D0E4[10], 4);
+                DbCamera_SetTextValue(BINANG_TO_DEGF(spFC.pitch), &D_8012D0E4[10], 4);
                 func_8006376C(3, 0x17, 3, D_8012D0E4);
-                DbCamera_SetTextValue(spFC.yaw * 0.00549325f, &D_8012D0F8[10], 4);
+                DbCamera_SetTextValue(BINANG_TO_DEGF(spFC.yaw), &D_8012D0F8[10], 4);
                 func_8006376C(3, 0x18, 3, D_8012D0F8);
                 DbCamera_SetTextValue(spFC.r, &D_8012D0D4[7], 6);
                 func_8006376C(3, 0x19, 3, D_8012D0D4);
@@ -1376,9 +1376,9 @@ void DbCamera_Update(DbCamera* dbCamera, Camera* cam) {
                               : D_80161144                                                               ? 4
                                                                                                          : 3,
                               D_8012CF34);
-                DbCamera_SetTextValue(spFC.pitch * 0.00549325f, &D_8012D0E4[10], 4);
+                DbCamera_SetTextValue(BINANG_TO_DEGF(spFC.pitch), &D_8012D0E4[10], 4);
                 func_8006376C(0x1C, 0x17, 3, D_8012D0E4);
-                DbCamera_SetTextValue(spFC.yaw * 0.00549325f, &D_8012D0F8[10], 4);
+                DbCamera_SetTextValue(BINANG_TO_DEGF(spFC.yaw), &D_8012D0F8[10], 4);
                 func_8006376C(0x1C, 0x18, 3, D_8012D0F8);
                 DbCamera_SetTextValue(spFC.r, &D_8012D0D4[7], 6);
                 func_8006376C(0x1C, 0x19, 3, D_8012D0D4);
@@ -1451,9 +1451,9 @@ void DbCamera_Update(DbCamera* dbCamera, Camera* cam) {
         DbCamera_SetTextValue(dbCamera->eye.z, &sp111, 6);
         func_8006376C(0x1E, 0x19, 2, &sp110);
         func_8006376C(0xD, 0x18, 3, !D_80161144 ? D_8012CF04 : D_8012CF08);
-        DbCamera_SetTextValue(sp104.pitch * 0.00549325f, &D_8012D0E4[11], 4);
+        DbCamera_SetTextValue(BINANG_TO_DEGF(sp104.pitch), &D_8012D0E4[11], 4);
         func_8006376C(0xF, 0x17, 3, D_8012D0E4);
-        DbCamera_SetTextValue(sp104.yaw * 0.00549325f, &D_8012D0F8[11], 4);
+        DbCamera_SetTextValue(BINANG_TO_DEGF(sp104.yaw), &D_8012D0F8[11], 4);
         func_8006376C(0xF, 0x18, 3, D_8012D0F8);
         DbCamera_SetTextValue(sp104.r, &D_8012D0D4[8], 6);
         func_8006376C(0xF, 0x19, 3, D_8012D0D4);

--- a/src/code/sys_math.c
+++ b/src/code/sys_math.c
@@ -39,9 +39,9 @@ f32 Math_PowF(f32 base, s32 exp) {
 }
 
 f32 Math_SinF(f32 angle) {
-    return sins((s16)(angle * (32767.0f / M_PI))) * SHT_MINV;
+    return sins((s16)(angle * (0x7FFF / M_PI))) * SHT_MINV;
 }
 
 f32 Math_CosF(f32 angle) {
-    return coss((s16)(angle * (32767.0f / M_PI))) * SHT_MINV;
+    return coss((s16)(angle * (0x7FFF / M_PI))) * SHT_MINV;
 }

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -1921,13 +1921,13 @@ void Actor_DrawFaroresWindPointer(GlobalContext* globalCtx) {
             gDPSetPrimColor(POLY_XLU_DISP++, 128, 128, 255, 255, 200, alpha);
             gDPSetEnvColor(POLY_XLU_DISP++, 100, 200, 0, 255);
 
-            Matrix_RotateZ(((globalCtx->gameplayFrames * 1500) & 0xFFFF) * M_PI / 32768.0f, MTXMODE_APPLY);
+            Matrix_RotateZ(BINANG_TO_RAD_ALT2((globalCtx->gameplayFrames * 1500) & 0xFFFF), MTXMODE_APPLY);
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_actor.c", 5458),
                       G_MTX_MODELVIEW | G_MTX_LOAD | G_MTX_NOPUSH);
             gSPDisplayList(POLY_XLU_DISP++, gEffFlash1DL);
 
             Matrix_Pop();
-            Matrix_RotateZ(~((globalCtx->gameplayFrames * 1200) & 0xFFFF) * M_PI / 32768.0f, MTXMODE_APPLY);
+            Matrix_RotateZ(BINANG_TO_RAD_ALT2(~((globalCtx->gameplayFrames * 1200) & 0xFFFF)), MTXMODE_APPLY);
 
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_actor.c", 5463),
                       G_MTX_MODELVIEW | G_MTX_LOAD | G_MTX_NOPUSH);

--- a/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.c
+++ b/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.c
@@ -290,7 +290,7 @@ void func_808AD450(Actor* thisx, GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_bg_spot02_objects.c", 736);
 
     if (globalCtx->csCtx.state != 0 && globalCtx->csCtx.npcActions[2] != NULL) {
-        u16 temp_v1 = globalCtx->csCtx.npcActions[2]->urot.z * 0.00549325f;
+        u16 temp_v1 = BINANG_TO_DEGF(globalCtx->csCtx.npcActions[2]->urot.z);
 
         if (this->unk_170 != temp_v1) {
             if (this->unk_170 == 0xFFFF) {

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -948,7 +948,7 @@ f32 BossTw_GetFloorY(Vec3f* pos) {
     }
 
     Matrix_Push();
-    Matrix_RotateY(DEG_TO_RAD(45), MTXMODE_NEW);
+    Matrix_RotateY(M_PI / 4, MTXMODE_NEW);
     Matrix_MultVec3f(pos, &posRotated);
     Matrix_Pop();
 

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -845,7 +845,7 @@ s32 BossTw_CheckBeamReflection(BossTw* this, GlobalContext* globalCtx) {
         offset.z = 10.0f;
 
         // set beam check point to 10 units in front of link.
-        Matrix_RotateY(player->actor.shape.rot.y / 32768.0f * M_PI, MTXMODE_NEW);
+        Matrix_RotateY(player->actor.shape.rot.y / (f32)0x8000 * M_PI, MTXMODE_NEW);
         Matrix_MultVec3f(&offset, &vec);
 
         // calculates a vector where the origin is at the beams origin,
@@ -1579,11 +1579,11 @@ void BossTw_TwinrovaMergeCS(BossTw* this, GlobalContext* globalCtx) {
             sKoumePtr->actor.world.pos.x = spA4.x;
             sKoumePtr->actor.world.pos.y = spA4.y;
             sKoumePtr->actor.world.pos.z = spA4.z;
-            sKoumePtr->actor.shape.rot.y = (this->workf[UNK_F9] / M_PI) * 32768.0f;
+            sKoumePtr->actor.shape.rot.y = (this->workf[UNK_F9] / M_PI) * (f32)0x8000;
             sKotakePtr->actor.world.pos.x = -spA4.x;
             sKotakePtr->actor.world.pos.y = spA4.y;
             sKotakePtr->actor.world.pos.z = -spA4.z;
-            sKotakePtr->actor.shape.rot.y = ((this->workf[UNK_F9] / M_PI) * 32768.0f) + 32768.0f;
+            sKotakePtr->actor.shape.rot.y = ((this->workf[UNK_F9] / M_PI) * (f32)0x8000) + (f32)0x8000;
             Math_ApproachF(&this->workf[UNK_F11], 0.0f, 0.1f, 7.0f);
             this->workf[UNK_F9] -= this->workf[UNK_F10];
             Math_ApproachF(&this->workf[UNK_F10], 0.5f, 1, 0.0039999997f);
@@ -2245,12 +2245,13 @@ void BossTw_TwinrovaIntroCS(BossTw* this, GlobalContext* globalCtx) {
                 sKoumePtr->actor.world.pos.x = sp84.x;
                 sKoumePtr->actor.world.pos.y = sp84.y;
                 sKoumePtr->actor.world.pos.z = sp84.z;
-                sKoumePtr->actor.world.rot.y = sKoumePtr->actor.shape.rot.y = (this->workf[UNK_F9] / M_PI) * 32768.0f;
+                sKoumePtr->actor.world.rot.y = sKoumePtr->actor.shape.rot.y =
+                    (this->workf[UNK_F9] / M_PI) * (f32)0x8000;
                 sKotakePtr->actor.world.pos.x = -sp84.x;
                 sKotakePtr->actor.world.pos.y = sp84.y;
                 sKotakePtr->actor.world.pos.z = -sp84.z;
                 sKotakePtr->actor.shape.rot.y = sKotakePtr->actor.world.rot.y =
-                    ((this->workf[UNK_F9] / M_PI) * 32768.0f) + 32768.0f;
+                    ((this->workf[UNK_F9] / M_PI) * (f32)0x8000) + (f32)0x8000;
                 Math_ApproachF(&this->workf[UNK_F11], 80.0f, 0.1f, 5.0f);
                 this->workf[UNK_F9] -= this->workf[UNK_F10];
                 Math_ApproachF(&this->workf[UNK_F10], 0.19999999f, 1.0f, 0.0019999994f);

--- a/src/overlays/actors/ovl_En_Cs/z_en_cs.c
+++ b/src/overlays/actors/ovl_En_Cs/z_en_cs.c
@@ -516,7 +516,7 @@ void EnCs_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Vec
         Matrix_Translate(0.0f, -200.0f, 0.0f, MTXMODE_APPLY);
         Matrix_RotateY(0.0f, MTXMODE_APPLY);
         Matrix_RotateX(0.0f, MTXMODE_APPLY);
-        Matrix_RotateZ(5.0 * M_PI / 9.0, MTXMODE_APPLY);
+        Matrix_RotateZ(DEG_TO_RAD(100), MTXMODE_APPLY);
         Matrix_Get(&this->spookyMaskMtx);
     }
 }

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -1095,8 +1095,8 @@ void EnFloormas_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dLis
     if (limbIndex == 2) {
         Matrix_Push();
         Matrix_Translate(1600.0f, -700.0f, -1700.0f, MTXMODE_APPLY);
-        Matrix_RotateY(DEG_TO_RAD(60.0f), MTXMODE_APPLY);
-        Matrix_RotateZ(DEG_TO_RAD(15.0f), MTXMODE_APPLY);
+        Matrix_RotateY(DEG_TO_RAD(60), MTXMODE_APPLY);
+        Matrix_RotateZ(DEG_TO_RAD(15), MTXMODE_APPLY);
         Matrix_Scale(2.0f, 2.0f, 2.0f, MTXMODE_APPLY);
         gSPMatrix((*gfx)++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_en_floormas.c", 2299), G_MTX_LOAD);
         gSPDisplayList((*gfx)++, gWallmasterFingerDL);

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -853,7 +853,7 @@ void EnHeishi2_Draw(Actor* thisx, GlobalContext* globalCtx) {
         if (linkObjBankIndex >= 0) {
             Matrix_Put(&this->mtxf_330);
             Matrix_Translate(-570.0f, 0.0f, 0.0f, MTXMODE_APPLY);
-            Matrix_RotateZ(DEG_TO_RAD(70.0), MTXMODE_APPLY);
+            Matrix_RotateZ(DEG_TO_RAD(70), MTXMODE_APPLY);
             mtx = Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_en_heishi2.c", 1820) - 7;
 
             gSPSegment(POLY_OPA_DISP++, 0x06, globalCtx->objectCtx.status[linkObjBankIndex].segment);

--- a/src/overlays/actors/ovl_End_Title/z_end_title.c
+++ b/src/overlays/actors/ovl_End_Title/z_end_title.c
@@ -61,7 +61,7 @@ void EndTitle_DrawFull(Actor* thisx, GlobalContext* globalCtx) {
     Matrix_Mult(mf, MTXMODE_NEW);
     Matrix_Translate(0.0f, 150.0f, 170.0f, MTXMODE_APPLY);
     Matrix_Scale(0.13f, 0.13f, 0.13f, MTXMODE_APPLY);
-    Matrix_RotateX(BINANG_TO_RAD_ALT(0xBB8), MTXMODE_APPLY);
+    Matrix_RotateX(BINANG_TO_RAD(0xBB8), MTXMODE_APPLY);
     Matrix_RotateY(0.0f, MTXMODE_APPLY);
     Matrix_RotateZ(0.0f, MTXMODE_APPLY);
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_end_title.c", 412), G_MTX_LOAD);

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -1356,9 +1356,9 @@ void Fishing_DrawEffects(FishingEffect* effect, GlobalContext* globalCtx) {
     effect = firstEffect;
     if (effect->type == FS_EFF_OWNER_HAT) {
         Matrix_Translate(effect->pos.x, effect->pos.y, effect->pos.z, MTXMODE_NEW);
-        Matrix_RotateY((sEffOwnerHatRot.y * M_PI) / 32768, MTXMODE_APPLY);
-        Matrix_RotateX((sEffOwnerHatRot.x * M_PI) / 32768, MTXMODE_APPLY);
-        Matrix_RotateZ((sEffOwnerHatRot.z * M_PI) / 32768, MTXMODE_APPLY);
+        Matrix_RotateY(BINANG_TO_RAD_ALT2(sEffOwnerHatRot.y), MTXMODE_APPLY);
+        Matrix_RotateX(BINANG_TO_RAD_ALT2(sEffOwnerHatRot.x), MTXMODE_APPLY);
+        Matrix_RotateZ(BINANG_TO_RAD_ALT2(sEffOwnerHatRot.z), MTXMODE_APPLY);
         Matrix_Scale(effect->unk_30, effect->unk_30, effect->unk_30, MTXMODE_APPLY);
         Matrix_Translate(-1250.0f, 0.0f, 0.0f, MTXMODE_APPLY);
         Matrix_RotateX(M_PI / 2, MTXMODE_APPLY);
@@ -4706,8 +4706,8 @@ void Fishing_DrawGroupFishes(GlobalContext* globalCtx) {
 
             if (fish->shouldDraw) {
                 Matrix_Translate(fish->pos.x, fish->pos.y, fish->pos.z, MTXMODE_NEW);
-                Matrix_RotateY(((f32)fish->unk_3E * M_PI) / 32768.0f, MTXMODE_APPLY);
-                Matrix_RotateX((-(f32)fish->unk_3C * M_PI) / 32768.0f, MTXMODE_APPLY);
+                Matrix_RotateY(BINANG_TO_RAD_ALT2((f32)fish->unk_3E), MTXMODE_APPLY);
+                Matrix_RotateX(BINANG_TO_RAD_ALT2(-(f32)fish->unk_3C), MTXMODE_APPLY);
                 Matrix_Scale(fish->unk_2C * scale, scale, scale, MTXMODE_APPLY);
 
                 gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_fishing.c", 8093),

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -5655,7 +5655,7 @@ void Fishing_UpdateOwner(Actor* thisx, GlobalContext* globalCtx2) {
 
         rot.x = M_PI / 2.0f + 0.1f;
         rot.y = 1.0f;
-        rot.z = (Camera_GetInputDirYaw(camera) * -(M_PI / 32768)) + rot.y;
+        rot.z = (Camera_GetInputDirYaw(camera) * -(M_PI / 0x8000)) + rot.y;
 
         for (i = 0; i < (u8)D_80B7A650; i++) {
             pos.x = Rand_CenteredFloat(700.0f) + globalCtx->view.eye.x;

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -741,8 +741,8 @@ void ObjectKankyo_DrawLightning(ObjectKankyo* this, GlobalContext* globalCtx) {
     if (this->effects[0].state == 1) {
         Matrix_Translate(globalCtx->csCtx.npcActions[0]->startPos.x, globalCtx->csCtx.npcActions[0]->startPos.y,
                          globalCtx->csCtx.npcActions[0]->startPos.z, MTXMODE_NEW);
-        Matrix_RotateX(DEG_TO_RAD(20.0f), MTXMODE_APPLY);
-        Matrix_RotateZ(DEG_TO_RAD(20.0f), MTXMODE_APPLY);
+        Matrix_RotateX(DEG_TO_RAD(20), MTXMODE_APPLY);
+        Matrix_RotateZ(DEG_TO_RAD(20), MTXMODE_APPLY);
         Matrix_Scale(2.0f, 5.0f, 2.0f, MTXMODE_APPLY);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 255, 128);
         gDPSetEnvColor(POLY_XLU_DISP++, 0, 255, 255, 128);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10674,8 +10674,8 @@ void Player_Draw(Actor* thisx, GlobalContext* globalCtx2) {
         }
 
         if (this->stateFlags2 & PLAYER_STATE2_26) {
-            f32 sp78 = ((u16)(globalCtx->gameplayFrames * 600) * M_PI) / 0x8000;
-            f32 sp74 = ((u16)(globalCtx->gameplayFrames * 1000) * M_PI) / 0x8000;
+            f32 sp78 = BINANG_TO_RAD_ALT2((u16)(globalCtx->gameplayFrames * 600));
+            f32 sp74 = BINANG_TO_RAD_ALT2((u16)(globalCtx->gameplayFrames * 1000));
 
             Matrix_Push();
             this->actor.scale.y = -this->actor.scale.y;


### PR DESCRIPTION
Adds `BINANG_TO_RAD_ALT2` but idk if it's worth having since it only gets 9 uses

---------

If someone has an idea if this can use a macro let me know:
https://github.com/zeldaret/oot/blob/2306e094b28620f0e323bf4af61f8e00450e38fa/src/code/z_scene_table.c#L2316-L2318

---------

I think there are rodata memes (?) in z_boss_tw.c (twinrova) that are preventing using some angle macros, if someone wants to try understand it be my guest

---------

Some cleanup around angle literals, like
- `DEG_TO_RAD(100)` instead of `5.0 * M_PI / 9.0` (and type degree amount as int, it doesn't matter idk)
- `M_PI / 4` instead of `DEG_TO_RAD(45)`, just use radians directly for nice radians values, typically pi, pi/2, pi/4 (as it currently mostly is in the repo)