### PR TITLE
Document object_bdoor (boss doors)

### DIFF
--- a/assets/xml/objects/gameplay_dangeon_keep.xml
+++ b/assets/xml/objects/gameplay_dangeon_keep.xml
@@ -4,7 +4,7 @@
         <DList Name="gBrownFragmentDL" Offset="0x530"/>
         <Texture Name="gUnusedStoneTex" OutName="unused_stone" Format="rgba16" Width="32" Height="32" Offset="0x7C0"/>
         <DList Name="gDoorLockDL" Offset="0x1100"/>
-        <DList Name="gDoorChainsDL" Offset="0x11F0"/>
+        <DList Name="gDoorChainDL" Offset="0x11F0"/>
         <Texture Name="gUnusedGoldLockTex" OutName="unused_gold_lock" Format="rgba16" Width="32" Height="32" Offset="0x1A80"/>
         <Texture Name="gDoorChainTex" OutName="door_chain" Format="rgba16" Width="16" Height="128" Offset="0x2280"/>
         <DList Name="gUnusedBombBagDL" Offset="0x32C0"/>

--- a/assets/xml/objects/object_bdoor.xml
+++ b/assets/xml/objects/object_bdoor.xml
@@ -1,15 +1,22 @@
 <Root>
     <ExternalFile XmlPath="objects/gameplay_dangeon_keep.xml" OutPath="assets/objects/gameplay_dangeon_keep/"/>
     <File Name="object_bdoor" Segment="6">
