### PR TITLE
Move fault_drawer bss to data/ asm

### DIFF
--- a/data/fault_drawer.bss.s
+++ b/data/fault_drawer.bss.s
@@ -1,0 +1,16 @@
+.include "macro.inc"
+
+# assembler directives
+.set noat      # allow manual use of $at
+.set noreorder # don't insert nops after branches
+.set gp=64     # allow use of 64-bit general purpose registers
+
+.section .bss
+
+.balign 16
+
+glabel sFaultDrawer
+    .space 0x3C
+
+glabel D_8016B6C0
+    .space 0x20

--- a/spec
+++ b/spec
@@ -409,6 +409,7 @@ beginseg
     include "build/src/code/fault.o"
     include "build/data/fault.bss.o"
     include "build/src/code/fault_drawer.o"
+    include "build/data/fault_drawer.bss.o"
     include "build/src/code/kanread.o"
     include "build/src/code/ucode_disas.o"
     pad_text // audio library aligned to 32 bytes?

--- a/src/code/fault_drawer.c
+++ b/src/code/fault_drawer.c
@@ -10,13 +10,13 @@
 typedef struct {
     /* 0x00 */ u16* fb;
     /* 0x04 */ u16 w;
-    /* 0x08 */ u16 h;
-    /* 0x0A */ u16 yStart;
-    /* 0x0C */ u16 yEnd;
-    /* 0x0E */ u16 xStart;
-    /* 0x10 */ u16 xEnd;
-    /* 0x12 */ u16 foreColor;
-    /* 0x14 */ u16 backColor;
+    /* 0x06 */ u16 h;
+    /* 0x08 */ u16 yStart;
+    /* 0x0A */ u16 yEnd;
+    /* 0x0C */ u16 xStart;
+    /* 0x0E */ u16 xEnd;
+    /* 0x10 */ u16 foreColor;
+    /* 0x12 */ u16 backColor;
     /* 0x14 */ u16 cursorX;
     /* 0x16 */ u16 cursorY;
     /* 0x18 */ const u32* fontData;
@@ -99,8 +99,7 @@ FaultDrawer sFaultDrawerDefault = {
     NULL,
 };
 
-FaultDrawer sFaultDrawer;
-char D_8016B6C0[0x20];
+extern FaultDrawer sFaultDrawer;
 
 void FaultDrawer_SetOsSyncPrintfEnabled(u32 enabled) {
     sFaultDrawer.osSyncPrintfEnabled = enabled;


### PR DESCRIPTION
Encountered a bss reordering issue in https://github.com/zeldaret/oot/pull/1243 so moving bss to asm for now at least.
I copypasted the new .s file from fault.bss.s