### PR TITLE
Enable int-conversion warnings and fix all current instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ EMU_FLAGS = --noosd
 INC        := -Iinclude -Isrc -Ibuild -I.
 
 # Check code syntax with host compiler
-CHECK_WARNINGS := -Wall -Wextra -Wno-format-security -Wno-unknown-pragmas -Wno-unused-parameter -Wno-unused-variable -Wno-missing-braces -Wno-int-conversion
+CHECK_WARNINGS := -Wall -Wextra -Wno-format-security -Wno-unknown-pragmas -Wno-unused-parameter -Wno-unused-variable -Wno-missing-braces
 
 CPP        := cpp
 MKLDSCRIPT := tools/mkldscript

--- a/include/functions.h
+++ b/include/functions.h
@@ -522,7 +522,7 @@ void Actor_SetDropFlag(Actor* actor, ColliderInfo* colInfo, s32 freezeFlag);
 void Actor_SetDropFlagJntSph(Actor* actor, ColliderJntSph* jntSph, s32 freezeFlag);
 void func_80035844(Vec3f* arg0, Vec3f* arg1, Vec3s* arg2, s32 arg3);
 Actor* func_800358DC(Actor* actor, Vec3f* spawnPos, Vec3s* spawnRot, f32* arg3, s32 timer, s16* unused,
-                     PlayState* play, s16 params, s32 arg8);
+                     PlayState* play, s16 params, Gfx* dList);
 void func_800359B8(Actor* actor, s16 arg1, Vec3s* arg2);
 s32 Flags_GetEventChkInf(s32 flag);
 void Flags_SetEventChkInf(s32 flag);

