### PR TITLE
Use intptr types in more code files

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1574,8 +1574,8 @@ void SpeedMeter_InitAllocEntry(SpeedMeterAllocEntry* this, u32 maxval, u32 val, 
 void SpeedMeter_DrawAllocEntry(SpeedMeterAllocEntry* this, GraphicsContext* gfxCtx);
 void SpeedMeter_DrawAllocEntries(SpeedMeter* meter, GraphicsContext* gfxCtx, GameState* state);
 void SysCfb_Init(s32 n64dd);
-uintptr_t SysCfb_GetFbPtr(s32 idx);
-uintptr_t SysCfb_GetFbEnd(void);
+void* SysCfb_GetFbPtr(s32 idx);
+void* SysCfb_GetFbEnd(void);
 f32 Math_FactorialF(f32 n);
 f32 Math_Factorial(s32 n);
 f32 Math_PowF(f32 base, s32 exp);

--- a/include/functions.h
+++ b/include/functions.h
@@ -1574,8 +1574,8 @@ void SpeedMeter_InitAllocEntry(SpeedMeterAllocEntry* this, u32 maxval, u32 val, 
 void SpeedMeter_DrawAllocEntry(SpeedMeterAllocEntry* this, GraphicsContext* gfxCtx);
 void SpeedMeter_DrawAllocEntries(SpeedMeter* meter, GraphicsContext* gfxCtx, GameState* state);
 void SysCfb_Init(s32 n64dd);
-u32 SysCfb_GetFbPtr(s32 idx);
-u32 SysCfb_GetFbEnd(void);
+uintptr_t SysCfb_GetFbPtr(s32 idx);
+uintptr_t SysCfb_GetFbEnd(void);
 f32 Math_FactorialF(f32 n);
 f32 Math_Factorial(s32 n);
 f32 Math_PowF(f32 base, s32 exp);

--- a/include/macros.h
+++ b/include/macros.h
@@ -17,8 +17,8 @@
 #define ARRAY_COUNT(arr) (s32)(sizeof(arr) / sizeof(arr[0]))
 #define ARRAY_COUNTU(arr) (u32)(sizeof(arr) / sizeof(arr[0]))
 
-#define PHYSICAL_TO_VIRTUAL(addr) (void*)((u32)(addr) + 0x80000000)
-#define VIRTUAL_TO_PHYSICAL(addr) (u32)((u8*)(addr) - 0x80000000)
+#define PHYSICAL_TO_VIRTUAL(addr) (void*)((uintptr_t)(addr) + 0x80000000)
+#define VIRTUAL_TO_PHYSICAL(addr) (uintptr_t)((u8*)(addr) - 0x80000000)
 #define SEGMENTED_TO_VIRTUAL(addr) PHYSICAL_TO_VIRTUAL(gSegments[SEGMENT_NUMBER(addr)] + SEGMENT_OFFSET(addr))
 
 #define SQ(x) ((x)*(x))

--- a/include/variables.h
+++ b/include/variables.h
@@ -191,7 +191,7 @@ extern s32 gTrnsnUnkState;
 extern Color_RGBA8_u32 D_801614B0;
 extern PreNmiBuff* gAppNmiBufferPtr;
 extern Scheduler gScheduler;
-extern u32 gSegments[NUM_SEGMENTS];
+extern uintptr_t gSegments[NUM_SEGMENTS];
 extern volatile OSTime D_8016A520;
 extern volatile OSTime D_8016A528;
 extern volatile OSTime D_8016A530;

--- a/include/z64.h
+++ b/include/z64.h
@@ -704,8 +704,8 @@ typedef struct {
 
 typedef struct {
     /* 0x00 */ void* loadedRamAddr;
-    /* 0x04 */ u32 vromStart;
-    /* 0x08 */ u32 vromEnd;
+    /* 0x04 */ uintptr_t vromStart;
+    /* 0x08 */ uintptr_t vromEnd;
     /* 0x0C */ void* vramStart;
     /* 0x10 */ void* vramEnd;
     /* 0x14 */ u32 offset; // loadedRamAddr - vramStart
@@ -1372,8 +1372,8 @@ typedef struct {
 
 typedef struct {
     /* 0x00 */ void*     loadedRamAddr;
-    /* 0x04 */ u32       vromStart; // if applicable
-    /* 0x08 */ u32       vromEnd;   // if applicable
+    /* 0x04 */ uintptr_t vromStart; // if applicable
+    /* 0x08 */ uintptr_t vromEnd;   // if applicable
     /* 0x0C */ void*     vramStart; // if applicable
     /* 0x10 */ void*     vramEnd;   // if applicable
     /* 0x14 */ void*     unk_14;
@@ -1878,9 +1878,9 @@ typedef struct {
 } SkyboxFile; // size = 0x10
 
 #define ROM_FILE(name) \
-    { (u32) _##name##SegmentRomStart, (u32)_##name##SegmentRomEnd }
+    { (uintptr_t)_##name##SegmentRomStart, (uintptr_t)_##name##SegmentRomEnd }
 #define ROM_FILE_EMPTY(name) \
-    { (u32) _##name##SegmentRomStart, (u32)_##name##SegmentRomStart }
+    { (uintptr_t)_##name##SegmentRomStart, (uintptr_t)_##name##SegmentRomStart }
 #define ROM_FILE_UNSET \
     { 0 }
 

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -85,8 +85,8 @@ typedef struct {
 #define ACTOROVL_ALLOC_PERSISTENT (1 << 1)
 
 typedef struct {
-    /* 0x00 */ u32 vromStart;
-    /* 0x04 */ u32 vromEnd;
+    /* 0x00 */ uintptr_t vromStart;
+    /* 0x04 */ uintptr_t vromEnd;
     /* 0x08 */ void* vramStart;
     /* 0x0C */ void* vramEnd;
     /* 0x10 */ void* loadedRamAddr; // original name: "allocp"

--- a/include/z64effect.h
+++ b/include/z64effect.h
@@ -202,8 +202,8 @@ typedef struct {
 } EffectSsInit; // size = 0x08
 
 typedef struct {
-    /* 0x00 */ u32 vromStart;
-    /* 0x04 */ u32 vromEnd;
+    /* 0x00 */ uintptr_t vromStart;
+    /* 0x04 */ uintptr_t vromEnd;
     /* 0x08 */ void* vramStart;
     /* 0x0C */ void* vramEnd;
     /* 0x10 */ void* loadedRamAddr;

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -6,8 +6,8 @@
 #include "command_macros_base.h"
 
 typedef struct {
-    /* 0x00 */ u32 vromStart;
-    /* 0x04 */ u32 vromEnd;
+    /* 0x00 */ uintptr_t vromStart;
+    /* 0x04 */ uintptr_t vromEnd;
 } RomFile; // size = 0x8
 
 typedef struct {

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -24,7 +24,7 @@ UCodeInfo D_8012D248[3] = {
 
 void Graph_FaultClient(void) {
     void* nextFb = osViGetNextFramebuffer();
-    void* newFb = (void*)((SysCfb_GetFbPtr(0) != (uintptr_t)nextFb) ? SysCfb_GetFbPtr(0) : SysCfb_GetFbPtr(1));
+    void* newFb = (SysCfb_GetFbPtr(0) != nextFb) ? SysCfb_GetFbPtr(0) : SysCfb_GetFbPtr(1);
 
     osViSwapBuffer(newFb);
     Fault_WaitForInput();
@@ -95,7 +95,7 @@ void Graph_InitTHGA(GraphicsContext* gfxCtx) {
     gfxCtx->overlayBuffer = pool->overlayBuffer;
     gfxCtx->workBuffer = pool->workBuffer;
 
-    gfxCtx->curFrameBuffer = (u16*)SysCfb_GetFbPtr(gfxCtx->fbIdx % 2);
+    gfxCtx->curFrameBuffer = SysCfb_GetFbPtr(gfxCtx->fbIdx % 2);
     gfxCtx->unk_014 = 0;
 }
 

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -24,7 +24,7 @@ UCodeInfo D_8012D248[3] = {
 
 void Graph_FaultClient(void) {
     void* nextFb = osViGetNextFramebuffer();
-    void* newFb = (void*)((SysCfb_GetFbPtr(0) != (u32)nextFb) ? SysCfb_GetFbPtr(0) : SysCfb_GetFbPtr(1));
+    void* newFb = (void*)((SysCfb_GetFbPtr(0) != (uintptr_t)nextFb) ? SysCfb_GetFbPtr(0) : SysCfb_GetFbPtr(1));
 
     osViSwapBuffer(newFb);
     Fault_WaitForInput();

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -9,7 +9,7 @@ PreNmiBuff* gAppNmiBufferPtr;
 Scheduler gScheduler;
 PadMgr gPadMgr;
 IrqMgr gIrqMgr;
-u32 gSegments[NUM_SEGMENTS];
+uintptr_t gSegments[NUM_SEGMENTS];
 OSThread sGraphThread;
 STACK(sGraphStack, 0x1800);
 STACK(sSchedStack, 0x600);
@@ -37,9 +37,9 @@ void Main(void* arg) {
     IrqMgrClient irqClient;
     OSMesgQueue irqMgrMsgQueue;
     OSMesg irqMgrMsgBuf[60];
-    u32 systemHeapStart;
-    u32 fb;
-    u32 debugHeapStart;
+    uintptr_t systemHeapStart;
+    uintptr_t fb;
+    uintptr_t debugHeapStart;
     u32 debugHeapSize;
     s16* msg;
 
@@ -50,7 +50,7 @@ void Main(void* arg) {
     PreNmiBuff_Init(gAppNmiBufferPtr);
     Fault_Init();
     SysCfb_Init(0);
-    systemHeapStart = (u32)gSystemHeap;
+    systemHeapStart = (uintptr_t)gSystemHeap;
     fb = SysCfb_GetFbPtr(0);
     gSystemHeapSize = fb - systemHeapStart;
     // "System heap initalization"
@@ -61,7 +61,7 @@ void Main(void* arg) {
         debugHeapSize = PHYS_TO_K0(0x600000) - debugHeapStart;
     } else {
         debugHeapSize = 0x400;
-        debugHeapStart = (u32)SystemArena_MallocDebug(debugHeapSize, "../main.c", 565);
+        debugHeapStart = (uintptr_t)SystemArena_MallocDebug(debugHeapSize, "../main.c", 565);
     }
     osSyncPrintf("debug_InitArena(%08x, %08x)\n", debugHeapStart, debugHeapSize);
     DebugArena_Init((void*)debugHeapStart, debugHeapSize);

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -39,7 +39,7 @@ void Main(void* arg) {
     OSMesg irqMgrMsgBuf[60];
     uintptr_t systemHeapStart;
     uintptr_t fb;
-    uintptr_t debugHeapStart;
+    void* debugHeapStart;
     u32 debugHeapSize;
     s16* msg;
 
@@ -51,20 +51,20 @@ void Main(void* arg) {
     Fault_Init();
     SysCfb_Init(0);
     systemHeapStart = (uintptr_t)gSystemHeap;
-    fb = SysCfb_GetFbPtr(0);
+    fb = (uintptr_t)SysCfb_GetFbPtr(0);
     gSystemHeapSize = fb - systemHeapStart;
     // "System heap initalization"
     osSyncPrintf("システムヒープ初期化 %08x-%08x %08x\n", systemHeapStart, fb, gSystemHeapSize);
     SystemHeap_Init((void*)systemHeapStart, gSystemHeapSize); // initializes the system heap
     if (osMemSize >= 0x800000) {
         debugHeapStart = SysCfb_GetFbEnd();
-        debugHeapSize = PHYS_TO_K0(0x600000) - debugHeapStart;
+        debugHeapSize = PHYS_TO_K0(0x600000) - (uintptr_t)debugHeapStart;
     } else {
         debugHeapSize = 0x400;
-        debugHeapStart = (uintptr_t)SystemArena_MallocDebug(debugHeapSize, "../main.c", 565);
+        debugHeapStart = SystemArena_MallocDebug(debugHeapSize, "../main.c", 565);
     }
     osSyncPrintf("debug_InitArena(%08x, %08x)\n", debugHeapStart, debugHeapSize);
-    DebugArena_Init((void*)debugHeapStart, debugHeapSize);
+    DebugArena_Init(debugHeapStart, debugHeapSize);
     func_800636C0();
 
     R_ENABLE_ARENA_DBG = 0;

--- a/src/code/sys_cfb.c
+++ b/src/code/sys_cfb.c
@@ -1,11 +1,11 @@
 #include "global.h"
 
-u32 sSysCfbFbPtr[2];
-u32 sSysCfbEnd;
+uintptr_t sSysCfbFbPtr[2];
+uintptr_t sSysCfbEnd;
 
 void SysCfb_Init(s32 n64dd) {
     u32 screenSize;
-    u32 tmpFbEnd;
+    uintptr_t tmpFbEnd;
 
     if (osMemSize >= 0x800000) {
         // "8MB or more memory is installed"
@@ -42,13 +42,13 @@ void SysCfb_Reset(void) {
     sSysCfbEnd = 0;
 }
 
-u32 SysCfb_GetFbPtr(s32 idx) {
+uintptr_t SysCfb_GetFbPtr(s32 idx) {
     if (idx < 2) {
         return sSysCfbFbPtr[idx];
     }
     return 0;
 }
 
-u32 SysCfb_GetFbEnd(void) {
+uintptr_t SysCfb_GetFbEnd(void) {
     return sSysCfbEnd;
 }

--- a/src/code/sys_cfb.c
+++ b/src/code/sys_cfb.c
@@ -42,13 +42,13 @@ void SysCfb_Reset(void) {
     sSysCfbEnd = 0;
 }
 
-uintptr_t SysCfb_GetFbPtr(s32 idx) {
+void* SysCfb_GetFbPtr(s32 idx) {
     if (idx < 2) {
-        return sSysCfbFbPtr[idx];
+        return (void*)sSysCfbFbPtr[idx];
     }
-    return 0;
+    return NULL;
 }
 
-uintptr_t SysCfb_GetFbEnd(void) {
-    return sSysCfbEnd;
+void* SysCfb_GetFbEnd(void) {
+    return (void*)sSysCfbEnd;
 }

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2661,7 +2661,7 @@ Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 pos
     ActorInit* actorInit;
     s32 objBankIndex;
     ActorOverlay* overlayEntry;
-    u32 temp;
+    uintptr_t temp;
     char* name;
     u32 overlaySize;
 

--- a/src/code/z_actor_dlftbls.c
+++ b/src/code/z_actor_dlftbls.c
@@ -24,8 +24,8 @@
 
 // Actor Overlay Table definition
 #define DEFINE_ACTOR(name, _1, allocType, nameString) \
-    { (u32)_ovl_##name##SegmentRomStart,              \
-      (u32)_ovl_##name##SegmentRomEnd,                \
+    { (uintptr_t)_ovl_##name##SegmentRomStart,        \
+      (uintptr_t)_ovl_##name##SegmentRomEnd,          \
       _ovl_##name##SegmentStart,                      \
       _ovl_##name##SegmentEnd,                        \
       NULL,                                           \

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -27,7 +27,7 @@ void Interface_Init(PlayState* play) {
         interfaceCtx->cDownAlpha = interfaceCtx->cRightAlpha = interfaceCtx->healthAlpha = interfaceCtx->startAlpha =
             interfaceCtx->magicAlpha = 0;
 
-    parameterSize = (u32)_parameter_staticSegmentRomEnd - (u32)_parameter_staticSegmentRomStart;
+    parameterSize = (uintptr_t)_parameter_staticSegmentRomEnd - (uintptr_t)_parameter_staticSegmentRomStart;
 
     // "Permanent PARAMETER Segment = %x"
     osSyncPrintf("常駐ＰＡＲＡＭＥＴＥＲセグメント=%x\n", parameterSize);
@@ -37,7 +37,7 @@ void Interface_Init(PlayState* play) {
     osSyncPrintf("parameter->parameterSegment=%x\n", interfaceCtx->parameterSegment);
 
     ASSERT(interfaceCtx->parameterSegment != NULL, "parameter->parameterSegment != NULL", "../z_construct.c", 161);
-    DmaMgr_SendRequest1(interfaceCtx->parameterSegment, (u32)_parameter_staticSegmentRomStart, parameterSize,
+    DmaMgr_SendRequest1(interfaceCtx->parameterSegment, (uintptr_t)_parameter_staticSegmentRomStart, parameterSize,
                         "../z_construct.c", 162);
 
     interfaceCtx->doActionSegment = GameState_Alloc(&play->state, 0x480, "../z_construct.c", 166);
@@ -55,8 +55,8 @@ void Interface_Init(PlayState* play) {
         doActionOffset = 0x5700;
     }
 
-    DmaMgr_SendRequest1(interfaceCtx->doActionSegment, (u32)_do_action_staticSegmentRomStart + doActionOffset, 0x300,
-                        "../z_construct.c", 174);
+    DmaMgr_SendRequest1(interfaceCtx->doActionSegment, (uintptr_t)_do_action_staticSegmentRomStart + doActionOffset,
+                        0x300, "../z_construct.c", 174);
 
     if (gSaveContext.language == LANGUAGE_ENG) {
         doActionOffset = 0x480;
@@ -66,8 +66,8 @@ void Interface_Init(PlayState* play) {
         doActionOffset = 0x5B80;
     }
 
-    DmaMgr_SendRequest1(interfaceCtx->doActionSegment + 0x300, (u32)_do_action_staticSegmentRomStart + doActionOffset,
-                        0x180, "../z_construct.c", 178);
+    DmaMgr_SendRequest1(interfaceCtx->doActionSegment + 0x300,
+                        (uintptr_t)_do_action_staticSegmentRomStart + doActionOffset, 0x180, "../z_construct.c", 178);
 
     interfaceCtx->iconItemSegment = GameState_Alloc(&play->state, 0x4000, "../z_construct.c", 190);
 
@@ -83,30 +83,30 @@ void Interface_Init(PlayState* play) {
 
     if (gSaveContext.equips.buttonItems[0] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment,
-                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[0] * 0x1000, 0x1000,
-                            "../z_construct.c", 198);
+                            (uintptr_t)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[0] * 0x1000,
+                            0x1000, "../z_construct.c", 198);
     } else if (gSaveContext.equips.buttonItems[0] != 0xFF) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment,
-                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[0] * 0x1000, 0x1000,
-                            "../z_construct.c", 203);
+                            (uintptr_t)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[0] * 0x1000,
+                            0x1000, "../z_construct.c", 203);
     }
 
     if (gSaveContext.equips.buttonItems[1] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment + 0x1000,
-                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[1] * 0x1000, 0x1000,
-                            "../z_construct.c", 209);
+                            (uintptr_t)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[1] * 0x1000,
+                            0x1000, "../z_construct.c", 209);
     }
 
     if (gSaveContext.equips.buttonItems[2] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment + 0x2000,
-                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[2] * 0x1000, 0x1000,
-                            "../z_construct.c", 214);
+                            (uintptr_t)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[2] * 0x1000,
+                            0x1000, "../z_construct.c", 214);
     }
 
     if (gSaveContext.equips.buttonItems[3] < 0xF0) {
         DmaMgr_SendRequest1(interfaceCtx->iconItemSegment + 0x3000,
-                            (u32)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[3] * 0x1000, 0x1000,
-                            "../z_construct.c", 219);
+                            (uintptr_t)_icon_item_staticSegmentRomStart + gSaveContext.equips.buttonItems[3] * 0x1000,
+                            0x1000, "../z_construct.c", 219);
     }
 
     osSyncPrintf("ＥＶＥＮＴ＝%d\n", ((void)0, gSaveContext.timer1State));

--- a/src/code/z_effect_soft_sprite_dlftbls.c
+++ b/src/code/z_effect_soft_sprite_dlftbls.c
@@ -19,15 +19,15 @@
 #undef DEFINE_EFFECT_SS_UNSET
 
 // Effect SS Overlay Table definition
-#define DEFINE_EFFECT_SS(name, _1)         \
-    {                                      \
-        (u32)_ovl_##name##SegmentRomStart, \
-        (u32)_ovl_##name##SegmentRomEnd,   \
-        _ovl_##name##SegmentStart,         \
-        _ovl_##name##SegmentEnd,           \
-        NULL,                              \
-        &name##_InitVars,                  \
-        1,                                 \
+#define DEFINE_EFFECT_SS(name, _1)               \
+    {                                            \
+        (uintptr_t)_ovl_##name##SegmentRomStart, \
+        (uintptr_t)_ovl_##name##SegmentRomEnd,   \
+        _ovl_##name##SegmentStart,               \
+        _ovl_##name##SegmentEnd,                 \
+        NULL,                                    \
+        &name##_InitVars,                        \
+        1,                                       \
     },
 
 #define DEFINE_EFFECT_SS_UNSET(_0) { 0 },

--- a/src/code/z_game_dlftbls.c
+++ b/src/code/z_game_dlftbls.c
@@ -1,9 +1,9 @@
 #include "global.h"
 
-#define GAMESTATE_OVERLAY(name, init, destroy, size)                                                         \
-    {                                                                                                        \
-        NULL, (u32)_ovl_##name##SegmentRomStart, (u32)_ovl_##name##SegmentRomEnd, _ovl_##name##SegmentStart, \
-            _ovl_##name##SegmentEnd, NULL, init, destroy, NULL, NULL, 0, size                                \
+#define GAMESTATE_OVERLAY(name, init, destroy, size)                                                     \
+    {                                                                                                    \
+        NULL, (uintptr_t)_ovl_##name##SegmentRomStart, (uintptr_t)_ovl_##name##SegmentRomEnd,            \
+            _ovl_##name##SegmentStart, _ovl_##name##SegmentEnd, NULL, init, destroy, NULL, NULL, 0, size \
     }
 #define GAMESTATE_OVERLAY_INTERNAL(init, destroy, size) \
     { NULL, 0, 0, NULL, NULL, NULL, init, destroy, NULL, NULL, 0, size }

--- a/src/code/z_kaleido_manager.c
+++ b/src/code/z_kaleido_manager.c
@@ -1,10 +1,10 @@
 #include "global.h"
 #include "vt.h"
 
-#define KALEIDO_OVERLAY(name, nameString)                                                                    \
-    {                                                                                                        \
-        NULL, (u32)_ovl_##name##SegmentRomStart, (u32)_ovl_##name##SegmentRomEnd, _ovl_##name##SegmentStart, \
-            _ovl_##name##SegmentEnd, 0, nameString,                                                          \
+#define KALEIDO_OVERLAY(name, nameString)                                                     \
+    {                                                                                         \
+        NULL, (uintptr_t)_ovl_##name##SegmentRomStart, (uintptr_t)_ovl_##name##SegmentRomEnd, \
+            _ovl_##name##SegmentStart, _ovl_##name##SegmentEnd, 0, nameString,                \
     }
 
 KaleidoMgrOverlay gKaleidoMgrOverlayTable[] = {

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -131,7 +131,8 @@ void Map_InitData(PlayState* play, s16 room) {
             osSyncPrintf(VT_RST);
             sEntranceIconMapIndex = extendedMapIndex;
             DmaMgr_SendRequest1(interfaceCtx->mapSegment,
-                                (u32)_map_grand_staticSegmentRomStart + gMapData->owMinimapTexOffset[extendedMapIndex],
+                                (uintptr_t)_map_grand_staticSegmentRomStart +
+                                    gMapData->owMinimapTexOffset[extendedMapIndex],
                                 gMapData->owMinimapTexSize[mapIndex], "../z_map_exp.c", 309);
             interfaceCtx->unk_258 = mapIndex;
             break;
@@ -159,7 +160,7 @@ void Map_InitData(PlayState* play, s16 room) {
                          mapIndex, VREG(30));
             osSyncPrintf(VT_RST);
             DmaMgr_SendRequest1(play->interfaceCtx.mapSegment,
-                                (u32)_map_i_staticSegmentRomStart +
+                                (uintptr_t)_map_i_staticSegmentRomStart +
                                     ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * 0xFF0),
                                 0xFF0, "../z_map_exp.c", 346);
             R_COMPASS_OFFSET_X = gMapData->roomCompassOffsetX[mapIndex][room];

--- a/src/code/z_map_mark.c
+++ b/src/code/z_map_mark.c
@@ -16,8 +16,8 @@ typedef struct {
 
 typedef struct {
     /* 0x00 */ void* loadedRamAddr; // original name: "allocp"
-    /* 0x04 */ u32 vromStart;
-    /* 0x08 */ u32 vromEnd;
+    /* 0x04 */ uintptr_t vromStart;
+    /* 0x08 */ uintptr_t vromEnd;
     /* 0x0C */ void* vramStart;
     /* 0x10 */ void* vramEnd;
     /* 0x14 */ void* vramTable;
@@ -44,8 +44,8 @@ static MapMarkInfo sMapMarkInfoTable[] = {
 
 static MapMarkDataOverlay sMapMarkDataOvl = {
     NULL,
-    (u32)_ovl_map_mark_dataSegmentRomStart,
-    (u32)_ovl_map_mark_dataSegmentRomEnd,
+    (uintptr_t)_ovl_map_mark_dataSegmentRomStart,
+    (uintptr_t)_ovl_map_mark_dataSegmentRomEnd,
     _ovl_map_mark_dataSegmentStart,
     _ovl_map_mark_dataSegmentEnd,
     gMapMarkDataTable,

--- a/src/code/z_message_PAL.c
+++ b/src/code/z_message_PAL.c
@@ -1636,23 +1636,23 @@ void Message_OpenText(PlayState* play, u16 textId) {
     if (sTextIsCredits) {
         Message_FindCreditsMessage(play, textId);
         msgCtx->msgLength = font->msgLength;
-        DmaMgr_SendRequest1(font->msgBuf, (u32)(_staff_message_data_staticSegmentRomStart + font->msgOffset),
+        DmaMgr_SendRequest1(font->msgBuf, (uintptr_t)_staff_message_data_staticSegmentRomStart + font->msgOffset,
                             font->msgLength, "../z_message_PAL.c", 1954);
     } else {
         if (gSaveContext.language == LANGUAGE_ENG) {
             Message_FindMessage(play, textId);
             msgCtx->msgLength = font->msgLength;
-            DmaMgr_SendRequest1(font->msgBuf, (u32)(_nes_message_data_staticSegmentRomStart + font->msgOffset),
+            DmaMgr_SendRequest1(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
                                 font->msgLength, "../z_message_PAL.c", 1966);
         } else if (gSaveContext.language == LANGUAGE_GER) {
             Message_FindMessage(play, textId);
             msgCtx->msgLength = font->msgLength;
-            DmaMgr_SendRequest1(font->msgBuf, (u32)(_ger_message_data_staticSegmentRomStart + font->msgOffset),
+            DmaMgr_SendRequest1(font->msgBuf, (uintptr_t)_ger_message_data_staticSegmentRomStart + font->msgOffset,
                                 font->msgLength, "../z_message_PAL.c", 1978);
         } else {
             Message_FindMessage(play, textId);
             msgCtx->msgLength = font->msgLength;
-            DmaMgr_SendRequest1(font->msgBuf, (u32)(_fra_message_data_staticSegmentRomStart + font->msgOffset),
+            DmaMgr_SendRequest1(font->msgBuf, (uintptr_t)_fra_message_data_staticSegmentRomStart + font->msgOffset,
                                 font->msgLength, "../z_message_PAL.c", 1990);
         }
     }
@@ -1663,10 +1663,10 @@ void Message_OpenText(PlayState* play, u16 textId) {
     // "Text Box Type"
     osSyncPrintf("吹き出し種類＝%d\n", msgCtx->textBoxType);
     if (textBoxType < TEXTBOX_TYPE_NONE_BOTTOM) {
-        DmaMgr_SendRequest1(
-            msgCtx->textboxSegment,
-            (u32)(_message_staticSegmentRomStart + (messageStaticIndices[textBoxType] * MESSAGE_STATIC_TEX_SIZE)),
-            MESSAGE_STATIC_TEX_SIZE, "../z_message_PAL.c", 2006);
+        DmaMgr_SendRequest1(msgCtx->textboxSegment,
+                            (uintptr_t)_message_staticSegmentRomStart +
+                                (messageStaticIndices[textBoxType] * MESSAGE_STATIC_TEX_SIZE),
+                            MESSAGE_STATIC_TEX_SIZE, "../z_message_PAL.c", 2006);
         if (textBoxType == TEXTBOX_TYPE_BLACK) {
             msgCtx->textboxColorRed = 0;
             msgCtx->textboxColorGreen = 0;

--- a/src/code/z_message_PAL.c
+++ b/src/code/z_message_PAL.c
@@ -1167,8 +1167,8 @@ void Message_LoadItemIcon(PlayState* play, u16 itemId, s16 y) {
         R_TEXTBOX_ICON_YPOS = y + 6;
         R_TEXTBOX_ICON_SIZE = 32;
         DmaMgr_SendRequest1(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE,
-                            (u32)_icon_item_staticSegmentRomStart + (itemId * 0x1000), 0x1000, "../z_message_PAL.c",
-                            1473);
+                            (uintptr_t)_icon_item_staticSegmentRomStart + (itemId * 0x1000), 0x1000,
+                            "../z_message_PAL.c", 1473);
         // "Item 32-0"
         osSyncPrintf("アイテム32-0\n");
     } else {
@@ -1176,8 +1176,8 @@ void Message_LoadItemIcon(PlayState* play, u16 itemId, s16 y) {
         R_TEXTBOX_ICON_YPOS = y + 10;
         R_TEXTBOX_ICON_SIZE = 24;
         DmaMgr_SendRequest1(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE,
-                            (u32)_icon_item_24_staticSegmentRomStart + (itemId - ITEM_MEDALLION_FOREST) * 0x900, 0x900,
-                            "../z_message_PAL.c", 1482);
+                            (uintptr_t)_icon_item_24_staticSegmentRomStart + (itemId - ITEM_MEDALLION_FOREST) * 0x900,
+                            0x900, "../z_message_PAL.c", 1482);
         // "Item 24"
         osSyncPrintf("アイテム24＝%d (%d) {%d}\n", itemId, itemId - ITEM_KOKIRI_EMERALD, 84);
     }
@@ -1535,10 +1535,11 @@ void Message_Decode(PlayState* play) {
             msgCtx->textboxBackgroundYOffsetIdx = (font->msgBuf[msgCtx->msgBufPos + 3] & 0xF0) >> 4;
             msgCtx->textboxBackgroundUnkArg = font->msgBuf[msgCtx->msgBufPos + 3] & 0xF;
             DmaMgr_SendRequest1(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE,
-                                (u32)_message_texture_staticSegmentRomStart + msgCtx->textboxBackgroundIdx * 0x900,
+                                (uintptr_t)_message_texture_staticSegmentRomStart +
+                                    msgCtx->textboxBackgroundIdx * 0x900,
                                 0x900, "../z_message_PAL.c", 1830);
             DmaMgr_SendRequest1(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE + 0x900,
-                                (u32)_message_texture_staticSegmentRomStart +
+                                (uintptr_t)_message_texture_staticSegmentRomStart +
                                     (msgCtx->textboxBackgroundIdx + 1) * 0x900,
                                 0x900, "../z_message_PAL.c", 1834);
             msgCtx->msgBufPos += 3;

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -1277,7 +1277,8 @@ void Interface_LoadItemIcon1(PlayState* play, u16 button) {
 
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
     DmaMgr_SendRequest2(&interfaceCtx->dmaRequest_160, interfaceCtx->iconItemSegment + button * 0x1000,
-                        (u32)_icon_item_staticSegmentRomStart + (gSaveContext.equips.buttonItems[button] * 0x1000),
+                        (uintptr_t)_icon_item_staticSegmentRomStart +
+                            (gSaveContext.equips.buttonItems[button] * 0x1000),
                         0x1000, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1171);
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 }
@@ -1287,7 +1288,8 @@ void Interface_LoadItemIcon2(PlayState* play, u16 button) {
 
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
     DmaMgr_SendRequest2(&interfaceCtx->dmaRequest_180, interfaceCtx->iconItemSegment + button * 0x1000,
-                        (u32)_icon_item_staticSegmentRomStart + (gSaveContext.equips.buttonItems[button] * 0x1000),
+                        (uintptr_t)_icon_item_staticSegmentRomStart +
+                            (gSaveContext.equips.buttonItems[button] * 0x1000),
                         0x1000, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 1193);
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 }
@@ -2085,8 +2087,8 @@ void Interface_LoadActionLabel(InterfaceContext* interfaceCtx, u16 action, s16 l
         osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
         DmaMgr_SendRequest2(&interfaceCtx->dmaRequest_160,
                             interfaceCtx->doActionSegment + (loadOffset * DO_ACTION_TEX_SIZE),
-                            (u32)_do_action_staticSegmentRomStart + (action * DO_ACTION_TEX_SIZE), DO_ACTION_TEX_SIZE,
-                            0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 2145);
+                            (uintptr_t)_do_action_staticSegmentRomStart + (action * DO_ACTION_TEX_SIZE),
+                            DO_ACTION_TEX_SIZE, 0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 2145);
         osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
     } else {
         gSegments[7] = VIRTUAL_TO_PHYSICAL(interfaceCtx->doActionSegment);
@@ -2148,8 +2150,8 @@ void Interface_LoadActionLabelB(PlayState* play, u16 action) {
 
     osCreateMesgQueue(&interfaceCtx->loadQueue, &interfaceCtx->loadMsg, 1);
     DmaMgr_SendRequest2(&interfaceCtx->dmaRequest_160, interfaceCtx->doActionSegment + DO_ACTION_TEX_SIZE,
-                        (u32)_do_action_staticSegmentRomStart + (action * DO_ACTION_TEX_SIZE), DO_ACTION_TEX_SIZE, 0,
-                        &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 2228);
+                        (uintptr_t)_do_action_staticSegmentRomStart + (action * DO_ACTION_TEX_SIZE), DO_ACTION_TEX_SIZE,
+                        0, &interfaceCtx->loadQueue, NULL, "../z_parameter.c", 2228);
     osRecvMesg(&interfaceCtx->loadQueue, NULL, OS_MESG_BLOCK);
 
     interfaceCtx->unk_1FA = true;

--- a/src/code/z_sample.c
+++ b/src/code/z_sample.c
@@ -80,7 +80,7 @@ void Sample_LoadTitleStatic(SampleState* this) {
     u32 size = _title_staticSegmentRomEnd - _title_staticSegmentRomStart;
 
     this->staticSegment = GameState_Alloc(&this->state, size, "../z_sample.c", 163);
-    DmaMgr_SendRequest1(this->staticSegment, (u32)_title_staticSegmentRomStart, size, "../z_sample.c", 164);
+    DmaMgr_SendRequest1(this->staticSegment, (uintptr_t)_title_staticSegmentRomStart, size, "../z_sample.c", 164);
 }
 
 void Sample_Init(GameState* thisx) {

--- a/src/code/z_vr_box.c
+++ b/src/code/z_vr_box.c
@@ -449,16 +449,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_BAZAAR:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_SP1a_staticSegmentRomStart;
-            size = (u32)_vr_SP1a_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_SP1a_staticSegmentRomStart;
+            size = (uintptr_t)_vr_SP1a_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1127);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1128);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1129);
 
-            start = (u32)_vr_SP1a_pal_staticSegmentRomStart;
-            size = (u32)_vr_SP1a_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_SP1a_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_SP1a_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1132);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1133);
 
@@ -466,8 +466,8 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
             skyboxCtx->rot.y = 0.8f;
             break;
         case SKYBOX_OVERCAST_SUNSET:
-            start = (u32)_vr_cloud2_staticSegmentRomStart;
-            size = (u32)_vr_cloud2_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_cloud2_staticSegmentRomStart;
+            size = (uintptr_t)_vr_cloud2_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1155);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1156);
@@ -480,8 +480,8 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[1], start, size, "../z_vr_box.c", 1166);
 
-            start = (u32)_vr_cloud2_pal_staticSegmentRomStart;
-            size = (u32)_vr_cloud2_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_cloud2_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_cloud2_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size * 2, "../z_vr_box.c", 1170);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1171);
 
@@ -491,16 +491,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_MARKET_ADULT:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_RUVR_staticSegmentRomStart;
-            size = (u32)_vr_RUVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_RUVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_RUVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1182);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1183);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1184);
 
-            start = (u32)_vr_RUVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_RUVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_RUVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_RUVR_pal_staticSegmentRomEnd - start;
             osSyncPrintf("ＳＩＺＥ = %d\n", size);
 
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1188);
@@ -509,44 +509,44 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
             DmaMgr_SendRequest1(skyboxCtx->palettes, start, size, "../z_vr_box.c", 1190);
             break;
         case SKYBOX_CUTSCENE_MAP:
-            start = (u32)_vr_holy0_staticSegmentRomStart;
-            size = (u32)_vr_holy0_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_holy0_staticSegmentRomStart;
+            size = (uintptr_t)_vr_holy0_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1196);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1197);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1200);
 
-            start = (u32)_vr_holy1_staticSegmentRomStart;
-            size = (u32)_vr_holy1_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_holy1_staticSegmentRomStart;
+            size = (uintptr_t)_vr_holy1_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[1] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1203);
             ASSERT(skyboxCtx->staticSegments[1] != NULL, "vr_box->vr_box_staticSegment[1] != NULL", "../z_vr_box.c",
                    1204);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[1], start, size, "../z_vr_box.c", 1207);
 
-            start = (u32)_vr_holy0_pal_staticSegmentRomStart;
-            size = (u32)_vr_holy0_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_holy0_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_holy0_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size * 2, "../z_vr_box.c", 1211);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1212);
 
             DmaMgr_SendRequest1(skyboxCtx->palettes, start, size, "../z_vr_box.c", 1214);
-            DmaMgr_SendRequest1((u8*)skyboxCtx->palettes + size, (u32)_vr_holy1_pal_staticSegmentRomStart, size,
+            DmaMgr_SendRequest1((u8*)skyboxCtx->palettes + size, (uintptr_t)_vr_holy1_pal_staticSegmentRomStart, size,
                                 "../z_vr_box.c", 1216);
             break;
         case SKYBOX_HOUSE_LINK:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_LHVR_staticSegmentRomStart;
-            size = (u32)_vr_LHVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_LHVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_LHVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1226);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1227);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1228);
 
-            start = (u32)_vr_LHVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_LHVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_LHVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_LHVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1231);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1232);
 
@@ -555,16 +555,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_MARKET_CHILD_DAY:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_MDVR_staticSegmentRomStart;
-            size = (u32)_vr_MDVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_MDVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_MDVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1257);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1258);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1259);
 
-            start = (u32)_vr_MDVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_MDVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_MDVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_MDVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1262);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1263);
 
@@ -573,16 +573,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_MARKET_CHILD_NIGHT:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_MNVR_staticSegmentRomStart;
-            size = (u32)_vr_MNVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_MNVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_MNVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1271);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1272);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1273);
 
-            start = (u32)_vr_MNVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_MNVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_MNVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_MNVR_pal_staticSegmentRomEnd - start;
             osSyncPrintf("ＳＩＺＥ = %d\n", size);
 
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1277);
@@ -593,16 +593,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HAPPY_MASK_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_FCVR_staticSegmentRomStart;
-            size = (u32)_vr_FCVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_FCVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_FCVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1286);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1287);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1288);
 
-            start = (u32)_vr_FCVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_FCVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_FCVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_FCVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1291);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1292);
 
@@ -612,16 +612,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_KNOW_IT_ALL_BROTHERS:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_KHVR_staticSegmentRomStart;
-            size = (u32)_vr_KHVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_KHVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_KHVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1301);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1302);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1303);
 
