### PR TITLE
Cleanup C-Up/Navi msgs names

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -800,7 +800,7 @@ void SfxSource_InitAll(PlayState* play);
 void SfxSource_UpdateAll(PlayState* play);
 void SfxSource_PlaySfxAtFixedWorldPos(PlayState* play, Vec3f* worldPos, s32 duration, u16 sfxId);
 u16 ElfMessage_GetSariaText(PlayState* play);
-u16 ElfMessage_GetCUpText(PlayState* play);
+u16 ElfMessage_GetNaviText(PlayState* play);
 u16 Text_GetFaceReaction(PlayState* play, u32 reactionSet);
 void Flags_UnsetAllEnv(PlayState* play);
 void Flags_SetEnv(PlayState* play, s16 flag);

--- a/include/z64.h
+++ b/include/z64.h
@@ -1192,7 +1192,7 @@ typedef struct PlayState {
     /* 0x11E00 */ EntranceEntry* setupEntranceList;
     /* 0x11E04 */ s16* setupExitList;
     /* 0x11E08 */ Path* setupPathList;
-    /* 0x11E0C */ ElfMessage* cUpMsgs;
+    /* 0x11E0C */ ElfMessage* naviMsgs;
     /* 0x11E10 */ void* specialEffects;
     /* 0x11E14 */ u8 skyboxId;
     /* 0x11E15 */ s8 transitionTrigger; // "fade_direction"

--- a/include/z64.h
+++ b/include/z64.h
@@ -1192,7 +1192,7 @@ typedef struct PlayState {
     /* 0x11E00 */ EntranceEntry* setupEntranceList;
     /* 0x11E04 */ s16* setupExitList;
     /* 0x11E08 */ Path* setupPathList;
-    /* 0x11E0C */ ElfMessage* cUpElfMsgs;
+    /* 0x11E0C */ ElfMessage* cUpMsgs;
     /* 0x11E10 */ void* specialEffects;
     /* 0x11E14 */ u8 skyboxId;
     /* 0x11E15 */ s8 transitionTrigger; // "fade_direction"

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -223,7 +223,7 @@ typedef struct {
 
 typedef struct {
     /* 0x00 */ u8  code;
-    /* 0x01 */ u8  cUpElfMsgNum;
+    /* 0x01 */ u8  cUpMsgsNum;
     /* 0x04 */ u32 keepObjectId;
 } SCmdSpecialFiles;
 
@@ -522,8 +522,8 @@ typedef enum {
 #define SCENE_CMD_ENTRANCE_LIST(entranceList) \
     { SCENE_CMD_ID_ENTRANCE_LIST, 0, CMD_PTR(entranceList) }
 
-#define SCENE_CMD_SPECIAL_FILES(elfMessageFile, keepObjectId) \
-    { SCENE_CMD_ID_SPECIAL_FILES, elfMessageFile, CMD_W(keepObjectId) }
+#define SCENE_CMD_SPECIAL_FILES(cUpMsgsNum, keepObjectId) \
+    { SCENE_CMD_ID_SPECIAL_FILES, cUpMsgsNum, CMD_W(keepObjectId) }
 
 #define SCENE_CMD_ROOM_BEHAVIOR(curRoomUnk3, curRoomUnk2, showInvisActors, disableWarpSongs) \
     { SCENE_CMD_ID_ROOM_BEHAVIOR, curRoomUnk3, \

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -223,7 +223,7 @@ typedef struct {
 
 typedef struct {
     /* 0x00 */ u8  code;
-    /* 0x01 */ u8  cUpMsgsNum;
+    /* 0x01 */ u8  naviMsgsNum;
     /* 0x04 */ u32 keepObjectId;
 } SCmdSpecialFiles;
 
@@ -522,8 +522,8 @@ typedef enum {
 #define SCENE_CMD_ENTRANCE_LIST(entranceList) \
     { SCENE_CMD_ID_ENTRANCE_LIST, 0, CMD_PTR(entranceList) }
 
-#define SCENE_CMD_SPECIAL_FILES(cUpMsgsNum, keepObjectId) \
-    { SCENE_CMD_ID_SPECIAL_FILES, cUpMsgsNum, CMD_W(keepObjectId) }
+#define SCENE_CMD_SPECIAL_FILES(naviMsgsNum, keepObjectId) \
+    { SCENE_CMD_ID_SPECIAL_FILES, naviMsgsNum, CMD_W(keepObjectId) }
 
 #define SCENE_CMD_ROOM_BEHAVIOR(curRoomUnk3, curRoomUnk2, showInvisActors, disableWarpSongs) \
     { SCENE_CMD_ID_ROOM_BEHAVIOR, curRoomUnk3, \

--- a/src/code/z_elf_message.c
+++ b/src/code/z_elf_message.c
@@ -165,10 +165,10 @@ u16 ElfMessage_GetSariaText(PlayState* play) {
     return ElfMessage_GetTextFromMsgs(msgs);
 }
 
-u16 ElfMessage_GetCUpText(PlayState* play) {
-    if (play->cUpMsgs == NULL) {
+u16 ElfMessage_GetNaviText(PlayState* play) {
+    if (play->naviMsgs == NULL) {
         return 0;
     } else {
-        return ElfMessage_GetTextFromMsgs(play->cUpMsgs);
+        return ElfMessage_GetTextFromMsgs(play->naviMsgs);
     }
 }

--- a/src/code/z_elf_message.c
+++ b/src/code/z_elf_message.c
@@ -166,9 +166,9 @@ u16 ElfMessage_GetSariaText(PlayState* play) {
 }
 
 u16 ElfMessage_GetCUpText(PlayState* play) {
-    if (play->cUpElfMsgs == NULL) {
+    if (play->cUpMsgs == NULL) {
         return 0;
     } else {
-        return ElfMessage_GetTextFromMsgs(play->cUpElfMsgs);
+        return ElfMessage_GetTextFromMsgs(play->cUpMsgs);
     }
 }

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -1403,7 +1403,7 @@ void Play_InitScene(PlayState* this, s32 spawn) {
     this->unk_11DFC = NULL;
     this->setupEntranceList = NULL;
     this->setupExitList = NULL;
-    this->cUpElfMsgs = NULL;
+    this->cUpMsgs = NULL;
     this->setupPathList = NULL;
     this->numSetupActors = 0;
     Object_InitBank(this, &this->objectCtx);

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -1403,7 +1403,7 @@ void Play_InitScene(PlayState* this, s32 spawn) {
     this->unk_11DFC = NULL;
     this->setupEntranceList = NULL;
     this->setupExitList = NULL;
-    this->cUpMsgs = NULL;
+    this->naviMsgs = NULL;
     this->setupPathList = NULL;
     this->numSetupActors = 0;
     Object_InitBank(this, &this->objectCtx);

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -232,7 +232,7 @@ void Scene_CommandSpecialFiles(PlayState* play, SceneCmd* cmd) {
     }
 
     if (cmd->specialFiles.cUpElfMsgNum != 0) {
-        play->cUpElfMsgs = Play_LoadFile(play, &sNaviMsgFiles[cmd->specialFiles.cUpElfMsgNum - 1]);
+        play->cUpMsgs = Play_LoadFile(play, &sNaviMsgFiles[cmd->specialFiles.cUpElfMsgNum - 1]);
     }
 }
 

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "vt.h"
 
-RomFile sCUpMsgsFiles[];
+RomFile sNaviMsgsFiles[];
 
 s32 Object_Spawn(ObjectContext* objectCtx, s16 objectId) {
     u32 size;
@@ -231,8 +231,8 @@ void Scene_CommandSpecialFiles(PlayState* play, SceneCmd* cmd) {
         gSegments[5] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[play->objectCtx.subKeepIndex].segment);
     }
 
-    if (cmd->specialFiles.cUpMsgsNum != 0) {
-        play->cUpMsgs = Play_LoadFile(play, &sCUpMsgsFiles[cmd->specialFiles.cUpMsgsNum - 1]);
+    if (cmd->specialFiles.naviMsgsNum != 0) {
+        play->naviMsgs = Play_LoadFile(play, &sNaviMsgsFiles[cmd->specialFiles.naviMsgsNum - 1]);
     }
 }
 
@@ -498,7 +498,7 @@ void (*gSceneCmdHandlers[SCENE_CMD_ID_MAX])(PlayState*, SceneCmd*) = {
     Scene_CommandMiscSettings,        // SCENE_CMD_ID_MISC_SETTINGS
 };
 
-RomFile sCUpMsgsFiles[] = {
+RomFile sNaviMsgsFiles[] = {
     ROM_FILE(elf_message_field),
     ROM_FILE(elf_message_ydan),
     ROM_FILE_UNSET,

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "vt.h"
 
-RomFile sNaviMsgFiles[];
+RomFile sCUpMsgsFiles[];
 
 s32 Object_Spawn(ObjectContext* objectCtx, s16 objectId) {
     u32 size;
@@ -231,8 +231,8 @@ void Scene_CommandSpecialFiles(PlayState* play, SceneCmd* cmd) {
         gSegments[5] = VIRTUAL_TO_PHYSICAL(play->objectCtx.status[play->objectCtx.subKeepIndex].segment);
     }
 
-    if (cmd->specialFiles.cUpElfMsgNum != 0) {
-        play->cUpMsgs = Play_LoadFile(play, &sNaviMsgFiles[cmd->specialFiles.cUpElfMsgNum - 1]);
+    if (cmd->specialFiles.cUpMsgsNum != 0) {
+        play->cUpMsgs = Play_LoadFile(play, &sCUpMsgsFiles[cmd->specialFiles.cUpMsgsNum - 1]);
     }
 }
 
@@ -498,7 +498,7 @@ void (*gSceneCmdHandlers[SCENE_CMD_ID_MAX])(PlayState*, SceneCmd*) = {
     Scene_CommandMiscSettings,        // SCENE_CMD_ID_MISC_SETTINGS
 };
 
-RomFile sNaviMsgFiles[] = {
+RomFile sCUpMsgsFiles[] = {
     ROM_FILE(elf_message_field),
     ROM_FILE(elf_message_ydan),
     ROM_FILE_UNSET,

--- a/src/elf_message/elf_message_field.c
+++ b/src/elf_message/elf_message_field.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "z64elf_message.h"
 
-ElfMessage sOverworldCUpMsgs[] = {
+ElfMessage sOverworldNaviMsgs[] = {
     ELF_MSG_FLAG(CHECK, 0x40, false, EVENTCHKINF_05),
     ELF_MSG_FLAG(CHECK, 0x41, false, EVENTCHKINF_09),
     ELF_MSG_FLAG(CHECK, 0x42, false, EVENTCHKINF_12),

--- a/src/elf_message/elf_message_field.c
+++ b/src/elf_message/elf_message_field.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "z64elf_message.h"
 
-ElfMessage gOverworldNaviMsgs[] = {
+ElfMessage sOverworldCUpMsgs[] = {
     ELF_MSG_FLAG(CHECK, 0x40, false, EVENTCHKINF_05),
     ELF_MSG_FLAG(CHECK, 0x41, false, EVENTCHKINF_09),
     ELF_MSG_FLAG(CHECK, 0x42, false, EVENTCHKINF_12),

--- a/src/elf_message/elf_message_field.c
+++ b/src/elf_message/elf_message_field.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "z64elf_message.h"
 
-ElfMessage sOverworldNaviMsgs[] = {
+static ElfMessage sOverworldNaviMsgs[] = {
     ELF_MSG_FLAG(CHECK, 0x40, false, EVENTCHKINF_05),
     ELF_MSG_FLAG(CHECK, 0x41, false, EVENTCHKINF_09),
     ELF_MSG_FLAG(CHECK, 0x42, false, EVENTCHKINF_12),

--- a/src/elf_message/elf_message_ydan.c
+++ b/src/elf_message/elf_message_ydan.c
@@ -1,6 +1,6 @@
 #include "global.h"
 #include "z64elf_message.h"
 
-ElfMessage gDungeonNaviMsgs[] = {
+ElfMessage gDungeonCUpMsgs[] = {
     ELF_MSG_END(0x5F),
 };

--- a/src/elf_message/elf_message_ydan.c
+++ b/src/elf_message/elf_message_ydan.c
@@ -1,6 +1,6 @@
 #include "global.h"
 #include "z64elf_message.h"
 
-ElfMessage sDungeonNaviMsgs[] = {
+static ElfMessage sDungeonNaviMsgs[] = {
     ELF_MSG_END(0x5F),
 };

--- a/src/elf_message/elf_message_ydan.c
+++ b/src/elf_message/elf_message_ydan.c
@@ -1,6 +1,6 @@
 #include "global.h"
 #include "z64elf_message.h"
 
-ElfMessage gDungeonCUpMsgs[] = {
+ElfMessage sDungeonNaviMsgs[] = {
     ELF_MSG_END(0x5F),
 };

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -1310,7 +1310,7 @@ void func_80A05188(Actor* thisx, PlayState* play) {
 
 // ask to talk to navi
 void func_80A05208(Actor* thisx, PlayState* play) {
-    s32 naviCUpText;
+    s32 naviTextId;
     EnElf* this = (EnElf*)thisx;
 
     func_80A04DE4(this, play);
@@ -1318,10 +1318,10 @@ void func_80A05208(Actor* thisx, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_CHOICE) && Message_ShouldAdvance(play)) {
         switch (play->msgCtx.choiceIndex) {
             case 0: // yes
-                naviCUpText = ElfMessage_GetCUpText(play);
+                naviTextId = ElfMessage_GetNaviText(play);
 
-                if (naviCUpText != 0) {
-                    Message_ContinueTextbox(play, naviCUpText);
+                if (naviTextId != 0) {
+                    Message_ContinueTextbox(play, naviTextId);
                 } else {
                     Message_ContinueTextbox(play, 0x15F);
                 }
@@ -1379,7 +1379,7 @@ void func_80A053F0(Actor* thisx, PlayState* play) {
     if (player->naviTextId == 0) {
         if (player->unk_664 == NULL) {
             if (((gSaveContext.naviTimer >= 600) && (gSaveContext.naviTimer <= 3000)) || (nREG(89) != 0)) {
-                player->naviTextId = ElfMessage_GetCUpText(play);
+                player->naviTextId = ElfMessage_GetNaviText(play);
 
                 if (player->naviTextId == 0x15F) {
                     player->naviTextId = 0;
@@ -1395,7 +1395,7 @@ void func_80A053F0(Actor* thisx, PlayState* play) {
         func_800F4524(&gSfxDefaultPos, NA_SE_VO_SK_LAUGH, 0x20);
         thisx->focus.pos = thisx->world.pos;
 
-        if (thisx->textId == ElfMessage_GetCUpText(play)) {
+        if (thisx->textId == ElfMessage_GetNaviText(play)) {
             this->fairyFlags |= 0x80;
             gSaveContext.naviTimer = 3001;
         }


### PR DESCRIPTION
Moving this topic from #1344 for which it is out of scope

This renames everything involved in the navi c-up messages (ElfMessage data/system, which also handles Saria messages through Saria's song)

~~Names now consistently use "C-Up" but it could also be "C-Up Navi", "Navi C-Up" or "Navi".~~

~~I went with "C-Up" because that's what `ElfMessage_GetCUpText` uses, but this is debatable (I just would like the names to be consistent)~~

