### PR TITLE
Actor prototype cleanup

### DIFF
--- a/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.h
@@ -4,7 +4,10 @@
 #include "ultra64.h"
 #include "global.h"
 
-#define BGMIZUSHUTTER_PARAM(size, timer, switchFlag) (size << 0xC) | (timer << 0x6) | switchFlag
+#define BGMIZUSHUTTER_SIZE_PARAM(thisx)   (((u16)(thisx)->params >> 0xC) & 0xF)
+#define BGMIZUSHUTTER_TIMER_PARAM(thisx)  (((u16)(thisx)->params >> 0x6) & 0x3F)
+#define BGMIZUSHUTTER_SWITCH_PARAM(thisx) (((u16)(thisx)->params >> 0x0) & 0x3F)
+#define BGMIZUSHUTTER_PARAMS(size, timer, switchFlag) (((size) << 0xC) | ((timer) << 0x6) | (switchFlag))
 
 struct BgMizuShutter;
 

--- a/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.c
+++ b/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.c
@@ -9,10 +9,10 @@
 
 #define FLAGS (ACTOR_FLAG_4 | ACTOR_FLAG_5)
 
-void BgSstFloor_Init(BgSstFloor* this, PlayState* play);
-void BgSstFloor_Destroy(BgSstFloor* this, PlayState* play);
-void BgSstFloor_Update(BgSstFloor* this, PlayState* play);
-void BgSstFloor_Draw(BgSstFloor* this, PlayState* play);
+void BgSstFloor_Init(Actor* thisx, PlayState* play);
+void BgSstFloor_Destroy(Actor* thisx, PlayState* play);
+void BgSstFloor_Update(Actor* thisx, PlayState* play);
+void BgSstFloor_Draw(Actor* thisx, PlayState* play);
 
 static s32 sUnkValues[] = { 0, 0, 0 }; // Unused, probably a zero vector
 
@@ -32,7 +32,7 @@ static InitChainEntry sInitChain[] = {
     ICHAIN_VEC3F_DIV1000(scale.x, 100, ICHAIN_STOP),
 };
 
