### PR TITLE
Cleanup `pad`'s in z_scene_table.c

### DIFF
--- a/src/code/z_fbdemo_fade.c
+++ b/src/code/z_fbdemo_fade.c
@@ -26,7 +26,7 @@ void TransitionFade_Start(void* thisx) {
             this->fadeColor.a = 0;
             break;
     }
-    this->isDone = 0;
+    this->isDone = false;
 }
 
 void* TransitionFade_Init(void* thisx) {
@@ -51,7 +51,7 @@ void TransitionFade_Update(void* thisx, s32 updateRate) {
             this->fadeTimer += updateRate;
             if (this->fadeTimer >= gSaveContext.transFadeDuration) {
                 this->fadeTimer = gSaveContext.transFadeDuration;
-                this->isDone = 1;
+                this->isDone = true;
             }
             if (!gSaveContext.transFadeDuration) {
                 // "Divide by 0! Zero is included in ZCommonGet fade_speed"
@@ -72,7 +72,7 @@ void TransitionFade_Update(void* thisx, s32 updateRate) {
                     Math_StepToS(&iREG(50), 20, 60);
                     if (Math_StepToS(&newAlpha, 0, iREG(50))) {
                         iREG(50) = 0;
-                        this->isDone = 1;
+                        this->isDone = true;
                     }
                 }
             }

--- a/src/code/z_fbdemo_wipe1.c
+++ b/src/code/z_fbdemo_wipe1.c
@@ -63,19 +63,16 @@ void TransitionWipe_Destroy(void* thisx) {
 
 void TransitionWipe_Update(void* thisx, s32 updateRate) {
     TransitionWipe* this = (TransitionWipe*)thisx;
-    u8 speed;
 
     if (this->direction != 0) {
-        speed = gSaveContext.transWipeSpeed;
-        this->texY += (speed * 3) / updateRate;
+        this->texY += (((void)0, gSaveContext.transWipeSpeed) * 3) / updateRate;
         if (this->texY >= 0x264) {
             this->texY = 0x264;
             this->isDone = 1;
         }
     } else {
-        speed = gSaveContext.transWipeSpeed;
-        this->texY -= (speed * 3) / updateRate;
-        if (this->texY < 0x14E) {
+        this->texY -= (((void)0, gSaveContext.transWipeSpeed) * 3) / updateRate;
+        if (this->texY <= 0x14D) {
             this->texY = 0x14D;
             this->isDone = 1;
         }

--- a/src/code/z_fbdemo_wipe1.c
+++ b/src/code/z_fbdemo_wipe1.c
@@ -39,7 +39,7 @@ Gfx sWipeSyncDList[] = {
 void TransitionWipe_Start(void* thisx) {
     TransitionWipe* this = (TransitionWipe*)thisx;
 
-    this->isDone = 0;
+    this->isDone = false;
 
     if (this->direction) {
         this->texY = 0x14D;
@@ -68,13 +68,13 @@ void TransitionWipe_Update(void* thisx, s32 updateRate) {
         this->texY += (((void)0, gSaveContext.transWipeSpeed) * 3) / updateRate;
         if (this->texY >= 0x264) {
             this->texY = 0x264;
-            this->isDone = 1;
+            this->isDone = true;
         }
     } else {
         this->texY -= (((void)0, gSaveContext.transWipeSpeed) * 3) / updateRate;
         if (this->texY <= 0x14D) {
             this->texY = 0x14D;
-            this->isDone = 1;
+            this->isDone = true;
         }
     }
 }

--- a/src/code/z_scene_table.c
+++ b/src/code/z_scene_table.c
@@ -1852,9 +1852,7 @@ void func_800995DC(GlobalContext* globalCtx) {
     gDPPipeSync(POLY_XLU_DISP++);
     gDPSetEnvColor(POLY_XLU_DISP++, 128, 128, 128, 128);
 
-    { s32 pad; }
-
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(D_8012A2F8[gSaveContext.nightFlag]));
+    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(D_8012A2F8[((void)0, gSaveContext.nightFlag)]));
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 4783);
 }
@@ -1894,7 +1892,7 @@ void func_80099878(GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 4905);
 
     gameplayFrames = globalCtx->gameplayFrames;
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(gDCEntranceTextures[gSaveContext.nightFlag]));
+    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(gDCEntranceTextures[((void)0, gSaveContext.nightFlag)]));
     gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(sDCLavaFloorTextures[(s32)(gameplayFrames & 14) >> 1]));
     gSPSegment(POLY_XLU_DISP++, 0x09,
                Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, (gameplayFrames * 1) % 256, 0, 64, 32, 1, 0,
@@ -1902,8 +1900,6 @@ void func_80099878(GlobalContext* globalCtx) {
     gSPSegment(POLY_OPA_DISP++, 0x0A,
                Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 0, (gameplayFrames * 1) % 128, 32, 32, 1, 0,
                                 (gameplayFrames * 2) % 128, 32, 32));
-
-    { s32 pad2[2]; }
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
@@ -2147,9 +2143,8 @@ void func_8009AFE0(GlobalContext* globalCtx) {
     gameplayFrames = globalCtx->gameplayFrames;
     gSPSegment(POLY_OPA_DISP++, 0x09, Gfx_TexScroll(globalCtx->state.gfxCtx, 0, (gameplayFrames * 3) % 128, 32, 32));
 
-    { s32 pad[2]; }
-
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sThievesHideoutEntranceTextures[gSaveContext.nightFlag]));
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sThievesHideoutEntranceTextures[((void)0, gSaveContext.nightFlag)]));
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 5507);
 }