--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -742,7 +742,7 @@ typedef struct {
     /* 0x01 */ u8 seqOrFontId;
     /* 0x02 */ u16 instId;
     /* 0x04 */ s32 unkMediumParam;
-    /* 0x08 */ s32 curDevAddr;
+    /* 0x08 */ u32 curDevAddr;
     /* 0x0C */ u8* curRamAddr;
     /* 0x10 */ u8* ramAddr;
     /* 0x14 */ s32 state;

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -110,9 +110,9 @@ typedef struct {
 typedef struct {
     /* 0x00 */ u16   unk_00;
     /* 0x02 */ u8    id;
-    /* 0x04 */ u32   source;
+    /* 0x04 */ void* source;
     /* 0x08 */ u32   unk_0C;
-    /* 0x0C */ u32   tlut;
+    /* 0x0C */ void* tlut;
     /* 0x10 */ u16   width;
     /* 0x12 */ u16   height;
     /* 0x14 */ u8    fmt;

--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -77,7 +77,7 @@ void Idle_ThreadEntry(void* arg) {
     osViSetMode(&gViConfigMode);
     ViConfig_UpdateVi(true);
     osViBlack(true);
-    osViSwapBuffer(0x803DA80); //! @bug Invalid vram address (probably intended to be 0x803DA800)
+    osViSwapBuffer((void*)0x803DA80); //! @bug Invalid vram address (probably intended to be 0x803DA800)
     osCreatePiManager(OS_PRIORITY_PIMGR, &gPiMgrCmdQueue, sPiMgrCmdBuff, ARRAY_COUNT(sPiMgrCmdBuff));
     StackCheck_Init(&sMainStackInfo, sMainStack, STACK_TOP(sMainStack), 0, 0x400, "main");
     osCreateThread(&gMainThread, THREAD_ID_MAIN, Main_ThreadEntry, arg, STACK_TOP(sMainStack), THREAD_PRI_MAIN_INIT);

--- a/src/boot/is_debug.c
+++ b/src/boot/is_debug.c
@@ -48,7 +48,7 @@ void* is_proutSyncPrintf(void* arg, const char* str, u32 count) {
 
     osEPiReadIo(sISVHandle, (u32)&gISVDbgPrnAdrs->magic, &data);
     if (data != ASCII_TO_U32('I', 'S', '6', '4')) {
-        return 1;
+        return (void*)1;
     }
     osEPiReadIo(sISVHandle, (u32)&gISVDbgPrnAdrs->get, &data);
     pos = data;
@@ -58,11 +58,11 @@ void* is_proutSyncPrintf(void* arg, const char* str, u32 count) {
     if (end >= 0xFFE0) {
         end -= 0xFFE0;
         if (pos < end || start < pos) {
-            return 1;
+            return (void*)1;
         }
     } else {
         if (start < pos && pos < end) {
-            return 1;
+            return (void*)1;
         }
     }
     while (count) {
@@ -83,7 +83,7 @@ void* is_proutSyncPrintf(void* arg, const char* str, u32 count) {
     }
     osEPiWriteIo(sISVHandle, (u32)&gISVDbgPrnAdrs->put, start);
 
-    return 1;
+    return (void*)1;
 }
 
 void func_80002384(const char* exp, const char* file, u32 line) {

--- a/src/boot/stackcheck.c
+++ b/src/boot/stackcheck.c
@@ -103,7 +103,7 @@ s32 StackCheck_GetState(StackEntry* entry) {
     osSyncPrintf(VT_RST);
 
     if (ret != STACK_STATUS_OK) {
-        LogUtils_LogHexDump(entry->head, entry->tail - entry->head);
+        LogUtils_LogHexDump((void*)entry->head, entry->tail - entry->head);
     }
 
     return ret;

--- a/src/code/TwoHeadArena.c
+++ b/src/code/TwoHeadArena.c
@@ -79,7 +79,7 @@ void* THA_GetTail(TwoHeadArena* tha) {
 void* THA_AllocStart(TwoHeadArena* tha, u32 size) {
     void* start = tha->head;
 
-    tha->head = (u32)tha->head + size;
+    tha->head = (void*)((u32)tha->head + size);
     return start;
 }
 
@@ -100,19 +100,19 @@ void* THA_AllocEnd(TwoHeadArena* tha, u32 size) {
         mask = (size >= 0x10) ? ~0xF : 0;
     }
 
-    tha->tail = (((u32)tha->tail & mask) - size) & mask;
+    tha->tail = (void*)((((u32)tha->tail & mask) - size) & mask);
     return tha->tail;
 }
 
 void* THA_AllocEndAlign16(TwoHeadArena* tha, u32 size) {
     u32 mask = ~0xF;
 
-    tha->tail = (((u32)tha->tail & mask) - size) & (u64)mask;
+    tha->tail = (void*)((((u32)tha->tail & mask) - size) & (u32)(u64)mask);
     return tha->tail;
 }
 
 void* THA_AllocEndAlign(TwoHeadArena* tha, u32 size, u32 mask) {
-    tha->tail = (((u32)tha->tail & mask) - size) & mask;
+    tha->tail = (void*)((((u32)tha->tail & mask) - size) & mask);
     return tha->tail;
 }
 
@@ -126,7 +126,7 @@ u32 THA_IsCrash(TwoHeadArena* tha) {
 
 void THA_Init(TwoHeadArena* tha) {
     tha->head = tha->bufp;
-    tha->tail = (u32)tha->bufp + tha->size;
+    tha->tail = (void*)((u32)tha->bufp + tha->size);
 }
 
 void THA_Ct(TwoHeadArena* tha, void* ptr, u32 size) {

--- a/src/code/__osMalloc.c
+++ b/src/code/__osMalloc.c
@@ -442,7 +442,7 @@ void __osFree_NoLock(Arena* arena, void* ptr) {
     ArenaImpl_SetDebugInfo(node, NULL, 0, arena);
 
     if (arena->flag & FILL_FREEBLOCK) {
-        __osMemset((u32)node + sizeof(ArenaNode), BLOCK_FREE_MAGIC, node->size);
+        __osMemset((void*)((u32)node + sizeof(ArenaNode)), BLOCK_FREE_MAGIC, node->size);
     }
 
     newNext = next;
@@ -512,7 +512,7 @@ void __osFree_NoLockDebug(Arena* arena, void* ptr, const char* file, s32 line) {
     ArenaImpl_SetDebugInfo(node, file, line, arena);
 
     if (arena->flag & FILL_FREEBLOCK) {
-        __osMemset((u32)node + sizeof(ArenaNode), BLOCK_FREE_MAGIC, node->size);
+        __osMemset((void*)((u32)node + sizeof(ArenaNode)), BLOCK_FREE_MAGIC, node->size);
     }
 
     newNext = node->next;

--- a/src/code/audio_heap.c
+++ b/src/code/audio_heap.c
@@ -1400,7 +1400,7 @@ void AudioHeap_ApplySampleBankCacheInternal(s32 apply, s32 sampleBankId) {
 
     sampleBankTable = gAudioContext.sampleBankTable;
     numFonts = gAudioContext.soundFontTable->numEntries;
-    change.oldAddr = AudioHeap_SearchCaches(SAMPLE_TABLE, CACHE_EITHER, sampleBankId);
+    change.oldAddr = (u32)AudioHeap_SearchCaches(SAMPLE_TABLE, CACHE_EITHER, sampleBankId);
     if (change.oldAddr == 0) {
         return;
     }

--- a/src/code/audio_load.c
+++ b/src/code/audio_load.c
@@ -863,14 +863,11 @@ void AudioLoad_RelocateFont(s32 fontId, SoundFontData* fontDataStartAddr, Sample
         for (i = 0; i < numSfx; i++) {
             // Get a pointer to the i'th sound effect
             soundOffset = (u32)(((SoundFontSound*)fontData[1]) + i);
+            sfx = (SoundFontSound*)soundOffset;
 
             // Check for NULL (note: the pointer is guaranteed to be in fontData and can never be NULL)
-            if (soundOffset != 0) {
-                sfx = (SoundFontSound*)soundOffset;
-
-                if (sfx->sample != NULL) {
-                    AudioLoad_RelocateSample(sfx, fontDataStartAddr, sampleBankReloc);
-                }
+            if ((sfx != NULL) && ((u32)sfx->sample != 0)) {
+                AudioLoad_RelocateSample(sfx, fontDataStartAddr, sampleBankReloc);
             }
         }
     }

--- a/src/code/audio_load.c
+++ b/src/code/audio_load.c
@@ -407,10 +407,10 @@ s32 AudioLoad_SyncLoadSample(SoundFontSample* sample, s32 fontId) {
             }
 
             if (sample->medium == MEDIUM_UNK) {
-                AudioLoad_SyncDmaUnkMedium(sample->sampleAddr, sampleAddr, sample->size,
+                AudioLoad_SyncDmaUnkMedium((u32)sample->sampleAddr, sampleAddr, sample->size,
                                            gAudioContext.sampleBankTable->unkMediumParam);
             } else {
-                AudioLoad_SyncDma(sample->sampleAddr, sampleAddr, sample->size, sample->medium);
+                AudioLoad_SyncDma((u32)sample->sampleAddr, sampleAddr, sample->size, sample->medium);
             }
             sample->medium = MEDIUM_RAM;
             sample->sampleAddr = sampleAddr;
@@ -600,7 +600,7 @@ u32 AudioLoad_TrySyncLoadSampleBank(u32 sampleBankId, u32* outMedium, s32 noLoad
             AudioLoad_SetSampleFontLoadStatus(realTableId, LOAD_STATUS_COMPLETE);
         }
         *outMedium = MEDIUM_RAM;
-        return ramAddr;
+        return (u32)ramAddr;
     }
 
     cachePolicy = sampleBankTable->entries[sampleBankId].cachePolicy;
@@ -612,7 +612,7 @@ u32 AudioLoad_TrySyncLoadSampleBank(u32 sampleBankId, u32* outMedium, s32 noLoad
     ramAddr = AudioLoad_SyncLoad(SAMPLE_TABLE, sampleBankId, &noLoad);
     if (ramAddr != NULL) {
         *outMedium = MEDIUM_RAM;
-        return ramAddr;
+        return (u32)ramAddr;
     }
 
     *outMedium = sampleBankTable->entries[sampleBankId].medium;
@@ -809,10 +809,10 @@ void AudioLoad_RelocateFont(s32 fontId, SoundFontData* fontDataStartAddr, Sample
     s32 numDrums = gAudioContext.soundFonts[fontId].numDrums;
     s32 numInstruments = gAudioContext.soundFonts[fontId].numInstruments;
     s32 numSfx = gAudioContext.soundFonts[fontId].numSfx;
-    void** fontData = (void**)fontDataStartAddr;
+    u32* fontData = (u32*)fontDataStartAddr;
 
     // Relocate an offset (relative to the start of the font data) to a pointer (a ram address)
-#define RELOC_TO_RAM(offset) (void*)((u32)(offset) + (u32)(fontDataStartAddr))
+#define RELOC_TO_RAM(offset) ((u32)(offset) + (u32)(fontDataStartAddr))
 
     // Drums relocation
 
@@ -828,19 +828,19 @@ void AudioLoad_RelocateFont(s32 fontId, SoundFontData* fontDataStartAddr, Sample
         // Loop through the drum offsets
         for (i = 0; i < numDrums; i++) {
             // Get the i'th drum offset
-            soundOffset = ((Drum**)fontData[0])[i];
+            soundOffset = (u32)((Drum**)fontData[0])[i];
 
             // Some drum data entries are empty, represented by an offset of 0 in the list of drum offsets
             if (soundOffset != 0) {
                 soundOffset = RELOC_TO_RAM(soundOffset);
-                ((Drum**)fontData[0])[i] = drum = soundOffset;
+                ((Drum**)fontData[0])[i] = drum = (Drum*)soundOffset;
 
                 // The drum may be in the list multiple times and already relocated
                 if (!drum->isRelocated) {
                     AudioLoad_RelocateSample(&drum->sound, fontDataStartAddr, sampleBankReloc);
 
-                    soundOffset = drum->envelope;
-                    drum->envelope = RELOC_TO_RAM(soundOffset);
+                    soundOffset = (u32)drum->envelope;
+                    drum->envelope = (AdsrEnvelope*)RELOC_TO_RAM(soundOffset);
 
                     drum->isRelocated = true;
                 }
@@ -862,13 +862,13 @@ void AudioLoad_RelocateFont(s32 fontId, SoundFontData* fontDataStartAddr, Sample
         // Loop through the sound effects
         for (i = 0; i < numSfx; i++) {
             // Get a pointer to the i'th sound effect
-            soundOffset = ((SoundFontSound*)fontData[1]) + i;
+            soundOffset = (u32)(((SoundFontSound*)fontData[1]) + i);
 
             // Check for NULL (note: the pointer is guaranteed to be in fontData and can never be NULL)
-            if ((SoundFontSound*)soundOffset != NULL) {
-                sfx = soundOffset;
+            if (soundOffset != 0) {
+                sfx = (SoundFontSound*)soundOffset;
 
-                if ((u32)sfx->sample != 0) {
+                if (sfx->sample != NULL) {
                     AudioLoad_RelocateSample(sfx, fontDataStartAddr, sampleBankReloc);
                 }
             }
@@ -887,9 +887,9 @@ void AudioLoad_RelocateFont(s32 fontId, SoundFontData* fontDataStartAddr, Sample
     // Loop through the instruments
     for (i = 2; i <= 2 + numInstruments - 1; i++) {
         // Some instrument data entries are empty, represented by an offset of 0 in the list of instrument offsets
-        if ((u32)fontData[i] != 0) {
+        if (fontData[i] != 0) {
             fontData[i] = RELOC_TO_RAM(fontData[i]);
-            inst = fontData[i];
+            inst = (Instrument*)fontData[i];
 
             // The instrument may be in the list multiple times and already relocated
             if (!inst->isRelocated) {
@@ -906,8 +906,8 @@ void AudioLoad_RelocateFont(s32 fontId, SoundFontData* fontDataStartAddr, Sample
                     AudioLoad_RelocateSample(&inst->highNotesSound, fontDataStartAddr, sampleBankReloc);
                 }
 
-                soundOffset = inst->envelope;
-                inst->envelope = RELOC_TO_RAM(soundOffset);
+                soundOffset = (u32)inst->envelope;
+                inst->envelope = (AdsrEnvelope*)RELOC_TO_RAM(soundOffset);
 
                 inst->isRelocated = true;
             }
@@ -1221,9 +1221,9 @@ void AudioLoad_Init(void* heap, u32 heapSize) {
     AudioHeap_ResetStep();
 
     // Initialize audio tables
-    AudioLoad_InitTable(gAudioContext.sequenceTable, _AudioseqSegmentRomStart, 0);
-    AudioLoad_InitTable(gAudioContext.soundFontTable, _AudiobankSegmentRomStart, 0);
-    AudioLoad_InitTable(gAudioContext.sampleBankTable, _AudiotableSegmentRomStart, 0);
+    AudioLoad_InitTable(gAudioContext.sequenceTable, (u32)_AudioseqSegmentRomStart, 0);
+    AudioLoad_InitTable(gAudioContext.soundFontTable, (u32)_AudiobankSegmentRomStart, 0);
+    AudioLoad_InitTable(gAudioContext.sampleBankTable, (u32)_AudiotableSegmentRomStart, 0);
     numFonts = gAudioContext.soundFontTable->numEntries;
     gAudioContext.soundFonts = AudioHeap_Alloc(&gAudioContext.initPool, numFonts * sizeof(SoundFont));
 
@@ -1285,7 +1285,7 @@ s32 AudioLoad_SlowLoadSample(s32 fontId, s32 instId, s8* status) {
     slowLoad->state = SLOW_LOAD_STATE_START;
     slowLoad->bytesRemaining = ALIGN16(sample->size);
     slowLoad->ramAddr = slowLoad->curRamAddr;
-    slowLoad->curDevAddr = sample->sampleAddr;
+    slowLoad->curDevAddr = (u32)sample->sampleAddr;
     slowLoad->medium = sample->medium;
     slowLoad->seqOrFontId = fontId;
     slowLoad->instId = instId;
@@ -1577,7 +1577,7 @@ void AudioLoad_FinishAsyncLoad(AudioAsyncLoad* asyncLoad) {
             break;
     }
 
-    doneMsg = asyncLoad->retMsg;
+    doneMsg = (OSMesg)asyncLoad->retMsg;
     if (1) {}
     asyncLoad->status = 0;
     osSendMesg(asyncLoad->retQueue, doneMsg, OS_MESG_NOBLOCK);

--- a/src/code/audio_synthesis.c
+++ b/src/code/audio_synthesis.c
@@ -392,11 +392,11 @@ void AudioSynth_EnvSetup1(Acmd* cmd, s32 arg1, s32 arg2, s32 arg3, s32 arg4) {
 void func_800DBD08(void) {
 }
 
-void AudioSynth_LoadBuffer(Acmd* cmd, s32 arg1, s32 arg2, s32 arg3) {
+void AudioSynth_LoadBuffer(Acmd* cmd, s32 arg1, s32 arg2, void* arg3) {
     aLoadBuffer(cmd, arg3, arg1, arg2);
 }
 
-void AudioSynth_SaveBuffer(Acmd* cmd, s32 arg1, s32 arg2, s32 arg3) {
+void AudioSynth_SaveBuffer(Acmd* cmd, s32 arg1, s32 arg2, void* arg3) {
     aSaveBuffer(cmd, arg1, arg3, arg2);
 }
 
@@ -454,11 +454,11 @@ void func_800DBE64(void) {
 void func_800DBE6C(void) {
 }
 
-void AudioSynth_LoadFilter(Acmd* cmd, s32 flags, s32 countOrBuf, s32 addr) {
+void AudioSynth_LoadFilter(Acmd* cmd, s32 flags, s32 countOrBuf, void* addr) {
     aFilter(cmd, flags, countOrBuf, addr);
 }
 
-void AudioSynth_LoadFilterCount(Acmd* cmd, s32 count, s32 addr) {
+void AudioSynth_LoadFilterCount(Acmd* cmd, s32 count, void* addr) {
     aFilter(cmd, 2, count, addr);
 }
 
@@ -781,7 +781,7 @@ Acmd* AudioSynth_ProcessNote(s32 noteIndex, NoteSubEu* noteSubEu, NoteSynthesisS
         sample = noteSubEu->sound.soundFontSound->sample;
         loopInfo = sample->loop;
         loopEndPos = loopInfo->end;
-        sampleAddr = sample->sampleAddr;
+        sampleAddr = (u32)sample->sampleAddr;
         resampledTempLen = 0;
 
         for (curPart = 0; curPart < nParts; curPart++) {

--- a/src/code/code_800E4FE0.c
+++ b/src/code/code_800E4FE0.c
@@ -223,11 +223,11 @@ void func_800E5584(AudioCmd* cmd) {
 
         case 0x82:
             AudioLoad_SyncInitSeqPlayer(cmd->arg0, cmd->arg1, cmd->arg2);
-            func_800E59AC(cmd->arg0, cmd->data);
+            func_800E59AC(cmd->arg0, cmd->asInt);
             break;
 
         case 0x85:
-            AudioLoad_SyncInitSeqPlayerSkipTicks(cmd->arg0, cmd->arg1, cmd->data);
+            AudioLoad_SyncInitSeqPlayerSkipTicks(cmd->arg0, cmd->arg1, cmd->asInt);
             break;
 
         case 0x83:

--- a/src/code/fault.c
+++ b/src/code/fault.c
@@ -335,7 +335,7 @@ uintptr_t Fault_ConvertAddress(uintptr_t addr) {
 
     while (client != NULL) {
         if (client->callback != NULL) {
-            ret = Fault_ProcessClient(client->callback, addr, client->arg);
+            ret = Fault_ProcessClient(client->callback, (void*)addr, client->arg);
             if (ret == -1) {
                 Fault_RemoveAddrConvClient(client);
             } else if (ret != 0) {
@@ -1093,9 +1093,9 @@ void Fault_ResumeThread(OSThread* thread) {
     thread->context.cause = 0;
     thread->context.fpcsr = 0;
     thread->context.pc += sizeof(u32);
-    *(u32*)thread->context.pc = 0x0000000D; // write in a break instruction
-    osWritebackDCache(thread->context.pc, 4);
-    osInvalICache(thread->context.pc, 4);
+    *((u32*)thread->context.pc) = 0x0000000D; // write in a break instruction
+    osWritebackDCache((void*)thread->context.pc, 4);
+    osInvalICache((void*)thread->context.pc, 4);
     osStartThread(thread);
 }
 
@@ -1112,7 +1112,7 @@ void Fault_DisplayFrameBuffer(void) {
     } else {
         fb = osViGetNextFramebuffer();
         if ((uintptr_t)fb == K0BASE) {
-            fb = (PHYS_TO_K0(osMemSize) - sizeof(u16[SCREEN_HEIGHT][SCREEN_WIDTH]));
+            fb = (void*)(PHYS_TO_K0(osMemSize) - sizeof(u16[SCREEN_HEIGHT][SCREEN_WIDTH]));
         }
     }
 

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -24,7 +24,7 @@ UCodeInfo D_8012D248[3] = {
 
 void Graph_FaultClient(void) {
     void* nextFb = osViGetNextFramebuffer();
-    void* newFb = ((u32)SysCfb_GetFbPtr(0) != (u32)nextFb) ? SysCfb_GetFbPtr(0) : SysCfb_GetFbPtr(1);
+    void* newFb = (void*)((SysCfb_GetFbPtr(0) != (u32)nextFb) ? SysCfb_GetFbPtr(0) : SysCfb_GetFbPtr(1));
 
     osViSwapBuffer(newFb);
     Fault_WaitForInput();

--- a/src/code/load.c
+++ b/src/code/load.c
@@ -41,7 +41,7 @@ s32 Overlay_Load(uintptr_t vRomStart, uintptr_t vRomEnd, void* vRamStart, void* 
             // "Clear BSS area (% 08x-% 08x)"
             osSyncPrintf("BSS領域をクリアします(%08x-%08x)\n", end, end + ovl->bssSize);
         }
-        bzero(end, ovl->bssSize);
+        bzero((void*)end, ovl->bssSize);
     }
 
     size = (uintptr_t)&ovl->relocations[ovl->nRelocations] - (uintptr_t)ovl;

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -39,8 +39,8 @@ void Main(void* arg) {
     OSMesg irqMgrMsgBuf[60];
     u32 systemHeapStart;
     u32 fb;
-    s32 debugHeapStart;
-    s32 debugHeapSize;
+    u32 debugHeapStart;
+    u32 debugHeapSize;
     s16* msg;
 
     osSyncPrintf("mainproc 実行開始\n"); // "Start running"
@@ -55,16 +55,16 @@ void Main(void* arg) {
     gSystemHeapSize = fb - systemHeapStart;
     // "System heap initalization"
     osSyncPrintf("システムヒープ初期化 %08x-%08x %08x\n", systemHeapStart, fb, gSystemHeapSize);
-    SystemHeap_Init(systemHeapStart, gSystemHeapSize); // initializes the system heap
+    SystemHeap_Init((void*)systemHeapStart, gSystemHeapSize); // initializes the system heap
     if (osMemSize >= 0x800000) {
         debugHeapStart = SysCfb_GetFbEnd();
         debugHeapSize = PHYS_TO_K0(0x600000) - debugHeapStart;
     } else {
         debugHeapSize = 0x400;
-        debugHeapStart = SystemArena_MallocDebug(debugHeapSize, "../main.c", 565);
+        debugHeapStart = (u32)SystemArena_MallocDebug(debugHeapSize, "../main.c", 565);
     }
     osSyncPrintf("debug_InitArena(%08x, %08x)\n", debugHeapStart, debugHeapSize);
-    DebugArena_Init(debugHeapStart, debugHeapSize);
+    DebugArena_Init((void*)debugHeapStart, debugHeapSize);
     func_800636C0();
 
     R_ENABLE_ARENA_DBG = 0;

--- a/src/code/sched.c
+++ b/src/code/sched.c
@@ -657,8 +657,8 @@ void Sched_Init(Scheduler* sc, void* stack, OSPri priority, UNK_TYPE arg3, UNK_T
     // Create message queues for receiving interrupt events and tasks
     osCreateMesgQueue(&sc->interruptQueue, sc->interruptMsgBuf, ARRAY_COUNT(sc->interruptMsgBuf));
     osCreateMesgQueue(&sc->cmdQueue, sc->cmdMsgBuf, ARRAY_COUNT(sc->cmdMsgBuf));
-    osSetEventMesg(OS_EVENT_SP, &sc->interruptQueue, RSP_DONE_MSG);
-    osSetEventMesg(OS_EVENT_DP, &sc->interruptQueue, RDP_DONE_MSG);
+    osSetEventMesg(OS_EVENT_SP, &sc->interruptQueue, (OSMesg)RSP_DONE_MSG);
+    osSetEventMesg(OS_EVENT_DP, &sc->interruptQueue, (OSMesg)RDP_DONE_MSG);
     IrqMgr_AddClient(irqMgr, &sc->irqClient, &sc->interruptQueue);
     osCreateThread(&sc->thread, THREAD_ID_SCHED, Sched_ThreadEntry, sc, stack, priority);
     osStartThread(&sc->thread);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -4142,7 +4142,7 @@ void func_80035844(Vec3f* arg0, Vec3f* arg1, Vec3s* arg2, s32 arg3) {
  * Spawns En_Part (Dissipating Flames) actor as a child of the given actor.
  */
 Actor* func_800358DC(Actor* actor, Vec3f* spawnPos, Vec3s* spawnRot, f32* arg3, s32 timer, s16* unused, PlayState* play,
-                     s16 params, s32 arg8) {
+                     s16 params, Gfx* dList) {
     EnPart* spawnedEnPart;
 
     spawnedEnPart = (EnPart*)Actor_SpawnAsChild(&play->actorCtx, actor, play, ACTOR_EN_PART, spawnPos->x, spawnPos->y,
@@ -4150,7 +4150,7 @@ Actor* func_800358DC(Actor* actor, Vec3f* spawnPos, Vec3s* spawnRot, f32* arg3, 
     if (spawnedEnPart != NULL) {
         spawnedEnPart->actor.scale = actor->scale;
         spawnedEnPart->actor.speedXZ = arg3[0];
-        spawnedEnPart->displayList = arg8;
+        spawnedEnPart->displayList = dList;
         spawnedEnPart->action = 2;
         spawnedEnPart->timer = timer;
         spawnedEnPart->rotZ = arg3[1];

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -6072,7 +6072,7 @@ s32 Camera_Demo5(Camera* camera) {
 
     framesDiff = sDemo5PrevSfxFrame - camera->play->state.frames;
     if ((framesDiff > 50) || (framesDiff < -50)) {
-        func_80078884(camera->data1);
+        func_80078884((u32)camera->data1);
     }
 
     sDemo5PrevSfxFrame = camera->play->state.frames;

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -105,7 +105,7 @@ void func_801109B0(PlayState* play) {
 
     if (gSaveContext.equips.buttonItems[3] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment + 0x3000,
-                           (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[3] * 0x1000, 0x1000,
+                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[3] * 0x1000, 0x1000,
                             "../z_construct.c", 219);
     }
 

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -83,29 +83,29 @@ void func_801109B0(PlayState* play) {
 
     if (gSaveContext.equips.buttonItems[0] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment,
-                            _icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[0] * 0x1000, 0x1000,
+                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[0] * 0x1000, 0x1000,
                             "../z_construct.c", 198);
     } else if (gSaveContext.equips.buttonItems[0] != 0xFF) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment,
-                            _icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[0] * 0x1000, 0x1000,
+                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[0] * 0x1000, 0x1000,
                             "../z_construct.c", 203);
     }
 
     if (gSaveContext.equips.buttonItems[1] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment + 0x1000,
-                            _icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[1] * 0x1000, 0x1000,
+                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[1] * 0x1000, 0x1000,
                             "../z_construct.c", 209);
     }
 
     if (gSaveContext.equips.buttonItems[2] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment + 0x2000,
-                            _icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[2] * 0x1000, 0x1000,
+                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[2] * 0x1000, 0x1000,
                             "../z_construct.c", 214);
     }
 
     if (gSaveContext.equips.buttonItems[3] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment + 0x3000,
-                            _icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[3] * 0x1000, 0x1000,
+                           (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[3] * 0x1000, 0x1000,
                             "../z_construct.c", 219);
     }
 

--- a/src/code/z_kanfont.c
+++ b/src/code/z_kanfont.c
@@ -31,7 +31,7 @@ void Font_LoadMessageBoxIcon(Font* font, u16 icon) {
  */
 void Font_LoadOrderedFont(Font* font) {
     u8* fontBuf;
-    s32 fontStatic;
+    u32 fontStatic;
     s32 len;
     s32 jj;
     s32 codePointIndex;

--- a/src/code/z_kanfont.c
+++ b/src/code/z_kanfont.c
@@ -41,8 +41,8 @@ void Font_LoadOrderedFont(Font* font) {
     font->msgOffset = _message_0xFFFC_nes - (const char*)_nes_message_data_staticSegmentStart;
     len = font->msgLength = _message_0xFFFD_nes - _message_0xFFFC_nes;
 
-    DmaMgr_SendRequest1(font->msgBuf, (u32)&_nes_message_data_staticSegmentRomStart[font->msgOffset], len, "../z_kanfont.c",
-                        122);
+    DmaMgr_SendRequest1(font->msgBuf, (u32)&_nes_message_data_staticSegmentRomStart[font->msgOffset], len,
+                        "../z_kanfont.c", 122);
     osSyncPrintf("msg_data=%x,  msg_data0=%x   jj=%x\n", font->msgOffset, font->msgLength, jj = len);
 
     len = jj;

--- a/src/code/z_kanfont.c
+++ b/src/code/z_kanfont.c
@@ -10,7 +10,7 @@ void func_8006EE50(Font* font, u16 arg1, u16 arg2) {
  */
 void Font_LoadChar(Font* font, u8 character, u16 codePointIndex) {
     DmaMgr_SendRequest1(&font->charTexBuf[codePointIndex],
-                        &_nes_font_staticSegmentRomStart[character * FONT_CHAR_TEX_SIZE], FONT_CHAR_TEX_SIZE,
+                        (u32)&_nes_font_staticSegmentRomStart[character * FONT_CHAR_TEX_SIZE], FONT_CHAR_TEX_SIZE,
                         "../z_kanfont.c", 93);
 }
 
@@ -21,7 +21,7 @@ void Font_LoadChar(Font* font, u8 character, u16 codePointIndex) {
  */
 void Font_LoadMessageBoxIcon(Font* font, u16 icon) {
     DmaMgr_SendRequest1(font->iconBuf,
-                        &_message_staticSegmentRomStart[4 * MESSAGE_STATIC_TEX_SIZE + icon * FONT_CHAR_TEX_SIZE],
+                        (u32)&_message_staticSegmentRomStart[4 * MESSAGE_STATIC_TEX_SIZE + icon * FONT_CHAR_TEX_SIZE],
                         FONT_CHAR_TEX_SIZE, "../z_kanfont.c", 100);
 }
 
@@ -36,12 +36,12 @@ void Font_LoadOrderedFont(Font* font) {
     s32 jj;
     s32 codePointIndex;
     s32 fontBufIndex;
-    s32 offset;
+    u32 offset;
 
     font->msgOffset = _message_0xFFFC_nes - (const char*)_nes_message_data_staticSegmentStart;
     len = font->msgLength = _message_0xFFFD_nes - _message_0xFFFC_nes;
 
-    DmaMgr_SendRequest1(font->msgBuf, &_nes_message_data_staticSegmentRomStart[font->msgOffset], len, "../z_kanfont.c",
+    DmaMgr_SendRequest1(font->msgBuf, (u32)&_nes_message_data_staticSegmentRomStart[font->msgOffset], len, "../z_kanfont.c",
                         122);
     osSyncPrintf("msg_data=%x,  msg_data0=%x   jj=%x\n", font->msgOffset, font->msgLength, jj = len);
 
@@ -54,7 +54,7 @@ void Font_LoadOrderedFont(Font* font) {
 
         if (font->msgBuf[codePointIndex] != MESSAGE_NEWLINE) {
             fontBuf = font->fontBuf + fontBufIndex * 8;
-            fontStatic = _nes_font_staticSegmentRomStart;
+            fontStatic = (u32)_nes_font_staticSegmentRomStart;
 
             osSyncPrintf("nes_mes_buf[%d]=%d\n", codePointIndex, font->msgBuf[codePointIndex]);
 

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -371,9 +371,9 @@ void Play_Init(GameState* thisx) {
 
     osSyncPrintf("ZELDA ALLOC SIZE=%x\n", THA_GetSize(&this->state.tha));
     zAllocSize = THA_GetSize(&this->state.tha);
-    zAlloc = GameState_Alloc(&this->state, zAllocSize, "../z_play.c", 2918);
+    zAlloc = (u32)GameState_Alloc(&this->state, zAllocSize, "../z_play.c", 2918);
     zAllocAligned = (zAlloc + 8) & ~0xF;
-    ZeldaArena_Init(zAllocAligned, zAllocSize - zAllocAligned + zAlloc);
+    ZeldaArena_Init((void*)zAllocAligned, zAllocSize - zAllocAligned + zAlloc);
     // "Zelda Heap"
     osSyncPrintf("ゼルダヒープ %08x-%08x\n", zAllocAligned,
                  (s32)(zAllocAligned + zAllocSize) - (s32)(zAllocAligned - zAlloc));

--- a/src/code/z_sample.c
+++ b/src/code/z_sample.c
@@ -80,7 +80,7 @@ void Sample_LoadTitleStatic(SampleContext* this) {
     u32 size = _title_staticSegmentRomEnd - _title_staticSegmentRomStart;
 
     this->staticSegment = GameState_Alloc(&this->state, size, "../z_sample.c", 163);
-    DmaMgr_SendRequest1(this->staticSegment, _title_staticSegmentRomStart, size, "../z_sample.c", 164);
+    DmaMgr_SendRequest1(this->staticSegment, (u32)_title_staticSegmentRomStart, size, "../z_sample.c", 164);
 }
 
 void Sample_Init(GameState* thisx) {

--- a/src/code/z_ss_sram.c
+++ b/src/code/z_ss_sram.c
@@ -16,7 +16,7 @@ void SsSram_Init(u32 addr, u8 handleType, u8 handleDomain, u8 handleLatency, u8 
 
     if ((u32)OS_PHYSICAL_TO_K1(addr) != (*handle).baseAddress) {
         sSsSramContext.piHandle.type = handleType;
-        (*handle).baseAddress = OS_PHYSICAL_TO_K1(addr);
+        (*handle).baseAddress = (u32)OS_PHYSICAL_TO_K1(addr);
         sSsSramContext.piHandle.latency = handleLatency;
         sSsSramContext.piHandle.pulse = handlePulse;
         sSsSramContext.piHandle.pageSize = handlePageSize;

--- a/src/code/z_vr_box.c
+++ b/src/code/z_vr_box.c
@@ -449,16 +449,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_BAZAAR:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_SP1a_staticSegmentRomStart;
-            size = _vr_SP1a_staticSegmentRomEnd - start;
+            start = (u32)_vr_SP1a_staticSegmentRomStart;
+            size = (u32)_vr_SP1a_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1127);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1128);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1129);
 
-            start = _vr_SP1a_pal_staticSegmentRomStart;
-            size = _vr_SP1a_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_SP1a_pal_staticSegmentRomStart;
+            size = (u32)_vr_SP1a_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1132);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1133);
 
@@ -466,8 +466,8 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
             skyboxCtx->rot.y = 0.8f;
             break;
         case SKYBOX_OVERCAST_SUNSET:
-            start = _vr_cloud2_staticSegmentRomStart;
-            size = _vr_cloud2_staticSegmentRomEnd - start;
+            start = (u32)_vr_cloud2_staticSegmentRomStart;
+            size = (u32)_vr_cloud2_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1155);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1156);
@@ -480,8 +480,8 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[1], start, size, "../z_vr_box.c", 1166);
 
-            start = _vr_cloud2_pal_staticSegmentRomStart;
-            size = _vr_cloud2_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_cloud2_pal_staticSegmentRomStart;
+            size = (u32)_vr_cloud2_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size * 2, "../z_vr_box.c", 1170);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1171);
 
@@ -491,16 +491,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_MARKET_ADULT:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_RUVR_staticSegmentRomStart;
-            size = _vr_RUVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_RUVR_staticSegmentRomStart;
+            size = (u32)_vr_RUVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1182);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1183);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1184);
 
-            start = _vr_RUVR_pal_staticSegmentRomStart;
-            size = _vr_RUVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_RUVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_RUVR_pal_staticSegmentRomEnd - start;
             osSyncPrintf("ＳＩＺＥ = %d\n", size);
 
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1188);
@@ -509,44 +509,44 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
             DmaMgr_SendRequest1(skyboxCtx->palettes, start, size, "../z_vr_box.c", 1190);
             break;
         case SKYBOX_CUTSCENE_MAP:
-            start = _vr_holy0_staticSegmentRomStart;
-            size = _vr_holy0_staticSegmentRomEnd - start;
+            start = (u32)_vr_holy0_staticSegmentRomStart;
+            size = (u32)_vr_holy0_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1196);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1197);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1200);
 
-            start = _vr_holy1_staticSegmentRomStart;
-            size = _vr_holy1_staticSegmentRomEnd - start;
+            start = (u32)_vr_holy1_staticSegmentRomStart;
+            size = (u32)_vr_holy1_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[1] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1203);
             ASSERT(skyboxCtx->staticSegments[1] != NULL, "vr_box->vr_box_staticSegment[1] != NULL", "../z_vr_box.c",
                    1204);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[1], start, size, "../z_vr_box.c", 1207);
 
-            start = _vr_holy0_pal_staticSegmentRomStart;
-            size = _vr_holy0_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_holy0_pal_staticSegmentRomStart;
+            size = (u32)_vr_holy0_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size * 2, "../z_vr_box.c", 1211);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1212);
 
             DmaMgr_SendRequest1(skyboxCtx->palettes, start, size, "../z_vr_box.c", 1214);
-            DmaMgr_SendRequest1((u8*)skyboxCtx->palettes + size, _vr_holy1_pal_staticSegmentRomStart, size,
+            DmaMgr_SendRequest1((u8*)skyboxCtx->palettes + size, (u32)_vr_holy1_pal_staticSegmentRomStart, size,
                                 "../z_vr_box.c", 1216);
             break;
         case SKYBOX_HOUSE_LINK:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_LHVR_staticSegmentRomStart;
-            size = _vr_LHVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_LHVR_staticSegmentRomStart;
+            size = (u32)_vr_LHVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1226);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1227);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1228);
 
-            start = _vr_LHVR_pal_staticSegmentRomStart;
-            size = _vr_LHVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_LHVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_LHVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1231);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1232);
 
@@ -555,16 +555,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_MARKET_CHILD_DAY:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_MDVR_staticSegmentRomStart;
-            size = _vr_MDVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_MDVR_staticSegmentRomStart;
+            size = (u32)_vr_MDVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1257);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1258);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1259);
 
-            start = _vr_MDVR_pal_staticSegmentRomStart;
-            size = _vr_MDVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_MDVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_MDVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1262);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1263);
 
@@ -573,16 +573,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_MARKET_CHILD_NIGHT:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_MNVR_staticSegmentRomStart;
-            size = _vr_MNVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_MNVR_staticSegmentRomStart;
+            size = (u32)_vr_MNVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1271);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1272);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1273);
 
-            start = _vr_MNVR_pal_staticSegmentRomStart;
-            size = _vr_MNVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_MNVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_MNVR_pal_staticSegmentRomEnd - start;
             osSyncPrintf("ＳＩＺＥ = %d\n", size);
 
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1277);
@@ -593,16 +593,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HAPPY_MASK_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_FCVR_staticSegmentRomStart;
-            size = _vr_FCVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_FCVR_staticSegmentRomStart;
+            size = (u32)_vr_FCVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1286);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1287);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1288);
 
-            start = _vr_FCVR_pal_staticSegmentRomStart;
-            size = _vr_FCVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_FCVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_FCVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1291);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1292);
 
@@ -612,16 +612,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_KNOW_IT_ALL_BROTHERS:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_KHVR_staticSegmentRomStart;
-            size = _vr_KHVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_KHVR_staticSegmentRomStart;
+            size = (u32)_vr_KHVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1301);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1302);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1303);
 
-            start = _vr_KHVR_pal_staticSegmentRomStart;
-            size = _vr_KHVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_KHVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_KHVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1306);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1307);
 
@@ -630,16 +630,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_OF_TWINS:
             skyboxCtx->unk_140 = 2;
 
-            start = _vr_K3VR_staticSegmentRomStart;
-            size = _vr_K3VR_staticSegmentRomEnd - start;
+            start = (u32)_vr_K3VR_staticSegmentRomStart;
+            size = (u32)_vr_K3VR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1331);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1332);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1333);
 
-            start = _vr_K3VR_pal_staticSegmentRomStart;
-            size = _vr_K3VR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_K3VR_pal_staticSegmentRomStart;
+            size = (u32)_vr_K3VR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1336);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1337);
 
@@ -648,16 +648,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_STABLES:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_MLVR_staticSegmentRomStart;
-            size = _vr_MLVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_MLVR_staticSegmentRomStart;
+            size = (u32)_vr_MLVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1345);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1346);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1347);
 
-            start = _vr_MLVR_pal_staticSegmentRomStart;
-            size = _vr_MLVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_MLVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_MLVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1350);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1351);
 
@@ -666,16 +666,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_KAKARIKO:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_KKRVR_staticSegmentRomStart;
-            size = _vr_KKRVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_KKRVR_staticSegmentRomStart;
+            size = (u32)_vr_KKRVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1359);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1360);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1361);
 
-            start = _vr_KKRVR_pal_staticSegmentRomStart;
-            size = _vr_KKRVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_KKRVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_KKRVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1364);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1365);
 
@@ -684,16 +684,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_KOKIRI_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_KSVR_staticSegmentRomStart;
-            size = _vr_KSVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_KSVR_staticSegmentRomStart;
+            size = (u32)_vr_KSVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1373);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1374);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1375);
 
