### PR TITLE
Use correct name for player trade item comparison in en_ko

### DIFF
--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -950,7 +950,7 @@ void func_80A9877C(EnKo* this, PlayState* play) {
         ENKO_TYPE == ENKO_TYPE_CHILD_FADO && play->sceneId == SCENE_SPOT10) {
         this->actor.textId = INV_CONTENT(ITEM_TRADE_ADULT) > ITEM_ODD_POTION ? 0x10B9 : 0x10DF;
 
-        if (func_8002F368(play) == ENKO_TYPE_CHILD_9) {
+        if (func_8002F368(play) == EXCH_ITEM_ODD_POTION) {
             this->actor.textId = GET_INFTABLE(INFTABLE_BC) ? 0x10B8 : 0x10B7;
             this->unk_210 = 0;
         }


### PR DESCRIPTION
`func_8002F368` returns the current player trade item ID. Fado checks this for the odd potion when giving it to her.