### PR TITLE
Don't use colorama anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,6 @@ sudo apt-get update
 sudo apt-get install git build-essential binutils-mips-linux-gnu python3 libpng-dev
 ```
 
-To install the Python dependencies simply run in a terminal:
-
-```bash
-python3 -m pip install colorama
-```
-
 If you are using GCC as the compiler for Ocarina of Time, you will also need:
 
 * gcc-mips-linux-gnu

--- a/docs/BUILDING_CYGWIN.md
+++ b/docs/BUILDING_CYGWIN.md
@@ -67,15 +67,7 @@ Add the new binutils binaries to your system PATH:
 - Scroll to the bottom and add `PATH=$PATH:/opt/cross/bin` to a new line and save the file
 - Run `source .bashrc` or close and reopen cygwin
 
-## 3. Install required Python packages
-
-To install the Python dependencies simply run in a terminal:
-
-```bash
-python3 -m pip install colorama
-```
-
-## 4. Continue with Linux instructions
+## 3. Continue with Linux instructions
 
 You should be able to continue from step [step 2](../README.md#2-clone-the-repository) of the Linux instructions.
 

--- a/docs/BUILDING_MACOS.md
+++ b/docs/BUILDING_MACOS.md
@@ -23,12 +23,6 @@ brew install coreutils make python3 libpng bash clang-format
 
 (The repository expects Homebrew-installed programs to be either linked correctly in `$PATH` etc. or in their default locations.)
 
-To install the Python dependencies simply run in a terminal:
-
-```bash
-python3 -m pip install colorama
-```
-
 
 ## 2. Building mips-linux-binutils
 

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 
-import argparse, json, os, signal, time, colorama, multiprocessing
+import argparse
+import json
+import os
+import signal
+import time
+import multiprocessing
 
-colorama.init()
 
 EXTRACTED_ASSETS_NAMEFILE = ".extracted-assets.json"
 
@@ -72,7 +76,7 @@ def processZAPDArgs(argsZ):
     badZAPDArg = False
     for z in argsZ:
         if z[0] == '-':
-            print(f"{colorama.Fore.LIGHTRED_EX}error{colorama.Fore.RESET}: argument \"{z}\" starts with \"-\", which is not supported.", file=os.sys.stderr)
+            print(f'error: argument "{z}" starts with "-", which is not supported.', file=os.sys.stderr)
             badZAPDArg = True
 
     if badZAPDArg:


### PR DESCRIPTION
Motivation: incidentally fixing #1186 (the building instructions don't mention needing `pip` to install `colorama`)

`colorama` is a Python package for printing messages with colors or as bold, underlined, etc. (and it also makes colors work in Windows prompts out of the box but we wouldn't really care imo)

-----------

Initially I wanted to make `colorama` optional instead, by using it (using colors) if it was present, and not using it (no colors) otherwise.
But I really don't like how it looked in the code, and also it's just for a single word that colorama is currently used.

So I ended up with ditching `colorama` entirely.

I wouldn't be opposed to someone in the future going through all tools and adding colored output everywhere (may be me, even), but that would require a strategy on how to make `colorama` optional.
Best option imo would be to not use `colorama` and have our own, single, `tools/ansi_color_codes.py` file with the color constants, unless we do care about supporting the Windows prompt (again, I don't :p)