-            start = _vr_KSVR_pal_staticSegmentRomStart;
-            size = _vr_KSVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_KSVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_KSVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1378);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1379);
 
@@ -703,16 +703,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_GORON_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_GLVR_staticSegmentRomStart;
-            size = _vr_GLVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_GLVR_staticSegmentRomStart;
+            size = (u32)_vr_GLVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1405);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1406);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1407);
 
-            start = _vr_GLVR_pal_staticSegmentRomStart;
-            size = _vr_GLVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_GLVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_GLVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1410);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1411);
 
@@ -722,16 +722,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_ZORA_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_ZRVR_staticSegmentRomStart;
-            size = _vr_ZRVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_ZRVR_staticSegmentRomStart;
+            size = (u32)_vr_ZRVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1420);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1421);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1422);
 
-            start = _vr_ZRVR_pal_staticSegmentRomStart;
-            size = _vr_ZRVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_ZRVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_ZRVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1425);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1426);
 
@@ -741,16 +741,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_POTION_SHOP_KAKARIKO:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_DGVR_staticSegmentRomStart;
-            size = _vr_DGVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_DGVR_staticSegmentRomStart;
+            size = (u32)_vr_DGVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1451);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1452);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1453);
 
-            start = _vr_DGVR_pal_staticSegmentRomStart;
-            size = _vr_DGVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_DGVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_DGVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1456);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1457);
 
