### PR TITLE
Document Table For Sequence Instruction Arguments

### DIFF
--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -112,20 +112,21 @@ u8 sSeqInstructionArgsTable[] = {
     CMD_ARGS_2(ARG_S16, ARG_U8),        // 0xEF
     CMD_ARGS_0(),                       // 0xF0
     CMD_ARGS_1(ARG_U8),                 // 0xF1
-    CMD_ARGS_1(ARG_U8),                 // 0xF2
-    CMD_ARGS_1(ARG_U8),                 // 0xF3
-    CMD_ARGS_1(ARG_U8),                 // 0xF4
-    CMD_ARGS_1(ARG_S16),                // 0xF5
-    CMD_ARGS_0(),                       // 0xF6
-    CMD_ARGS_0(),                       // 0xF7
-    CMD_ARGS_1(ARG_U8),                 // 0xF8
-    CMD_ARGS_1(ARG_S16),                // 0xF9
-    CMD_ARGS_1(ARG_S16),                // 0xFA
-    CMD_ARGS_1(ARG_S16),                // 0xFB
-    CMD_ARGS_1(ARG_S16),                // 0xFC
-    CMD_ARGS_0(),                       // 0xFD
-    CMD_ARGS_0(),                       // 0xFE
-    CMD_ARGS_0(),                       // 0xFF
+    // Control Flow Instructions (>= 0xF2) can only have 0 or 1 args
+    CMD_ARGS_1(ARG_U8),  // 0xF2
+    CMD_ARGS_1(ARG_U8),  // 0xF3
+    CMD_ARGS_1(ARG_U8),  // 0xF4
+    CMD_ARGS_1(ARG_S16), // 0xF5
+    CMD_ARGS_0(),        // 0xF6
+    CMD_ARGS_0(),        // 0xF7
+    CMD_ARGS_1(ARG_U8),  // 0xF8
+    CMD_ARGS_1(ARG_S16), // 0xF9
+    CMD_ARGS_1(ARG_S16), // 0xFA
+    CMD_ARGS_1(ARG_S16), // 0xFB
+    CMD_ARGS_1(ARG_S16), // 0xFC
+    CMD_ARGS_0(),        // 0xFD
+    CMD_ARGS_0(),        // 0xFE
+    CMD_ARGS_0(),        // 0xFF
 };
 
 #undef ARG_U8

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -1108,7 +1108,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         s32 pad2;
 
         if (command >= 0xB0) {
-            highBits = sSeqInstructionArgsTable[(s32)command - 0xB0];
+            highBits = sSeqInstructionArgsTable[command - 0xB0];
             lowBits = highBits & 3;
 
             for (i = 0; i < lowBits; i++, highBits <<= 1) {

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -15,21 +15,126 @@ u16 AudioSeq_ScriptReadCompressedU16(SeqScriptState* state);
 
 u8 AudioSeq_GetInstrument(SequenceChannel* channel, u8 instId, Instrument** instOut, AdsrSettings* adsr);
 
-u8 D_80130520[] = {
-    0x81, 0x00, 0x81, 0x01, 0x00, 0x00, 0x00, 0x81, 0x01, 0x01, 0x01, 0x42, 0x81, 0xC2, 0x00, 0x00,
-    0x00, 0x01, 0x81, 0x00, 0x00, 0x00, 0x01, 0x42, 0x01, 0x01, 0x01, 0x81, 0x01, 0x01, 0x81, 0x81,
-    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x81, 0x01, 0x01, 0x01, 0x81, 0x01,
-    0x01, 0x03, 0x03, 0x01, 0x00, 0x01, 0x01, 0x81, 0x03, 0x01, 0x00, 0x02, 0x00, 0x01, 0x01, 0x82,
-    0x00, 0x01, 0x01, 0x01, 0x01, 0x81, 0x00, 0x00, 0x01, 0x81, 0x81, 0x81, 0x81, 0x00, 0x00, 0x00,
+/**
+ * sSeqInstructionArgsTable is a table for each sequence instruction
+ * that contains both how many arguments an instruction takes, as well
+ * as the type of each argument
+ *
+ * sSeqInstructionArgsTable is bitpacked as follows:
+ * abcUUUnn
+ *
+ * n - number of arguments that the sequence instruction takes
+ *
+ * a - bitFlag for the size of arg0 if it exists
+ * b - bitFlag for the size of arg1 if it exists
+ * c - bitFlag for the size of arg2 if it exists
+ *
+ * bit on - argument is 16 bytes
+ * bit off - argument is 8 bytes
+ *
+ * U - Unused
+ */
+
+// argType
+#define CMD_ARG_U8 0
+#define CMD_ARG_S16 1
+
+// CMD_ARGS_(NUMBER_OF_ARGS)
+#define CMD_ARGS_0 0
+#define CMD_ARGS_1(argType) ((argType << 7) | 1)
+#define CMD_ARGS_2(argType0, argType1) ((argType0 << 7) | (argType1 << 6) | 2)
+#define CMD_ARGS_3(argType0, argType1, argType2) ((argType0 << 7) | (argType1 << 6) | (argType1 << 5) | 3)
+
+u8 sSeqInstructionArgsTable[] = {
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xB0
+    CMD_ARGS_0,                                     // 0xB1
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xB2
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xB3
+    CMD_ARGS_0,                                     // 0xB4
+    CMD_ARGS_0,                                     // 0xB5
+    CMD_ARGS_0,                                     // 0xB6
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xB7
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xB8
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xB9
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xBA
+    CMD_ARGS_2(CMD_ARG_U8, CMD_ARG_S16),            // 0xBB
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xBC
+    CMD_ARGS_2(CMD_ARG_S16, CMD_ARG_S16),           // 0xBD
+    CMD_ARGS_0,                                     // 0xBE
+    CMD_ARGS_0,                                     // 0xBF
+    CMD_ARGS_0,                                     // 0xC0
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xC1
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xC2
+    CMD_ARGS_0,                                     // 0xC3
+    CMD_ARGS_0,                                     // 0xC4
+    CMD_ARGS_0,                                     // 0xC5
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xC6
+    CMD_ARGS_2(CMD_ARG_U8, CMD_ARG_S16),            // 0xC7
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xC8
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xC9
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xCA
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xCB
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xCC
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xCD
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xCE
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xCF
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD0
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD1
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD2
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD3
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD4
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD5
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD6
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD7
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD8
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD9
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xDA
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xDB
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xDC
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xDD
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xDE
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xDF
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE0
+    CMD_ARGS_3(CMD_ARG_U8, CMD_ARG_U8, CMD_ARG_U8), // 0xE1
+    CMD_ARGS_3(CMD_ARG_U8, CMD_ARG_U8, CMD_ARG_U8), // 0xE2
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE3
+    CMD_ARGS_0,                                     // 0xE4
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE5
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE6
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xE7
+    CMD_ARGS_3(CMD_ARG_U8, CMD_ARG_U8, CMD_ARG_U8), // 0xE8
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE9
+    CMD_ARGS_0,                                     // 0xEA
+    CMD_ARGS_2(CMD_ARG_U8, CMD_ARG_U8),             // 0xEB
+    CMD_ARGS_0,                                     // 0xEC
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xED
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xEE
+    CMD_ARGS_2(CMD_ARG_S16, CMD_ARG_U8),            // 0xEF
+    CMD_ARGS_0,                                     // 0xF0
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF1
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF2
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF3
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF4
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xF5
+    CMD_ARGS_0,                                     // 0xF6
+    CMD_ARGS_0,                                     // 0xF7
+    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF8
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xF9
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xFA
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xFB
+    CMD_ARGS_1(CMD_ARG_S16),                        // 0xFC
+    CMD_ARGS_0,                                     // 0xFD
+    CMD_ARGS_0,                                     // 0xFE
+    CMD_ARGS_0,                                     // 0xFF
 };
 
 u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 arg1) {
-    u8 temp_v0 = D_80130520[arg1 - 0xB0];
-    u8 loBits = temp_v0 & 3;
+    u8 highBits = sSeqInstructionArgsTable[arg1 - 0xB0];
+    u8 lowBits = highBits & 3;
     u16 ret = 0;
 
-    if (loBits == 1) {
-        if ((temp_v0 & 0x80) == 0) {
+    if (lowBits == 1) {
+        if (!(highBits & 0x80)) {
             ret = AudioSeq_ScriptReadU8(state);
         } else {
             ret = AudioSeq_ScriptReadS16(state);
@@ -998,7 +1103,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         s32 pad2;
 
         if (command >= 0xB0) {
-            highBits = D_80130520[(s32)command - 0xB0];
+            highBits = sSeqInstructionArgsTable[(s32)command - 0xB0];
             lowBits = highBits & 3;
 
             for (i = 0; i < lowBits; i++, highBits <<= 1) {

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -127,8 +127,8 @@ u8 sSeqInstructionArgsTable[] = {
 };
 
 /**
- * Read and return the argument from the sequence script for a control flow instructions
- * Control flow instructions (>= 0xF2) can only have 0 or 1 args
+ * Read and return the argument from the sequence script for a control flow instruction.
+ * Control flow instructions (>= 0xF2) can only have 0 or 1 args.
  * @return the argument value for a control flow instruction, or 0 if there is no argument
  */
 u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
@@ -705,11 +705,10 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 layer->stereo.asByte = AudioSeq_ScriptReadU8(state);
                 break;
 
-            case 0xCE: {
+            case 0xCE:
                 tempByte = AudioSeq_ScriptReadU8(state);
                 layer->unk_34 = gBendPitchTwoSemitonesFrequencies[(tempByte + 0x80) & 0xFF];
                 break;
-            }
 
             default:
                 switch (cmd & 0xF0) {

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -25,117 +25,111 @@ u8 AudioSeq_GetInstrument(SequenceChannel* channel, u8 instId, Instrument** inst
  *
  * n - number of arguments that the sequence instruction takes
  *
- * a - bitFlag for the size of arg0 if it exists
- * b - bitFlag for the size of arg1 if it exists
- * c - bitFlag for the size of arg2 if it exists
+ * a - bitFlag for the type of arg0 if it exists
+ * b - bitFlag for the type of arg1 if it exists
+ * c - bitFlag for the type of arg2 if it exists
  *
- * bit on - argument is 16 bytes
- * bit off - argument is 8 bytes
+ * bitFlag on - argument is s16
+ * bitFlag off - argument is u8
  *
  * U - Unused
  */
 
-// argType
-#define ARG_U8 0
-#define ARG_S16 1
-
 // CMD_ARGS_(NUMBER_OF_ARGS)
 #define CMD_ARGS_0() 0
-#define CMD_ARGS_1(arg0Type) ((arg0Type << 7) | 1)
-#define CMD_ARGS_2(arg0Type, arg1Type) ((arg0Type << 7) | (arg1Type << 6) | 2)
-#define CMD_ARGS_3(arg0Type, arg1Type, arg2Type) ((arg0Type << 7) | (arg1Type << 6) | (arg2Type << 5) | 3)
+#define CMD_ARGS_1(arg0Type) (((sizeof(arg0Type) - 1) << 7) | 1)
+#define CMD_ARGS_2(arg0Type, arg1Type) (((sizeof(arg0Type) - 1) << 7) | ((sizeof(arg1Type) - 1) << 6) | 2)
+#define CMD_ARGS_3(arg0Type, arg1Type, arg2Type) \
+    (((sizeof(arg0Type) - 1) << 7) | ((sizeof(arg1Type) - 1) << 6) | ((sizeof(arg2Type) - 1) << 5) | 3)
 
 u8 sSeqInstructionArgsTable[] = {
-    CMD_ARGS_1(ARG_S16),                // 0xB0
-    CMD_ARGS_0(),                       // 0xB1
-    CMD_ARGS_1(ARG_S16),                // 0xB2
-    CMD_ARGS_1(ARG_U8),                 // 0xB3
-    CMD_ARGS_0(),                       // 0xB4
-    CMD_ARGS_0(),                       // 0xB5
-    CMD_ARGS_0(),                       // 0xB6
-    CMD_ARGS_1(ARG_S16),                // 0xB7
-    CMD_ARGS_1(ARG_U8),                 // 0xB8
-    CMD_ARGS_1(ARG_U8),                 // 0xB9
-    CMD_ARGS_1(ARG_U8),                 // 0xBA
-    CMD_ARGS_2(ARG_U8, ARG_S16),        // 0xBB
-    CMD_ARGS_1(ARG_S16),                // 0xBC
-    CMD_ARGS_2(ARG_S16, ARG_S16),       // 0xBD
-    CMD_ARGS_0(),                       // 0xBE
-    CMD_ARGS_0(),                       // 0xBF
-    CMD_ARGS_0(),                       // 0xC0
-    CMD_ARGS_1(ARG_U8),                 // 0xC1
-    CMD_ARGS_1(ARG_S16),                // 0xC2
-    CMD_ARGS_0(),                       // 0xC3
-    CMD_ARGS_0(),                       // 0xC4
-    CMD_ARGS_0(),                       // 0xC5
-    CMD_ARGS_1(ARG_U8),                 // 0xC6
-    CMD_ARGS_2(ARG_U8, ARG_S16),        // 0xC7
-    CMD_ARGS_1(ARG_U8),                 // 0xC8
-    CMD_ARGS_1(ARG_U8),                 // 0xC9
-    CMD_ARGS_1(ARG_U8),                 // 0xCA
-    CMD_ARGS_1(ARG_S16),                // 0xCB
-    CMD_ARGS_1(ARG_U8),                 // 0xCC
-    CMD_ARGS_1(ARG_U8),                 // 0xCD
-    CMD_ARGS_1(ARG_S16),                // 0xCE
-    CMD_ARGS_1(ARG_S16),                // 0xCF
-    CMD_ARGS_1(ARG_U8),                 // 0xD0
-    CMD_ARGS_1(ARG_U8),                 // 0xD1
-    CMD_ARGS_1(ARG_U8),                 // 0xD2
-    CMD_ARGS_1(ARG_U8),                 // 0xD3
-    CMD_ARGS_1(ARG_U8),                 // 0xD4
-    CMD_ARGS_1(ARG_U8),                 // 0xD5
-    CMD_ARGS_1(ARG_U8),                 // 0xD6
-    CMD_ARGS_1(ARG_U8),                 // 0xD7
-    CMD_ARGS_1(ARG_U8),                 // 0xD8
-    CMD_ARGS_1(ARG_U8),                 // 0xD9
-    CMD_ARGS_1(ARG_S16),                // 0xDA
-    CMD_ARGS_1(ARG_U8),                 // 0xDB
-    CMD_ARGS_1(ARG_U8),                 // 0xDC
-    CMD_ARGS_1(ARG_U8),                 // 0xDD
-    CMD_ARGS_1(ARG_S16),                // 0xDE
-    CMD_ARGS_1(ARG_U8),                 // 0xDF
-    CMD_ARGS_1(ARG_U8),                 // 0xE0
-    CMD_ARGS_3(ARG_U8, ARG_U8, ARG_U8), // 0xE1
-    CMD_ARGS_3(ARG_U8, ARG_U8, ARG_U8), // 0xE2
-    CMD_ARGS_1(ARG_U8),                 // 0xE3
-    CMD_ARGS_0(),                       // 0xE4
-    CMD_ARGS_1(ARG_U8),                 // 0xE5
-    CMD_ARGS_1(ARG_U8),                 // 0xE6
-    CMD_ARGS_1(ARG_S16),                // 0xE7
-    CMD_ARGS_3(ARG_U8, ARG_U8, ARG_U8), // 0xE8
-    CMD_ARGS_1(ARG_U8),                 // 0xE9
-    CMD_ARGS_0(),                       // 0xEA
-    CMD_ARGS_2(ARG_U8, ARG_U8),         // 0xEB
-    CMD_ARGS_0(),                       // 0xEC
-    CMD_ARGS_1(ARG_U8),                 // 0xED
-    CMD_ARGS_1(ARG_U8),                 // 0xEE
-    CMD_ARGS_2(ARG_S16, ARG_U8),        // 0xEF
-    CMD_ARGS_0(),                       // 0xF0
-    CMD_ARGS_1(ARG_U8),                 // 0xF1
+    CMD_ARGS_1(s16),        // 0xB0
+    CMD_ARGS_0(),           // 0xB1
+    CMD_ARGS_1(s16),        // 0xB2
+    CMD_ARGS_1(u8),         // 0xB3
+    CMD_ARGS_0(),           // 0xB4
+    CMD_ARGS_0(),           // 0xB5
+    CMD_ARGS_0(),           // 0xB6
+    CMD_ARGS_1(s16),        // 0xB7
+    CMD_ARGS_1(u8),         // 0xB8
+    CMD_ARGS_1(u8),         // 0xB9
+    CMD_ARGS_1(u8),         // 0xBA
+    CMD_ARGS_2(u8, s16),    // 0xBB
+    CMD_ARGS_1(s16),        // 0xBC
+    CMD_ARGS_2(s16, s16),   // 0xBD
+    CMD_ARGS_0(),           // 0xBE
+    CMD_ARGS_0(),           // 0xBF
+    CMD_ARGS_0(),           // 0xC0
+    CMD_ARGS_1(u8),         // 0xC1
+    CMD_ARGS_1(s16),        // 0xC2
+    CMD_ARGS_0(),           // 0xC3
+    CMD_ARGS_0(),           // 0xC4
+    CMD_ARGS_0(),           // 0xC5
+    CMD_ARGS_1(u8),         // 0xC6
+    CMD_ARGS_2(u8, s16),    // 0xC7
+    CMD_ARGS_1(u8),         // 0xC8
+    CMD_ARGS_1(u8),         // 0xC9
+    CMD_ARGS_1(u8),         // 0xCA
+    CMD_ARGS_1(s16),        // 0xCB
+    CMD_ARGS_1(u8),         // 0xCC
+    CMD_ARGS_1(u8),         // 0xCD
+    CMD_ARGS_1(s16),        // 0xCE
+    CMD_ARGS_1(s16),        // 0xCF
+    CMD_ARGS_1(u8),         // 0xD0
+    CMD_ARGS_1(u8),         // 0xD1
+    CMD_ARGS_1(u8),         // 0xD2
+    CMD_ARGS_1(u8),         // 0xD3
+    CMD_ARGS_1(u8),         // 0xD4
+    CMD_ARGS_1(u8),         // 0xD5
+    CMD_ARGS_1(u8),         // 0xD6
+    CMD_ARGS_1(u8),         // 0xD7
+    CMD_ARGS_1(u8),         // 0xD8
+    CMD_ARGS_1(u8),         // 0xD9
+    CMD_ARGS_1(s16),        // 0xDA
+    CMD_ARGS_1(u8),         // 0xDB
+    CMD_ARGS_1(u8),         // 0xDC
+    CMD_ARGS_1(u8),         // 0xDD
+    CMD_ARGS_1(s16),        // 0xDE
+    CMD_ARGS_1(u8),         // 0xDF
+    CMD_ARGS_1(u8),         // 0xE0
+    CMD_ARGS_3(u8, u8, u8), // 0xE1
+    CMD_ARGS_3(u8, u8, u8), // 0xE2
+    CMD_ARGS_1(u8),         // 0xE3
+    CMD_ARGS_0(),           // 0xE4
+    CMD_ARGS_1(u8),         // 0xE5
+    CMD_ARGS_1(u8),         // 0xE6
+    CMD_ARGS_1(s16),        // 0xE7
+    CMD_ARGS_3(u8, u8, u8), // 0xE8
+    CMD_ARGS_1(u8),         // 0xE9
+    CMD_ARGS_0(),           // 0xEA
+    CMD_ARGS_2(u8, u8),     // 0xEB
+    CMD_ARGS_0(),           // 0xEC
+    CMD_ARGS_1(u8),         // 0xED
+    CMD_ARGS_1(u8),         // 0xEE
+    CMD_ARGS_2(s16, u8),    // 0xEF
+    CMD_ARGS_0(),           // 0xF0
+    CMD_ARGS_1(u8),         // 0xF1
     // Control flow instructions (>= 0xF2) can only have 0 or 1 args
-    CMD_ARGS_1(ARG_U8),  // 0xF2
-    CMD_ARGS_1(ARG_U8),  // 0xF3
-    CMD_ARGS_1(ARG_U8),  // 0xF4
-    CMD_ARGS_1(ARG_S16), // 0xF5
-    CMD_ARGS_0(),        // 0xF6
-    CMD_ARGS_0(),        // 0xF7
-    CMD_ARGS_1(ARG_U8),  // 0xF8
-    CMD_ARGS_1(ARG_S16), // 0xF9
-    CMD_ARGS_1(ARG_S16), // 0xFA
-    CMD_ARGS_1(ARG_S16), // 0xFB
-    CMD_ARGS_1(ARG_S16), // 0xFC
-    CMD_ARGS_0(),        // 0xFD
-    CMD_ARGS_0(),        // 0xFE
-    CMD_ARGS_0(),        // 0xFF
+    CMD_ARGS_1(u8),  // 0xF2
+    CMD_ARGS_1(u8),  // 0xF3
+    CMD_ARGS_1(u8),  // 0xF4
+    CMD_ARGS_1(s16), // 0xF5
+    CMD_ARGS_0(),    // 0xF6
+    CMD_ARGS_0(),    // 0xF7
+    CMD_ARGS_1(u8),  // 0xF8
+    CMD_ARGS_1(s16), // 0xF9
+    CMD_ARGS_1(s16), // 0xFA
+    CMD_ARGS_1(s16), // 0xFB
+    CMD_ARGS_1(s16), // 0xFC
+    CMD_ARGS_0(),    // 0xFD
+    CMD_ARGS_0(),    // 0xFE
+    CMD_ARGS_0(),    // 0xFF
 };
-
-#undef ARG_U8
-#undef ARG_S16
 
 /**
  * Read and return the argument from the sequence script for a control flow instructions
  * Control flow instructions (>= 0xF2) can only have 0 or 1 args
- * @return the argument value for a control flow instruction. If there are no arguments, return 0
+ * @return the argument value for a control flow instruction, or 0 if there is no argument
  */
 u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
     u8 highBits = sSeqInstructionArgsTable[cmd - 0xB0];

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -140,17 +140,17 @@ u8 sSeqInstructionArgsTable[] = {
 u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
     u8 highBits = sSeqInstructionArgsTable[cmd - 0xB0];
     u8 lowBits = highBits & 3;
-    u16 ret = 0;
+    u16 cmdArg = 0;
 
     // only 1 argument
     if (lowBits == 1) {
         if (!(highBits & 0x80)) {
-            ret = AudioSeq_ScriptReadU8(state);
+            cmdArg = AudioSeq_ScriptReadU8(state);
         } else {
-            ret = AudioSeq_ScriptReadS16(state);
+            cmdArg = AudioSeq_ScriptReadS16(state);
         }
     }
-    return ret;
+    return cmdArg;
 }
 
 s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* state, s32 cmd, s32 cmdArg) {

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -128,11 +128,12 @@ u8 sSeqInstructionArgsTable[] = {
     CMD_ARGS_0,                                     // 0xFF
 };
 
-u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 arg1) {
-    u8 highBits = sSeqInstructionArgsTable[arg1 - 0xB0];
+u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
+    u8 highBits = sSeqInstructionArgsTable[cmd - 0xB0];
     u8 lowBits = highBits & 3;
     u16 ret = 0;
 
+    // only 1 argument
     if (lowBits == 1) {
         if (!(highBits & 0x80)) {
             ret = AudioSeq_ScriptReadU8(state);

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -153,7 +153,7 @@ u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
     return ret;
 }
 
-s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* state, s32 cmd, s32 arg) {
+s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* state, s32 cmd, s32 cmdArg) {
     switch (cmd) {
         case 0xFF:
             if (state->depth == 0) {
@@ -170,11 +170,11 @@ s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* 
 
         case 0xFC:
             state->stack[state->depth++] = state->pc;
-            state->pc = seqPlayer->seqData + (u16)arg;
+            state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
         case 0xF8:
-            state->remLoopIters[state->depth] = arg;
+            state->remLoopIters[state->depth] = cmdArg;
             state->stack[state->depth++] = state->pc;
             break;
 
@@ -204,7 +204,7 @@ s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* 
             if (cmd == 0xF5 && state->value < 0) {
                 break;
             }
-            state->pc = seqPlayer->seqData + (u16)arg;
+            state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
         case 0xF2:
@@ -216,7 +216,7 @@ s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* 
             if (cmd == 0xF2 && state->value >= 0) {
                 break;
             }
-            state->pc += (s8)(arg & 0xFF);
+            state->pc += (s8)(cmdArg & 0xFF);
             break;
     }
 

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -1114,7 +1114,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
             highBits = sSeqInstructionArgsTable[cmd - 0xB0];
             lowBits = highBits & 3;
 
-            // read in arguments for the command
+            // read in arguments for the instruction
             for (i = 0; i < lowBits; i++, highBits <<= 1) {
                 if (!(highBits & 0x80)) {
                     cmdArgs[i] = AudioSeq_ScriptReadU8(scriptState);

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -36,97 +36,100 @@ u8 AudioSeq_GetInstrument(SequenceChannel* channel, u8 instId, Instrument** inst
  */
 
 // argType
-#define CMD_ARG_U8 0
-#define CMD_ARG_S16 1
+#define ARG_U8 0
+#define ARG_S16 1
 
 // CMD_ARGS_(NUMBER_OF_ARGS)
-#define CMD_ARGS_0 0
+#define CMD_ARGS_0() 0
 #define CMD_ARGS_1(arg0Type) ((arg0Type << 7) | 1)
 #define CMD_ARGS_2(arg0Type, arg1Type) ((arg0Type << 7) | (arg1Type << 6) | 2)
 #define CMD_ARGS_3(arg0Type, arg1Type, arg2Type) ((arg0Type << 7) | (arg1Type << 6) | (arg2Type << 5) | 3)
 
 u8 sSeqInstructionArgsTable[] = {
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xB0
-    CMD_ARGS_0,                                     // 0xB1
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xB2
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xB3
-    CMD_ARGS_0,                                     // 0xB4
-    CMD_ARGS_0,                                     // 0xB5
-    CMD_ARGS_0,                                     // 0xB6
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xB7
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xB8
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xB9
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xBA
-    CMD_ARGS_2(CMD_ARG_U8, CMD_ARG_S16),            // 0xBB
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xBC
-    CMD_ARGS_2(CMD_ARG_S16, CMD_ARG_S16),           // 0xBD
-    CMD_ARGS_0,                                     // 0xBE
-    CMD_ARGS_0,                                     // 0xBF
-    CMD_ARGS_0,                                     // 0xC0
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xC1
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xC2
-    CMD_ARGS_0,                                     // 0xC3
-    CMD_ARGS_0,                                     // 0xC4
-    CMD_ARGS_0,                                     // 0xC5
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xC6
-    CMD_ARGS_2(CMD_ARG_U8, CMD_ARG_S16),            // 0xC7
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xC8
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xC9
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xCA
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xCB
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xCC
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xCD
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xCE
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xCF
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD0
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD1
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD2
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD3
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD4
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD5
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD6
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD7
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD8
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xD9
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xDA
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xDB
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xDC
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xDD
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xDE
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xDF
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE0
-    CMD_ARGS_3(CMD_ARG_U8, CMD_ARG_U8, CMD_ARG_U8), // 0xE1
-    CMD_ARGS_3(CMD_ARG_U8, CMD_ARG_U8, CMD_ARG_U8), // 0xE2
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE3
-    CMD_ARGS_0,                                     // 0xE4
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE5
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE6
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xE7
-    CMD_ARGS_3(CMD_ARG_U8, CMD_ARG_U8, CMD_ARG_U8), // 0xE8
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xE9
-    CMD_ARGS_0,                                     // 0xEA
-    CMD_ARGS_2(CMD_ARG_U8, CMD_ARG_U8),             // 0xEB
-    CMD_ARGS_0,                                     // 0xEC
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xED
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xEE
-    CMD_ARGS_2(CMD_ARG_S16, CMD_ARG_U8),            // 0xEF
-    CMD_ARGS_0,                                     // 0xF0
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF1
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF2
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF3
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF4
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xF5
-    CMD_ARGS_0,                                     // 0xF6
-    CMD_ARGS_0,                                     // 0xF7
-    CMD_ARGS_1(CMD_ARG_U8),                         // 0xF8
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xF9
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xFA
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xFB
-    CMD_ARGS_1(CMD_ARG_S16),                        // 0xFC
-    CMD_ARGS_0,                                     // 0xFD
-    CMD_ARGS_0,                                     // 0xFE
-    CMD_ARGS_0,                                     // 0xFF
+    CMD_ARGS_1(ARG_S16),                // 0xB0
+    CMD_ARGS_0(),                       // 0xB1
+    CMD_ARGS_1(ARG_S16),                // 0xB2
+    CMD_ARGS_1(ARG_U8),                 // 0xB3
+    CMD_ARGS_0(),                       // 0xB4
+    CMD_ARGS_0(),                       // 0xB5
+    CMD_ARGS_0(),                       // 0xB6
+    CMD_ARGS_1(ARG_S16),                // 0xB7
+    CMD_ARGS_1(ARG_U8),                 // 0xB8
+    CMD_ARGS_1(ARG_U8),                 // 0xB9
+    CMD_ARGS_1(ARG_U8),                 // 0xBA
+    CMD_ARGS_2(ARG_U8, ARG_S16),        // 0xBB
+    CMD_ARGS_1(ARG_S16),                // 0xBC
+    CMD_ARGS_2(ARG_S16, ARG_S16),       // 0xBD
+    CMD_ARGS_0(),                       // 0xBE
+    CMD_ARGS_0(),                       // 0xBF
+    CMD_ARGS_0(),                       // 0xC0
+    CMD_ARGS_1(ARG_U8),                 // 0xC1
+    CMD_ARGS_1(ARG_S16),                // 0xC2
+    CMD_ARGS_0(),                       // 0xC3
+    CMD_ARGS_0(),                       // 0xC4
+    CMD_ARGS_0(),                       // 0xC5
+    CMD_ARGS_1(ARG_U8),                 // 0xC6
+    CMD_ARGS_2(ARG_U8, ARG_S16),        // 0xC7
+    CMD_ARGS_1(ARG_U8),                 // 0xC8
+    CMD_ARGS_1(ARG_U8),                 // 0xC9
+    CMD_ARGS_1(ARG_U8),                 // 0xCA
+    CMD_ARGS_1(ARG_S16),                // 0xCB
+    CMD_ARGS_1(ARG_U8),                 // 0xCC
+    CMD_ARGS_1(ARG_U8),                 // 0xCD
+    CMD_ARGS_1(ARG_S16),                // 0xCE
+    CMD_ARGS_1(ARG_S16),                // 0xCF
+    CMD_ARGS_1(ARG_U8),                 // 0xD0
+    CMD_ARGS_1(ARG_U8),                 // 0xD1
+    CMD_ARGS_1(ARG_U8),                 // 0xD2
+    CMD_ARGS_1(ARG_U8),                 // 0xD3
+    CMD_ARGS_1(ARG_U8),                 // 0xD4
+    CMD_ARGS_1(ARG_U8),                 // 0xD5
+    CMD_ARGS_1(ARG_U8),                 // 0xD6
+    CMD_ARGS_1(ARG_U8),                 // 0xD7
+    CMD_ARGS_1(ARG_U8),                 // 0xD8
+    CMD_ARGS_1(ARG_U8),                 // 0xD9
+    CMD_ARGS_1(ARG_S16),                // 0xDA
+    CMD_ARGS_1(ARG_U8),                 // 0xDB
+    CMD_ARGS_1(ARG_U8),                 // 0xDC
+    CMD_ARGS_1(ARG_U8),                 // 0xDD
+    CMD_ARGS_1(ARG_S16),                // 0xDE
+    CMD_ARGS_1(ARG_U8),                 // 0xDF
+    CMD_ARGS_1(ARG_U8),                 // 0xE0
+    CMD_ARGS_3(ARG_U8, ARG_U8, ARG_U8), // 0xE1
+    CMD_ARGS_3(ARG_U8, ARG_U8, ARG_U8), // 0xE2
+    CMD_ARGS_1(ARG_U8),                 // 0xE3
+    CMD_ARGS_0(),                       // 0xE4
+    CMD_ARGS_1(ARG_U8),                 // 0xE5
+    CMD_ARGS_1(ARG_U8),                 // 0xE6
+    CMD_ARGS_1(ARG_S16),                // 0xE7
+    CMD_ARGS_3(ARG_U8, ARG_U8, ARG_U8), // 0xE8
+    CMD_ARGS_1(ARG_U8),                 // 0xE9
+    CMD_ARGS_0(),                       // 0xEA
+    CMD_ARGS_2(ARG_U8, ARG_U8),         // 0xEB
+    CMD_ARGS_0(),                       // 0xEC
+    CMD_ARGS_1(ARG_U8),                 // 0xED
+    CMD_ARGS_1(ARG_U8),                 // 0xEE
+    CMD_ARGS_2(ARG_S16, ARG_U8),        // 0xEF
+    CMD_ARGS_0(),                       // 0xF0
+    CMD_ARGS_1(ARG_U8),                 // 0xF1
+    CMD_ARGS_1(ARG_U8),                 // 0xF2
+    CMD_ARGS_1(ARG_U8),                 // 0xF3
+    CMD_ARGS_1(ARG_U8),                 // 0xF4
+    CMD_ARGS_1(ARG_S16),                // 0xF5
+    CMD_ARGS_0(),                       // 0xF6
+    CMD_ARGS_0(),                       // 0xF7
+    CMD_ARGS_1(ARG_U8),                 // 0xF8
+    CMD_ARGS_1(ARG_S16),                // 0xF9
+    CMD_ARGS_1(ARG_S16),                // 0xFA
+    CMD_ARGS_1(ARG_S16),                // 0xFB
+    CMD_ARGS_1(ARG_S16),                // 0xFC
+    CMD_ARGS_0(),                       // 0xFD
+    CMD_ARGS_0(),                       // 0xFE
+    CMD_ARGS_0(),                       // 0xFF
 };
+
+#undef ARG_U8
+#undef ARG_S16
 
 u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
     u8 highBits = sSeqInstructionArgsTable[cmd - 0xB0];

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -41,9 +41,9 @@ u8 AudioSeq_GetInstrument(SequenceChannel* channel, u8 instId, Instrument** inst
 
 // CMD_ARGS_(NUMBER_OF_ARGS)
 #define CMD_ARGS_0 0
-#define CMD_ARGS_1(argType) ((argType << 7) | 1)
-#define CMD_ARGS_2(argType0, argType1) ((argType0 << 7) | (argType1 << 6) | 2)
-#define CMD_ARGS_3(argType0, argType1, argType2) ((argType0 << 7) | (argType1 << 6) | (argType1 << 5) | 3)
+#define CMD_ARGS_1(arg0Type) ((arg0Type << 7) | 1)
+#define CMD_ARGS_2(arg0Type, arg1Type) ((arg0Type << 7) | (arg1Type << 6) | 2)
+#define CMD_ARGS_3(arg0Type, arg1Type, arg2Type) ((arg0Type << 7) | (arg1Type << 6) | (arg2Type << 5) | 3)
 
 u8 sSeqInstructionArgsTable[] = {
     CMD_ARGS_1(CMD_ARG_S16),                        // 0xB0


### PR DESCRIPTION
Audio sequences written in the midi-based scripting language have a wide range of available sequence instructions, and each instruction can have a different number of arguments of different types. This script is interpreted in audio_seqplayer.c.

Within that file, there is a table that maps each instruction (with cmd above 0xB0) to how many arguments it has, as well as the type of each argument.

This PR documents that table. Other macro prefix names are welcome, or perhaps a different way to structure these macros.

To see these commands documented, you can look at the audio extraction PR https://github.com/zeldaret/oot/pull/1236, particularly the sequence disassembly:
https://github.com/MNGoldenEagle/oot/blob/3e298fa818569f9323138ec34f9e3127fa435b9f/tools/disassemble_sequence.py#L56

Hopefully these little PR's help with understanding those scripts a bit better