-            start = (u32)_vr_KHVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_KHVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_KHVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_KHVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1306);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1307);
 
@@ -630,16 +630,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_OF_TWINS:
             skyboxCtx->unk_140 = 2;
 
-            start = (u32)_vr_K3VR_staticSegmentRomStart;
-            size = (u32)_vr_K3VR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_K3VR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_K3VR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1331);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1332);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1333);
 
-            start = (u32)_vr_K3VR_pal_staticSegmentRomStart;
-            size = (u32)_vr_K3VR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_K3VR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_K3VR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1336);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1337);
 
@@ -648,16 +648,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_STABLES:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_MLVR_staticSegmentRomStart;
-            size = (u32)_vr_MLVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_MLVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_MLVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1345);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1346);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1347);
 
-            start = (u32)_vr_MLVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_MLVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_MLVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_MLVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1350);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1351);
 
@@ -666,16 +666,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_KAKARIKO:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_KKRVR_staticSegmentRomStart;
-            size = (u32)_vr_KKRVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_KKRVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_KKRVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1359);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1360);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1361);
 
-            start = (u32)_vr_KKRVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_KKRVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_KKRVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_KKRVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1364);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1365);
 
@@ -684,16 +684,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_KOKIRI_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_KSVR_staticSegmentRomStart;
-            size = (u32)_vr_KSVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_KSVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_KSVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1373);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1374);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1375);
 
