### PR TITLE
Improve match for Lights_GlowCheck, add PROJECTED_TO_SCREEN macros

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -141,6 +141,13 @@
     }                                      \
     (void)0
 
+// horizontal, left to right
+#define PROJECTED_TO_SCREEN_X(projectedPos, invW) (s32)((projectedPos).x * (invW) * (SCREEN_WIDTH / 2) + (SCREEN_WIDTH / 2))
+// vertical, top to bottom
+#define PROJECTED_TO_SCREEN_Y(projectedPos, invW) (s32)((projectedPos).y * (invW) * (-SCREEN_HEIGHT / 2) + (SCREEN_HEIGHT / 2))
+// depth
+#define PROJECTED_TO_SCREEN_Z(projectedPos, invW) (s32)(((projectedPos).z * (invW)) * 16352) + 16352
+
 extern GraphicsContext* __gfxCtx;
 
 #define WORK_DISP       __gfxCtx->work.p

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -337,11 +337,11 @@ void func_8002C124(TargetContext* targetCtx, PlayState* play) {
 
         Actor_ProjectPos(play, &targetCtx->targetCenterPos, &projTargetCenter, &projTargetCappedInvW);
 
-        projTargetCenter.x = (160 * (projTargetCenter.x * projTargetCappedInvW)) * var1;
-        projTargetCenter.x = CLAMP(projTargetCenter.x, -320.0f, 320.0f);
+        projTargetCenter.x = ((SCREEN_WIDTH / 2) * (projTargetCenter.x * projTargetCappedInvW)) * var1;
+        projTargetCenter.x = CLAMP(projTargetCenter.x, -SCREEN_WIDTH, SCREEN_WIDTH);
 
-        projTargetCenter.y = (120 * (projTargetCenter.y * projTargetCappedInvW)) * var1;
-        projTargetCenter.y = CLAMP(projTargetCenter.y, -240.0f, 240.0f);
+        projTargetCenter.y = ((SCREEN_HEIGHT / 2) * (projTargetCenter.y * projTargetCappedInvW)) * var1;
+        projTargetCenter.y = CLAMP(projTargetCenter.y, -SCREEN_HEIGHT, SCREEN_HEIGHT);
 
         projTargetCenter.z = projTargetCenter.z * var1;
 
@@ -1554,8 +1554,8 @@ void Actor_GetScreenPos(PlayState* play, Actor* actor, s16* x, s16* y) {
     f32 cappedInvW;
 
     Actor_ProjectPos(play, &actor->focus.pos, &projectedPos, &cappedInvW);
-    *x = projectedPos.x * cappedInvW * (SCREEN_WIDTH / 2) + (SCREEN_WIDTH / 2);
-    *y = projectedPos.y * cappedInvW * -(SCREEN_HEIGHT / 2) + (SCREEN_HEIGHT / 2);
+    *x = PROJECTED_TO_SCREEN_X(projectedPos, cappedInvW);
+    *y = PROJECTED_TO_SCREEN_Y(projectedPos, cappedInvW);
 }
 
 u32 Actor_HasParent(Actor* actor, PlayState* play) {

--- a/src/code/z_fbdemo_triforce.c
+++ b/src/code/z_fbdemo_triforce.c
@@ -10,6 +10,9 @@ void TransitionTriforce_Start(void* thisx) {
         case 2:
             this->transPos = 1.0f;
             return;
+
+        default:
+            break;
     }
     this->transPos = 0.03f;
 }
@@ -18,7 +21,7 @@ void* TransitionTriforce_Init(void* thisx) {
     TransitionTriforce* this = (TransitionTriforce*)thisx;
 
     bzero(this, sizeof(*this));
-    guOrtho(&this->projection, -160.0f, 160.0f, -120.0f, 120.0f, -1000.0f, 1000.0f, 1.0f);
+    guOrtho(&this->projection, -SCREEN_WIDTH / 2, SCREEN_WIDTH / 2, - SCREEN_HEIGHT / 2, SCREEN_HEIGHT / 2, -1000.0f, 1000.0f, 1.0f);
     this->transPos = 1.0f;
     this->state = 2;
     this->step = 0.015f;

--- a/src/code/z_lights.c
+++ b/src/code/z_lights.c
@@ -335,9 +335,9 @@ void Lights_GlowCheck(PlayState* play) {
             params->drawGlow = false;
 
             if ((multDest.z > 1) && (fabsf(multDest.x * cappedInvWDest) < 1) && (fabsf(multDest.y * cappedInvWDest) < 1)) {
-                s32 wX = multDest.x * cappedInvWDest * 160 + 160;
-                s32 wY = multDest.y * cappedInvWDest * -120 + 120;
-                s32 wZ = (s32)((multDest.z * cappedInvWDest) * 16352) + 16352;
+                s32 wX = PROJECTED_TO_SCREEN_X(multDest, cappedInvWDest);
+                s32 wY = PROJECTED_TO_SCREEN_Y(multDest, cappedInvWDest);
+                s32 wZ = PROJECTED_TO_SCREEN_Z(multDest, cappedInvWDest);
                 s32 zBuf = gZBuffer[wY][wX] << 2;
 
                 if (wZ < (Environment_ZBufValToFixedPoint(zBuf) >> 3)) {

--- a/src/code/z_lights.c
+++ b/src/code/z_lights.c
@@ -317,42 +317,36 @@ Lights* Lights_New(GraphicsContext* gfxCtx, u8 ambientR, u8 ambientG, u8 ambient
 }
 
 void Lights_GlowCheck(PlayState* play) {
-    LightNode* node;
-    LightPoint* params;
-    Vec3f pos;
-    Vec3f multDest;
-    f32 cappedInvWDest;
-    f32 wX;
-    f32 wY;
-    s32 wZ;
-    s32 zBuf;
+    LightNode* light = play->lightCtx.listHead;
 
-    node = play->lightCtx.listHead;
+    while (light != NULL) {
+        LightPoint* params = &light->info->params.point;
 
-    while (node != NULL) {
-        params = &node->info->params.point;
+        if (light->info->type == LIGHT_POINT_GLOW) {
+            Vec3f pos;
+            Vec3f multDest;
+            f32 wDest;
 
-        if (node->info->type == LIGHT_POINT_GLOW) {
             pos.x = params->x;
             pos.y = params->y;
             pos.z = params->z;
-            Actor_ProjectPos(play, &pos, &multDest, &cappedInvWDest);
-            params->drawGlow = false;
-            wX = multDest.x * cappedInvWDest;
-            wY = multDest.y * cappedInvWDest;
+            Actor_ProjectPos(play, &pos, &multDest, &wDest);
 
-            if ((multDest.z > 1.0f) && (fabsf(wX) < 1.0f) && (fabsf(wY) < 1.0f)) {
-                wZ = (s32)((multDest.z * cappedInvWDest) * 16352.0f) + 16352;
-                zBuf = gZBuffer[(s32)((wY * -120.0f) + 120.0f)][(s32)((wX * 160.0f) + 160.0f)] * 4;
-                if (1) {}
-                if (1) {}
+            params->drawGlow = false;
+
+            if ((multDest.z > 1) && (fabsf(multDest.x * wDest) < 1) && (fabsf(multDest.y * wDest) < 1)) {
+                s32 wX = multDest.x * wDest * 160 + 160;
+                s32 wY = multDest.y * wDest * -120 + 120;
+                s32 wZ = (s32)((multDest.z * wDest) * 16352) + 16352;
+                s32 zBuf = gZBuffer[wY][wX] << 2;
 
                 if (wZ < (Environment_ZBufValToFixedPoint(zBuf) >> 3)) {
                     params->drawGlow = true;
                 }
             }
         }
-        node = node->next;
+
+        light = light->next;
     }
 }
 

--- a/src/code/z_lights.c
+++ b/src/code/z_lights.c
@@ -325,19 +325,19 @@ void Lights_GlowCheck(PlayState* play) {
         if (light->info->type == LIGHT_POINT_GLOW) {
             Vec3f pos;
             Vec3f multDest;
-            f32 wDest;
+            f32 cappedInvWDest;
 
             pos.x = params->x;
             pos.y = params->y;
             pos.z = params->z;
-            Actor_ProjectPos(play, &pos, &multDest, &wDest);
+            Actor_ProjectPos(play, &pos, &multDest, &cappedInvWDest);
 
             params->drawGlow = false;
 
-            if ((multDest.z > 1) && (fabsf(multDest.x * wDest) < 1) && (fabsf(multDest.y * wDest) < 1)) {
-                s32 wX = multDest.x * wDest * 160 + 160;
-                s32 wY = multDest.y * wDest * -120 + 120;
-                s32 wZ = (s32)((multDest.z * wDest) * 16352) + 16352;
+            if ((multDest.z > 1) && (fabsf(multDest.x * cappedInvWDest) < 1) && (fabsf(multDest.y * cappedInvWDest) < 1)) {
+                s32 wX = multDest.x * cappedInvWDest * 160 + 160;
+                s32 wY = multDest.y * cappedInvWDest * -120 + 120;
+                s32 wZ = (s32)((multDest.z * cappedInvWDest) * 16352) + 16352;
                 s32 zBuf = gZBuffer[wY][wX] << 2;
 
                 if (wZ < (Environment_ZBufValToFixedPoint(zBuf) >> 3)) {

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
@@ -23,8 +23,8 @@ typedef struct {
     /* 0x30 */ f32 scale;
     /* 0x34 */ s16 timer; // lifetime
     /* 0x36 */ s16 type; // 0 is general radiance, else is directed towards Player
-    /* 0x36 */ f32 pitch;
-    /* 0x36 */ f32 yaw;
+    /* 0x38 */ f32 pitch;
+    /* 0x3C */ f32 yaw;
     /* 0x40 */ f32 roll;
 } BgDyYoseizoEffect; // size = 0x44
 

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -75,7 +75,7 @@ const ActorInit Demo_Effect_InitVars = {
 };
 
 // This variable assures only one jewel will play SFX
-static s16 sSfxJewelId[] = { 0 };
+static s16 sSfxJewelId = 0;
 
 // The object used by the effectType
 static s16 sEffectTypeObjects[] = {
@@ -154,7 +154,7 @@ void DemoEffect_InitJewel(PlayState* play, DemoEffect* this) {
     DemoEffect_InitJewelColor(this);
     this->jewel.alpha = 0;
     this->jewelCsRotation.x = this->jewelCsRotation.y = this->jewelCsRotation.z = 0;
-    sSfxJewelId[0] = 0;
+    sSfxJewelId = 0;
 }
 
 /**
@@ -673,7 +673,7 @@ void DemoEffect_UpdateGetItem(DemoEffect* this, PlayState* play) {
 
 /**
  * Initializes Timewarp Actors.
- * This is an Update Function that is only ran for one frame.
+ * This is an Update Function that is only run for one frame.
  * Timewarp actors are spawned when Link...
  * 1) Pulls the Master Sword
  * 2) Returns from the Chamber of Sages for the first time
@@ -809,7 +809,7 @@ void DemoEffect_UpdateTimeWarpTimeblock(DemoEffect* this, PlayState* play) {
 
 /**
  * Initializes information for the Timewarp Actor used for the Timeblock clear effect.
- * This is an Update Func that is only ran for one frame.
+ * This is an Update Func that is only run for one frame.
  */
 void DemoEffect_InitTimeWarpTimeblock(DemoEffect* this, PlayState* play) {
     func_8002F948(&this->actor, NA_SE_EV_TIMETRIP_LIGHT - SFX_FLAG);
@@ -1518,14 +1518,14 @@ void DemoEffect_JewelSparkle(DemoEffect* this, PlayState* play, s32 spawnerCount
 
 /**
  * Plays Jewel sound effects.
- * The sSfxJewelId global variable is used to ensure only one Jewel Actor is playing SFX when all are spawned.
+ * The sSfxJewelId static variable is used to ensure only one Jewel Actor is playing SFX when all are spawned.
  */
 void DemoEffect_PlayJewelSfx(DemoEffect* this, PlayState* play) {
     if (!DemoEffect_CheckCsAction(this, play, 1)) {
-        if (this->actor.params == sSfxJewelId[0]) {
+        if (sSfxJewelId == this->actor.params) {
             func_8002F974(&this->actor, NA_SE_EV_SPIRIT_STONE - SFX_FLAG);
-        } else if (sSfxJewelId[0] == 0) {
-            sSfxJewelId[0] = this->actor.params;
+        } else if (sSfxJewelId == 0) {
+            sSfxJewelId = this->actor.params;
             func_8002F974(&this->actor, NA_SE_EV_SPIRIT_STONE - SFX_FLAG);
         }
     }
@@ -1644,6 +1644,7 @@ void DemoEffect_UpdateDust(DemoEffect* this, PlayState* play) {
  */
 void DemoEffect_Update(Actor* thisx, PlayState* play) {
     DemoEffect* this = (DemoEffect*)thisx;
+
     this->updateFunc(this, play);
 }
 
@@ -1653,10 +1654,10 @@ void DemoEffect_Update(Actor* thisx, PlayState* play) {
 s32 DemoEffect_CheckCsAction(DemoEffect* this, PlayState* play, s32 csActionCompareId) {
     if (play->csCtx.state != CS_STATE_IDLE && play->csCtx.npcActions[this->csActionId] != NULL &&
         play->csCtx.npcActions[this->csActionId]->action == csActionCompareId) {
-        return 1;
+        return true;
     }
 
-    return 0;
+    return false;
 }
 
 /**
@@ -1899,6 +1900,7 @@ void DemoEffect_DrawBlueOrb(Actor* thisx, PlayState* play) {
     s32 pad2;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_demo_effect.c", 2892);
+
     gDPSetPrimColor(POLY_XLU_DISP++, 128, 128, 188, 255, 255, this->blueOrb.alpha);
     gDPSetEnvColor(POLY_XLU_DISP++, 0, 100, 255, 255);
     Gfx_SetupDL_25Xlu(play->state.gfxCtx);
@@ -1908,6 +1910,7 @@ void DemoEffect_DrawBlueOrb(Actor* thisx, PlayState* play) {
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     this->blueOrb.rotation += 0x01F4;
     gSPDisplayList(POLY_XLU_DISP++, gEffFlash1DL);
+
     CLOSE_DISPS(play->state.gfxCtx, "../z_demo_effect.c", 2907);
 }
 
@@ -1920,6 +1923,7 @@ void DemoEffect_DrawLgtShower(Actor* thisx, PlayState* play) {
     u32 frames = play->gameplayFrames;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_demo_effect.c", 2921);
+
     gDPSetPrimColor(POLY_XLU_DISP++, 64, 64, 255, 255, 160, this->lgtShower.alpha);
     gDPSetEnvColor(POLY_XLU_DISP++, 50, 200, 0, 255);
     Gfx_SetupDL_25Xlu(play->state.gfxCtx);
@@ -1929,6 +1933,7 @@ void DemoEffect_DrawLgtShower(Actor* thisx, PlayState* play) {
                Gfx_TwoTexScroll(play->state.gfxCtx, 0, (frames * 5) % 1024, 0, 256, 64, 1, (frames * 10) % 128,
                                 512 - ((frames * 50) % 512), 32, 16));
     gSPDisplayList(POLY_XLU_DISP++, gEnliveningLightDL);
+
     CLOSE_DISPS(play->state.gfxCtx, "../z_demo_effect.c", 2942);
 }
 
@@ -2024,7 +2029,7 @@ void DemoEffect_DrawTriforceSpot(Actor* thisx, PlayState* play) {
  */
 void DemoEffect_DrawGetItem(Actor* thisx, PlayState* play) {
     DemoEffect* this = (DemoEffect*)thisx;
-    if (!DemoEffect_CheckCsAction(this, play, 1) && !DemoEffect_CheckCsAction(this, play, 4)) {
+    if (!(DemoEffect_CheckCsAction(this, play, 1) || DemoEffect_CheckCsAction(this, play, 4))) {
         if (!this->getItem.isLoaded) {
             this->getItem.isLoaded = 1;
             return;


### PR DESCRIPTION
Inspired by MM. This does have a slight tweak for treatment of the z buffer, but the same way of doing the calculation works.

I wonder if there ought to be macros for whatever
```c
                s32 wX = multDest.x * wDest * 160 + 160;
                s32 wY = multDest.y * wDest * -120 + 120;
                s32 wZ = (s32)((multDest.z * wDest) * 16352) + 16352;
```
is doing (especially the 16352 / 0x3FE0, I assume this is some sort of fixed-point conversion?)