### PR TITLE
Doc Actor Rotation Functions (last 4 funcs in actor.c)

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -535,7 +535,7 @@ s32 Flags_GetInfTable(s32 flag);
 void Flags_SetInfTable(s32 flag);
 u16 func_80037C30(PlayState* play, s16 arg1);
 s32 func_80037D98(PlayState* play, Actor* actor, s16 arg2, s32* arg3);
-s32 Actor_TurnToPlayerSetFocus(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, Vec3f focusPos);
+s32 Actor_TrackPlayer(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, Vec3f focusPos);
 void ActorOverlayTable_LogPrint(void);
 void ActorOverlayTable_Init(void);
 void ActorOverlayTable_Cleanup(void);

--- a/include/functions.h
+++ b/include/functions.h
@@ -535,7 +535,7 @@ s32 Flags_GetInfTable(s32 flag);
 void Flags_SetInfTable(s32 flag);
 u16 func_80037C30(PlayState* play, s16 arg1);
 s32 func_80037D98(PlayState* play, Actor* actor, s16 arg2, s32* arg3);
-s32 func_80038290(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, Vec3f focusPos);
+s32 Actor_TurnToPlayerSetFocus(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, Vec3f focusPos);
 void ActorOverlayTable_LogPrint(void);
 void ActorOverlayTable_Init(void);
 void ActorOverlayTable_Cleanup(void);

--- a/include/functions.h
+++ b/include/functions.h
@@ -535,7 +535,7 @@ s32 Flags_GetInfTable(s32 flag);
 void Flags_SetInfTable(s32 flag);
 u16 func_80037C30(PlayState* play, s16 arg1);
 s32 func_80037D98(PlayState* play, Actor* actor, s16 arg2, s32* arg3);
-s32 func_80038290(PlayState* play, Actor* actor, Vec3s* arg2, Vec3s* arg3, Vec3f arg4);
+s32 func_80038290(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, Vec3f focusPos);
 void ActorOverlayTable_LogPrint(void);
 void ActorOverlayTable_Init(void);
 void ActorOverlayTable_Cleanup(void);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -5503,7 +5503,7 @@ s32 func_80037D98(PlayState* play, Actor* actor, s16 arg2, s32* arg3) {
     return false;
 }
 
