### PR TITLE
Introduce PLAY_LOG()

### DIFF
--- a/include/regs.h
+++ b/include/regs.h
@@ -47,6 +47,7 @@
 #define R_ENV_FOG_NEAR              REG(14)
 #define R_ENV_TIME_SPEED_OLD        REG(15) // Most likely used during development. Unused in the final game.
 #define R_RUN_SPEED_LIMIT           REG(45)
+#define R_ENABLE_PLAY_LOGS          HREG(63)
 #define R_ENABLE_ARENA_DBG          SREG(0)
 #define R_UPDATE_RATE               SREG(30)
 #define R_ENABLE_AUDIO_DBG          SREG(36)

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -15,6 +15,14 @@ u64 D_801614D0[0xA00];
 
 void Play_SpawnScene(PlayState* this, s32 sceneNum, s32 spawn);
 
+// If R_ENABLE_PLAY_LOGS is enabled, the number "1" with a file and line number will be printed during
+// various phases of the Play update cycle. This can be helpful for debugging at what stage a problem may be occuring.
+// Due to the high number of logs occuring rapidly, the game will run slow with this enabled.
+#define PLAY_LOG(line)                        \
+    if (1 && R_ENABLE_PLAY_LOGS) {            \
+        LOG_NUM("1", 1, "../z_play.c", line); \
+    }
+
 void func_800BC450(PlayState* this) {
     Camera_ChangeDataIdx(GET_ACTIVE_CAM(this), this->unk_1242B - 1);
 }
