### PR TITLE
Define gMorphaAndPoolWaterTex to remove unknown bytes.

### DIFF
--- a/assets/xml/objects/object_mo.xml
+++ b/assets/xml/objects/object_mo.xml
@@ -50,7 +50,7 @@
         <DList Name="gMorphaTentaclePart38DL" Offset="0x87A8"/>
         <DList Name="gMorphaTentaclePart39DL" Offset="0x87F0"/>
         <DList Name="gMorphaTentaclePart40DL" Offset="0x8838"/>
-        <Texture Name="gMorphaAndPoolWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
+        <Texture Name="gMorphaWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
 
         <!-- DLists for Morpha's particles -->
         <DList Name="gMorphaBubbleDL" Offset="0x140"/>

--- a/assets/xml/objects/object_mo.xml
+++ b/assets/xml/objects/object_mo.xml
@@ -50,6 +50,7 @@
         <DList Name="gMorphaTentaclePart38DL" Offset="0x87A8"/>
         <DList Name="gMorphaTentaclePart39DL" Offset="0x87F0"/>
         <DList Name="gMorphaTentaclePart40DL" Offset="0x8838"/>
+        <Texture Name="gMorphaAndPoolWaterTex" Format="rgba16" Width="32" Height="32" Offset="0x8870"/>
 
         <!-- DLists for Morpha's particles -->
         <DList Name="gMorphaBubbleDL" Offset="0x140"/>


### PR DESCRIPTION
Note that this texture should be exported as an rgba16.

But it's rendered twice in-game.
Rgba16 for the pool water.
i8 for the morpha tentacle base.