@@ -760,16 +760,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_POTION_SHOP_MARKET:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_ALVR_staticSegmentRomStart;
-            size = _vr_ALVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_ALVR_staticSegmentRomStart;
+            size = (u32)_vr_ALVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1466);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1467);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1468);
 
-            start = _vr_ALVR_pal_staticSegmentRomStart;
-            size = _vr_ALVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_ALVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_ALVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1471);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1472);
 
@@ -779,16 +779,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_BOMBCHU_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_NSVR_staticSegmentRomStart;
-            size = _vr_NSVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_NSVR_staticSegmentRomStart;
+            size = (u32)_vr_NSVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1481);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1482);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1483);
 
-            start = _vr_NSVR_pal_staticSegmentRomStart;
-            size = _vr_NSVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_NSVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_NSVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1486);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1487);
 
@@ -798,16 +798,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_RICHARD:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_IPVR_staticSegmentRomStart;
-            size = _vr_IPVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_IPVR_staticSegmentRomStart;
+            size = (u32)_vr_IPVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1512);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1513);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1514);
 
-            start = _vr_IPVR_pal_staticSegmentRomStart;
-            size = _vr_IPVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_IPVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_IPVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1517);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1518);
 
@@ -816,16 +816,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_IMPA:
             skyboxCtx->unk_140 = 1;
 
