### PR TITLE
Introduce Mutebehavior Flags

### DIFF
--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -12,6 +12,12 @@
 
 #define MAX_CHANNELS_PER_BANK 3
 
+#define MUTE_BEHAVIOR_3 (1 << 3)           // stop processing noteSubEu
+#define MUTE_BEHAVIOR_4 (1 << 4)           // stop something in seqLayer instructions
+#define MUTE_BEHAVIOR_SOFTEN (1 << 5)      // lower volume, by default to half
+#define MUTE_BEHAVIOR_STOP_NOTES (1 << 6)  // prevent further notes from playing
+#define MUTE_BEHAVIOR_STOP_SCRIPT (1 << 7) // stop processing sequence/channel scripts
+
 #define ADSR_DISABLE 0
 #define ADSR_HANG -1
 #define ADSR_GOTO -2
@@ -23,6 +29,7 @@
 #define WAVE_SAMPLE_COUNT 64
 
 #define AUDIO_RELOCATED_ADDRESS_START K0BASE
+
 
 typedef enum {
     /* 0 */ SOUNDMODE_STEREO,

--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -12,7 +12,7 @@
 
 #define MAX_CHANNELS_PER_BANK 3
 
-#define MUTE_BEHAVIOR_3 (1 << 3)           // stop processing noteSubEu
+#define MUTE_BEHAVIOR_3 (1 << 3)           // prevent further noteSubEus from playing
 #define MUTE_BEHAVIOR_4 (1 << 4)           // stop something in seqLayer scripts
 #define MUTE_BEHAVIOR_SOFTEN (1 << 5)      // lower volume, by default to half
 #define MUTE_BEHAVIOR_STOP_NOTES (1 << 6)  // prevent further notes from playing

--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -13,7 +13,7 @@
 #define MAX_CHANNELS_PER_BANK 3
 
 #define MUTE_BEHAVIOR_3 (1 << 3)           // stop processing noteSubEu
-#define MUTE_BEHAVIOR_4 (1 << 4)           // stop something in seqLayer instructions
+#define MUTE_BEHAVIOR_4 (1 << 4)           // stop something in seqLayer scripts
 #define MUTE_BEHAVIOR_SOFTEN (1 << 5)      // lower volume, by default to half
 #define MUTE_BEHAVIOR_STOP_NOTES (1 << 6)  // prevent further notes from playing
 #define MUTE_BEHAVIOR_STOP_SCRIPT (1 << 7) // stop processing sequence/channel scripts
@@ -29,7 +29,6 @@
 #define WAVE_SAMPLE_COUNT 64
 
 #define AUDIO_RELOCATED_ADDRESS_START K0BASE
-
 
 typedef enum {
     /* 0 */ SOUNDMODE_STEREO,

--- a/src/code/audio_effects.c
+++ b/src/code/audio_effects.c
@@ -8,7 +8,7 @@ void Audio_SequenceChannelProcessSound(SequenceChannel* channel, s32 recalculate
 
     if (channel->changes.s.volume || recalculateVolume) {
         channelVolume = channel->volume * channel->volumeScale * channel->seqPlayer->appliedFadeVolume;
-        if (channel->seqPlayer->muted && (channel->muteBehavior & 0x20)) {
+        if (channel->seqPlayer->muted && (channel->muteBehavior & MUTE_BEHAVIOR_SOFTEN)) {
             channelVolume = channel->seqPlayer->muteVolumeScale * channelVolume;
         }
         channel->appliedVolume = channelVolume * channelVolume;

--- a/src/code/audio_playback.c
+++ b/src/code/audio_playback.c
@@ -186,7 +186,7 @@ void Audio_ProcessNotes(void) {
                 playbackState->unk_04 = 1;
                 continue;
             } else if (playbackState->parentLayer->channel->seqPlayer->muted &&
-                       (playbackState->parentLayer->channel->muteBehavior & 0x40)) {
+                       (playbackState->parentLayer->channel->muteBehavior & MUTE_BEHAVIOR_STOP_NOTES)) {
                 // do nothing
             } else {
                 goto out;
@@ -277,7 +277,7 @@ void Audio_ProcessNotes(void) {
                 subAttrs.unk_16 = channel->unk_20;
                 bookOffset = channel->bookOffset & 0x7;
 
-                if (channel->seqPlayer->muted && (channel->muteBehavior & 8)) {
+                if (channel->seqPlayer->muted && (channel->muteBehavior & MUTE_BEHAVIOR_3)) {
                     subAttrs.frequency = 0.0f;
                     subAttrs.velocity = 0.0f;
                 }
@@ -481,7 +481,7 @@ void Audio_SeqLayerDecayRelease(SequenceLayer* layer, s32 target) {
 
             attrs->unk_6 = chan->unk_20;
             attrs->unk_4 = chan->unk_0F;
-            if (chan->seqPlayer->muted && (chan->muteBehavior & 8)) {
+            if (chan->seqPlayer->muted && (chan->muteBehavior & MUTE_BEHAVIOR_3)) {
                 note->noteSubEu.bitField0.finished = true;
             }
 

--- a/src/code/audio_seqplayer.c
+++ b/src/code/audio_seqplayer.c
@@ -1077,7 +1077,8 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
         }
     }
 
-    if ((seqPlayer->muted && (channel->muteBehavior & (0x40 | 0x10)) != 0) || channel->stopSomething2) {
+    if ((seqPlayer->muted && (channel->muteBehavior & (MUTE_BEHAVIOR_STOP_NOTES | MUTE_BEHAVIOR_4))) ||
+        channel->stopSomething2) {
         layer->stopSomething = true;
         return PROCESS_SCRIPT_END;
     }
@@ -1160,7 +1161,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
     }
 
     seqPlayer = channel->seqPlayer;
-    if (seqPlayer->muted && (channel->muteBehavior & 0x80)) {
+    if (seqPlayer->muted && (channel->muteBehavior & MUTE_BEHAVIOR_STOP_SCRIPT)) {
         return;
     }
 
@@ -1737,7 +1738,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
     AudioLoad_SetSeqLoadStatus(seqPlayer->seqId, LOAD_STATUS_COMPLETE);
     AudioLoad_SetFontLoadStatus(seqPlayer->defaultFont, LOAD_STATUS_COMPLETE);
 
-    if (seqPlayer->muted && (seqPlayer->muteBehavior & 0x80)) {
+    if (seqPlayer->muted && (seqPlayer->muteBehavior & MUTE_BEHAVIOR_STOP_SCRIPT)) {
         return;
     }
 
@@ -2126,7 +2127,7 @@ void AudioSeq_InitSequencePlayer(SequencePlayer* seqPlayer) {
         seqPlayer->soundScriptIO[j] = -1;
     }
 
-    seqPlayer->muteBehavior = 0x40 | 0x20;
+    seqPlayer->muteBehavior = MUTE_BEHAVIOR_SOFTEN | MUTE_BEHAVIOR_STOP_NOTES;
     seqPlayer->fadeVolumeScale = 1.0f;
     seqPlayer->bend = 1.0f;
     Audio_InitNoteLists(&seqPlayer->notePool);

--- a/src/code/code_800E4FE0.c
+++ b/src/code/code_800E4FE0.c
@@ -264,8 +264,8 @@ void func_800E5584(AudioCmd* cmd) {
                     NoteSubEu* subEu = &note->noteSubEu;
 
                     if (subEu->bitField0.enabled && note->playbackState.unk_04 == 0) {
-                        if (note->playbackState.parentLayer->channel->muteBehavior & 8) {
-                            subEu->bitField0.finished = 1;
+                        if (note->playbackState.parentLayer->channel->muteBehavior & MUTE_BEHAVIOR_3) {
+                            subEu->bitField0.finished = true;
                         }
                     }
                 }


### PR DESCRIPTION
In audio, there are only 5 flags used with `muteBehavior`. The three named flags were taken from `SM64`, and their names do seem to translate over to OoT. I've avoided naming `MUTE_BEHAVIOR_3` until we decide what to call `noteSubEu` and `MUTE_BEHAVIOR_4` needs more docs in general to understand.