### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ The build process has the following package requirements:
 * build-essential
 * binutils-mips-linux-gnu
 * python3
+* python3-pip
 * libpng-dev
 
 Under Debian / Ubuntu (which we recommend using), you can install them with the following commands:
 
 ```bash
 sudo apt-get update
-sudo apt-get install git build-essential binutils-mips-linux-gnu python3 libpng-dev
+sudo apt-get install git build-essential binutils-mips-linux-gnu python3 python3-pip libpng-dev
 ```
 
 To install the Python dependencies simply run in a terminal:


### PR DESCRIPTION
The package `python3-pip` is needed in order to install the pip package "colorama" used by this project, yet, the README makes no mention of this. I had to install it in order to build this project on my copy of Ubuntu v20.04 inside WSL2, at the very least, and I've seen other people having to go out of their way to install said package as well.
This PR intends to correct that.