@@ -158,6 +166,7 @@ void Play_Destroy(GameState* thisx) {
 
     this->state.gfxCtx->callback = NULL;
     this->state.gfxCtx->callbackParam = 0;
+
     SREG(91) = 0;
     R_PAUSE_MENU_MODE = 0;
 
@@ -300,6 +309,7 @@ void Play_Init(GameState* thisx) {
     Play_SpawnScene(
         this, gEntranceTable[((void)0, gSaveContext.entranceIndex) + ((void)0, gSaveContext.sceneSetupIndex)].scene,
         gEntranceTable[((void)0, gSaveContext.entranceIndex) + ((void)0, gSaveContext.sceneSetupIndex)].spawn);
+
     osSyncPrintf("\nSCENE_NO=%d COUNTER=%d\n", ((void)0, gSaveContext.entranceIndex), gSaveContext.sceneSetupIndex);
 
     // When entering Gerudo Valley in the right setup, trigger the GC emulator to play the ending movie.
@@ -320,10 +330,12 @@ void Play_Init(GameState* thisx) {
             gSaveContext.totalDays++;
             gSaveContext.bgsDayCount++;
             gSaveContext.dogIsLost = true;
+
             if (Inventory_ReplaceItem(this, ITEM_WEIRD_EGG, ITEM_CHICKEN) ||
                 Inventory_ReplaceItem(this, ITEM_POCKET_EGG, ITEM_POCKET_CUCCO)) {
                 Message_StartTextbox(this, 0x3066, NULL);
             }
+
             gSaveContext.nextDayTime = NEXT_TIME_DAY_SET;
         } else {
             gSaveContext.nextDayTime = NEXT_TIME_NIGHT_SET;
@@ -435,12 +447,14 @@ void Play_Update(PlayState* this) {
         HREG(81) = 0;
         osSyncPrintf("object_exchange_rom_address %u\n", gObjectTableSize);
         osSyncPrintf("RomStart RomEnd   Size\n");
+
         for (i = 0; i < gObjectTableSize; i++) {
             s32 size = gObjectTable[i].vromEnd - gObjectTable[i].vromStart;
 
             osSyncPrintf("%08x-%08x %08x(%8.3fKB)\n", gObjectTable[i].vromStart, gObjectTable[i].vromEnd, size,
                          size / 1024.0f);
         }
+
         osSyncPrintf("\n");
     }
 
@@ -477,6 +491,8 @@ void Play_Update(PlayState* this) {
         }
 
         if (this->transitionMode) {
+            // if `transitionMode` is not TRANS_MODE_OFF
+
             switch (this->transitionMode) {
                 case TRANS_MODE_SETUP:
                     if (this->transitionTrigger != TRANS_TRIGGER_END) {
@@ -550,6 +566,7 @@ void Play_Update(PlayState* this) {
                         (this->transitionCtx.transitionType == TRANS_TYPE_FADE_WHITE_CS_DELAYED) ||
                         (this->transitionCtx.transitionType == TRANS_TYPE_FADE_WHITE_INSTANT)) {
                         this->transitionCtx.setColor(&this->transitionCtx.instanceData, RGBA8(160, 160, 160, 255));
+
                         if (this->transitionCtx.setUnkColor != NULL) {
                             this->transitionCtx.setUnkColor(&this->transitionCtx.instanceData,
                                                             RGBA8(160, 160, 160, 255));
@@ -716,7 +733,6 @@ void Play_Update(PlayState* this) {
 
                 case TRANS_MODE_SANDSTORM_INIT:
                     if (this->transitionTrigger != TRANS_TRIGGER_END) {
-                        // trigger in, leaving area
                         this->envCtx.sandstormState = SANDSTORM_FILL;
                         this->transitionMode = TRANS_MODE_SANDSTORM;
                     } else {
@@ -767,6 +783,7 @@ void Play_Update(PlayState* this) {
                     Audio_PlaySoundGeneral(NA_SE_EV_SAND_STORM - SFX_FLAG, &gSfxDefaultPos, 4,
                                            &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
                                            &gSfxDefaultReverb);
+
                     if (this->transitionTrigger == TRANS_TRIGGER_END) {
                         if (this->envCtx.sandstormPrimA <= 0) {
                             gTrnsnUnkState = 0;
@@ -790,6 +807,7 @@ void Play_Update(PlayState* this) {
                 case TRANS_MODE_CS_BLACK_FILL:
                     if (gSaveContext.cutsceneTransitionControl != 0) {
                         this->envCtx.screenFillColor[3] = gSaveContext.cutsceneTransitionControl;
+
                         if (gSaveContext.cutsceneTransitionControl <= 100) {
                             gTrnsnUnkState = 0;
                             R_UPDATE_RATE = 3;
@@ -801,53 +819,36 @@ void Play_Update(PlayState* this) {
             }
         }
 
-        if (1 && HREG(63)) {
-            LOG_NUM("1", 1, "../z_play.c", 3533);
-        }
+        PLAY_LOG(3533);
 
         if (1 && (gTrnsnUnkState != 3)) {
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3542);
-            }
+            PLAY_LOG(3542);
 
             if ((gSaveContext.gameMode == 0) && (this->msgCtx.msgMode == MSGMODE_NONE) &&
                 (this->gameOverCtx.state == GAMEOVER_INACTIVE)) {
                 KaleidoSetup_Update(this);
             }
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3551);
-            }
-
+            PLAY_LOG(3551);
             sp80 = (this->pauseCtx.state != 0) || (this->pauseCtx.debugState != 0);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3555);
-            }
-
+            PLAY_LOG(3555);
             AnimationContext_Reset(&this->animationCtx);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3561);
-            }
-
+            PLAY_LOG(3561);
             Object_UpdateBank(&this->objectCtx);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3577);
-            }
+            PLAY_LOG(3577);
 
             if ((sp80 == 0) && (IREG(72) == 0)) {
-                if (1 && HREG(63)) {
-                    LOG_NUM("1", 1, "../z_play.c", 3580);
-                }
+                PLAY_LOG(3580);
 
                 this->gameplayFrames++;
-
                 func_800AA178(1);
 
                 if (this->actorCtx.freezeFlashTimer && (this->actorCtx.freezeFlashTimer-- < 5)) {
                     osSyncPrintf("FINISH=%d\n", this->actorCtx.freezeFlashTimer);
+
                     if ((this->actorCtx.freezeFlashTimer > 0) && ((this->actorCtx.freezeFlashTimer % 2) != 0)) {
                         this->envCtx.fillScreen = true;
                         this->envCtx.screenFillColor[0] = this->envCtx.screenFillColor[1] =
@@ -857,91 +858,52 @@ void Play_Update(PlayState* this) {
                         this->envCtx.fillScreen = false;
                     }
                 } else {
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3606);
-                    }
-
+                    PLAY_LOG(3606);
                     func_800973FC(this, &this->roomCtx);
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3612);
-                    }
-
+                    PLAY_LOG(3612);
                     CollisionCheck_AT(this, &this->colChkCtx);
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3618);
-                    }
-
+                    PLAY_LOG(3618);
                     CollisionCheck_OC(this, &this->colChkCtx);
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3624);
-                    }
-
+                    PLAY_LOG(3624);
                     CollisionCheck_Damage(this, &this->colChkCtx);
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3631);
-                    }
-
+                    PLAY_LOG(3631);
                     CollisionCheck_ClearContext(this, &this->colChkCtx);
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3637);
-                    }
+                    PLAY_LOG(3637);
 
                     if (!this->unk_11DE9) {
                         Actor_UpdateAll(this, &this->actorCtx);
                     }
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3643);
-                    }
-
+                    PLAY_LOG(3643);
                     func_80064558(this, &this->csCtx);
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3648);
-                    }
-
+                    PLAY_LOG(3648);
                     func_800645A0(this, &this->csCtx);
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3651);
-                    }
-
+                    PLAY_LOG(3651);
                     Effect_UpdateAll(this);
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3657);
-                    }
-
+                    PLAY_LOG(3657);
                     EffectSs_UpdateAll(this);
 
-                    if (1 && HREG(63)) {
-                        LOG_NUM("1", 1, "../z_play.c", 3662);
-                    }
+                    PLAY_LOG(3662);
                 }
             } else {
                 func_800AA178(0);
             }
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3672);
-            }
-
+            PLAY_LOG(3672);
             func_80095AA0(this, &this->roomCtx.curRoom, &input[1], 0);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3675);
-            }
-
+            PLAY_LOG(3675);
             func_80095AA0(this, &this->roomCtx.prevRoom, &input[1], 1);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3677);
