### PR TITLE
Enable more IDO warnings and apply fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ ifeq ($(COMPILER),gcc)
   MIPS_VERSION := -mips3
 else 
   # we support Microsoft extensions such as anonymous structs, which the compiler does support but warns for their usage. Surpress the warnings with -woff.
-  CFLAGS += -G 0 -non_shared -Xfullwarn -Xcpluscomm $(INC) -Wab,-r4300_mul -woff 649,838,712 
+  CFLAGS += -G 0 -non_shared -fullwarn -verbose -Xcpluscomm $(INC) -Wab,-r4300_mul -woff 516,649,838,712
   MIPS_VERSION := -mips2
 endif
 

--- a/include/z64animation.h
+++ b/include/z64animation.h
@@ -209,7 +209,7 @@ typedef struct SkelAnime {
     /* 0x2C */ f32 morphRate;     // Reciprocal of the number of frames in the morph
     /* 0x30 */ union {
                     s32 (*normal)(struct SkelAnime*); // Can be Loop, Partial loop, Play once, Morph, or Tapered morph
-                    s32 (*link)(struct PlayState*, struct SkelAnime*); // Loop, Play once, and Morph
+                    s32 (*link)(struct PlayState*, struct SkelAnime*); // Can be Loop, Play once, or Morph
                 } update;
     /* 0x34 */ s8 initFlags;      // Flags used when initializing Link's skeleton
     /* 0x35 */ u8 moveFlags;      // Flags used for animations that move the actor in worldspace.

--- a/include/z64animation.h
+++ b/include/z64animation.h
@@ -207,7 +207,10 @@ typedef struct SkelAnime {
     /* 0x24 */ Vec3s* morphTable; // Table of values used to morph between animations
     /* 0x28 */ f32 morphWeight;   // Weight of the current animation morph as a fraction in [0,1]
     /* 0x2C */ f32 morphRate;     // Reciprocal of the number of frames in the morph
-    /* 0x30 */ s32 (*update)();   // Can be Loop, Partial loop, Play once, Morph, or Tapered morph. Link only has Loop, Play once, and Morph.
+    /* 0x30 */ union {
+                    s32 (*normal)(struct SkelAnime*); // Can be Loop, Partial loop, Play once, Morph, or Tapered morph
+                    s32 (*link)(struct PlayState*, struct SkelAnime*); // Loop, Play once, and Morph
+                } update;
     /* 0x34 */ s8 initFlags;      // Flags used when initializing Link's skeleton
     /* 0x35 */ u8 moveFlags;      // Flags used for animations that move the actor in worldspace.
     /* 0x36 */ s16 prevRot;       // Previous rotation in worldspace.

--- a/include/z64cutscene.h
+++ b/include/z64cutscene.h
@@ -144,7 +144,7 @@ typedef enum {
  * on its own line.
  *
  * Files that contain this type that are included in other C files
- * must be preceded by a '#pragma asmproc recurse qualifier' to
+ * must be preceded by a '#pragma asmproc recurse' qualifier to
  * inform asm-processor that it must recursively process that include.
  *
  * Example:

--- a/include/z64cutscene.h
+++ b/include/z64cutscene.h
@@ -144,10 +144,12 @@ typedef enum {
  * on its own line.
  *
  * Files that contain this type that are included in other C files
- * must include an 'EARLY' qualifier to inform asm-processor that it
- * must recursively process that include.
+ * must be preceded by a '#pragma asmproc recurse qualifier' to
+ * inform asm-processor that it must recursively process that include.
  *
- * Example: #include "file.c" EARLY
+ * Example:
+ * #pragma asmproc recurse
+ * #include "file.c"
  */
 typedef union CutsceneData {
     s32 i;

--- a/src/code/code_800F9280.c
+++ b/src/code/code_800F9280.c
@@ -96,9 +96,10 @@ typedef enum {
 } SeqCmdType;
 
 void Audio_ProcessSeqCmd(u32 cmd) {
-    s32 pad[2];
+    s32 pad;
     u16 fadeTimer;
     u16 channelMask;
+    u32 channelMaskReversed;
     u16 val;
     u8 oldSpec;
     u8 spec;
@@ -305,9 +306,10 @@ void Audio_ProcessSeqCmd(u32 cmd) {
                 // stop channels
                 Audio_QueueCmdS8(0x08000000 | _SHIFTL(playerIdx, 16, 8) | 0xFF00, 1);
             }
-            if ((channelMask ^ 0xFFFF) != 0) {
+            channelMaskReversed = channelMask ^ 0xFFFF;
+            if (channelMaskReversed != 0) {
                 // with channel mask ~channelMask...
-                Audio_QueueCmdU16(0x90000000 | _SHIFTL(playerIdx, 16, 8), (channelMask ^ 0xFFFF));
+                Audio_QueueCmdU16(0x90000000 | _SHIFTL(playerIdx, 16, 8), channelMaskReversed);
                 // unstop channels
                 Audio_QueueCmdS8(0x08000000 | _SHIFTL(playerIdx, 16, 8) | 0xFF00, 0);
             }

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -31,6 +31,9 @@ void Graph_FaultClient(void) {
     osViSwapBuffer(nextFb);
 }
 
+// TODO: merge Gfx and GfxMod to make this function's arguments consistent
+void UCodeDisas_Disassemble(UCodeDisas*, Gfx*);
+
 void Graph_DisassembleUCode(Gfx* workBuf) {
     UCodeDisas disassembler;
 

--- a/src/code/sys_cfb.c
+++ b/src/code/sys_cfb.c
@@ -36,7 +36,7 @@ void SysCfb_Init(s32 n64dd) {
     osSyncPrintf("フレームバッファのアドレスは %08x と %08x です\n", sSysCfbFbPtr[0], sSysCfbFbPtr[1]);
 }
 
-void SysCfb_Reset() {
+void SysCfb_Reset(void) {
     sSysCfbFbPtr[0] = 0;
     sSysCfbFbPtr[1] = 0;
     sSysCfbEnd = 0;

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -8142,7 +8142,7 @@ s32 Camera_Copy(Camera* dstCamera, Camera* srcCamera) {
     return true;
 }
 
-s32 Camera_GetDbgCamEnabled() {
+s32 Camera_GetDbgCamEnabled(void) {
     return gDbgCamEnabled;
 }
 

--- a/src/code/z_lights.c
+++ b/src/code/z_lights.c
@@ -161,7 +161,7 @@ void Lights_BindAll(Lights* lights, LightNode* listHead, Vec3f* vec) {
     }
 }
 
-LightNode* Lights_FindBufSlot() {
+LightNode* Lights_FindBufSlot(void) {
     LightNode* node;
 
     if (sLightsBuffer.numOccupied >= LIGHTS_BUFFER_SIZE) {

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -307,7 +307,7 @@ void Play_Init(GameState* thisx) {
     if ((gEntranceTable[((void)0, gSaveContext.entranceIndex)].scene == SCENE_SPOT09) &&
         gSaveContext.sceneSetupIndex == 6) {
         osSyncPrintf("エンディングはじまるよー\n"); // "The ending starts"
-        ((void (*)())0x81000000)();
+        ((void (*)(void))0x81000000)();
         osSyncPrintf("出戻り？\n"); // "Return?"
     }
 

--- a/src/code/z_skelanime.c
+++ b/src/code/z_skelanime.c
@@ -1086,9 +1086,9 @@ void SkelAnime_InitLink(PlayState* play, SkelAnime* skelAnime, FlexSkeletonHeade
  */
 void LinkAnimation_SetUpdateFunction(SkelAnime* skelAnime) {
     if (skelAnime->mode <= ANIMMODE_LOOP_INTERP) {
-        skelAnime->update = LinkAnimation_Loop;
+        skelAnime->update.link = LinkAnimation_Loop;
     } else {
-        skelAnime->update = LinkAnimation_Once;
+        skelAnime->update.link = LinkAnimation_Once;
     }
     skelAnime->morphWeight = 0.0f;
 }
@@ -1098,7 +1098,7 @@ void LinkAnimation_SetUpdateFunction(SkelAnime* skelAnime) {
  * finishes.
  */
 s32 LinkAnimation_Update(PlayState* play, SkelAnime* skelAnime) {
-    return skelAnime->update(play, skelAnime);
+    return skelAnime->update.link(play, skelAnime);
 }
 
 /**
@@ -1201,7 +1201,7 @@ void LinkAnimation_Change(PlayState* play, SkelAnime* skelAnime, LinkAnimationHe
             SkelAnime_CopyFrameTable(skelAnime, skelAnime->morphTable, skelAnime->jointTable);
             morphFrames = -morphFrames;
         } else {
-            skelAnime->update = LinkAnimation_Morph;
+            skelAnime->update.link = LinkAnimation_Morph;
             AnimationContext_SetLoadFrame(play, animation, (s32)startFrame, skelAnime->limbCount,
                                           skelAnime->morphTable);
         }
@@ -1463,11 +1463,11 @@ SkelAnime_InitSkin(PlayState* play, SkelAnime* skelAnime, SkeletonHeader* skelet
  */
 void SkelAnime_SetUpdate(SkelAnime* skelAnime) {
     if (skelAnime->mode <= ANIMMODE_LOOP_INTERP) {
-        skelAnime->update = SkelAnime_LoopFull;
+        skelAnime->update.normal = SkelAnime_LoopFull;
     } else if (skelAnime->mode <= ANIMMODE_ONCE_INTERP) {
-        skelAnime->update = SkelAnime_Once;
+        skelAnime->update.normal = SkelAnime_Once;
     } else {
-        skelAnime->update = SkelAnime_LoopPartial;
+        skelAnime->update.normal = SkelAnime_LoopPartial;
     }
 }
 
@@ -1476,7 +1476,7 @@ void SkelAnime_SetUpdate(SkelAnime* skelAnime) {
  * finishes.
  */
 s32 SkelAnime_Update(SkelAnime* skelAnime) {
-    return skelAnime->update(skelAnime);
+    return skelAnime->update.normal(skelAnime);
 }
 
 /**
@@ -1636,10 +1636,10 @@ void Animation_ChangeImpl(SkelAnime* skelAnime, AnimationHeader* animation, f32 
             morphFrames = -morphFrames;
         } else {
             if (taper != ANIMTAPER_NONE) {
-                skelAnime->update = SkelAnime_MorphTaper;
+                skelAnime->update.normal = SkelAnime_MorphTaper;
                 skelAnime->taper = taper;
             } else {
-                skelAnime->update = SkelAnime_Morph;
+                skelAnime->update.normal = SkelAnime_Morph;
             }
             SkelAnime_GetFrameData(animation, startFrame, skelAnime->limbCount, skelAnime->morphTable);
         }

--- a/src/code/z_vr_box.c
+++ b/src/code/z_vr_box.c
@@ -266,7 +266,7 @@ s32 func_800AE2C0(SkyboxContext* skyboxCtx, Vtx* roomVtx, s32 arg2, s32 arg3, s3
             }
             break;
     }
-    skyboxCtx->unk_138 = &skyboxCtx->dListBuf[2 * arg8];
+    skyboxCtx->unk_138 = &skyboxCtx->dListBuf[2 * arg8][0];
 
     for (i = 0; i < 0x20; i++) {
         index = D_8012ADD8[i];

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -2038,7 +2038,7 @@ void BossVa_ZapperAttack(BossVa* this, PlayState* play) {
 
             this->skelAnime.playSpeed = 0.0f;
             if (Math_SmoothStepToF(&this->skelAnime.curFrame, 0.0f, 1.0f, 2.0f, 0.0f) == 0.0f) {
-                if (sp88 < sp90) {
+                if (sp88 < (u32)sp90) {
                     this->timer2 = 0;
                     this->burst++;
                     this->unk_1D8 = sp7C;

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
@@ -708,7 +708,7 @@ void DemoDu_InitCs_AfterGanon(DemoDu* this, PlayState* play) {
     this->actor.shape.shadowAlpha = 0;
 }
 
-void DemoDu_CsPlaySfx_WhiteOut() {
+void DemoDu_CsPlaySfx_WhiteOut(void) {
     func_800788CC(NA_SE_SY_WHITE_OUT_T);
 }
 

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
@@ -16,7 +16,8 @@ void DemoDu_Draw(Actor* thisx, PlayState* play);
 
 static s32 sUnused = 0;
 
-#include "z_demo_du_cutscene_data.c" EARLY
+#pragma asmproc recurse
+#include "z_demo_du_cutscene_data.c"
 
 static void* sEyeTextures[] = { gDaruniaEyeOpenTex, gDaruniaEyeOpeningTex, gDaruniaEyeShutTex, gDaruniaEyeClosingTex };
 static void* sMouthTextures[] = { gDaruniaMouthSeriousTex, gDaruniaMouthGrinningTex, gDaruniaMouthOpenTex,

--- a/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.c
+++ b/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.c
@@ -19,7 +19,7 @@ void DemoGt_Destroy(Actor* thisx, PlayState* play) {
     }
 }
 
-void DemoGt_PlayEarthquakeSfx() {
+void DemoGt_PlayEarthquakeSfx(void) {
     func_800788CC(NA_SE_EV_EARTHQUAKE - SFX_FLAG);
 }
 
@@ -435,7 +435,7 @@ void func_8097ED64(DemoGt* this, PlayState* play, s32 actionIdx) {
     func_8097E824(this, actionIdx);
 }
 
-u8 func_8097ED94() {
+u8 func_8097ED94(void) {
     if (kREG(2) != 0) {
         return true;
     } else if (gSaveContext.sceneSetupIndex < 4) {

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -72,7 +72,8 @@ static ColliderCylinderInitType1 sCylinderInit = {
     { 25, 80, 0, { 0, 0, 0 } },
 };
 
-#include "z_demo_im_cutscene_data.c" EARLY
+#pragma asmproc recurse
+#include "z_demo_im_cutscene_data.c"
 
 static DemoImActionFunc sActionFuncs[] = {
     func_809856F8, func_80985718, func_80985738, func_80985770, func_809857B0, func_809857F0, func_80985830,

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
@@ -71,7 +71,8 @@ static void* sMouthTextures[] = {
 
 static u32 D_80990108 = 0;
 
-#include "z_demo_sa_cutscene_data.c" EARLY
+#pragma asmproc recurse
+#include "z_demo_sa_cutscene_data.c"
 
 static DemoSaActionFunc sActionFuncs[] = {
     func_8098EBB8, func_8098EBD8, func_8098EBF8, func_8098EC28, func_8098EC60, func_8098EC94, func_8098ECCC,

--- a/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -155,7 +155,7 @@ void EnDs_OfferOddPotion(EnDs* this, PlayState* play) {
     }
 }
 
-s32 EnDs_CheckRupeesAndBottle() {
+s32 EnDs_CheckRupeesAndBottle(void) {
     if (gSaveContext.rupees < 100) {
         return 0;
     } else if (Inventory_HasEmptyBottle() == 0) {

--- a/src/overlays/actors/ovl_En_Eg/z_en_eg.c
+++ b/src/overlays/actors/ovl_En_Eg/z_en_eg.c
@@ -34,7 +34,7 @@ const ActorInit En_Eg_InitVars = {
     (ActorFunc)EnEg_Draw,
 };
 
-void EnEg_PlayVoidOutSFX() {
+void EnEg_PlayVoidOutSFX(void) {
     func_800788CC(NA_SE_OC_ABYSS);
 }
 

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -798,7 +798,7 @@ void EnFr_CheckOcarinaInputFrogSong(u8 ocarinaNote) {
     }
 }
 
-void EnFr_DeactivateButterfly() {
+void EnFr_DeactivateButterfly(void) {
     s32 frogIndex;
     EnFr* frog;
 

--- a/src/overlays/actors/ovl_En_Holl/z_en_holl.c
+++ b/src/overlays/actors/ovl_En_Holl/z_en_holl.c
@@ -75,7 +75,7 @@ void EnHoll_SetupAction(EnHoll* this, EnHollActionFunc func) {
     this->actionFunc = func;
 }
 
-s32 EnHoll_IsKokiriSetup8() {
+s32 EnHoll_IsKokiriSetup8(void) {
     return gSaveContext.entranceIndex == ENTR_SPOT04_0 && gSaveContext.sceneSetupIndex == 8;
 }
 

--- a/src/overlays/actors/ovl_En_Jj/z_en_jj.c
+++ b/src/overlays/actors/ovl_En_Jj/z_en_jj.c
@@ -42,7 +42,8 @@ const ActorInit En_Jj_InitVars = {
 
 static s32 sUnused = 0;
 
-#include "z_en_jj_cutscene_data.c" EARLY
+#pragma asmproc recurse
+#include "z_en_jj_cutscene_data.c"
 
 static s32 sUnused2[] = { 0, 0 };
 

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -69,7 +69,7 @@ typedef enum {
     /* 10 */ ENMD_ANIM_10,
     /* 11 */ ENMD_ANIM_11,
     /* 12 */ ENMD_ANIM_12,
-    /* 13 */ ENMD_ANIM_13,
+    /* 13 */ ENMD_ANIM_13
 } EnMdAnimation;
 
 static AnimationInfo sAnimationInfo[] = {

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -85,7 +85,8 @@ static void* sEyeTextures[] = {
 
 static s32 D_80AB4318 = 0;
 
-#include "z_en_nb_cutscene_data.c" EARLY
+#pragma asmproc recurse
+#include "z_en_nb_cutscene_data.c"
 
 s32 EnNb_GetPath(EnNb* this) {
     s32 path = this->actor.params >> 8;

--- a/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
+++ b/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
@@ -105,7 +105,8 @@ static void* sMouthTextures[] = {
 
 static s32 sUnused = 0;
 
-#include "z_en_ru1_cutscene_data.c" EARLY
+#pragma asmproc recurse
+#include "z_en_ru1_cutscene_data.c"
 
 static u32 D_80AF1938 = 0;
 

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -63,7 +63,8 @@ static void* sEyeTextures[] = {
 
 static UNK_TYPE D_80AF4118 = 0;
 
-#include "z_en_ru2_cutscene_data.c" EARLY
+#pragma asmproc recurse
+#include "z_en_ru2_cutscene_data.c"
 
 static EnRu2ActionFunc sActionFuncs[] = {
     func_80AF2CB4, func_80AF2CD4, func_80AF2CF4, func_80AF2D2C, func_80AF2D6C, func_80AF2DAC, func_80AF2DEC,

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -380,7 +380,7 @@ void func_80AF2E1C(EnRu2* this, PlayState* play) {
     this->actor.shape.shadowAlpha = 0;
 }
 
-void func_80AF2E64() {
+void func_80AF2E64(void) {
     func_800788CC(NA_SE_SY_WHITE_OUT_T);
 }
 

--- a/src/overlays/actors/ovl_En_Tp/z_en_tp.c
+++ b/src/overlays/actors/ovl_En_Tp/z_en_tp.c
@@ -160,7 +160,8 @@ void EnTp_Init(Actor* thisx, PlayState* play2) {
             next = (EnTp*)Actor_Spawn(&play->actorCtx, play, ACTOR_EN_TP, this->actor.world.pos.x,
                                       this->actor.world.pos.y, this->actor.world.pos.z, 0, 0, 0, 0 * i);
 
-            if (0 * i) {} // Very fake, but needed to get the s registers right
+            if ((0 * i) != 0) {} // Very fake, but needed to get the s registers right
+
             if (next != NULL) {
                 now->actor.child = &next->actor;
                 next->actor.parent = &now->actor;
@@ -176,7 +177,8 @@ void EnTp_Init(Actor* thisx, PlayState* play2) {
                 next->timer = next->unk_15C = i * -5;
                 next->horizontalVariation = 6.0f - (i * 0.75f);
                 now = next;
-                if (0 * i) {}
+
+                if ((0 * i) != 0) {}
             }
         }
     } else if (this->actor.params == TAILPASARAN_TAIL) {

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -1360,7 +1360,7 @@ void func_80B3F3C8(EnXc* this, PlayState* play) {
     this->action = SHEIK_ACTION_45;
 }
 
-void func_80B3F3D8() {
+void func_80B3F3D8(void) {
     func_800788CC(NA_SE_PL_SKIP);
 }
 

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -113,6 +113,8 @@ void KaleidoScope_DrawPlayerWork(PlayState* play) {
                      BOOTS_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS)));
 }
 
+void KaleidoScope_ProcessPlayerPreRender(PlayState* play);
+
 void KaleidoScope_DrawEquipment(PlayState* play) {
     PauseContext* pauseCtx = &play->pauseCtx;
     Input* input = &play->state.input[0];

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -113,6 +113,7 @@ void KaleidoScope_DrawPlayerWork(PlayState* play) {
                      BOOTS_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS)));
 }
 
+// Wrong prototype; this function is called with `play` even though it has no arguments
 void KaleidoScope_ProcessPlayerPreRender(PlayState* play);
 
 void KaleidoScope_DrawEquipment(PlayState* play) {

--- a/tools/asm_processor/build.py
+++ b/tools/asm_processor/build.py
@@ -109,6 +109,6 @@ with tempfile.TemporaryDirectory(prefix="asm_processor") as tmpdirname:
                 f.write("\n" + dep + ":\n")
     else:
         try:
-            deps_file.unlink(missing_ok=True)
+            deps_file.unlink()
         except OSError:
             pass

--- a/tools/asm_processor/build.py
+++ b/tools/asm_processor/build.py
@@ -1,64 +1,114 @@
 #!/usr/bin/env python3
 import sys
-import os
+from pathlib import Path
 import shlex
 import subprocess
 import tempfile
+import uuid
 import asm_processor
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-prelude = os.path.join(dir_path, "prelude.inc")
+# Boolean for debugging purposes
+# Preprocessed files are temporary, set to True to keep a copy
+keep_preprocessed_files = False
+
+dir_path = Path(__file__).resolve().parent
+asm_prelude_path = dir_path / "prelude.inc"
 
 all_args = sys.argv[1:]
-sep1 = all_args.index('--')
-sep2 = all_args.index('--', sep1+1)
+sep0 = next(index for index, arg in enumerate(all_args) if not arg.startswith("-"))
+sep1 = all_args.index("--")
+sep2 = all_args.index("--", sep1 + 1)
 
-compiler = all_args[:sep1]
+asmproc_flags = all_args[:sep0]
+compiler = all_args[sep0:sep1]
 
-assembler = all_args[sep1+1:sep2]
-assembler_sh = ' '.join(shlex.quote(x) for x in assembler)
+assembler_args = all_args[sep1 + 1 : sep2]
+assembler_sh = " ".join(shlex.quote(x) for x in assembler_args)
 
-compile_args = all_args[sep2+1:]
-in_file = compile_args[-1]
-out_ind = compile_args.index('-o')
-out_file = compile_args[out_ind + 1]
+
+compile_args = all_args[sep2 + 1 :]
+
+in_file = Path(compile_args[-1])
 del compile_args[-1]
+
+out_ind = compile_args.index("-o")
+out_file = Path(compile_args[out_ind + 1])
 del compile_args[out_ind + 1]
 del compile_args[out_ind]
 
-in_dir = os.path.split(os.path.realpath(in_file))[0]
-opt_flags = [x for x in compile_args if x in ['-g3', '-g', '-O1', '-O2', '-framepointer']]
 
-preprocessed_file = tempfile.NamedTemporaryFile(prefix='preprocessed', suffix='.c', delete=False)
+in_dir = in_file.resolve().parent
+opt_flags = [
+    x for x in compile_args if x in {"-g3", "-g", "-O0", "-O1", "-O2", "-framepointer"}
+]
+if "-mips2" not in compile_args:
+    opt_flags.append("-mips1")
 
-try:
-    asmproc_flags = opt_flags + [in_file, '--input-enc', 'utf-8', '--output-enc', 'euc-jp']
-    compile_cmdline = compiler + compile_args + ['-I', in_dir, '-o', out_file, preprocessed_file.name]
+asmproc_flags += opt_flags + [str(in_file)]
 
-    functions, deps = asm_processor.run(asmproc_flags, outfile=preprocessed_file)
+# Drop .mdebug and .gptab sections from resulting binaries. This makes
+# resulting .o files much smaller and speeds up builds, but loses line
+# number debug data.
+# asmproc_flags += ["--drop-mdebug-gptab"]
+
+# Convert encoding before compiling.
+asmproc_flags += ["--input-enc", "utf-8", "--output-enc", "euc-jp"]
+
+with tempfile.TemporaryDirectory(prefix="asm_processor") as tmpdirname:
+    tmpdir_path = Path(tmpdirname)
+    preprocessed_filename = "preprocessed_" + uuid.uuid4().hex + ".c"
+    preprocessed_path = tmpdir_path / preprocessed_filename
+
+    with preprocessed_path.open("wb") as f:
+        functions, deps = asm_processor.run(asmproc_flags, outfile=f)
+
+    if keep_preprocessed_files:
+        import shutil
+
+        keep_output_dir = Path("./asm_processor_preprocessed")
+        keep_output_dir.mkdir(parents=True, exist_ok=True)
+
+        shutil.copy(
+            preprocessed_path,
+            keep_output_dir / (in_file.stem + "_" + preprocessed_filename),
+        )
+
+    compile_cmdline = (
+        compiler
+        + compile_args
+        + ["-I", str(in_dir), "-o", str(out_file), str(preprocessed_path)]
+    )
+
     try:
         subprocess.check_call(compile_cmdline)
     except subprocess.CalledProcessError as e:
-        print("Failed to compile file " + in_file + ". Command line:")
+        print("Failed to compile file " + str(in_file) + ". Command line:")
         print()
-        print(' '.join(shlex.quote(x) for x in compile_cmdline))
+        print(" ".join(shlex.quote(x) for x in compile_cmdline))
         print()
         sys.exit(55)
-        # To keep the preprocessed file:
-        # os._exit(1)
 
-    asm_processor.run(asmproc_flags + ['--post-process', out_file, '--assembler', assembler_sh, '--asm-prelude', prelude], functions=functions)
+    asm_processor.run(
+        asmproc_flags
+        + [
+            "--post-process",
+            str(out_file),
+            "--assembler",
+            assembler_sh,
+            "--asm-prelude",
+            str(asm_prelude_path),
+        ],
+        functions=functions,
+    )
 
-    deps_file = out_file[:-2] + ".asmproc.d"
+    deps_file = out_file.with_suffix(".asmproc.d")
     if deps:
-        with open(deps_file, "w") as f:
-            f.write(out_file + ": " + " \\\n    ".join(deps) + "\n")
+        with deps_file.open("w") as f:
+            f.write(str(out_file) + ": " + " \\\n    ".join(deps) + "\n")
             for dep in deps:
                 f.write("\n" + dep + ":\n")
     else:
         try:
-            os.remove(deps_file)
+            deps_file.unlink(missing_ok=True)
         except OSError:
             pass
-finally:
-    os.remove(preprocessed_file.name)


### PR DESCRIPTION
Following the example of https://github.com/zeldaret/mm/pull/781, I enabled more IDO warnings with `-fullwarn` and added `-verbose` to get more details in warnings. Then I fixed every new warning generated as well as a few old warnings we still had in the repo. Just like the MM PR, I had to disable one new type of warning (number 516) because it's unusable in our case as it warns for any 64 bit integer (eg. in every texture). 

I also updated asm-processor to use a `#pragma` instead of the former `EARLY` includes for cs data, which avoids another type of warning and is an overall improvement.

---

Note:
For normal linux builds, the only warnings left after this are the GCC warnings from `-Wtype-limits`, which are basically unfixable without changing the code logic. So at this point our options are either to keep them forever, to disable them globally with a simple `-Wno-type-limits` in the makefile, or to ignore them locally with pragmas surrounding the issue.
For future reference, this is how it would look if we disabled them locally:
```c
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wtype-limits"
    // rot.x < 0x8000 is always true since it's a s16
    if ((this->actor.shape.rot.x > 0) && (this->actor.shape.rot.x < 0x8000)) {
#pragma GCC diagnostic pop
```