-            start = _vr_LBVR_staticSegmentRomStart;
-            size = _vr_LBVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_LBVR_staticSegmentRomStart;
+            size = (u32)_vr_LBVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1526);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1527);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1528);
 
-            start = _vr_LBVR_pal_staticSegmentRomStart;
-            size = _vr_LBVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_LBVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_LBVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1531);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1532);
 
@@ -834,16 +834,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_TENT:
             skyboxCtx->unk_140 = 2;
 
-            start = _vr_TTVR_staticSegmentRomStart;
-            size = _vr_TTVR_staticSegmentRomEnd - start;
+            start = (u32)_vr_TTVR_staticSegmentRomStart;
+            size = (u32)_vr_TTVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1540);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1541);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1542);
 
-            start = _vr_TTVR_pal_staticSegmentRomStart;
-            size = _vr_TTVR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_TTVR_pal_staticSegmentRomStart;
+            size = (u32)_vr_TTVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1545);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1546);
 
@@ -852,16 +852,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_MIDO:
             skyboxCtx->unk_140 = 2;
 
-            start = _vr_K4VR_staticSegmentRomStart;
-            size = _vr_K4VR_staticSegmentRomEnd - start;
+            start = (u32)_vr_K4VR_staticSegmentRomStart;
+            size = (u32)_vr_K4VR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1560);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1561);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1562);
 