-            start = (u32)_vr_KSVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_KSVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_KSVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_KSVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1378);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1379);
 
@@ -703,16 +703,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_GORON_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_GLVR_staticSegmentRomStart;
-            size = (u32)_vr_GLVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_GLVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_GLVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1405);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1406);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1407);
 
-            start = (u32)_vr_GLVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_GLVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_GLVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_GLVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1410);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1411);
 
@@ -722,16 +722,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_ZORA_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_ZRVR_staticSegmentRomStart;
-            size = (u32)_vr_ZRVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_ZRVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_ZRVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1420);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1421);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1422);
 
-            start = (u32)_vr_ZRVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_ZRVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_ZRVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_ZRVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1425);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1426);
 
@@ -741,16 +741,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_POTION_SHOP_KAKARIKO:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_DGVR_staticSegmentRomStart;
-            size = (u32)_vr_DGVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_DGVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_DGVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1451);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1452);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1453);
 
-            start = (u32)_vr_DGVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_DGVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_DGVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_DGVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1456);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1457);
 
@@ -760,16 +760,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_POTION_SHOP_MARKET:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_ALVR_staticSegmentRomStart;
-            size = (u32)_vr_ALVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_ALVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_ALVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1466);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1467);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1468);
 
-            start = (u32)_vr_ALVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_ALVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_ALVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_ALVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1471);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1472);
 