@@ -2173,7 +2168,7 @@ void func_8009B0FC(GlobalContext* globalCtx) {
     spAC = globalCtx->roomCtx.unk_74[1] & 0xFF;
     gameplayFrames = globalCtx->gameplayFrames;
 
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(D_8012A330[gSaveContext.nightFlag]));
+    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(D_8012A330[((void)0, gSaveContext.nightFlag)]));
 
     if (spB0 == 1) {
         gSPSegment(POLY_OPA_DISP++, 0x08,
@@ -2225,8 +2220,6 @@ void func_8009B0FC(GlobalContext* globalCtx) {
     gSPSegment(POLY_XLU_DISP++, 0x0D,
                Gfx_TwoTexScrollEnvColor(globalCtx->state.gfxCtx, 0, gameplayFrames * 4, 0, 32, 32, 1,
                                         gameplayFrames * 4, 0, 32, 32, 0, 0, 0, 128));
-
-    { s32 pad[2]; }
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 5644);
 }
@@ -2404,15 +2397,14 @@ void func_8009C3EC(GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 6042);
 
     gameplayFrames = globalCtx->gameplayFrames;
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sIceCavernEntranceTextures[gSaveContext.nightFlag]));
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sIceCavernEntranceTextures[((void)0, gSaveContext.nightFlag)]));
     gSPSegment(POLY_OPA_DISP++, 0x09,
                Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 127 - gameplayFrames % 128, (gameplayFrames * 1) % 128, 32,
                                 32, 1, gameplayFrames % 128, (gameplayFrames * 1) % 128, 32, 32));
     gSPSegment(POLY_XLU_DISP++, 0x0A,
                Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 127 - gameplayFrames % 128, (gameplayFrames * 1) % 128, 32,
                                 32, 1, gameplayFrames % 128, (gameplayFrames * 1) % 128, 32, 32));
-
-    { s32 pad[2]; }
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
@@ -2508,15 +2500,13 @@ void func_8009CC00(GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 6290);
 
     gameplayFrames = globalCtx->gameplayFrames;
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sGTGEntranceTextures[gSaveContext.nightFlag]));
+    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sGTGEntranceTextures[((void)0, gSaveContext.nightFlag)]));
     gSPSegment(POLY_OPA_DISP++, 0x09,
                Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 127 - gameplayFrames % 128, (gameplayFrames * 1) % 128, 32,
                                 32, 1, gameplayFrames % 128, (gameplayFrames * 1) % 128, 32, 32));
     gSPSegment(POLY_XLU_DISP++, 0x0A,
                Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 127 - gameplayFrames % 128, (gameplayFrames * 1) % 128, 32,
                                 32, 1, gameplayFrames % 128, (gameplayFrames * 1) % 128, 32, 32));
-
-    { s32 pad[2]; }
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
@@ -2602,9 +2592,8 @@ void* sLonLonHouseEntranceTextures[] = {
 void func_8009D31C(GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 6515);
 
-    { s32 pad[2]; }
-
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sLonLonHouseEntranceTextures[gSaveContext.nightFlag]));
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sLonLonHouseEntranceTextures[((void)0, gSaveContext.nightFlag)]));
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
@@ -2678,20 +2667,19 @@ void* sForestTempleEntranceTextures[] = {
 void func_8009D758(GlobalContext* globalCtx) {
     u32 gameplayFrames;
 
-    if (0) {} // Necessary to match
+    if (1) {} // Necessary to match
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 6640);
 
     gameplayFrames = globalCtx->gameplayFrames;
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sForestTempleEntranceTextures[gSaveContext.nightFlag]));
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sForestTempleEntranceTextures[((void)0, gSaveContext.nightFlag)]));
     gSPSegment(POLY_XLU_DISP++, 0x09,
                Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 127 - gameplayFrames % 128, (gameplayFrames * 1) % 128, 32,
                                 32, 1, gameplayFrames % 128, (gameplayFrames * 1) % 128, 32, 32));
     gSPSegment(POLY_OPA_DISP++, 0x0A,
                Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 127 - gameplayFrames % 128, (gameplayFrames * 1) % 128, 32,
                                 32, 1, gameplayFrames % 128, (gameplayFrames * 1) % 128, 32, 32));