-s32 func_80037F30(Vec3s* headRot, Vec3s* torsoRot) {
+s32 Actor_RotateForward(Vec3s* headRot, Vec3s* torsoRot) {
     Math_SmoothStepToS(&headRot->y, 0, 6, 6200, 100);
     Math_SmoothStepToS(&headRot->x, 0, 6, 6200, 100);
     Math_SmoothStepToS(&torsoRot->y, 0, 6, 6200, 100);
@@ -5511,7 +5511,7 @@ s32 func_80037F30(Vec3s* headRot, Vec3s* torsoRot) {
     return true;
 }
 
-s32 func_80037FC8(Actor* actor, Vec3f* target, Vec3s* headRot, Vec3s* torsoRot) {
+s32 Actor_RotateToPoint(Actor* actor, Vec3f* target, Vec3s* headRot, Vec3s* torsoRot) {
     s16 pitch;
     s16 yaw;
     s16 yawDiff;
@@ -5535,7 +5535,7 @@ s32 func_80037FC8(Actor* actor, Vec3f* target, Vec3s* headRot, Vec3s* torsoRot) 
     return true;
 }
 
-s32 func_80038154(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, f32 focusPosYAdj) {
+s32 Actor_TurnToPlayer(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, f32 focusPosYAdj) {
     Player* player = GET_PLAYER(play);
     s16 yaw;
     Vec3f target;
@@ -5546,7 +5546,7 @@ s32 func_80038154(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot
     if (!(((play->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) && (gSaveContext.entranceIndex == ENTR_SPOT04_0))) {
         yaw = ABS(BINANG_SUB(actor->yawTowardsPlayer, actor->shape.rot.y));
         if (yaw >= 0x4300) {
-            func_80037F30(headRot, torsoRot);
+            Actor_RotateForward(headRot, torsoRot);
             return false;
         }
     }
@@ -5557,12 +5557,12 @@ s32 func_80038154(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot
         target = player->actor.focus.pos;
     }
 
-    func_80037FC8(actor, &target, headRot, torsoRot);
+    Actor_RotateToPoint(actor, &target, headRot, torsoRot);
 
     return true;
 }
 
-s32 func_80038290(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, Vec3f focusPos) {
+s32 Actor_TurnToPlayerSetFocus(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, Vec3f focusPos) {
     Player* player = GET_PLAYER(play);
     s16 yaw;
     Vec3f target;
@@ -5572,7 +5572,7 @@ s32 func_80038290(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot
     if (!(((play->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) && (gSaveContext.entranceIndex == ENTR_SPOT04_0))) {
         yaw = ABS(BINANG_SUB(actor->yawTowardsPlayer, actor->shape.rot.y));
         if (yaw >= 0x4300) {
-            func_80037F30(headRot, torsoRot);
+            Actor_RotateForward(headRot, torsoRot);
             return false;
         }
     }
@@ -5583,7 +5583,7 @@ s32 func_80038290(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot
         target = player->actor.focus.pos;
     }
 
-    func_80037FC8(actor, &target, headRot, torsoRot);
+    Actor_RotateToPoint(actor, &target, headRot, torsoRot);
 
     return true;
 }

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -5542,8 +5542,8 @@ s32 Actor_RotateToPoint(Actor* actor, Vec3f* target, Vec3s* headRot, Vec3s* tors
  *
  * @param play
  * @param actor
- * @param headRot the computed actors' head's rotation step
- * @param torsoRot the computed actors' torso's rotation step
+ * @param headRot the computed actor's head's rotation step
+ * @param torsoRot the computed actor's torso's rotation step
  * @param focusPosYAdj how much to adjust the focus position's Y value from the actor's world position
  *
  * @return s32 boolean, true if rotated towards player, false if roatated back forwards.
@@ -5585,8 +5585,8 @@ s32 Actor_TurnToPlayer(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* tor
  *
  * @param play
  * @param actor
- * @param headRot the computed actors' head's rotation step
- * @param torsoRot the computed actors' torso's rotation step
+ * @param headRot the computed actor's head's rotation step
+ * @param torsoRot the computed actor's torso's rotation step
  * @param focusPos the point to set as the actor's focus position
  *
  * @return s32 boolean, true if rotated towards player, false if roatated back forwards.

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -5503,93 +5503,87 @@ s32 func_80037D98(PlayState* play, Actor* actor, s16 arg2, s32* arg3) {
     return false;
 }
 
-s32 func_80037F30(Vec3s* arg0, Vec3s* arg1) {
-    Math_SmoothStepToS(&arg0->y, 0, 6, 6200, 100);
-    Math_SmoothStepToS(&arg0->x, 0, 6, 6200, 100);
-    Math_SmoothStepToS(&arg1->y, 0, 6, 6200, 100);
-    Math_SmoothStepToS(&arg1->x, 0, 6, 6200, 100);
+s32 func_80037F30(Vec3s* headRot, Vec3s* torsoRot) {
+    Math_SmoothStepToS(&headRot->y, 0, 6, 6200, 100);
+    Math_SmoothStepToS(&headRot->x, 0, 6, 6200, 100);
+    Math_SmoothStepToS(&torsoRot->y, 0, 6, 6200, 100);
+    Math_SmoothStepToS(&torsoRot->x, 0, 6, 6200, 100);
     return true;
 }
 
-s32 func_80037FC8(Actor* actor, Vec3f* arg1, Vec3s* arg2, Vec3s* arg3) {
-    s16 sp36;
-    s16 sp34;
-    s16 var;
+s32 func_80037FC8(Actor* actor, Vec3f* target, Vec3s* headRot, Vec3s* torsoRot) {
+    s16 pitch;
+    s16 yaw;
+    s16 yawDiff;
 
-    sp36 = Math_Vec3f_Pitch(&actor->focus.pos, arg1);
-    sp34 = Math_Vec3f_Yaw(&actor->focus.pos, arg1) - actor->world.rot.y;
+    pitch = Math_Vec3f_Pitch(&actor->focus.pos, target);
+    yaw = Math_Vec3f_Yaw(&actor->focus.pos, target) - actor->world.rot.y;
 
-    Math_SmoothStepToS(&arg2->x, sp36, 6, 2000, 1);
-    arg2->x = (arg2->x < -6000) ? -6000 : ((arg2->x > 6000) ? 6000 : arg2->x);
+    Math_SmoothStepToS(&headRot->x, pitch, 6, 2000, 1);
+    headRot->x = CLAMP(headRot->x, -6000, 6000);
 
-    var = Math_SmoothStepToS(&arg2->y, sp34, 6, 2000, 1);
-    arg2->y = (arg2->y < -8000) ? -8000 : ((arg2->y > 8000) ? 8000 : arg2->y);
+    yawDiff = Math_SmoothStepToS(&headRot->y, yaw, 6, 2000, 1);
+    headRot->y = CLAMP(headRot->y, -8000, 8000);
 
-    if (var && (ABS(arg2->y) < 8000)) {
+    if ((yawDiff != 0) && (ABS(headRot->y) < 8000)) {
         return false;
     }
 
-    Math_SmoothStepToS(&arg3->y, sp34 - arg2->y, 4, 2000, 1);
-    arg3->y = (arg3->y < -12000) ? -12000 : ((arg3->y > 12000) ? 12000 : arg3->y);
+    Math_SmoothStepToS(&torsoRot->y, yaw - headRot->y, 4, 2000, 1);
+    torsoRot->y = CLAMP(torsoRot->y, -12000, 12000);
 
     return true;
 }
 
-s32 func_80038154(PlayState* play, Actor* actor, Vec3s* arg2, Vec3s* arg3, f32 arg4) {
+s32 func_80038154(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, f32 focusPosYAdj) {
     Player* player = GET_PLAYER(play);
-    s32 pad;
-    Vec3f sp2C;
-    s16 var;
-    s16 abs_var;
+    s16 yaw;
+    Vec3f target;
 
     actor->focus.pos = actor->world.pos;
-    actor->focus.pos.y += arg4;
+    actor->focus.pos.y += focusPosYAdj;
 
     if (!(((play->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) && (gSaveContext.entranceIndex == ENTR_SPOT04_0))) {
-        var = actor->yawTowardsPlayer - actor->shape.rot.y;
-        abs_var = ABS(var);
-        if (abs_var >= 0x4300) {
-            func_80037F30(arg2, arg3);
+        yaw = ABS(BINANG_SUB(actor->yawTowardsPlayer, actor->shape.rot.y));
+        if (yaw >= 0x4300) {
+            func_80037F30(headRot, torsoRot);
             return false;
         }
     }
 
     if (((play->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) && (gSaveContext.entranceIndex == ENTR_SPOT04_0)) {
-        sp2C = play->view.eye;
+        target = play->view.eye;
     } else {
-        sp2C = player->actor.focus.pos;
+        target = player->actor.focus.pos;
     }
 
-    func_80037FC8(actor, &sp2C, arg2, arg3);
+    func_80037FC8(actor, &target, headRot, torsoRot);
 
     return true;
 }
 
-s32 func_80038290(PlayState* play, Actor* actor, Vec3s* arg2, Vec3s* arg3, Vec3f arg4) {
+s32 func_80038290(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, Vec3f focusPos) {
     Player* player = GET_PLAYER(play);
-    s32 pad;
-    Vec3f sp24;
-    s16 var;
-    s16 abs_var;
+    s16 yaw;
+    Vec3f target;
 
-    actor->focus.pos = arg4;
+    actor->focus.pos = focusPos;
 
     if (!(((play->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) && (gSaveContext.entranceIndex == ENTR_SPOT04_0))) {
-        var = actor->yawTowardsPlayer - actor->shape.rot.y;
-        abs_var = ABS(var);
-        if (abs_var >= 0x4300) {
-            func_80037F30(arg2, arg3);
+        yaw = ABS(BINANG_SUB(actor->yawTowardsPlayer, actor->shape.rot.y));
+        if (yaw >= 0x4300) {
+            func_80037F30(headRot, torsoRot);
             return false;
         }
     }
 
     if (((play->csCtx.state != CS_STATE_IDLE) || gDbgCamEnabled) && (gSaveContext.entranceIndex == ENTR_SPOT04_0)) {
-        sp24 = play->view.eye;
+        target = play->view.eye;
     } else {
-        sp24 = player->actor.focus.pos;
+        target = player->actor.focus.pos;
     }
 
-    func_80037FC8(actor, &sp24, arg2, arg3);
+    func_80037FC8(actor, &target, headRot, torsoRot);
 
     return true;
 }

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -5535,6 +5535,22 @@ s32 Actor_RotateToPoint(Actor* actor, Vec3f* target, Vec3s* headRot, Vec3s* tors
     return true;
 }
 
+/**
+ * Computes the necessary HeadRot and TorsoRot steps to be added to the normal rotation to smoothly turn an actors's
+ * head and torso towards the player if within a certain yaw.
+ * Also sets the focus position to the actor's world position with the specified Y adjustment.
+ *
+ * @param play
+ * @param actor
+ * @param headRot the computed actors' head's rotation step
+ * @param torsoRot the computed actors' torso's rotation step
+ * @param focusPosYAdj how much to adjust the focus position's Y value from the actor's world position
+ *
+ * @return s32 boolean, true if rotated towards player, false if roatated back forwards.
+ *
+ * @note if in a cutscene or debug camera is enabled, and the entrance was from Kokiri Forest entrance 0, the computed
+ * rotation will instead turn towards the view eye no matter the yaw.
+ */
 s32 Actor_TurnToPlayer(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, f32 focusPosYAdj) {
     Player* player = GET_PLAYER(play);
     s16 yaw;
@@ -5562,6 +5578,22 @@ s32 Actor_TurnToPlayer(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* tor
     return true;
 }
 
+/**
+ * Computes the necessary HeadRot and TorsoRot steps to be added to the normal rotation to smoothly turn an actors's
+ * head and torso towards the player if within a certain yaw, else rotate back forward.
+ * Also sets the focus position with the specified point.
+ *
+ * @param play
+ * @param actor
+ * @param headRot the computed actors' head's rotation step
+ * @param torsoRot the computed actors' torso's rotation step
+ * @param focusPos the point to set as the actor's focus position
+ *
+ * @return s32 boolean, true if rotated towards player, false if roatated back forwards.
+ *
+ * @note if in a cutscene or debug camera is enabled, and the entrance was from Kokiri Forest entrance 0, the computed
+ * rotation will instead turn towards the view eye no matter the yaw.
+ */
 s32 Actor_TurnToPlayerSetFocus(PlayState* play, Actor* actor, Vec3s* headRot, Vec3s* torsoRot, Vec3f focusPos) {
     Player* player = GET_PLAYER(play);
     s16 yaw;

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -859,7 +859,7 @@ void BgDyYoseizo_Update(Actor* thisx, PlayState* play2) {
     this->heightOffset = this->scale * 7500.0f;
     Actor_SetFocus(&this->actor, this->heightOffset);
     this->actor.focus.pos.y = this->heightOffset;
-    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->torsoRot, this->actor.focus.pos);
+    Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->torsoRot, this->actor.focus.pos);
     BgDyYoseizo_UpdateEffects(this, play);
     Actor_SetScale(&this->actor, this->scale);
 }

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -859,7 +859,7 @@ void BgDyYoseizo_Update(Actor* thisx, PlayState* play2) {
     this->heightOffset = this->scale * 7500.0f;
     Actor_SetFocus(&this->actor, this->heightOffset);
     this->actor.focus.pos.y = this->heightOffset;
-    func_80038290(play, &this->actor, &this->headRot, &this->torsoRot, this->actor.focus.pos);
+    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->torsoRot, this->actor.focus.pos);
     BgDyYoseizo_UpdateEffects(this, play);
     Actor_SetScale(&this->actor, this->scale);
 }

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -270,7 +270,7 @@ void EnAni_Update(Actor* thisx, PlayState* play) {
     }
 
     if (this->unk_2A8 & 1) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
         this->unk_2A2.z = 0;
         this->unk_2A2.y = this->unk_2A2.z;
         this->unk_2A2.x = this->unk_2A2.z;

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -270,7 +270,7 @@ void EnAni_Update(Actor* thisx, PlayState* play) {
     }
 
     if (this->unk_2A8 & 1) {
-        func_80038290(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
         this->unk_2A2.z = 0;
         this->unk_2A2.y = this->unk_2A2.z;
         this->unk_2A2.x = this->unk_2A2.z;

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -497,7 +497,7 @@ void EnBomBowlMan_Update(Actor* thisx, PlayState* play) {
                 }
             }
 
-            Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_218, &this->unk_224, this->actor.focus.pos);
+            Actor_TrackPlayer(play, &this->actor, &this->unk_218, &this->unk_224, this->actor.focus.pos);
             break;
     }
 

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -497,7 +497,7 @@ void EnBomBowlMan_Update(Actor* thisx, PlayState* play) {
                 }
             }
 
-            func_80038290(play, &this->actor, &this->unk_218, &this->unk_224, this->actor.focus.pos);
+            Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_218, &this->unk_224, this->actor.focus.pos);
             break;
     }
 

--- a/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -243,7 +243,7 @@ void EnDs_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
 
     if (this->unk_1E8 & 1) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_1D8, &this->unk_1DE, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->unk_1D8, &this->unk_1DE, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->unk_1D8.x, 0, 6, 0x1838, 100);
         Math_SmoothStepToS(&this->unk_1D8.y, 0, 6, 0x1838, 100);

--- a/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -243,7 +243,7 @@ void EnDs_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
 
     if (this->unk_1E8 & 1) {
-        func_80038290(play, &this->actor, &this->unk_1D8, &this->unk_1DE, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_1D8, &this->unk_1DE, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->unk_1D8.x, 0, 6, 0x1838, 100);
         Math_SmoothStepToS(&this->unk_1D8.y, 0, 6, 0x1838, 100);

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -253,7 +253,7 @@ void EnFu_Update(Actor* thisx, PlayState* play) {
         Math_SmoothStepToS(&this->unk_2A2.y, 0, 6, 6200, 100);
         this->behaviorFlags &= ~FU_RESET_LOOK_ANGLE;
     } else {
-        func_80038290(play, &this->actor, &this->lookAngleOffset, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->lookAngleOffset, &this->unk_2A2, this->actor.focus.pos);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -253,7 +253,7 @@ void EnFu_Update(Actor* thisx, PlayState* play) {
         Math_SmoothStepToS(&this->unk_2A2.y, 0, 6, 6200, 100);
         this->behaviorFlags &= ~FU_RESET_LOOK_ANGLE;
     } else {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->lookAngleOffset, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->lookAngleOffset, &this->unk_2A2, this->actor.focus.pos);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -693,7 +693,7 @@ void EnGe1_TurnToFacePlayer(EnGe1* this, PlayState* play) {
     if (ABS(angleDiff) <= 0x4000) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 6, 4000, 100);
         this->actor.world.rot.y = this->actor.shape.rot.y;
-        func_80038290(play, &this->actor, &this->headRot, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2A2, this->actor.focus.pos);
     } else {
         if (angleDiff < 0) {
             Math_SmoothStepToS(&this->headRot.y, -0x2000, 6, 6200, 0x100);
@@ -710,7 +710,7 @@ void EnGe1_LookAtPlayer(EnGe1* this, PlayState* play) {
     s16 angleDiff = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
 
     if ((ABS(angleDiff) <= 0x4300) && (this->actor.xzDistToPlayer < 100.0f)) {
-        func_80038290(play, &this->actor, &this->headRot, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2A2, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRot.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->headRot.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -693,7 +693,7 @@ void EnGe1_TurnToFacePlayer(EnGe1* this, PlayState* play) {
     if (ABS(angleDiff) <= 0x4000) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 6, 4000, 100);
         this->actor.world.rot.y = this->actor.shape.rot.y;
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->unk_2A2, this->actor.focus.pos);
     } else {
         if (angleDiff < 0) {
             Math_SmoothStepToS(&this->headRot.y, -0x2000, 6, 6200, 0x100);
@@ -710,7 +710,7 @@ void EnGe1_LookAtPlayer(EnGe1* this, PlayState* play) {
     s16 angleDiff = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
 
     if ((ABS(angleDiff) <= 0x4300) && (this->actor.xzDistToPlayer < 100.0f)) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->unk_2A2, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRot.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->headRot.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -397,7 +397,7 @@ void EnGe2_TurnToFacePlayer(EnGe2* this, PlayState* play) {
     if (ABS(angleDiff) <= 0x4000) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 6, 4000, 100);
         this->actor.world.rot.y = this->actor.shape.rot.y;
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2EE, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->unk_2EE, this->actor.focus.pos);
     } else {
         if (angleDiff < 0) {
             Math_SmoothStepToS(&this->headRot.y, -0x2000, 6, 6200, 0x100);
@@ -413,7 +413,7 @@ void EnGe2_TurnToFacePlayer(EnGe2* this, PlayState* play) {
 void EnGe2_LookAtPlayer(EnGe2* this, PlayState* play) {
     if ((ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) <= 0x4300) &&
         (this->actor.xzDistToPlayer < 200.0f)) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2EE, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->unk_2EE, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRot.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->headRot.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -397,7 +397,7 @@ void EnGe2_TurnToFacePlayer(EnGe2* this, PlayState* play) {
     if (ABS(angleDiff) <= 0x4000) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 6, 4000, 100);
         this->actor.world.rot.y = this->actor.shape.rot.y;
-        func_80038290(play, &this->actor, &this->headRot, &this->unk_2EE, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2EE, this->actor.focus.pos);
     } else {
         if (angleDiff < 0) {
             Math_SmoothStepToS(&this->headRot.y, -0x2000, 6, 6200, 0x100);
@@ -413,7 +413,7 @@ void EnGe2_TurnToFacePlayer(EnGe2* this, PlayState* play) {
 void EnGe2_LookAtPlayer(EnGe2* this, PlayState* play) {
     if ((ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) <= 0x4300) &&
         (this->actor.xzDistToPlayer < 200.0f)) {
-        func_80038290(play, &this->actor, &this->headRot, &this->unk_2EE, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2EE, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRot.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->headRot.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -98,7 +98,7 @@ void EnGe3_TurnToFacePlayer(EnGe3* this, PlayState* play) {
     if (ABS(angleDiff) <= 0x4000) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 6, 4000, 100);
         this->actor.world.rot.y = this->actor.shape.rot.y;
-        func_80038290(play, &this->actor, &this->headRot, &this->unk_306, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_306, this->actor.focus.pos);
     } else {
         if (angleDiff < 0) {
             Math_SmoothStepToS(&this->headRot.y, -0x2000, 6, 6200, 0x100);
@@ -114,7 +114,7 @@ void EnGe3_TurnToFacePlayer(EnGe3* this, PlayState* play) {
 void EnGe3_LookAtPlayer(EnGe3* this, PlayState* play) {
     if ((ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) <= 0x2300) &&
         (this->actor.xzDistToPlayer < 100.0f)) {
-        func_80038290(play, &this->actor, &this->headRot, &this->unk_306, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_306, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRot.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->headRot.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -98,7 +98,7 @@ void EnGe3_TurnToFacePlayer(EnGe3* this, PlayState* play) {
     if (ABS(angleDiff) <= 0x4000) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 6, 4000, 100);
         this->actor.world.rot.y = this->actor.shape.rot.y;
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_306, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->unk_306, this->actor.focus.pos);
     } else {
         if (angleDiff < 0) {
             Math_SmoothStepToS(&this->headRot.y, -0x2000, 6, 6200, 0x100);
@@ -114,7 +114,7 @@ void EnGe3_TurnToFacePlayer(EnGe3* this, PlayState* play) {
 void EnGe3_LookAtPlayer(EnGe3* this, PlayState* play) {
     if ((ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) <= 0x2300) &&
         (this->actor.xzDistToPlayer < 100.0f)) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_306, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->unk_306, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRot.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->headRot.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -769,7 +769,7 @@ void EnHeishi2_Update(Actor* thisx, PlayState* play) {
     if ((this->type == 2) || (this->type == 5)) {
         this->actor.focus.pos.y = 70.0f;
         Actor_SetFocus(&this->actor, 70.0f);
-        func_80038290(play, &this->actor, &this->unk_260, &this->unk_26C, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_260, &this->unk_26C, this->actor.focus.pos);
     }
 
     this->unk_2FC++;

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -769,7 +769,7 @@ void EnHeishi2_Update(Actor* thisx, PlayState* play) {
     if ((this->type == 2) || (this->type == 5)) {
         this->actor.focus.pos.y = 70.0f;
         Actor_SetFocus(&this->actor, 70.0f);
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_260, &this->unk_26C, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->unk_260, &this->unk_26C, this->actor.focus.pos);
     }
 
     this->unk_2FC++;

--- a/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
+++ b/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
@@ -262,7 +262,7 @@ void func_80A56900(EnHeishi4* this, PlayState* play) {
 
 void func_80A56994(EnHeishi4* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    func_80038290(play, &this->actor, &this->unk_260, &this->unk_266, this->actor.focus.pos);
+    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_260, &this->unk_266, this->actor.focus.pos);
     if ((this->unk_282 == Message_GetState(&play->msgCtx)) && Message_ShouldAdvance(play)) {
         Message_CloseTextbox(play);
         SET_INFTABLE(INFTABLE_6C);

--- a/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
+++ b/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
@@ -262,7 +262,7 @@ void func_80A56900(EnHeishi4* this, PlayState* play) {
 
 void func_80A56994(EnHeishi4* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_260, &this->unk_266, this->actor.focus.pos);
+    Actor_TrackPlayer(play, &this->actor, &this->unk_260, &this->unk_266, this->actor.focus.pos);
     if ((this->unk_282 == Message_GetState(&play->msgCtx)) && Message_ShouldAdvance(play)) {
         Message_CloseTextbox(play);
         SET_INFTABLE(INFTABLE_6C);

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -241,7 +241,7 @@ void EnHs_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
 
     if (this->unk_2A8 & 1) {
-        func_80038290(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
         this->unk_2A8 &= ~1;
     } else {
         Math_SmoothStepToS(&this->unk_29C.x, 12800, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -241,7 +241,7 @@ void EnHs_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
 
     if (this->unk_2A8 & 1) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
         this->unk_2A8 &= ~1;
     } else {
         Math_SmoothStepToS(&this->unk_29C.x, 12800, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
+++ b/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
@@ -118,7 +118,7 @@ void EnHs2_Update(Actor* thisx, PlayState* play) {
     }
     this->actionFunc(this, play);
     if (this->unk_2A8 & 0x1) {
-        func_80038290(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
         this->unk_2A8 &= ~1;
     } else {
         Math_SmoothStepToS(&this->unk_29C.x, 12800, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
+++ b/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
@@ -118,7 +118,7 @@ void EnHs2_Update(Actor* thisx, PlayState* play) {
     }
     this->actionFunc(this, play);
     if (this->unk_2A8 & 0x1) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->unk_29C, &this->unk_2A2, this->actor.focus.pos);
         this->unk_2A8 &= ~1;
     } else {
         Math_SmoothStepToS(&this->unk_29C.x, 12800, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -185,7 +185,7 @@ void EnJs_Update(Actor* thisx, PlayState* play) {
     }
     this->actionFunc(this, play);
     if (this->unk_284 & 1) {
-        func_80038290(play, &this->actor, &this->unk_278, &this->unk_27E, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_278, &this->unk_27E, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->unk_278.x, 0, 6, 0x1838, 0x64);
         Math_SmoothStepToS(&this->unk_278.y, 0, 6, 0x1838, 0x64);

--- a/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -185,7 +185,7 @@ void EnJs_Update(Actor* thisx, PlayState* play) {
     }
     this->actionFunc(this, play);
     if (this->unk_284 & 1) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_278, &this->unk_27E, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->unk_278, &this->unk_27E, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->unk_278.x, 0, 6, 0x1838, 0x64);
         Math_SmoothStepToS(&this->unk_278.y, 0, 6, 0x1838, 0x64);

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -298,7 +298,7 @@ void EnMk_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
 
     if (this->flags & 1) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRotation, &vec, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->headRotation, &vec, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRotation.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->headRotation.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -298,7 +298,7 @@ void EnMk_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
 
     if (this->flags & 1) {
-        func_80038290(play, &this->actor, &this->headRotation, &vec, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRotation, &vec, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRotation.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->headRotation.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -488,7 +488,7 @@ void func_80AAE50C(EnMm* this, PlayState* play) {
 }
 
 void func_80AAE598(EnMm* this, PlayState* play) {
-    func_80038290(play, &this->actor, &this->unk_248, &this->unk_24E, this->actor.focus.pos);
+    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_248, &this->unk_24E, this->actor.focus.pos);
     SkelAnime_Update(&this->skelAnime);
 
     if ((func_80AADA70() != 0) && (this->unk_1E0 == 0)) {

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -488,7 +488,7 @@ void func_80AAE50C(EnMm* this, PlayState* play) {
 }
 
 void func_80AAE598(EnMm* this, PlayState* play) {
-    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_248, &this->unk_24E, this->actor.focus.pos);
+    Actor_TrackPlayer(play, &this->actor, &this->unk_248, &this->unk_24E, this->actor.focus.pos);
     SkelAnime_Update(&this->skelAnime);
 
     if ((func_80AADA70() != 0) && (this->unk_1E0 == 0)) {

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
@@ -292,7 +292,7 @@ void EnMm2_Update(Actor* thisx, PlayState* play) {
     s32 pad;
 
     if (this->unk_1F4 & 1) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_1E8, &this->unk_1EE, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->unk_1E8, &this->unk_1EE, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->unk_1E8.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->unk_1E8.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
@@ -292,7 +292,7 @@ void EnMm2_Update(Actor* thisx, PlayState* play) {
     s32 pad;
 
     if (this->unk_1F4 & 1) {
-        func_80038290(play, &this->actor, &this->unk_1E8, &this->unk_1EE, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_1E8, &this->unk_1EE, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->unk_1E8.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->unk_1E8.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -184,7 +184,7 @@ void EnSth_FacePlayer(EnSth* this, PlayState* play) {
     if (ABS(diffRot) <= 0x4000) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 6, 0xFA0, 0x64);
         this->actor.world.rot.y = this->actor.shape.rot.y;
-        func_80038290(play, &this->actor, &this->headRot, &this->unk_2AC, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2AC, this->actor.focus.pos);
     } else {
         if (diffRot < 0) {
             Math_SmoothStepToS(&this->headRot.y, -0x2000, 6, 0x1838, 0x100);
@@ -200,7 +200,7 @@ void EnSth_LookAtPlayer(EnSth* this, PlayState* play) {
     s16 diffRot = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
 
     if ((ABS(diffRot) <= 0x4300) && (this->actor.xzDistToPlayer < 100.0f)) {
-        func_80038290(play, &this->actor, &this->headRot, &this->unk_2AC, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2AC, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRot.x, 0, 6, 0x1838, 0x64);
         Math_SmoothStepToS(&this->headRot.y, 0, 6, 0x1838, 0x64);

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -184,7 +184,7 @@ void EnSth_FacePlayer(EnSth* this, PlayState* play) {
     if (ABS(diffRot) <= 0x4000) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 6, 0xFA0, 0x64);
         this->actor.world.rot.y = this->actor.shape.rot.y;
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2AC, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->unk_2AC, this->actor.focus.pos);
     } else {
         if (diffRot < 0) {
             Math_SmoothStepToS(&this->headRot.y, -0x2000, 6, 0x1838, 0x100);
@@ -200,7 +200,7 @@ void EnSth_LookAtPlayer(EnSth* this, PlayState* play) {
     s16 diffRot = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
 
     if ((ABS(diffRot) <= 0x4300) && (this->actor.xzDistToPlayer < 100.0f)) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->unk_2AC, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->unk_2AC, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->headRot.x, 0, 6, 0x1838, 0x64);
         Math_SmoothStepToS(&this->headRot.y, 0, 6, 0x1838, 0x64);

--- a/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -471,7 +471,7 @@ void EnSyatekiMan_Update(Actor* thisx, PlayState* play) {
     this->blinkFunc(this);
     this->actor.focus.pos.y = 70.0f;
     Actor_SetFocus(&this->actor, 70.0f);
-    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->bodyRot, this->actor.focus.pos);
+    Actor_TrackPlayer(play, &this->actor, &this->headRot, &this->bodyRot, this->actor.focus.pos);
 }
 
 s32 EnSyatekiMan_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {

--- a/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -471,7 +471,7 @@ void EnSyatekiMan_Update(Actor* thisx, PlayState* play) {
     this->blinkFunc(this);
     this->actor.focus.pos.y = 70.0f;
     Actor_SetFocus(&this->actor, 70.0f);
-    func_80038290(play, &this->actor, &this->headRot, &this->bodyRot, this->actor.focus.pos);
+    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->headRot, &this->bodyRot, this->actor.focus.pos);
 }
 
 s32 EnSyatekiMan_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -1146,7 +1146,7 @@ void EnTa_Update(Actor* thisx, PlayState* play) {
     }
 
     if (this->unk_2E0 & 1) {
-        func_80038290(play, &this->actor, &this->unk_2D4, &this->unk_2DA, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_2D4, &this->unk_2DA, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->unk_2D4.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->unk_2D4.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -1146,7 +1146,7 @@ void EnTa_Update(Actor* thisx, PlayState* play) {
     }
 
     if (this->unk_2E0 & 1) {
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_2D4, &this->unk_2DA, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->unk_2D4, &this->unk_2DA, this->actor.focus.pos);
     } else {
         Math_SmoothStepToS(&this->unk_2D4.x, 0, 6, 6200, 100);
         Math_SmoothStepToS(&this->unk_2D4.y, 0, 6, 6200, 100);

--- a/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
+++ b/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
@@ -185,7 +185,7 @@ void EnTakaraMan_Update(Actor* thisx, PlayState* play) {
     }
 
     Actor_SetFocus(&this->actor, this->height);
-    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_22C, &this->unk_232, this->actor.focus.pos);
+    Actor_TrackPlayer(play, &this->actor, &this->unk_22C, &this->unk_232, this->actor.focus.pos);
     if (this->eyeTimer == 0) {
         this->eyeTextureIdx++;
         if (this->eyeTextureIdx >= 2) {

--- a/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
+++ b/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
@@ -185,7 +185,7 @@ void EnTakaraMan_Update(Actor* thisx, PlayState* play) {
     }
 
     Actor_SetFocus(&this->actor, this->height);
-    func_80038290(play, &this->actor, &this->unk_22C, &this->unk_232, this->actor.focus.pos);
+    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_22C, &this->unk_232, this->actor.focus.pos);
     if (this->eyeTimer == 0) {
         this->eyeTextureIdx++;
         if (this->eyeTextureIdx >= 2) {

--- a/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
+++ b/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
@@ -140,7 +140,7 @@ void func_80B4AF18(EnZl1* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 pad;
 
-    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
+    Actor_TrackPlayer(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
 
     if (this->unk_1E6 != 0) {
         if (Actor_TextboxIsClosing(&this->actor, play)) {
@@ -329,7 +329,7 @@ void func_80B4B240(EnZl1* this, PlayState* play) {
         frameCount = Animation_GetLastFrame(animHeaderSeg);
         Animation_Change(&this->skelAnime, animHeaderSeg, 1.0f, 0.0f, frameCount, sp54[sp3C], -10.0f);
     }
-    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
+    Actor_TrackPlayer(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
 }
 
 void func_80B4B7F4(CsCmdActorAction* npcAction, Vec3f* pos) {
@@ -410,7 +410,7 @@ void func_80B4B8B4(EnZl1* this, PlayState* play) {
             }
             this->actor.velocity.z = (sp68.z - sp74.z) / actionLength;
         }
-        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
+        Actor_TrackPlayer(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
         Play_CameraSetAtEye(play, this->subCamId, &subCamAt, &subCamEye);
         Play_CameraSetFov(play, this->subCamId, 70.0f);
     }
@@ -562,7 +562,7 @@ void func_80B4BF2C(EnZl1* this, PlayState* play) {
             }
             break;
     }
-    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
+    Actor_TrackPlayer(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
 }
 
 void EnZl1_Update(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
+++ b/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
@@ -140,7 +140,7 @@ void func_80B4AF18(EnZl1* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 pad;
 
-    func_80038290(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
+    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
 
     if (this->unk_1E6 != 0) {
         if (Actor_TextboxIsClosing(&this->actor, play)) {
@@ -329,7 +329,7 @@ void func_80B4B240(EnZl1* this, PlayState* play) {
         frameCount = Animation_GetLastFrame(animHeaderSeg);
         Animation_Change(&this->skelAnime, animHeaderSeg, 1.0f, 0.0f, frameCount, sp54[sp3C], -10.0f);
     }
-    func_80038290(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
+    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
 }
 
 void func_80B4B7F4(CsCmdActorAction* npcAction, Vec3f* pos) {
@@ -410,7 +410,7 @@ void func_80B4B8B4(EnZl1* this, PlayState* play) {
             }
             this->actor.velocity.z = (sp68.z - sp74.z) / actionLength;
         }
-        func_80038290(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
+        Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
         Play_CameraSetAtEye(play, this->subCamId, &subCamAt, &subCamEye);
         Play_CameraSetFov(play, this->subCamId, 70.0f);
     }
@@ -562,7 +562,7 @@ void func_80B4BF2C(EnZl1* this, PlayState* play) {
             }
             break;
     }
-    func_80038290(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
+    Actor_TurnToPlayerSetFocus(play, &this->actor, &this->unk_200, &this->unk_206, this->actor.focus.pos);
 }
 
 void EnZl1_Update(Actor* thisx, PlayState* play) {


### PR DESCRIPTION
Documents the last 4 functions in `actor.c` which are used to rotate actors' heads and torsos towards player.