@@ -779,16 +779,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_BOMBCHU_SHOP:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_NSVR_staticSegmentRomStart;
-            size = (u32)_vr_NSVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_NSVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_NSVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1481);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1482);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1483);
 
-            start = (u32)_vr_NSVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_NSVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_NSVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_NSVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1486);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1487);
 
@@ -798,16 +798,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_RICHARD:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_IPVR_staticSegmentRomStart;
-            size = (u32)_vr_IPVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_IPVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_IPVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1512);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1513);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1514);
 
-            start = (u32)_vr_IPVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_IPVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_IPVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_IPVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1517);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1518);
 
@@ -816,16 +816,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_IMPA:
             skyboxCtx->unk_140 = 1;
 
-            start = (u32)_vr_LBVR_staticSegmentRomStart;
-            size = (u32)_vr_LBVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_LBVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_LBVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1526);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1527);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1528);
 
-            start = (u32)_vr_LBVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_LBVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_LBVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_LBVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1531);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1532);
 
@@ -834,16 +834,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_TENT:
             skyboxCtx->unk_140 = 2;
 
-            start = (u32)_vr_TTVR_staticSegmentRomStart;
-            size = (u32)_vr_TTVR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_TTVR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_TTVR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1540);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1541);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1542);
 
-            start = (u32)_vr_TTVR_pal_staticSegmentRomStart;
-            size = (u32)_vr_TTVR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_TTVR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_TTVR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1545);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1546);
 