-void BgSstFloor_Init(BgSstFloor* thisx, PlayState* play) {
+void BgSstFloor_Init(Actor* thisx, PlayState* play) {
     s32 pad;
     BgSstFloor* this = (BgSstFloor*)thisx;
     CollisionHeader* colHeader = NULL;
@@ -43,14 +43,14 @@ void BgSstFloor_Init(BgSstFloor* thisx, PlayState* play) {
     this->dyna.bgId = DynaPoly_SetBgActor(play, &play->colCtx.dyna, &this->dyna.actor, colHeader);
 }
 
-void BgSstFloor_Destroy(BgSstFloor* thisx, PlayState* play) {
+void BgSstFloor_Destroy(Actor* thisx, PlayState* play) {
     s32 pad;
     BgSstFloor* this = (BgSstFloor*)thisx;
 
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
 }
 
-void BgSstFloor_Update(BgSstFloor* thisx, PlayState* play) {
+void BgSstFloor_Update(Actor* thisx, PlayState* play) {
     s32 pad;
     BgSstFloor* this = (BgSstFloor*)thisx;
     Player* player = GET_PLAYER(play);
@@ -120,7 +120,7 @@ void BgSstFloor_Update(BgSstFloor* thisx, PlayState* play) {
     func_8003EE6C(play, &play->colCtx.dyna);
 }
 
-void BgSstFloor_Draw(BgSstFloor* thisx, PlayState* play) {
+void BgSstFloor_Draw(Actor* thisx, PlayState* play) {
     BgSstFloor* this = (BgSstFloor*)thisx;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_bg_sst_floor.c", 277);

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -155,6 +155,9 @@ void ObjectKankyo_Init(Actor* thisx, PlayState* play) {
             this->requiredObjectLoaded = false;
             ObjectKankyo_SetupAction(this, ObjectKankyo_InitBeams);
             break;
+
+        default:
+            break;
     }
 }
 
@@ -216,6 +219,9 @@ void ObjectKankyo_Fairies(ObjectKankyo* this, PlayState* play) {
 
             case 771:
                 func_80078884(NA_SE_VO_RT_THROW);
+                break;
+
+            default:
                 break;
         }
     }
@@ -348,6 +354,9 @@ void ObjectKankyo_Fairies(ObjectKankyo* this, PlayState* play) {
                             this->effects[i].dirPhase.y += 0.08f * Rand_ZeroOne();
                             this->effects[i].dirPhase.z += 0.05f * Rand_ZeroOne();
                             break;
+
+                        default:
+                            break;
                     }
                 } else if (this->effects[i].state == 2) {
                     // scatter when the player moves or after a long enough time
@@ -443,6 +452,9 @@ void ObjectKankyo_Fairies(ObjectKankyo* this, PlayState* play) {
 
             case 3: // reset, never reached
                 this->effects[i].state = 0;
+                break;
+
+            default:
                 break;
         }
     }
@@ -675,6 +687,9 @@ void ObjectKankyo_DrawSnow(Actor* thisx, PlayState* play2) {
                 case 2:
                     this->effects[i].state = 0;
                     break;
+
+                default:
+                    break;
             }
 
             if (1) {}
@@ -726,6 +741,9 @@ void ObjectKankyo_Lightning(ObjectKankyo* this, PlayState* play) {
                 if (play->csCtx.npcActions[0]->action == 1) {
                     this->effects[0].state = 0;
                 }
+                break;
+            
+            default:
                 break;
         }
     }

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -27,11 +27,11 @@ void ObjectKankyo_SunGraveSpark(ObjectKankyo* this, PlayState* play);
 void ObjectKankyo_WaitForBeamObject(ObjectKankyo* this, PlayState* play);
 void ObjectKankyo_Beams(ObjectKankyo* this, PlayState* play);
 
-void ObjectKankyo_DrawFairies(ObjectKankyo* this, PlayState* play);
-void ObjectKankyo_DrawSnow(ObjectKankyo* this, PlayState* play);
-void ObjectKankyo_DrawLightning(ObjectKankyo* this, PlayState* play);
-void ObjectKankyo_DrawSunGraveSpark(ObjectKankyo* this, PlayState* play);
-void ObjectKankyo_DrawBeams(ObjectKankyo* this, PlayState* play);
+void ObjectKankyo_DrawFairies(Actor* this, PlayState* play);
+void ObjectKankyo_DrawSnow(Actor* this, PlayState* play);
+void ObjectKankyo_DrawLightning(Actor* this, PlayState* play);
+void ObjectKankyo_DrawSunGraveSpark(Actor* this, PlayState* play);
+void ObjectKankyo_DrawBeams(Actor* this, PlayState* play);
 
 static void* sEffLightningTextures[] = {
     gEffLightning1Tex, gEffLightning2Tex, gEffLightning3Tex, gEffLightning4Tex,
@@ -455,34 +455,35 @@ void ObjectKankyo_Update(Actor* thisx, PlayState* play) {
 }
 
 void ObjectKankyo_Draw(Actor* thisx, PlayState* play) {
-    ObjectKankyo* this = (ObjectKankyo*)thisx;
-
-    switch (this->actor.params) {
+    switch (thisx->params) {
         case 0:
-            ObjectKankyo_DrawFairies(this, play);
+            ObjectKankyo_DrawFairies(thisx, play);
             break;
 
         case 2:
-            ObjectKankyo_DrawLightning(this, play);
+            ObjectKankyo_DrawLightning(thisx, play);
             break;
 
         case 3:
-            ObjectKankyo_DrawSnow(this, play);
+            ObjectKankyo_DrawSnow(thisx, play);
             break;
 
         case 4:
-            ObjectKankyo_DrawSunGraveSpark(this, play);
+            ObjectKankyo_DrawSunGraveSpark(thisx, play);
             break;
 
         case 5:
-            ObjectKankyo_DrawBeams(this, play);
+            ObjectKankyo_DrawBeams(thisx, play);
+            break;
+
+        default:
             break;
     }
 }
 
-void ObjectKankyo_DrawFairies(ObjectKankyo* this2, PlayState* play2) {
-    ObjectKankyo* this = this2;
+void ObjectKankyo_DrawFairies(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
+    ObjectKankyo* this = (ObjectKankyo*)thisx;
     f32 alphaScale;
     Vec3f vec1 = { 0.0f, 0.0f, 0.0f };
     Vec3f vec2 = { 0.0f, 0.0f, 0.0f };
@@ -565,9 +566,9 @@ void ObjectKankyo_DrawFairies(ObjectKankyo* this2, PlayState* play2) {
     }
 }
 
-void ObjectKankyo_DrawSnow(ObjectKankyo* this2, PlayState* play2) {
-    ObjectKankyo* this = this2;
+void ObjectKankyo_DrawSnow(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
+    ObjectKankyo* this = (ObjectKankyo*)thisx;
     f32 dist;
     f32 dx;
     f32 dy;
@@ -730,9 +731,9 @@ void ObjectKankyo_Lightning(ObjectKankyo* this, PlayState* play) {
     }
 }
 
-void ObjectKankyo_DrawLightning(ObjectKankyo* this, PlayState* play) {
+void ObjectKankyo_DrawLightning(Actor* thisx, PlayState* play) {
     s32 pad;
-    s32 pad2;
+    ObjectKankyo* this = (ObjectKankyo*)thisx;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_object_kankyo.c", 1182);
 
@@ -791,9 +792,9 @@ void ObjectKankyo_SunGraveSpark(ObjectKankyo* this, PlayState* play) {
     }
 }
 
-void ObjectKankyo_DrawSunGraveSpark(ObjectKankyo* this2, PlayState* play2) {
-    ObjectKankyo* this = this2;
+void ObjectKankyo_DrawSunGraveSpark(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
+    ObjectKankyo* this = (ObjectKankyo*)thisx;
     Vec3f start;
     Vec3f end;
     f32 weight;
@@ -889,7 +890,7 @@ void ObjectKankyo_Beams(ObjectKankyo* this, PlayState* play) {
     }
 }
 
-void ObjectKankyo_DrawBeams(ObjectKankyo* this2, PlayState* play2) {
+void ObjectKankyo_DrawBeams(Actor* thisx, PlayState* play2) {
     static Color_RGB8 sBeamPrimColors[] = {
         { 255, 255, 170 }, { 170, 255, 255 }, { 255, 170, 255 },
         { 255, 255, 170 }, { 255, 255, 170 }, { 255, 255, 170 },
@@ -897,8 +898,8 @@ void ObjectKankyo_DrawBeams(ObjectKankyo* this2, PlayState* play2) {
     static Color_RGB8 sBeamEnvColors[] = {
         { 0, 200, 0 }, { 0, 50, 255 }, { 100, 0, 200 }, { 200, 0, 0 }, { 200, 255, 0 }, { 255, 120, 0 },
     };
-    ObjectKankyo* this = this2;
     PlayState* play = play2;
+    ObjectKankyo* this = (ObjectKankyo*)thisx;
     s16 i;
     f32 beamX[] = { 430.0f, 860.0f, 430.0f, -426.0f, -862.0f, -440.0f };
     f32 beamY[] = { 551.0f, 551.0f, 551.0f, 554.0f, 551.0f, 547.0f };


### PR DESCRIPTION
- Fixed all the ActorFunc function prototypes that were not using `Actor*`.
- Make the params macros in BgMizuShutter a bit more consistent, although I'm not proposing this as any definitive style.
- Add defaults to switches in ObjectKankyo and give the Draw functions more plausible prototypes.