### PR TITLE
Fix clang compilation error due to a fallthrough

### DIFF
--- a/src/code/audio_effects.c
+++ b/src/code/audio_effects.c
@@ -243,7 +243,7 @@ f32 Audio_AdsrUpdate(AdsrState* adsr) {
             adsr->envIndex = 0;
             adsr->action.s.state = ADSR_STATE_LOOP;
             FALLTHROUGH;
-        retry:
+        retry:;
         case ADSR_STATE_LOOP:
             adsr->delay = adsr->envelope[adsr->envIndex].delay;
             switch (adsr->delay) {


### PR DESCRIPTION
Tested with clang 10.0.0 and 12.0.0