@@ -852,16 +852,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_MIDO:
             skyboxCtx->unk_140 = 2;
 
-            start = (u32)_vr_K4VR_staticSegmentRomStart;
-            size = (u32)_vr_K4VR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_K4VR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_K4VR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1560);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1561);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1562);
 
-            start = (u32)_vr_K4VR_pal_staticSegmentRomStart;
-            size = (u32)_vr_K4VR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_K4VR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_K4VR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1565);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1566);
 
@@ -870,16 +870,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_SARIA:
             skyboxCtx->unk_140 = 2;
 
-            start = (u32)_vr_K5VR_staticSegmentRomStart;
-            size = (u32)_vr_K5VR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_K5VR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_K5VR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1574);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1575);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1576);
 
-            start = (u32)_vr_K5VR_pal_staticSegmentRomStart;
-            size = (u32)_vr_K5VR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_K5VR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_K5VR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1579);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1580);
 
@@ -888,16 +888,16 @@ void Skybox_Setup(PlayState* play, SkyboxContext* skyboxCtx, s16 skyboxId) {
         case SKYBOX_HOUSE_ALLEY:
             skyboxCtx->unk_140 = 2;
 
-            start = (u32)_vr_KR3VR_staticSegmentRomStart;
-            size = (u32)_vr_KR3VR_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_KR3VR_staticSegmentRomStart;
+            size = (uintptr_t)_vr_KR3VR_staticSegmentRomEnd - start;
             skyboxCtx->staticSegments[0] = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1588);
             ASSERT(skyboxCtx->staticSegments[0] != NULL, "vr_box->vr_box_staticSegment[0] != NULL", "../z_vr_box.c",
                    1589);
 
             DmaMgr_SendRequest1(skyboxCtx->staticSegments[0], start, size, "../z_vr_box.c", 1590);
 
