### PR TITLE
Small collision_check improvements

### DIFF
--- a/include/z64collision_check.h
+++ b/include/z64collision_check.h
@@ -272,7 +272,7 @@ typedef enum {
     /* 7 */ ELEMTYPE_UNK7
 } ElementType;
 
-#define SAC_ON (1 << 0)
+#define SAC_ENABLE (1 << 0)
 
 #define AT_NONE 0 // No flags set. Cannot have AT collisions when set as AT
 #define AT_ON (1 << 0) // Can have AT collisions when set as AT

--- a/include/z64collision_check.h
+++ b/include/z64collision_check.h
@@ -252,7 +252,7 @@ typedef enum {
     /* 1 */ COLSHAPE_CYLINDER,
     /* 2 */ COLSHAPE_TRIS,
     /* 3 */ COLSHAPE_QUAD,
-    /* 4 */ COLSHAPE_INVALID
+    /* 4 */ COLSHAPE_MAX
 } ColliderShape;
 
 /**

--- a/include/z64collision_check.h
+++ b/include/z64collision_check.h
@@ -272,6 +272,8 @@ typedef enum {
     /* 7 */ ELEMTYPE_UNK7
 } ElementType;
 
+#define SAC_ON (1 << 0)
+
 #define AT_NONE 0 // No flags set. Cannot have AT collisions when set as AT
 #define AT_ON (1 << 0) // Can have AT collisions when set as AT
 #define AT_HIT (1 << 1) // Had an AT collision

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -1998,7 +1998,7 @@ void CollisionCheck_AC_JntSphVsQuad(GlobalContext* globalCtx, CollisionCheckCont
             if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == 1) {
                 continue;
             }