-        <Texture Name="object_bdoor_Tex_000000" OutName="tex_00000000" Format="rgba16" Width="32" Height="64" Offset="0x0"/>
-        <DList Name="object_bdoor_DL_0010C0" Offset="0x10C0"/>
-        <DList Name="object_bdoor_DL_001400" Offset="0x1400"/>
-        <DList Name="object_bdoor_DL_001530" Offset="0x1530"/>
-        <Texture Name="object_bdoor_Tex_0015C0" OutName="tex_000015C0" Format="rgba16" Width="32" Height="64" Offset="0x15C0"/>
-        <Texture Name="object_bdoor_Tex_0025C0" OutName="tex_000025C0" Format="rgba16" Width="32" Height="64" Offset="0x25C0"/>
-        <Texture Name="object_bdoor_Tex_0035C0" OutName="tex_000035C0" Format="rgba16" Width="32" Height="64" Offset="0x35C0"/>
-        <Texture Name="object_bdoor_Tex_0045C0" OutName="tex_000045C0" Format="rgba16" Width="32" Height="64" Offset="0x45C0"/>
-        <Texture Name="object_bdoor_Tex_0055C0" OutName="tex_000055C0" Format="rgba16" Width="32" Height="64" Offset="0x55C0"/>
-        <Texture Name="object_bdoor_Tex_0065C0" OutName="tex_000065C0" Format="rgba16" Width="32" Height="64" Offset="0x65C0"/>
+        <!-- One of the Boss Door Textures -->
+        <Texture Name="gBossDoorGanonsCastleTex" OutName="boss_door_ganons_castle" Format="rgba16" Width="32" Height="64" Offset="0x0"/>
+
+        <!-- Boss Door, Lock, and Chain DisplayLists -->
+        <DList Name="gBossDoorDL" Offset="0x10C0"/> <!-- Original name is "bossdoor_model" -->
+        <DList Name="gBossDoorLockDL" Offset="0x1400"/> <!-- Original name is "doorkagiboss_model" -->
+        <DList Name="gBossDoorChainDL" Offset="0x1530"/> <!-- Original name is "doorkusariboss_model" -->
+
+        <!-- The rest of the Boss Door Textures -->
+        <Texture Name="gBossDoorSpiritTex" OutName="boss_door_spirit" Format="rgba16" Width="32" Height="64" Offset="0x15C0"/>
+        <Texture Name="gBossDoorForestTex" OutName="boss_door_forest" Format="rgba16" Width="32" Height="64" Offset="0x25C0"/>
+        <Texture Name="gBossDoorFireTex" OutName="boss_door_fire" Format="rgba16" Width="32" Height="64" Offset="0x35C0"/>
+        <Texture Name="gBossDoorShadowTex" OutName="boss_door_shadow" Format="rgba16" Width="32" Height="64" Offset="0x45C0"/>
+        <Texture Name="gBossDoorWaterTex" OutName="boss_door_water" Format="rgba16" Width="32" Height="64" Offset="0x55C0"/>
+
+        <!-- A default texture only used if a Boss Door is present outside of the six adult dungeons, which is never the case in the final game. -->
+        <Texture Name="gBossDoorDefaultTex" OutName="boss_door_unused" Format="rgba16" Width="32" Height="64" Offset="0x65C0"/>
     </File>
 </Root>

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -3550,9 +3550,9 @@ typedef struct {
 } DoorLockInfo; // size = 0x1C
 
 static DoorLockInfo sDoorLocksInfo[] = {
-    /* DOORLOCK_NORMAL */ { 0.54f, 6000.0f, 5000.0f, 1.0f, 0.0f, gDoorChainsDL, gDoorLockDL },
-    /* DOORLOCK_BOSS */ { 0.644f, 12000.0f, 8000.0f, 1.0f, 0.0f, object_bdoor_DL_001530, object_bdoor_DL_001400 },
-    /* DOORLOCK_NORMAL_SPIRIT */ { 0.64000005f, 8500.0f, 8000.0f, 1.75f, 0.1f, gDoorChainsDL, gDoorLockDL },
+    /* DOORLOCK_NORMAL */ { 0.54f, 6000.0f, 5000.0f, 1.0f, 0.0f, gDoorChainDL, gDoorLockDL },
+    /* DOORLOCK_BOSS */ { 0.644f, 12000.0f, 8000.0f, 1.0f, 0.0f, gBossDoorChainDL, gBossDoorLockDL },
+    /* DOORLOCK_NORMAL_SPIRIT */ { 0.64000005f, 8500.0f, 8000.0f, 1.75f, 0.1f, gDoorChainDL, gDoorLockDL },
 };
 
 /**

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -102,7 +102,7 @@ static ShutterInfo sShutterInfo[] = {
     { gPhantomGanonBarsDL, NULL, 130, 12, 50, 15 },
     { gGohmaDoorDL, NULL, 130, 12, 50, 15 },
     { gSpiritDoorDL, gJyaDoorMetalBarsDL, 240, 14, 50, 15 },
-    { object_bdoor_DL_0010C0, NULL, 130, 12, 50, 15 },
+    { gBossDoorDL, NULL, 130, 12, 50, 15 },
     { gDungeonDoorDL, gDoorMetalBarsDL, 130, 12, 20, 15 },
     { gFireTempleDoorFrontDL, gDoorMetalBarsDL, 130, 12, 20, 15 },
     { gFireTempleDoorBackDL, gDoorMetalBarsDL, 130, 12, 20, 15 },
@@ -164,8 +164,8 @@ static Gfx* sJabuDoorDLists[] = {
 };
 
 static void* D_809982D4[] = {
-    object_bdoor_Tex_0065C0, object_bdoor_Tex_0035C0, object_bdoor_Tex_0055C0, object_bdoor_Tex_0045C0,
-    object_bdoor_Tex_000000, object_bdoor_Tex_0025C0, object_bdoor_Tex_0015C0,
+    gBossDoorDefaultTex,      gBossDoorFireTex,   gBossDoorWaterTex,  gBossDoorShadowTex,
+    gBossDoorGanonsCastleTex, gBossDoorForestTex, gBossDoorSpiritTex,
 };
 
 void DoorShutter_SetupAction(DoorShutter* this, DoorShutterActionFunc actionFunc) {


### PR DESCRIPTION
I did this in MM (because it was easy), and now I'm doing it in OoT (because it is easy).

I also renamed gDoorChainsDL to gDoorChainDL because the DisplayList is only a single chain:
![image](https://user-images.githubusercontent.com/12245827/195209022-ab68cd76-446c-460a-b69c-64af26ca965a.png)