-            start = _vr_K4VR_pal_staticSegmentRomStart;
-            size = _vr_K4VR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_K4VR_pal_staticSegmentRomStart;
+            size = (u32)_vr_K4VR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1565);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1566);
 
@@ -870,16 +870,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_SARIA:
             skyboxCtx->unk_140 = 2;
 
-            start = _vr_K5VR_staticSegmentRomStart;
-            size = _vr_K5VR_staticSegmentRomEnd - start;
+            start = (u32)_vr_K5VR_staticSegmentRomStart;
+            size = (u32)_vr_K5VR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1574);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1575);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1576);
 
-            start = _vr_K5VR_pal_staticSegmentRomStart;
-            size = _vr_K5VR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_K5VR_pal_staticSegmentRomStart;
+            size = (u32)_vr_K5VR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1579);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1580);
 
@@ -888,16 +888,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_ALLEY:
             skyboxCtx->unk_140 = 2;
 
-            start = _vr_KR3VR_staticSegmentRomStart;
-            size = _vr_KR3VR_staticSegmentRomEnd - start;
+            start = (u32)_vr_KR3VR_staticSegmentRomStart;
+            size = (u32)_vr_KR3VR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1588);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1589);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1590);
 
-            start = _vr_KR3VR_pal_staticSegmentRomStart;
-            size = _vr_KR3VR_pal_staticSegmentRomEnd - start;
+            start = (u32)_vr_KR3VR_pal_staticSegmentRomStart;
+            size = (u32)_vr_KR3VR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1593);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1594);
 

--- a/src/libultra/io/sptask.c
+++ b/src/libultra/io/sptask.c
@@ -32,7 +32,7 @@ void osSpTaskLoad(OSTask* intp) {
         intp->t.flags &= ~OS_TASK_YIELDED;
 
         if (tp->t.flags & OS_TASK_LOADABLE) {
-            tp->t.ucode = (void*)HW_REG((u32)intp->t.yield_data_ptr + OS_YIELD_DATA_SIZE - 4, u32);
+            tp->t.ucode = (u64*)HW_REG((u32)intp->t.yield_data_ptr + OS_YIELD_DATA_SIZE - 4, u32);
         }
     }
     osWritebackDCache(tp, sizeof(OSTask));

--- a/src/libultra/io/sptask.c
+++ b/src/libultra/io/sptask.c
@@ -32,7 +32,7 @@ void osSpTaskLoad(OSTask* intp) {
         intp->t.flags &= ~OS_TASK_YIELDED;
 
         if (tp->t.flags & OS_TASK_LOADABLE) {
-            tp->t.ucode = HW_REG((u32)intp->t.yield_data_ptr + OS_YIELD_DATA_SIZE - 4, u32);
+            tp->t.ucode = (void*)HW_REG((u32)intp->t.yield_data_ptr + OS_YIELD_DATA_SIZE - 4, u32);
         }
     }
     osWritebackDCache(tp, sizeof(OSTask));