-            start = (u32)_vr_KR3VR_pal_staticSegmentRomStart;
-            size = (u32)_vr_KR3VR_pal_staticSegmentRomEnd - start;
+            start = (uintptr_t)_vr_KR3VR_pal_staticSegmentRomStart;
+            size = (uintptr_t)_vr_KR3VR_pal_staticSegmentRomEnd - start;
             skyboxCtx->palettes = GameState_Alloc(&play->state, size, "../z_vr_box.c", 1593);
             ASSERT(skyboxCtx->palettes != NULL, "vr_box->vr_box_staticSegment[2] != NULL", "../z_vr_box.c", 1594);
 

--- a/src/overlays/effects/ovl_Effect_Ss_Extra/z_eff_ss_extra.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Extra/z_eff_ss_extra.c
@@ -27,7 +27,7 @@ u32 EffectSsExtra_Init(PlayState* play, u32 index, EffectSs* this, void* initPar
     EffectSsExtraInitParams* initParams = (EffectSsExtraInitParams*)initParamsx;
     s32 pad;
     s32 objBankIndex;
-    u32 oldSeg6;
+    uintptr_t oldSeg6;
 
     objBankIndex = Object_GetIndex(&play->objectCtx, OBJECT_YABUSAME_POINT);
 

--- a/src/overlays/effects/ovl_Effect_Ss_Fhg_Flash/z_eff_ss_fhg_flash.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Fhg_Flash/z_eff_ss_fhg_flash.c
@@ -34,7 +34,7 @@ u32 EffectSsFhgFlash_Init(PlayState* play, u32 index, EffectSs* this, void* init
     s32 objBankIdx;
     Vec3f zeroVec = { 0.0f, 0.0f, 0.0f };
     Vec3f sp34 = { 0.0f, -1000.0f, 0.0f };
-    u32 oldSeg6;
+    uintptr_t oldSeg6;
 
     if (initParams->type == FHGFLASH_LIGHTBALL) {
         objBankIdx = Object_GetIndex(&play->objectCtx, OBJECT_FHG);

--- a/src/overlays/effects/ovl_Effect_Ss_Ice_Smoke/z_eff_ss_ice_smoke.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Ice_Smoke/z_eff_ss_ice_smoke.c
@@ -24,7 +24,7 @@ u32 EffectSsIceSmoke_Init(PlayState* play, u32 index, EffectSs* this, void* init
     EffectSsIceSmokeInitParams* initParams = (EffectSsIceSmokeInitParams*)initParamsx;
     s32 pad;
     s32 objBankIdx;
-    u32 oldSeg6;
+    uintptr_t oldSeg6;
 
     objBankIdx = Object_GetIndex(&play->objectCtx, OBJECT_FZ);
 


### PR DESCRIPTION
Another chunk of intptr type updates (following #1301 and #1325). This one has a bit more changes, but a lot of them were straightforward u32 -> uintptr_t changes for rom addresses. I also updated `gSegments` and its corresponding macros/variables to use uintptr, as well as the code in `main.c` and `sys_cfb.c`.

Note: `ucode_disas.c` should also be updated with the `gSegments` change, but there are a lot more types to change in there so I think it should get its own pass later.