-            }
+            PLAY_LOG(3677);
 
             if (this->unk_1242B != 0) {
                 if (CHECK_BTN_ALL(input[0].press.button, BTN_CUP)) {
@@ -958,85 +920,51 @@ void Play_Update(PlayState* this) {
                         func_800BC490(this, this->unk_1242B ^ 3);
                     }
                 }
+
                 func_800BC450(this);
             }
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3708);
-            }
-
+            PLAY_LOG(3708);
             SkyboxDraw_Update(&this->skyboxCtx);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3716);
-            }
+            PLAY_LOG(3716);
 
             if ((this->pauseCtx.state != 0) || (this->pauseCtx.debugState != 0)) {
-                if (1 && HREG(63)) {
-                    LOG_NUM("1", 1, "../z_play.c", 3721);
-                }
-
+                PLAY_LOG(3721);
                 KaleidoScopeCall_Update(this);
             } else if (this->gameOverCtx.state != GAMEOVER_INACTIVE) {
-                if (1 && HREG(63)) {
-                    LOG_NUM("1", 1, "../z_play.c", 3727);
-                }
-
+                PLAY_LOG(3727);
                 GameOver_Update(this);
             } else {
-                if (1 && HREG(63)) {
-                    LOG_NUM("1", 1, "../z_play.c", 3733);
-                }
-
+                PLAY_LOG(3733);
                 Message_Update(this);
             }
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3737);
-            }
+            PLAY_LOG(3737);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3742);
-            }
-
+            PLAY_LOG(3742);
             Interface_Update(this);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3765);
-            }
-
+            PLAY_LOG(3765);
             AnimationContext_Update(this, &this->animationCtx);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3771);
-            }
-
+            PLAY_LOG(3771);
             SoundSource_UpdateAll(this);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3777);
-            }
-
+            PLAY_LOG(3777);
             ShrinkWindow_Update(R_UPDATE_RATE);
 
-            if (1 && HREG(63)) {
-                LOG_NUM("1", 1, "../z_play.c", 3783);
-            }
-
+            PLAY_LOG(3783);
             TransitionFade_Update(&this->transitionFade, R_UPDATE_RATE);
         } else {
             goto skip;
         }
     }
 
-    if (1 && HREG(63)) {
-        LOG_NUM("1", 1, "../z_play.c", 3799);
-    }
+    PLAY_LOG(3799);
 
 skip:
-    if (1 && HREG(63)) {
-        LOG_NUM("1", 1, "../z_play.c", 3801);
-    }
+    PLAY_LOG(3801);
 
     if ((sp80 == 0) || gDbgCamEnabled) {
         s32 pad3[5];
@@ -1044,31 +972,21 @@ skip:
 
         this->nextCamId = this->activeCamId;
 
-        if (1 && HREG(63)) {
-            LOG_NUM("1", 1, "../z_play.c", 3806);
-        }
+        PLAY_LOG(3806);
 
         for (i = 0; i < NUM_CAMS; i++) {
             if ((i != this->nextCamId) && (this->cameraPtrs[i] != NULL)) {
-                if (1 && HREG(63)) {
-                    LOG_NUM("1", 1, "../z_play.c", 3809);
-                }
-
+                PLAY_LOG(3809);
                 Camera_Update(this->cameraPtrs[i]);
             }
         }
 
         Camera_Update(this->cameraPtrs[this->nextCamId]);
 
-        if (1 && HREG(63)) {
-            LOG_NUM("1", 1, "../z_play.c", 3814);
-        }
+        PLAY_LOG(3814);
     }
 
-    if (1 && HREG(63)) {
-        LOG_NUM("1", 1, "../z_play.c", 3816);
-    }
-
+    PLAY_LOG(3816);
     Environment_Update(this, &this->envCtx, &this->lightCtx, &this->pauseCtx, &this->msgCtx, &this->gameOverCtx,
                        this->state.gfxCtx);
 }
@@ -1352,9 +1270,7 @@ void Play_Main(GameState* thisx) {
 
     DebugDisplay_Init();
 
-    if (1 && HREG(63)) {
-        LOG_NUM("1", 1, "../z_play.c", 4556);
-    }
+    PLAY_LOG(4556);
 
     if ((HREG(80) == 10) && (HREG(94) != 10)) {
         HREG(81) = 1;
@@ -1377,15 +1293,11 @@ void Play_Main(GameState* thisx) {
         Play_Update(this);
     }
 
-    if (1 && HREG(63)) {
-        LOG_NUM("1", 1, "../z_play.c", 4583);
-    }
+    PLAY_LOG(4583);
 
     Play_Draw(this);
 
-    if (1 && HREG(63)) {
-        LOG_NUM("1", 1, "../z_play.c", 4587);
-    }
+    PLAY_LOG(4587);
 }
 
 // original name: "Game_play_demo_mode_check"


### PR DESCRIPTION
play has a logging system, which when enabled, prints out a file and line number at various parts of an update cycle. can be helpful for debugging at what stage in the play lifecycle something goes wrong.

A macro is introduced here to condense the (imo) spammy code that is needed for it. This makes things easier to read, and will make it easier to ifdef it out when we eventually get to retail 