-            if (Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &tri1, &hitPos) == 1 ||
+            if (Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &tri1, &hitPos) == true ||
                 Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &tri2, &hitPos) == 1) {
                 Vec3f atPos;
                 Vec3f acPos;
@@ -2205,7 +2205,7 @@ void CollisionCheck_AC_CylVsQuad(GlobalContext* globalCtx, CollisionCheckContext
         }
         Math3D_TriNorm(&tri1, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
         Math3D_TriNorm(&tri2, &ac->dim.quad[1], &ac->dim.quad[0], &ac->dim.quad[2]);
-        if (Math3D_CylTriVsIntersect(&at->dim, &tri1, &intersection) == 1) {
+        if (Math3D_CylTriVsIntersect(&at->dim, &tri1, &intersection) == true) {
             Vec3f atPos1;
             Vec3f acPos1;
 
@@ -2359,7 +2359,7 @@ void CollisionCheck_AC_TrisVsQuad(GlobalContext* globalCtx, CollisionCheckContex
             if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == 1) {
                 continue;
             }
-            if (Math3D_TriVsTriIntersect(&tri1, &atItem->dim, &intersection) == 1 ||
+            if (Math3D_TriVsTriIntersect(&tri1, &atItem->dim, &intersection) == true ||
                 Math3D_TriVsTriIntersect(&tri2, &atItem->dim, &intersection) == 1) {
                 Vec3f atPos;
                 Vec3f acPos;
@@ -3098,7 +3098,7 @@ s32 CollisionCheck_LineOC_JntSph(GlobalContext* globalCtx, CollisionCheckContext
         }
         lineSeg.a = *a;
         lineSeg.b = *b;
-        if (Math3D_LineVsSph(&element->dim.worldSphere, &lineSeg) == 1) {
+        if (Math3D_LineVsSph(&element->dim.worldSphere, &lineSeg) == true) {
             return true;
         }
     }

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -102,7 +102,7 @@ void Collider_DrawPoly(GraphicsContext* gfxCtx, Vec3f* vA, Vec3f* vB, Vec3f* vC,
 
 s32 Collider_InitBase(GlobalContext* globalCtx, Collider* collider) {
     static Collider init = {
-        NULL, NULL, NULL, NULL, AT_NONE, AC_NONE, OC1_NONE, OC2_NONE, COLTYPE_HIT3, COLSHAPE_INVALID,
+        NULL, NULL, NULL, NULL, AT_NONE, AC_NONE, OC1_NONE, OC2_NONE, COLTYPE_HIT3, COLSHAPE_MAX,
     };
 
     *collider = init;
@@ -1180,7 +1180,7 @@ s32 CollisionCheck_SetAT(GlobalContext* globalCtx, CollisionCheckContext* colChk
     if (FrameAdvance_IsEnabled(globalCtx) == true) {
         return -1;
     }
-    ASSERT(collider->shape <= COLSHAPE_QUAD, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 2997);
+    ASSERT(collider->shape < COLSHAPE_MAX, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 2997);
     sATResetFuncs[collider->shape](globalCtx, collider);
     if (collider->actor != NULL && collider->actor->update == NULL) {
         return -1;
@@ -1205,7 +1205,7 @@ s32 CollisionCheck_SetAT(GlobalContext* globalCtx, CollisionCheckContext* colChk
  */
 s32 CollisionCheck_SetAT_SAC(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* collider,
                              s32 index) {
-    ASSERT(collider->shape <= COLSHAPE_QUAD, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3037);
+    ASSERT(collider->shape < COLSHAPE_MAX, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3037);
     if (FrameAdvance_IsEnabled(globalCtx) == true) {
         return -1;
     }
@@ -1249,7 +1249,7 @@ s32 CollisionCheck_SetAC(GlobalContext* globalCtx, CollisionCheckContext* colChk
     if (FrameAdvance_IsEnabled(globalCtx) == true) {
         return -1;
     }
-    ASSERT(collider->shape <= COLSHAPE_QUAD, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3114);
+    ASSERT(collider->shape < COLSHAPE_MAX, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3114);
     sACResetFuncs[collider->shape](globalCtx, collider);
     if (collider->actor != NULL && collider->actor->update == NULL) {
         return -1;
@@ -1274,7 +1274,7 @@ s32 CollisionCheck_SetAC(GlobalContext* globalCtx, CollisionCheckContext* colChk
  */
 s32 CollisionCheck_SetAC_SAC(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* collider,
                              s32 index) {
-    ASSERT(collider->shape <= COLSHAPE_QUAD, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3153);
+    ASSERT(collider->shape < COLSHAPE_MAX, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3153);
     if (FrameAdvance_IsEnabled(globalCtx) == true) {
         return -1;
     }
@@ -1319,7 +1319,7 @@ s32 CollisionCheck_SetOC(GlobalContext* globalCtx, CollisionCheckContext* colChk
         return -1;
     }
 
-    ASSERT(collider->shape <= COLSHAPE_QUAD, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3229);
+    ASSERT(collider->shape < COLSHAPE_MAX, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3229);
 
     sOCResetFuncs[collider->shape](globalCtx, collider);
     if (collider->actor != NULL && collider->actor->update == NULL) {
@@ -1348,7 +1348,7 @@ s32 CollisionCheck_SetOC_SAC(GlobalContext* globalCtx, CollisionCheckContext* co
     if (FrameAdvance_IsEnabled(globalCtx) == true) {
         return -1;
     }
-    ASSERT(collider->shape <= COLSHAPE_QUAD, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3274);
+    ASSERT(collider->shape < COLSHAPE_MAX, "pcl_obj->data_type <= CL_DATA_LBL_SWRD", "../z_collision_check.c", 3274);
     sOCResetFuncs[collider->shape](globalCtx, collider);
     if (collider->actor != NULL && collider->actor->update == NULL) {
         return -1;
@@ -1436,52 +1436,52 @@ void CollisionCheck_NoBlood(GlobalContext* globalCtx, Collider* collider, Vec3f*
  * Used by collider types HIT0 and HIT8.
  */
 void CollisionCheck_BlueBlood(GlobalContext* globalCtx, Collider* collider, Vec3f* v) {
-    static EffectSparkInit D_8015D8A0;
+    static EffectSparkInit sparkInit;
     s32 effectIndex;
 
-    D_8015D8A0.position.x = v->x;
-    D_8015D8A0.position.y = v->y;
-    D_8015D8A0.position.z = v->z;
-    D_8015D8A0.uDiv = 5;
-    D_8015D8A0.vDiv = 5;
-    D_8015D8A0.colorStart[0].r = 10;
-    D_8015D8A0.colorStart[0].g = 10;
-    D_8015D8A0.colorStart[0].b = 200;
-    D_8015D8A0.colorStart[0].a = 255;
-    D_8015D8A0.colorStart[1].r = 0;
-    D_8015D8A0.colorStart[1].g = 0;
-    D_8015D8A0.colorStart[1].b = 128;
-    D_8015D8A0.colorStart[1].a = 255;
-    D_8015D8A0.colorStart[2].r = 0;
-    D_8015D8A0.colorStart[2].g = 0;
-    D_8015D8A0.colorStart[2].b = 128;
-    D_8015D8A0.colorStart[2].a = 255;
-    D_8015D8A0.colorStart[3].r = 0;
-    D_8015D8A0.colorStart[3].g = 0;
-    D_8015D8A0.colorStart[3].b = 128;
-    D_8015D8A0.colorStart[3].a = 255;
-    D_8015D8A0.colorEnd[0].r = 0;
-    D_8015D8A0.colorEnd[0].g = 0;
-    D_8015D8A0.colorEnd[0].b = 32;
-    D_8015D8A0.colorEnd[0].a = 0;
-    D_8015D8A0.colorEnd[1].r = 0;
-    D_8015D8A0.colorEnd[1].g = 0;
-    D_8015D8A0.colorEnd[1].b = 32;
-    D_8015D8A0.colorEnd[1].a = 0;
-    D_8015D8A0.colorEnd[2].r = 0;
-    D_8015D8A0.colorEnd[2].g = 0;
-    D_8015D8A0.colorEnd[2].b = 64;
-    D_8015D8A0.colorEnd[2].a = 0;
-    D_8015D8A0.colorEnd[3].r = 0;
-    D_8015D8A0.colorEnd[3].g = 0;
-    D_8015D8A0.colorEnd[3].b = 64;
-    D_8015D8A0.colorEnd[3].a = 0;
-    D_8015D8A0.timer = 0;
-    D_8015D8A0.duration = 16;
-    D_8015D8A0.speed = 8.0f;
-    D_8015D8A0.gravity = -1.0f;
+    sparkInit.position.x = v->x;
+    sparkInit.position.y = v->y;
+    sparkInit.position.z = v->z;
+    sparkInit.uDiv = 5;
+    sparkInit.vDiv = 5;
+    sparkInit.colorStart[0].r = 10;
+    sparkInit.colorStart[0].g = 10;
+    sparkInit.colorStart[0].b = 200;
+    sparkInit.colorStart[0].a = 255;
+    sparkInit.colorStart[1].r = 0;
+    sparkInit.colorStart[1].g = 0;
+    sparkInit.colorStart[1].b = 128;
+    sparkInit.colorStart[1].a = 255;
+    sparkInit.colorStart[2].r = 0;
+    sparkInit.colorStart[2].g = 0;
+    sparkInit.colorStart[2].b = 128;
+    sparkInit.colorStart[2].a = 255;
+    sparkInit.colorStart[3].r = 0;
+    sparkInit.colorStart[3].g = 0;
+    sparkInit.colorStart[3].b = 128;
+    sparkInit.colorStart[3].a = 255;
+    sparkInit.colorEnd[0].r = 0;
+    sparkInit.colorEnd[0].g = 0;
+    sparkInit.colorEnd[0].b = 32;
+    sparkInit.colorEnd[0].a = 0;
+    sparkInit.colorEnd[1].r = 0;
+    sparkInit.colorEnd[1].g = 0;
+    sparkInit.colorEnd[1].b = 32;
+    sparkInit.colorEnd[1].a = 0;
+    sparkInit.colorEnd[2].r = 0;
+    sparkInit.colorEnd[2].g = 0;
+    sparkInit.colorEnd[2].b = 64;
+    sparkInit.colorEnd[2].a = 0;
+    sparkInit.colorEnd[3].r = 0;
+    sparkInit.colorEnd[3].g = 0;
+    sparkInit.colorEnd[3].b = 64;
+    sparkInit.colorEnd[3].a = 0;
+    sparkInit.timer = 0;
+    sparkInit.duration = 16;
+    sparkInit.speed = 8.0f;
+    sparkInit.gravity = -1.0f;
 
-    Effect_Add(globalCtx, &effectIndex, EFFECT_SPARK, 0, 1, &D_8015D8A0);
+    Effect_Add(globalCtx, &effectIndex, EFFECT_SPARK, 0, 1, &sparkInit);
 }
 
 /**
@@ -1489,52 +1489,52 @@ void CollisionCheck_BlueBlood(GlobalContext* globalCtx, Collider* collider, Vec3
  * Used by collider types HIT2 and HIT6. No actor has type HIT2.
  */
 void CollisionCheck_GreenBlood(GlobalContext* globalCtx, Collider* collider, Vec3f* v) {
-    static EffectSparkInit D_8015DD68;
+    static EffectSparkInit sparkInit;
     s32 effectIndex;
 
-    D_8015DD68.position.x = v->x;
-    D_8015DD68.position.y = v->y;
-    D_8015DD68.position.z = v->z;
-    D_8015DD68.uDiv = 5;
-    D_8015DD68.vDiv = 5;
-    D_8015DD68.colorStart[0].r = 10;
-    D_8015DD68.colorStart[0].g = 200;
-    D_8015DD68.colorStart[0].b = 10;
-    D_8015DD68.colorStart[0].a = 255;
-    D_8015DD68.colorStart[1].r = 0;
-    D_8015DD68.colorStart[1].g = 128;
-    D_8015DD68.colorStart[1].b = 0;
-    D_8015DD68.colorStart[1].a = 255;
-    D_8015DD68.colorStart[2].r = 0;
-    D_8015DD68.colorStart[2].g = 128;
-    D_8015DD68.colorStart[2].b = 0;
-    D_8015DD68.colorStart[2].a = 255;
-    D_8015DD68.colorStart[3].r = 0;
-    D_8015DD68.colorStart[3].g = 128;
-    D_8015DD68.colorStart[3].b = 0;
-    D_8015DD68.colorStart[3].a = 255;
-    D_8015DD68.colorEnd[0].r = 0;
-    D_8015DD68.colorEnd[0].g = 32;
-    D_8015DD68.colorEnd[0].b = 0;
-    D_8015DD68.colorEnd[0].a = 0;
-    D_8015DD68.colorEnd[1].r = 0;
-    D_8015DD68.colorEnd[1].g = 32;
-    D_8015DD68.colorEnd[1].b = 0;
-    D_8015DD68.colorEnd[1].a = 0;
-    D_8015DD68.colorEnd[2].r = 0;
-    D_8015DD68.colorEnd[2].g = 64;
-    D_8015DD68.colorEnd[2].b = 0;
-    D_8015DD68.colorEnd[2].a = 0;
-    D_8015DD68.colorEnd[3].r = 0;
-    D_8015DD68.colorEnd[3].g = 64;
-    D_8015DD68.colorEnd[3].b = 0;
-    D_8015DD68.colorEnd[3].a = 0;
-    D_8015DD68.timer = 0;
-    D_8015DD68.duration = 16;
-    D_8015DD68.speed = 8.0f;
-    D_8015DD68.gravity = -1.0f;
+    sparkInit.position.x = v->x;
+    sparkInit.position.y = v->y;
+    sparkInit.position.z = v->z;
+    sparkInit.uDiv = 5;
+    sparkInit.vDiv = 5;
+    sparkInit.colorStart[0].r = 10;
+    sparkInit.colorStart[0].g = 200;
+    sparkInit.colorStart[0].b = 10;
+    sparkInit.colorStart[0].a = 255;
+    sparkInit.colorStart[1].r = 0;
+    sparkInit.colorStart[1].g = 128;
+    sparkInit.colorStart[1].b = 0;
+    sparkInit.colorStart[1].a = 255;
+    sparkInit.colorStart[2].r = 0;
+    sparkInit.colorStart[2].g = 128;
+    sparkInit.colorStart[2].b = 0;
+    sparkInit.colorStart[2].a = 255;
+    sparkInit.colorStart[3].r = 0;
+    sparkInit.colorStart[3].g = 128;
+    sparkInit.colorStart[3].b = 0;
+    sparkInit.colorStart[3].a = 255;
+    sparkInit.colorEnd[0].r = 0;
+    sparkInit.colorEnd[0].g = 32;
+    sparkInit.colorEnd[0].b = 0;
+    sparkInit.colorEnd[0].a = 0;
+    sparkInit.colorEnd[1].r = 0;
+    sparkInit.colorEnd[1].g = 32;
+    sparkInit.colorEnd[1].b = 0;
+    sparkInit.colorEnd[1].a = 0;
+    sparkInit.colorEnd[2].r = 0;
+    sparkInit.colorEnd[2].g = 64;
+    sparkInit.colorEnd[2].b = 0;
+    sparkInit.colorEnd[2].a = 0;
+    sparkInit.colorEnd[3].r = 0;
+    sparkInit.colorEnd[3].g = 64;
+    sparkInit.colorEnd[3].b = 0;
+    sparkInit.colorEnd[3].a = 0;
+    sparkInit.timer = 0;
+    sparkInit.duration = 16;
+    sparkInit.speed = 8.0f;
+    sparkInit.gravity = -1.0f;
 
-    Effect_Add(globalCtx, &effectIndex, EFFECT_SPARK, 0, 1, &D_8015DD68);
+    Effect_Add(globalCtx, &effectIndex, EFFECT_SPARK, 0, 1, &sparkInit);
 }
 
 /**
@@ -1978,8 +1978,8 @@ void CollisionCheck_AC_TrisVsJntSph(GlobalContext* globalCtx, CollisionCheckCont
  */
 void CollisionCheck_AC_JntSphVsQuad(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* colAT,
                                     Collider* colAC) {
-    static TriNorm D_8015E230;
-    static TriNorm D_8015E268;
+    static TriNorm tri1;
+    static TriNorm tri2;
     ColliderJntSph* at = (ColliderJntSph*)colAT;
     ColliderQuad* ac = (ColliderQuad*)colAC;
     Vec3f hitPos;
@@ -1989,8 +1989,8 @@ void CollisionCheck_AC_JntSphVsQuad(GlobalContext* globalCtx, CollisionCheckCont
         if (CollisionCheck_SkipBump(&ac->info) == 1) {
             return;
         }
-        Math3D_TriNorm(&D_8015E230, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
-        Math3D_TriNorm(&D_8015E268, &ac->dim.quad[1], &ac->dim.quad[0], &ac->dim.quad[2]);
+        Math3D_TriNorm(&tri1, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
+        Math3D_TriNorm(&tri2, &ac->dim.quad[1], &ac->dim.quad[0], &ac->dim.quad[2]);
         for (atItem = at->elements; atItem < at->elements + at->count; atItem++) {
             if (CollisionCheck_SkipTouch(&atItem->info) == 1) {
                 continue;
@@ -1998,8 +1998,8 @@ void CollisionCheck_AC_JntSphVsQuad(GlobalContext* globalCtx, CollisionCheckCont
             if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == 1) {
                 continue;
             }
-            if (Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &D_8015E230, &hitPos) == 1 ||
-                Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &D_8015E268, &hitPos) == 1) {
+            if (Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &tri1, &hitPos) == 1 ||
+                Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &tri2, &hitPos) == 1) {
                 Vec3f atPos;
                 Vec3f acPos;
 
@@ -2022,8 +2022,8 @@ void CollisionCheck_AC_JntSphVsQuad(GlobalContext* globalCtx, CollisionCheckCont
  */
 void CollisionCheck_AC_QuadVsJntSph(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* colAT,
                                     Collider* colAC) {
-    static TriNorm D_8015E2A0;
-    static TriNorm D_8015E2D8;
+    static TriNorm tri1;
+    static TriNorm tri2;
     ColliderJntSph* ac = (ColliderJntSph*)colAC;
     Vec3f hitPos;
     ColliderQuad* at = (ColliderQuad*)colAT;
@@ -2033,8 +2033,8 @@ void CollisionCheck_AC_QuadVsJntSph(GlobalContext* globalCtx, CollisionCheckCont
         if (CollisionCheck_SkipTouch(&at->info) == 1) {
             return;
         }
-        Math3D_TriNorm(&D_8015E2A0, &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
-        Math3D_TriNorm(&D_8015E2D8, &at->dim.quad[2], &at->dim.quad[1], &at->dim.quad[0]);
+        Math3D_TriNorm(&tri1, &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
+        Math3D_TriNorm(&tri2, &at->dim.quad[2], &at->dim.quad[1], &at->dim.quad[0]);
         for (acElem = ac->elements; acElem < ac->elements + ac->count; acElem++) {
             if (CollisionCheck_SkipBump(&acElem->info) == 1) {
                 continue;
@@ -2042,8 +2042,8 @@ void CollisionCheck_AC_QuadVsJntSph(GlobalContext* globalCtx, CollisionCheckCont
             if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == 1) {
                 continue;
             }
-            if (Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &D_8015E2A0, &hitPos) == 1 ||
-                Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &D_8015E2D8, &hitPos) == 1) {
+            if (Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &tri1, &hitPos) == 1 ||
+                Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &tri2, &hitPos) == 1) {
                 if (Collider_QuadSetNearestAC(globalCtx, at, &hitPos)) {
                     Vec3f atPos;
                     Vec3f acPos;
@@ -2153,7 +2153,7 @@ void CollisionCheck_AC_CylVsTris(GlobalContext* globalCtx, CollisionCheckContext
  */
 void CollisionCheck_AC_TrisVsCyl(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* colAT,
                                  Collider* colAC) {
-    static Vec3f D_8015E310;
+    static Vec3f intersection;
     ColliderTris* at = (ColliderTris*)colAT;
     ColliderTrisElement* atItem;
     ColliderCylinder* ac = (ColliderCylinder*)colAC;
@@ -2172,13 +2172,13 @@ void CollisionCheck_AC_TrisVsCyl(GlobalContext* globalCtx, CollisionCheckContext
                 continue;
             }
 
-            if (Math3D_CylTriVsIntersect(&ac->dim, &atItem->dim, &D_8015E310) == 1) {
+            if (Math3D_CylTriVsIntersect(&ac->dim, &atItem->dim, &intersection) == 1) {
                 atPos.x = (atItem->dim.vtx[0].x + atItem->dim.vtx[1].x + atItem->dim.vtx[2].x) * (1.0f / 3);
                 atPos.y = (atItem->dim.vtx[0].y + atItem->dim.vtx[1].y + atItem->dim.vtx[2].y) * (1.0f / 3);
                 atPos.z = (atItem->dim.vtx[0].z + atItem->dim.vtx[1].z + atItem->dim.vtx[2].z) * (1.0f / 3);
                 Math_Vec3s_ToVec3f(&acPos, &ac->dim.pos);
                 CollisionCheck_SetATvsAC(globalCtx, &at->base, &atItem->info, &atPos, &ac->base, &ac->info, &acPos,
-                                         &D_8015E310);
+                                         &intersection);
                 return;
             }
         }
@@ -2190,9 +2190,9 @@ void CollisionCheck_AC_TrisVsCyl(GlobalContext* globalCtx, CollisionCheckContext
  */
 void CollisionCheck_AC_CylVsQuad(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* colAT,
                                  Collider* colAC) {
-    static TriNorm D_8015E320;
-    static TriNorm D_8015E358;
-    static Vec3f D_8015E390;
+    static TriNorm tri1;
+    static TriNorm tri2;
+    static Vec3f intersection;
     ColliderCylinder* at = (ColliderCylinder*)colAT;
     ColliderQuad* ac = (ColliderQuad*)colAC;
 
@@ -2203,9 +2203,9 @@ void CollisionCheck_AC_CylVsQuad(GlobalContext* globalCtx, CollisionCheckContext
         if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == 1) {
             return;
         }
-        Math3D_TriNorm(&D_8015E320, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
-        Math3D_TriNorm(&D_8015E358, &ac->dim.quad[1], &ac->dim.quad[0], &ac->dim.quad[2]);
-        if (Math3D_CylTriVsIntersect(&at->dim, &D_8015E320, &D_8015E390) == 1) {
+        Math3D_TriNorm(&tri1, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
+        Math3D_TriNorm(&tri2, &ac->dim.quad[1], &ac->dim.quad[0], &ac->dim.quad[2]);
+        if (Math3D_CylTriVsIntersect(&at->dim, &tri1, &intersection) == 1) {
             Vec3f atPos1;
             Vec3f acPos1;
 
@@ -2214,8 +2214,8 @@ void CollisionCheck_AC_CylVsQuad(GlobalContext* globalCtx, CollisionCheckContext
             acPos1.y = (ac->dim.quad[0].y + (ac->dim.quad[1].y + (ac->dim.quad[3].y + ac->dim.quad[2].y))) / 4.0f;
             acPos1.z = (ac->dim.quad[0].z + (ac->dim.quad[1].z + (ac->dim.quad[3].z + ac->dim.quad[2].z))) / 4.0f;
             CollisionCheck_SetATvsAC(globalCtx, &at->base, &at->info, &atPos1, &ac->base, &ac->info, &acPos1,
-                                     &D_8015E390);
-        } else if (Math3D_CylTriVsIntersect(&at->dim, &D_8015E358, &D_8015E390) == 1) {
+                                     &intersection);
+        } else if (Math3D_CylTriVsIntersect(&at->dim, &tri2, &intersection) == 1) {
             Vec3f atPos2;
             Vec3f acPos2;
 
@@ -2224,7 +2224,7 @@ void CollisionCheck_AC_CylVsQuad(GlobalContext* globalCtx, CollisionCheckContext
             acPos2.y = (ac->dim.quad[0].y + (ac->dim.quad[1].y + (ac->dim.quad[3].y + ac->dim.quad[2].y))) / 4.0f;
             acPos2.z = (ac->dim.quad[0].z + (ac->dim.quad[1].z + (ac->dim.quad[3].z + ac->dim.quad[2].z))) / 4.0f;
             CollisionCheck_SetATvsAC(globalCtx, &at->base, &at->info, &atPos2, &ac->base, &ac->info, &acPos2,
-                                     &D_8015E390);
+                                     &intersection);
         }
     }
 }
@@ -2237,9 +2237,9 @@ static s8 sBssDummy1;
  */
 void CollisionCheck_AC_QuadVsCyl(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* colAT,
                                  Collider* colAC) {
-    static TriNorm D_8015E3A0;
-    static TriNorm D_8015E3D8;
-    static Vec3f D_8015E410;
+    static TriNorm tri1;
+    static TriNorm tri2;
+    static Vec3f intersection;
     ColliderQuad* at = (ColliderQuad*)colAT;
     ColliderCylinder* ac = (ColliderCylinder*)colAC;
 
@@ -2250,10 +2250,10 @@ void CollisionCheck_AC_QuadVsCyl(GlobalContext* globalCtx, CollisionCheckContext
         if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == 1) {
             return;
         }
-        Math3D_TriNorm(&D_8015E3A0, &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
-        Math3D_TriNorm(&D_8015E3D8, &at->dim.quad[2], &at->dim.quad[1], &at->dim.quad[0]);
-        if (Math3D_CylTriVsIntersect(&ac->dim, &D_8015E3A0, &D_8015E410) == 1) {
-            if (Collider_QuadSetNearestAC(globalCtx, at, &D_8015E410)) {
+        Math3D_TriNorm(&tri1, &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
+        Math3D_TriNorm(&tri2, &at->dim.quad[2], &at->dim.quad[1], &at->dim.quad[0]);
+        if (Math3D_CylTriVsIntersect(&ac->dim, &tri1, &intersection) == 1) {
+            if (Collider_QuadSetNearestAC(globalCtx, at, &intersection)) {
                 Vec3f atPos1;
                 Vec3f acPos1;
 
@@ -2262,12 +2262,12 @@ void CollisionCheck_AC_QuadVsCyl(GlobalContext* globalCtx, CollisionCheckContext
                 atPos1.z = (at->dim.quad[0].z + (at->dim.quad[1].z + (at->dim.quad[3].z + at->dim.quad[2].z))) / 4.0f;
                 Math_Vec3s_ToVec3f(&acPos1, &ac->dim.pos);
                 CollisionCheck_SetATvsAC(globalCtx, &at->base, &at->info, &atPos1, &ac->base, &ac->info, &acPos1,
-                                         &D_8015E410);
+                                         &intersection);
                 return;
             }
         }
-        if (Math3D_CylTriVsIntersect(&ac->dim, &D_8015E3D8, &D_8015E410) == 1) {
-            if (Collider_QuadSetNearestAC(globalCtx, at, &D_8015E410)) {
+        if (Math3D_CylTriVsIntersect(&ac->dim, &tri2, &intersection) == 1) {
+            if (Collider_QuadSetNearestAC(globalCtx, at, &intersection)) {
                 Vec3f atPos2;
                 Vec3f acPos2;
 
@@ -2276,7 +2276,7 @@ void CollisionCheck_AC_QuadVsCyl(GlobalContext* globalCtx, CollisionCheckContext
                 atPos2.z = (at->dim.quad[0].z + (at->dim.quad[1].z + (at->dim.quad[3].z + at->dim.quad[2].z))) / 4.0f;
                 Math_Vec3s_ToVec3f(&acPos2, &ac->dim.pos);
                 CollisionCheck_SetATvsAC(globalCtx, &at->base, &at->info, &atPos2, &ac->base, &ac->info, &acPos2,
-                                         &D_8015E410);
+                                         &intersection);
             }
         }
     }
@@ -2292,7 +2292,7 @@ static s8 sBssDummy6;
  */
 void CollisionCheck_AC_TrisVsTris(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* colAT,
                                   Collider* colAC) {
-    static Vec3f D_8015E420;
+    static Vec3f intersection;
     ColliderTris* at = (ColliderTris*)colAT;
     ColliderTrisElement* atItem;
     ColliderTris* ac = (ColliderTris*)colAC;
@@ -2310,7 +2310,7 @@ void CollisionCheck_AC_TrisVsTris(GlobalContext* globalCtx, CollisionCheckContex
                 if (CollisionCheck_NoSharedFlags(&atItem->info, &acElem->info) == 1) {
                     continue;
                 }
-                if (Math3D_TriVsTriIntersect(&atItem->dim, &acElem->dim, &D_8015E420) == 1) {
+                if (Math3D_TriVsTriIntersect(&atItem->dim, &acElem->dim, &intersection) == 1) {
                     Vec3f atPos;
                     Vec3f acPos;
 
@@ -2321,7 +2321,7 @@ void CollisionCheck_AC_TrisVsTris(GlobalContext* globalCtx, CollisionCheckContex
                     acPos.y = (acElem->dim.vtx[0].y + acElem->dim.vtx[1].y + acElem->dim.vtx[2].y) * (1.0f / 3);
                     acPos.z = (acElem->dim.vtx[0].z + acElem->dim.vtx[1].z + acElem->dim.vtx[2].z) * (1.0f / 3);
                     CollisionCheck_SetATvsAC(globalCtx, &at->base, &atItem->info, &atPos, &ac->base, &acElem->info,
-                                             &acPos, &D_8015E420);
+                                             &acPos, &intersection);
                     return;
                 }
             }
@@ -2339,9 +2339,9 @@ static s8 sBssDummy10;
  */
 void CollisionCheck_AC_TrisVsQuad(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* colAT,
                                   Collider* colAC) {
-    static Vec3f D_8015E430;
-    static TriNorm D_8015E440;
-    static TriNorm D_8015E478;
+    static Vec3f intersection;
+    static TriNorm tri1;
+    static TriNorm tri2;
     ColliderTris* at = (ColliderTris*)colAT;
     ColliderTrisElement* atItem;
     ColliderQuad* ac = (ColliderQuad*)colAC;
@@ -2350,8 +2350,8 @@ void CollisionCheck_AC_TrisVsQuad(GlobalContext* globalCtx, CollisionCheckContex
         if (CollisionCheck_SkipBump(&ac->info) == 1) {
             return;
         }
-        Math3D_TriNorm(&D_8015E440, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
-        Math3D_TriNorm(&D_8015E478, &ac->dim.quad[1], &ac->dim.quad[0], &ac->dim.quad[2]);
+        Math3D_TriNorm(&tri1, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
+        Math3D_TriNorm(&tri2, &ac->dim.quad[1], &ac->dim.quad[0], &ac->dim.quad[2]);
         for (atItem = at->elements; atItem < at->elements + at->count; atItem++) {
             if (CollisionCheck_SkipTouch(&atItem->info) == 1) {
                 continue;
@@ -2359,8 +2359,8 @@ void CollisionCheck_AC_TrisVsQuad(GlobalContext* globalCtx, CollisionCheckContex
             if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == 1) {
                 continue;
             }
-            if (Math3D_TriVsTriIntersect(&D_8015E440, &atItem->dim, &D_8015E430) == 1 ||
-                Math3D_TriVsTriIntersect(&D_8015E478, &atItem->dim, &D_8015E430) == 1) {
+            if (Math3D_TriVsTriIntersect(&tri1, &atItem->dim, &intersection) == 1 ||
+                Math3D_TriVsTriIntersect(&tri2, &atItem->dim, &intersection) == 1) {
                 Vec3f atPos;
                 Vec3f acPos;
 
@@ -2371,7 +2371,7 @@ void CollisionCheck_AC_TrisVsQuad(GlobalContext* globalCtx, CollisionCheckContex
                 acPos.y = (ac->dim.quad[0].y + (ac->dim.quad[1].y + (ac->dim.quad[3].y + ac->dim.quad[2].y))) / 4.0f;
                 acPos.z = (ac->dim.quad[0].z + (ac->dim.quad[1].z + (ac->dim.quad[3].z + ac->dim.quad[2].z))) / 4.0f;
                 CollisionCheck_SetATvsAC(globalCtx, &at->base, &atItem->info, &atPos, &ac->base, &ac->info, &acPos,
-                                         &D_8015E430);
+                                         &intersection);
                 return;
             }
         }
@@ -2383,9 +2383,9 @@ void CollisionCheck_AC_TrisVsQuad(GlobalContext* globalCtx, CollisionCheckContex
  */
 void CollisionCheck_AC_QuadVsTris(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* colAT,
                                   Collider* colAC) {
-    static Vec3f D_8015E4B0;
-    static TriNorm D_8015E4C0;
-    static TriNorm D_8015E4F8;
+    static Vec3f intersection;
+    static TriNorm tri1;
+    static TriNorm tri2;
     ColliderQuad* at = (ColliderQuad*)colAT;
     ColliderTris* ac = (ColliderTris*)colAC;
     ColliderTrisElement* acElem;
@@ -2394,8 +2394,8 @@ void CollisionCheck_AC_QuadVsTris(GlobalContext* globalCtx, CollisionCheckContex
         if (CollisionCheck_SkipTouch(&at->info) == 1) {
             return;
         }
-        Math3D_TriNorm(&D_8015E4C0, &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
-        Math3D_TriNorm(&D_8015E4F8, &at->dim.quad[1], &at->dim.quad[0], &at->dim.quad[2]);
+        Math3D_TriNorm(&tri1, &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
+        Math3D_TriNorm(&tri2, &at->dim.quad[1], &at->dim.quad[0], &at->dim.quad[2]);
         for (acElem = ac->elements; acElem < ac->elements + ac->count; acElem++) {
             if (CollisionCheck_SkipBump(&acElem->info) == 1) {
                 continue;
@@ -2403,9 +2403,9 @@ void CollisionCheck_AC_QuadVsTris(GlobalContext* globalCtx, CollisionCheckContex
             if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == 1) {
                 continue;
             }
-            if (Math3D_TriVsTriIntersect(&D_8015E4C0, &acElem->dim, &D_8015E4B0) == 1 ||
-                Math3D_TriVsTriIntersect(&D_8015E4F8, &acElem->dim, &D_8015E4B0) == 1) {
-                if (Collider_QuadSetNearestAC(globalCtx, at, &D_8015E4B0)) {
+            if (Math3D_TriVsTriIntersect(&tri1, &acElem->dim, &intersection) == 1 ||
+                Math3D_TriVsTriIntersect(&tri2, &acElem->dim, &intersection) == 1) {
+                if (Collider_QuadSetNearestAC(globalCtx, at, &intersection)) {
                     Vec3f atPos;
                     Vec3f acPos;
 
@@ -2419,7 +2419,7 @@ void CollisionCheck_AC_QuadVsTris(GlobalContext* globalCtx, CollisionCheckContex
                     atPos.z =
                         (at->dim.quad[0].z + (at->dim.quad[1].z + (at->dim.quad[3].z + at->dim.quad[2].z))) / 4.0f;
                     CollisionCheck_SetATvsAC(globalCtx, &at->base, &at->info, &atPos, &ac->base, &acElem->info, &acPos,
-                                             &D_8015E4B0);
+                                             &intersection);
                     return;
                 }
             }
@@ -2432,9 +2432,9 @@ void CollisionCheck_AC_QuadVsTris(GlobalContext* globalCtx, CollisionCheckContex
  */
 void CollisionCheck_AC_QuadVsQuad(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* colAT,
                                   Collider* colAC) {
-    static TriNorm D_8015E530[2];
-    static Vec3f D_8015E598;
-    static TriNorm D_8015E5A8[2];
+    static TriNorm acTris[2];
+    static Vec3f intersection;
+    static TriNorm atTris[2];
     ColliderQuad* at = (ColliderQuad*)colAT;
     ColliderQuad* ac = (ColliderQuad*)colAC;
     s32 i;
@@ -2450,15 +2450,15 @@ void CollisionCheck_AC_QuadVsQuad(GlobalContext* globalCtx, CollisionCheckContex
         return;
     }
 
-    Math3D_TriNorm(&D_8015E5A8[0], &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
-    Math3D_TriNorm(&D_8015E5A8[1], &at->dim.quad[2], &at->dim.quad[1], &at->dim.quad[0]);
-    Math3D_TriNorm(&D_8015E530[0], &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
-    Math3D_TriNorm(&D_8015E530[1], &ac->dim.quad[2], &ac->dim.quad[1], &ac->dim.quad[0]);
+    Math3D_TriNorm(&atTris[0], &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
+    Math3D_TriNorm(&atTris[1], &at->dim.quad[2], &at->dim.quad[1], &at->dim.quad[0]);
+    Math3D_TriNorm(&acTris[0], &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
+    Math3D_TriNorm(&acTris[1], &ac->dim.quad[2], &ac->dim.quad[1], &ac->dim.quad[0]);
 
     for (i = 0; i < 2; i++) {
         for (j = 0; j < 2; j++) {
-            if (Math3D_TriVsTriIntersect(&D_8015E5A8[j], &D_8015E530[i], &D_8015E598) == 1) {
-                if (Collider_QuadSetNearestAC(globalCtx, at, &D_8015E598)) {
+            if (Math3D_TriVsTriIntersect(&atTris[j], &acTris[i], &intersection) == 1) {
+                if (Collider_QuadSetNearestAC(globalCtx, at, &intersection)) {
                     Vec3f atPos;
                     Vec3f acPos;
 
@@ -2475,7 +2475,7 @@ void CollisionCheck_AC_QuadVsQuad(GlobalContext* globalCtx, CollisionCheckContex
                     acPos.z =
                         (ac->dim.quad[0].z + (ac->dim.quad[1].z + (ac->dim.quad[3].z + ac->dim.quad[2].z))) / 4.0f;
                     CollisionCheck_SetATvsAC(globalCtx, &at->base, &at->info, &atPos, &ac->base, &ac->info, &acPos,
-                                             &D_8015E598);
+                                             &intersection);
                     return;
                 }
             }
@@ -2579,7 +2579,7 @@ void CollisionCheck_SetHitEffects(GlobalContext* globalCtx, CollisionCheckContex
     }
 }
 
-static ColChkVsFunc sACVsFuncs[4][4] = {
+static ColChkVsFunc sACVsFuncs[COLSHAPE_MAX][COLSHAPE_MAX] = {
     { CollisionCheck_AC_JntSphVsJntSph, CollisionCheck_AC_JntSphVsCyl, CollisionCheck_AC_JntSphVsTris,
       CollisionCheck_AC_JntSphVsQuad },
     { CollisionCheck_AC_CylVsJntSph, CollisionCheck_AC_CylVsCyl, CollisionCheck_AC_CylVsTris,
@@ -2869,7 +2869,7 @@ s32 CollisionCheck_Incompatible(Collider* left, Collider* right) {
     return 0;
 }
 
-static ColChkVsFunc sOCVsFuncs[4][4] = {
+static ColChkVsFunc sOCVsFuncs[COLSHAPE_MAX][COLSHAPE_MAX] = {
     { CollisionCheck_OC_JntSphVsJntSph, CollisionCheck_OC_JntSphVsCyl, NULL, NULL },
     { CollisionCheck_OC_CylVsJntSph, CollisionCheck_OC_CylVsCyl, NULL, NULL },
     { NULL, NULL, NULL, NULL },
@@ -2998,7 +2998,7 @@ void CollisionCheck_ApplyDamage(GlobalContext* globalCtx, CollisionCheckContext*
         s32 i;
         u32 flags = info->acHitInfo->toucher.dmgFlags;
 
-        for (i = 0; i < 0x20; i++, flags >>= 1) {
+        for (i = 0; i < ARRAY_COUNT(tbl->table); i++, flags >>= 1) {
             if (flags == 1) {
                 break;
             }
@@ -3054,7 +3054,7 @@ void CollisionCheck_ApplyDamageQuad(GlobalContext* globalCtx, CollisionCheckCont
     CollisionCheck_ApplyDamage(globalCtx, colChkCtx, &quad->base, &quad->info);
 }
 
-static ColChkApplyFunc sApplyDamageFuncs[4] = {
+static ColChkApplyFunc sApplyDamageFuncs[COLSHAPE_MAX] = {
     CollisionCheck_ApplyDamageJntSph,
     CollisionCheck_ApplyDamageCyl,
     CollisionCheck_ApplyDamageTris,
@@ -3086,7 +3086,7 @@ void CollisionCheck_Damage(GlobalContext* globalCtx, CollisionCheckContext* colC
  */
 s32 CollisionCheck_LineOC_JntSph(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* collider,
                                  Vec3f* a, Vec3f* b) {
-    static Linef D_8015E610;
+    static Linef lineSeg;
     ColliderJntSph* jntSph = (ColliderJntSph*)collider;
     s32 i;
 
@@ -3096,9 +3096,9 @@ s32 CollisionCheck_LineOC_JntSph(GlobalContext* globalCtx, CollisionCheckContext
         if (!(element->info.ocElemFlags & OCELEM_ON)) {
             continue;
         }
-        D_8015E610.a = *a;
-        D_8015E610.b = *b;
-        if (Math3D_LineVsSph(&element->dim.worldSphere, &D_8015E610) == 1) {
+        lineSeg.a = *a;
+        lineSeg.b = *b;
+        if (Math3D_LineVsSph(&element->dim.worldSphere, &lineSeg) == 1) {
             return true;
         }
     }
@@ -3110,20 +3110,20 @@ s32 CollisionCheck_LineOC_JntSph(GlobalContext* globalCtx, CollisionCheckContext
  */
 s32 CollisionCheck_LineOC_Cyl(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx, Collider* collider, Vec3f* a,
                               Vec3f* b) {
-    static Vec3f D_8015E628;
-    static Vec3f D_8015E638;
+    static Vec3f intersectA;
+    static Vec3f intersectB;
     ColliderCylinder* cylinder = (ColliderCylinder*)collider;
 
     if (!(cylinder->info.ocElemFlags & OCELEM_ON)) {
         return false;
     }
-    if (Math3D_CylVsLineSeg(&cylinder->dim, a, b, &D_8015E628, &D_8015E638) != 0) {
+    if (Math3D_CylVsLineSeg(&cylinder->dim, a, b, &intersectA, &intersectB) != 0) {
         return true;
     }
     return false;
 }
 
-static ColChkLineFunc sOCLineCheckFuncs[4] = {
+static ColChkLineFunc sOCLineCheckFuncs[COLSHAPE_MAX] = {
     CollisionCheck_LineOC_JntSph,
     CollisionCheck_LineOC_Cyl,
     NULL,
@@ -3146,14 +3146,14 @@ s32 CollisionCheck_LineOC(GlobalContext* globalCtx, CollisionCheckContext* colCh
         if (CollisionCheck_SkipOC(*col) == 1) {
             continue;
         }
-        exclude = 0;
+        exclude = false;
         for (i = 0; i < numExclusions; i++) {
             if ((*col)->actor == exclusions[i]) {
-                exclude = 1;
+                exclude = true;
                 break;
             }
         }
-        if (exclude == 1) {
+        if (exclude == true) {
             continue;
         }
         lineCheck = sOCLineCheckFuncs[(*col)->shape];
@@ -3258,19 +3258,19 @@ static s8 sBssDummy14;
  * Updates the world spheres for all of the collider's JntSph elements attached to the specified limb
  */
 void Collider_UpdateSpheres(s32 limb, ColliderJntSph* collider) {
-    static Vec3f D_8015E648;
-    static Vec3f D_8015CF00; // bss ordering changes here
+    static Vec3f modelPos;
+    static Vec3f worldPos; // bss ordering changes here
     s32 i;
 
     for (i = 0; i < collider->count; i++) {
         if (limb == collider->elements[i].dim.limb) {
-            D_8015E648.x = collider->elements[i].dim.modelSphere.center.x;
-            D_8015E648.y = collider->elements[i].dim.modelSphere.center.y;
-            D_8015E648.z = collider->elements[i].dim.modelSphere.center.z;
-            Matrix_MultVec3f(&D_8015E648, &D_8015CF00);
-            collider->elements[i].dim.worldSphere.center.x = D_8015CF00.x;
-            collider->elements[i].dim.worldSphere.center.y = D_8015CF00.y;
-            collider->elements[i].dim.worldSphere.center.z = D_8015CF00.z;
+            modelPos.x = collider->elements[i].dim.modelSphere.center.x;
+            modelPos.y = collider->elements[i].dim.modelSphere.center.y;
+            modelPos.z = collider->elements[i].dim.modelSphere.center.z;
+            Matrix_MultVec3f(&modelPos, &worldPos);
+            collider->elements[i].dim.worldSphere.center.x = worldPos.x;
+            collider->elements[i].dim.worldSphere.center.y = worldPos.y;
+            collider->elements[i].dim.worldSphere.center.z = worldPos.z;
             collider->elements[i].dim.worldSphere.radius =
                 collider->elements[i].dim.modelSphere.radius * collider->elements[i].dim.scale;
         }
@@ -3282,52 +3282,52 @@ void Collider_UpdateSpheres(s32 limb, ColliderJntSph* collider) {
  * No actor has a collision type that spawns red blood.
  */
 void CollisionCheck_SpawnRedBlood(GlobalContext* globalCtx, Vec3f* v) {
-    static EffectSparkInit D_8015CF10;
+    static EffectSparkInit sparkInit;
     s32 effectIndex;
 
-    D_8015CF10.position.x = v->x;
-    D_8015CF10.position.y = v->y;
-    D_8015CF10.position.z = v->z;
-    D_8015CF10.uDiv = 5;
-    D_8015CF10.vDiv = 5;
-    D_8015CF10.colorStart[0].r = 128;
-    D_8015CF10.colorStart[0].g = 0;
-    D_8015CF10.colorStart[0].b = 64;
-    D_8015CF10.colorStart[0].a = 255;
-    D_8015CF10.colorStart[1].r = 128;
-    D_8015CF10.colorStart[1].g = 0;
-    D_8015CF10.colorStart[1].b = 64;
-    D_8015CF10.colorStart[1].a = 255;
-    D_8015CF10.colorStart[2].r = 255;
-    D_8015CF10.colorStart[2].g = 128;
-    D_8015CF10.colorStart[2].b = 0;
-    D_8015CF10.colorStart[2].a = 255;
-    D_8015CF10.colorStart[3].r = 255;
-    D_8015CF10.colorStart[3].g = 128;
-    D_8015CF10.colorStart[3].b = 0;
-    D_8015CF10.colorStart[3].a = 255;
-    D_8015CF10.colorEnd[0].r = 64;
-    D_8015CF10.colorEnd[0].g = 0;
-    D_8015CF10.colorEnd[0].b = 32;
-    D_8015CF10.colorEnd[0].a = 0;
-    D_8015CF10.colorEnd[1].r = 64;
-    D_8015CF10.colorEnd[1].g = 0;
-    D_8015CF10.colorEnd[1].b = 32;
-    D_8015CF10.colorEnd[1].a = 0;
-    D_8015CF10.colorEnd[2].r = 128;
-    D_8015CF10.colorEnd[2].g = 0;
-    D_8015CF10.colorEnd[2].b = 64;
-    D_8015CF10.colorEnd[2].a = 0;
-    D_8015CF10.colorEnd[3].r = 128;
-    D_8015CF10.colorEnd[3].g = 0;
-    D_8015CF10.colorEnd[3].b = 64;
-    D_8015CF10.colorEnd[3].a = 0;
-    D_8015CF10.timer = 0;
-    D_8015CF10.duration = 16;
-    D_8015CF10.speed = 8.0f;
-    D_8015CF10.gravity = -1.0f;
+    sparkInit.position.x = v->x;
+    sparkInit.position.y = v->y;
+    sparkInit.position.z = v->z;
+    sparkInit.uDiv = 5;
+    sparkInit.vDiv = 5;
+    sparkInit.colorStart[0].r = 128;
+    sparkInit.colorStart[0].g = 0;
+    sparkInit.colorStart[0].b = 64;
+    sparkInit.colorStart[0].a = 255;
+    sparkInit.colorStart[1].r = 128;
+    sparkInit.colorStart[1].g = 0;
+    sparkInit.colorStart[1].b = 64;
+    sparkInit.colorStart[1].a = 255;
+    sparkInit.colorStart[2].r = 255;
+    sparkInit.colorStart[2].g = 128;
+    sparkInit.colorStart[2].b = 0;
+    sparkInit.colorStart[2].a = 255;
+    sparkInit.colorStart[3].r = 255;
+    sparkInit.colorStart[3].g = 128;
+    sparkInit.colorStart[3].b = 0;
+    sparkInit.colorStart[3].a = 255;
+    sparkInit.colorEnd[0].r = 64;
+    sparkInit.colorEnd[0].g = 0;
+    sparkInit.colorEnd[0].b = 32;
+    sparkInit.colorEnd[0].a = 0;
+    sparkInit.colorEnd[1].r = 64;
+    sparkInit.colorEnd[1].g = 0;
+    sparkInit.colorEnd[1].b = 32;
+    sparkInit.colorEnd[1].a = 0;
+    sparkInit.colorEnd[2].r = 128;
+    sparkInit.colorEnd[2].g = 0;
+    sparkInit.colorEnd[2].b = 64;
+    sparkInit.colorEnd[2].a = 0;
+    sparkInit.colorEnd[3].r = 128;
+    sparkInit.colorEnd[3].g = 0;
+    sparkInit.colorEnd[3].b = 64;
+    sparkInit.colorEnd[3].a = 0;
+    sparkInit.timer = 0;
+    sparkInit.duration = 16;
+    sparkInit.speed = 8.0f;
+    sparkInit.gravity = -1.0f;
 
-    Effect_Add(globalCtx, &effectIndex, EFFECT_SPARK, 0, 1, &D_8015CF10);
+    Effect_Add(globalCtx, &effectIndex, EFFECT_SPARK, 0, 1, &sparkInit);
 }
 
 /**
@@ -3335,59 +3335,59 @@ void CollisionCheck_SpawnRedBlood(GlobalContext* globalCtx, Vec3f* v) {
  * No actor has a collision type that spawns water droplets.
  */
 void CollisionCheck_SpawnWaterDroplets(GlobalContext* globalCtx, Vec3f* v) {
-    static EffectSparkInit D_8015D3D8;
+    static EffectSparkInit sparkInit;
     s32 effectIndex;
 
-    D_8015D3D8.position.x = v->x;
-    D_8015D3D8.position.y = v->y;
-    D_8015D3D8.position.z = v->z;
-    D_8015D3D8.uDiv = 5;
-    D_8015D3D8.vDiv = 5;
-    D_8015D3D8.colorStart[0].r = 255;
-    D_8015D3D8.colorStart[0].g = 255;
-    D_8015D3D8.colorStart[0].b = 255;
-    D_8015D3D8.colorStart[0].a = 255;
-    D_8015D3D8.colorStart[1].r = 100;
-    D_8015D3D8.colorStart[1].g = 100;
-    D_8015D3D8.colorStart[1].b = 100;
-    D_8015D3D8.colorStart[1].a = 100;
-    D_8015D3D8.colorStart[2].r = 100;
-    D_8015D3D8.colorStart[2].g = 100;
-    D_8015D3D8.colorStart[2].b = 100;
-    D_8015D3D8.colorStart[2].a = 100;
-    D_8015D3D8.colorStart[3].r = 100;
-    D_8015D3D8.colorStart[3].g = 100;
-    D_8015D3D8.colorStart[3].b = 100;
-    D_8015D3D8.colorStart[3].a = 100;
-    D_8015D3D8.colorEnd[0].r = 50;
-    D_8015D3D8.colorEnd[0].g = 50;
-    D_8015D3D8.colorEnd[0].b = 50;
-    D_8015D3D8.colorEnd[0].a = 50;
-    D_8015D3D8.colorEnd[1].r = 50;
-    D_8015D3D8.colorEnd[1].g = 50;
-    D_8015D3D8.colorEnd[1].b = 50;
-    D_8015D3D8.colorEnd[1].a = 50;
-    D_8015D3D8.colorEnd[2].r = 50;
-    D_8015D3D8.colorEnd[2].g = 50;
-    D_8015D3D8.colorEnd[2].b = 50;
-    D_8015D3D8.colorEnd[2].a = 50;
-    D_8015D3D8.colorEnd[3].r = 0;
-    D_8015D3D8.colorEnd[3].g = 0;
-    D_8015D3D8.colorEnd[3].b = 0;
-    D_8015D3D8.colorEnd[3].a = 0;
-    D_8015D3D8.timer = 0;
-    D_8015D3D8.duration = 16;
-    D_8015D3D8.speed = 8.0f;
-    D_8015D3D8.gravity = -1.0f;
+    sparkInit.position.x = v->x;
+    sparkInit.position.y = v->y;
+    sparkInit.position.z = v->z;
+    sparkInit.uDiv = 5;
+    sparkInit.vDiv = 5;
+    sparkInit.colorStart[0].r = 255;
+    sparkInit.colorStart[0].g = 255;
+    sparkInit.colorStart[0].b = 255;
+    sparkInit.colorStart[0].a = 255;
+    sparkInit.colorStart[1].r = 100;
+    sparkInit.colorStart[1].g = 100;
+    sparkInit.colorStart[1].b = 100;
+    sparkInit.colorStart[1].a = 100;
+    sparkInit.colorStart[2].r = 100;
+    sparkInit.colorStart[2].g = 100;
+    sparkInit.colorStart[2].b = 100;
+    sparkInit.colorStart[2].a = 100;
+    sparkInit.colorStart[3].r = 100;
+    sparkInit.colorStart[3].g = 100;
+    sparkInit.colorStart[3].b = 100;
+    sparkInit.colorStart[3].a = 100;
+    sparkInit.colorEnd[0].r = 50;
+    sparkInit.colorEnd[0].g = 50;
+    sparkInit.colorEnd[0].b = 50;
+    sparkInit.colorEnd[0].a = 50;
+    sparkInit.colorEnd[1].r = 50;
+    sparkInit.colorEnd[1].g = 50;
+    sparkInit.colorEnd[1].b = 50;
+    sparkInit.colorEnd[1].a = 50;
+    sparkInit.colorEnd[2].r = 50;
+    sparkInit.colorEnd[2].g = 50;
+    sparkInit.colorEnd[2].b = 50;
+    sparkInit.colorEnd[2].a = 50;
+    sparkInit.colorEnd[3].r = 0;
+    sparkInit.colorEnd[3].g = 0;
+    sparkInit.colorEnd[3].b = 0;
+    sparkInit.colorEnd[3].a = 0;
+    sparkInit.timer = 0;
+    sparkInit.duration = 16;
+    sparkInit.speed = 8.0f;
+    sparkInit.gravity = -1.0f;
 
-    Effect_Add(globalCtx, &effectIndex, EFFECT_SPARK, 0, 1, &D_8015D3D8);
+    Effect_Add(globalCtx, &effectIndex, EFFECT_SPARK, 0, 1, &sparkInit);
 }
 
 /**
  * Spawns streaks of light from hits against solid objects
  */
 void CollisionCheck_SpawnShieldParticles(GlobalContext* globalCtx, Vec3f* v) {
-    static EffectShieldParticleInit initMetal = {
+    static EffectShieldParticleInit metalInit = {
         16,
         { 0, 0, 0 },
         { 0, 200, 255, 255 },
@@ -3405,14 +3405,14 @@ void CollisionCheck_SpawnShieldParticles(GlobalContext* globalCtx, Vec3f* v) {
     };
     s32 effectIndex;
 
-    initMetal.position.x = v->x;
-    initMetal.position.y = v->y;
-    initMetal.position.z = v->z;
-    initMetal.lightPoint.x = initMetal.position.x;
-    initMetal.lightPoint.y = initMetal.position.y;
-    initMetal.lightPoint.z = initMetal.position.z;
+    metalInit.position.x = v->x;
+    metalInit.position.y = v->y;
+    metalInit.position.z = v->z;
+    metalInit.lightPoint.x = metalInit.position.x;
+    metalInit.lightPoint.y = metalInit.position.y;
+    metalInit.lightPoint.z = metalInit.position.z;
 
-    Effect_Add(globalCtx, &effectIndex, EFFECT_SHIELD_PARTICLE, 0, 1, &initMetal);
+    Effect_Add(globalCtx, &effectIndex, EFFECT_SHIELD_PARTICLE, 0, 1, &metalInit);
 }
 
 /**
@@ -3442,7 +3442,7 @@ void CollisionCheck_SpawnShieldParticlesMetal2(GlobalContext* globalCtx, Vec3f* 
  * Spawns streaks of light and makes a wooden sound
  */
 void CollisionCheck_SpawnShieldParticlesWood(GlobalContext* globalCtx, Vec3f* v, Vec3f* actorPos) {
-    static EffectShieldParticleInit initWood = {
+    static EffectShieldParticleInit woodInit = {
         16,
         { 0, 0, 0 },
         { 0, 200, 255, 255 },
@@ -3460,14 +3460,14 @@ void CollisionCheck_SpawnShieldParticlesWood(GlobalContext* globalCtx, Vec3f* v,
     };
     s32 effectIndex;
 
-    initWood.position.x = v->x;
-    initWood.position.y = v->y;
-    initWood.position.z = v->z;
-    initWood.lightPoint.x = initWood.position.x;
-    initWood.lightPoint.y = initWood.position.y;
-    initWood.lightPoint.z = initWood.position.z;
+    woodInit.position.x = v->x;
+    woodInit.position.y = v->y;
+    woodInit.position.z = v->z;
+    woodInit.lightPoint.x = woodInit.position.x;
+    woodInit.lightPoint.y = woodInit.position.y;
+    woodInit.lightPoint.z = woodInit.position.z;
 
-    Effect_Add(globalCtx, &effectIndex, EFFECT_SHIELD_PARTICLE, 0, 1, &initWood);
+    Effect_Add(globalCtx, &effectIndex, EFFECT_SHIELD_PARTICLE, 0, 1, &woodInit);
     Audio_PlaySoundGeneral(NA_SE_IT_REFLECTION_WOOD, actorPos, 4, &D_801333E0, &D_801333E0, &D_801333E8);
 }
 

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -106,11 +106,11 @@ s32 Collider_InitBase(GlobalContext* globalCtx, Collider* collider) {
     };
 
     *collider = init;
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyBase(GlobalContext* globalCtx, Collider* collider) {
-    return 1;
+    return true;
 }
 
 /**
@@ -123,7 +123,7 @@ s32 Collider_SetBaseToActor(GlobalContext* globalCtx, Collider* collider, Collid
     collider->ocFlags1 = src->ocFlags1;
     collider->ocFlags2 = OC2_TYPE_1;
     collider->shape = src->shape;
-    return 1;
+    return true;
 }
 
 /**
@@ -137,7 +137,7 @@ s32 Collider_SetBaseType1(GlobalContext* globalCtx, Collider* collider, Actor* a
     collider->ocFlags1 = src->ocFlags1;
     collider->ocFlags2 = OC2_TYPE_1;
     collider->shape = src->shape;
-    return 1;
+    return true;
 }
 
 s32 Collider_SetBase(GlobalContext* globalCtx, Collider* collider, Actor* actor, ColliderInit* src) {
@@ -148,7 +148,7 @@ s32 Collider_SetBase(GlobalContext* globalCtx, Collider* collider, Actor* actor,
     collider->ocFlags1 = src->ocFlags1;
     collider->ocFlags2 = src->ocFlags2;
     collider->shape = src->shape;
-    return 1;
+    return true;
 }
 
 void Collider_ResetATBase(GlobalContext* globalCtx, Collider* collider) {
@@ -171,18 +171,18 @@ s32 Collider_InitTouch(GlobalContext* globalCtx, ColliderTouch* touch) {
     static ColliderTouch init = { 0x00000000, 0, 0 };
 
     *touch = init;
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyTouch(GlobalContext* globalCtx, ColliderTouch* touch) {
-    return 1;
+    return true;
 }
 
 s32 Collider_SetTouch(GlobalContext* globalCtx, ColliderTouch* dest, ColliderTouch* src) {
     dest->dmgFlags = src->dmgFlags;
     dest->effect = src->effect;
     dest->damage = src->damage;
-    return 1;
+    return true;
 }
 
 void Collider_ResetATInfo_Unk(GlobalContext* globalCtx, ColliderInfo* info) {
@@ -192,18 +192,18 @@ s32 Collider_InitBump(GlobalContext* globalCtx, ColliderBump* bump) {
     static ColliderBump init = { 0xFFCFFFFF, 0, 0, { 0, 0, 0 } };
 
     *bump = init;
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyBump(GlobalContext* globalCtx, ColliderBump* bump) {
-    return 1;
+    return true;
 }
 
 s32 Collider_SetBump(GlobalContext* globalCtx, ColliderBump* bump, ColliderBumpInit* init) {
     bump->dmgFlags = init->dmgFlags;
     bump->effect = init->effect;
     bump->defense = init->defense;
-    return 1;
+    return true;
 }
 
 s32 Collider_InitInfo(GlobalContext* globalCtx, ColliderInfo* info) {
@@ -218,13 +218,13 @@ s32 Collider_InitInfo(GlobalContext* globalCtx, ColliderInfo* info) {
     *info = init;
     Collider_InitTouch(globalCtx, &info->toucher);
     Collider_InitBump(globalCtx, &info->bumper);
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyInfo(GlobalContext* globalCtx, ColliderInfo* info) {
     Collider_DestroyTouch(globalCtx, &info->toucher);
     Collider_DestroyBump(globalCtx, &info->bumper);
-    return 1;
+    return true;
 }
 
 s32 Collider_SetInfo(GlobalContext* globalCtx, ColliderInfo* info, ColliderInfoInit* infoInit) {
@@ -234,7 +234,7 @@ s32 Collider_SetInfo(GlobalContext* globalCtx, ColliderInfo* info, ColliderInfoI
     info->toucherFlags = infoInit->toucherFlags;
     info->bumperFlags = infoInit->bumperFlags;
     info->ocElemFlags = infoInit->ocElemFlags;
-    return 1;
+    return true;
 }
 
 void Collider_ResetATInfo(GlobalContext* globalCtx, ColliderInfo* info) {
@@ -265,11 +265,11 @@ s32 Collider_InitJntSphElementDim(GlobalContext* globalCtx, ColliderJntSphElemen
         0,
     };
     *dim = init;
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyJntSphElementDim(GlobalContext* globalCtx, ColliderJntSphElementDim* element) {
-    return 1;
+    return true;
 }
 
 s32 Collider_SetJntSphElementDim(GlobalContext* globalCtx, ColliderJntSphElementDim* dest,
@@ -277,40 +277,40 @@ s32 Collider_SetJntSphElementDim(GlobalContext* globalCtx, ColliderJntSphElement
     dest->limb = src->limb;
     dest->modelSphere = src->modelSphere;
     dest->scale = src->scale * 0.01f;
-    return 1;
+    return true;
 }
 
 s32 Collider_InitJntSphElement(GlobalContext* globalCtx, ColliderJntSphElement* element) {
     Collider_InitInfo(globalCtx, &element->info);
     Collider_InitJntSphElementDim(globalCtx, &element->dim);
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyJntSphElement(GlobalContext* globalCtx, ColliderJntSphElement* element) {
     Collider_DestroyInfo(globalCtx, &element->info);
     Collider_DestroyJntSphElementDim(globalCtx, &element->dim);
-    return 1;
+    return true;
 }
 
 s32 Collider_SetJntSphElement(GlobalContext* globalCtx, ColliderJntSphElement* dest, ColliderJntSphElementInit* src) {
     Collider_SetInfo(globalCtx, &dest->info, &src->info);
     Collider_SetJntSphElementDim(globalCtx, &dest->dim, &src->dim);
-    return 1;
+    return true;
 }
 
 s32 Collider_ResetJntSphElementAT(GlobalContext* globalCtx, ColliderJntSphElement* collider) {
     Collider_ResetATInfo(globalCtx, &collider->info);
-    return 1;
+    return true;
 }
 
 s32 Collider_ResetJntSphElementAC(GlobalContext* globalCtx, ColliderJntSphElement* collider) {
     Collider_ResetACInfo(globalCtx, &collider->info);
-    return 1;
+    return true;
 }
 
 s32 Collider_ResetJntSphElementOC(GlobalContext* globalCtx, ColliderJntSphElement* collider) {
     Collider_ResetOCInfo(globalCtx, &collider->info);
-    return 1;
+    return true;
 }
 
 /**
@@ -320,7 +320,7 @@ s32 Collider_InitJntSph(GlobalContext* globalCtx, ColliderJntSph* collider) {
     Collider_InitBase(globalCtx, &collider->base);
     collider->count = 0;
     collider->elements = NULL;
-    return 1;
+    return true;
 }
 
 /**
@@ -339,7 +339,7 @@ s32 Collider_FreeJntSph(GlobalContext* globalCtx, ColliderJntSph* collider) {
         ZeldaArena_FreeDebug(collider->elements, "../z_collision_check.c", 1393);
     }
     collider->elements = NULL;
-    return 1;
+    return true;
 }
 
 /**
@@ -354,7 +354,7 @@ s32 Collider_DestroyJntSph(GlobalContext* globalCtx, ColliderJntSph* collider) {
     }
     collider->count = 0;
     collider->elements = NULL;
-    return 1;
+    return true;
 }
 
 /**
@@ -374,7 +374,7 @@ s32 Collider_SetJntSphToActor(GlobalContext* globalCtx, ColliderJntSph* dest, Co
         osSyncPrintf(VT_FGCOL(RED));
         osSyncPrintf("ClObjJntSph_set():zelda_malloc()出来ません。\n"); // "Can not."
         osSyncPrintf(VT_RST);
-        return 0;
+        return false;
     }
 
     for (destElem = dest->elements, srcElem = src->elements; destElem < dest->elements + dest->count;
@@ -382,7 +382,7 @@ s32 Collider_SetJntSphToActor(GlobalContext* globalCtx, ColliderJntSph* dest, Co
         Collider_InitJntSphElement(globalCtx, destElem);
         Collider_SetJntSphElement(globalCtx, destElem, srcElem);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -403,7 +403,7 @@ s32 Collider_SetJntSphAllocType1(GlobalContext* globalCtx, ColliderJntSph* dest,
         osSyncPrintf(VT_FGCOL(RED));
         osSyncPrintf("ClObjJntSph_set3():zelda_malloc_出来ません。\n"); // "Can not."
         osSyncPrintf(VT_RST);
-        return 0;
+        return false;
     }
 
     for (destElem = dest->elements, srcElem = src->elements; destElem < dest->elements + dest->count;
@@ -411,7 +411,7 @@ s32 Collider_SetJntSphAllocType1(GlobalContext* globalCtx, ColliderJntSph* dest,
         Collider_InitJntSphElement(globalCtx, destElem);
         Collider_SetJntSphElement(globalCtx, destElem, srcElem);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -431,14 +431,14 @@ s32 Collider_SetJntSphAlloc(GlobalContext* globalCtx, ColliderJntSph* dest, Acto
         osSyncPrintf(VT_FGCOL(RED));
         osSyncPrintf("ClObjJntSph_set5():zelda_malloc出来ません\n"); // "Can not."
         osSyncPrintf(VT_RST);
-        return 0;
+        return false;
     }
     for (destElem = dest->elements, srcElem = src->elements; destElem < dest->elements + dest->count;
          destElem++, srcElem++) {
         Collider_InitJntSphElement(globalCtx, destElem);
         Collider_SetJntSphElement(globalCtx, destElem, srcElem);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -459,7 +459,7 @@ s32 Collider_SetJntSph(GlobalContext* globalCtx, ColliderJntSph* dest, Actor* ac
         Collider_InitJntSphElement(globalCtx, destElem);
         Collider_SetJntSphElement(globalCtx, destElem, srcElem);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -474,7 +474,7 @@ s32 Collider_ResetJntSphAT(GlobalContext* globalCtx, Collider* collider) {
     for (element = jntSph->elements; element < jntSph->elements + jntSph->count; element++) {
         Collider_ResetJntSphElementAT(globalCtx, element);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -489,7 +489,7 @@ s32 Collider_ResetJntSphAC(GlobalContext* globalCtx, Collider* collider) {
     for (element = jntSph->elements; element < jntSph->elements + jntSph->count; element++) {
         Collider_ResetJntSphElementAC(globalCtx, element);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -504,23 +504,23 @@ s32 Collider_ResetJntSphOC(GlobalContext* globalCtx, Collider* collider) {
     for (element = jntSph->elements; element < jntSph->elements + jntSph->count; element++) {
         Collider_ResetJntSphElementOC(globalCtx, element);
     }
-    return 1;
+    return true;
 }
 
 s32 Collider_InitCylinderDim(GlobalContext* globalCtx, Cylinder16* dim) {
     Cylinder16 init = { 0, 0, 0, { 0, 0, 0 } };
 
     *dim = init;
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyCylinderDim(GlobalContext* globalCtx, Cylinder16* dim) {
-    return 1;
+    return true;
 }
 
 s32 Collider_SetCylinderDim(GlobalContext* globalCtx, Cylinder16* dest, Cylinder16* src) {
     *dest = *src;
-    return 1;
+    return true;
 }
 
 /**
@@ -530,7 +530,7 @@ s32 Collider_InitCylinder(GlobalContext* globalCtx, ColliderCylinder* collider) 
     Collider_InitBase(globalCtx, &collider->base);
     Collider_InitInfo(globalCtx, &collider->info);
     Collider_InitCylinderDim(globalCtx, &collider->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -540,7 +540,7 @@ s32 Collider_DestroyCylinder(GlobalContext* globalCtx, ColliderCylinder* collide
     Collider_DestroyBase(globalCtx, &collider->base);
     Collider_DestroyInfo(globalCtx, &collider->info);
     Collider_DestroyCylinderDim(globalCtx, &collider->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -552,7 +552,7 @@ s32 Collider_SetCylinderToActor(GlobalContext* globalCtx, ColliderCylinder* coll
     Collider_SetBaseToActor(globalCtx, &collider->base, &src->base);
     Collider_SetInfo(globalCtx, &collider->info, &src->info);
     Collider_SetCylinderDim(globalCtx, &collider->dim, &src->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -563,7 +563,7 @@ s32 Collider_SetCylinderType1(GlobalContext* globalCtx, ColliderCylinder* collid
     Collider_SetBaseType1(globalCtx, &collider->base, actor, &src->base);
     Collider_SetInfo(globalCtx, &collider->info, &src->info);
     Collider_SetCylinderDim(globalCtx, &collider->dim, &src->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -574,7 +574,7 @@ s32 Collider_SetCylinder(GlobalContext* globalCtx, ColliderCylinder* collider, A
     Collider_SetBase(globalCtx, &collider->base, actor, &src->base);
     Collider_SetInfo(globalCtx, &collider->info, &src->info);
     Collider_SetCylinderDim(globalCtx, &collider->dim, &src->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -585,7 +585,7 @@ s32 Collider_ResetCylinderAT(GlobalContext* globalCtx, Collider* collider) {
 
     Collider_ResetATBase(globalCtx, &cylinder->base);
     Collider_ResetATInfo(globalCtx, &cylinder->info);
-    return 1;
+    return true;
 }
 
 /**
@@ -596,7 +596,7 @@ s32 Collider_ResetCylinderAC(GlobalContext* globalCtx, Collider* collider) {
 
     Collider_ResetACBase(globalCtx, &cylinder->base);
     Collider_ResetACInfo(globalCtx, &cylinder->info);
-    return 1;
+    return true;
 }
 
 /**
@@ -607,7 +607,7 @@ s32 Collider_ResetCylinderOC(GlobalContext* globalCtx, Collider* collider) {
 
     Collider_ResetOCBase(globalCtx, &cylinder->base);
     Collider_ResetOCInfo(globalCtx, &cylinder->info);
-    return 1;
+    return true;
 }
 
 s32 Collider_InitTrisElementDim(GlobalContext* globalCtx, TriNorm* dim) {
@@ -617,11 +617,11 @@ s32 Collider_InitTrisElementDim(GlobalContext* globalCtx, TriNorm* dim) {
     };
 
     *dim = init;
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyTrisElementDim(GlobalContext* globalCtx, TriNorm* dim) {
-    return 1;
+    return true;
 }
 
 s32 Collider_SetTrisElementDim(GlobalContext* globalCtx, TriNorm* dest, ColliderTrisElementDimInit* src) {
@@ -642,40 +642,40 @@ s32 Collider_SetTrisElementDim(GlobalContext* globalCtx, TriNorm* dest, Collider
     dest->plane.normal.y = ny;
     dest->plane.normal.z = nz;
     dest->plane.originDist = originDist;
-    return 1;
+    return true;
 }
 
 s32 Collider_InitTrisElement(GlobalContext* globalCtx, ColliderTrisElement* collider) {
     Collider_InitInfo(globalCtx, &collider->info);
     Collider_InitTrisElementDim(globalCtx, &collider->dim);
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyTrisElement(GlobalContext* globalCtx, ColliderTrisElement* collider) {
     Collider_DestroyInfo(globalCtx, &collider->info);
     Collider_DestroyTrisElementDim(globalCtx, &collider->dim);
-    return 1;
+    return true;
 }
 
 s32 Collider_SetTrisElement(GlobalContext* globalCtx, ColliderTrisElement* dest, ColliderTrisElementInit* src) {
     Collider_SetInfo(globalCtx, &dest->info, &src->info);
     Collider_SetTrisElementDim(globalCtx, &dest->dim, &src->dim);
-    return 1;
+    return true;
 }
 
 s32 Collider_ResetTrisElementAT(GlobalContext* globalCtx, ColliderTrisElement* element) {
     Collider_ResetATInfo(globalCtx, &element->info);
-    return 1;
+    return true;
 }
 
 s32 Collider_ResetTrisElementAC(GlobalContext* globalCtx, ColliderTrisElement* element) {
     Collider_ResetACInfo(globalCtx, &element->info);
-    return 1;
+    return true;
 }
 
 s32 Collider_ResetTrisElementOC(GlobalContext* globalCtx, ColliderTrisElement* element) {
     Collider_ResetOCInfo(globalCtx, &element->info);
-    return 1;
+    return true;
 }
 
 /**
@@ -685,7 +685,7 @@ s32 Collider_InitTris(GlobalContext* globalCtx, ColliderTris* tris) {
     Collider_InitBase(globalCtx, &tris->base);
     tris->count = 0;
     tris->elements = 0;
-    return 1;
+    return true;
 }
 
 /**
@@ -705,7 +705,7 @@ s32 Collider_FreeTris(GlobalContext* globalCtx, ColliderTris* tris) {
         ZeldaArena_FreeDebug(tris->elements, "../z_collision_check.c", 2099);
     }
     tris->elements = NULL;
-    return 1;
+    return true;
 }
 
 /**
@@ -721,7 +721,7 @@ s32 Collider_DestroyTris(GlobalContext* globalCtx, ColliderTris* tris) {
 
     tris->count = 0;
     tris->elements = NULL;
-    return 1;
+    return true;
 }
 
 /**
@@ -740,14 +740,14 @@ s32 Collider_SetTrisAllocType1(GlobalContext* globalCtx, ColliderTris* dest, Act
         osSyncPrintf(VT_FGCOL(RED));
         osSyncPrintf("ClObjTris_set3():zelda_malloc()出来ません\n"); // "Can not."
         osSyncPrintf(VT_RST);
-        return 0;
+        return false;
     }
     for (destElem = dest->elements, srcElem = src->elements; destElem < dest->elements + dest->count;
          destElem++, srcElem++) {
         Collider_InitTrisElement(globalCtx, destElem);
         Collider_SetTrisElement(globalCtx, destElem, srcElem);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -767,7 +767,7 @@ s32 Collider_SetTrisAlloc(GlobalContext* globalCtx, ColliderTris* dest, Actor* a
         osSyncPrintf("ClObjTris_set5():zelda_malloc出来ません\n"); // "Can not."
         osSyncPrintf(VT_RST);
         dest->count = 0;
-        return 0;
+        return false;
     }
 
     for (destElem = dest->elements, srcElem = src->elements; destElem < dest->elements + dest->count;
@@ -775,7 +775,7 @@ s32 Collider_SetTrisAlloc(GlobalContext* globalCtx, ColliderTris* dest, Actor* a
         Collider_InitTrisElement(globalCtx, destElem);
         Collider_SetTrisElement(globalCtx, destElem, srcElem);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -796,7 +796,7 @@ s32 Collider_SetTris(GlobalContext* globalCtx, ColliderTris* dest, Actor* actor,
         Collider_InitTrisElement(globalCtx, destElem);
         Collider_SetTrisElement(globalCtx, destElem, srcElem);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -810,7 +810,7 @@ s32 Collider_ResetTrisAT(GlobalContext* globalCtx, Collider* collider) {
     for (element = tris->elements; element < tris->elements + tris->count; element++) {
         Collider_ResetTrisElementAT(globalCtx, element);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -824,7 +824,7 @@ s32 Collider_ResetTrisAC(GlobalContext* globalCtx, Collider* collider) {
     for (element = tris->elements; element < tris->elements + tris->count; element++) {
         Collider_ResetTrisElementAC(globalCtx, element);
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -838,7 +838,7 @@ s32 Collider_ResetTrisOC(GlobalContext* globalCtx, Collider* collider) {
     for (element = tris->elements; element < tris->elements + tris->count; element++) {
         Collider_ResetTrisElementOC(globalCtx, element);
     }
-    return 1;
+    return true;
 }
 
 s32 Collider_InitQuadDim(GlobalContext* globalCtx, ColliderQuadDim* dim) {
@@ -850,16 +850,16 @@ s32 Collider_InitQuadDim(GlobalContext* globalCtx, ColliderQuadDim* dim) {
     };
 
     *dim = init;
-    return 1;
+    return true;
 }
 
 s32 Collider_DestroyQuadDim(GlobalContext* globalCtx, ColliderQuadDim* dim) {
-    return 1;
+    return true;
 }
 
 s32 Collider_ResetQuadACDist(GlobalContext* globalCtx, ColliderQuadDim* dim) {
     dim->acDist = 1.0E38f;
-    return 1;
+    return true;
 }
 
 void Collider_SetQuadMidpoints(ColliderQuadDim* dim) {
@@ -877,7 +877,7 @@ s32 Collider_SetQuadDim(GlobalContext* globalCtx, ColliderQuadDim* dest, Collide
     dest->quad[2] = src->quad[2];
     dest->quad[3] = src->quad[3];
     Collider_SetQuadMidpoints(dest);
-    return 1;
+    return true;
 }
 
 /**
@@ -887,7 +887,7 @@ s32 Collider_InitQuad(GlobalContext* globalCtx, ColliderQuad* collider) {
     Collider_InitBase(globalCtx, &collider->base);
     Collider_InitInfo(globalCtx, &collider->info);
     Collider_InitQuadDim(globalCtx, &collider->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -897,7 +897,7 @@ s32 Collider_DestroyQuad(GlobalContext* globalCtx, ColliderQuad* collider) {
     Collider_DestroyBase(globalCtx, &collider->base);
     Collider_DestroyInfo(globalCtx, &collider->info);
     Collider_DestroyQuadDim(globalCtx, &collider->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -907,7 +907,7 @@ s32 Collider_SetQuadType1(GlobalContext* globalCtx, ColliderQuad* collider, Acto
     Collider_SetBaseType1(globalCtx, &collider->base, actor, &src->base);
     Collider_SetInfo(globalCtx, &collider->info, &src->info);
     Collider_SetQuadDim(globalCtx, &collider->dim, &src->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -917,7 +917,7 @@ s32 Collider_SetQuad(GlobalContext* globalCtx, ColliderQuad* collider, Actor* ac
     Collider_SetBase(globalCtx, &collider->base, actor, &src->base);
     Collider_SetInfo(globalCtx, &collider->info, &src->info);
     Collider_SetQuadDim(globalCtx, &collider->dim, &src->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -929,7 +929,7 @@ s32 Collider_ResetQuadAT(GlobalContext* globalCtx, Collider* collider) {
     Collider_ResetATBase(globalCtx, &quad->base);
     Collider_ResetATInfo(globalCtx, &quad->info);
     Collider_ResetQuadACDist(globalCtx, &quad->dim);
-    return 1;
+    return true;
 }
 
 /**
@@ -940,7 +940,7 @@ s32 Collider_ResetQuadAC(GlobalContext* globalCtx, Collider* collider) {
 
     Collider_ResetACBase(globalCtx, &quad->base);
     Collider_ResetACInfo(globalCtx, &quad->info);
-    return 1;
+    return true;
 }
 
 /**
@@ -951,7 +951,7 @@ s32 Collider_ResetQuadOC(GlobalContext* globalCtx, Collider* collider) {
 
     Collider_ResetOCBase(globalCtx, &quad->base);
     Collider_ResetOCInfo(globalCtx, &quad->info);
-    return 1;
+    return true;
 }
 
 /**
@@ -989,7 +989,7 @@ s32 Collider_InitLine(GlobalContext* globalCtx, OcLine* line) {
 
     Math_Vec3f_Copy(&line->line.a, &init);
     Math_Vec3f_Copy(&line->line.b, &init);
-    return 1;
+    return true;
 }
 
 /**
@@ -997,7 +997,7 @@ s32 Collider_InitLine(GlobalContext* globalCtx, OcLine* line) {
  * OcLines are entirely unused.
  */
 s32 Collider_DestroyLine(GlobalContext* globalCtx, OcLine* line) {
-    return 1;
+    return true;
 }
 
 /**
@@ -1007,7 +1007,7 @@ s32 Collider_DestroyLine(GlobalContext* globalCtx, OcLine* line) {
 s32 Collider_SetLinePoints(GlobalContext* globalCtx, OcLine* ocLine, Vec3f* a, Vec3f* b) {
     Math_Vec3f_Copy(&ocLine->line.a, a);
     Math_Vec3f_Copy(&ocLine->line.b, b);
-    return 1;
+    return true;
 }
 
 /**
@@ -1017,7 +1017,7 @@ s32 Collider_SetLinePoints(GlobalContext* globalCtx, OcLine* ocLine, Vec3f* a, V
 s32 Collider_SetLine(GlobalContext* globalCtx, OcLine* dest, OcLine* src) {
     dest->ocFlags = src->ocFlags;
     Collider_SetLinePoints(globalCtx, dest, &src->line.a, &src->line.b);
-    return 1;
+    return true;
 }
 
 /**
@@ -1026,7 +1026,7 @@ s32 Collider_SetLine(GlobalContext* globalCtx, OcLine* dest, OcLine* src) {
  */
 s32 Collider_ResetLineOC(GlobalContext* globalCtx, OcLine* line) {
     line->ocFlags &= ~OCLINE_HIT;
-    return 1;
+    return true;
 }
 
 /**
@@ -1050,7 +1050,7 @@ void CollisionCheck_ClearContext(GlobalContext* globalCtx, CollisionCheckContext
     Collider** col;
     OcLine** line;
 
-    if (!(colChkCtx->sacFlags & 1)) {
+    if (!(colChkCtx->sacFlags & SAC_ON)) {
         colChkCtx->colATCount = 0;
         colChkCtx->colACCount = 0;
         colChkCtx->colOCCount = 0;
@@ -1077,14 +1077,14 @@ void CollisionCheck_ClearContext(GlobalContext* globalCtx, CollisionCheckContext
  * Enables SAC, an alternate collision check mode that allows direct management of collider lists. Unused.
  */
 void CollisionCheck_EnableSAC(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx) {
-    colChkCtx->sacFlags |= 1;
+    colChkCtx->sacFlags |= SAC_ON;
 }
 
 /**
  * Disables SAC, an alternate collision check mode that allows direct management of collider lists. Unused.
  */
 void CollisionCheck_DisableSAC(GlobalContext* globalCtx, CollisionCheckContext* colChkCtx) {
-    colChkCtx->sacFlags &= ~1;
+    colChkCtx->sacFlags &= ~SAC_ON;
 }
 
 /**
@@ -1190,7 +1190,7 @@ s32 CollisionCheck_SetAT(GlobalContext* globalCtx, CollisionCheckContext* colChk
         osSyncPrintf("CollisionCheck_setAT():インデックスがオーバーして追加不能\n");
         return -1;
     }
-    if (colChkCtx->sacFlags & 1) {
+    if (colChkCtx->sacFlags & SAC_ON) {
         return -1;
     }
     index = colChkCtx->colATCount;
@@ -1213,7 +1213,7 @@ s32 CollisionCheck_SetAT_SAC(GlobalContext* globalCtx, CollisionCheckContext* co
     if (collider->actor != NULL && collider->actor->update == NULL) {
         return -1;
     }
-    if (colChkCtx->sacFlags & 1) {
+    if (colChkCtx->sacFlags & SAC_ON) {
         if (!(index < colChkCtx->colATCount)) {
             // "You are trying to register a location that is larger than the total number of data."
             osSyncPrintf("CollisionCheck_setAT_SAC():全データ数より大きいところに登録しようとしている。\n");
@@ -1259,7 +1259,7 @@ s32 CollisionCheck_SetAC(GlobalContext* globalCtx, CollisionCheckContext* colChk
         osSyncPrintf("CollisionCheck_setAC():インデックスがオーバして追加不能\n");
         return -1;
     }
-    if (colChkCtx->sacFlags & 1) {
+    if (colChkCtx->sacFlags & SAC_ON) {
         return -1;
     }
     index = colChkCtx->colACCount;
@@ -1282,7 +1282,7 @@ s32 CollisionCheck_SetAC_SAC(GlobalContext* globalCtx, CollisionCheckContext* co
     if (collider->actor != NULL && collider->actor->update == NULL) {
         return -1;
     }
-    if (colChkCtx->sacFlags & 1) {
+    if (colChkCtx->sacFlags & SAC_ON) {
         if (!(index < colChkCtx->colACCount)) {
             // "You are trying to register a location that is larger than the total number of data."
             osSyncPrintf("CollisionCheck_setAC_SAC():全データ数より大きいところに登録しようとしている。\n");
@@ -1330,7 +1330,7 @@ s32 CollisionCheck_SetOC(GlobalContext* globalCtx, CollisionCheckContext* colChk
         osSyncPrintf("CollisionCheck_setOC():インデックスがオーバして追加不能\n");
         return -1;
     }
-    if (colChkCtx->sacFlags & 1) {
+    if (colChkCtx->sacFlags & SAC_ON) {
         return -1;
     }
     index = colChkCtx->colOCCount;
@@ -1353,7 +1353,7 @@ s32 CollisionCheck_SetOC_SAC(GlobalContext* globalCtx, CollisionCheckContext* co
     if (collider->actor != NULL && collider->actor->update == NULL) {
         return -1;
     }
-    if (colChkCtx->sacFlags & 1) {
+    if (colChkCtx->sacFlags & SAC_ON) {
         if (!(index < colChkCtx->colOCCount)) {
             // "You are trying to register a location that is larger than the total number of data."
             osSyncPrintf("CollisionCheck_setOC_SAC():全データ数より大きいところに登録しようとしている。\n");
@@ -1399,9 +1399,9 @@ s32 CollisionCheck_SetOCLine(GlobalContext* globalCtx, CollisionCheckContext* co
  */
 s32 CollisionCheck_SkipTouch(ColliderInfo* info) {
     if (!(info->toucherFlags & TOUCH_ON)) {
-        return 1;
+        return true;
     }
-    return 0;
+    return false;
 }
 
 /**
@@ -1409,9 +1409,9 @@ s32 CollisionCheck_SkipTouch(ColliderInfo* info) {
  */
 s32 CollisionCheck_SkipBump(ColliderInfo* info) {
     if (!(info->bumperFlags & BUMP_ON)) {
-        return 1;
+        return true;
     }
-    return 0;
+    return false;
 }
 
 /**
@@ -1419,9 +1419,9 @@ s32 CollisionCheck_SkipBump(ColliderInfo* info) {
  */
 s32 CollisionCheck_NoSharedFlags(ColliderInfo* atInfo, ColliderInfo* acInfo) {
     if (!(atInfo->toucher.dmgFlags & acInfo->bumper.dmgFlags)) {
-        return 1;
+        return true;
     }
-    return 0;
+    return false;
 }
 
 /**
@@ -1621,7 +1621,7 @@ s32 CollisionCheck_SwordHitAudio(Collider* at, ColliderInfo* acInfo) {
                                    &D_801333E0, &D_801333E8);
         }
     }
-    return 1;
+    return true;
 }
 
 static ColChkBloodFunc sBloodFuncs[] = {
@@ -1720,7 +1720,7 @@ s32 CollisionCheck_SetATvsAC(GlobalContext* globalCtx, Collider* at, ColliderInf
         CollisionCheck_HitEffects(globalCtx, at, atInfo, ac, acInfo, hitPos);
         atInfo->toucherFlags |= TOUCH_DREW_HITMARK;
     }
-    return 1;
+    return true;
 }
 
 /**
@@ -1737,18 +1737,18 @@ void CollisionCheck_AC_JntSphVsJntSph(GlobalContext* globalCtx, CollisionCheckCo
 
     if (at->count > 0 && at->elements != NULL && ac->count > 0 && ac->elements != NULL) {
         for (atItem = at->elements; atItem < at->elements + at->count; atItem++) {
-            if (CollisionCheck_SkipTouch(&atItem->info) == 1) {
+            if (CollisionCheck_SkipTouch(&atItem->info) == true) {
                 continue;
             }
             for (acElem = ac->elements; acElem < ac->elements + ac->count; acElem++) {
-                if (CollisionCheck_SkipBump(&acElem->info) == 1) {
+                if (CollisionCheck_SkipBump(&acElem->info) == true) {
                     continue;
                 }
-                if (CollisionCheck_NoSharedFlags(&atItem->info, &acElem->info) == 1) {
+                if (CollisionCheck_NoSharedFlags(&atItem->info, &acElem->info) == true) {
                     continue;
                 }
                 if (Math3D_SphVsSphOverlapCenter(&atItem->dim.worldSphere, &acElem->dim.worldSphere, &overlapSize,
-                                                 &centerDist) == 1) {
+                                                 &centerDist) == true) {
                     f32 acToHit;
                     Vec3f hitPos;
                     Vec3f atPos;
@@ -1791,14 +1791,14 @@ void CollisionCheck_AC_JntSphVsCyl(GlobalContext* globalCtx, CollisionCheckConte
     f32 centerDist;
 
     if (at->count > 0 && at->elements != NULL && ac->dim.radius > 0 && ac->dim.height > 0) {
-        if (CollisionCheck_SkipBump(&ac->info) == 1) {
+        if (CollisionCheck_SkipBump(&ac->info) == true) {
             return;
         }
         for (atItem = at->elements; atItem < at->elements + at->count; atItem++) {
-            if (CollisionCheck_SkipTouch(&atItem->info) == 1) {
+            if (CollisionCheck_SkipTouch(&atItem->info) == true) {
                 continue;
             }
-            if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == 1) {
+            if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == true) {
                 continue;
             }
             if (Math3D_SphVsCylOverlapCenterDist(&atItem->dim.worldSphere, &ac->dim, &overlapSize, &centerDist)) {
@@ -1845,14 +1845,14 @@ void CollisionCheck_AC_CylVsJntSph(GlobalContext* globalCtx, CollisionCheckConte
     ColliderJntSphElement* acElem;
 
     if (ac->count > 0 && ac->elements != NULL && at->dim.radius > 0 && at->dim.height > 0) {
-        if (CollisionCheck_SkipTouch(&at->info) == 1) {
+        if (CollisionCheck_SkipTouch(&at->info) == true) {
             return;
         }
         for (acElem = ac->elements; acElem < ac->elements + ac->count; acElem++) {
-            if (CollisionCheck_SkipBump(&acElem->info) == 1) {
+            if (CollisionCheck_SkipBump(&acElem->info) == true) {
                 continue;
             }
-            if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == 1) {
+            if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == true) {
                 continue;
             }
             if (Math3D_SphVsCylOverlapCenterDist(&acElem->dim.worldSphere, &at->dim, &overlapSize, &centerDist)) {
@@ -1902,17 +1902,17 @@ void CollisionCheck_AC_JntSphVsTris(GlobalContext* globalCtx, CollisionCheckCont
 
     if (at->count > 0 && at->elements != NULL && ac->count > 0 && ac->elements != NULL) {
         for (atSph = at->elements; atSph < at->elements + at->count; atSph++) {
-            if (CollisionCheck_SkipTouch(&atSph->info) == 1) {
+            if (CollisionCheck_SkipTouch(&atSph->info) == true) {
                 continue;
             }
             for (acTri = ac->elements; acTri < ac->elements + ac->count; acTri++) {
-                if (CollisionCheck_SkipBump(&acTri->info) == 1) {
+                if (CollisionCheck_SkipBump(&acTri->info) == true) {
                     continue;
                 }
-                if (CollisionCheck_NoSharedFlags(&atSph->info, &acTri->info) == 1) {
+                if (CollisionCheck_NoSharedFlags(&atSph->info, &acTri->info) == true) {
                     continue;
                 }
-                if (Math3D_TriVsSphIntersect(&atSph->dim.worldSphere, &acTri->dim, &hitPos) == 1) {
+                if (Math3D_TriVsSphIntersect(&atSph->dim.worldSphere, &acTri->dim, &hitPos) == true) {
                     Vec3f atPos;
                     Vec3f acPos;
 
@@ -1944,17 +1944,17 @@ void CollisionCheck_AC_TrisVsJntSph(GlobalContext* globalCtx, CollisionCheckCont
 
     if (ac->count > 0 && ac->elements != NULL && at->count > 0 && at->elements != NULL) {
         for (acElem = ac->elements; acElem < ac->elements + ac->count; acElem++) {
-            if (CollisionCheck_SkipBump(&acElem->info) == 1) {
+            if (CollisionCheck_SkipBump(&acElem->info) == true) {
                 continue;
             }
             for (atItem = at->elements; atItem < at->elements + at->count; atItem++) {
-                if (CollisionCheck_SkipTouch(&atItem->info) == 1) {
+                if (CollisionCheck_SkipTouch(&atItem->info) == true) {
                     continue;
                 }
-                if (CollisionCheck_NoSharedFlags(&atItem->info, &acElem->info) == 1) {
+                if (CollisionCheck_NoSharedFlags(&atItem->info, &acElem->info) == true) {
                     continue;
                 }
-                if (Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &atItem->dim, &hitPos) == 1) {
+                if (Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &atItem->dim, &hitPos) == true) {
                     Vec3f atPos;
                     Vec3f acPos;
 
@@ -1986,20 +1986,20 @@ void CollisionCheck_AC_JntSphVsQuad(GlobalContext* globalCtx, CollisionCheckCont
     ColliderJntSphElement* atItem;
 
     if (at->count > 0 && at->elements != NULL) {
-        if (CollisionCheck_SkipBump(&ac->info) == 1) {
+        if (CollisionCheck_SkipBump(&ac->info) == true) {
             return;
         }
         Math3D_TriNorm(&tri1, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
         Math3D_TriNorm(&tri2, &ac->dim.quad[1], &ac->dim.quad[0], &ac->dim.quad[2]);
         for (atItem = at->elements; atItem < at->elements + at->count; atItem++) {
-            if (CollisionCheck_SkipTouch(&atItem->info) == 1) {
+            if (CollisionCheck_SkipTouch(&atItem->info) == true) {
                 continue;
             }
-            if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == 1) {
+            if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == true) {
                 continue;
             }
             if (Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &tri1, &hitPos) == true ||
-                Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &tri2, &hitPos) == 1) {
+                Math3D_TriVsSphIntersect(&atItem->dim.worldSphere, &tri2, &hitPos) == true) {
                 Vec3f atPos;
                 Vec3f acPos;
 
@@ -2030,20 +2030,20 @@ void CollisionCheck_AC_QuadVsJntSph(GlobalContext* globalCtx, CollisionCheckCont
     ColliderJntSphElement* acElem;
 
     if (ac->count > 0 && ac->elements != NULL) {
-        if (CollisionCheck_SkipTouch(&at->info) == 1) {
+        if (CollisionCheck_SkipTouch(&at->info) == true) {
             return;
         }
         Math3D_TriNorm(&tri1, &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
         Math3D_TriNorm(&tri2, &at->dim.quad[2], &at->dim.quad[1], &at->dim.quad[0]);
         for (acElem = ac->elements; acElem < ac->elements + ac->count; acElem++) {
-            if (CollisionCheck_SkipBump(&acElem->info) == 1) {
+            if (CollisionCheck_SkipBump(&acElem->info) == true) {
                 continue;
             }
-            if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == 1) {
+            if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == true) {
                 continue;
             }
-            if (Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &tri1, &hitPos) == 1 ||
-                Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &tri2, &hitPos) == 1) {
+            if (Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &tri1, &hitPos) == true ||
+                Math3D_TriVsSphIntersect(&acElem->dim.worldSphere, &tri2, &hitPos) == true) {
                 if (Collider_QuadSetNearestAC(globalCtx, at, &hitPos)) {
                     Vec3f atPos;
                     Vec3f acPos;
@@ -2081,16 +2081,16 @@ void CollisionCheck_AC_CylVsCyl(GlobalContext* globalCtx, CollisionCheckContext*
     Vec3f hitPos;
 
     if (at->dim.radius > 0 && at->dim.height > 0 && ac->dim.radius > 0 && ac->dim.height > 0) {
-        if (CollisionCheck_SkipBump(&ac->info) == 1) {
+        if (CollisionCheck_SkipBump(&ac->info) == true) {
             return;
         }
-        if (CollisionCheck_SkipTouch(&at->info) == 1) {
+        if (CollisionCheck_SkipTouch(&at->info) == true) {
             return;
         }
-        if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == 1) {
+        if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == true) {
             return;
         }
-        if (Math3D_CylOutsideCylDist(&at->dim, &ac->dim, &deadSpace, &centerDistXZ) == 1) {
+        if (Math3D_CylOutsideCylDist(&at->dim, &ac->dim, &deadSpace, &centerDistXZ) == true) {
             Vec3f atPos;
             Vec3f acPos;
             f32 acToHit;
@@ -2121,17 +2121,17 @@ void CollisionCheck_AC_CylVsTris(GlobalContext* globalCtx, CollisionCheckContext
     Vec3f hitPos;
 
     if (at->dim.radius > 0 && at->dim.height > 0 && ac->count > 0 && ac->elements != NULL) {
-        if (CollisionCheck_SkipTouch(&at->info) == 1) {
+        if (CollisionCheck_SkipTouch(&at->info) == true) {
             return;
         }
         for (acElem = ac->elements; acElem < ac->elements + ac->count; acElem++) {
-            if (CollisionCheck_SkipBump(&acElem->info) == 1) {
+            if (CollisionCheck_SkipBump(&acElem->info) == true) {
                 continue;
             }
-            if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == 1) {
+            if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == true) {
                 continue;
             }
-            if (Math3D_CylTriVsIntersect(&at->dim, &acElem->dim, &hitPos) == 1) {
+            if (Math3D_CylTriVsIntersect(&at->dim, &acElem->dim, &hitPos) == true) {
                 Vec3f atpos;
                 Vec3f acPos;
 
@@ -2161,18 +2161,18 @@ void CollisionCheck_AC_TrisVsCyl(GlobalContext* globalCtx, CollisionCheckContext
     Vec3f acPos;
 
     if (ac->dim.radius > 0 && ac->dim.height > 0 && at->count > 0 && at->elements != NULL) {
-        if (CollisionCheck_SkipBump(&ac->info) == 1) {
+        if (CollisionCheck_SkipBump(&ac->info) == true) {
             return;
         }
         for (atItem = at->elements; atItem < at->elements + at->count; atItem++) {
-            if (CollisionCheck_SkipTouch(&atItem->info) == 1) {
+            if (CollisionCheck_SkipTouch(&atItem->info) == true) {
                 continue;
             }
-            if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == 1) {
+            if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == true) {
                 continue;
             }
 
-            if (Math3D_CylTriVsIntersect(&ac->dim, &atItem->dim, &intersection) == 1) {
+            if (Math3D_CylTriVsIntersect(&ac->dim, &atItem->dim, &intersection) == true) {
                 atPos.x = (atItem->dim.vtx[0].x + atItem->dim.vtx[1].x + atItem->dim.vtx[2].x) * (1.0f / 3);
                 atPos.y = (atItem->dim.vtx[0].y + atItem->dim.vtx[1].y + atItem->dim.vtx[2].y) * (1.0f / 3);
                 atPos.z = (atItem->dim.vtx[0].z + atItem->dim.vtx[1].z + atItem->dim.vtx[2].z) * (1.0f / 3);
@@ -2197,10 +2197,10 @@ void CollisionCheck_AC_CylVsQuad(GlobalContext* globalCtx, CollisionCheckContext
     ColliderQuad* ac = (ColliderQuad*)colAC;
 
     if (at->dim.height > 0 && at->dim.radius > 0) {
-        if (CollisionCheck_SkipTouch(&at->info) == 1 || CollisionCheck_SkipBump(&ac->info) == 1) {
+        if (CollisionCheck_SkipTouch(&at->info) == true || CollisionCheck_SkipBump(&ac->info) == true) {
             return;
         }
-        if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == 1) {
+        if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == true) {
             return;
         }
         Math3D_TriNorm(&tri1, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
@@ -2215,7 +2215,7 @@ void CollisionCheck_AC_CylVsQuad(GlobalContext* globalCtx, CollisionCheckContext
             acPos1.z = (ac->dim.quad[0].z + (ac->dim.quad[1].z + (ac->dim.quad[3].z + ac->dim.quad[2].z))) / 4.0f;
             CollisionCheck_SetATvsAC(globalCtx, &at->base, &at->info, &atPos1, &ac->base, &ac->info, &acPos1,
                                      &intersection);
-        } else if (Math3D_CylTriVsIntersect(&at->dim, &tri2, &intersection) == 1) {
+        } else if (Math3D_CylTriVsIntersect(&at->dim, &tri2, &intersection) == true) {
             Vec3f atPos2;
             Vec3f acPos2;
 
@@ -2244,15 +2244,15 @@ void CollisionCheck_AC_QuadVsCyl(GlobalContext* globalCtx, CollisionCheckContext
     ColliderCylinder* ac = (ColliderCylinder*)colAC;
 
     if (ac->dim.height > 0 && ac->dim.radius > 0) {
-        if (CollisionCheck_SkipBump(&ac->info) == 1 || CollisionCheck_SkipTouch(&at->info) == 1) {
+        if (CollisionCheck_SkipBump(&ac->info) == true || CollisionCheck_SkipTouch(&at->info) == true) {
             return;
         }
-        if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == 1) {
+        if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == true) {
             return;
         }
         Math3D_TriNorm(&tri1, &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
         Math3D_TriNorm(&tri2, &at->dim.quad[2], &at->dim.quad[1], &at->dim.quad[0]);
-        if (Math3D_CylTriVsIntersect(&ac->dim, &tri1, &intersection) == 1) {
+        if (Math3D_CylTriVsIntersect(&ac->dim, &tri1, &intersection) == true) {
             if (Collider_QuadSetNearestAC(globalCtx, at, &intersection)) {
                 Vec3f atPos1;
                 Vec3f acPos1;
@@ -2266,7 +2266,7 @@ void CollisionCheck_AC_QuadVsCyl(GlobalContext* globalCtx, CollisionCheckContext
                 return;
             }
         }
-        if (Math3D_CylTriVsIntersect(&ac->dim, &tri2, &intersection) == 1) {
+        if (Math3D_CylTriVsIntersect(&ac->dim, &tri2, &intersection) == true) {
             if (Collider_QuadSetNearestAC(globalCtx, at, &intersection)) {
                 Vec3f atPos2;
                 Vec3f acPos2;
@@ -2300,17 +2300,17 @@ void CollisionCheck_AC_TrisVsTris(GlobalContext* globalCtx, CollisionCheckContex
 
     if (ac->count > 0 && ac->elements != NULL && at->count > 0 && at->elements != NULL) {
         for (acElem = ac->elements; acElem < ac->elements + ac->count; acElem++) {
-            if (CollisionCheck_SkipBump(&acElem->info) == 1) {
+            if (CollisionCheck_SkipBump(&acElem->info) == true) {
                 continue;
             }
             for (atItem = at->elements; atItem < at->elements + at->count; atItem++) {
-                if (CollisionCheck_SkipTouch(&atItem->info) == 1) {
+                if (CollisionCheck_SkipTouch(&atItem->info) == true) {
                     continue;
                 }
-                if (CollisionCheck_NoSharedFlags(&atItem->info, &acElem->info) == 1) {
+                if (CollisionCheck_NoSharedFlags(&atItem->info, &acElem->info) == true) {
                     continue;
                 }
-                if (Math3D_TriVsTriIntersect(&atItem->dim, &acElem->dim, &intersection) == 1) {
+                if (Math3D_TriVsTriIntersect(&atItem->dim, &acElem->dim, &intersection) == true) {
                     Vec3f atPos;
                     Vec3f acPos;
 
@@ -2347,20 +2347,20 @@ void CollisionCheck_AC_TrisVsQuad(GlobalContext* globalCtx, CollisionCheckContex
     ColliderQuad* ac = (ColliderQuad*)colAC;
 
     if (at->count > 0 && at->elements != NULL) {
-        if (CollisionCheck_SkipBump(&ac->info) == 1) {
+        if (CollisionCheck_SkipBump(&ac->info) == true) {
             return;
         }
         Math3D_TriNorm(&tri1, &ac->dim.quad[2], &ac->dim.quad[3], &ac->dim.quad[1]);
         Math3D_TriNorm(&tri2, &ac->dim.quad[1], &ac->dim.quad[0], &ac->dim.quad[2]);
         for (atItem = at->elements; atItem < at->elements + at->count; atItem++) {
-            if (CollisionCheck_SkipTouch(&atItem->info) == 1) {
+            if (CollisionCheck_SkipTouch(&atItem->info) == true) {
                 continue;
             }
-            if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == 1) {
+            if (CollisionCheck_NoSharedFlags(&atItem->info, &ac->info) == true) {
                 continue;
             }
             if (Math3D_TriVsTriIntersect(&tri1, &atItem->dim, &intersection) == true ||
-                Math3D_TriVsTriIntersect(&tri2, &atItem->dim, &intersection) == 1) {
+                Math3D_TriVsTriIntersect(&tri2, &atItem->dim, &intersection) == true) {
                 Vec3f atPos;
                 Vec3f acPos;
 
@@ -2391,20 +2391,20 @@ void CollisionCheck_AC_QuadVsTris(GlobalContext* globalCtx, CollisionCheckContex
     ColliderTrisElement* acElem;
 
     if (ac->count > 0 && ac->elements != NULL) {
-        if (CollisionCheck_SkipTouch(&at->info) == 1) {
+        if (CollisionCheck_SkipTouch(&at->info) == true) {
             return;
         }
         Math3D_TriNorm(&tri1, &at->dim.quad[2], &at->dim.quad[3], &at->dim.quad[1]);
         Math3D_TriNorm(&tri2, &at->dim.quad[1], &at->dim.quad[0], &at->dim.quad[2]);
         for (acElem = ac->elements; acElem < ac->elements + ac->count; acElem++) {
-            if (CollisionCheck_SkipBump(&acElem->info) == 1) {
+            if (CollisionCheck_SkipBump(&acElem->info) == true) {
                 continue;
             }
-            if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == 1) {
+            if (CollisionCheck_NoSharedFlags(&at->info, &acElem->info) == true) {
                 continue;
             }
-            if (Math3D_TriVsTriIntersect(&tri1, &acElem->dim, &intersection) == 1 ||
-                Math3D_TriVsTriIntersect(&tri2, &acElem->dim, &intersection) == 1) {
+            if (Math3D_TriVsTriIntersect(&tri1, &acElem->dim, &intersection) == true ||
+                Math3D_TriVsTriIntersect(&tri2, &acElem->dim, &intersection) == true) {
                 if (Collider_QuadSetNearestAC(globalCtx, at, &intersection)) {
                     Vec3f atPos;
                     Vec3f acPos;
@@ -2440,13 +2440,13 @@ void CollisionCheck_AC_QuadVsQuad(GlobalContext* globalCtx, CollisionCheckContex
     s32 i;
     s32 j;
 
-    if (CollisionCheck_SkipTouch(&at->info) == 1) {
+    if (CollisionCheck_SkipTouch(&at->info) == true) {
         return;
     }
-    if (CollisionCheck_SkipBump(&ac->info) == 1) {
+    if (CollisionCheck_SkipBump(&ac->info) == true) {
         return;
     }
-    if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == 1) {
+    if (CollisionCheck_NoSharedFlags(&at->info, &ac->info) == true) {
         return;
     }
 
@@ -2457,7 +2457,7 @@ void CollisionCheck_AC_QuadVsQuad(GlobalContext* globalCtx, CollisionCheckContex
 
     for (i = 0; i < 2; i++) {
         for (j = 0; j < 2; j++) {
-            if (Math3D_TriVsTriIntersect(&atTris[j], &acTris[i], &intersection) == 1) {
+            if (Math3D_TriVsTriIntersect(&atTris[j], &acTris[i], &intersection) == true) {
                 if (Collider_QuadSetNearestAC(globalCtx, at, &intersection)) {
                     Vec3f atPos;
                     Vec3f acPos;
@@ -2766,7 +2766,7 @@ void CollisionCheck_OC_JntSphVsJntSph(GlobalContext* globalCtx, CollisionCheckCo
                 if (!(rightElem->info.ocElemFlags & OCELEM_ON)) {
                     continue;
                 }
-                if (Math3D_SphVsSphOverlap(&leftElem->dim.worldSphere, &rightElem->dim.worldSphere, &overlap) == 1) {
+                if (Math3D_SphVsSphOverlap(&leftElem->dim.worldSphere, &rightElem->dim.worldSphere, &overlap) == true) {
                     Vec3f leftPos;
                     Vec3f rightPos;
 
@@ -2796,7 +2796,7 @@ void CollisionCheck_OC_JntSphVsCyl(GlobalContext* globalCtx, CollisionCheckConte
                 if (!(leftElem->info.ocElemFlags & OCELEM_ON)) {
                     continue;
                 }
-                if (Math3D_SphVsCylOverlapDist(&leftElem->dim.worldSphere, &right->dim, &overlap) == 1) {
+                if (Math3D_SphVsCylOverlapDist(&leftElem->dim.worldSphere, &right->dim, &overlap) == true) {
                     Vec3f leftPos;
                     Vec3f rightPos;
 
@@ -2828,7 +2828,7 @@ void CollisionCheck_OC_CylVsCyl(GlobalContext* globalCtx, CollisionCheckContext*
 
     if ((left->base.ocFlags1 & OC1_ON) && (right->base.ocFlags1 & OC1_ON)) {
         if ((left->info.ocElemFlags & OCELEM_ON) && (right->info.ocElemFlags & OCELEM_ON)) {
-            if (Math3D_CylOutsideCyl(&left->dim, &right->dim, &deadSpace) == 1) {
+            if (Math3D_CylOutsideCyl(&left->dim, &right->dim, &deadSpace) == true) {
                 Vec3f leftPos;
                 Vec3f rightPos;
 
@@ -2846,9 +2846,9 @@ void CollisionCheck_OC_CylVsCyl(GlobalContext* globalCtx, CollisionCheckContext*
  */
 s32 CollisionCheck_SkipOC(Collider* collider) {
     if (!(collider->ocFlags1 & OC1_ON)) {
-        return 1;
+        return true;
     }
-    return 0;
+    return false;
 }
 
 /**
@@ -2861,12 +2861,12 @@ s32 CollisionCheck_Incompatible(Collider* left, Collider* right) {
     if (!(left->ocFlags1 & right->ocFlags2 & OC1_TYPE_ALL) || !(left->ocFlags2 & right->ocFlags1 & OC1_TYPE_ALL) ||
         ((left->ocFlags2 & OC2_UNK1) && (right->ocFlags2 & OC2_UNK2)) ||
         ((right->ocFlags2 & OC2_UNK1) && (left->ocFlags2 & OC2_UNK2))) {
-        return 1;
+        return true;
     }
     if (left->actor == right->actor) {
-        return 1;
+        return true;
     }
-    return 0;
+    return false;
 }
 
 static ColChkVsFunc sOCVsFuncs[COLSHAPE_MAX][COLSHAPE_MAX] = {
@@ -2889,12 +2889,12 @@ void CollisionCheck_OC(GlobalContext* globalCtx, CollisionCheckContext* colChkCt
     ColChkVsFunc vsFunc;
 
     for (left = colChkCtx->colOC; left < colChkCtx->colOC + colChkCtx->colOCCount; left++) {
-        if (*left == NULL || CollisionCheck_SkipOC(*left) == 1) {
+        if (*left == NULL || CollisionCheck_SkipOC(*left) == true) {
             continue;
         }
         for (right = left + 1; right < colChkCtx->colOC + colChkCtx->colOCCount; right++) {
-            if (*right == NULL || CollisionCheck_SkipOC(*right) == 1 ||
-                CollisionCheck_Incompatible(*left, *right) == 1) {
+            if (*right == NULL || CollisionCheck_SkipOC(*right) == true ||
+                CollisionCheck_Incompatible(*left, *right) == true) {
                 continue;
             }
             vsFunc = sOCVsFuncs[(*left)->shape][(*right)->shape];
@@ -3143,7 +3143,7 @@ s32 CollisionCheck_LineOC(GlobalContext* globalCtx, CollisionCheckContext* colCh
     s32 result = 0;
 
     for (col = colChkCtx->colOC; col < colChkCtx->colOC + colChkCtx->colOCCount; col++) {
-        if (CollisionCheck_SkipOC(*col) == 1) {
+        if (CollisionCheck_SkipOC(*col) == true) {
             continue;
         }
         exclude = false;
@@ -3521,21 +3521,21 @@ s32 CollisionCheck_CylSideVsLineSeg(f32 radius, f32 height, f32 offset, Vec3f* a
             return 0;
         }
         if (SQ(actorDotItemXZ) - (4.0f * SQXZ(itemStep) * radSqDiff) > zero) {
-            intersect1 = intersect2 = 1;
+            intersect1 = intersect2 = true;
         } else {
-            intersect1 = 1;
-            intersect2 = 0;
+            intersect1 = true;
+            intersect2 = false;
         }
         closeDist = sqrtf(SQ(actorDotItemXZ) - (4.0f * SQXZ(itemStep) * radSqDiff));
-        if (intersect1 == 1) {
+        if (intersect1 == true) {
             frac1 = (closeDist - actorDotItemXZ) / (2.0f * SQXZ(itemStep));
         }
-        if (intersect2 == 1) {
+        if (intersect2 == true) {
             frac2 = (-actorDotItemXZ - closeDist) / (2.0f * SQXZ(itemStep));
         }
     } else if (!IS_ZERO(DOTXZ(2.0f * itemStep, actorToItem))) {
-        intersect1 = 1;
-        intersect2 = 0;
+        intersect1 = true;
+        intersect2 = false;
         frac1 = -radSqDiff / DOTXZ(2.0f * itemStep, actorToItem);
     } else {
         if (radSqDiff <= 0.0f) {
@@ -3559,7 +3559,7 @@ s32 CollisionCheck_CylSideVsLineSeg(f32 radius, f32 height, f32 offset, Vec3f* a
         return 0;
     }
 
-    if (intersect2 == 0) {
+    if (intersect2 == false) {
         if (frac1 < 0.0f || 1.0f < frac1) {
             return 0;
         }
@@ -3571,24 +3571,24 @@ s32 CollisionCheck_CylSideVsLineSeg(f32 radius, f32 height, f32 offset, Vec3f* a
             return 0;
         }
         if (test1) {
-            intersect1 = 0;
+            intersect1 = false;
         }
         if (test2) {
-            intersect2 = 0;
+            intersect2 = false;
         }
     }
 
-    if ((intersect1 == 1) &&
+    if ((intersect1 == true) &&
         ((frac1 * itemStep.y + actorToItem.y < 0.0f) || (height < frac1 * itemStep.y + actorToItem.y))) {
-        intersect1 = 0;
+        intersect1 = false;
     }
-    if ((intersect2 == 1) &&
+    if ((intersect2 == true) &&
         ((frac2 * itemStep.y + actorToItem.y < 0.0f) || (height < frac2 * itemStep.y + actorToItem.y))) {
-        intersect2 = 0;
+        intersect2 = false;
     }
-    if (intersect1 == 0 && intersect2 == 0) {
+    if (intersect1 == false && intersect2 == false) {
         return 0;
-    } else if ((intersect1 == 1) && (intersect2 == 1)) {
+    } else if ((intersect1 == true) && (intersect2 == true)) {
         out1->x = frac1 * itemStep.x + actorToItem.x + actorPos->x;
         out1->y = frac1 * itemStep.y + actorToItem.y + actorPos->y;
         out1->z = frac1 * itemStep.z + actorToItem.z + actorPos->z;
@@ -3596,12 +3596,12 @@ s32 CollisionCheck_CylSideVsLineSeg(f32 radius, f32 height, f32 offset, Vec3f* a
         out2->y = frac2 * itemStep.y + actorToItem.y + actorPos->y;
         out2->z = frac2 * itemStep.z + actorToItem.z + actorPos->z;
         return 2;
-    } else if (intersect1 == 1) {
+    } else if (intersect1 == true) {
         out1->x = frac1 * itemStep.x + actorToItem.x + actorPos->x;
         out1->y = frac1 * itemStep.y + actorToItem.y + actorPos->y;
         out1->z = frac1 * itemStep.z + actorToItem.z + actorPos->z;
         return 1;
-    } else if (intersect2 == 1) {
+    } else if (intersect2 == true) {
         out1->x = frac2 * itemStep.x + actorToItem.x + actorPos->x;
         out1->y = frac2 * itemStep.y + actorToItem.y + actorPos->y;
         out1->z = frac2 * itemStep.z + actorToItem.z + actorPos->z;


### PR DESCRIPTION
 - Changed `COLSHAPE_INVALID` to `COLSHAPE_MAX` and used it more, in particular to enforce sizes of arrays that are accessed using the `shape` collider struct field
 - Named more static variables

Added in review:
 - Used `true`/`false` more
 - `SAC_ON` define for `sacFlags`