### PR TITLE
Remove many redundant parentheses (eg. in boolean conditions)

### DIFF
--- a/src/code/ucode_disas.c
+++ b/src/code/ucode_disas.c
@@ -716,7 +716,7 @@ void UCodeDisas_Disassemble(UCodeDisas* this, GfxMod* ptr) {
                           : (setscissor.pad == G_SC_EVEN_INTERLACE) ? "G_SC_EVEN_INTERLACE"
                                                                     : "???";
 
-                if ((setscissor.x0frac | setscissor.y0frac | setscissor.x1frac | setscissor.y1frac)) {
+                if (setscissor.x0frac | setscissor.y0frac | setscissor.x1frac | setscissor.y1frac) {
                     if (1) {}
                     DISAS_LOG("gsDPSetScissorFrac(%s, %d, %d, %d, %d),", modeStr,
                               (setscissor.x0 << 2) + setscissor.x0frac, (setscissor.y0 << 2) + setscissor.y0frac,
@@ -1189,7 +1189,7 @@ void UCodeDisas_Disassemble(UCodeDisas* this, GfxMod* ptr) {
                                     } break;
 
                                     case G_MV_LIGHT: {
-                                        switch ((movemem.offset * 8)) {
+                                        switch (movemem.offset * 8) {
                                             case G_MVO_LOOKATX: {
                                                 DISAS_LOG("gsSPLookAtX(0x%08x),", movemem.data);
                                             } break;

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -353,7 +353,7 @@ void func_8002C124(TargetContext* targetCtx, GlobalContext* globalCtx) {
 
         func_8002BE64(targetCtx, targetCtx->unk_4C, projTargetCenter.x, projTargetCenter.y, projTargetCenter.z);
 
-        if ((!(player->stateFlags1 & PLAYER_STATE1_6)) || (actor != player->unk_664)) {
+        if (!(player->stateFlags1 & PLAYER_STATE1_6) || (actor != player->unk_664)) {
             OVERLAY_DISP = Gfx_CallSetupDL(OVERLAY_DISP, 0x39);
 
             for (spB0 = 0, spAC = targetCtx->unk_4C; spB0 < spB8; spB0++, spAC = (spAC + 1) % 3) {
@@ -3888,7 +3888,7 @@ s16 func_80034DD4(Actor* actor, GlobalContext* globalCtx, s16 arg2, f32 arg3) {
     Player* player = GET_PLAYER(globalCtx);
     f32 var;
 
-    if ((globalCtx->csCtx.state != CS_STATE_IDLE) || (gDbgCamEnabled)) {
+    if ((globalCtx->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) {
         var = Math_Vec3f_DistXYZ(&actor->world.pos, &globalCtx->view.eye) * 0.25f;
     } else {
         var = Math_Vec3f_DistXYZ(&actor->world.pos, &player->actor.world.pos);
@@ -5550,7 +5550,7 @@ s32 func_80038154(GlobalContext* globalCtx, Actor* actor, Vec3s* arg2, Vec3s* ar
     actor->focus.pos = actor->world.pos;
     actor->focus.pos.y += arg4;
 
-    if (!(((globalCtx->csCtx.state != CS_STATE_IDLE) || (gDbgCamEnabled)) &&
+    if (!(((globalCtx->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) &&
           (gSaveContext.entranceIndex == ENTR_SPOT04_0))) {
         var = actor->yawTowardsPlayer - actor->shape.rot.y;
         abs_var = ABS(var);
@@ -5560,7 +5560,7 @@ s32 func_80038154(GlobalContext* globalCtx, Actor* actor, Vec3s* arg2, Vec3s* ar
         }
     }
 
-    if (((globalCtx->csCtx.state != CS_STATE_IDLE) || (gDbgCamEnabled)) &&
+    if (((globalCtx->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) &&
         (gSaveContext.entranceIndex == ENTR_SPOT04_0)) {
         sp2C = globalCtx->view.eye;
     } else {
@@ -5581,7 +5581,7 @@ s32 func_80038290(GlobalContext* globalCtx, Actor* actor, Vec3s* arg2, Vec3s* ar
 
     actor->focus.pos = arg4;
 
-    if (!(((globalCtx->csCtx.state != CS_STATE_IDLE) || (gDbgCamEnabled)) &&
+    if (!(((globalCtx->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) &&
           (gSaveContext.entranceIndex == ENTR_SPOT04_0))) {
         var = actor->yawTowardsPlayer - actor->shape.rot.y;
         abs_var = ABS(var);
@@ -5591,7 +5591,7 @@ s32 func_80038290(GlobalContext* globalCtx, Actor* actor, Vec3s* arg2, Vec3s* ar
         }
     }
 
-    if (((globalCtx->csCtx.state != CS_STATE_IDLE) || (gDbgCamEnabled)) &&
+    if (((globalCtx->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) &&
         (gSaveContext.entranceIndex == ENTR_SPOT04_0)) {
         sp24 = globalCtx->view.eye;
     } else {

--- a/src/code/z_bgcheck.c
+++ b/src/code/z_bgcheck.c
@@ -2920,7 +2920,7 @@ void func_8003F8EC(GlobalContext* globalCtx, DynaCollisionContext* dyna, Actor* 
     s32 i;
 
     for (i = 0; i < BG_ACTOR_MAX; i++) {
-        if ((dyna->bgActorFlags[i] & 1)) {
+        if (dyna->bgActorFlags[i] & 1) {
             dynaActor = DynaPoly_GetActor(&globalCtx->colCtx, i);
             if (dynaActor != NULL && &dynaActor->actor == actor) {
                 func_800434A0((DynaPolyActor*)actor);
@@ -4245,7 +4245,7 @@ s32 WaterBox_GetSurface2(GlobalContext* globalCtx, CollisionContext* colCtx, Vec
         if (!(room == globalCtx->roomCtx.curRoom.num || room == 0x3F)) {
             continue;
         }
-        if ((waterBox->properties & 0x80000)) {
+        if (waterBox->properties & 0x80000) {
             continue;
         }
         if (!(waterBox->xMin < pos->x && pos->x < waterBox->xMin + waterBox->xLength)) {

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -1604,7 +1604,7 @@ s32 Camera_Normal1(Camera* camera) {
     }
 
     Camera_Vec3fVecSphGeoAdd(eyeNext, at, &eyeAdjustment);
-    if ((camera->status == CAM_STAT_ACTIVE) && (!(roData->interfaceFlags & 0x10))) {
+    if ((camera->status == CAM_STAT_ACTIVE) && !(roData->interfaceFlags & 0x10)) {
         rwData->swingYawTarget = BINANG_ROT180(camera->playerPosRot.rot.y);
         if (rwData->startSwingTimer > 0) {
             func_80046E20(camera, &eyeAdjustment, roData->distMin, roData->unk_0C, &sp98, &rwData->swing);
@@ -4881,7 +4881,7 @@ s32 Camera_Unique0(Camera* camera) {
         if (rwData->animTimer > 0) {
             rwData->animTimer--;
             rwData->initalPos = playerPosRot->pos;
-        } else if ((!(player->stateFlags1 & PLAYER_STATE1_29)) &&
+        } else if (!(player->stateFlags1 & PLAYER_STATE1_29) &&
                    ((OLib_Vec3fDistXZ(&playerPosRot->pos, &rwData->initalPos) >= 10.0f) ||
                     CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_A) ||
                     CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_B) ||
@@ -4909,7 +4909,7 @@ s32 Camera_Unique0(Camera* camera) {
             rwData->initalPos = playerPosRot->pos;
         }
 
-        if ((!(player->stateFlags1 & PLAYER_STATE1_29)) &&
+        if (!(player->stateFlags1 & PLAYER_STATE1_29) &&
             ((0.001f < camera->xzSpeed) || CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_A) ||
              CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_B) ||
              CHECK_BTN_ALL(D_8015BD7C->state.input[0].press.button, BTN_CLEFT) ||
@@ -7444,7 +7444,7 @@ Vec3s Camera_Update(Camera* camera) {
                 camera->nextCamDataIdx = -1;
             }
 
-            if ((camera->unk_14C & 1) && (camera->unk_14C & 4) && (!(camera->unk_14C & 0x400)) &&
+            if ((camera->unk_14C & 1) && (camera->unk_14C & 4) && !(camera->unk_14C & 0x400) &&
                 (!(camera->unk_14C & 0x200) || (player->currentBoots == PLAYER_BOOTS_IRON)) &&
                 (!(camera->unk_14C & (s16)0x8000)) && (playerGroundY != BGCHECK_Y_MIN)) {
                 camDataIdx = Camera_GetDataIdxForPoly(camera, &bgId, playerFloorPoly);
@@ -7833,7 +7833,7 @@ s16 Camera_ChangeSettingFlags(Camera* camera, s16 setting, s16 flags) {
         return -99;
     }
 
-    if ((setting == camera->setting) && (!(flags & 1))) {
+    if ((setting == camera->setting) && !(flags & 1)) {
         camera->unk_14A |= 0x10;
         if (!(flags & 2)) {
             camera->unk_14A |= 1;

--- a/src/code/z_debug.c
+++ b/src/code/z_debug.c
@@ -67,7 +67,7 @@ void func_8006376C(u8 x, u8 y, u8 colorId, const char* text) {
 
         i = 0;
         bufText = buf->text;
-        while ((*bufText++ = *text++)) {
+        while ((*bufText++ = *text++) != 0) {
             if (i++ > 0x14) {
                 break;
             }

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -3711,7 +3711,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
                                                                        &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                                             }
                                         } else if (gSaveContext.timer2Value > 10) {
-                                            if ((timerDigits[4] & 1)) {
+                                            if (timerDigits[4] & 1) {
                                                 Audio_PlaySoundGeneral(NA_SE_SY_WARNING_COUNT_N, &gSfxDefaultPos, 4,
                                                                        &gSfxDefaultFreqAndVolScale,
                                                                        &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -1043,7 +1043,7 @@ skip:
         LOG_NUM("1", 1, "../z_play.c", 3801);
     }
 
-    if ((sp80 == 0) || (gDbgCamEnabled)) {
+    if ((sp80 == 0) || gDbgCamEnabled) {
         s32 pad3[5];
         s32 i;
 

--- a/src/code/z_vimode.c
+++ b/src/code/z_vimode.c
@@ -56,7 +56,7 @@ void ViMode_Configure(ViMode* viMode, s32 mode, s32 type, s32 unk_70, s32 unk_74
     unk_top &= ~1;
     unk_bottom &= ~1;
 
-    yScaleLo = (cond_4C ? 2 : 1) * (((height << 11)) / (SCREEN_HEIGHT * 2 + unk_bottom - unk_top) / (unk_70 ? 1 : 2));
+    yScaleLo = (cond_4C ? 2 : 1) * ((height << 11) / (SCREEN_HEIGHT * 2 + unk_bottom - unk_top) / (unk_70 ? 1 : 2));
 
     yScaleHi0 = not_78 ? (cond_40 ? 0x1000000 : 0x2000000) : 0;
     yScaleHi1 = not_78 ? (cond_40 ? 0x3000000 : 0x2000000) : 0;

--- a/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.c
@@ -89,7 +89,7 @@ void func_80886FCC(BgHidanFslift* this, GlobalContext* globalCtx) {
         if ((this->dyna.actor.world.pos.y - this->dyna.actor.home.pos.y) < 0.5f) {
             heightBool = true;
         }
-        if (func_80043590(&this->dyna) && (heightBool)) {
+        if (func_80043590(&this->dyna) && heightBool) {
             this->actionFunc = func_808870D8;
         } else if (!heightBool) {
             this->actionFunc = func_8088706C;

--- a/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
@@ -137,7 +137,7 @@ void BgJyaLift_Update(Actor* thisx, GlobalContext* globalCtx2) {
     }
     if ((this->dyna.unk_160 & 4) && ((this->unk_16B & 4) == 0)) {
         Camera_ChangeSetting(globalCtx->cameraPtrs[MAIN_CAM], CAM_SET_DIRECTED_YAW);
-    } else if (((this->dyna.unk_160) & 4) == 0 && ((this->unk_16B & 4)) &&
+    } else if (((this->dyna.unk_160) & 4) == 0 && (this->unk_16B & 4) &&
                (globalCtx->cameraPtrs[MAIN_CAM]->setting == CAM_SET_DIRECTED_YAW)) {
         Camera_ChangeSetting(globalCtx->cameraPtrs[MAIN_CAM], CAM_SET_DUNGEON0);
     }

--- a/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.c
+++ b/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.c
@@ -92,7 +92,7 @@ void BgTreemouth_Destroy(Actor* thisx, GlobalContext* globalCtx) {
 void func_808BC65C(BgTreemouth* this, GlobalContext* globalCtx) {
     CsCmdActorAction* npcAction;
 
-    if ((globalCtx->csCtx.state != CS_STATE_IDLE)) {
+    if (globalCtx->csCtx.state != CS_STATE_IDLE) {
         npcAction = globalCtx->csCtx.npcActions[0];
         if (npcAction != NULL) {
             if (npcAction->action == 2) {

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -4523,7 +4523,7 @@ void func_808E2544(Actor* thisx, GlobalContext* globalCtx) {
         xzDist = (this->unk_1C2 == 0xC) ? -65.0f : 0.0f;
 
         if ((fabsf(this->actor.world.pos.x) > (465.0f + xzDist)) ||
-            (fabsf(this->actor.world.pos.z) > (465.0f + xzDist)) || ((this->actor.world.pos.y < 0.0f)) ||
+            (fabsf(this->actor.world.pos.z) > (465.0f + xzDist)) || (this->actor.world.pos.y < 0.0f) ||
             (this->actor.world.pos.y > 450.0f)) {
             this->unk_1C2 = 1;
             this->actor.speedXZ = 0.0f;

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -2869,7 +2869,7 @@ void BossGanon2_UpdateEffects(BossGanon2* this, GlobalContext* globalCtx) {
                             effect->type = 0;
                         }
                     }
-                } else if ((effect->position.y < 0.0f)) {
+                } else if (effect->position.y < 0.0f) {
                     effect->type = 0;
                 }
             }

--- a/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
+++ b/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
@@ -833,7 +833,7 @@ void func_8096F2B0(DemoEc* this, GlobalContext* globalCtx, s32 arg2) {
 
     if (npcAction != NULL) {
         sp18 = npcAction->action;
-        if ((sp18 != this->npcAction)) {
+        if (sp18 != this->npcAction) {
             if (this->npcAction) {}
             if (sp18 == 2) {
                 func_8096F224(this, globalCtx);
@@ -906,7 +906,7 @@ void func_8096F578(DemoEc* this, GlobalContext* globalCtx, s32 arg2) {
     npcAction = DemoEc_GetNpcAction(globalCtx, arg2);
     if (npcAction != NULL) {
         sp18 = npcAction->action;
-        if ((sp18 != this->npcAction)) {
+        if (sp18 != this->npcAction) {
             if (this->npcAction) {}
             if (sp18 == 2) {
                 func_8096F4FC(this, globalCtx);

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -287,7 +287,7 @@ void EnArrow_Fly(EnArrow* this, GlobalContext* globalCtx) {
             if (atTouched && (this->collider.info.atHitInfo->elemType != ELEMTYPE_UNK4)) {
                 hitActor = this->collider.base.at;
 
-                if ((hitActor->update != NULL) && (!(this->collider.base.atFlags & AT_BOUNCED)) &&
+                if ((hitActor->update != NULL) && !(this->collider.base.atFlags & AT_BOUNCED) &&
                     (hitActor->flags & ACTOR_FLAG_14)) {
                     this->hitActor = hitActor;
                     EnArrow_CarryActor(this, globalCtx);

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -167,7 +167,7 @@ void func_809DF494(EnCow* this, GlobalContext* globalCtx) {
                          Animation_GetLastFrame(&gCowBodyChewAnim), ANIMMODE_ONCE, 1.0f);
     }
 
-    if ((this->actor.xzDistToPlayer < 150.0f) && (!(this->unk_276 & 2))) {
+    if ((this->actor.xzDistToPlayer < 150.0f) && !(this->unk_276 & 2)) {
         this->unk_276 |= 2;
         if (this->skelAnime.animation == &gCowBodyChewAnim) {
             this->unk_278 = 0;
@@ -284,7 +284,7 @@ void func_809DFA84(EnCow* this, GlobalContext* globalCtx) {
     }
 
     if ((this->actor.xzDistToPlayer < 150.0f) &&
-        (ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) >= 0x61A9) && (!(this->unk_276 & 2))) {
+        (ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) >= 0x61A9) && !(this->unk_276 & 2)) {
         this->unk_276 |= 2;
         if (this->skelAnime.animation == &gCowTailIdleAnim) {
             this->unk_278 = 0;

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -259,7 +259,7 @@ void EnCrow_FlyIdle(EnCrow* this, GlobalContext* globalCtx) {
         this->aimRotX = 0x800 + (Rand_ZeroOne() * 0x800);
     }
 
-    if ((Math_SmoothStepToS(&this->actor.shape.rot.x, this->aimRotX, 10, 0x100, 8) == 0) && (skelanimeUpdated) &&
+    if ((Math_SmoothStepToS(&this->actor.shape.rot.x, this->aimRotX, 10, 0x100, 8) == 0) && skelanimeUpdated &&
         (Rand_ZeroOne() < 0.1f)) {
         if (this->actor.home.pos.y < this->actor.world.pos.y) {
             this->aimRotX -= (0x400 * Rand_ZeroOne()) + 0x400;

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -241,12 +241,12 @@ void EnFu_Update(Actor* thisx, GlobalContext* globalCtx) {
     CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
     Actor_MoveForward(&this->actor);
     Actor_UpdateBgCheckInfo(globalCtx, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
-    if ((!(this->behaviorFlags & FU_WAIT)) && (SkelAnime_Update(&this->skelanime) != 0)) {
+    if (!(this->behaviorFlags & FU_WAIT) && (SkelAnime_Update(&this->skelanime) != 0)) {
         Animation_Change(&this->skelanime, this->skelanime.animation, 1.0f, 0.0f,
                          Animation_GetLastFrame(this->skelanime.animation), ANIMMODE_ONCE, 0.0f);
     }
     this->actionFunc(this, globalCtx);
-    if ((this->behaviorFlags & FU_RESET_LOOK_ANGLE)) {
+    if (this->behaviorFlags & FU_RESET_LOOK_ANGLE) {
         Math_SmoothStepToS(&this->lookAngleOffset.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->lookAngleOffset.y, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->unk_2A2.x, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -1171,7 +1171,7 @@ void EnGeldB_Block(EnGeldB* this, GlobalContext* globalCtx) {
         if (player->meleeWeaponAnimation == PLAYER_MWA_JUMPSLASH_START) {
             EnGeldB_SetupSpinDodge(this, globalCtx);
         } else if (!EnGeldB_DodgeRanged(globalCtx, this)) {
-            if ((globalCtx->gameplayFrames & 1)) {
+            if (globalCtx->gameplayFrames & 1) {
                 if ((this->actor.xzDistToPlayer < 100.0f) && (Rand_ZeroOne() > 0.7f)) {
                     EnGeldB_SetupJump(this);
                 } else {

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -546,7 +546,7 @@ s32 EnGo_IsRollingOnGround(EnGo* this, s16 unkArg1, f32 unkArg2) {
     } else if (this->unk_1E0.unk_00 != 0) {
         return true;
     } else if (DECR(this->unk_21C)) {
-        if ((this->unk_21C & 1)) {
+        if (this->unk_21C & 1) {
             this->actor.world.pos.y += 1.5f;
         } else {
             this->actor.world.pos.y -= 1.5f;

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -500,7 +500,7 @@ void func_80A53F30(EnHeishi2* this, GlobalContext* globalCtx) {
     if ((this->unk_2F2[0] == 0) || (gate->openingState == 0)) {
         Gameplay_ClearCamera(globalCtx, this->cameraId);
         Gameplay_ChangeCameraStatus(globalCtx, MAIN_CAM, CAM_STAT_ACTIVE);
-        if ((this->unk_30A != 2)) {
+        if (this->unk_30A != 2) {
             if (this->unk_30A == 0) {
                 this->actor.textId = 0x2015;
                 Message_ContinueTextbox(globalCtx, this->actor.textId);

--- a/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
+++ b/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
@@ -150,7 +150,7 @@ void EnHeishi3_StandSentinelInCastle(EnHeishi3* this, GlobalContext* globalCtx) 
         (fabsf(player->actor.world.pos.y - this->actor.world.pos.y) < 100.0f) &&
         (player->actor.world.pos.z < 1020.0f) && (player->actor.world.pos.z > 700.0f) && (sPlayerCaught == 0)) {
         if (this->unk_278 == 1) {
-            if ((player->actor.world.pos.x < -290.0f)) {
+            if (player->actor.world.pos.x < -290.0f) {
                 return;
             }
         } else {

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -2988,7 +2988,7 @@ void EnHorse_CheckFloors(EnHorse* this, GlobalContext* globalCtx) {
         if (ny < 0.81915206f || // cos(35 degrees)
             SurfaceType_IsHorseBlocked(&globalCtx->colCtx, this->actor.floorPoly, this->actor.floorBgId) ||
             func_80041D4C(&globalCtx->colCtx, this->actor.floorPoly, this->actor.floorBgId) == 7) {
-            if ((this->actor.speedXZ >= 0.0f)) {
+            if (this->actor.speedXZ >= 0.0f) {
                 EnHorse_ObstructMovement(this, globalCtx, 4, galloping);
             } else {
                 EnHorse_ObstructMovement(this, globalCtx, 5, galloping);

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -97,7 +97,7 @@ u16 func_80AA2AA0(GlobalContext* globalCtx, Actor* thisx) {
             return 0x2004;
         }
     }
-    if ((!(player->stateFlags1 & PLAYER_STATE1_23)) &&
+    if (!(player->stateFlags1 & PLAYER_STATE1_23) &&
         (Actor_FindNearby(globalCtx, thisx, ACTOR_EN_HORSE, 1, 1200.0f) == NULL)) {
         return 0x2001;
     }

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -291,7 +291,7 @@ void EnMk_Update(Actor* thisx, GlobalContext* globalCtx) {
     Actor_MoveForward(&this->actor);
     Actor_UpdateBgCheckInfo(globalCtx, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
 
-    if ((!(this->flags & 2)) && (SkelAnime_Update(&this->skelAnime))) {
+    if (!(this->flags & 2) && (SkelAnime_Update(&this->skelAnime))) {
         this->flags |= 2;
     }
 
@@ -332,7 +332,7 @@ void EnMk_Update(Actor* thisx, GlobalContext* globalCtx) {
                 if (this->swimFlag < swimFlag) {
                     this->swimFlag = swimFlag;
 
-                    if ((!(this->flags & 4)) && (this->swimFlag >= 8)) {
+                    if (!(this->flags & 4) && (this->swimFlag >= 8)) {
                         this->flags |= 4;
                         func_80078884(NA_SE_SY_CORRECT_CHIME);
                     }

--- a/src/overlays/actors/ovl_En_Sb/z_en_sb.c
+++ b/src/overlays/actors/ovl_En_Sb/z_en_sb.c
@@ -371,13 +371,13 @@ s32 EnSb_UpdateDamage(EnSb* this, GlobalContext* globalCtx) {
     u8 hitByWindArrow;
 
     // hit box collided, switch to cool down
-    if ((this->collider.base.atFlags & AT_HIT)) {
+    if (this->collider.base.atFlags & AT_HIT) {
         EnSb_SetupCooldown(this, 1);
         return 1;
     }
 
     // hurt box collided, take damage if appropriate
-    if ((this->collider.base.acFlags & AC_HIT)) {
+    if (this->collider.base.acFlags & AC_HIT) {
         hitByWindArrow = false;
         tookDamage = false;
         this->collider.base.acFlags &= ~AC_HIT;

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.c
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.c
@@ -527,7 +527,7 @@ s32 EnSkb_OverrideLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList,
     if (limbIndex == 11) {
         if ((this->unk_283 & 2) == 0) {
             OPEN_DISPS(globalCtx->state.gfxCtx, "../z_en_skb.c", 972);
-            color = ABS((s16)(Math_SinS((globalCtx->gameplayFrames * 0x1770)) * 95.0f)) + 160;
+            color = ABS((s16)(Math_SinS(globalCtx->gameplayFrames * 0x1770) * 95.0f)) + 160;
             gDPPipeSync(POLY_OPA_DISP++);
             gDPSetEnvColor(POLY_OPA_DISP++, color, color, color, 255);
             CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_en_skb.c", 978);

--- a/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -1790,7 +1790,7 @@ void EnTest_Update(Actor* thisx, GlobalContext* globalCtx) {
         CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this->bodyCollider.base);
 
         if ((this->unk_7C8 >= 0xA) &&
-            ((this->actor.colorFilterTimer == 0) || (!(this->actor.colorFilterParams & 0x4000)))) {
+            ((this->actor.colorFilterTimer == 0) || !(this->actor.colorFilterParams & 0x4000))) {
             CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->bodyCollider.base);
         }
 

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -565,7 +565,7 @@ void EnTite_MoveTowardPlayer(EnTite* this, GlobalContext* globalCtx) {
         // Idle or turn if player is too far away, otherwise keep jumping
         if (((this->actor.xzDistToPlayer > 300.0f) && (this->actor.yDistToPlayer > 80.0f))) {
             EnTite_SetupIdle(this);
-        } else if (((this->actor.xzDistToPlayer <= 180.0f)) && ((this->actor.yDistToPlayer <= 80.0f))) {
+        } else if ((this->actor.xzDistToPlayer <= 180.0f) && (this->actor.yDistToPlayer <= 80.0f)) {
             if (this->vQueuedJumps <= 0) {
                 EnTite_SetupTurnTowardPlayer(this);
             } else {

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -258,7 +258,7 @@ s32 func_80B206A0(EnToryo* this, GlobalContext* globalCtx) {
     s32 ret = textId;
 
     if (textId == 0) {
-        if ((this->stateFlags & 1)) {
+        if (this->stateFlags & 1) {
             if (CHECK_FLAG_ALL(gSaveContext.eventChkInf[EVENTCHKINF_90_91_92_93_INDEX],
                                EVENTCHKINF_90_MASK | EVENTCHKINF_91_MASK | EVENTCHKINF_92_MASK | EVENTCHKINF_93_MASK)) {
                 ret = 0x606C;
@@ -267,7 +267,7 @@ s32 func_80B206A0(EnToryo* this, GlobalContext* globalCtx) {
             } else {
                 ret = 0x606A;
             }
-        } else if ((this->stateFlags & 2)) {
+        } else if (this->stateFlags & 2) {
             if (GET_INFTABLE(INFTABLE_172)) {
                 ret = 0x5029;
             } else {
@@ -275,7 +275,7 @@ s32 func_80B206A0(EnToryo* this, GlobalContext* globalCtx) {
             }
         } else {
             ret = textId;
-            if ((this->stateFlags & 4)) {
+            if (this->stateFlags & 4) {
                 ret = 0x506C;
             }
         }
@@ -358,12 +358,12 @@ void EnToryo_Update(Actor* thisx, GlobalContext* globalCtx) {
 
     this->actionFunc(this, globalCtx);
 
-    if ((this->stateFlags & 8)) {
+    if (this->stateFlags & 8) {
         this->unk_1EC.unk_18.x = player->actor.focus.pos.x;
         this->unk_1EC.unk_18.y = player->actor.focus.pos.y;
         this->unk_1EC.unk_18.z = player->actor.focus.pos.z;
 
-        if ((this->stateFlags & 0x10)) {
+        if (this->stateFlags & 0x10) {
             func_80034A14(thisx, &this->unk_1EC, 0, 4);
             return;
         }
@@ -389,7 +389,7 @@ s32 EnToryo_OverrideLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dLis
                              void* thisx) {
     EnToryo* this = (EnToryo*)thisx;
 
-    if ((this->stateFlags & 8)) {
+    if (this->stateFlags & 8) {
         switch (limbIndex) {
             case 8:
                 rot->x += this->unk_1EC.unk_0E.y;

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -175,15 +175,15 @@ void ObjBean_UpdatePosition(ObjBean* this) {
 
     Math_StepToF(&this->unk_1E4, 2.0f, 0.1f);
     temp_f20 = Math_SinS(this->unk_1B6.x * 3);
-    this->posOffsetX = (Math_SinS(((this->unk_1B6.y * 3))) + temp_f20) * this->unk_1E4;
+    this->posOffsetX = (Math_SinS(this->unk_1B6.y * 3) + temp_f20) * this->unk_1E4;
     temp_f20 = Math_CosS(this->unk_1B6.x * 4);
-    this->posOffsetZ = (Math_CosS((this->unk_1B6.y * 4)) + temp_f20) * this->unk_1E4;
+    this->posOffsetZ = (Math_CosS(this->unk_1B6.y * 4) + temp_f20) * this->unk_1E4;
     temp_f20 = Math_SinS(this->unk_1B6.z * 5);
 
     this->dyna.actor.scale.x = this->dyna.actor.scale.z =
-        ((Math_SinS((this->unk_1B6.y * 8)) * 0.01f) + (temp_f20 * 0.06f) + 1.07f) * 0.1f;
+        ((Math_SinS(this->unk_1B6.y * 8) * 0.01f) + (temp_f20 * 0.06f) + 1.07f) * 0.1f;
 
-    this->dyna.actor.scale.y = ((Math_CosS(((this->unk_1B6.z * 10))) * 0.2f) + 1.0f) * 0.1f;
+    this->dyna.actor.scale.y = ((Math_CosS(this->unk_1B6.z * 10) * 0.2f) + 1.0f) * 0.1f;
     temp_f20 = Math_SinS(this->unk_1B6.x * 3);
     this->dyna.actor.shape.rot.y =
         (Math_SinS((s16)(this->unk_1B6.z * 2)) * 2100.0f) + ((f32)this->dyna.actor.home.rot.y + (temp_f20 * 1000.0f));

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -350,14 +350,14 @@ void ObjSwitch_Init(Actor* thisx, GlobalContext* globalCtx) {
 void ObjSwitch_Destroy(Actor* thisx, GlobalContext* globalCtx) {
     ObjSwitch* this = (ObjSwitch*)thisx;
 
-    switch ((this->dyna.actor.params & 7)) {
+    switch (this->dyna.actor.params & 7) {
         case OBJSWITCH_TYPE_FLOOR:
         case OBJSWITCH_TYPE_FLOOR_RUSTY:
             DynaPoly_DeleteBgActor(globalCtx, &globalCtx->colCtx.dyna, this->dyna.bgId);
             break;
     }
 
-    switch ((this->dyna.actor.params & 7)) {
+    switch (this->dyna.actor.params & 7) {
         case OBJSWITCH_TYPE_FLOOR_RUSTY:
         case OBJSWITCH_TYPE_EYE:
             Collider_DestroyTris(globalCtx, &this->tris.col);
@@ -384,7 +384,7 @@ void ObjSwitch_FloorUp(ObjSwitch* this, GlobalContext* globalCtx) {
             CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->tris.col.base);
         }
     } else {
-        switch ((this->dyna.actor.params >> 4 & 7)) {
+        switch (this->dyna.actor.params >> 4 & 7) {
             case OBJSWITCH_SUBTYPE_ONCE:
                 if (func_8004356C(&this->dyna)) {
                     ObjSwitch_FloorPressInit(this);
@@ -437,7 +437,7 @@ void ObjSwitch_FloorDownInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_FloorDown(ObjSwitch* this, GlobalContext* globalCtx) {
-    switch ((this->dyna.actor.params >> 4 & 7)) {
+    switch (this->dyna.actor.params >> 4 & 7) {
         case OBJSWITCH_SUBTYPE_ONCE:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_FloorReleaseInit(this);
@@ -550,7 +550,7 @@ void ObjSwitch_EyeClosedInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_EyeClosed(ObjSwitch* this, GlobalContext* globalCtx) {
-    switch ((this->dyna.actor.params >> 4 & 7)) {
+    switch (this->dyna.actor.params >> 4 & 7) {
         case OBJSWITCH_SUBTYPE_ONCE:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
                 ObjSwitch_EyeOpeningInit(this);
@@ -592,7 +592,7 @@ void ObjSwitch_CrystalOffInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_CrystalOff(ObjSwitch* this, GlobalContext* globalCtx) {
-    switch ((this->dyna.actor.params >> 4 & 7)) {
+    switch (this->dyna.actor.params >> 4 & 7) {
         case OBJSWITCH_SUBTYPE_ONCE:
             if ((this->jntSph.col.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
@@ -643,7 +643,7 @@ void ObjSwitch_CrystalOnInit(ObjSwitch* this) {
 }
 
 void ObjSwitch_CrystalOn(ObjSwitch* this, GlobalContext* globalCtx) {
-    switch ((this->dyna.actor.params >> 4 & 7)) {
+    switch (this->dyna.actor.params >> 4 & 7) {
         case OBJSWITCH_SUBTYPE_ONCE:
         case OBJSWITCH_SUBTYPE_SYNC:
             if (!Flags_GetSwitch(globalCtx, (this->dyna.actor.params >> 8 & 0x3F))) {
@@ -688,7 +688,7 @@ void ObjSwitch_Update(Actor* thisx, GlobalContext* globalCtx) {
 
     this->actionFunc(this, globalCtx);
 
-    switch ((this->dyna.actor.params & 7)) {
+    switch (this->dyna.actor.params & 7) {
         case OBJSWITCH_TYPE_FLOOR:
         case OBJSWITCH_TYPE_FLOOR_RUSTY:
             this->unk_17F = this->dyna.unk_160;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2792,7 +2792,7 @@ s32 func_80835C58(GlobalContext* globalCtx, Player* this, PlayerFunc674 func, s3
         func_8008EC70(this);
     }
 
-    if (!(flags & 1) && (!(this->stateFlags1 & PLAYER_STATE1_11))) {
+    if (!(flags & 1) && !(this->stateFlags1 & PLAYER_STATE1_11)) {
         func_80834644(globalCtx, this);
         this->stateFlags1 &= ~PLAYER_STATE1_22;
     }

--- a/src/overlays/effects/ovl_Effect_Ss_En_Fire/z_eff_ss_en_fire.c
+++ b/src/overlays/effects/ovl_Effect_Ss_En_Fire/z_eff_ss_en_fire.c
@@ -131,7 +131,7 @@ void EffectSsEnFire_Update(GlobalContext* globalCtx, u32 index, EffectSs* this) 
                 Matrix_RotateX(BINANG_TO_RAD(this->rPitch + this->actor->shape.rot.x), MTXMODE_APPLY);
                 Matrix_MultVec3f(&this->vec, &this->pos);
             } else {
-                if ((this->rFlags & 0x8000)) {
+                if (this->rFlags & 0x8000) {
                     this->pos.x = ((FireActorS*)this->actor)->firePos[this->rBodyPart].x;
                     this->pos.y = ((FireActorS*)this->actor)->firePos[this->rBodyPart].y;
                     this->pos.z = ((FireActorS*)this->actor)->firePos[this->rBodyPart].z;

--- a/src/overlays/effects/ovl_Effect_Ss_En_Ice/z_eff_ss_en_ice.c
+++ b/src/overlays/effects/ovl_Effect_Ss_En_Ice/z_eff_ss_en_ice.c
@@ -137,7 +137,7 @@ void EffectSsEnIce_UpdateFlying(GlobalContext* globalCtx, u32 index, EffectSs* t
     s16 rand;
 
     if ((this->actor != NULL) && (this->actor->update != NULL)) {
-        if ((this->life >= 9) && (this->actor->colorFilterTimer != 0) && (!(this->actor->colorFilterParams & 0xC000))) {
+        if ((this->life >= 9) && (this->actor->colorFilterTimer != 0) && !(this->actor->colorFilterParams & 0xC000)) {
             this->pos.x = this->actor->world.pos.x + this->vec.x;
             this->pos.y = this->actor->world.pos.y + this->vec.y;
             this->pos.z = this->actor->world.pos.z + this->vec.z;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
@@ -208,7 +208,7 @@ void FileChoose_SelectCopyDest(GameState* thisx) {
             if (this->stickRelY >= 30) {
                 this->buttonIndex--;
 
-                if ((this->buttonIndex == this->selectedFileIndex)) {
+                if (this->buttonIndex == this->selectedFileIndex) {
                     this->buttonIndex--;
 
                     if (this->buttonIndex < FS_BTN_COPY_FILE_1) {


### PR DESCRIPTION
Tried to find and fix most cases of redundant parens for boolean conditions like `if ((foo))` or `if (foo && (!(bar & 1)))`.
Also found a few function calls and switches with double (or even triple) parens so I fixed those as well

Note: To be clear, I didn't get rid of any parens that exist to not rely on operator precendence (eg. having `if ((foo == 1) && (foo == 2))` instead of `if (foo == 1 && foo == 2)`). I'm actually in favor of that personally