### PR TITLE
Document code_800C3C20: Audio_StopAllSfx

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1557,7 +1557,7 @@ u32 THA_IsCrash(TwoHeadArena* tha);
 void THA_Init(TwoHeadArena* tha);
 void THA_Ct(TwoHeadArena* tha, void* ptr, u32 size);
 void THA_Dt(TwoHeadArena* tha);
-void Audio_StopAllSfx(void);
+void AudioMgr_StopAllSfx(void);
 void func_800C3C80(AudioMgr* audioMgr);
 void AudioMgr_HandleRetrace(AudioMgr* audioMgr);
 void AudioMgr_HandlePreNMI(AudioMgr* audioMgr);

--- a/include/functions.h
+++ b/include/functions.h
@@ -1557,7 +1557,7 @@ u32 THA_IsCrash(TwoHeadArena* tha);
 void THA_Init(TwoHeadArena* tha);
 void THA_Ct(TwoHeadArena* tha, void* ptr, u32 size);
 void THA_Dt(TwoHeadArena* tha);
-void func_800C3C20(void);
+void Audio_StopAllSfx(void);
 void func_800C3C80(AudioMgr* audioMgr);
 void AudioMgr_HandleRetrace(AudioMgr* audioMgr);
 void AudioMgr_HandlePreNMI(AudioMgr* audioMgr);

--- a/src/code/code_800C3C20.c
+++ b/src/code/code_800C3C20.c
@@ -4,7 +4,7 @@ u8 sSfxBankIds[] = {
     BANK_PLAYER, BANK_ITEM, BANK_ENV, BANK_ENEMY, BANK_SYSTEM, BANK_OCARINA, BANK_VOICE,
 };
 
-void Audio_StopAllSfx(void) {
+void AudioMgr_StopAllSfx(void) {
     u32 i;
 
     for (i = 0; (u32)(i < ARRAY_COUNT(sSfxBankIds)); i++) {

--- a/src/code/code_800C3C20.c
+++ b/src/code/code_800C3C20.c
@@ -1,13 +1,13 @@
 #include "global.h"
 
-u8 D_8012D200[] = {
-    0, 1, 2, 3, 4, 5, 6,
+u8 sSfxBankIds[] = {
+    BANK_PLAYER, BANK_ITEM, BANK_ENV, BANK_ENEMY, BANK_SYSTEM, BANK_OCARINA, BANK_VOICE,
 };
 
-void func_800C3C20(void) {
-    s32 i;
+void Audio_StopAllSfx(void) {
+    u32 i;
 
-    for (i = 0; (i < ARRAY_COUNT(D_8012D200)) & 0xFFFFFFFF; i++) {
-        Audio_StopSfxByBank(D_8012D200[i]);
+    for (i = 0; (u32)(i < ARRAY_COUNT(sSfxBankIds)); i++) {
+        Audio_StopSfxByBank(sSfxBankIds[i]);
     }
 }

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -424,7 +424,7 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
 
 void GameState_Destroy(GameState* gameState) {
     osSyncPrintf("game デストラクタ開始\n"); // "game destructor start"
-    func_800C3C20();
+    Audio_StopAllSfx();
     func_800F3054();
     osRecvMesg(&gameState->gfxCtx->queue, NULL, OS_MESG_BLOCK);
     LogUtils_CheckNullPointer("this->cleanup", gameState->destroy, "../game.c", 1139);

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -424,7 +424,7 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
 
 void GameState_Destroy(GameState* gameState) {
     osSyncPrintf("game デストラクタ開始\n"); // "game destructor start"
-    Audio_StopAllSfx();
+    AudioMgr_StopAllSfx();
     func_800F3054();
     osRecvMesg(&gameState->gfxCtx->queue, NULL, OS_MESG_BLOCK);
     LogUtils_CheckNullPointer("this->cleanup", gameState->destroy, "../game.c", 1139);


### PR DESCRIPTION
A simple file with only 1 single function that stops all sfx across all banks. Notably, this file is not part of the audio library, so I don't like giving this function the `Audio_` prefix, but I'm not really sure what the alternative could be. `Sfx_StopAll` maybe?