### PR TITLE
Better AudioMgr_StopAllSfx match

### DIFF
--- a/src/code/code_800C3C20.c
+++ b/src/code/code_800C3C20.c
@@ -5,9 +5,9 @@ u8 sSfxBankIds[] = {
 };
 
 void AudioMgr_StopAllSfx(void) {
-    u32 i;
+    volatile u8* bank;
 
-    for (i = 0; (u32)(i < ARRAY_COUNT(sSfxBankIds)); i++) {
-        Audio_StopSfxByBank(sSfxBankIds[i]);
+    for (bank = &sSfxBankIds[0]; bank < (sSfxBankIds + ARRAY_COUNT(sSfxBankIds)); bank++) {
+        Audio_StopSfxByBank(*bank);
     }
 }


### PR DESCRIPTION
Removes the `(u32)` cast by just using a pointer iterator.