-
-    { s32 pad[2]; }
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
@@ -2711,9 +2699,8 @@ void* sSpiritTempleEntranceTextures[] = {
 void func_8009D974(GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 6752);
 
-    { s32 pad[2]; }
-
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sSpiritTempleEntranceTextures[gSaveContext.nightFlag]));
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sSpiritTempleEntranceTextures[((void)0, gSaveContext.nightFlag)]));
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 6762);
 }
@@ -2773,9 +2760,7 @@ void* sKakarikoWindowTextures[] = {
 void func_8009DD5C(GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 6890);
 
-    { s32 pad[2]; }
-
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sKakarikoWindowTextures[gSaveContext.nightFlag]));
+    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sKakarikoWindowTextures[((void)0, gSaveContext.nightFlag)]));
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
@@ -2914,9 +2899,8 @@ void func_8009E730(GlobalContext* globalCtx) {
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
 
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sZorasDomainEntranceTextures[gSaveContext.nightFlag]));
-
-    { s32 pad[2]; }
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sZorasDomainEntranceTextures[((void)0, gSaveContext.nightFlag)]));
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 7147);
 }
@@ -3042,9 +3026,7 @@ void* D_8012A380[] = {
 void func_8009F1B4(GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 7363);
 
-    { s32 pad[2]; }
-
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(D_8012A380[gSaveContext.nightFlag]));
+    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(D_8012A380[((void)0, gSaveContext.nightFlag)]));
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 7371);
 }
@@ -3177,9 +3159,8 @@ void func_8009F9D0(GlobalContext* globalCtx) {
     gDPPipeSync(POLY_XLU_DISP++);
     gDPSetEnvColor(POLY_XLU_DISP++, 128, 128, 128, 128);
 
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sGoronCityEntranceTextures[gSaveContext.nightFlag]));
-
-    { s32 pad[2]; }
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sGoronCityEntranceTextures[((void)0, gSaveContext.nightFlag)]));
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 7578);
 }
@@ -3193,9 +3174,8 @@ void* sLonLonRanchWindowTextures[] = {
 void func_8009FB74(GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 7602);
 
-    { s32 pad[2]; }
-
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sLonLonRanchWindowTextures[gSaveContext.nightFlag]));
+    gSPSegment(POLY_OPA_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sLonLonRanchWindowTextures[((void)0, gSaveContext.nightFlag)]));
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);

--- a/src/code/z_scene_table.c
+++ b/src/code/z_scene_table.c
@@ -2667,7 +2667,7 @@ void* sForestTempleEntranceTextures[] = {
 void func_8009D758(GlobalContext* globalCtx) {
     u32 gameplayFrames;
 
-    if (1) {} // Necessary to match
+    if (0) {} // Necessary to match
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_scene_table.c", 6640);
 

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1072,12 +1072,10 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, GlobalContext* globalCtx, Player* play
 
 void func_80A45288(EnGo2* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
-    s32 linkAge;
 
     if (this->actionFunc != EnGo2_GoronFireGenericAction) {
         this->unk_194.unk_18 = player->actor.world.pos;
-        linkAge = gSaveContext.linkAge;
-        this->unk_194.unk_14 = D_80A482D8[this->actor.params & 0x1F][linkAge];
+        this->unk_194.unk_14 = D_80A482D8[this->actor.params & 0x1F][((void)0, gSaveContext.linkAge)];
         func_80034A14(&this->actor, &this->unk_194, 4, this->unk_26E);
     }
     if ((this->actionFunc != EnGo2_SetGetItem) && (this->isAwake == true)) {


### PR DESCRIPTION
All the required `pad`'s floating around in `z_scene_table.c` seem to be from a lack of a `(void)0` access of `gSaveContext.nightFlag`.

I also added `(void)0` access to both a `gSaveContext.transWipeSpeed` and a `gSaveContext.linkAge` to save a temp, which I'm not sure if that's preferred and can easily revert that.