--- a/src/libultra/os/createthread.c
+++ b/src/libultra/os/createthread.c
@@ -16,9 +16,9 @@ void osCreateThread(OSThread* thread, OSId id, void (*entry)(void*), void* arg, 
     thread->next = NULL;
     thread->queue = NULL;
     thread->context.pc = (u32)entry;
-    thread->context.a0 = arg;
+    thread->context.a0 = (u64)(s32)arg;
     thread->context.sp = (u64)(s32)sp - FRAMESZ(SZREG * NARGSAVE);
-    thread->context.ra = __osCleanupThread;
+    thread->context.ra = (u64)(s32)__osCleanupThread;
 
     mask = OS_IM_ALL;
     thread->context.sr = (mask & OS_IM_CPU) | SR_EXL;

--- a/src/libultra/os/initialize.c
+++ b/src/libultra/os/initialize.c
@@ -51,8 +51,8 @@ void __osInitialize_common(void) {
     *(struct_exceptionPreamble*)ECC_VEC = *(struct_exceptionPreamble*)__osExceptionPreamble; // cache errors
     *(struct_exceptionPreamble*)E_VEC = *(struct_exceptionPreamble*)__osExceptionPreamble;   // general exceptions
 
-    osWritebackDCache(K0BASE, E_VEC - K0BASE + sizeof(struct_exceptionPreamble));
-    osInvalICache(K0BASE, E_VEC - K0BASE + sizeof(struct_exceptionPreamble));
+    osWritebackDCache((void*)K0BASE, E_VEC - K0BASE + sizeof(struct_exceptionPreamble));
+    osInvalICache((void*)K0BASE, E_VEC - K0BASE + sizeof(struct_exceptionPreamble));
     __createSpeedParam();
     osUnmapTLBAll();
     osMapTLBRdb();

--- a/src/libultra/rmon/xprintf.c
+++ b/src/libultra/rmon/xprintf.c
@@ -5,13 +5,13 @@
         if (i < 999)                         \
             i = *a + i * 10 - '0';
 
-#define _PROUT(fmt, _size)                 \
-    if (_size > 0) {                       \
-        arg = (void*)pfn(arg, fmt, _size); \
-        if (arg != 0)                      \
-            x.nchar += _size;              \
-        else                               \
-            return x.nchar;                \
+#define _PROUT(fmt, _size)          \
+    if (_size > 0) {                \
+        arg = pfn(arg, fmt, _size); \
+        if (arg != NULL)            \
+            x.nchar += _size;       \
+        else                        \
+            return x.nchar;         \
     }
 #define _PAD(m, src, extracond)      \
     if (extracond && m > 0) {        \
@@ -196,7 +196,7 @@ void _Putfld(_Pft* px, va_list* pap, u8 code, u8* ac) {
             break;
 
         case 'p':
-            px->v.ll = va_arg(*pap, void*);
+            px->v.ll = (s32)va_arg(*pap, void*);
             px->s = (char*)&ac[px->n0];
             _Litob(px, 'x');
             break;

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -79,7 +79,7 @@ void BossGanon2_SetObjectSegment(BossGanon2* this, PlayState* play, s32 objectId
     s32 pad;
     s32 objectIdx = Object_GetIndex(&play->objectCtx, objectId);
 
-    gSegments[6] = PHYSICAL_TO_VIRTUAL(play->objectCtx.status[objectIdx].segment);
+    gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[objectIdx].segment);
 
     if (setRSPSegment) {
         OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 790);
@@ -1042,7 +1042,7 @@ void func_808FFDB0(BossGanon2* this, PlayState* play) {
     s32 objectIdx = Object_GetIndex(&play->objectCtx, OBJECT_GANON2);
 
     if (Object_IsLoaded(&play->objectCtx, objectIdx)) {
-        gSegments[6] = PHYSICAL_TO_VIRTUAL(play->objectCtx.status[objectIdx].segment);
+        gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[objectIdx].segment);
         Animation_MorphToLoop(&this->skelAnime, &object_ganon2_Anim_00FFE4, -10.0f);
         this->actionFunc = func_808FFEBC;
 

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -308,7 +308,9 @@ void BossGoma_ClearPixels32x32Rgba16(s16* rgba16image, u8* clearPixelTable, s16 
     if (clearPixelTable[i]) {
         // address of the top left pixel in a 2x2 pixels block located at
         // (i & 0xF, i >> 4) in a 16x16 grid of 2x2 pixels
-        targetPixel = (s32)rgba16image + (s16)((i & 0xF) * 2 + (i & 0xF0) * 4) * 2;
+        targetPixel = rgba16image;
+        targetPixel += (s16)((i & 0xF) * 2 + (i & 0xF0) * 4);
+
         // set the 2x2 block of pixels to 0
         targetPixel[0] = 0;
         targetPixel[1] = 0;

--- a/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
+++ b/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
@@ -329,7 +329,7 @@ void DemoEc_UseDrawObject(DemoEc* this, PlayState* play) {
 void DemoEc_UseAnimationObject(DemoEc* this, PlayState* play) {
     s32 animObjBankIndex = this->animObjBankIndex;
 
-    gSegments[6] = PHYSICAL_TO_VIRTUAL(play->objectCtx.status[animObjBankIndex].segment);
+    gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[animObjBankIndex].segment);
 }
 
 CsCmdActorAction* DemoEc_GetNpcAction(PlayState* play, s32 actionIndex) {

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1855,7 +1855,7 @@ void DemoEffect_DrawGodLgt(Actor* thisx, PlayState* play) {
 void DemoEffect_DrawLightEffect(Actor* thisx, PlayState* play) {
     DemoEffect* this = (DemoEffect*)thisx;
     u8* alpha;
-    u32 disp;
+    Gfx* disp;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_demo_effect.c", 2842);
 
@@ -1864,7 +1864,7 @@ void DemoEffect_DrawLightEffect(Actor* thisx, PlayState* play) {
         if (this->light.flicker == 0) {
             this->light.flicker = 1;
         } else {
-            disp = (u32)gEffFlash1DL; // necessary to match, should be able to remove after fake matches are fixed
+            disp = (Gfx*)(u32)gEffFlash1DL; // necessary to match, should be able to remove after fake matches are fixed
             alpha = &this->light.alpha;
             Gfx_SetupDL_25Xlu(play->state.gfxCtx);
             gDPSetPrimColor(POLY_XLU_DISP++, 0, 128, this->primXluColor[0], this->primXluColor[1],

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1855,7 +1855,7 @@ void DemoEffect_DrawGodLgt(Actor* thisx, PlayState* play) {
 void DemoEffect_DrawLightEffect(Actor* thisx, PlayState* play) {
     DemoEffect* this = (DemoEffect*)thisx;
     u8* alpha;
-    Gfx* disp;
+    u32 disp;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_demo_effect.c", 2842);
 

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -763,7 +763,7 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
     s16 i;
     f32 temp_f22;
     DemoKankyo* this = (DemoKankyo*)thisx;
-    u32 disp;
+    Gfx* disp;
     Player* player = GET_PLAYER(play);
     Vec3f camPos;
     f32 translateX;
@@ -859,7 +859,7 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
         translateZ = this->unk_150[i].unk_C.z + this->unk_150[i].unk_0.z;
 
         if (this->unk_150[i].unk_22 < 2) {
-            disp = (u32)gEffFlash1DL;
+            disp = (Gfx*)(u32)gEffFlash1DL;
             if (linkAge != LINK_AGE_ADULT) {
                 Matrix_Translate(translateX, translateY, translateZ, MTXMODE_NEW);
             } else {

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -763,7 +763,7 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
     s16 i;
     f32 temp_f22;
     DemoKankyo* this = (DemoKankyo*)thisx;
-    Gfx* disp;
+    u32 disp;
     Player* player = GET_PLAYER(play);
     Vec3f camPos;
     f32 translateX;

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -170,7 +170,7 @@ void EnDntNomal_Destroy(Actor* thisx, PlayState* play) {
 
 void EnDntNomal_WaitForObject(EnDntNomal* this, PlayState* play) {
     if (Object_IsLoaded(&play->objectCtx, this->objIndex)) {
-        gSegments[6] = PHYSICAL_TO_VIRTUAL(play->objectCtx.status[this->objIndex].segment);
+        gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[this->objIndex].segment);
         this->actor.objBankIndex = this->objIndex;
         ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 0.0f);
         this->actor.gravity = -2.0f;

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -858,7 +858,9 @@ void EnHorse_Init(Actor* thisx, PlayState* play2) {
     this->animationIdx = ENHORSE_ANIM_IDLE;
     Animation_PlayOnce(&this->skin.skelAnime, sAnimationHeaders[this->type][this->animationIdx]);
     this->numBoosts = 6;
-    this->blinkTimer = this->postDrawFunc = this->boostRegenTime = 0;
+    this->boostRegenTime = 0;
+    this->postDrawFunc = NULL;
+    this->blinkTimer = 0;
     EnHorse_ResetCutscene(this, play);
     EnHorse_ResetRace(this, play);
     EnHorse_ResetHorsebackArchery(this, play);

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -864,7 +864,7 @@ void EnMb_ClubAttack(EnMb* this, PlayState* play) {
             func_80033480(play, &effSpawnPos, 2.0f, 3, 0x12C, 0xB4, 1);
             Camera_AddQuake(&play->mainCamera, 2, 0x19, 5);
             func_800358DC(&this->actor, &effSpawnPos, &this->actor.world.rot, flamesParams, 20, flamesUnused, play, -1,
-                          0);
+                          NULL);
             EnMb_SetupClubWaitAfterAttack(this);
         }
     } else {

--- a/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -1989,7 +1989,7 @@ void EnOssan_InitBazaarShopkeeper(EnOssan* this, PlayState* play) {
 
 void EnOssan_InitKokiriShopkeeper(EnOssan* this, PlayState* play) {
     SkelAnime_InitFlex(play, &this->skelAnime, &gKm1Skel, NULL, NULL, NULL, 0);
-    gSegments[6] = PHYSICAL_TO_VIRTUAL(play->objectCtx.status[this->objBankIndex3].segment);
+    gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[this->objBankIndex3].segment);
     Animation_Change(&this->skelAnime, &object_masterkokiri_Anim_0004A8, 1.0f, 0.0f,
                      Animation_GetLastFrame(&object_masterkokiri_Anim_0004A8), 0, 0.0f);
     this->actor.draw = EnOssan_DrawKokiriShopkeeper;
@@ -2000,7 +2000,7 @@ void EnOssan_InitKokiriShopkeeper(EnOssan* this, PlayState* play) {
 
 void EnOssan_InitGoronShopkeeper(EnOssan* this, PlayState* play) {
     SkelAnime_InitFlex(play, &this->skelAnime, &gGoronSkel, NULL, NULL, NULL, 0);
-    gSegments[6] = PHYSICAL_TO_VIRTUAL(play->objectCtx.status[this->objBankIndex3].segment);
+    gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[this->objBankIndex3].segment);
     Animation_Change(&this->skelAnime, &gGoronShopkeeperAnim, 1.0f, 0.0f, Animation_GetLastFrame(&gGoronShopkeeperAnim),
                      0, 0.0f);
     this->actor.draw = EnOssan_DrawGoronShopkeeper;
@@ -2009,7 +2009,7 @@ void EnOssan_InitGoronShopkeeper(EnOssan* this, PlayState* play) {
 
 void EnOssan_InitZoraShopkeeper(EnOssan* this, PlayState* play) {
     SkelAnime_InitFlex(play, &this->skelAnime, &gZoraSkel, NULL, NULL, NULL, 0);
-    gSegments[6] = PHYSICAL_TO_VIRTUAL(play->objectCtx.status[this->objBankIndex3].segment);
+    gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[this->objBankIndex3].segment);
     Animation_Change(&this->skelAnime, &gZoraShopkeeperAnim, 1.0f, 0.0f, Animation_GetLastFrame(&gZoraShopkeeperAnim),
                      0, 0.0f);
     this->actor.draw = EnOssan_DrawZoraShopkeeper;

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -150,7 +150,7 @@ void EnSth_SetupAfterObjectLoaded(EnSth* this, PlayState* play) {
     s16* params;
 
     EnSth_SetupShapeColliderUpdate2AndDraw(this, play);
-    gSegments[6] = PHYSICAL_TO_VIRTUAL(play->objectCtx.status[this->objectBankIdx].segment);
+    gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[this->objectBankIdx].segment);
     SkelAnime_InitFlex(play, &this->skelAnime, sSkeletons[this->actor.params], NULL, this->jointTable, this->morphTable,
                        16);
     Animation_PlayLoop(&this->skelAnime, sAnimations[this->actor.params]);
@@ -389,7 +389,7 @@ void EnSth_Draw(Actor* thisx, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_sth.c", 2133);
 
-    gSegments[6] = PHYSICAL_TO_VIRTUAL(play->objectCtx.status[this->objectBankIdx].segment);
+    gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[this->objectBankIdx].segment);
     Gfx_SetupDL_37Opa(play->state.gfxCtx);
 
     gSPSegment(POLY_OPA_DISP++, 0x08,

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -742,7 +742,7 @@ void ObjectKankyo_Lightning(ObjectKankyo* this, PlayState* play) {
                     this->effects[0].state = 0;
                 }
                 break;
-            
+
             default:
                 break;
         }

--- a/src/overlays/effects/ovl_Effect_Ss_Fhg_Flash/z_eff_ss_fhg_flash.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Fhg_Flash/z_eff_ss_fhg_flash.c
@@ -34,7 +34,7 @@ u32 EffectSsFhgFlash_Init(PlayState* play, u32 index, EffectSs* this, void* init
     s32 objBankIdx;
     Vec3f zeroVec = { 0.0f, 0.0f, 0.0f };
     Vec3f sp34 = { 0.0f, -1000.0f, 0.0f };
-    void* oldSeg6;
+    u32 oldSeg6;
 
     if (initParams->type == FHGFLASH_LIGHTBALL) {
         objBankIdx = Object_GetIndex(&play->objectCtx, OBJECT_FHG);

--- a/src/overlays/effects/ovl_Effect_Ss_Ice_Smoke/z_eff_ss_ice_smoke.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Ice_Smoke/z_eff_ss_ice_smoke.c
@@ -24,7 +24,7 @@ u32 EffectSsIceSmoke_Init(PlayState* play, u32 index, EffectSs* this, void* init
     EffectSsIceSmokeInitParams* initParams = (EffectSsIceSmokeInitParams*)initParamsx;
     s32 pad;
     s32 objBankIdx;
-    void* oldSeg6;
+    u32 oldSeg6;
 
     objBankIdx = Object_GetIndex(&play->objectCtx, OBJECT_FZ);
 

--- a/src/overlays/gamestates/ovl_select/z_select.c
+++ b/src/overlays/gamestates/ovl_select/z_select.c
@@ -761,7 +761,7 @@ void Select_Init(GameState* thisx) {
     R_UPDATE_RATE = 1;
 
     this->staticSegment = GameState_Alloc(&this->state, size, "../z_select.c", 1114);
-    DmaMgr_SendRequest1(this->staticSegment, _z_select_staticSegmentRomStart, size, "../z_select.c", 1115);
+    DmaMgr_SendRequest1(this->staticSegment, (u32)_z_select_staticSegmentRomStart, size, "../z_select.c", 1115);
     gSaveContext.cutsceneIndex = 0x8000;
     gSaveContext.linkAge = LINK_AGE_CHILD;
 }

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -2595,7 +2595,7 @@ void KaleidoScope_Update(PlayState* play) {
             if (gSaveContext.language == LANGUAGE_ENG) {
                 size = (u32)_icon_item_nes_staticSegmentRomEnd - (u32)_icon_item_nes_staticSegmentRomStart;
                 osSyncPrintf("icon_item_dungeon dungeon-size=%x\n", size);
-                DmaMgr_SendRequest1(pauseCtx->iconItemLangSegment, _icon_item_nes_staticSegmentRomStart, size,
+                DmaMgr_SendRequest1(pauseCtx->iconItemLangSegment, (u32)_icon_item_nes_staticSegmentRomStart, size,
                                     "../z_kaleido_scope_PAL.c", 3739);
             } else if (gSaveContext.language == LANGUAGE_GER) {
                 size = (u32)_icon_item_ger_staticSegmentRomEnd - (u32)_icon_item_ger_staticSegmentRomStart;


### PR DESCRIPTION
More warning checks for a better codebase 💪😤

Simply removed `-Wno-int-conversion` from gcc/clang options and fixed the warnings it triggered in various places. This warning was disabled in the past because it was triggered wherever we had hardcoded addresses in data (eg. for texture pointer arrays). Fixing the remaining issues means adding a bunch of new casts ofc, but I think it's better to be explicit for those anyway.

---

Note: After this I plan to start making PRs that introduce intptr types wherever necessary (including a lot of these casts), but I didn't use any here since I wanted to keep the PR about warnings