### PR TITLE
Various minor fixes

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -53,7 +53,7 @@ void* is_proutSyncPrintf(void* arg, const char* str, u32 count);
 void func_80002384(const char* exp, const char* file, u32 line);
 OSPiHandle* osDriveRomInit(void);
 void Mio0_Decompress(Yaz0Header* hdr, u8* dst);
-void StackCheck_Init(StackEntry* entry, void* stackTop, void* stackBottom, u32 initValue, s32 minSpace,
+void StackCheck_Init(StackEntry* entry, void* stackBottom, void* stackTop, u32 initValue, s32 minSpace,
                      const char* name);
 void StackCheck_Cleanup(StackEntry* entry);
 u32 StackCheck_GetState(StackEntry* entry);

--- a/include/z64.h
+++ b/include/z64.h
@@ -42,8 +42,8 @@
 #define SCREEN_HEIGHT 240
 
 #define REGION_NULL 0
-#define REGION_US 1
-#define REGION_JP 2
+#define REGION_JP 1
+#define REGION_US 2
 #define REGION_EU 3
 
 #define THREAD_PRI_IDLE_INIT    10

--- a/spec
+++ b/spec
@@ -38,7 +38,7 @@ beginseg
     include "build/src/libultra/os/exceptasm.o"
     include "build/src/libultra/os/dequeuethread.o"
     include "build/src/libultra/os/destroythread.o"
-    include "build/src/libultra/libc//bzero.o"
+    include "build/src/libultra/libc/bzero.o"
     include "build/src/libultra/os/parameters.o"
     include "build/src/libultra/os/createthread.o"
     include "build/src/libultra/os/setsr.o"

--- a/src/boot/stackcheck.c
+++ b/src/boot/stackcheck.c
@@ -4,7 +4,7 @@
 StackEntry* sStackInfoListStart = NULL;
 StackEntry* sStackInfoListEnd = NULL;
 
-void StackCheck_Init(StackEntry* entry, void* stackTop, void* stackBottom, u32 initValue, s32 minSpace,
+void StackCheck_Init(StackEntry* entry, void* stackBottom, void* stackTop, u32 initValue, s32 minSpace,
                      const char* name) {
     StackEntry* iter;
     u32* addr;
@@ -12,8 +12,8 @@ void StackCheck_Init(StackEntry* entry, void* stackTop, void* stackBottom, u32 i
     if (entry == NULL) {
         sStackInfoListStart = NULL;
     } else {
-        entry->head = stackTop;
-        entry->tail = stackBottom;
+        entry->head = stackBottom;
+        entry->tail = stackTop;
         entry->initValue = initValue;
         entry->minSpace = minSpace;
         entry->name = name;

--- a/src/boot/z_locale.c
+++ b/src/boot/z_locale.c
@@ -10,10 +10,10 @@ void Locale_Init(void) {
 
     switch (sCartInfo.countryCode) {
         case 'J': // "NTSC-U (North America)"
-            gCurrentRegion = REGION_US;
+            gCurrentRegion = REGION_JP;
             break;
         case 'E': // "NTSC-J (Japan)"
-            gCurrentRegion = REGION_JP;
+            gCurrentRegion = REGION_US;
             break;
         case 'P': // "PAL (Europe)"
             gCurrentRegion = REGION_EU;

--- a/src/boot/z_locale.c
+++ b/src/boot/z_locale.c
@@ -9,10 +9,10 @@ void Locale_Init(void) {
     osEPiReadIo(gCartHandle, 0x3C, &sCartInfo.regionInfo);
 
     switch (sCartInfo.countryCode) {
-        case 'J': // "NTSC-U (North America)"
+        case 'J': // "NTSC-J (Japan)"
             gCurrentRegion = REGION_JP;
             break;
-        case 'E': // "NTSC-J (Japan)"
+        case 'E': // "NTSC-U (North America)"
             gCurrentRegion = REGION_US;
             break;
         case 'P': // "PAL (Europe)"

--- a/src/code/fault.c
+++ b/src/code/fault.c
@@ -1271,7 +1271,7 @@ void Fault_Init(void) {
     sFaultInstance->autoScroll = false;
     gFaultMgr.faultHandlerEnabled = true;
     osCreateMesgQueue(&sFaultInstance->queue, &sFaultInstance->msg, 1);
-    StackCheck_Init(&sFaultThreadInfo, &sFaultStack, STACK_TOP(sFaultStack), 0, 0x100, "fault");
+    StackCheck_Init(&sFaultThreadInfo, sFaultStack, STACK_TOP(sFaultStack), 0, 0x100, "fault");
     osCreateThread(&sFaultInstance->thread, THREAD_ID_FAULT, Fault_ThreadEntry, 0, STACK_TOP(sFaultStack),
                    THREAD_PRI_FAULT);
     osStartThread(&sFaultInstance->thread);

--- a/src/code/z_debug.c
+++ b/src/code/z_debug.c
@@ -96,7 +96,7 @@ char sRegGroupChars[REG_GROUPS] = {
 void func_800636C0(void) {
     s32 i;
 
-    gGameInfo = (GameInfo*)SystemArena_MallocDebug(sizeof(GameInfo), "../z_debug.c", 260);
+    gGameInfo = SystemArena_MallocDebug(sizeof(GameInfo), "../z_debug.c", 260);
     gGameInfo->regPage = 0;
     gGameInfo->regGroup = 0;
     gGameInfo->regCur = 0;

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -1463,7 +1463,7 @@ void BossGanondrof_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec
 }
 
 Gfx* BossGanondrof_GetClearPixelDList(GraphicsContext* gfxCtx) {
-    Gfx* dList = (Gfx*)Graph_Alloc(gfxCtx, sizeof(Gfx) * 4);
+    Gfx* dList = Graph_Alloc(gfxCtx, sizeof(Gfx) * 4);
     Gfx* dListHead = dList;
 
     gDPPipeSync(dListHead++);
@@ -1475,7 +1475,7 @@ Gfx* BossGanondrof_GetClearPixelDList(GraphicsContext* gfxCtx) {
 }
 
 Gfx* BossGanondrof_EmptyDList(GraphicsContext* gfxCtx) {
-    Gfx* dList = (Gfx*)Graph_Alloc(gfxCtx, sizeof(Gfx) * 1);
+    Gfx* dList = Graph_Alloc(gfxCtx, sizeof(Gfx) * 1);
     Gfx* dListHead = dList;
 
     gSPEndDisplayList(dListHead++);

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -471,7 +471,7 @@ void EnGe2_ForceTalk(EnGe2* this, PlayState* play) {
     } else {
         this->actor.textId = 0x6004;
         this->actor.flags |= ACTOR_FLAG_16;
-        func_8002F1C4(&this->actor, play, 300.0f, 300.0f, 0);
+        func_8002F1C4(&this->actor, play, 300.0f, 300.0f, EXCH_ITEM_NONE);
     }
     EnGe2_LookAtPlayer(this, play);
 }

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -164,7 +164,7 @@ void EnGe3_ForceTalk(EnGe3* this, PlayState* play) {
         }
         this->actor.textId = 0x6004;
         this->actor.flags |= ACTOR_FLAG_16;
-        func_8002F1C4(&this->actor, play, 300.0f, 300.0f, 0);
+        func_8002F1C4(&this->actor, play, 300.0f, 300.0f, EXCH_ITEM_NONE);
     }
     EnGe3_LookAtPlayer(this, play);
 }

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -206,7 +206,7 @@ void func_80A6E9AC(EnHs* this, PlayState* play) {
     s16 yawDiff;
 
     if (Actor_ProcessTalkRequest(&this->actor, play)) {
-        if (func_8002F368(play) == 7) {
+        if (func_8002F368(play) == EXCH_ITEM_COJIRO) {
             player->actor.textId = 0x10B2;
             func_80A6E3A0(this, func_80A6E8CC);
             Animation_Change(&this->skelAnime, &object_hs_Anim_000304, 1.0f, 0.0f,
@@ -221,7 +221,7 @@ void func_80A6E9AC(EnHs* this, PlayState* play) {
         yawDiff = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
         this->actor.textId = 0x10B1;
         if ((ABS(yawDiff) <= 0x2150) && (this->actor.xzDistToPlayer < 100.0f)) {
-            func_8002F298(&this->actor, play, 100.0f, 7);
+            func_8002F298(&this->actor, play, 100.0f, EXCH_ITEM_COJIRO);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Jj/z_en_jj.c
+++ b/src/overlays/actors/ovl_En_Jj/z_en_jj.c
@@ -215,7 +215,7 @@ void EnJj_BeginCutscene(EnJj* this, PlayState* play) {
         this->cutsceneCountdownTimer--;
     } else {
         EnJj_SetupAction(this, EnJj_RemoveDust);
-        play->csCtx.segment = &D_80A88164;
+        play->csCtx.segment = D_80A88164;
         gSaveContext.cutsceneTrigger = 1;
         DynaPoly_DisableCollision(play, &play->colCtx.dyna, bodyCollisionActor->bgId);
         func_8005B1A4(GET_ACTIVE_CAM(play));

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -336,7 +336,7 @@ void EnNb_SetupChamberCsImpl(EnNb* this, PlayState* play) {
     if ((gSaveContext.chamberCutsceneNum == 3) && !IS_CUTSCENE_LAYER) {
         player = GET_PLAYER(play);
         this->action = NB_CHAMBER_UNDERGROUND;
-        play->csCtx.segment = &D_80AB431C;
+        play->csCtx.segment = D_80AB431C;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_SPIRIT);
         player->actor.world.rot.y = player->actor.shape.rot.y = this->actor.world.rot.y + 0x8000;

--- a/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -380,7 +380,7 @@ void func_80ABA878(EnNiwLady* this, PlayState* play) {
             this->actionFunc = !this->unk_273 ? func_80ABA778 : func_80ABA9B8;
         }
     } else {
-        func_8002F298(&this->actor, play, 50.0f, 6);
+        func_8002F298(&this->actor, play, 50.0f, EXCH_ITEM_POCKET_CUCCO);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -250,8 +250,8 @@ void func_80ABF4C8(EnOkarinaTag* this, PlayState* play) {
                 gSaveContext.cutsceneTrigger = 1;
                 break;
             case 6:
-                play->csCtx.segment = LINK_IS_ADULT ? SEGMENTED_TO_VIRTUAL(&spot02_scene_Cs_003C80)
-                                                    : SEGMENTED_TO_VIRTUAL(&spot02_scene_Cs_005020);
+                play->csCtx.segment = LINK_IS_ADULT ? SEGMENTED_TO_VIRTUAL(spot02_scene_Cs_003C80)
+                                                    : SEGMENTED_TO_VIRTUAL(spot02_scene_Cs_005020);
                 gSaveContext.cutsceneTrigger = 1;
                 SET_EVENTCHKINF(EVENTCHKINF_1D);
                 func_80078884(NA_SE_SY_CORRECT_CHIME);
@@ -304,7 +304,7 @@ void func_80ABF7CC(EnOkarinaTag* this, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_EVENT) && Message_ShouldAdvance(play)) {
         Message_CloseTextbox(play);
         if (!CHECK_QUEST_ITEM(QUEST_SONG_SUN)) {
-            play->csCtx.segment = SEGMENTED_TO_VIRTUAL(&gSunSongGraveSunSongTeachCs);
+            play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gSunSongGraveSunSongTeachCs);
             gSaveContext.cutsceneTrigger = 1;
         }
         this->actionFunc = func_80ABF708;

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -277,7 +277,7 @@ s32 EnOwl_CheckInitTalk(EnOwl* this, PlayState* play, u16 textId, f32 targetDist
         distCheck = (flags & 2) ? 200.0f : 1000.0f;
         if (this->actor.xzDistToPlayer < targetDist) {
             this->actor.flags |= ACTOR_FLAG_16;
-            func_8002F1C4(&this->actor, play, targetDist, distCheck, 0);
+            func_8002F1C4(&this->actor, play, targetDist, distCheck, EXCH_ITEM_NONE);
         }
         return false;
     }
@@ -289,7 +289,7 @@ s32 func_80ACA558(EnOwl* this, PlayState* play, u16 textId) {
     } else {
         this->actor.textId = textId;
         if (this->actor.xzDistToPlayer < 120.0f) {
-            func_8002F1C4(&this->actor, play, 350.0f, 1000.0f, 0);
+            func_8002F1C4(&this->actor, play, 350.0f, 1000.0f, EXCH_ITEM_NONE);
         }
         return false;
     }

--- a/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
+++ b/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
@@ -860,7 +860,7 @@ void func_80AEC780(EnRu1* this, PlayState* play) {
         (!(player->stateFlags1 & (PLAYER_STATE1_13 | PLAYER_STATE1_14 | PLAYER_STATE1_21))) &&
         (player->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
 
-        play->csCtx.segment = &D_80AF0880;
+        play->csCtx.segment = D_80AF0880;
         gSaveContext.cutsceneTrigger = 1;
         player->linearVelocity = 0.0f;
         this->action = 8;
@@ -1542,7 +1542,7 @@ s32 func_80AEE394(EnRu1* this, PlayState* play) {
         if (dynaPolyActor != NULL && dynaPolyActor->actor.id == ACTOR_BG_BDAN_OBJECTS &&
             dynaPolyActor->actor.params == 0 && !Player_InCsMode(play) && play->msgCtx.msgLength == 0) {
             func_80AEE02C(this);
-            play->csCtx.segment = &D_80AF10A4;
+            play->csCtx.segment = D_80AF10A4;
             gSaveContext.cutsceneTrigger = 1;
             this->action = 36;
             this->drawConfig = 0;
@@ -1608,7 +1608,7 @@ s32 func_80AEE6D0(EnRu1* this, PlayState* play) {
             func_80AED600(this);
             this->action = 34;
             this->unk_26C = 0.0f;
-            play->csCtx.segment = &D_80AF1728;
+            play->csCtx.segment = D_80AF1728;
             gSaveContext.cutsceneTrigger = 1;
         }
         this->roomNum3 = curRoomNum;

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -268,7 +268,7 @@ void func_80AF2AB4(EnRu2* this, PlayState* play) {
     if ((gSaveContext.chamberCutsceneNum == 2) && !IS_CUTSCENE_LAYER) {
         player = GET_PLAYER(play);
         this->action = 1;
-        play->csCtx.segment = &D_80AF411C;
+        play->csCtx.segment = D_80AF411C;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_WATER);
         temp = this->actor.world.rot.y + 0x8000;

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -343,7 +343,7 @@ void func_80B14634(EnTa* this, PlayState* play) {
         }
     } else {
         this->actor.textId = 0x702A;
-        func_8002F298(&this->actor, play, 100.0f, 3);
+        func_8002F298(&this->actor, play, 100.0f, EXCH_ITEM_CHICKEN);
     }
 }
 
@@ -376,7 +376,7 @@ void func_80B14754(EnTa* this, PlayState* play) {
         }
     } else {
         this->actor.textId = 0x5015;
-        func_8002F298(&this->actor, play, 100.0f, 6);
+        func_8002F298(&this->actor, play, 100.0f, EXCH_ITEM_POCKET_CUCCO);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -330,7 +330,7 @@ void func_80B20768(EnToryo* this, PlayState* play) {
         Actor_GetScreenPos(play, &this->actor, &sp32, &sp30);
         if ((sp32 >= 0) && (sp32 < 0x141) && (sp30 >= 0) && (sp30 < 0xF1)) {
             this->actor.textId = func_80B206A0(this, play);
-            func_8002F298(&this->actor, play, 100.0f, 10);
+            func_8002F298(&this->actor, play, 100.0f, EXCH_ITEM_SAW);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
+++ b/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
@@ -541,23 +541,23 @@ void EnViewer_DrawGanondorf(EnViewer* this, PlayState* play) {
         }
 
         if (frames + 1127 >= play->csCtx.frames) {
-            gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(&gYoungGanondorfEyeOpenTex));
-            gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(&gYoungGanondorfEyeOpenTex));
+            gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(gYoungGanondorfEyeOpenTex));
+            gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(gYoungGanondorfEyeOpenTex));
 
         } else if (frames + 1128 >= play->csCtx.frames) {
-            gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(&gYoungGanondorfEyeHalfTex));
-            gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(&gYoungGanondorfEyeHalfTex));
+            gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(gYoungGanondorfEyeHalfTex));
+            gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(gYoungGanondorfEyeHalfTex));
 
         } else if (frames + 1129 >= play->csCtx.frames) {
-            gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(&gYoungGanondorfEyeClosedTex));
-            gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(&gYoungGanondorfEyeClosedTex));
+            gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(gYoungGanondorfEyeClosedTex));
+            gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(gYoungGanondorfEyeClosedTex));
 
         } else {
-            gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(&gYoungGanondorfEyeLookingDownTex));
-            gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(&gYoungGanondorfEyeLookingDownTex));
+            gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(gYoungGanondorfEyeLookingDownTex));
+            gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(gYoungGanondorfEyeLookingDownTex));
         }
     } else if (type == ENVIEWER_TYPE_9_GANONDORF) {
-        gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(&gGanondorfCrazedEyeTex));
+        gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(gGanondorfCrazedEyeTex));
     }
 
     if (type == ENVIEWER_TYPE_9_GANONDORF) {

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -287,7 +287,7 @@ s32 EnXc_MinuetCS(EnXc* this, PlayState* play) {
 
         if (z < -2225.0f) {
             if (!Play_InCsMode(play)) {
-                play->csCtx.segment = SEGMENTED_TO_VIRTUAL(&gMinuetCs);
+                play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gMinuetCs);
                 gSaveContext.cutsceneTrigger = 1;
                 SET_EVENTCHKINF(EVENTCHKINF_50);
                 Item_Give(play, ITEM_SONG_MINUET);
@@ -318,7 +318,7 @@ s32 EnXc_BoleroCS(EnXc* this, PlayState* play) {
         if ((posRot->pos.x > -784.0f) && (posRot->pos.x < -584.0f) && (posRot->pos.y > 447.0f) &&
             (posRot->pos.y < 647.0f) && (posRot->pos.z > -446.0f) && (posRot->pos.z < -246.0f) &&
             !Play_InCsMode(play)) {
-            play->csCtx.segment = SEGMENTED_TO_VIRTUAL(&gDeathMountainCraterBoleroCs);
+            play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gDeathMountainCraterBoleroCs);
             gSaveContext.cutsceneTrigger = 1;
             SET_EVENTCHKINF(EVENTCHKINF_51);
             Item_Give(play, ITEM_SONG_BOLERO);
@@ -348,7 +348,7 @@ s32 EnXc_SerenadeCS(EnXc* this, PlayState* play) {
 
         if (CHECK_OWNED_EQUIP(EQUIP_TYPE_BOOTS, EQUIP_INV_BOOTS_IRON) && !GET_EVENTCHKINF(EVENTCHKINF_52) &&
             !(stateFlags & PLAYER_STATE1_29) && !Play_InCsMode(play)) {
-            Cutscene_SetSegment(play, &gIceCavernSerenadeCs);
+            Cutscene_SetSegment(play, gIceCavernSerenadeCs);
             gSaveContext.cutsceneTrigger = 1;
             SET_EVENTCHKINF(EVENTCHKINF_52); // Learned Serenade of Water Flag
             Item_Give(play, ITEM_SONG_SERENADE);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -8213,7 +8213,8 @@ s32 func_80843E64(PlayState* play, Player* this) {
 
         func_80837AE0(this, 40);
         func_808429B4(play, 32967, 2, 30);
-        Player_RequestRumble(this, impactInfo->rumbleStrength, impactInfo->rumbleDuration, impactInfo->rumbleDecreaseRate, 0);
+        Player_RequestRumble(this, impactInfo->rumbleStrength, impactInfo->rumbleDuration,
+                             impactInfo->rumbleDecreaseRate, 0);
         func_8002F7DC(&this->actor, NA_SE_PL_BODY_HIT);
         func_80832698(this, impactInfo->sfxId);
 


### PR DESCRIPTION
Another batch of minor fixes (mostly straightfoward stuff I noted or noticed recently):
* Swap `REGION_US` and `REGION_JP` to match country codes
* Fix a few missing `EXCH_ITEM` enum values
* Remove unnecessary casts on some alloc function calls
* Fix a `//` (double slash) in the spec file
* Swap top and bottom args in `StackCheck_Init` to match how it's called
* Remove some unnecessary `&` in array references

Also ran the formatter which fixed an unrelated issue from a recent merge