### PR TITLE
"NpcInfo" / `struct_80034A14_arg1` talkState docs

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -498,8 +498,8 @@ void func_8003424C(PlayState* play, Vec3f* arg1);
 void Actor_SetColorFilter(Actor* actor, s16 colorFlag, s16 colorIntensityMax, s16 xluFlag, s16 duration);
 Hilite* func_800342EC(Vec3f* object, PlayState* play);
 Hilite* func_8003435C(Vec3f* object, PlayState* play);
-s32 func_800343CC(PlayState* play, Actor* actor, s16* arg2, f32 interactRange,
-                  u16 (*unkFunc1)(PlayState*, Actor*), s16 (*unkFunc2)(PlayState*, Actor*));
+s32 Actor_NpcUpdateTalking(PlayState* play, Actor* actor, s16* talkState, f32 interactRange,
+                           ActorNpcGetTextIdFunc getTextId, ActorNpcGetTalkStateFunc getTalkState);
 s16 func_800347E8(s16 arg0);
 void func_80034A14(Actor* actor, struct_80034A14_arg1* arg1, s16 arg2, s16 arg3);
 void func_80034BA0(PlayState* play, SkelAnime* skelAnime, OverrideLimbDraw overrideLimbDraw,

--- a/include/z64.h
+++ b/include/z64.h
@@ -1345,10 +1345,10 @@ typedef struct {
 } struct_80034A14_arg1; // size = 0x28
 
 typedef enum {
-    /* 0x0 */ NPC_TALKING_STATE_0,
-    /* 0x1 */ NPC_TALKING_STATE_1,
-    /* 0x2 */ NPC_TALKING_STATE_2,
-    /* 0x3 */ NPC_TALKING_STATE_3,
+    /* 0x0 */ NPC_TALK_STATE_IDLE, // NPC not currently talking to player
+    /* 0x1 */ NPC_TALK_STATE_TALKING, // NPC is currently talking to player
+    /* 0x2 */ NPC_TALK_STATE_ACTION, // An NPC-defined action triggered in the conversation
+    /* 0x3 */ NPC_TALK_STATE_ITEM_GIVEN // NPC finished giving an item and text box is done
 } NpcTalkState;
 
 // Macros for `EntranceInfo.field`

--- a/include/z64.h
+++ b/include/z64.h
@@ -1333,7 +1333,7 @@ typedef struct {
 } AnimationMinimalInfo; // size = 0xC
 
 typedef struct {
-    /* 0x00 */ s16 unk_00;
+    /* 0x00 */ s16 talkState;
     /* 0x02 */ s16 unk_02;
     /* 0x04 */ s16 unk_04;
     /* 0x06 */ s16 unk_06;

--- a/include/z64.h
+++ b/include/z64.h
@@ -1344,6 +1344,13 @@ typedef struct {
     /* 0x24 */ s16 unk_24;
 } struct_80034A14_arg1; // size = 0x28
 
+typedef enum {
+    /* 0x0 */ NPC_TALKING_STATE_0,
+    /* 0x1 */ NPC_TALKING_STATE_1,
+    /* 0x2 */ NPC_TALKING_STATE_2,
+    /* 0x3 */ NPC_TALKING_STATE_3,
+} NpcTalkState;
+
 // Macros for `EntranceInfo.field`
 #define ENTRANCE_INFO_CONTINUE_BGM_FLAG (1 << 15)
 #define ENTRANCE_INFO_DISPLAY_TITLE_CARD_FLAG (1 << 14)

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -19,8 +19,8 @@ struct Lights;
 
 typedef void (*ActorFunc)(struct Actor*, struct PlayState*);
 typedef void (*ActorShadowFunc)(struct Actor*, struct Lights*, struct PlayState*);
-typedef u16 (*callback1_800343CC)(struct PlayState*, struct Actor*);
-typedef s16 (*callback2_800343CC)(struct PlayState*, struct Actor*);
+typedef u16 (*ActorNpcGetTextIdFunc)(struct PlayState*, struct Actor*);
+typedef s16 (*ActorNpcGetTalkStateFunc)(struct PlayState*, struct Actor*);
 
 typedef struct {
     Vec3f pos;

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -3643,18 +3643,18 @@ Hilite* func_8003435C(Vec3f* object, PlayState* play) {
     return func_8002EB44(object, &play->view.eye, &lightDir, play->state.gfxCtx);
 }
 
-s32 func_800343CC(PlayState* play, Actor* actor, s16* arg2, f32 interactRange, callback1_800343CC unkFunc1,
-                  callback2_800343CC unkFunc2) {
+s32 func_800343CC(PlayState* play, Actor* actor, s16* talkState, f32 interactRange, callback1_800343CC getTextID,
+                  callback2_800343CC getTalkState) {
     s16 x;
     s16 y;
 
     if (Actor_ProcessTalkRequest(actor, play)) {
-        *arg2 = 1;
+        *talkState = 1;
         return true;
     }
 
-    if (*arg2 != 0) {
-        *arg2 = unkFunc2(play, actor);
+    if (*talkState != 0) {
+        *talkState = getTalkState(play, actor);
         return false;
     }
 
@@ -3668,7 +3668,7 @@ s32 func_800343CC(PlayState* play, Actor* actor, s16* arg2, f32 interactRange, c
         return false;
     }
 
-    actor->textId = unkFunc1(play, actor);
+    actor->textId = getTextID(play, actor);
 
     return false;
 }
@@ -3762,7 +3762,7 @@ s16 func_80034810(Actor* actor, struct_80034A14_arg1* arg1, f32 arg2, s16 arg3, 
         return arg4;
     }
 
-    if (arg1->unk_00 != 0) {
+    if (arg1->talkState != 0) {
         return 4;
     }
 

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -3661,11 +3661,11 @@ s32 Actor_NpcUpdateTalking(PlayState* play, Actor* actor, s16* talkState, f32 in
     s16 y;
 
     if (Actor_ProcessTalkRequest(actor, play)) {
-        *talkState = 1;
+        *talkState = NPC_TALK_STATE_TALKING;
         return true;
     }
 
-    if (*talkState != 0) {
+    if (*talkState != NPC_TALK_STATE_IDLE) {
         *talkState = getTalkState(play, actor);
         return false;
     }
@@ -3677,7 +3677,7 @@ s32 Actor_NpcUpdateTalking(PlayState* play, Actor* actor, s16* talkState, f32 in
     }
 
     if (!func_8002F2CC(actor, play, interactRange)) {
-        // Player not in interact range or can't talk now
+        // Player cannot talk to actor now
         return false;
     }
 
@@ -3775,7 +3775,7 @@ s16 func_80034810(Actor* actor, struct_80034A14_arg1* arg1, f32 arg2, s16 arg3, 
         return arg4;
     }
 
-    if (arg1->talkState != 0) {
+    if (arg1->talkState != NPC_TALK_STATE_IDLE) {
         return 4;
     }
 

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -3643,8 +3643,20 @@ Hilite* func_8003435C(Vec3f* object, PlayState* play) {
     return func_8002EB44(object, &play->view.eye, &lightDir, play->state.gfxCtx);
 }
 
-s32 func_800343CC(PlayState* play, Actor* actor, s16* talkState, f32 interactRange, callback1_800343CC getTextID,
-                  callback2_800343CC getTalkState) {
+/**
+ * Updates NPC talking state. Updates the talkState parameter
+ * when a dialog is ongoing. Otherwise checks if the actor is onscreen,
+ * advertises the interaction in a range and sets the current text id if
+ * necessary.
+ *
+ * @param talkState Pointer to dialog state
+ * @param interactRange The interact (talking) range for the actor
+ * @param getTextId Callback for getting the next text id
+ * @param getTalkState Callback for getting the next talkState value
+ * @return s32 True if a new dialog was started (player talked to the actor). False otherwise.
+ */
+s32 Actor_NpcUpdateTalking(PlayState* play, Actor* actor, s16* talkState, f32 interactRange,
+                           ActorNpcGetTextIdFunc getTextId, ActorNpcGetTalkStateFunc getTalkState) {
     s16 x;
     s16 y;
 
@@ -3659,16 +3671,17 @@ s32 func_800343CC(PlayState* play, Actor* actor, s16* talkState, f32 interactRan
     }
 
     Actor_GetScreenPos(play, actor, &x, &y);
-
     if ((x < 0) || (x > SCREEN_WIDTH) || (y < 0) || (y > SCREEN_HEIGHT)) {
+        // Actor is offscreen
         return false;
     }
 
     if (!func_8002F2CC(actor, play, interactRange)) {
+        // Player not in interact range or can't talk now
         return false;
     }
 
-    actor->textId = getTextID(play, actor);
+    actor->textId = getTextId(play, actor);
 
     return false;
 }

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -560,8 +560,8 @@ void EnDu_Update(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
 
     if (this->actionFunc != func_809FE4A4) {
-        func_800343CC(play, &this->actor, &this->unk_1F4.talkState, this->collider.dim.radius + 116.0f, func_809FDC38,
-                      func_809FDCDC);
+        Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1F4.talkState, this->collider.dim.radius + 116.0f,
+                               func_809FDC38, func_809FDCDC);
     }
     this->actionFunc(this, play);
 }

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -166,7 +166,7 @@ void func_809FDE24(EnDu* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3 = 0;
 
-    if (this->unk_1F4.unk_00 == 0) {
+    if (this->unk_1F4.talkState == 0) {
         phi_a3 = 1;
     }
     if (this->actionFunc == func_809FE890) {
@@ -292,7 +292,7 @@ void EnDu_Init(Actor* thisx, PlayState* play) {
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENDU_ANIM_0);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.targetMode = 1;
-    this->unk_1F4.unk_00 = 0;
+    this->unk_1F4.talkState = 0;
 
     if (gSaveContext.cutsceneIndex >= 0xFFF0) {
         play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gGoronCityDarunia01Cs);
@@ -327,9 +327,9 @@ void func_809FE3C0(EnDu* this, PlayState* play) {
         EnDu_SetupAction(this, func_809FE4A4);
         return;
     }
-    if (this->unk_1F4.unk_00 == 2) {
+    if (this->unk_1F4.talkState == 2) {
         func_8002DF54(play, &this->actor, 7);
-        this->unk_1F4.unk_00 = 0;
+        this->unk_1F4.talkState = 0;
     }
     if (this->actor.xzDistToPlayer < 116.0f + this->collider.dim.radius) {
         player->stateFlags2 |= PLAYER_STATE2_23;
@@ -377,13 +377,13 @@ void func_809FE6CC(EnDu* this, PlayState* play) {
     if (DECR(this->unk_1E2) == 0) {
         this->actor.textId = 0x3039;
         Message_StartTextbox(play, this->actor.textId, NULL);
-        this->unk_1F4.unk_00 = 1;
+        this->unk_1F4.talkState = 1;
         EnDu_SetupAction(this, func_809FE740);
     }
 }
 
 void func_809FE740(EnDu* this, PlayState* play) {
-    if (this->unk_1F4.unk_00 == 0) {
+    if (this->unk_1F4.talkState == 0) {
         func_8005B1A4(GET_ACTIVE_CAM(play));
         this->unk_1E2 = 0x5A;
         EnDu_SetupAction(this, func_809FE798);
@@ -504,11 +504,11 @@ void func_809FEB08(EnDu* this, PlayState* play) {
     }
     Message_StartTextbox(play, this->actor.textId, NULL);
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENDU_ANIM_14);
-    this->unk_1F4.unk_00 = 1;
+    this->unk_1F4.talkState = 1;
 }
 
 void func_809FEC14(EnDu* this, PlayState* play) {
-    if (this->unk_1F4.unk_00 == 2) {
+    if (this->unk_1F4.talkState == 2) {
         func_8002DF54(play, &this->actor, 7);
         EnDu_SetupAction(this, func_809FEC70);
         func_809FEC70(this, play);
@@ -527,8 +527,8 @@ void func_809FEC70(EnDu* this, PlayState* play) {
 }
 
 void func_809FECE4(EnDu* this, PlayState* play) {
-    if (this->unk_1F4.unk_00 == 3) {
-        this->unk_1F4.unk_00 = 0;
+    if (this->unk_1F4.talkState == 3) {
+        this->unk_1F4.talkState = 0;
         EnDu_SetupAction(this, func_809FE3C0);
     }
 }
@@ -560,7 +560,7 @@ void EnDu_Update(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
 
     if (this->actionFunc != func_809FE4A4) {
-        func_800343CC(play, &this->actor, &this->unk_1F4.unk_00, this->collider.dim.radius + 116.0f, func_809FDC38,
+        func_800343CC(play, &this->actor, &this->unk_1F4.talkState, this->collider.dim.radius + 116.0f, func_809FDC38,
                       func_809FDCDC);
     }
     this->actionFunc(this, play);

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -130,19 +130,19 @@ s16 func_809FDCDC(PlayState* play, Actor* actor) {
                     break;
                 case 0x301C:
                 case 0x301F:
-                    return 2;
+                    return NPC_TALKING_STATE_2;
                 case 0x3020:
                     SET_EVENTCHKINF(EVENTCHKINF_22);
                     break;
             }
-            return 0;
+            return NPC_TALKING_STATE_0;
         case TEXT_STATE_DONE_FADING:
         case TEXT_STATE_CHOICE:
         case TEXT_STATE_EVENT:
             break;
         case TEXT_STATE_DONE:
             if (Message_ShouldAdvance(play)) {
-                return 3;
+                return NPC_TALKING_STATE_3;
             }
             break;
         case TEXT_STATE_SONG_DEMO_DONE:
@@ -150,7 +150,7 @@ s16 func_809FDCDC(PlayState* play, Actor* actor) {
         case TEXT_STATE_9:
             break;
     }
-    return 1;
+    return NPC_TALKING_STATE_1;
 }
 
 s32 func_809FDDB4(EnDu* this, PlayState* play) {
@@ -166,7 +166,7 @@ void func_809FDE24(EnDu* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3 = 0;
 
-    if (this->unk_1F4.talkState == 0) {
+    if (this->unk_1F4.talkState == NPC_TALKING_STATE_0) {
         phi_a3 = 1;
     }
     if (this->actionFunc == func_809FE890) {
@@ -292,7 +292,7 @@ void EnDu_Init(Actor* thisx, PlayState* play) {
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENDU_ANIM_0);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.targetMode = 1;
-    this->unk_1F4.talkState = 0;
+    this->unk_1F4.talkState = NPC_TALKING_STATE_0;
 
     if (gSaveContext.cutsceneIndex >= 0xFFF0) {
         play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gGoronCityDarunia01Cs);
@@ -327,9 +327,9 @@ void func_809FE3C0(EnDu* this, PlayState* play) {
         EnDu_SetupAction(this, func_809FE4A4);
         return;
     }
-    if (this->unk_1F4.talkState == 2) {
+    if (this->unk_1F4.talkState == NPC_TALKING_STATE_2) {
         func_8002DF54(play, &this->actor, 7);
-        this->unk_1F4.talkState = 0;
+        this->unk_1F4.talkState = NPC_TALKING_STATE_0;
     }
     if (this->actor.xzDistToPlayer < 116.0f + this->collider.dim.radius) {
         player->stateFlags2 |= PLAYER_STATE2_23;
@@ -377,13 +377,13 @@ void func_809FE6CC(EnDu* this, PlayState* play) {
     if (DECR(this->unk_1E2) == 0) {
         this->actor.textId = 0x3039;
         Message_StartTextbox(play, this->actor.textId, NULL);
-        this->unk_1F4.talkState = 1;
+        this->unk_1F4.talkState = NPC_TALKING_STATE_1;
         EnDu_SetupAction(this, func_809FE740);
     }
 }
 
 void func_809FE740(EnDu* this, PlayState* play) {
-    if (this->unk_1F4.talkState == 0) {
+    if (this->unk_1F4.talkState == NPC_TALKING_STATE_0) {
         func_8005B1A4(GET_ACTIVE_CAM(play));
         this->unk_1E2 = 0x5A;
         EnDu_SetupAction(this, func_809FE798);
@@ -504,11 +504,11 @@ void func_809FEB08(EnDu* this, PlayState* play) {
     }
     Message_StartTextbox(play, this->actor.textId, NULL);
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENDU_ANIM_14);
-    this->unk_1F4.talkState = 1;
+    this->unk_1F4.talkState = NPC_TALKING_STATE_1;
 }
 
 void func_809FEC14(EnDu* this, PlayState* play) {
-    if (this->unk_1F4.talkState == 2) {
+    if (this->unk_1F4.talkState == NPC_TALKING_STATE_2) {
         func_8002DF54(play, &this->actor, 7);
         EnDu_SetupAction(this, func_809FEC70);
         func_809FEC70(this, play);
@@ -527,8 +527,8 @@ void func_809FEC70(EnDu* this, PlayState* play) {
 }
 
 void func_809FECE4(EnDu* this, PlayState* play) {
-    if (this->unk_1F4.talkState == 3) {
-        this->unk_1F4.talkState = 0;
+    if (this->unk_1F4.talkState == NPC_TALKING_STATE_3) {
+        this->unk_1F4.talkState = NPC_TALKING_STATE_0;
         EnDu_SetupAction(this, func_809FE3C0);
     }
 }

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -130,19 +130,19 @@ s16 func_809FDCDC(PlayState* play, Actor* actor) {
                     break;
                 case 0x301C:
                 case 0x301F:
-                    return NPC_TALKING_STATE_2;
+                    return NPC_TALK_STATE_ACTION;
                 case 0x3020:
                     SET_EVENTCHKINF(EVENTCHKINF_22);
                     break;
             }
-            return NPC_TALKING_STATE_0;
+            return NPC_TALK_STATE_IDLE;
         case TEXT_STATE_DONE_FADING:
         case TEXT_STATE_CHOICE:
         case TEXT_STATE_EVENT:
             break;
         case TEXT_STATE_DONE:
             if (Message_ShouldAdvance(play)) {
-                return NPC_TALKING_STATE_3;
+                return NPC_TALK_STATE_ITEM_GIVEN;
             }
             break;
         case TEXT_STATE_SONG_DEMO_DONE:
@@ -150,7 +150,7 @@ s16 func_809FDCDC(PlayState* play, Actor* actor) {
         case TEXT_STATE_9:
             break;
     }
-    return NPC_TALKING_STATE_1;
+    return NPC_TALK_STATE_TALKING;
 }
 
 s32 func_809FDDB4(EnDu* this, PlayState* play) {
@@ -166,7 +166,7 @@ void func_809FDE24(EnDu* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3 = 0;
 
-    if (this->unk_1F4.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_1F4.talkState == NPC_TALK_STATE_IDLE) {
         phi_a3 = 1;
     }
     if (this->actionFunc == func_809FE890) {
@@ -292,7 +292,7 @@ void EnDu_Init(Actor* thisx, PlayState* play) {
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENDU_ANIM_0);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.targetMode = 1;
-    this->unk_1F4.talkState = NPC_TALKING_STATE_0;
+    this->unk_1F4.talkState = NPC_TALK_STATE_IDLE;
 
     if (gSaveContext.cutsceneIndex >= 0xFFF0) {
         play->csCtx.segment = SEGMENTED_TO_VIRTUAL(gGoronCityDarunia01Cs);
@@ -327,9 +327,9 @@ void func_809FE3C0(EnDu* this, PlayState* play) {
         EnDu_SetupAction(this, func_809FE4A4);
         return;
     }
-    if (this->unk_1F4.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_1F4.talkState == NPC_TALK_STATE_ACTION) {
         func_8002DF54(play, &this->actor, 7);
-        this->unk_1F4.talkState = NPC_TALKING_STATE_0;
+        this->unk_1F4.talkState = NPC_TALK_STATE_IDLE;
     }
     if (this->actor.xzDistToPlayer < 116.0f + this->collider.dim.radius) {
         player->stateFlags2 |= PLAYER_STATE2_23;
@@ -377,13 +377,13 @@ void func_809FE6CC(EnDu* this, PlayState* play) {
     if (DECR(this->unk_1E2) == 0) {
         this->actor.textId = 0x3039;
         Message_StartTextbox(play, this->actor.textId, NULL);
-        this->unk_1F4.talkState = NPC_TALKING_STATE_1;
+        this->unk_1F4.talkState = NPC_TALK_STATE_TALKING;
         EnDu_SetupAction(this, func_809FE740);
     }
 }
 
 void func_809FE740(EnDu* this, PlayState* play) {
-    if (this->unk_1F4.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_1F4.talkState == NPC_TALK_STATE_IDLE) {
         func_8005B1A4(GET_ACTIVE_CAM(play));
         this->unk_1E2 = 0x5A;
         EnDu_SetupAction(this, func_809FE798);
@@ -504,11 +504,11 @@ void func_809FEB08(EnDu* this, PlayState* play) {
     }
     Message_StartTextbox(play, this->actor.textId, NULL);
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENDU_ANIM_14);
-    this->unk_1F4.talkState = NPC_TALKING_STATE_1;
+    this->unk_1F4.talkState = NPC_TALK_STATE_TALKING;
 }
 
 void func_809FEC14(EnDu* this, PlayState* play) {
-    if (this->unk_1F4.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_1F4.talkState == NPC_TALK_STATE_ACTION) {
         func_8002DF54(play, &this->actor, 7);
         EnDu_SetupAction(this, func_809FEC70);
         func_809FEC70(this, play);
@@ -527,8 +527,8 @@ void func_809FEC70(EnDu* this, PlayState* play) {
 }
 
 void func_809FECE4(EnDu* this, PlayState* play) {
-    if (this->unk_1F4.talkState == NPC_TALKING_STATE_3) {
-        this->unk_1F4.talkState = NPC_TALKING_STATE_0;
+    if (this->unk_1F4.talkState == NPC_TALK_STATE_ITEM_GIVEN) {
+        this->unk_1F4.talkState = NPC_TALK_STATE_IDLE;
         EnDu_SetupAction(this, func_809FE3C0);
     }
 }

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -588,8 +588,8 @@ void func_80A3F908(EnGo* this, PlayState* play) {
         if ((this->actor.params & 0xF0) == 0x90) {
             isUnkCondition = func_80A3ED24(play, this, &this->unk_1E0, float1, EnGo_GetTextID, EnGo_SetFlagsGetStates);
         } else {
-            isUnkCondition = func_800343CC(play, &this->actor, &this->unk_1E0.talkState, float1, EnGo_GetTextID,
-                                           EnGo_SetFlagsGetStates);
+            isUnkCondition = Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, float1,
+                                                    EnGo_GetTextID, EnGo_SetFlagsGetStates);
         }
 
         if (((this->actor.params & 0xF0) == 0x90) && (isUnkCondition == true)) {

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -196,7 +196,7 @@ u16 EnGo_GetTextID(PlayState* play, Actor* thisx) {
 }
 
 s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
-    s16 unkState = 1;
+    s16 unkState = NPC_TALKING_STATE_1;
     f32 xzRange;
     f32 yRange = fabsf(thisx->yDistToPlayer) + 1.0f;
 
@@ -207,51 +207,51 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
             switch (thisx->textId) {
                 case 0x3008:
                     SET_INFTABLE(INFTABLE_E0);
-                    unkState = 0;
+                    unkState = NPC_TALKING_STATE_0;
                     break;
                 case 0x300B:
                     SET_INFTABLE(INFTABLE_EB);
-                    unkState = 0;
+                    unkState = NPC_TALKING_STATE_0;
                     break;
                 case 0x3014:
                     SET_INFTABLE(INFTABLE_F0);
-                    unkState = 0;
+                    unkState = NPC_TALKING_STATE_0;
                     break;
                 case 0x3016:
                     SET_INFTABLE(INFTABLE_F4);
-                    unkState = 0;
+                    unkState = NPC_TALKING_STATE_0;
                     break;
                 case 0x3018:
                     SET_INFTABLE(INFTABLE_F8);
-                    unkState = 0;
+                    unkState = NPC_TALKING_STATE_0;
                     break;
                 case 0x3036:
                     func_8002F434(thisx, play, GI_TUNIC_GORON, xzRange, yRange);
                     SET_INFTABLE(INFTABLE_10D); // EnGo exclusive flag
-                    unkState = 2;
+                    unkState = NPC_TALKING_STATE_2;
                     break;
                 case 0x3037:
                     SET_INFTABLE(INFTABLE_10E);
-                    unkState = 0;
+                    unkState = NPC_TALKING_STATE_0;
                     break;
                 case 0x3041:
                     SET_INFTABLE(INFTABLE_10F);
-                    unkState = 0;
+                    unkState = NPC_TALKING_STATE_0;
                     break;
                 case 0x3059:
-                    unkState = 2;
+                    unkState = NPC_TALKING_STATE_2;
                     break;
                 case 0x3052:
                 case 0x3054:
                 case 0x3055:
                 case 0x305A:
-                    unkState = 2;
+                    unkState = NPC_TALKING_STATE_2;
                     break;
                 case 0x305E:
-                    unkState = 2;
+                    unkState = NPC_TALKING_STATE_2;
                     break;
                 default:
-                    unkState = 0;
+                    unkState = NPC_TALKING_STATE_0;
                     break;
             }
             break;
@@ -269,7 +269,7 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
                             thisx->textId = 0x300D;
                         }
                         Message_ContinueTextbox(play, thisx->textId);
-                        unkState = 1;
+                        unkState = NPC_TALKING_STATE_1;
                         break;
                     case 0x3034:
                         if (play->msgCtx.choiceIndex == 0) {
@@ -284,16 +284,16 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
                             thisx->textId = 0x3033;
                         }
                         Message_ContinueTextbox(play, thisx->textId);
-                        unkState = 1;
+                        unkState = NPC_TALKING_STATE_1;
                         break;
                     case 0x3054:
                     case 0x3055:
                         if (play->msgCtx.choiceIndex == 0) {
-                            unkState = 2;
+                            unkState = NPC_TALKING_STATE_2;
                         } else {
                             thisx->textId = 0x3056;
                             Message_ContinueTextbox(play, thisx->textId);
-                            unkState = 1;
+                            unkState = NPC_TALKING_STATE_1;
                         }
                         SET_INFTABLE(INFTABLE_B4);
                         break;
@@ -310,17 +310,17 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
                     case 0x3033:
                         thisx->textId = 0x3034;
                         Message_ContinueTextbox(play, thisx->textId);
-                        unkState = 1;
+                        unkState = NPC_TALKING_STATE_1;
                         break;
                     default:
-                        unkState = 2;
+                        unkState = NPC_TALKING_STATE_2;
                         break;
                 }
             }
             break;
         case TEXT_STATE_DONE:
             if (Message_ShouldAdvance(play)) {
-                unkState = 3;
+                unkState = NPC_TALKING_STATE_3;
             }
             break;
         case TEXT_STATE_NONE:
@@ -333,13 +333,13 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
     return unkState;
 }
 
-s32 func_80A3ED24(PlayState* play, EnGo* this, struct_80034A14_arg1* arg2, f32 arg3,
-                  u16 (*getTextId)(PlayState*, Actor*), s16 (*unkFunc2)(PlayState*, Actor*)) {
-    if (arg2->talkState) {
-        arg2->talkState = unkFunc2(play, &this->actor);
+s32 func_80A3ED24(PlayState* play, EnGo* this, struct_80034A14_arg1* arg2, f32 arg3, ActorNpcGetTextIdFunc getTextId,
+                  ActorNpcGetTalkStateFunc getTalkState) {
+    if (arg2->talkState != NPC_TALKING_STATE_0) {
+        arg2->talkState = getTalkState(play, &this->actor);
         return false;
     } else if (Actor_ProcessTalkRequest(&this->actor, play)) {
-        arg2->talkState = 1;
+        arg2->talkState = NPC_TALKING_STATE_1;
         return true;
     } else if (!func_8002F2CC(&this->actor, play, arg3)) {
         return false;
@@ -544,7 +544,7 @@ s32 EnGo_SpawnDust(EnGo* this, u8 initialTimer, f32 scale, f32 scaleStep, s32 nu
 s32 EnGo_IsRollingOnGround(EnGo* this, s16 unkArg1, f32 unkArg2) {
     if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) || this->actor.velocity.y > 0.0f) {
         return false;
-    } else if (this->unk_1E0.talkState != 0) {
+    } else if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
         return true;
     } else if (DECR(this->unk_21C)) {
         if (this->unk_21C & 1) {
@@ -642,7 +642,7 @@ void EnGo_Init(Actor* thisx, PlayState* play) {
 
     EnGo_ChangeAnim(this, ENGO_ANIM_0);
     this->actor.targetMode = 6;
-    this->unk_1E0.talkState = 0;
+    this->unk_1E0.talkState = NPC_TALKING_STATE_0;
     this->actor.gravity = -1.0f;
 
     switch (this->actor.params & 0xF0) {
@@ -855,26 +855,26 @@ void func_80A405CC(EnGo* this, PlayState* play) {
 }
 
 void EnGo_BiggoronActionFunc(EnGo* this, PlayState* play) {
-    if (((this->actor.params & 0xF0) == 0x90) && (this->unk_1E0.talkState == 2)) {
+    if (((this->actor.params & 0xF0) == 0x90) && (this->unk_1E0.talkState == NPC_TALKING_STATE_2)) {
         if (gSaveContext.bgsFlag) {
-            this->unk_1E0.talkState = 0;
+            this->unk_1E0.talkState = NPC_TALKING_STATE_0;
         } else {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYEDROPS) {
                 EnGo_ChangeAnim(this, ENGO_ANIM_2);
                 this->unk_21E = 100;
-                this->unk_1E0.talkState = 0;
+                this->unk_1E0.talkState = NPC_TALKING_STATE_0;
                 EnGo_SetupAction(this, EnGo_Eyedrops);
                 play->msgCtx.msgMode = MSGMODE_PAUSED;
                 gSaveContext.timer2State = 0;
                 OnePointCutscene_Init(play, 4190, -99, &this->actor, CAM_ID_MAIN);
             } else {
-                this->unk_1E0.talkState = 0;
+                this->unk_1E0.talkState = NPC_TALKING_STATE_0;
                 EnGo_SetupAction(this, EnGo_GetItem);
                 Message_CloseTextbox(play);
                 EnGo_GetItem(this, play);
             }
         }
-    } else if (((this->actor.params & 0xF0) == 0) && (this->unk_1E0.talkState == 2)) {
+    } else if (((this->actor.params & 0xF0) == 0) && (this->unk_1E0.talkState == NPC_TALKING_STATE_2)) {
         EnGo_SetupAction(this, EnGo_GetItem);
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -947,7 +947,7 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
     s32 getItemId;
 
     if (Actor_HasParent(&this->actor, play)) {
-        this->unk_1E0.talkState = 2;
+        this->unk_1E0.talkState = NPC_TALKING_STATE_2;
         this->actor.parent = NULL;
         EnGo_SetupAction(this, func_80A40C78);
     } else {
@@ -976,21 +976,21 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
 }
 
 void func_80A40C78(EnGo* this, PlayState* play) {
-    if (this->unk_1E0.talkState == 3) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_3) {
         EnGo_SetupAction(this, EnGo_BiggoronActionFunc);
         if ((this->actor.params & 0xF0) != 0x90) {
-            this->unk_1E0.talkState = 0;
+            this->unk_1E0.talkState = NPC_TALKING_STATE_0;
         } else if (this->unk_20C) {
-            this->unk_1E0.talkState = 0;
+            this->unk_1E0.talkState = NPC_TALKING_STATE_0;
             gSaveContext.bgsFlag = true;
         } else if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_PRESCRIPTION) {
             this->actor.textId = 0x3058;
             Message_ContinueTextbox(play, this->actor.textId);
-            this->unk_1E0.talkState = 1;
+            this->unk_1E0.talkState = NPC_TALKING_STATE_1;
         } else if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_CLAIM_CHECK) {
             this->actor.textId = 0x305C;
             Message_ContinueTextbox(play, this->actor.textId);
-            this->unk_1E0.talkState = 1;
+            this->unk_1E0.talkState = NPC_TALKING_STATE_1;
             Environment_ClearBgsDayCount();
         }
     }
@@ -1000,13 +1000,13 @@ void EnGo_Eyedrops(EnGo* this, PlayState* play) {
     if (DECR(this->unk_21E) == 0) {
         this->actor.textId = 0x305A;
         Message_ContinueTextbox(play, this->actor.textId);
-        this->unk_1E0.talkState = 1;
+        this->unk_1E0.talkState = NPC_TALKING_STATE_1;
         EnGo_SetupAction(this, func_80A40DCC);
     }
 }
 
 void func_80A40DCC(EnGo* this, PlayState* play) {
-    if (this->unk_1E0.talkState == 2) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
         EnGo_ChangeAnim(this, ENGO_ANIM_1);
         this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronAnim_004930);
         Message_CloseTextbox(play);
@@ -1030,7 +1030,7 @@ void EnGo_Update(Actor* thisx, PlayState* play) {
 
     EnGo_UpdateShadow(this);
 
-    if (this->unk_1E0.talkState == 0) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
         Actor_MoveForward(&this->actor);
     }
 

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -335,11 +335,11 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
 
 s32 func_80A3ED24(PlayState* play, EnGo* this, struct_80034A14_arg1* arg2, f32 arg3,
                   u16 (*getTextId)(PlayState*, Actor*), s16 (*unkFunc2)(PlayState*, Actor*)) {
-    if (arg2->unk_00) {
-        arg2->unk_00 = unkFunc2(play, &this->actor);
+    if (arg2->talkState) {
+        arg2->talkState = unkFunc2(play, &this->actor);
         return false;
     } else if (Actor_ProcessTalkRequest(&this->actor, play)) {
-        arg2->unk_00 = 1;
+        arg2->talkState = 1;
         return true;
     } else if (!func_8002F2CC(&this->actor, play, arg3)) {
         return false;
@@ -544,7 +544,7 @@ s32 EnGo_SpawnDust(EnGo* this, u8 initialTimer, f32 scale, f32 scaleStep, s32 nu
 s32 EnGo_IsRollingOnGround(EnGo* this, s16 unkArg1, f32 unkArg2) {
     if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) || this->actor.velocity.y > 0.0f) {
         return false;
-    } else if (this->unk_1E0.unk_00 != 0) {
+    } else if (this->unk_1E0.talkState != 0) {
         return true;
     } else if (DECR(this->unk_21C)) {
         if (this->unk_21C & 1) {
@@ -588,7 +588,7 @@ void func_80A3F908(EnGo* this, PlayState* play) {
         if ((this->actor.params & 0xF0) == 0x90) {
             isUnkCondition = func_80A3ED24(play, this, &this->unk_1E0, float1, EnGo_GetTextID, EnGo_SetFlagsGetStates);
         } else {
-            isUnkCondition = func_800343CC(play, &this->actor, &this->unk_1E0.unk_00, float1, EnGo_GetTextID,
+            isUnkCondition = func_800343CC(play, &this->actor, &this->unk_1E0.talkState, float1, EnGo_GetTextID,
                                            EnGo_SetFlagsGetStates);
         }
 
@@ -642,7 +642,7 @@ void EnGo_Init(Actor* thisx, PlayState* play) {
 
     EnGo_ChangeAnim(this, ENGO_ANIM_0);
     this->actor.targetMode = 6;
-    this->unk_1E0.unk_00 = 0;
+    this->unk_1E0.talkState = 0;
     this->actor.gravity = -1.0f;
 
     switch (this->actor.params & 0xF0) {
@@ -855,26 +855,26 @@ void func_80A405CC(EnGo* this, PlayState* play) {
 }
 
 void EnGo_BiggoronActionFunc(EnGo* this, PlayState* play) {
-    if (((this->actor.params & 0xF0) == 0x90) && (this->unk_1E0.unk_00 == 2)) {
+    if (((this->actor.params & 0xF0) == 0x90) && (this->unk_1E0.talkState == 2)) {
         if (gSaveContext.bgsFlag) {
-            this->unk_1E0.unk_00 = 0;
+            this->unk_1E0.talkState = 0;
         } else {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYEDROPS) {
                 EnGo_ChangeAnim(this, ENGO_ANIM_2);
                 this->unk_21E = 100;
-                this->unk_1E0.unk_00 = 0;
+                this->unk_1E0.talkState = 0;
                 EnGo_SetupAction(this, EnGo_Eyedrops);
                 play->msgCtx.msgMode = MSGMODE_PAUSED;
                 gSaveContext.timer2State = 0;
                 OnePointCutscene_Init(play, 4190, -99, &this->actor, CAM_ID_MAIN);
             } else {
-                this->unk_1E0.unk_00 = 0;
+                this->unk_1E0.talkState = 0;
                 EnGo_SetupAction(this, EnGo_GetItem);
                 Message_CloseTextbox(play);
                 EnGo_GetItem(this, play);
             }
         }
-    } else if (((this->actor.params & 0xF0) == 0) && (this->unk_1E0.unk_00 == 2)) {
+    } else if (((this->actor.params & 0xF0) == 0) && (this->unk_1E0.talkState == 2)) {
         EnGo_SetupAction(this, EnGo_GetItem);
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -947,7 +947,7 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
     s32 getItemId;
 
     if (Actor_HasParent(&this->actor, play)) {
-        this->unk_1E0.unk_00 = 2;
+        this->unk_1E0.talkState = 2;
         this->actor.parent = NULL;
         EnGo_SetupAction(this, func_80A40C78);
     } else {
@@ -976,21 +976,21 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
 }
 
 void func_80A40C78(EnGo* this, PlayState* play) {
-    if (this->unk_1E0.unk_00 == 3) {
+    if (this->unk_1E0.talkState == 3) {
         EnGo_SetupAction(this, EnGo_BiggoronActionFunc);
         if ((this->actor.params & 0xF0) != 0x90) {
-            this->unk_1E0.unk_00 = 0;
+            this->unk_1E0.talkState = 0;
         } else if (this->unk_20C) {
-            this->unk_1E0.unk_00 = 0;
+            this->unk_1E0.talkState = 0;
             gSaveContext.bgsFlag = true;
         } else if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_PRESCRIPTION) {
             this->actor.textId = 0x3058;
             Message_ContinueTextbox(play, this->actor.textId);
-            this->unk_1E0.unk_00 = 1;
+            this->unk_1E0.talkState = 1;
         } else if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_CLAIM_CHECK) {
             this->actor.textId = 0x305C;
             Message_ContinueTextbox(play, this->actor.textId);
-            this->unk_1E0.unk_00 = 1;
+            this->unk_1E0.talkState = 1;
             Environment_ClearBgsDayCount();
         }
     }
@@ -1000,13 +1000,13 @@ void EnGo_Eyedrops(EnGo* this, PlayState* play) {
     if (DECR(this->unk_21E) == 0) {
         this->actor.textId = 0x305A;
         Message_ContinueTextbox(play, this->actor.textId);
-        this->unk_1E0.unk_00 = 1;
+        this->unk_1E0.talkState = 1;
         EnGo_SetupAction(this, func_80A40DCC);
     }
 }
 
 void func_80A40DCC(EnGo* this, PlayState* play) {
-    if (this->unk_1E0.unk_00 == 2) {
+    if (this->unk_1E0.talkState == 2) {
         EnGo_ChangeAnim(this, ENGO_ANIM_1);
         this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronAnim_004930);
         Message_CloseTextbox(play);
@@ -1030,7 +1030,7 @@ void EnGo_Update(Actor* thisx, PlayState* play) {
 
     EnGo_UpdateShadow(this);
 
-    if (this->unk_1E0.unk_00 == 0) {
+    if (this->unk_1E0.talkState == 0) {
         Actor_MoveForward(&this->actor);
     }
 

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -196,7 +196,7 @@ u16 EnGo_GetTextID(PlayState* play, Actor* thisx) {
 }
 
 s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
-    s16 unkState = NPC_TALKING_STATE_1;
+    s16 unkState = NPC_TALK_STATE_TALKING;
     f32 xzRange;
     f32 yRange = fabsf(thisx->yDistToPlayer) + 1.0f;
 
@@ -207,51 +207,51 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
             switch (thisx->textId) {
                 case 0x3008:
                     SET_INFTABLE(INFTABLE_E0);
-                    unkState = NPC_TALKING_STATE_0;
+                    unkState = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x300B:
                     SET_INFTABLE(INFTABLE_EB);
-                    unkState = NPC_TALKING_STATE_0;
+                    unkState = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x3014:
                     SET_INFTABLE(INFTABLE_F0);
-                    unkState = NPC_TALKING_STATE_0;
+                    unkState = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x3016:
                     SET_INFTABLE(INFTABLE_F4);
-                    unkState = NPC_TALKING_STATE_0;
+                    unkState = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x3018:
                     SET_INFTABLE(INFTABLE_F8);
-                    unkState = NPC_TALKING_STATE_0;
+                    unkState = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x3036:
                     func_8002F434(thisx, play, GI_TUNIC_GORON, xzRange, yRange);
                     SET_INFTABLE(INFTABLE_10D); // EnGo exclusive flag
-                    unkState = NPC_TALKING_STATE_2;
+                    unkState = NPC_TALK_STATE_ACTION;
                     break;
                 case 0x3037:
                     SET_INFTABLE(INFTABLE_10E);
-                    unkState = NPC_TALKING_STATE_0;
+                    unkState = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x3041:
                     SET_INFTABLE(INFTABLE_10F);
-                    unkState = NPC_TALKING_STATE_0;
+                    unkState = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x3059:
-                    unkState = NPC_TALKING_STATE_2;
+                    unkState = NPC_TALK_STATE_ACTION;
                     break;
                 case 0x3052:
                 case 0x3054:
                 case 0x3055:
                 case 0x305A:
-                    unkState = NPC_TALKING_STATE_2;
+                    unkState = NPC_TALK_STATE_ACTION;
                     break;
                 case 0x305E:
-                    unkState = NPC_TALKING_STATE_2;
+                    unkState = NPC_TALK_STATE_ACTION;
                     break;
                 default:
-                    unkState = NPC_TALKING_STATE_0;
+                    unkState = NPC_TALK_STATE_IDLE;
                     break;
             }
             break;
@@ -269,7 +269,7 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
                             thisx->textId = 0x300D;
                         }
                         Message_ContinueTextbox(play, thisx->textId);
-                        unkState = NPC_TALKING_STATE_1;
+                        unkState = NPC_TALK_STATE_TALKING;
                         break;
                     case 0x3034:
                         if (play->msgCtx.choiceIndex == 0) {
@@ -284,16 +284,16 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
                             thisx->textId = 0x3033;
                         }
                         Message_ContinueTextbox(play, thisx->textId);
-                        unkState = NPC_TALKING_STATE_1;
+                        unkState = NPC_TALK_STATE_TALKING;
                         break;
                     case 0x3054:
                     case 0x3055:
                         if (play->msgCtx.choiceIndex == 0) {
-                            unkState = NPC_TALKING_STATE_2;
+                            unkState = NPC_TALK_STATE_ACTION;
                         } else {
                             thisx->textId = 0x3056;
                             Message_ContinueTextbox(play, thisx->textId);
-                            unkState = NPC_TALKING_STATE_1;
+                            unkState = NPC_TALK_STATE_TALKING;
                         }
                         SET_INFTABLE(INFTABLE_B4);
                         break;
@@ -310,17 +310,17 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
                     case 0x3033:
                         thisx->textId = 0x3034;
                         Message_ContinueTextbox(play, thisx->textId);
-                        unkState = NPC_TALKING_STATE_1;
+                        unkState = NPC_TALK_STATE_TALKING;
                         break;
                     default:
-                        unkState = NPC_TALKING_STATE_2;
+                        unkState = NPC_TALK_STATE_ACTION;
                         break;
                 }
             }
             break;
         case TEXT_STATE_DONE:
             if (Message_ShouldAdvance(play)) {
-                unkState = NPC_TALKING_STATE_3;
+                unkState = NPC_TALK_STATE_ITEM_GIVEN;
             }
             break;
         case TEXT_STATE_NONE:
@@ -335,11 +335,11 @@ s16 EnGo_SetFlagsGetStates(PlayState* play, Actor* thisx) {
 
 s32 func_80A3ED24(PlayState* play, EnGo* this, struct_80034A14_arg1* arg2, f32 arg3, ActorNpcGetTextIdFunc getTextId,
                   ActorNpcGetTalkStateFunc getTalkState) {
-    if (arg2->talkState != NPC_TALKING_STATE_0) {
+    if (arg2->talkState != NPC_TALK_STATE_IDLE) {
         arg2->talkState = getTalkState(play, &this->actor);
         return false;
     } else if (Actor_ProcessTalkRequest(&this->actor, play)) {
-        arg2->talkState = NPC_TALKING_STATE_1;
+        arg2->talkState = NPC_TALK_STATE_TALKING;
         return true;
     } else if (!func_8002F2CC(&this->actor, play, arg3)) {
         return false;
@@ -544,7 +544,7 @@ s32 EnGo_SpawnDust(EnGo* this, u8 initialTimer, f32 scale, f32 scaleStep, s32 nu
 s32 EnGo_IsRollingOnGround(EnGo* this, s16 unkArg1, f32 unkArg2) {
     if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) || this->actor.velocity.y > 0.0f) {
         return false;
-    } else if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
+    } else if (this->unk_1E0.talkState != NPC_TALK_STATE_IDLE) {
         return true;
     } else if (DECR(this->unk_21C)) {
         if (this->unk_21C & 1) {
@@ -642,7 +642,7 @@ void EnGo_Init(Actor* thisx, PlayState* play) {
 
     EnGo_ChangeAnim(this, ENGO_ANIM_0);
     this->actor.targetMode = 6;
-    this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+    this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
     this->actor.gravity = -1.0f;
 
     switch (this->actor.params & 0xF0) {
@@ -855,26 +855,26 @@ void func_80A405CC(EnGo* this, PlayState* play) {
 }
 
 void EnGo_BiggoronActionFunc(EnGo* this, PlayState* play) {
-    if (((this->actor.params & 0xF0) == 0x90) && (this->unk_1E0.talkState == NPC_TALKING_STATE_2)) {
+    if (((this->actor.params & 0xF0) == 0x90) && (this->unk_1E0.talkState == NPC_TALK_STATE_ACTION)) {
         if (gSaveContext.bgsFlag) {
-            this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+            this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
         } else {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYEDROPS) {
                 EnGo_ChangeAnim(this, ENGO_ANIM_2);
                 this->unk_21E = 100;
-                this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+                this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
                 EnGo_SetupAction(this, EnGo_Eyedrops);
                 play->msgCtx.msgMode = MSGMODE_PAUSED;
                 gSaveContext.timer2State = 0;
                 OnePointCutscene_Init(play, 4190, -99, &this->actor, CAM_ID_MAIN);
             } else {
-                this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+                this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
                 EnGo_SetupAction(this, EnGo_GetItem);
                 Message_CloseTextbox(play);
                 EnGo_GetItem(this, play);
             }
         }
-    } else if (((this->actor.params & 0xF0) == 0) && (this->unk_1E0.talkState == NPC_TALKING_STATE_2)) {
+    } else if (((this->actor.params & 0xF0) == 0) && (this->unk_1E0.talkState == NPC_TALK_STATE_ACTION)) {
         EnGo_SetupAction(this, EnGo_GetItem);
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -947,7 +947,7 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
     s32 getItemId;
 
     if (Actor_HasParent(&this->actor, play)) {
-        this->unk_1E0.talkState = NPC_TALKING_STATE_2;
+        this->unk_1E0.talkState = NPC_TALK_STATE_ACTION;
         this->actor.parent = NULL;
         EnGo_SetupAction(this, func_80A40C78);
     } else {
@@ -976,21 +976,21 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
 }
 
 void func_80A40C78(EnGo* this, PlayState* play) {
-    if (this->unk_1E0.talkState == NPC_TALKING_STATE_3) {
+    if (this->unk_1E0.talkState == NPC_TALK_STATE_ITEM_GIVEN) {
         EnGo_SetupAction(this, EnGo_BiggoronActionFunc);
         if ((this->actor.params & 0xF0) != 0x90) {
-            this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+            this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
         } else if (this->unk_20C) {
-            this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+            this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
             gSaveContext.bgsFlag = true;
         } else if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_PRESCRIPTION) {
             this->actor.textId = 0x3058;
             Message_ContinueTextbox(play, this->actor.textId);
-            this->unk_1E0.talkState = NPC_TALKING_STATE_1;
+            this->unk_1E0.talkState = NPC_TALK_STATE_TALKING;
         } else if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_CLAIM_CHECK) {
             this->actor.textId = 0x305C;
             Message_ContinueTextbox(play, this->actor.textId);
-            this->unk_1E0.talkState = NPC_TALKING_STATE_1;
+            this->unk_1E0.talkState = NPC_TALK_STATE_TALKING;
             Environment_ClearBgsDayCount();
         }
     }
@@ -1000,13 +1000,13 @@ void EnGo_Eyedrops(EnGo* this, PlayState* play) {
     if (DECR(this->unk_21E) == 0) {
         this->actor.textId = 0x305A;
         Message_ContinueTextbox(play, this->actor.textId);
-        this->unk_1E0.talkState = NPC_TALKING_STATE_1;
+        this->unk_1E0.talkState = NPC_TALK_STATE_TALKING;
         EnGo_SetupAction(this, func_80A40DCC);
     }
 }
 
 void func_80A40DCC(EnGo* this, PlayState* play) {
-    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_1E0.talkState == NPC_TALK_STATE_ACTION) {
         EnGo_ChangeAnim(this, ENGO_ANIM_1);
         this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronAnim_004930);
         Message_CloseTextbox(play);
@@ -1030,7 +1030,7 @@ void EnGo_Update(Actor* thisx, PlayState* play) {
 
     EnGo_UpdateShadow(this);
 
-    if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) {
         Actor_MoveForward(&this->actor);
     }
 

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -338,7 +338,7 @@ s16 EnGo2_GetStateGoronCityRollingBig(PlayState* play, EnGo2* this) {
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_CLOSING:
-            return 2;
+            return NPC_TALKING_STATE_2;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
                 if (this->actor.textId == 0x3012) {
@@ -347,14 +347,14 @@ s16 EnGo2_GetStateGoronCityRollingBig(PlayState* play, EnGo2* this) {
                     EnGo2_GetItem(this, play, bombBagUpgrade);
                     Message_CloseTextbox(play);
                     SET_INFTABLE(INFTABLE_11E);
-                    return 2;
+                    return NPC_TALKING_STATE_2;
                 } else {
-                    return 2;
+                    return NPC_TALKING_STATE_2;
                 }
             }
             FALLTHROUGH;
         default:
-            return 1;
+            return NPC_TALKING_STATE_1;
     }
 }
 
@@ -368,9 +368,9 @@ s16 EnGo2_GetStateGoronDmtBombFlower(PlayState* play, EnGo2* this) {
         case TEXT_STATE_CLOSING:
             if ((this->actor.textId == 0x300B) && !GET_INFTABLE(INFTABLE_EB)) {
                 SET_INFTABLE(INFTABLE_EB);
-                return 2;
+                return NPC_TALKING_STATE_2;
             } else {
-                return 0;
+                return NPC_TALKING_STATE_0;
             }
         case TEXT_STATE_CHOICE:
             if (Message_ShouldAdvance(play)) {
@@ -383,11 +383,11 @@ s16 EnGo2_GetStateGoronDmtBombFlower(PlayState* play, EnGo2* this) {
                     }
                     Message_ContinueTextbox(play, this->actor.textId);
                 }
-                return 1;
+                return NPC_TALKING_STATE_1;
             }
             FALLTHROUGH;
         default:
-            return 1;
+            return NPC_TALKING_STATE_1;
     }
 }
 
@@ -401,9 +401,9 @@ u16 EnGo2_GetTextIdGoronDmtRollingSmall(PlayState* play, EnGo2* this) {
 
 s16 EnGo2_GetStateGoronDmtRollingSmall(PlayState* play, EnGo2* this) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-        return 0;
+        return NPC_TALKING_STATE_0;
     } else {
-        return 1;
+        return NPC_TALKING_STATE_1;
     }
 }
 
@@ -422,9 +422,9 @@ s16 EnGo2_GetStateGoronDmtDcEntrance(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3008) {
             SET_INFTABLE(INFTABLE_E0);
         }
-        return 0;
+        return NPC_TALKING_STATE_0;
     } else {
-        return 1;
+        return NPC_TALKING_STATE_1;
     }
 }
 
@@ -443,9 +443,9 @@ s16 EnGo2_GetStateGoronCityEntrance(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3014) {
             SET_INFTABLE(INFTABLE_F0);
         }
-        return 0;
+        return NPC_TALKING_STATE_0;
     } else {
-        return 1;
+        return NPC_TALKING_STATE_1;
     }
 }
 
@@ -464,9 +464,9 @@ s16 EnGo2_GetStateGoronCityIsland(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3016) {
             SET_INFTABLE(INFTABLE_F4);
         }
-        return 0;
+        return NPC_TALKING_STATE_0;
     } else {
-        return 1;
+        return NPC_TALKING_STATE_1;
     }
 }
 
@@ -488,9 +488,9 @@ s16 EnGo2_GetStateGoronCityLowestFloor(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3018) {
             SET_INFTABLE(INFTABLE_F8);
         }
-        return 0;
+        return NPC_TALKING_STATE_0;
     } else {
-        return 1;
+        return NPC_TALKING_STATE_1;
     }
 }
 
@@ -515,12 +515,12 @@ s16 EnGo2_GetStateGoronCityLink(PlayState* play, EnGo2* this) {
                 case 0x3036:
                     EnGo2_GetItem(this, play, GI_TUNIC_GORON);
                     this->actionFunc = EnGo2_SetupGetItem;
-                    return 2;
+                    return NPC_TALKING_STATE_2;
                 case 0x3037:
                     SET_INFTABLE(INFTABLE_10E);
                     FALLTHROUGH;
                 default:
-                    return 0;
+                    return NPC_TALKING_STATE_0;
             }
         case TEXT_STATE_CHOICE:
             if (Message_ShouldAdvance(play)) {
@@ -542,7 +542,7 @@ s16 EnGo2_GetStateGoronCityLink(PlayState* play, EnGo2* this) {
             } else {
                 break;
             }
-            return 1;
+            return NPC_TALKING_STATE_1;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
                 switch (this->actor.textId) {
@@ -553,14 +553,14 @@ s16 EnGo2_GetStateGoronCityLink(PlayState* play, EnGo2* this) {
                     case 0x3033:
                         this->actor.textId = 0x3034;
                         Message_ContinueTextbox(play, this->actor.textId);
-                        return 1;
+                        return NPC_TALKING_STATE_1;
                     default:
-                        return 2;
+                        return NPC_TALKING_STATE_2;
                 }
             }
             break;
     }
-    return 1;
+    return NPC_TALKING_STATE_1;
 }
 
 u16 EnGo2_GetTextIdGoronDmtBiggoron(PlayState* play, EnGo2* this) {
@@ -591,12 +591,12 @@ s16 EnGo2_GetStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
                 if (!gSaveContext.bgsFlag) {
                     EnGo2_GetItem(this, play, GI_SWORD_BGS);
                     this->actionFunc = EnGo2_SetupGetItem;
-                    return 2;
+                    return NPC_TALKING_STATE_2;
                 } else {
-                    return 0;
+                    return NPC_TALKING_STATE_0;
                 }
             } else {
-                return 0;
+                return NPC_TALKING_STATE_0;
             }
         case TEXT_STATE_DONE_FADING:
             switch (this->actor.textId) {
@@ -617,19 +617,19 @@ s16 EnGo2_GetStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
                     }
                     break;
             }
-            return 1;
+            return NPC_TALKING_STATE_1;
         case TEXT_STATE_CHOICE:
             if (Message_ShouldAdvance(play)) {
                 if ((this->actor.textId == 0x3054) || (this->actor.textId == 0x3055)) {
                     if (play->msgCtx.choiceIndex == 0) {
                         EnGo2_GetItem(this, play, GI_PRESCRIPTION);
                         this->actionFunc = EnGo2_SetupGetItem;
-                        return 2;
+                        return NPC_TALKING_STATE_2;
                     }
                     this->actor.textId = 0x3056;
                     Message_ContinueTextbox(play, this->actor.textId);
                 }
-                return 1;
+                return NPC_TALKING_STATE_1;
             }
             break;
         case TEXT_STATE_EVENT:
@@ -638,11 +638,11 @@ s16 EnGo2_GetStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
                     play->msgCtx.msgMode = MSGMODE_PAUSED;
                     this->actionFunc = EnGo2_BiggoronEyedrops;
                 }
-                return 2;
+                return NPC_TALKING_STATE_2;
             }
             break;
     }
-    return 1;
+    return NPC_TALKING_STATE_1;
 }
 
 u16 EnGo2_GetTextIdGoronFireGeneric(PlayState* play, EnGo2* this) {
@@ -656,18 +656,18 @@ u16 EnGo2_GetTextIdGoronFireGeneric(PlayState* play, EnGo2* this) {
 s16 EnGo2_GetStateGoronFireGeneric(PlayState* play, EnGo2* this) {
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_CLOSING:
-            return 0;
+            return NPC_TALKING_STATE_0;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
                 if (this->actor.textId == 0x3071) {
                     this->actor.textId = EnGo2_GoronFireGenericGetTextId(this);
                     Message_ContinueTextbox(play, this->actor.textId);
                 }
-                return 1;
+                return NPC_TALKING_STATE_1;
             }
             FALLTHROUGH;
         default:
-            return 1;
+            return NPC_TALKING_STATE_1;
     }
 }
 
@@ -680,9 +680,9 @@ s16 EnGo2_GetStateGoronCityStairwell(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x300E) {
             SET_INFTABLE(INFTABLE_E3);
         }
-        return 0;
+        return NPC_TALKING_STATE_0;
     } else {
-        return 1;
+        return NPC_TALKING_STATE_1;
     }
 }
 
@@ -693,9 +693,9 @@ u16 EnGo2_GetTextIdGoronMarketBazaar(PlayState* play, EnGo2* this) {
 
 s16 EnGo2_GetStateGoronMarketBazaar(PlayState* play, EnGo2* this) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-        return 0;
+        return NPC_TALKING_STATE_0;
     } else {
-        return 1;
+        return NPC_TALKING_STATE_1;
     }
 }
 
@@ -716,9 +716,9 @@ s16 EnGo2_GetStateGoronCityLostWoods(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3024) {
             SET_INFTABLE(INFTABLE_E6);
         }
-        return 0;
+        return NPC_TALKING_STATE_0;
     } else {
-        return 1;
+        return NPC_TALKING_STATE_1;
     }
 }
 
@@ -733,9 +733,9 @@ u16 EnGo2_GetTextIdGoronDmtFairyHint(PlayState* play, EnGo2* this) {
 
 s16 EnGo2_GetStateGoronDmtFairyHint(PlayState* play, EnGo2* this) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-        return 0;
+        return NPC_TALKING_STATE_0;
     } else {
-        return 1;
+        return NPC_TALKING_STATE_1;
     }
 }
 
@@ -830,9 +830,9 @@ s32 func_80A44790(EnGo2* this, PlayState* play) {
         return false;
     } else {
         if (Actor_ProcessTalkRequest(&this->actor, play)) {
-            this->unk_194.talkState = 1;
+            this->unk_194.talkState = NPC_TALKING_STATE_1;
             return true;
-        } else if (this->unk_194.talkState != 0) {
+        } else if (this->unk_194.talkState != NPC_TALKING_STATE_0) {
             this->unk_194.talkState = EnGo2_GetState(play, &this->actor);
             return false;
         } else if (func_8002F2CC(&this->actor, play, this->unk_218)) {
@@ -1116,7 +1116,7 @@ void func_80A45360(EnGo2* this, f32* alpha) {
 void EnGo2_RollForward(EnGo2* this) {
     f32 speedXZ = this->actor.speedXZ;
 
-    if (this->unk_194.talkState != 0) {
+    if (this->unk_194.talkState != NPC_TALKING_STATE_0) {
         this->actor.speedXZ = 0.0f;
     }
 
@@ -1191,7 +1191,7 @@ void EnGo2_DefaultWakingUp(EnGo2* this) {
         this->unk_26E = 1;
     }
 
-    if (this->unk_194.talkState != 0) {
+    if (this->unk_194.talkState != NPC_TALKING_STATE_0) {
         this->unk_26E = 4;
     }
 
@@ -1204,7 +1204,7 @@ void EnGo2_WakingUp(EnGo2* this) {
 
     xyzDist = SQ(xyzDist);
     this->unk_26E = 1;
-    if ((this->actor.xyzDistToPlayerSq <= xyzDist) || (this->unk_194.talkState != 0)) {
+    if ((this->actor.xyzDistToPlayerSq <= xyzDist) || (this->unk_194.talkState != NPC_TALKING_STATE_0)) {
         this->unk_26E = 4;
     }
 
@@ -1212,7 +1212,7 @@ void EnGo2_WakingUp(EnGo2* this) {
 }
 
 void EnGo2_BiggoronWakingUp(EnGo2* this) {
-    if (EnGo2_IsWakingUp(this) || this->unk_194.talkState != 0) {
+    if (EnGo2_IsWakingUp(this) || this->unk_194.talkState != NPC_TALKING_STATE_0) {
         this->unk_26E = 2;
         this->isAwake = true;
     } else {
@@ -1397,12 +1397,12 @@ s32 EnGo2_IsFreeingGoronInFire(EnGo2* this, PlayState* play) {
 }
 
 s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
-    if ((this->actor.params & 0x1F) != GORON_DMT_BOMB_FLOWER || this->unk_194.talkState != 2) {
+    if ((this->actor.params & 0x1F) != GORON_DMT_BOMB_FLOWER || this->unk_194.talkState != NPC_TALKING_STATE_2) {
         return false;
     }
 
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_3);
-    this->unk_194.talkState = 0;
+    this->unk_194.talkState = NPC_TALKING_STATE_0;
     this->isAwake = false;
     this->unk_26E = 1;
     this->actionFunc = EnGo2_GoronDmtBombFlowerAnimation;
@@ -1410,17 +1410,17 @@ s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
 }
 
 s32 EnGo2_IsGoronRollingBig(EnGo2* this, PlayState* play) {
-    if ((this->actor.params & 0x1F) != GORON_CITY_ROLLING_BIG || (this->unk_194.talkState != 2)) {
+    if ((this->actor.params & 0x1F) != GORON_CITY_ROLLING_BIG || (this->unk_194.talkState != NPC_TALKING_STATE_2)) {
         return false;
     }
-    this->unk_194.talkState = 0;
+    this->unk_194.talkState = NPC_TALKING_STATE_0;
     EnGo2_RollingAnimation(this, play);
     this->actionFunc = EnGo2_GoronRollingBigContinueRolling;
     return true;
 }
 
 s32 EnGo2_IsGoronFireGeneric(EnGo2* this) {
-    if ((this->actor.params & 0x1F) != GORON_FIRE_GENERIC || this->unk_194.talkState == 0) {
+    if ((this->actor.params & 0x1F) != GORON_FIRE_GENERIC || this->unk_194.talkState == NPC_TALKING_STATE_0) {
         return false;
     }
     this->actionFunc = EnGo2_GoronFireGenericAction;
@@ -1436,7 +1436,7 @@ s32 EnGo2_IsGoronLinkReversing(EnGo2* this) {
 }
 
 s32 EnGo2_IsRolling(EnGo2* this) {
-    if (this->unk_194.talkState == 0 || this->actor.speedXZ < 1.0f) {
+    if (this->unk_194.talkState == NPC_TALKING_STATE_0 || this->actor.speedXZ < 1.0f) {
         return false;
     }
     if (EnGo2_IsRollingOnGround(this, 2, 20.0 / 3.0f, 0)) {
@@ -1504,7 +1504,7 @@ void EnGo2_GoronFireClearCamera(EnGo2* this, PlayState* play) {
 
 void EnGo2_BiggoronAnimation(EnGo2* this) {
     if (INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_SWORD_BROKEN && INV_CONTENT(ITEM_TRADE_ADULT) <= ITEM_EYEDROPS &&
-        (this->actor.params & 0x1F) == GORON_DMT_BIGGORON && this->unk_194.talkState == 0) {
+        (this->actor.params & 0x1F) == GORON_DMT_BIGGORON && this->unk_194.talkState == NPC_TALKING_STATE_0) {
         if (DECR(this->animTimer) == 0) {
             this->animTimer = Rand_S16Offset(30, 30);
             func_800F4524(&gSfxDefaultPos, NA_SE_EN_GOLON_EYE_BIG, 60);
@@ -1800,7 +1800,7 @@ void EnGo2_SetupGetItem(EnGo2* this, PlayState* play) {
 
 void EnGo2_SetGetItem(EnGo2* this, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_DONE) && Message_ShouldAdvance(play)) {
-        this->unk_194.talkState = 0;
+        this->unk_194.talkState = NPC_TALKING_STATE_0;
         switch (this->getItemId) {
             case GI_CLAIM_CHECK:
                 Environment_ClearBgsDayCount();
@@ -1980,7 +1980,7 @@ void EnGo2_Update(Actor* thisx, PlayState* play) {
     EnGo2_RollForward(this);
     Actor_UpdateBgCheckInfo(play, &this->actor, (f32)this->collider.dim.height * 0.5f,
                             (f32)this->collider.dim.radius * 0.6f, 0.0f, UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
-    if (this->unk_194.talkState == 0) {
+    if (this->unk_194.talkState == NPC_TALKING_STATE_0) {
         func_80A44AB0(this, play);
     }
     this->actionFunc(this, play);

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -823,7 +823,8 @@ s16 EnGo2_GetState(PlayState* play, Actor* thisx) {
 
 s32 func_80A44790(EnGo2* this, PlayState* play) {
     if ((this->actor.params & 0x1F) != GORON_DMT_BIGGORON && (this->actor.params & 0x1F) != GORON_CITY_ROLLING_BIG) {
-        return func_800343CC(play, &this->actor, &this->unk_194.talkState, this->unk_218, EnGo2_GetTextId, EnGo2_GetState);
+        return Actor_NpcUpdateTalking(play, &this->actor, &this->unk_194.talkState, this->unk_218, EnGo2_GetTextId,
+                                      EnGo2_GetState);
     } else if (((this->actor.params & 0x1F) == GORON_DMT_BIGGORON) &&
                !(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
         return false;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -823,16 +823,16 @@ s16 EnGo2_GetState(PlayState* play, Actor* thisx) {
 
 s32 func_80A44790(EnGo2* this, PlayState* play) {
     if ((this->actor.params & 0x1F) != GORON_DMT_BIGGORON && (this->actor.params & 0x1F) != GORON_CITY_ROLLING_BIG) {
-        return func_800343CC(play, &this->actor, &this->unk_194.unk_00, this->unk_218, EnGo2_GetTextId, EnGo2_GetState);
+        return func_800343CC(play, &this->actor, &this->unk_194.talkState, this->unk_218, EnGo2_GetTextId, EnGo2_GetState);
     } else if (((this->actor.params & 0x1F) == GORON_DMT_BIGGORON) &&
                !(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
         return false;
     } else {
         if (Actor_ProcessTalkRequest(&this->actor, play)) {
-            this->unk_194.unk_00 = 1;
+            this->unk_194.talkState = 1;
             return true;
-        } else if (this->unk_194.unk_00 != 0) {
-            this->unk_194.unk_00 = EnGo2_GetState(play, &this->actor);
+        } else if (this->unk_194.talkState != 0) {
+            this->unk_194.talkState = EnGo2_GetState(play, &this->actor);
             return false;
         } else if (func_8002F2CC(&this->actor, play, this->unk_218)) {
             this->actor.textId = EnGo2_GetTextId(play, &this->actor);
@@ -1115,7 +1115,7 @@ void func_80A45360(EnGo2* this, f32* alpha) {
 void EnGo2_RollForward(EnGo2* this) {
     f32 speedXZ = this->actor.speedXZ;
 
-    if (this->unk_194.unk_00 != 0) {
+    if (this->unk_194.talkState != 0) {
         this->actor.speedXZ = 0.0f;
     }
 
@@ -1190,7 +1190,7 @@ void EnGo2_DefaultWakingUp(EnGo2* this) {
         this->unk_26E = 1;
     }
 
-    if (this->unk_194.unk_00 != 0) {
+    if (this->unk_194.talkState != 0) {
         this->unk_26E = 4;
     }
 
@@ -1203,7 +1203,7 @@ void EnGo2_WakingUp(EnGo2* this) {
 
     xyzDist = SQ(xyzDist);
     this->unk_26E = 1;
-    if ((this->actor.xyzDistToPlayerSq <= xyzDist) || (this->unk_194.unk_00 != 0)) {
+    if ((this->actor.xyzDistToPlayerSq <= xyzDist) || (this->unk_194.talkState != 0)) {
         this->unk_26E = 4;
     }
 
@@ -1211,7 +1211,7 @@ void EnGo2_WakingUp(EnGo2* this) {
 }
 
 void EnGo2_BiggoronWakingUp(EnGo2* this) {
-    if (EnGo2_IsWakingUp(this) || this->unk_194.unk_00 != 0) {
+    if (EnGo2_IsWakingUp(this) || this->unk_194.talkState != 0) {
         this->unk_26E = 2;
         this->isAwake = true;
     } else {
@@ -1396,12 +1396,12 @@ s32 EnGo2_IsFreeingGoronInFire(EnGo2* this, PlayState* play) {
 }
 
 s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
-    if ((this->actor.params & 0x1F) != GORON_DMT_BOMB_FLOWER || this->unk_194.unk_00 != 2) {
+    if ((this->actor.params & 0x1F) != GORON_DMT_BOMB_FLOWER || this->unk_194.talkState != 2) {
         return false;
     }
 
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_3);
-    this->unk_194.unk_00 = 0;
+    this->unk_194.talkState = 0;
     this->isAwake = false;
     this->unk_26E = 1;
     this->actionFunc = EnGo2_GoronDmtBombFlowerAnimation;
@@ -1409,17 +1409,17 @@ s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
 }
 
 s32 EnGo2_IsGoronRollingBig(EnGo2* this, PlayState* play) {
-    if ((this->actor.params & 0x1F) != GORON_CITY_ROLLING_BIG || (this->unk_194.unk_00 != 2)) {
+    if ((this->actor.params & 0x1F) != GORON_CITY_ROLLING_BIG || (this->unk_194.talkState != 2)) {
         return false;
     }
-    this->unk_194.unk_00 = 0;
+    this->unk_194.talkState = 0;
     EnGo2_RollingAnimation(this, play);
     this->actionFunc = EnGo2_GoronRollingBigContinueRolling;
     return true;
 }
 
 s32 EnGo2_IsGoronFireGeneric(EnGo2* this) {
-    if ((this->actor.params & 0x1F) != GORON_FIRE_GENERIC || this->unk_194.unk_00 == 0) {
+    if ((this->actor.params & 0x1F) != GORON_FIRE_GENERIC || this->unk_194.talkState == 0) {
         return false;
     }
     this->actionFunc = EnGo2_GoronFireGenericAction;
@@ -1435,7 +1435,7 @@ s32 EnGo2_IsGoronLinkReversing(EnGo2* this) {
 }
 
 s32 EnGo2_IsRolling(EnGo2* this) {
-    if (this->unk_194.unk_00 == 0 || this->actor.speedXZ < 1.0f) {
+    if (this->unk_194.talkState == 0 || this->actor.speedXZ < 1.0f) {
         return false;
     }
     if (EnGo2_IsRollingOnGround(this, 2, 20.0 / 3.0f, 0)) {
@@ -1503,7 +1503,7 @@ void EnGo2_GoronFireClearCamera(EnGo2* this, PlayState* play) {
 
 void EnGo2_BiggoronAnimation(EnGo2* this) {
     if (INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_SWORD_BROKEN && INV_CONTENT(ITEM_TRADE_ADULT) <= ITEM_EYEDROPS &&
-        (this->actor.params & 0x1F) == GORON_DMT_BIGGORON && this->unk_194.unk_00 == 0) {
+        (this->actor.params & 0x1F) == GORON_DMT_BIGGORON && this->unk_194.talkState == 0) {
         if (DECR(this->animTimer) == 0) {
             this->animTimer = Rand_S16Offset(30, 30);
             func_800F4524(&gSfxDefaultPos, NA_SE_EN_GOLON_EYE_BIG, 60);
@@ -1799,7 +1799,7 @@ void EnGo2_SetupGetItem(EnGo2* this, PlayState* play) {
 
 void EnGo2_SetGetItem(EnGo2* this, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_DONE) && Message_ShouldAdvance(play)) {
-        this->unk_194.unk_00 = 0;
+        this->unk_194.talkState = 0;
         switch (this->getItemId) {
             case GI_CLAIM_CHECK:
                 Environment_ClearBgsDayCount();
@@ -1979,7 +1979,7 @@ void EnGo2_Update(Actor* thisx, PlayState* play) {
     EnGo2_RollForward(this);
     Actor_UpdateBgCheckInfo(play, &this->actor, (f32)this->collider.dim.height * 0.5f,
                             (f32)this->collider.dim.radius * 0.6f, 0.0f, UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
-    if (this->unk_194.unk_00 == 0) {
+    if (this->unk_194.talkState == 0) {
         func_80A44AB0(this, play);
     }
     this->actionFunc(this, play);

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -338,7 +338,7 @@ s16 EnGo2_GetStateGoronCityRollingBig(PlayState* play, EnGo2* this) {
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_CLOSING:
-            return NPC_TALKING_STATE_2;
+            return NPC_TALK_STATE_ACTION;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
                 if (this->actor.textId == 0x3012) {
@@ -347,14 +347,14 @@ s16 EnGo2_GetStateGoronCityRollingBig(PlayState* play, EnGo2* this) {
                     EnGo2_GetItem(this, play, bombBagUpgrade);
                     Message_CloseTextbox(play);
                     SET_INFTABLE(INFTABLE_11E);
-                    return NPC_TALKING_STATE_2;
+                    return NPC_TALK_STATE_ACTION;
                 } else {
-                    return NPC_TALKING_STATE_2;
+                    return NPC_TALK_STATE_ACTION;
                 }
             }
             FALLTHROUGH;
         default:
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -368,9 +368,9 @@ s16 EnGo2_GetStateGoronDmtBombFlower(PlayState* play, EnGo2* this) {
         case TEXT_STATE_CLOSING:
             if ((this->actor.textId == 0x300B) && !GET_INFTABLE(INFTABLE_EB)) {
                 SET_INFTABLE(INFTABLE_EB);
-                return NPC_TALKING_STATE_2;
+                return NPC_TALK_STATE_ACTION;
             } else {
-                return NPC_TALKING_STATE_0;
+                return NPC_TALK_STATE_IDLE;
             }
         case TEXT_STATE_CHOICE:
             if (Message_ShouldAdvance(play)) {
@@ -383,11 +383,11 @@ s16 EnGo2_GetStateGoronDmtBombFlower(PlayState* play, EnGo2* this) {
                     }
                     Message_ContinueTextbox(play, this->actor.textId);
                 }
-                return NPC_TALKING_STATE_1;
+                return NPC_TALK_STATE_TALKING;
             }
             FALLTHROUGH;
         default:
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -401,9 +401,9 @@ u16 EnGo2_GetTextIdGoronDmtRollingSmall(PlayState* play, EnGo2* this) {
 
 s16 EnGo2_GetStateGoronDmtRollingSmall(PlayState* play, EnGo2* this) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     } else {
-        return NPC_TALKING_STATE_1;
+        return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -422,9 +422,9 @@ s16 EnGo2_GetStateGoronDmtDcEntrance(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3008) {
             SET_INFTABLE(INFTABLE_E0);
         }
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     } else {
-        return NPC_TALKING_STATE_1;
+        return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -443,9 +443,9 @@ s16 EnGo2_GetStateGoronCityEntrance(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3014) {
             SET_INFTABLE(INFTABLE_F0);
         }
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     } else {
-        return NPC_TALKING_STATE_1;
+        return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -464,9 +464,9 @@ s16 EnGo2_GetStateGoronCityIsland(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3016) {
             SET_INFTABLE(INFTABLE_F4);
         }
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     } else {
-        return NPC_TALKING_STATE_1;
+        return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -488,9 +488,9 @@ s16 EnGo2_GetStateGoronCityLowestFloor(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3018) {
             SET_INFTABLE(INFTABLE_F8);
         }
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     } else {
-        return NPC_TALKING_STATE_1;
+        return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -515,12 +515,12 @@ s16 EnGo2_GetStateGoronCityLink(PlayState* play, EnGo2* this) {
                 case 0x3036:
                     EnGo2_GetItem(this, play, GI_TUNIC_GORON);
                     this->actionFunc = EnGo2_SetupGetItem;
-                    return NPC_TALKING_STATE_2;
+                    return NPC_TALK_STATE_ACTION;
                 case 0x3037:
                     SET_INFTABLE(INFTABLE_10E);
                     FALLTHROUGH;
                 default:
-                    return NPC_TALKING_STATE_0;
+                    return NPC_TALK_STATE_IDLE;
             }
         case TEXT_STATE_CHOICE:
             if (Message_ShouldAdvance(play)) {
@@ -542,7 +542,7 @@ s16 EnGo2_GetStateGoronCityLink(PlayState* play, EnGo2* this) {
             } else {
                 break;
             }
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
                 switch (this->actor.textId) {
@@ -553,14 +553,14 @@ s16 EnGo2_GetStateGoronCityLink(PlayState* play, EnGo2* this) {
                     case 0x3033:
                         this->actor.textId = 0x3034;
                         Message_ContinueTextbox(play, this->actor.textId);
-                        return NPC_TALKING_STATE_1;
+                        return NPC_TALK_STATE_TALKING;
                     default:
-                        return NPC_TALKING_STATE_2;
+                        return NPC_TALK_STATE_ACTION;
                 }
             }
             break;
     }
-    return NPC_TALKING_STATE_1;
+    return NPC_TALK_STATE_TALKING;
 }
 
 u16 EnGo2_GetTextIdGoronDmtBiggoron(PlayState* play, EnGo2* this) {
@@ -591,12 +591,12 @@ s16 EnGo2_GetStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
                 if (!gSaveContext.bgsFlag) {
                     EnGo2_GetItem(this, play, GI_SWORD_BGS);
                     this->actionFunc = EnGo2_SetupGetItem;
-                    return NPC_TALKING_STATE_2;
+                    return NPC_TALK_STATE_ACTION;
                 } else {
-                    return NPC_TALKING_STATE_0;
+                    return NPC_TALK_STATE_IDLE;
                 }
             } else {
-                return NPC_TALKING_STATE_0;
+                return NPC_TALK_STATE_IDLE;
             }
         case TEXT_STATE_DONE_FADING:
             switch (this->actor.textId) {
@@ -617,19 +617,19 @@ s16 EnGo2_GetStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
                     }
                     break;
             }
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
         case TEXT_STATE_CHOICE:
             if (Message_ShouldAdvance(play)) {
                 if ((this->actor.textId == 0x3054) || (this->actor.textId == 0x3055)) {
                     if (play->msgCtx.choiceIndex == 0) {
                         EnGo2_GetItem(this, play, GI_PRESCRIPTION);
                         this->actionFunc = EnGo2_SetupGetItem;
-                        return NPC_TALKING_STATE_2;
+                        return NPC_TALK_STATE_ACTION;
                     }
                     this->actor.textId = 0x3056;
                     Message_ContinueTextbox(play, this->actor.textId);
                 }
-                return NPC_TALKING_STATE_1;
+                return NPC_TALK_STATE_TALKING;
             }
             break;
         case TEXT_STATE_EVENT:
@@ -638,11 +638,11 @@ s16 EnGo2_GetStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
                     play->msgCtx.msgMode = MSGMODE_PAUSED;
                     this->actionFunc = EnGo2_BiggoronEyedrops;
                 }
-                return NPC_TALKING_STATE_2;
+                return NPC_TALK_STATE_ACTION;
             }
             break;
     }
-    return NPC_TALKING_STATE_1;
+    return NPC_TALK_STATE_TALKING;
 }
 
 u16 EnGo2_GetTextIdGoronFireGeneric(PlayState* play, EnGo2* this) {
@@ -656,18 +656,18 @@ u16 EnGo2_GetTextIdGoronFireGeneric(PlayState* play, EnGo2* this) {
 s16 EnGo2_GetStateGoronFireGeneric(PlayState* play, EnGo2* this) {
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_CLOSING:
-            return NPC_TALKING_STATE_0;
+            return NPC_TALK_STATE_IDLE;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
                 if (this->actor.textId == 0x3071) {
                     this->actor.textId = EnGo2_GoronFireGenericGetTextId(this);
                     Message_ContinueTextbox(play, this->actor.textId);
                 }
-                return NPC_TALKING_STATE_1;
+                return NPC_TALK_STATE_TALKING;
             }
             FALLTHROUGH;
         default:
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -680,9 +680,9 @@ s16 EnGo2_GetStateGoronCityStairwell(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x300E) {
             SET_INFTABLE(INFTABLE_E3);
         }
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     } else {
-        return NPC_TALKING_STATE_1;
+        return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -693,9 +693,9 @@ u16 EnGo2_GetTextIdGoronMarketBazaar(PlayState* play, EnGo2* this) {
 
 s16 EnGo2_GetStateGoronMarketBazaar(PlayState* play, EnGo2* this) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     } else {
-        return NPC_TALKING_STATE_1;
+        return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -716,9 +716,9 @@ s16 EnGo2_GetStateGoronCityLostWoods(PlayState* play, EnGo2* this) {
         if (this->actor.textId == 0x3024) {
             SET_INFTABLE(INFTABLE_E6);
         }
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     } else {
-        return NPC_TALKING_STATE_1;
+        return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -733,9 +733,9 @@ u16 EnGo2_GetTextIdGoronDmtFairyHint(PlayState* play, EnGo2* this) {
 
 s16 EnGo2_GetStateGoronDmtFairyHint(PlayState* play, EnGo2* this) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     } else {
-        return NPC_TALKING_STATE_1;
+        return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -830,9 +830,9 @@ s32 func_80A44790(EnGo2* this, PlayState* play) {
         return false;
     } else {
         if (Actor_ProcessTalkRequest(&this->actor, play)) {
-            this->unk_194.talkState = NPC_TALKING_STATE_1;
+            this->unk_194.talkState = NPC_TALK_STATE_TALKING;
             return true;
-        } else if (this->unk_194.talkState != NPC_TALKING_STATE_0) {
+        } else if (this->unk_194.talkState != NPC_TALK_STATE_IDLE) {
             this->unk_194.talkState = EnGo2_GetState(play, &this->actor);
             return false;
         } else if (func_8002F2CC(&this->actor, play, this->unk_218)) {
@@ -1116,7 +1116,7 @@ void func_80A45360(EnGo2* this, f32* alpha) {
 void EnGo2_RollForward(EnGo2* this) {
     f32 speedXZ = this->actor.speedXZ;
 
-    if (this->unk_194.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_194.talkState != NPC_TALK_STATE_IDLE) {
         this->actor.speedXZ = 0.0f;
     }
 
@@ -1191,7 +1191,7 @@ void EnGo2_DefaultWakingUp(EnGo2* this) {
         this->unk_26E = 1;
     }
 
-    if (this->unk_194.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_194.talkState != NPC_TALK_STATE_IDLE) {
         this->unk_26E = 4;
     }
 
@@ -1204,7 +1204,7 @@ void EnGo2_WakingUp(EnGo2* this) {
 
     xyzDist = SQ(xyzDist);
     this->unk_26E = 1;
-    if ((this->actor.xyzDistToPlayerSq <= xyzDist) || (this->unk_194.talkState != NPC_TALKING_STATE_0)) {
+    if ((this->actor.xyzDistToPlayerSq <= xyzDist) || (this->unk_194.talkState != NPC_TALK_STATE_IDLE)) {
         this->unk_26E = 4;
     }
 
@@ -1212,7 +1212,7 @@ void EnGo2_WakingUp(EnGo2* this) {
 }
 
 void EnGo2_BiggoronWakingUp(EnGo2* this) {
-    if (EnGo2_IsWakingUp(this) || this->unk_194.talkState != NPC_TALKING_STATE_0) {
+    if (EnGo2_IsWakingUp(this) || this->unk_194.talkState != NPC_TALK_STATE_IDLE) {
         this->unk_26E = 2;
         this->isAwake = true;
     } else {
@@ -1397,12 +1397,12 @@ s32 EnGo2_IsFreeingGoronInFire(EnGo2* this, PlayState* play) {
 }
 
 s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
-    if ((this->actor.params & 0x1F) != GORON_DMT_BOMB_FLOWER || this->unk_194.talkState != NPC_TALKING_STATE_2) {
+    if ((this->actor.params & 0x1F) != GORON_DMT_BOMB_FLOWER || this->unk_194.talkState != NPC_TALK_STATE_ACTION) {
         return false;
     }
 
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_3);
-    this->unk_194.talkState = NPC_TALKING_STATE_0;
+    this->unk_194.talkState = NPC_TALK_STATE_IDLE;
     this->isAwake = false;
     this->unk_26E = 1;
     this->actionFunc = EnGo2_GoronDmtBombFlowerAnimation;
@@ -1410,17 +1410,17 @@ s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
 }
 
 s32 EnGo2_IsGoronRollingBig(EnGo2* this, PlayState* play) {
-    if ((this->actor.params & 0x1F) != GORON_CITY_ROLLING_BIG || (this->unk_194.talkState != NPC_TALKING_STATE_2)) {
+    if ((this->actor.params & 0x1F) != GORON_CITY_ROLLING_BIG || (this->unk_194.talkState != NPC_TALK_STATE_ACTION)) {
         return false;
     }
-    this->unk_194.talkState = NPC_TALKING_STATE_0;
+    this->unk_194.talkState = NPC_TALK_STATE_IDLE;
     EnGo2_RollingAnimation(this, play);
     this->actionFunc = EnGo2_GoronRollingBigContinueRolling;
     return true;
 }
 
 s32 EnGo2_IsGoronFireGeneric(EnGo2* this) {
-    if ((this->actor.params & 0x1F) != GORON_FIRE_GENERIC || this->unk_194.talkState == NPC_TALKING_STATE_0) {
+    if ((this->actor.params & 0x1F) != GORON_FIRE_GENERIC || this->unk_194.talkState == NPC_TALK_STATE_IDLE) {
         return false;
     }
     this->actionFunc = EnGo2_GoronFireGenericAction;
@@ -1436,7 +1436,7 @@ s32 EnGo2_IsGoronLinkReversing(EnGo2* this) {
 }
 
 s32 EnGo2_IsRolling(EnGo2* this) {
-    if (this->unk_194.talkState == NPC_TALKING_STATE_0 || this->actor.speedXZ < 1.0f) {
+    if (this->unk_194.talkState == NPC_TALK_STATE_IDLE || this->actor.speedXZ < 1.0f) {
         return false;
     }
     if (EnGo2_IsRollingOnGround(this, 2, 20.0 / 3.0f, 0)) {
@@ -1504,7 +1504,7 @@ void EnGo2_GoronFireClearCamera(EnGo2* this, PlayState* play) {
 
 void EnGo2_BiggoronAnimation(EnGo2* this) {
     if (INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_SWORD_BROKEN && INV_CONTENT(ITEM_TRADE_ADULT) <= ITEM_EYEDROPS &&
-        (this->actor.params & 0x1F) == GORON_DMT_BIGGORON && this->unk_194.talkState == NPC_TALKING_STATE_0) {
+        (this->actor.params & 0x1F) == GORON_DMT_BIGGORON && this->unk_194.talkState == NPC_TALK_STATE_IDLE) {
         if (DECR(this->animTimer) == 0) {
             this->animTimer = Rand_S16Offset(30, 30);
             func_800F4524(&gSfxDefaultPos, NA_SE_EN_GOLON_EYE_BIG, 60);
@@ -1800,7 +1800,7 @@ void EnGo2_SetupGetItem(EnGo2* this, PlayState* play) {
 
 void EnGo2_SetGetItem(EnGo2* this, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_DONE) && Message_ShouldAdvance(play)) {
-        this->unk_194.talkState = NPC_TALKING_STATE_0;
+        this->unk_194.talkState = NPC_TALK_STATE_IDLE;
         switch (this->getItemId) {
             case GI_CLAIM_CHECK:
                 Environment_ClearBgsDayCount();
@@ -1980,7 +1980,7 @@ void EnGo2_Update(Actor* thisx, PlayState* play) {
     EnGo2_RollForward(this);
     Actor_UpdateBgCheckInfo(play, &this->actor, (f32)this->collider.dim.height * 0.5f,
                             (f32)this->collider.dim.radius * 0.6f, 0.0f, UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
-    if (this->unk_194.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_194.talkState == NPC_TALK_STATE_IDLE) {
         func_80A44AB0(this, play);
     }
     this->actionFunc(this, play);

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -565,7 +565,7 @@ s16 func_80A70058(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
         case TEXT_STATE_DONE_FADING:
             switch (this->actor.textId) {
                 case 0x709E:
@@ -587,7 +587,7 @@ s16 func_80A70058(PlayState* play, Actor* thisx) {
                     }
                     break;
             }
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
         case TEXT_STATE_CLOSING:
             switch (this->actor.textId) {
                 case 0x70F0:
@@ -663,16 +663,16 @@ s16 func_80A70058(PlayState* play, Actor* thisx) {
                     this->actionFunc = func_80A714C4;
                     break;
             }
-            return NPC_TALKING_STATE_0;
+            return NPC_TALK_STATE_IDLE;
         case TEXT_STATE_EVENT:
             if (!Message_ShouldAdvance(play)) {
-                return NPC_TALKING_STATE_1;
+                return NPC_TALK_STATE_TALKING;
             } else {
-                return NPC_TALKING_STATE_2;
+                return NPC_TALK_STATE_ACTION;
             }
     }
 
-    return NPC_TALKING_STATE_1;
+    return NPC_TALK_STATE_TALKING;
 }
 
 void EnHy_UpdateEyes(EnHy* this) {
@@ -769,7 +769,7 @@ void func_80A70978(EnHy* this, PlayState* play) {
         case ENHY_TYPE_BJI_7:
         case ENHY_TYPE_BOJ_9:
         case ENHY_TYPE_BOJ_10:
-            phi_a3 = (this->unk_1E8.talkState == NPC_TALKING_STATE_0) ? 1 : 2;
+            phi_a3 = (this->unk_1E8.talkState == NPC_TALK_STATE_IDLE) ? 1 : 2;
             break;
         case ENHY_TYPE_BOJ_12:
             phi_a3 = 1;
@@ -780,7 +780,7 @@ void func_80A70978(EnHy* this, PlayState* play) {
             break;
         case ENHY_TYPE_AOB:
         case ENHY_TYPE_BOB_18:
-            phi_a3 = (this->unk_1E8.talkState == NPC_TALKING_STATE_0) ? 2 : 4;
+            phi_a3 = (this->unk_1E8.talkState == NPC_TALK_STATE_IDLE) ? 2 : 4;
             break;
         default:
             phi_a3 = 2;
@@ -967,7 +967,7 @@ void EnHy_InitImpl(EnHy* this, PlayState* play) {
 }
 
 void func_80A710F8(EnHy* this, PlayState* play) {
-    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E8.talkState != NPC_TALK_STATE_IDLE) {
         if (this->skelAnime.animation != &gObjOsAnim_0BFC) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_26);
         }
@@ -1017,11 +1017,11 @@ void func_80A7134C(EnHy* this, PlayState* play) {
     s16 yaw;
     f32 distSq;
 
-    if ((this->skelAnime.animation == &gObjOsAnim_2160) && (this->unk_1E8.talkState != NPC_TALKING_STATE_0)) {
+    if ((this->skelAnime.animation == &gObjOsAnim_2160) && (this->unk_1E8.talkState != NPC_TALK_STATE_IDLE)) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_8);
     }
 
-    if ((this->skelAnime.animation == &gObjOsAnim_265C) && (this->unk_1E8.talkState == NPC_TALKING_STATE_0)) {
+    if ((this->skelAnime.animation == &gObjOsAnim_265C) && (this->unk_1E8.talkState == NPC_TALK_STATE_IDLE)) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_7);
     }
 
@@ -1083,7 +1083,7 @@ void EnHy_Update(Actor* thisx, PlayState* play) {
         SkelAnime_Update(&this->skelAnime);
         EnHy_UpdateEyes(this);
 
-        if (this->unk_1E8.talkState == NPC_TALKING_STATE_0) {
+        if (this->unk_1E8.talkState == NPC_TALK_STATE_IDLE) {
             Actor_MoveForward(&this->actor);
         }
 

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -797,7 +797,8 @@ void func_80A70978(EnHy* this, PlayState* play) {
 
     func_80034A14(&this->actor, &this->unk_1E8, sInit1Info[this->actor.params & 0x7F].unkPresetIndex, phi_a3);
 
-    if (func_800343CC(play, &this->actor, &this->unk_1E8.talkState, this->unkRange, func_80A6F810, func_80A70058)) {
+    if (Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E8.talkState, this->unkRange, func_80A6F810,
+                               func_80A70058)) {
         func_80A70834(this, play);
     }
 }

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -769,7 +769,7 @@ void func_80A70978(EnHy* this, PlayState* play) {
         case ENHY_TYPE_BJI_7:
         case ENHY_TYPE_BOJ_9:
         case ENHY_TYPE_BOJ_10:
-            phi_a3 = (this->unk_1E8.unk_00 == 0) ? 1 : 2;
+            phi_a3 = (this->unk_1E8.talkState == 0) ? 1 : 2;
             break;
         case ENHY_TYPE_BOJ_12:
             phi_a3 = 1;
@@ -780,7 +780,7 @@ void func_80A70978(EnHy* this, PlayState* play) {
             break;
         case ENHY_TYPE_AOB:
         case ENHY_TYPE_BOB_18:
-            phi_a3 = (this->unk_1E8.unk_00 == 0) ? 2 : 4;
+            phi_a3 = (this->unk_1E8.talkState == 0) ? 2 : 4;
             break;
         default:
             phi_a3 = 2;
@@ -797,7 +797,7 @@ void func_80A70978(EnHy* this, PlayState* play) {
 
     func_80034A14(&this->actor, &this->unk_1E8, sInit1Info[this->actor.params & 0x7F].unkPresetIndex, phi_a3);
 
-    if (func_800343CC(play, &this->actor, &this->unk_1E8.unk_00, this->unkRange, func_80A6F810, func_80A70058)) {
+    if (func_800343CC(play, &this->actor, &this->unk_1E8.talkState, this->unkRange, func_80A6F810, func_80A70058)) {
         func_80A70834(this, play);
     }
 }
@@ -966,7 +966,7 @@ void EnHy_InitImpl(EnHy* this, PlayState* play) {
 }
 
 void func_80A710F8(EnHy* this, PlayState* play) {
-    if (this->unk_1E8.unk_00 != 0) {
+    if (this->unk_1E8.talkState != 0) {
         if (this->skelAnime.animation != &gObjOsAnim_0BFC) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_26);
         }
@@ -1016,11 +1016,11 @@ void func_80A7134C(EnHy* this, PlayState* play) {
     s16 yaw;
     f32 distSq;
 
-    if ((this->skelAnime.animation == &gObjOsAnim_2160) && (this->unk_1E8.unk_00 != 0)) {
+    if ((this->skelAnime.animation == &gObjOsAnim_2160) && (this->unk_1E8.talkState != 0)) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_8);
     }
 
-    if ((this->skelAnime.animation == &gObjOsAnim_265C) && (this->unk_1E8.unk_00 == 0)) {
+    if ((this->skelAnime.animation == &gObjOsAnim_265C) && (this->unk_1E8.talkState == 0)) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_7);
     }
 
@@ -1082,7 +1082,7 @@ void EnHy_Update(Actor* thisx, PlayState* play) {
         SkelAnime_Update(&this->skelAnime);
         EnHy_UpdateEyes(this);
 
-        if (this->unk_1E8.unk_00 == 0) {
+        if (this->unk_1E8.talkState == 0) {
             Actor_MoveForward(&this->actor);
         }
 

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -565,7 +565,7 @@ s16 func_80A70058(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            return 1;
+            return NPC_TALKING_STATE_1;
         case TEXT_STATE_DONE_FADING:
             switch (this->actor.textId) {
                 case 0x709E:
@@ -587,7 +587,7 @@ s16 func_80A70058(PlayState* play, Actor* thisx) {
                     }
                     break;
             }
-            return 1;
+            return NPC_TALKING_STATE_1;
         case TEXT_STATE_CLOSING:
             switch (this->actor.textId) {
                 case 0x70F0:
@@ -663,16 +663,16 @@ s16 func_80A70058(PlayState* play, Actor* thisx) {
                     this->actionFunc = func_80A714C4;
                     break;
             }
-            return 0;
+            return NPC_TALKING_STATE_0;
         case TEXT_STATE_EVENT:
             if (!Message_ShouldAdvance(play)) {
-                return 1;
+                return NPC_TALKING_STATE_1;
             } else {
-                return 2;
+                return NPC_TALKING_STATE_2;
             }
     }
 
-    return 1;
+    return NPC_TALKING_STATE_1;
 }
 
 void EnHy_UpdateEyes(EnHy* this) {
@@ -769,7 +769,7 @@ void func_80A70978(EnHy* this, PlayState* play) {
         case ENHY_TYPE_BJI_7:
         case ENHY_TYPE_BOJ_9:
         case ENHY_TYPE_BOJ_10:
-            phi_a3 = (this->unk_1E8.talkState == 0) ? 1 : 2;
+            phi_a3 = (this->unk_1E8.talkState == NPC_TALKING_STATE_0) ? 1 : 2;
             break;
         case ENHY_TYPE_BOJ_12:
             phi_a3 = 1;
@@ -780,7 +780,7 @@ void func_80A70978(EnHy* this, PlayState* play) {
             break;
         case ENHY_TYPE_AOB:
         case ENHY_TYPE_BOB_18:
-            phi_a3 = (this->unk_1E8.talkState == 0) ? 2 : 4;
+            phi_a3 = (this->unk_1E8.talkState == NPC_TALKING_STATE_0) ? 2 : 4;
             break;
         default:
             phi_a3 = 2;
@@ -967,7 +967,7 @@ void EnHy_InitImpl(EnHy* this, PlayState* play) {
 }
 
 void func_80A710F8(EnHy* this, PlayState* play) {
-    if (this->unk_1E8.talkState != 0) {
+    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
         if (this->skelAnime.animation != &gObjOsAnim_0BFC) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_26);
         }
@@ -1017,11 +1017,11 @@ void func_80A7134C(EnHy* this, PlayState* play) {
     s16 yaw;
     f32 distSq;
 
-    if ((this->skelAnime.animation == &gObjOsAnim_2160) && (this->unk_1E8.talkState != 0)) {
+    if ((this->skelAnime.animation == &gObjOsAnim_2160) && (this->unk_1E8.talkState != NPC_TALKING_STATE_0)) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_8);
     }
 
-    if ((this->skelAnime.animation == &gObjOsAnim_265C) && (this->unk_1E8.talkState == 0)) {
+    if ((this->skelAnime.animation == &gObjOsAnim_265C) && (this->unk_1E8.talkState == NPC_TALKING_STATE_0)) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_7);
     }
 
@@ -1083,7 +1083,7 @@ void EnHy_Update(Actor* thisx, PlayState* play) {
         SkelAnime_Update(&this->skelAnime);
         EnHy_UpdateEyes(this);
 
-        if (this->unk_1E8.talkState == 0) {
+        if (this->unk_1E8.talkState == NPC_TALKING_STATE_0) {
             Actor_MoveForward(&this->actor);
         }
 

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -191,14 +191,14 @@ u16 func_80A79168(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80A791CC(PlayState* play, Actor* thisx) {
-    s32 ret = 0;
+    s32 ret = NPC_TALKING_STATE_0;
 
     switch (thisx->textId) {
         case 0x2045:
             SET_INFTABLE(INFTABLE_97);
             break;
         case 0x203E:
-            ret = 2;
+            ret = NPC_TALKING_STATE_2;
             break;
         case 0x203F:
             SET_EVENTCHKINF(EVENTCHKINF_11);
@@ -210,7 +210,7 @@ s16 func_80A791CC(PlayState* play, Actor* thisx) {
 
 s16 func_80A7924C(PlayState* play, Actor* thisx) {
     EnIn* this = (EnIn*)thisx;
-    s32 sp18 = 1;
+    s32 sp18 = NPC_TALKING_STATE_1;
 
     switch (this->actor.textId) {
         case 0x2030:
@@ -237,7 +237,7 @@ s16 func_80A7924C(PlayState* play, Actor* thisx) {
         case 0x2036:
         case 0x2037:
             if (play->msgCtx.choiceIndex == 1) {
-                sp18 = 2;
+                sp18 = NPC_TALKING_STATE_2;
             } else {
                 this->actor.textId = 0x201F;
                 Message_ContinueTextbox(play, this->actor.textId);
@@ -245,7 +245,7 @@ s16 func_80A7924C(PlayState* play, Actor* thisx) {
             break;
         case 0x2038:
             if (play->msgCtx.choiceIndex == 0 && gSaveContext.rupees >= 50) {
-                sp18 = 2;
+                sp18 = NPC_TALKING_STATE_2;
             } else {
                 this->actor.textId = 0x2039;
                 Message_ContinueTextbox(play, this->actor.textId);
@@ -254,7 +254,7 @@ s16 func_80A7924C(PlayState* play, Actor* thisx) {
             break;
         case 0x205B:
             if (play->msgCtx.choiceIndex == 0 && gSaveContext.rupees >= 50) {
-                sp18 = 2;
+                sp18 = NPC_TALKING_STATE_2;
             } else {
                 Message_ContinueTextbox(play, this->actor.textId = 0x2039);
                 SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_0);
@@ -270,20 +270,20 @@ s16 func_80A7924C(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80A7949C(PlayState* play, Actor* thisx) {
-    s32 phi_v1 = 1;
+    s32 phi_v1 = NPC_TALKING_STATE_1;
 
     if (thisx->textId == 0x2035) {
         Rupees_ChangeBy(-10);
         thisx->textId = 0x205C;
         Message_ContinueTextbox(play, thisx->textId);
     } else {
-        phi_v1 = 2;
+        phi_v1 = NPC_TALKING_STATE_2;
     }
     return phi_v1;
 }
 
 s16 func_80A79500(PlayState* play, Actor* thisx) {
-    s16 sp1E = 1;
+    s16 sp1E = NPC_TALKING_STATE_1;
 
     osSyncPrintf("message_check->(%d[%x])\n", Message_GetState(&play->msgCtx), thisx->textId);
     switch (Message_GetState(&play->msgCtx)) {
@@ -460,7 +460,7 @@ void func_80A79C78(EnIn* this, PlayState* play) {
     this->unk_308.unk_08 = zeroVec;
     this->unk_308.unk_0E = zeroVec;
     Message_StartTextbox(play, 0x2025, NULL);
-    this->unk_308.talkState = 1;
+    this->unk_308.talkState = NPC_TALKING_STATE_1;
     player->actor.world.pos = this->actor.world.pos;
     player->actor.world.pos.x += 100.0f * Math_SinS(this->actor.shape.rot.y);
     player->actor.world.pos.z += 100.0f * Math_CosS(this->actor.shape.rot.y);
@@ -519,7 +519,7 @@ void func_80A79FB0(EnIn* this, PlayState* play) {
         }
         Actor_SetScale(&this->actor, 0.01f);
         this->actor.targetMode = 6;
-        this->unk_308.talkState = 0;
+        this->unk_308.talkState = NPC_TALKING_STATE_0;
         this->actionFunc = func_80A7A4BC;
 
         switch (func_80A79830(this, play)) {
@@ -637,7 +637,7 @@ void func_80A7A4BC(EnIn* this, PlayState* play) {
 }
 
 void func_80A7A4C8(EnIn* this, PlayState* play) {
-    if (this->unk_308.talkState == 2) {
+    if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
         func_80A79BAC(this, play, 1, TRANS_TYPE_CIRCLE(TCA_NORMAL, TCC_BLACK, TCS_FAST));
         SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_1);
         SET_EVENTINF_HORSES_0F(1);
@@ -645,7 +645,7 @@ void func_80A7A4C8(EnIn* this, PlayState* play) {
         Environment_ForcePlaySequence(NA_BGM_HORSE);
         play->msgCtx.stateTimer = 0;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = 0;
+        this->unk_308.talkState = NPC_TALKING_STATE_0;
     }
 }
 
@@ -663,12 +663,12 @@ void func_80A7A568(EnIn* this, PlayState* play) {
         func_80A79C78(this, play);
         this->actionFunc = func_80A7B024;
         gSaveContext.timer1State = 0;
-    } else if (this->unk_308.talkState == 2) {
+    } else if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
         if (play->msgCtx.choiceIndex == 0) {
             if (gSaveContext.rupees < 50) {
                 play->msgCtx.stateTimer = 4;
                 play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-                this->unk_308.talkState = 0;
+                this->unk_308.talkState = NPC_TALKING_STATE_0;
                 return;
             }
             SET_EVENTINF_HORSES_HORSETYPE(((EnHorse*)GET_PLAYER(play)->rideActor)->type);
@@ -692,20 +692,20 @@ void func_80A7A568(EnIn* this, PlayState* play) {
         play->msgCtx.stateTimer = 0;
         SET_EVENTINF_HORSES_0F(1);
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = 0;
+        this->unk_308.talkState = NPC_TALKING_STATE_0;
     }
 }
 
 void func_80A7A770(EnIn* this, PlayState* play) {
-    if (this->unk_308.talkState == 0) {
+    if (this->unk_308.talkState == NPC_TALKING_STATE_0) {
         this->actor.flags |= ACTOR_FLAG_16;
-    } else if (this->unk_308.talkState == 2) {
+    } else if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
         Rupees_ChangeBy(-50);
         this->actor.flags &= ~ACTOR_FLAG_16;
         EnIn_ChangeAnim(this, ENIN_ANIM_3);
         this->actionFunc = func_80A7A848;
         SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_7);
-        this->unk_308.talkState = 0;
+        this->unk_308.talkState = NPC_TALKING_STATE_0;
         gSaveContext.eventInf[EVENTINF_HORSES_INDEX] =
             (gSaveContext.eventInf[EVENTINF_HORSES_INDEX] & 0xFFFF) | EVENTINF_HORSES_05_MASK;
         if (!GET_EVENTINF(EVENTINF_HORSES_06)) {
@@ -716,7 +716,7 @@ void func_80A7A770(EnIn* this, PlayState* play) {
 }
 
 void func_80A7A848(EnIn* this, PlayState* play) {
-    if (this->unk_308.talkState == 2) {
+    if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
         if ((play->msgCtx.choiceIndex == 0 && gSaveContext.rupees < 50) || play->msgCtx.choiceIndex == 1) {
             SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_0);
             this->actionFunc = func_80A7A4C8;
@@ -727,14 +727,14 @@ void func_80A7A848(EnIn* this, PlayState* play) {
             play->msgCtx.stateTimer = 0;
             play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
         }
-        this->unk_308.talkState = 0;
+        this->unk_308.talkState = NPC_TALKING_STATE_0;
         CLEAR_EVENTINF(EVENTINF_HORSES_05);
         CLEAR_EVENTINF(EVENTINF_HORSES_06);
     }
 }
 
 void func_80A7A940(EnIn* this, PlayState* play) {
-    if (this->unk_308.talkState == 0) {
+    if (this->unk_308.talkState == NPC_TALKING_STATE_0) {
         this->actor.flags |= ACTOR_FLAG_16;
         return;
     }
@@ -744,14 +744,14 @@ void func_80A7A940(EnIn* this, PlayState* play) {
             Audio_PlayActorSfx2(&this->actor, NA_SE_VO_IN_LOST);
         }
     }
-    if (this->unk_308.talkState == 2) {
+    if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
         this->actor.flags &= ~ACTOR_FLAG_16;
         func_80A79BAC(this, play, 2, TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST));
         SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_2);
         SET_EVENTINF_HORSES_0F(1);
         play->msgCtx.stateTimer = 0;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = 0;
+        this->unk_308.talkState = NPC_TALKING_STATE_0;
         gSaveContext.eventInf[EVENTINF_HORSES_INDEX] =
             (gSaveContext.eventInf[EVENTINF_HORSES_INDEX] & 0xFFFF) | EVENTINF_HORSES_06_MASK;
     }
@@ -788,7 +788,7 @@ void func_80A7AA40(EnIn* this, PlayState* play) {
     Play_CameraSetAtEye(play, this->subCamId, &subCamAt, &subCamEye);
     this->actor.textId = 0x203B;
     Message_StartTextbox(play, this->actor.textId, NULL);
-    this->unk_308.talkState = 1;
+    this->unk_308.talkState = NPC_TALKING_STATE_1;
     this->unk_1FC = 0;
     play->csCtx.frames = 0;
     Letterbox_SetSizeTarget(32);
@@ -813,16 +813,16 @@ void func_80A7ABD4(EnIn* this, PlayState* play) {
             }
         }
     }
-    if (this->unk_308.talkState != 0) {
-        if (this->unk_308.talkState == 2) {
+    if (this->unk_308.talkState != NPC_TALKING_STATE_0) {
+        if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
             if (this->actor.textId == 0x203B) {
                 this->actor.textId = 0x203C;
                 Message_StartTextbox(play, this->actor.textId, NULL);
-                this->unk_308.talkState = 1;
+                this->unk_308.talkState = NPC_TALKING_STATE_1;
                 EnIn_ChangeAnim(this, ENIN_ANIM_3);
             } else {
                 play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-                this->unk_308.talkState = 0;
+                this->unk_308.talkState = NPC_TALKING_STATE_0;
             }
         }
     } else {
@@ -874,10 +874,10 @@ void func_80A7AEF0(EnIn* this, PlayState* play) {
         play->transitionTrigger = TRANS_TRIGGER_START;
         play->transitionType = TRANS_TYPE_FADE_WHITE_FAST;
         this->actionFunc = func_80A7B018;
-    } else if (this->unk_308.talkState == 2) {
+    } else if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = 0;
+        this->unk_308.talkState = NPC_TALKING_STATE_0;
     }
 }
 
@@ -891,7 +891,7 @@ void func_80A7B024(EnIn* this, PlayState* play) {
         player->rideActor->freezeTimer = 10;
     }
     player->actor.freezeTimer = 10;
-    if (this->unk_308.talkState == 2) {
+    if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
         if (1) {}
         if (!GET_EVENTCHKINF(EVENTCHKINF_1B) && GET_INFTABLE(INFTABLE_AB)) {
             SET_EVENTCHKINF(EVENTCHKINF_1B);
@@ -902,7 +902,7 @@ void func_80A7B024(EnIn* this, PlayState* play) {
         SET_EVENTINF_HORSES_0F(1);
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = 0;
+        this->unk_308.talkState = NPC_TALKING_STATE_0;
     }
 }
 
@@ -929,13 +929,14 @@ void EnIn_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
     if (this->actionFunc != func_80A7A304) {
         func_80A79AB4(this, play);
-        if (gSaveContext.timer2Value < 6 && gSaveContext.timer2State != 0 && this->unk_308.talkState == 0) {
+        if (gSaveContext.timer2Value < 6 && gSaveContext.timer2State != 0 &&
+            this->unk_308.talkState == NPC_TALKING_STATE_0) {
             if (Actor_ProcessTalkRequest(&this->actor, play)) {}
         } else {
             Actor_NpcUpdateTalking(play, &this->actor, &this->unk_308.talkState,
                                    ((this->actor.targetMode == 6) ? 80.0f : 320.0f) + this->collider.dim.radius,
                                    func_80A79168, func_80A79500);
-            if (this->unk_308.talkState != 0) {
+            if (this->unk_308.talkState != NPC_TALKING_STATE_0) {
                 this->unk_1FA = this->unk_1F8;
                 this->unk_1F8 = Message_GetState(&play->msgCtx);
             }

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -460,7 +460,7 @@ void func_80A79C78(EnIn* this, PlayState* play) {
     this->unk_308.unk_08 = zeroVec;
     this->unk_308.unk_0E = zeroVec;
     Message_StartTextbox(play, 0x2025, NULL);
-    this->unk_308.unk_00 = 1;
+    this->unk_308.talkState = 1;
     player->actor.world.pos = this->actor.world.pos;
     player->actor.world.pos.x += 100.0f * Math_SinS(this->actor.shape.rot.y);
     player->actor.world.pos.z += 100.0f * Math_CosS(this->actor.shape.rot.y);
@@ -519,7 +519,7 @@ void func_80A79FB0(EnIn* this, PlayState* play) {
         }
         Actor_SetScale(&this->actor, 0.01f);
         this->actor.targetMode = 6;
-        this->unk_308.unk_00 = 0;
+        this->unk_308.talkState = 0;
         this->actionFunc = func_80A7A4BC;
 
         switch (func_80A79830(this, play)) {
@@ -637,7 +637,7 @@ void func_80A7A4BC(EnIn* this, PlayState* play) {
 }
 
 void func_80A7A4C8(EnIn* this, PlayState* play) {
-    if (this->unk_308.unk_00 == 2) {
+    if (this->unk_308.talkState == 2) {
         func_80A79BAC(this, play, 1, TRANS_TYPE_CIRCLE(TCA_NORMAL, TCC_BLACK, TCS_FAST));
         SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_1);
         SET_EVENTINF_HORSES_0F(1);
@@ -645,7 +645,7 @@ void func_80A7A4C8(EnIn* this, PlayState* play) {
         Environment_ForcePlaySequence(NA_BGM_HORSE);
         play->msgCtx.stateTimer = 0;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.unk_00 = 0;
+        this->unk_308.talkState = 0;
     }
 }
 
@@ -663,12 +663,12 @@ void func_80A7A568(EnIn* this, PlayState* play) {
         func_80A79C78(this, play);
         this->actionFunc = func_80A7B024;
         gSaveContext.timer1State = 0;
-    } else if (this->unk_308.unk_00 == 2) {
+    } else if (this->unk_308.talkState == 2) {
         if (play->msgCtx.choiceIndex == 0) {
             if (gSaveContext.rupees < 50) {
                 play->msgCtx.stateTimer = 4;
                 play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-                this->unk_308.unk_00 = 0;
+                this->unk_308.talkState = 0;
                 return;
             }
             SET_EVENTINF_HORSES_HORSETYPE(((EnHorse*)GET_PLAYER(play)->rideActor)->type);
@@ -692,20 +692,20 @@ void func_80A7A568(EnIn* this, PlayState* play) {
         play->msgCtx.stateTimer = 0;
         SET_EVENTINF_HORSES_0F(1);
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.unk_00 = 0;
+        this->unk_308.talkState = 0;
     }
 }
 
 void func_80A7A770(EnIn* this, PlayState* play) {
-    if (this->unk_308.unk_00 == 0) {
+    if (this->unk_308.talkState == 0) {
         this->actor.flags |= ACTOR_FLAG_16;
-    } else if (this->unk_308.unk_00 == 2) {
+    } else if (this->unk_308.talkState == 2) {
         Rupees_ChangeBy(-50);
         this->actor.flags &= ~ACTOR_FLAG_16;
         EnIn_ChangeAnim(this, ENIN_ANIM_3);
         this->actionFunc = func_80A7A848;
         SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_7);
-        this->unk_308.unk_00 = 0;
+        this->unk_308.talkState = 0;
         gSaveContext.eventInf[EVENTINF_HORSES_INDEX] =
             (gSaveContext.eventInf[EVENTINF_HORSES_INDEX] & 0xFFFF) | EVENTINF_HORSES_05_MASK;
         if (!GET_EVENTINF(EVENTINF_HORSES_06)) {
@@ -716,7 +716,7 @@ void func_80A7A770(EnIn* this, PlayState* play) {
 }
 
 void func_80A7A848(EnIn* this, PlayState* play) {
-    if (this->unk_308.unk_00 == 2) {
+    if (this->unk_308.talkState == 2) {
         if ((play->msgCtx.choiceIndex == 0 && gSaveContext.rupees < 50) || play->msgCtx.choiceIndex == 1) {
             SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_0);
             this->actionFunc = func_80A7A4C8;
@@ -727,14 +727,14 @@ void func_80A7A848(EnIn* this, PlayState* play) {
             play->msgCtx.stateTimer = 0;
             play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
         }
-        this->unk_308.unk_00 = 0;
+        this->unk_308.talkState = 0;
         CLEAR_EVENTINF(EVENTINF_HORSES_05);
         CLEAR_EVENTINF(EVENTINF_HORSES_06);
     }
 }
 
 void func_80A7A940(EnIn* this, PlayState* play) {
-    if (this->unk_308.unk_00 == 0) {
+    if (this->unk_308.talkState == 0) {
         this->actor.flags |= ACTOR_FLAG_16;
         return;
     }
@@ -744,14 +744,14 @@ void func_80A7A940(EnIn* this, PlayState* play) {
             Audio_PlayActorSfx2(&this->actor, NA_SE_VO_IN_LOST);
         }
     }
-    if (this->unk_308.unk_00 == 2) {
+    if (this->unk_308.talkState == 2) {
         this->actor.flags &= ~ACTOR_FLAG_16;
         func_80A79BAC(this, play, 2, TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST));
         SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_2);
         SET_EVENTINF_HORSES_0F(1);
         play->msgCtx.stateTimer = 0;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.unk_00 = 0;
+        this->unk_308.talkState = 0;
         gSaveContext.eventInf[EVENTINF_HORSES_INDEX] =
             (gSaveContext.eventInf[EVENTINF_HORSES_INDEX] & 0xFFFF) | EVENTINF_HORSES_06_MASK;
     }
@@ -788,7 +788,7 @@ void func_80A7AA40(EnIn* this, PlayState* play) {
     Play_CameraSetAtEye(play, this->subCamId, &subCamAt, &subCamEye);
     this->actor.textId = 0x203B;
     Message_StartTextbox(play, this->actor.textId, NULL);
-    this->unk_308.unk_00 = 1;
+    this->unk_308.talkState = 1;
     this->unk_1FC = 0;
     play->csCtx.frames = 0;
     Letterbox_SetSizeTarget(32);
@@ -813,16 +813,16 @@ void func_80A7ABD4(EnIn* this, PlayState* play) {
             }
         }
     }
-    if (this->unk_308.unk_00 != 0) {
-        if (this->unk_308.unk_00 == 2) {
+    if (this->unk_308.talkState != 0) {
+        if (this->unk_308.talkState == 2) {
             if (this->actor.textId == 0x203B) {
                 this->actor.textId = 0x203C;
                 Message_StartTextbox(play, this->actor.textId, NULL);
-                this->unk_308.unk_00 = 1;
+                this->unk_308.talkState = 1;
                 EnIn_ChangeAnim(this, ENIN_ANIM_3);
             } else {
                 play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-                this->unk_308.unk_00 = 0;
+                this->unk_308.talkState = 0;
             }
         }
     } else {
@@ -874,10 +874,10 @@ void func_80A7AEF0(EnIn* this, PlayState* play) {
         play->transitionTrigger = TRANS_TRIGGER_START;
         play->transitionType = TRANS_TYPE_FADE_WHITE_FAST;
         this->actionFunc = func_80A7B018;
-    } else if (this->unk_308.unk_00 == 2) {
+    } else if (this->unk_308.talkState == 2) {
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.unk_00 = 0;
+        this->unk_308.talkState = 0;
     }
 }
 
@@ -891,7 +891,7 @@ void func_80A7B024(EnIn* this, PlayState* play) {
         player->rideActor->freezeTimer = 10;
     }
     player->actor.freezeTimer = 10;
-    if (this->unk_308.unk_00 == 2) {
+    if (this->unk_308.talkState == 2) {
         if (1) {}
         if (!GET_EVENTCHKINF(EVENTCHKINF_1B) && GET_INFTABLE(INFTABLE_AB)) {
             SET_EVENTCHKINF(EVENTCHKINF_1B);
@@ -902,7 +902,7 @@ void func_80A7B024(EnIn* this, PlayState* play) {
         SET_EVENTINF_HORSES_0F(1);
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.unk_00 = 0;
+        this->unk_308.talkState = 0;
     }
 }
 
@@ -929,13 +929,13 @@ void EnIn_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
     if (this->actionFunc != func_80A7A304) {
         func_80A79AB4(this, play);
-        if (gSaveContext.timer2Value < 6 && gSaveContext.timer2State != 0 && this->unk_308.unk_00 == 0) {
+        if (gSaveContext.timer2Value < 6 && gSaveContext.timer2State != 0 && this->unk_308.talkState == 0) {
             if (Actor_ProcessTalkRequest(&this->actor, play)) {}
         } else {
-            func_800343CC(play, &this->actor, &this->unk_308.unk_00,
+            func_800343CC(play, &this->actor, &this->unk_308.talkState,
                           ((this->actor.targetMode == 6) ? 80.0f : 320.0f) + this->collider.dim.radius, func_80A79168,
                           func_80A79500);
-            if (this->unk_308.unk_00 != 0) {
+            if (this->unk_308.talkState != 0) {
                 this->unk_1FA = this->unk_1F8;
                 this->unk_1F8 = Message_GetState(&play->msgCtx);
             }

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -191,14 +191,14 @@ u16 func_80A79168(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80A791CC(PlayState* play, Actor* thisx) {
-    s32 ret = NPC_TALKING_STATE_0;
+    s32 ret = NPC_TALK_STATE_IDLE;
 
     switch (thisx->textId) {
         case 0x2045:
             SET_INFTABLE(INFTABLE_97);
             break;
         case 0x203E:
-            ret = NPC_TALKING_STATE_2;
+            ret = NPC_TALK_STATE_ACTION;
             break;
         case 0x203F:
             SET_EVENTCHKINF(EVENTCHKINF_11);
@@ -210,7 +210,7 @@ s16 func_80A791CC(PlayState* play, Actor* thisx) {
 
 s16 func_80A7924C(PlayState* play, Actor* thisx) {
     EnIn* this = (EnIn*)thisx;
-    s32 sp18 = NPC_TALKING_STATE_1;
+    s32 sp18 = NPC_TALK_STATE_TALKING;
 
     switch (this->actor.textId) {
         case 0x2030:
@@ -237,7 +237,7 @@ s16 func_80A7924C(PlayState* play, Actor* thisx) {
         case 0x2036:
         case 0x2037:
             if (play->msgCtx.choiceIndex == 1) {
-                sp18 = NPC_TALKING_STATE_2;
+                sp18 = NPC_TALK_STATE_ACTION;
             } else {
                 this->actor.textId = 0x201F;
                 Message_ContinueTextbox(play, this->actor.textId);
@@ -245,7 +245,7 @@ s16 func_80A7924C(PlayState* play, Actor* thisx) {
             break;
         case 0x2038:
             if (play->msgCtx.choiceIndex == 0 && gSaveContext.rupees >= 50) {
-                sp18 = NPC_TALKING_STATE_2;
+                sp18 = NPC_TALK_STATE_ACTION;
             } else {
                 this->actor.textId = 0x2039;
                 Message_ContinueTextbox(play, this->actor.textId);
@@ -254,7 +254,7 @@ s16 func_80A7924C(PlayState* play, Actor* thisx) {
             break;
         case 0x205B:
             if (play->msgCtx.choiceIndex == 0 && gSaveContext.rupees >= 50) {
-                sp18 = NPC_TALKING_STATE_2;
+                sp18 = NPC_TALK_STATE_ACTION;
             } else {
                 Message_ContinueTextbox(play, this->actor.textId = 0x2039);
                 SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_0);
@@ -270,20 +270,20 @@ s16 func_80A7924C(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80A7949C(PlayState* play, Actor* thisx) {
-    s32 phi_v1 = NPC_TALKING_STATE_1;
+    s32 phi_v1 = NPC_TALK_STATE_TALKING;
 
     if (thisx->textId == 0x2035) {
         Rupees_ChangeBy(-10);
         thisx->textId = 0x205C;
         Message_ContinueTextbox(play, thisx->textId);
     } else {
-        phi_v1 = NPC_TALKING_STATE_2;
+        phi_v1 = NPC_TALK_STATE_ACTION;
     }
     return phi_v1;
 }
 
 s16 func_80A79500(PlayState* play, Actor* thisx) {
-    s16 sp1E = NPC_TALKING_STATE_1;
+    s16 sp1E = NPC_TALK_STATE_TALKING;
 
     osSyncPrintf("message_check->(%d[%x])\n", Message_GetState(&play->msgCtx), thisx->textId);
     switch (Message_GetState(&play->msgCtx)) {
@@ -460,7 +460,7 @@ void func_80A79C78(EnIn* this, PlayState* play) {
     this->unk_308.unk_08 = zeroVec;
     this->unk_308.unk_0E = zeroVec;
     Message_StartTextbox(play, 0x2025, NULL);
-    this->unk_308.talkState = NPC_TALKING_STATE_1;
+    this->unk_308.talkState = NPC_TALK_STATE_TALKING;
     player->actor.world.pos = this->actor.world.pos;
     player->actor.world.pos.x += 100.0f * Math_SinS(this->actor.shape.rot.y);
     player->actor.world.pos.z += 100.0f * Math_CosS(this->actor.shape.rot.y);
@@ -519,7 +519,7 @@ void func_80A79FB0(EnIn* this, PlayState* play) {
         }
         Actor_SetScale(&this->actor, 0.01f);
         this->actor.targetMode = 6;
-        this->unk_308.talkState = NPC_TALKING_STATE_0;
+        this->unk_308.talkState = NPC_TALK_STATE_IDLE;
         this->actionFunc = func_80A7A4BC;
 
         switch (func_80A79830(this, play)) {
@@ -637,7 +637,7 @@ void func_80A7A4BC(EnIn* this, PlayState* play) {
 }
 
 void func_80A7A4C8(EnIn* this, PlayState* play) {
-    if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_308.talkState == NPC_TALK_STATE_ACTION) {
         func_80A79BAC(this, play, 1, TRANS_TYPE_CIRCLE(TCA_NORMAL, TCC_BLACK, TCS_FAST));
         SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_1);
         SET_EVENTINF_HORSES_0F(1);
@@ -645,7 +645,7 @@ void func_80A7A4C8(EnIn* this, PlayState* play) {
         Environment_ForcePlaySequence(NA_BGM_HORSE);
         play->msgCtx.stateTimer = 0;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = NPC_TALKING_STATE_0;
+        this->unk_308.talkState = NPC_TALK_STATE_IDLE;
     }
 }
 
@@ -663,12 +663,12 @@ void func_80A7A568(EnIn* this, PlayState* play) {
         func_80A79C78(this, play);
         this->actionFunc = func_80A7B024;
         gSaveContext.timer1State = 0;
-    } else if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
+    } else if (this->unk_308.talkState == NPC_TALK_STATE_ACTION) {
         if (play->msgCtx.choiceIndex == 0) {
             if (gSaveContext.rupees < 50) {
                 play->msgCtx.stateTimer = 4;
                 play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-                this->unk_308.talkState = NPC_TALKING_STATE_0;
+                this->unk_308.talkState = NPC_TALK_STATE_IDLE;
                 return;
             }
             SET_EVENTINF_HORSES_HORSETYPE(((EnHorse*)GET_PLAYER(play)->rideActor)->type);
@@ -692,20 +692,20 @@ void func_80A7A568(EnIn* this, PlayState* play) {
         play->msgCtx.stateTimer = 0;
         SET_EVENTINF_HORSES_0F(1);
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = NPC_TALKING_STATE_0;
+        this->unk_308.talkState = NPC_TALK_STATE_IDLE;
     }
 }
 
 void func_80A7A770(EnIn* this, PlayState* play) {
-    if (this->unk_308.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_308.talkState == NPC_TALK_STATE_IDLE) {
         this->actor.flags |= ACTOR_FLAG_16;
-    } else if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
+    } else if (this->unk_308.talkState == NPC_TALK_STATE_ACTION) {
         Rupees_ChangeBy(-50);
         this->actor.flags &= ~ACTOR_FLAG_16;
         EnIn_ChangeAnim(this, ENIN_ANIM_3);
         this->actionFunc = func_80A7A848;
         SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_7);
-        this->unk_308.talkState = NPC_TALKING_STATE_0;
+        this->unk_308.talkState = NPC_TALK_STATE_IDLE;
         gSaveContext.eventInf[EVENTINF_HORSES_INDEX] =
             (gSaveContext.eventInf[EVENTINF_HORSES_INDEX] & 0xFFFF) | EVENTINF_HORSES_05_MASK;
         if (!GET_EVENTINF(EVENTINF_HORSES_06)) {
@@ -716,7 +716,7 @@ void func_80A7A770(EnIn* this, PlayState* play) {
 }
 
 void func_80A7A848(EnIn* this, PlayState* play) {
-    if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_308.talkState == NPC_TALK_STATE_ACTION) {
         if ((play->msgCtx.choiceIndex == 0 && gSaveContext.rupees < 50) || play->msgCtx.choiceIndex == 1) {
             SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_0);
             this->actionFunc = func_80A7A4C8;
@@ -727,14 +727,14 @@ void func_80A7A848(EnIn* this, PlayState* play) {
             play->msgCtx.stateTimer = 0;
             play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
         }
-        this->unk_308.talkState = NPC_TALKING_STATE_0;
+        this->unk_308.talkState = NPC_TALK_STATE_IDLE;
         CLEAR_EVENTINF(EVENTINF_HORSES_05);
         CLEAR_EVENTINF(EVENTINF_HORSES_06);
     }
 }
 
 void func_80A7A940(EnIn* this, PlayState* play) {
-    if (this->unk_308.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_308.talkState == NPC_TALK_STATE_IDLE) {
         this->actor.flags |= ACTOR_FLAG_16;
         return;
     }
@@ -744,14 +744,14 @@ void func_80A7A940(EnIn* this, PlayState* play) {
             Audio_PlayActorSfx2(&this->actor, NA_SE_VO_IN_LOST);
         }
     }
-    if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_308.talkState == NPC_TALK_STATE_ACTION) {
         this->actor.flags &= ~ACTOR_FLAG_16;
         func_80A79BAC(this, play, 2, TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST));
         SET_EVENTINF_HORSES_STATE(EVENTINF_HORSES_STATE_2);
         SET_EVENTINF_HORSES_0F(1);
         play->msgCtx.stateTimer = 0;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = NPC_TALKING_STATE_0;
+        this->unk_308.talkState = NPC_TALK_STATE_IDLE;
         gSaveContext.eventInf[EVENTINF_HORSES_INDEX] =
             (gSaveContext.eventInf[EVENTINF_HORSES_INDEX] & 0xFFFF) | EVENTINF_HORSES_06_MASK;
     }
@@ -788,7 +788,7 @@ void func_80A7AA40(EnIn* this, PlayState* play) {
     Play_CameraSetAtEye(play, this->subCamId, &subCamAt, &subCamEye);
     this->actor.textId = 0x203B;
     Message_StartTextbox(play, this->actor.textId, NULL);
-    this->unk_308.talkState = NPC_TALKING_STATE_1;
+    this->unk_308.talkState = NPC_TALK_STATE_TALKING;
     this->unk_1FC = 0;
     play->csCtx.frames = 0;
     Letterbox_SetSizeTarget(32);
@@ -813,16 +813,16 @@ void func_80A7ABD4(EnIn* this, PlayState* play) {
             }
         }
     }
-    if (this->unk_308.talkState != NPC_TALKING_STATE_0) {
-        if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_308.talkState != NPC_TALK_STATE_IDLE) {
+        if (this->unk_308.talkState == NPC_TALK_STATE_ACTION) {
             if (this->actor.textId == 0x203B) {
                 this->actor.textId = 0x203C;
                 Message_StartTextbox(play, this->actor.textId, NULL);
-                this->unk_308.talkState = NPC_TALKING_STATE_1;
+                this->unk_308.talkState = NPC_TALK_STATE_TALKING;
                 EnIn_ChangeAnim(this, ENIN_ANIM_3);
             } else {
                 play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-                this->unk_308.talkState = NPC_TALKING_STATE_0;
+                this->unk_308.talkState = NPC_TALK_STATE_IDLE;
             }
         }
     } else {
@@ -874,10 +874,10 @@ void func_80A7AEF0(EnIn* this, PlayState* play) {
         play->transitionTrigger = TRANS_TRIGGER_START;
         play->transitionType = TRANS_TYPE_FADE_WHITE_FAST;
         this->actionFunc = func_80A7B018;
-    } else if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
+    } else if (this->unk_308.talkState == NPC_TALK_STATE_ACTION) {
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = NPC_TALKING_STATE_0;
+        this->unk_308.talkState = NPC_TALK_STATE_IDLE;
     }
 }
 
@@ -891,7 +891,7 @@ void func_80A7B024(EnIn* this, PlayState* play) {
         player->rideActor->freezeTimer = 10;
     }
     player->actor.freezeTimer = 10;
-    if (this->unk_308.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_308.talkState == NPC_TALK_STATE_ACTION) {
         if (1) {}
         if (!GET_EVENTCHKINF(EVENTCHKINF_1B) && GET_INFTABLE(INFTABLE_AB)) {
             SET_EVENTCHKINF(EVENTCHKINF_1B);
@@ -902,7 +902,7 @@ void func_80A7B024(EnIn* this, PlayState* play) {
         SET_EVENTINF_HORSES_0F(1);
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-        this->unk_308.talkState = NPC_TALKING_STATE_0;
+        this->unk_308.talkState = NPC_TALK_STATE_IDLE;
     }
 }
 
@@ -930,13 +930,13 @@ void EnIn_Update(Actor* thisx, PlayState* play) {
     if (this->actionFunc != func_80A7A304) {
         func_80A79AB4(this, play);
         if (gSaveContext.timer2Value < 6 && gSaveContext.timer2State != 0 &&
-            this->unk_308.talkState == NPC_TALKING_STATE_0) {
+            this->unk_308.talkState == NPC_TALK_STATE_IDLE) {
             if (Actor_ProcessTalkRequest(&this->actor, play)) {}
         } else {
             Actor_NpcUpdateTalking(play, &this->actor, &this->unk_308.talkState,
                                    ((this->actor.targetMode == 6) ? 80.0f : 320.0f) + this->collider.dim.radius,
                                    func_80A79168, func_80A79500);
-            if (this->unk_308.talkState != NPC_TALKING_STATE_0) {
+            if (this->unk_308.talkState != NPC_TALK_STATE_IDLE) {
                 this->unk_1FA = this->unk_1F8;
                 this->unk_1F8 = Message_GetState(&play->msgCtx);
             }

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -932,9 +932,9 @@ void EnIn_Update(Actor* thisx, PlayState* play) {
         if (gSaveContext.timer2Value < 6 && gSaveContext.timer2State != 0 && this->unk_308.talkState == 0) {
             if (Actor_ProcessTalkRequest(&this->actor, play)) {}
         } else {
-            func_800343CC(play, &this->actor, &this->unk_308.talkState,
-                          ((this->actor.targetMode == 6) ? 80.0f : 320.0f) + this->collider.dim.radius, func_80A79168,
-                          func_80A79500);
+            Actor_NpcUpdateTalking(play, &this->actor, &this->unk_308.talkState,
+                                   ((this->actor.targetMode == 6) ? 80.0f : 320.0f) + this->collider.dim.radius,
+                                   func_80A79168, func_80A79500);
             if (this->unk_308.talkState != 0) {
                 this->unk_1FA = this->unk_1F8;
                 this->unk_1F8 = Message_GetState(&play->msgCtx);

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -530,9 +530,9 @@ s16 func_80A97738(PlayState* play, Actor* thisx) {
                     SET_INFTABLE(INFTABLE_B7);
                     break;
                 case 0x10BA:
-                    return NPC_TALKING_STATE_1;
+                    return NPC_TALK_STATE_TALKING;
             }
-            return NPC_TALKING_STATE_0;
+            return NPC_TALK_STATE_IDLE;
         case TEXT_STATE_DONE_FADING:
             switch (this->actor.textId) {
                 case 0x10B7:
@@ -543,7 +543,7 @@ s16 func_80A97738(PlayState* play, Actor* thisx) {
                         this->unk_210 = 1;
                     }
             }
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
         case TEXT_STATE_CHOICE:
             if (Message_ShouldAdvance(play)) {
                 switch (this->actor.textId) {
@@ -566,17 +566,17 @@ s16 func_80A97738(PlayState* play, Actor* thisx) {
                         FALLTHROUGH;
                     case 0x10B8:
                         this->actor.textId = (play->msgCtx.choiceIndex == 0) ? 0x10BA : 0x10B9;
-                        return (play->msgCtx.choiceIndex == 0) ? NPC_TALKING_STATE_2 : NPC_TALKING_STATE_1;
+                        return (play->msgCtx.choiceIndex == 0) ? NPC_TALK_STATE_ACTION : NPC_TALK_STATE_TALKING;
                 }
-                return NPC_TALKING_STATE_1;
+                return NPC_TALK_STATE_TALKING;
             }
             break;
         case TEXT_STATE_DONE:
             if (Message_ShouldAdvance(play)) {
-                return NPC_TALKING_STATE_3;
+                return NPC_TALK_STATE_ITEM_GIVEN;
             }
     }
-    return NPC_TALKING_STATE_1;
+    return NPC_TALK_STATE_TALKING;
 }
 
 s32 EnKo_GetForestQuestState(EnKo* this) {
@@ -663,7 +663,7 @@ s32 EnKo_IsWithinTalkAngle(EnKo* this) {
 s32 func_80A97D68(EnKo* this, PlayState* play) {
     s16 arg3;
 
-    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E8.talkState != NPC_TALK_STATE_IDLE) {
         if ((this->skelAnime.animation == &gObjOsAnim_6A60) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_32);
         }
@@ -687,7 +687,7 @@ s32 func_80A97E18(EnKo* this, PlayState* play) {
     } else {
         arg3 = 1;
     }
-    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E8.talkState != NPC_TALK_STATE_IDLE) {
         arg3 = 4;
     } else if (this->lookDist < this->actor.xzDistToPlayer) {
         arg3 = 1;
@@ -716,7 +716,7 @@ s32 func_80A97F20(EnKo* this, PlayState* play) {
 s32 func_80A97F70(EnKo* this, PlayState* play) {
     s16 arg3;
 
-    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E8.talkState != NPC_TALK_STATE_IDLE) {
         if ((this->skelAnime.animation == &gObjOsAnim_8F6C) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_29);
         }
@@ -736,7 +736,7 @@ s32 func_80A98034(EnKo* this, PlayState* play) {
     s16 arg3;
     s32 result;
 
-    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E8.talkState != NPC_TALK_STATE_IDLE) {
         if ((this->skelAnime.animation == &gObjOsAnim_8F6C) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_29);
         }
@@ -762,7 +762,7 @@ s32 func_80A98124(EnKo* this, PlayState* play) {
 }
 
 s32 func_80A98174(EnKo* this, PlayState* play) {
-    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E8.talkState != NPC_TALK_STATE_IDLE) {
         if (Animation_OnFrame(&this->skelAnime, 18.0f)) {
             this->skelAnime.playSpeed = 0.0f;
         }
@@ -942,7 +942,7 @@ void func_80A9877C(EnKo* this, PlayState* play) {
     } else {
         this->unk_1E8.unk_18 = player->actor.world.pos;
         this->unk_1E8.unk_14 = func_80A97BC0(this);
-        if ((func_80A98ECC(this, play) == 0) && (this->unk_1E8.talkState == NPC_TALKING_STATE_0)) {
+        if ((func_80A98ECC(this, play) == 0) && (this->unk_1E8.talkState == NPC_TALK_STATE_IDLE)) {
             return;
         }
     }
@@ -1172,11 +1172,11 @@ void func_80A99048(EnKo* this, PlayState* play) {
 }
 
 void func_80A99384(EnKo* this, PlayState* play) {
-    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState != NPC_TALKING_STATE_0 &&
+    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState != NPC_TALK_STATE_IDLE &&
         this->actor.textId == 0x10B9) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_7);
         this->actionFunc = func_80A99438;
-    } else if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == NPC_TALKING_STATE_2) {
+    } else if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == NPC_TALK_STATE_ACTION) {
         this->actionFunc = func_80A99504;
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -1184,12 +1184,12 @@ void func_80A99384(EnKo* this, PlayState* play) {
 }
 
 void func_80A99438(EnKo* this, PlayState* play) {
-    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == NPC_TALKING_STATE_2) {
+    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == NPC_TALK_STATE_ACTION) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_6);
         this->actionFunc = func_80A99504;
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-    } else if (this->unk_1E8.talkState == NPC_TALKING_STATE_0 || this->actor.textId != 0x10B9) {
+    } else if (this->unk_1E8.talkState == NPC_TALK_STATE_IDLE || this->actor.textId != 0x10B9) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_6);
         this->actionFunc = func_80A99384;
     }
@@ -1205,10 +1205,10 @@ void func_80A99504(EnKo* this, PlayState* play) {
 }
 
 void func_80A99560(EnKo* this, PlayState* play) {
-    if (this->unk_1E8.talkState == NPC_TALKING_STATE_3) {
+    if (this->unk_1E8.talkState == NPC_TALK_STATE_ITEM_GIVEN) {
         this->actor.textId = 0x10B9;
         Message_ContinueTextbox(play, this->actor.textId);
-        this->unk_1E8.talkState = NPC_TALKING_STATE_1;
+        this->unk_1E8.talkState = NPC_TALK_STATE_TALKING;
         SET_ITEMGETINF(ITEMGETINF_31);
         this->actionFunc = func_80A99384;
     }
@@ -1226,7 +1226,7 @@ void func_80A995CC(EnKo* this, PlayState* play) {
     this->actor.world.pos.z += 80.0f * Math_CosS(homeYawToPlayer);
     this->actor.shape.rot.y = this->actor.world.rot.y = this->actor.yawTowardsPlayer;
 
-    if (this->unk_1E8.talkState == NPC_TALKING_STATE_0 || !this->actor.isTargeted) {
+    if (this->unk_1E8.talkState == NPC_TALK_STATE_IDLE || !this->actor.isTargeted) {
         temp_f2 = fabsf((f32)this->actor.yawTowardsPlayer - homeYawToPlayer) * 0.001f * 3.0f;
         if (temp_f2 < 1.0f) {
             this->skelAnime.playSpeed = 1.0f;
@@ -1254,7 +1254,7 @@ void EnKo_Update(Actor* thisx, PlayState* play) {
             func_80A98DB4(this, play);
         }
     }
-    if (this->unk_1E8.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_1E8.talkState == NPC_TALK_STATE_IDLE) {
         Actor_MoveForward(&this->actor);
     }
     if (func_80A97C7C(this)) {

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -663,7 +663,7 @@ s32 EnKo_IsWithinTalkAngle(EnKo* this) {
 s32 func_80A97D68(EnKo* this, PlayState* play) {
     s16 arg3;
 
-    if (this->unk_1E8.unk_00 != 0) {
+    if (this->unk_1E8.talkState != 0) {
         if ((this->skelAnime.animation == &gObjOsAnim_6A60) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_32);
         }
@@ -687,7 +687,7 @@ s32 func_80A97E18(EnKo* this, PlayState* play) {
     } else {
         arg3 = 1;
     }
-    if (this->unk_1E8.unk_00 != 0) {
+    if (this->unk_1E8.talkState != 0) {
         arg3 = 4;
     } else if (this->lookDist < this->actor.xzDistToPlayer) {
         arg3 = 1;
@@ -716,7 +716,7 @@ s32 func_80A97F20(EnKo* this, PlayState* play) {
 s32 func_80A97F70(EnKo* this, PlayState* play) {
     s16 arg3;
 
-    if (this->unk_1E8.unk_00 != 0) {
+    if (this->unk_1E8.talkState != 0) {
         if ((this->skelAnime.animation == &gObjOsAnim_8F6C) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_29);
         }
@@ -736,7 +736,7 @@ s32 func_80A98034(EnKo* this, PlayState* play) {
     s16 arg3;
     s32 result;
 
-    if (this->unk_1E8.unk_00 != 0) {
+    if (this->unk_1E8.talkState != 0) {
         if ((this->skelAnime.animation == &gObjOsAnim_8F6C) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_29);
         }
@@ -762,7 +762,7 @@ s32 func_80A98124(EnKo* this, PlayState* play) {
 }
 
 s32 func_80A98174(EnKo* this, PlayState* play) {
-    if (this->unk_1E8.unk_00 != 0) {
+    if (this->unk_1E8.talkState != 0) {
         if (Animation_OnFrame(&this->skelAnime, 18.0f)) {
             this->skelAnime.playSpeed = 0.0f;
         }
@@ -942,11 +942,11 @@ void func_80A9877C(EnKo* this, PlayState* play) {
     } else {
         this->unk_1E8.unk_18 = player->actor.world.pos;
         this->unk_1E8.unk_14 = func_80A97BC0(this);
-        if ((func_80A98ECC(this, play) == 0) && (this->unk_1E8.unk_00 == 0)) {
+        if ((func_80A98ECC(this, play) == 0) && (this->unk_1E8.talkState == 0)) {
             return;
         }
     }
-    if (func_800343CC(play, &this->actor, &this->unk_1E8.unk_00, this->lookDist, func_80A97610, func_80A97738) &&
+    if (func_800343CC(play, &this->actor, &this->unk_1E8.talkState, this->lookDist, func_80A97610, func_80A97738) &&
         ENKO_TYPE == ENKO_TYPE_CHILD_FADO && play->sceneId == SCENE_SPOT10) {
         this->actor.textId = INV_CONTENT(ITEM_TRADE_ADULT) > ITEM_ODD_POTION ? 0x10B9 : 0x10DF;
 
@@ -1171,10 +1171,10 @@ void func_80A99048(EnKo* this, PlayState* play) {
 }
 
 void func_80A99384(EnKo* this, PlayState* play) {
-    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.unk_00 != 0 && this->actor.textId == 0x10B9) {
+    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState != 0 && this->actor.textId == 0x10B9) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_7);
         this->actionFunc = func_80A99438;
-    } else if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.unk_00 == 2) {
+    } else if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == 2) {
         this->actionFunc = func_80A99504;
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -1182,12 +1182,12 @@ void func_80A99384(EnKo* this, PlayState* play) {
 }
 
 void func_80A99438(EnKo* this, PlayState* play) {
-    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.unk_00 == 2) {
+    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == 2) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_6);
         this->actionFunc = func_80A99504;
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-    } else if (this->unk_1E8.unk_00 == 0 || this->actor.textId != 0x10B9) {
+    } else if (this->unk_1E8.talkState == 0 || this->actor.textId != 0x10B9) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_6);
         this->actionFunc = func_80A99384;
     }
@@ -1203,10 +1203,10 @@ void func_80A99504(EnKo* this, PlayState* play) {
 }
 
 void func_80A99560(EnKo* this, PlayState* play) {
-    if (this->unk_1E8.unk_00 == 3) {
+    if (this->unk_1E8.talkState == 3) {
         this->actor.textId = 0x10B9;
         Message_ContinueTextbox(play, this->actor.textId);
-        this->unk_1E8.unk_00 = 1;
+        this->unk_1E8.talkState = 1;
         SET_ITEMGETINF(ITEMGETINF_31);
         this->actionFunc = func_80A99384;
     }
@@ -1224,7 +1224,7 @@ void func_80A995CC(EnKo* this, PlayState* play) {
     this->actor.world.pos.z += 80.0f * Math_CosS(homeYawToPlayer);
     this->actor.shape.rot.y = this->actor.world.rot.y = this->actor.yawTowardsPlayer;
 
-    if (this->unk_1E8.unk_00 == 0 || !this->actor.isTargeted) {
+    if (this->unk_1E8.talkState == 0 || !this->actor.isTargeted) {
         temp_f2 = fabsf((f32)this->actor.yawTowardsPlayer - homeYawToPlayer) * 0.001f * 3.0f;
         if (temp_f2 < 1.0f) {
             this->skelAnime.playSpeed = 1.0f;
@@ -1252,7 +1252,7 @@ void EnKo_Update(Actor* thisx, PlayState* play) {
             func_80A98DB4(this, play);
         }
     }
-    if (this->unk_1E8.unk_00 == 0) {
+    if (this->unk_1E8.talkState == 0) {
         Actor_MoveForward(&this->actor);
     }
     if (func_80A97C7C(this)) {

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -530,9 +530,9 @@ s16 func_80A97738(PlayState* play, Actor* thisx) {
                     SET_INFTABLE(INFTABLE_B7);
                     break;
                 case 0x10BA:
-                    return 1;
+                    return NPC_TALKING_STATE_1;
             }
-            return 0;
+            return NPC_TALKING_STATE_0;
         case TEXT_STATE_DONE_FADING:
             switch (this->actor.textId) {
                 case 0x10B7:
@@ -543,7 +543,7 @@ s16 func_80A97738(PlayState* play, Actor* thisx) {
                         this->unk_210 = 1;
                     }
             }
-            return 1;
+            return NPC_TALKING_STATE_1;
         case TEXT_STATE_CHOICE:
             if (Message_ShouldAdvance(play)) {
                 switch (this->actor.textId) {
@@ -566,17 +566,17 @@ s16 func_80A97738(PlayState* play, Actor* thisx) {
                         FALLTHROUGH;
                     case 0x10B8:
                         this->actor.textId = (play->msgCtx.choiceIndex == 0) ? 0x10BA : 0x10B9;
-                        return (play->msgCtx.choiceIndex == 0) ? 2 : 1;
+                        return (play->msgCtx.choiceIndex == 0) ? NPC_TALKING_STATE_2 : NPC_TALKING_STATE_1;
                 }
-                return 1;
+                return NPC_TALKING_STATE_1;
             }
             break;
         case TEXT_STATE_DONE:
             if (Message_ShouldAdvance(play)) {
-                return 3;
+                return NPC_TALKING_STATE_3;
             }
     }
-    return 1;
+    return NPC_TALKING_STATE_1;
 }
 
 s32 EnKo_GetForestQuestState(EnKo* this) {
@@ -663,7 +663,7 @@ s32 EnKo_IsWithinTalkAngle(EnKo* this) {
 s32 func_80A97D68(EnKo* this, PlayState* play) {
     s16 arg3;
 
-    if (this->unk_1E8.talkState != 0) {
+    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
         if ((this->skelAnime.animation == &gObjOsAnim_6A60) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_32);
         }
@@ -687,7 +687,7 @@ s32 func_80A97E18(EnKo* this, PlayState* play) {
     } else {
         arg3 = 1;
     }
-    if (this->unk_1E8.talkState != 0) {
+    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
         arg3 = 4;
     } else if (this->lookDist < this->actor.xzDistToPlayer) {
         arg3 = 1;
@@ -716,7 +716,7 @@ s32 func_80A97F20(EnKo* this, PlayState* play) {
 s32 func_80A97F70(EnKo* this, PlayState* play) {
     s16 arg3;
 
-    if (this->unk_1E8.talkState != 0) {
+    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
         if ((this->skelAnime.animation == &gObjOsAnim_8F6C) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_29);
         }
@@ -736,7 +736,7 @@ s32 func_80A98034(EnKo* this, PlayState* play) {
     s16 arg3;
     s32 result;
 
-    if (this->unk_1E8.talkState != 0) {
+    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
         if ((this->skelAnime.animation == &gObjOsAnim_8F6C) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_29);
         }
@@ -762,7 +762,7 @@ s32 func_80A98124(EnKo* this, PlayState* play) {
 }
 
 s32 func_80A98174(EnKo* this, PlayState* play) {
-    if (this->unk_1E8.talkState != 0) {
+    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
         if (Animation_OnFrame(&this->skelAnime, 18.0f)) {
             this->skelAnime.playSpeed = 0.0f;
         }
@@ -942,7 +942,7 @@ void func_80A9877C(EnKo* this, PlayState* play) {
     } else {
         this->unk_1E8.unk_18 = player->actor.world.pos;
         this->unk_1E8.unk_14 = func_80A97BC0(this);
-        if ((func_80A98ECC(this, play) == 0) && (this->unk_1E8.talkState == 0)) {
+        if ((func_80A98ECC(this, play) == 0) && (this->unk_1E8.talkState == NPC_TALKING_STATE_0)) {
             return;
         }
     }
@@ -1172,10 +1172,11 @@ void func_80A99048(EnKo* this, PlayState* play) {
 }
 
 void func_80A99384(EnKo* this, PlayState* play) {
-    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState != 0 && this->actor.textId == 0x10B9) {
+    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState != NPC_TALKING_STATE_0 &&
+        this->actor.textId == 0x10B9) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_7);
         this->actionFunc = func_80A99438;
-    } else if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == 2) {
+    } else if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == NPC_TALKING_STATE_2) {
         this->actionFunc = func_80A99504;
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -1183,12 +1184,12 @@ void func_80A99384(EnKo* this, PlayState* play) {
 }
 
 void func_80A99438(EnKo* this, PlayState* play) {
-    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == 2) {
+    if (ENKO_TYPE == ENKO_TYPE_CHILD_FADO && this->unk_1E8.talkState == NPC_TALKING_STATE_2) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_6);
         this->actionFunc = func_80A99504;
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
-    } else if (this->unk_1E8.talkState == 0 || this->actor.textId != 0x10B9) {
+    } else if (this->unk_1E8.talkState == NPC_TALKING_STATE_0 || this->actor.textId != 0x10B9) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_6);
         this->actionFunc = func_80A99384;
     }
@@ -1204,10 +1205,10 @@ void func_80A99504(EnKo* this, PlayState* play) {
 }
 
 void func_80A99560(EnKo* this, PlayState* play) {
-    if (this->unk_1E8.talkState == 3) {
+    if (this->unk_1E8.talkState == NPC_TALKING_STATE_3) {
         this->actor.textId = 0x10B9;
         Message_ContinueTextbox(play, this->actor.textId);
-        this->unk_1E8.talkState = 1;
+        this->unk_1E8.talkState = NPC_TALKING_STATE_1;
         SET_ITEMGETINF(ITEMGETINF_31);
         this->actionFunc = func_80A99384;
     }
@@ -1225,7 +1226,7 @@ void func_80A995CC(EnKo* this, PlayState* play) {
     this->actor.world.pos.z += 80.0f * Math_CosS(homeYawToPlayer);
     this->actor.shape.rot.y = this->actor.world.rot.y = this->actor.yawTowardsPlayer;
 
-    if (this->unk_1E8.talkState == 0 || !this->actor.isTargeted) {
+    if (this->unk_1E8.talkState == NPC_TALKING_STATE_0 || !this->actor.isTargeted) {
         temp_f2 = fabsf((f32)this->actor.yawTowardsPlayer - homeYawToPlayer) * 0.001f * 3.0f;
         if (temp_f2 < 1.0f) {
             this->skelAnime.playSpeed = 1.0f;
@@ -1253,7 +1254,7 @@ void EnKo_Update(Actor* thisx, PlayState* play) {
             func_80A98DB4(this, play);
         }
     }
-    if (this->unk_1E8.talkState == 0) {
+    if (this->unk_1E8.talkState == NPC_TALKING_STATE_0) {
         Actor_MoveForward(&this->actor);
     }
     if (func_80A97C7C(this)) {

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -946,7 +946,8 @@ void func_80A9877C(EnKo* this, PlayState* play) {
             return;
         }
     }
-    if (func_800343CC(play, &this->actor, &this->unk_1E8.talkState, this->lookDist, func_80A97610, func_80A97738) &&
+    if (Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E8.talkState, this->lookDist, func_80A97610,
+                               func_80A97738) &&
         ENKO_TYPE == ENKO_TYPE_CHILD_FADO && play->sceneId == SCENE_SPOT10) {
         this->actor.textId = INV_CONTENT(ITEM_TRADE_ADULT) > ITEM_ODD_POTION ? 0x10B9 : 0x10DF;
 

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -117,15 +117,15 @@ u16 EnKz_GetText(PlayState* play, Actor* thisx) {
 
 s16 func_80A9C6C0(PlayState* play, Actor* thisx) {
     EnKz* this = (EnKz*)thisx;
-    s16 ret = 1;
+    s16 ret = NPC_TALKING_STATE_1;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_DONE:
-            ret = 0;
+            ret = NPC_TALKING_STATE_0;
             switch (this->actor.textId) {
                 case 0x4012:
                     SET_INFTABLE(INFTABLE_139);
-                    ret = 2;
+                    ret = NPC_TALKING_STATE_2;
                     break;
                 case 0x401B:
                     ret = !Message_ShouldAdvance(play) ? 1 : 2;
@@ -155,7 +155,7 @@ s16 func_80A9C6C0(PlayState* play, Actor* thisx) {
             if (this->actor.textId == 0x4014) {
                 if (play->msgCtx.choiceIndex == 0) {
                     EnKz_SetupGetItem(this, play);
-                    ret = 2;
+                    ret = NPC_TALKING_STATE_2;
                 } else {
                     this->actor.textId = 0x4016;
                     Message_ContinueTextbox(play, this->actor.textId);
@@ -164,7 +164,7 @@ s16 func_80A9C6C0(PlayState* play, Actor* thisx) {
             break;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
-                ret = 2;
+                ret = NPC_TALKING_STATE_2;
             }
             break;
         case TEXT_STATE_NONE:
@@ -327,7 +327,7 @@ void EnKz_Init(Actor* thisx, PlayState* play) {
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
     Actor_SetScale(&this->actor, 0.01);
     this->actor.targetMode = 3;
-    this->unk_1E0.talkState = 0;
+    this->unk_1E0.talkState = NPC_TALKING_STATE_0;
     Animation_ChangeByInfo(&this->skelanime, sAnimationInfo, ENKZ_ANIM_0);
 
     if (GET_EVENTCHKINF(EVENTCHKINF_33)) {
@@ -352,9 +352,9 @@ void EnKz_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnKz_PreMweepWait(EnKz* this, PlayState* play) {
-    if (this->unk_1E0.talkState == 2) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
         Animation_ChangeByInfo(&this->skelanime, sAnimationInfo, ENKZ_ANIM_2);
-        this->unk_1E0.talkState = 0;
+        this->unk_1E0.talkState = NPC_TALKING_STATE_0;
         this->actionFunc = EnKz_SetupMweep;
     } else {
         func_80034F54(play, this->unk_2A6, this->unk_2BE, 12);
@@ -413,7 +413,7 @@ void EnKz_StopMweep(EnKz* this, PlayState* play) {
 }
 
 void EnKz_Wait(EnKz* this, PlayState* play) {
-    if (this->unk_1E0.talkState == 2) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
         this->actionFunc = EnKz_SetupGetItem;
         EnKz_SetupGetItem(this, play);
     } else {
@@ -428,7 +428,7 @@ void EnKz_SetupGetItem(EnKz* this, PlayState* play) {
 
     if (Actor_HasParent(&this->actor, play)) {
         this->actor.parent = NULL;
-        this->unk_1E0.talkState = 1;
+        this->unk_1E0.talkState = NPC_TALKING_STATE_1;
         this->actionFunc = EnKz_StartTimer;
     } else {
         getItemId = this->isTrading == true ? GI_FROG : GI_TUNIC_ZORA;
@@ -444,7 +444,7 @@ void EnKz_StartTimer(EnKz* this, PlayState* play) {
             func_80088AA0(180); // start timer2 with 3 minutes
             CLEAR_EVENTINF(EVENTINF_10);
         }
-        this->unk_1E0.talkState = 0;
+        this->unk_1E0.talkState = NPC_TALKING_STATE_0;
         this->actionFunc = EnKz_Wait;
     }
 }

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -188,8 +188,8 @@ void EnKz_UpdateEyes(EnKz* this) {
     }
 }
 
-s32 func_80A9C95C(PlayState* play, EnKz* this, s16* arg2, f32 unkf, callback1_800343CC callback1,
-                  callback2_800343CC callback2) {
+s32 func_80A9C95C(PlayState* play, EnKz* this, s16* arg2, f32 unkf, ActorNpcGetTextIdFunc callback1,
+                  ActorNpcGettalkStateFunc callback2) {
     Player* player = GET_PLAYER(play);
     s16 sp32;
     s16 sp30;
@@ -235,7 +235,7 @@ s32 func_80A9C95C(PlayState* play, EnKz* this, s16* arg2, f32 unkf, callback1_80
 void func_80A9CB18(EnKz* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (func_80A9C95C(play, this, &this->unk_1E0.unk_00, 340.0f, EnKz_GetText, func_80A9C6C0)) {
+    if (func_80A9C95C(play, this, &this->unk_1E0.talkState, 340.0f, EnKz_GetText, func_80A9C6C0)) {
         if ((this->actor.textId == 0x401A) && !GET_EVENTCHKINF(EVENTCHKINF_33)) {
             if (func_8002F368(play) == EXCH_ITEM_LETTER_RUTO) {
                 this->actor.textId = 0x401B;
@@ -327,7 +327,7 @@ void EnKz_Init(Actor* thisx, PlayState* play) {
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
     Actor_SetScale(&this->actor, 0.01);
     this->actor.targetMode = 3;
-    this->unk_1E0.unk_00 = 0;
+    this->unk_1E0.talkState = 0;
     Animation_ChangeByInfo(&this->skelanime, sAnimationInfo, ENKZ_ANIM_0);
 
     if (GET_EVENTCHKINF(EVENTCHKINF_33)) {
@@ -352,9 +352,9 @@ void EnKz_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnKz_PreMweepWait(EnKz* this, PlayState* play) {
-    if (this->unk_1E0.unk_00 == 2) {
+    if (this->unk_1E0.talkState == 2) {
         Animation_ChangeByInfo(&this->skelanime, sAnimationInfo, ENKZ_ANIM_2);
-        this->unk_1E0.unk_00 = 0;
+        this->unk_1E0.talkState = 0;
         this->actionFunc = EnKz_SetupMweep;
     } else {
         func_80034F54(play, this->unk_2A6, this->unk_2BE, 12);
@@ -413,7 +413,7 @@ void EnKz_StopMweep(EnKz* this, PlayState* play) {
 }
 
 void EnKz_Wait(EnKz* this, PlayState* play) {
-    if (this->unk_1E0.unk_00 == 2) {
+    if (this->unk_1E0.talkState == 2) {
         this->actionFunc = EnKz_SetupGetItem;
         EnKz_SetupGetItem(this, play);
     } else {
@@ -428,7 +428,7 @@ void EnKz_SetupGetItem(EnKz* this, PlayState* play) {
 
     if (Actor_HasParent(&this->actor, play)) {
         this->actor.parent = NULL;
-        this->unk_1E0.unk_00 = 1;
+        this->unk_1E0.talkState = 1;
         this->actionFunc = EnKz_StartTimer;
     } else {
         getItemId = this->isTrading == true ? GI_FROG : GI_TUNIC_ZORA;
@@ -444,7 +444,7 @@ void EnKz_StartTimer(EnKz* this, PlayState* play) {
             func_80088AA0(180); // start timer2 with 3 minutes
             CLEAR_EVENTINF(EVENTINF_10);
         }
-        this->unk_1E0.unk_00 = 0;
+        this->unk_1E0.talkState = 0;
         this->actionFunc = EnKz_Wait;
     }
 }

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -188,8 +188,8 @@ void EnKz_UpdateEyes(EnKz* this) {
     }
 }
 
-s32 func_80A9C95C(PlayState* play, EnKz* this, s16* arg2, f32 unkf, ActorNpcGetTextIdFunc callback1,
-                  ActorNpcGettalkStateFunc callback2) {
+s32 func_80A9C95C(PlayState* play, EnKz* this, s16* talkState, f32 unkf, ActorNpcGetTextIdFunc getTextId,
+                  ActorNpcGetTalkStateFunc getTalkState) {
     Player* player = GET_PLAYER(play);
     s16 sp32;
     s16 sp30;
@@ -197,12 +197,12 @@ s32 func_80A9C95C(PlayState* play, EnKz* this, s16* arg2, f32 unkf, ActorNpcGetT
     f32 yaw;
 
     if (Actor_ProcessTalkRequest(&this->actor, play)) {
-        *arg2 = 1;
+        *talkState = 1;
         return 1;
     }
 
-    if (*arg2 != 0) {
-        *arg2 = callback2(play, &this->actor);
+    if (*talkState != 0) {
+        *talkState = getTalkState(play, &this->actor);
         return 0;
     }
 
@@ -227,7 +227,7 @@ s32 func_80A9C95C(PlayState* play, EnKz* this, s16* arg2, f32 unkf, ActorNpcGetT
         return 0;
     }
     this->actor.xzDistToPlayer = xzDistToPlayer;
-    this->actor.textId = callback1(play, &this->actor);
+    this->actor.textId = getTextId(play, &this->actor);
 
     return 0;
 }

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -124,7 +124,7 @@ u16 EnMa1_GetText(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80AA0778(PlayState* play, Actor* thisx) {
-    s16 ret = NPC_TALKING_STATE_1;
+    s16 ret = NPC_TALK_STATE_TALKING;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_CLOSING:
@@ -132,40 +132,40 @@ s16 func_80AA0778(PlayState* play, Actor* thisx) {
                 case 0x2041:
                     SET_INFTABLE(INFTABLE_84);
                     SET_EVENTCHKINF(EVENTCHKINF_10);
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x2043:
-                    ret = NPC_TALKING_STATE_1;
+                    ret = NPC_TALK_STATE_TALKING;
                     break;
                 case 0x2047:
                     SET_EVENTCHKINF(EVENTCHKINF_15);
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x2048:
                     SET_INFTABLE(INFTABLE_85);
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x2049:
                     SET_EVENTCHKINF(EVENTCHKINF_16);
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x2061:
-                    ret = NPC_TALKING_STATE_2;
+                    ret = NPC_TALK_STATE_ACTION;
                     break;
                 default:
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
             }
             break;
         case TEXT_STATE_CHOICE:
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
-                ret = NPC_TALKING_STATE_2;
+                ret = NPC_TALK_STATE_ACTION;
             }
             break;
         case TEXT_STATE_DONE:
             if (Message_ShouldAdvance(play)) {
-                ret = NPC_TALKING_STATE_3;
+                ret = NPC_TALK_STATE_ITEM_GIVEN;
             }
             break;
         case TEXT_STATE_NONE:
@@ -174,7 +174,7 @@ s16 func_80AA0778(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            ret = NPC_TALKING_STATE_1;
+            ret = NPC_TALK_STATE_TALKING;
             break;
     }
     return ret;
@@ -232,7 +232,7 @@ void func_80AA0AF4(EnMa1* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3;
 
-    if ((this->unk_1E8.talkState == NPC_TALKING_STATE_0) && (this->skelAnime.animation == &gMalonChildSingAnim)) {
+    if ((this->unk_1E8.talkState == NPC_TALK_STATE_IDLE) && (this->skelAnime.animation == &gMalonChildSingAnim)) {
         phi_a3 = 1;
     } else {
         phi_a3 = 0;
@@ -246,7 +246,7 @@ void func_80AA0AF4(EnMa1* this, PlayState* play) {
 
 void func_80AA0B74(EnMa1* this) {
     if (this->skelAnime.animation == &gMalonChildSingAnim) {
-        if (this->unk_1E8.talkState == NPC_TALKING_STATE_0) {
+        if (this->unk_1E8.talkState == NPC_TALK_STATE_IDLE) {
             if (this->isNotSinging) {
                 // Turn on singing
                 this->isNotSinging = false;
@@ -280,7 +280,7 @@ void EnMa1_Init(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.targetMode = 6;
-    this->unk_1E8.talkState = NPC_TALKING_STATE_0;
+    this->unk_1E8.talkState = NPC_TALK_STATE_IDLE;
 
     if (!GET_EVENTCHKINF(EVENTCHKINF_TALON_RETURNED_FROM_CASTLE) || CHECK_QUEST_ITEM(QUEST_SONG_EPONA)) {
         this->actionFunc = func_80AA0D88;
@@ -299,7 +299,7 @@ void EnMa1_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AA0D88(EnMa1* this, PlayState* play) {
-    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E8.talkState != NPC_TALK_STATE_IDLE) {
         if (this->skelAnime.animation != &gMalonChildIdleAnim) {
             EnMa1_ChangeAnim(this, ENMA1_ANIM_1);
         }
@@ -312,7 +312,7 @@ void func_80AA0D88(EnMa1* this, PlayState* play) {
     if ((play->sceneId == SCENE_SPOT15) && GET_EVENTCHKINF(EVENTCHKINF_TALON_RETURNED_FROM_CASTLE)) {
         Actor_Kill(&this->actor);
     } else if (!GET_EVENTCHKINF(EVENTCHKINF_TALON_RETURNED_FROM_CASTLE) || CHECK_QUEST_ITEM(QUEST_SONG_EPONA)) {
-        if (this->unk_1E8.talkState == NPC_TALKING_STATE_2) {
+        if (this->unk_1E8.talkState == NPC_TALK_STATE_ACTION) {
             this->actionFunc = func_80AA0EA0;
             play->msgCtx.stateTimer = 4;
             play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -330,8 +330,8 @@ void func_80AA0EA0(EnMa1* this, PlayState* play) {
 }
 
 void func_80AA0EFC(EnMa1* this, PlayState* play) {
-    if (this->unk_1E8.talkState == NPC_TALKING_STATE_3) {
-        this->unk_1E8.talkState = NPC_TALKING_STATE_0;
+    if (this->unk_1E8.talkState == NPC_TALK_STATE_ITEM_GIVEN) {
+        this->unk_1E8.talkState = NPC_TALK_STATE_IDLE;
         this->actionFunc = func_80AA0D88;
         SET_EVENTCHKINF(EVENTCHKINF_12);
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -341,7 +341,7 @@ void func_80AA0EFC(EnMa1* this, PlayState* play) {
 void func_80AA0F44(EnMa1* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E8.talkState != NPC_TALK_STATE_IDLE) {
         if (this->skelAnime.animation != &gMalonChildIdleAnim) {
             EnMa1_ChangeAnim(this, ENMA1_ANIM_1);
         }
@@ -357,7 +357,7 @@ void func_80AA0F44(EnMa1* this, PlayState* play) {
             player->unk_6A8 = &this->actor;
             this->actor.textId = 0x2061;
             Message_StartTextbox(play, this->actor.textId, NULL);
-            this->unk_1E8.talkState = NPC_TALKING_STATE_1;
+            this->unk_1E8.talkState = NPC_TALK_STATE_TALKING;
             this->actor.flags |= ACTOR_FLAG_16;
             this->actionFunc = func_80AA106C;
         } else if (this->actor.xzDistToPlayer < 30.0f + (f32)this->collider.dim.radius) {
@@ -368,7 +368,7 @@ void func_80AA0F44(EnMa1* this, PlayState* play) {
 
 void func_80AA106C(EnMa1* this, PlayState* play) {
     GET_PLAYER(play)->stateFlags2 |= PLAYER_STATE2_23;
-    if (this->unk_1E8.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_1E8.talkState == NPC_TALK_STATE_ACTION) {
         AudioOcarina_SetInstrument(OCARINA_INSTRUMENT_MALON);
         func_8010BD58(play, OCARINA_ACTION_TEACH_EPONA);
         this->actor.flags &= ~ACTOR_FLAG_16;

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -408,8 +408,8 @@ void EnMa1_Update(Actor* thisx, PlayState* play) {
     EnMa1_UpdateEyes(this);
     this->actionFunc(this, play);
     if (this->actionFunc != EnMa1_DoNothing) {
-        func_800343CC(play, &this->actor, &this->unk_1E8.talkState, (f32)this->collider.dim.radius + 30.0f, EnMa1_GetText,
-                      func_80AA0778);
+        Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E8.talkState, (f32)this->collider.dim.radius + 30.0f,
+                               EnMa1_GetText, func_80AA0778);
     }
     func_80AA0B74(this);
     func_80AA0AF4(this, play);

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -232,7 +232,7 @@ void func_80AA0AF4(EnMa1* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3;
 
-    if ((this->unk_1E8.unk_00 == 0) && (this->skelAnime.animation == &gMalonChildSingAnim)) {
+    if ((this->unk_1E8.talkState == 0) && (this->skelAnime.animation == &gMalonChildSingAnim)) {
         phi_a3 = 1;
     } else {
         phi_a3 = 0;
@@ -246,7 +246,7 @@ void func_80AA0AF4(EnMa1* this, PlayState* play) {
 
 void func_80AA0B74(EnMa1* this) {
     if (this->skelAnime.animation == &gMalonChildSingAnim) {
-        if (this->unk_1E8.unk_00 == 0) {
+        if (this->unk_1E8.talkState == 0) {
             if (this->isNotSinging) {
                 // Turn on singing
                 this->isNotSinging = false;
@@ -280,7 +280,7 @@ void EnMa1_Init(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.targetMode = 6;
-    this->unk_1E8.unk_00 = 0;
+    this->unk_1E8.talkState = 0;
 
     if (!GET_EVENTCHKINF(EVENTCHKINF_TALON_RETURNED_FROM_CASTLE) || CHECK_QUEST_ITEM(QUEST_SONG_EPONA)) {
         this->actionFunc = func_80AA0D88;
@@ -299,7 +299,7 @@ void EnMa1_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AA0D88(EnMa1* this, PlayState* play) {
-    if (this->unk_1E8.unk_00 != 0) {
+    if (this->unk_1E8.talkState != 0) {
         if (this->skelAnime.animation != &gMalonChildIdleAnim) {
             EnMa1_ChangeAnim(this, ENMA1_ANIM_1);
         }
@@ -312,7 +312,7 @@ void func_80AA0D88(EnMa1* this, PlayState* play) {
     if ((play->sceneId == SCENE_SPOT15) && GET_EVENTCHKINF(EVENTCHKINF_TALON_RETURNED_FROM_CASTLE)) {
         Actor_Kill(&this->actor);
     } else if (!GET_EVENTCHKINF(EVENTCHKINF_TALON_RETURNED_FROM_CASTLE) || CHECK_QUEST_ITEM(QUEST_SONG_EPONA)) {
-        if (this->unk_1E8.unk_00 == 2) {
+        if (this->unk_1E8.talkState == 2) {
             this->actionFunc = func_80AA0EA0;
             play->msgCtx.stateTimer = 4;
             play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -330,8 +330,8 @@ void func_80AA0EA0(EnMa1* this, PlayState* play) {
 }
 
 void func_80AA0EFC(EnMa1* this, PlayState* play) {
-    if (this->unk_1E8.unk_00 == 3) {
-        this->unk_1E8.unk_00 = 0;
+    if (this->unk_1E8.talkState == 3) {
+        this->unk_1E8.talkState = 0;
         this->actionFunc = func_80AA0D88;
         SET_EVENTCHKINF(EVENTCHKINF_12);
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -341,7 +341,7 @@ void func_80AA0EFC(EnMa1* this, PlayState* play) {
 void func_80AA0F44(EnMa1* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (this->unk_1E8.unk_00 != 0) {
+    if (this->unk_1E8.talkState != 0) {
         if (this->skelAnime.animation != &gMalonChildIdleAnim) {
             EnMa1_ChangeAnim(this, ENMA1_ANIM_1);
         }
@@ -357,7 +357,7 @@ void func_80AA0F44(EnMa1* this, PlayState* play) {
             player->unk_6A8 = &this->actor;
             this->actor.textId = 0x2061;
             Message_StartTextbox(play, this->actor.textId, NULL);
-            this->unk_1E8.unk_00 = 1;
+            this->unk_1E8.talkState = 1;
             this->actor.flags |= ACTOR_FLAG_16;
             this->actionFunc = func_80AA106C;
         } else if (this->actor.xzDistToPlayer < 30.0f + (f32)this->collider.dim.radius) {
@@ -368,7 +368,7 @@ void func_80AA0F44(EnMa1* this, PlayState* play) {
 
 void func_80AA106C(EnMa1* this, PlayState* play) {
     GET_PLAYER(play)->stateFlags2 |= PLAYER_STATE2_23;
-    if (this->unk_1E8.unk_00 == 2) {
+    if (this->unk_1E8.talkState == 2) {
         AudioOcarina_SetInstrument(OCARINA_INSTRUMENT_MALON);
         func_8010BD58(play, OCARINA_ACTION_TEACH_EPONA);
         this->actor.flags &= ~ACTOR_FLAG_16;
@@ -408,7 +408,7 @@ void EnMa1_Update(Actor* thisx, PlayState* play) {
     EnMa1_UpdateEyes(this);
     this->actionFunc(this, play);
     if (this->actionFunc != EnMa1_DoNothing) {
-        func_800343CC(play, &this->actor, &this->unk_1E8.unk_00, (f32)this->collider.dim.radius + 30.0f, EnMa1_GetText,
+        func_800343CC(play, &this->actor, &this->unk_1E8.talkState, (f32)this->collider.dim.radius + 30.0f, EnMa1_GetText,
                       func_80AA0778);
     }
     func_80AA0B74(this);

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -124,7 +124,7 @@ u16 EnMa1_GetText(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80AA0778(PlayState* play, Actor* thisx) {
-    s16 ret = 1;
+    s16 ret = NPC_TALKING_STATE_1;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_CLOSING:
@@ -132,40 +132,40 @@ s16 func_80AA0778(PlayState* play, Actor* thisx) {
                 case 0x2041:
                     SET_INFTABLE(INFTABLE_84);
                     SET_EVENTCHKINF(EVENTCHKINF_10);
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
                 case 0x2043:
-                    ret = 1;
+                    ret = NPC_TALKING_STATE_1;
                     break;
                 case 0x2047:
                     SET_EVENTCHKINF(EVENTCHKINF_15);
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
                 case 0x2048:
                     SET_INFTABLE(INFTABLE_85);
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
                 case 0x2049:
                     SET_EVENTCHKINF(EVENTCHKINF_16);
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
                 case 0x2061:
-                    ret = 2;
+                    ret = NPC_TALKING_STATE_2;
                     break;
                 default:
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
             }
             break;
         case TEXT_STATE_CHOICE:
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
-                ret = 2;
+                ret = NPC_TALKING_STATE_2;
             }
             break;
         case TEXT_STATE_DONE:
             if (Message_ShouldAdvance(play)) {
-                ret = 3;
+                ret = NPC_TALKING_STATE_3;
             }
             break;
         case TEXT_STATE_NONE:
@@ -174,7 +174,7 @@ s16 func_80AA0778(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            ret = 1;
+            ret = NPC_TALKING_STATE_1;
             break;
     }
     return ret;
@@ -232,7 +232,7 @@ void func_80AA0AF4(EnMa1* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3;
 
-    if ((this->unk_1E8.talkState == 0) && (this->skelAnime.animation == &gMalonChildSingAnim)) {
+    if ((this->unk_1E8.talkState == NPC_TALKING_STATE_0) && (this->skelAnime.animation == &gMalonChildSingAnim)) {
         phi_a3 = 1;
     } else {
         phi_a3 = 0;
@@ -246,7 +246,7 @@ void func_80AA0AF4(EnMa1* this, PlayState* play) {
 
 void func_80AA0B74(EnMa1* this) {
     if (this->skelAnime.animation == &gMalonChildSingAnim) {
-        if (this->unk_1E8.talkState == 0) {
+        if (this->unk_1E8.talkState == NPC_TALKING_STATE_0) {
             if (this->isNotSinging) {
                 // Turn on singing
                 this->isNotSinging = false;
@@ -280,7 +280,7 @@ void EnMa1_Init(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.targetMode = 6;
-    this->unk_1E8.talkState = 0;
+    this->unk_1E8.talkState = NPC_TALKING_STATE_0;
 
     if (!GET_EVENTCHKINF(EVENTCHKINF_TALON_RETURNED_FROM_CASTLE) || CHECK_QUEST_ITEM(QUEST_SONG_EPONA)) {
         this->actionFunc = func_80AA0D88;
@@ -299,7 +299,7 @@ void EnMa1_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AA0D88(EnMa1* this, PlayState* play) {
-    if (this->unk_1E8.talkState != 0) {
+    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
         if (this->skelAnime.animation != &gMalonChildIdleAnim) {
             EnMa1_ChangeAnim(this, ENMA1_ANIM_1);
         }
@@ -312,7 +312,7 @@ void func_80AA0D88(EnMa1* this, PlayState* play) {
     if ((play->sceneId == SCENE_SPOT15) && GET_EVENTCHKINF(EVENTCHKINF_TALON_RETURNED_FROM_CASTLE)) {
         Actor_Kill(&this->actor);
     } else if (!GET_EVENTCHKINF(EVENTCHKINF_TALON_RETURNED_FROM_CASTLE) || CHECK_QUEST_ITEM(QUEST_SONG_EPONA)) {
-        if (this->unk_1E8.talkState == 2) {
+        if (this->unk_1E8.talkState == NPC_TALKING_STATE_2) {
             this->actionFunc = func_80AA0EA0;
             play->msgCtx.stateTimer = 4;
             play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -330,8 +330,8 @@ void func_80AA0EA0(EnMa1* this, PlayState* play) {
 }
 
 void func_80AA0EFC(EnMa1* this, PlayState* play) {
-    if (this->unk_1E8.talkState == 3) {
-        this->unk_1E8.talkState = 0;
+    if (this->unk_1E8.talkState == NPC_TALKING_STATE_3) {
+        this->unk_1E8.talkState = NPC_TALKING_STATE_0;
         this->actionFunc = func_80AA0D88;
         SET_EVENTCHKINF(EVENTCHKINF_12);
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
@@ -341,7 +341,7 @@ void func_80AA0EFC(EnMa1* this, PlayState* play) {
 void func_80AA0F44(EnMa1* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (this->unk_1E8.talkState != 0) {
+    if (this->unk_1E8.talkState != NPC_TALKING_STATE_0) {
         if (this->skelAnime.animation != &gMalonChildIdleAnim) {
             EnMa1_ChangeAnim(this, ENMA1_ANIM_1);
         }
@@ -357,7 +357,7 @@ void func_80AA0F44(EnMa1* this, PlayState* play) {
             player->unk_6A8 = &this->actor;
             this->actor.textId = 0x2061;
             Message_StartTextbox(play, this->actor.textId, NULL);
-            this->unk_1E8.talkState = 1;
+            this->unk_1E8.talkState = NPC_TALKING_STATE_1;
             this->actor.flags |= ACTOR_FLAG_16;
             this->actionFunc = func_80AA106C;
         } else if (this->actor.xzDistToPlayer < 30.0f + (f32)this->collider.dim.radius) {
@@ -368,7 +368,7 @@ void func_80AA0F44(EnMa1* this, PlayState* play) {
 
 void func_80AA106C(EnMa1* this, PlayState* play) {
     GET_PLAYER(play)->stateFlags2 |= PLAYER_STATE2_23;
-    if (this->unk_1E8.talkState == 2) {
+    if (this->unk_1E8.talkState == NPC_TALKING_STATE_2) {
         AudioOcarina_SetInstrument(OCARINA_INSTRUMENT_MALON);
         func_8010BD58(play, OCARINA_ACTION_TEACH_EPONA);
         this->actor.flags &= ~ACTOR_FLAG_16;

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
@@ -90,21 +90,21 @@ u16 func_80AA19A0(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80AA1A38(PlayState* play, Actor* thisx) {
-    s16 ret = 1;
+    s16 ret = NPC_TALKING_STATE_1;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_CLOSING:
             switch (thisx->textId) {
                 case 0x2051:
                     SET_INFTABLE(INFTABLE_8C);
-                    ret = 2;
+                    ret = NPC_TALKING_STATE_2;
                     break;
                 case 0x2053:
                     SET_INFTABLE(INFTABLE_8D);
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
                 default:
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
             }
             break;
@@ -125,7 +125,7 @@ void func_80AA1AE4(EnMa2* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3;
 
-    if ((this->unk_1E0.talkState == 0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
+    if ((this->unk_1E0.talkState == NPC_TALKING_STATE_0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
         phi_a3 = 1;
     } else {
         phi_a3 = 0;
@@ -165,7 +165,7 @@ s32 func_80AA1C68(EnMa2* this) {
     if (this->skelAnime.animation != &gMalonAdultSingAnim) {
         return 0;
     }
-    if (this->unk_1E0.talkState != 0) {
+    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
         return 0;
     }
     this->blinkTimer = 0;
@@ -195,7 +195,7 @@ void EnMa2_ChangeAnim(EnMa2* this, s32 index) {
 
 void func_80AA1DB4(EnMa2* this, PlayState* play) {
     if (this->skelAnime.animation == &gMalonAdultSingAnim) {
-        if (this->unk_1E0.talkState == 0) {
+        if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
             if (this->isNotSinging) {
                 // Turn on singing
                 Audio_ToggleMalonSinging(false);
@@ -246,7 +246,7 @@ void EnMa2_Init(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.targetMode = 6;
-    this->unk_1E0.talkState = 0;
+    this->unk_1E0.talkState = NPC_TALKING_STATE_0;
 }
 
 void EnMa2_Destroy(Actor* thisx, PlayState* play) {
@@ -257,9 +257,9 @@ void EnMa2_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AA2018(EnMa2* this, PlayState* play) {
-    if (this->unk_1E0.talkState == 2) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
         this->actor.flags &= ~ACTOR_FLAG_16;
-        this->unk_1E0.talkState = 0;
+        this->unk_1E0.talkState = NPC_TALKING_STATE_0;
     }
 }
 
@@ -300,7 +300,7 @@ void func_80AA21C8(EnMa2* this, PlayState* play) {
     if (DECR(this->unk_208)) {
         player->stateFlags2 |= PLAYER_STATE2_23;
     } else {
-        if (this->unk_1E0.talkState == 0) {
+        if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
             this->actor.flags |= ACTOR_FLAG_16;
             Message_CloseTextbox(play);
         } else {

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
@@ -322,8 +322,8 @@ void EnMa2_Update(Actor* thisx, PlayState* play) {
     func_80AA1DB4(this, play);
     func_80AA1AE4(this, play);
     if (this->actionFunc != func_80AA20E4) {
-        func_800343CC(play, &this->actor, &this->unk_1E0.talkState, (f32)this->collider.dim.radius + 30.0f, func_80AA19A0,
-                      func_80AA1A38);
+        Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, (f32)this->collider.dim.radius + 30.0f,
+                               func_80AA19A0, func_80AA1A38);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
@@ -125,7 +125,7 @@ void func_80AA1AE4(EnMa2* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3;
 
-    if ((this->unk_1E0.unk_00 == 0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
+    if ((this->unk_1E0.talkState == 0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
         phi_a3 = 1;
     } else {
         phi_a3 = 0;
@@ -165,7 +165,7 @@ s32 func_80AA1C68(EnMa2* this) {
     if (this->skelAnime.animation != &gMalonAdultSingAnim) {
         return 0;
     }
-    if (this->unk_1E0.unk_00 != 0) {
+    if (this->unk_1E0.talkState != 0) {
         return 0;
     }
     this->blinkTimer = 0;
@@ -195,7 +195,7 @@ void EnMa2_ChangeAnim(EnMa2* this, s32 index) {
 
 void func_80AA1DB4(EnMa2* this, PlayState* play) {
     if (this->skelAnime.animation == &gMalonAdultSingAnim) {
-        if (this->unk_1E0.unk_00 == 0) {
+        if (this->unk_1E0.talkState == 0) {
             if (this->isNotSinging) {
                 // Turn on singing
                 Audio_ToggleMalonSinging(false);
@@ -246,7 +246,7 @@ void EnMa2_Init(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.targetMode = 6;
-    this->unk_1E0.unk_00 = 0;
+    this->unk_1E0.talkState = 0;
 }
 
 void EnMa2_Destroy(Actor* thisx, PlayState* play) {
@@ -257,9 +257,9 @@ void EnMa2_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AA2018(EnMa2* this, PlayState* play) {
-    if (this->unk_1E0.unk_00 == 2) {
+    if (this->unk_1E0.talkState == 2) {
         this->actor.flags &= ~ACTOR_FLAG_16;
-        this->unk_1E0.unk_00 = 0;
+        this->unk_1E0.talkState = 0;
     }
 }
 
@@ -300,7 +300,7 @@ void func_80AA21C8(EnMa2* this, PlayState* play) {
     if (DECR(this->unk_208)) {
         player->stateFlags2 |= PLAYER_STATE2_23;
     } else {
-        if (this->unk_1E0.unk_00 == 0) {
+        if (this->unk_1E0.talkState == 0) {
             this->actor.flags |= ACTOR_FLAG_16;
             Message_CloseTextbox(play);
         } else {
@@ -322,7 +322,7 @@ void EnMa2_Update(Actor* thisx, PlayState* play) {
     func_80AA1DB4(this, play);
     func_80AA1AE4(this, play);
     if (this->actionFunc != func_80AA20E4) {
-        func_800343CC(play, &this->actor, &this->unk_1E0.unk_00, (f32)this->collider.dim.radius + 30.0f, func_80AA19A0,
+        func_800343CC(play, &this->actor, &this->unk_1E0.talkState, (f32)this->collider.dim.radius + 30.0f, func_80AA19A0,
                       func_80AA1A38);
     }
 }

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
@@ -90,21 +90,21 @@ u16 func_80AA19A0(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80AA1A38(PlayState* play, Actor* thisx) {
-    s16 ret = NPC_TALKING_STATE_1;
+    s16 ret = NPC_TALK_STATE_TALKING;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_CLOSING:
             switch (thisx->textId) {
                 case 0x2051:
                     SET_INFTABLE(INFTABLE_8C);
-                    ret = NPC_TALKING_STATE_2;
+                    ret = NPC_TALK_STATE_ACTION;
                     break;
                 case 0x2053:
                     SET_INFTABLE(INFTABLE_8D);
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
                 default:
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
             }
             break;
@@ -125,7 +125,7 @@ void func_80AA1AE4(EnMa2* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3;
 
-    if ((this->unk_1E0.talkState == NPC_TALKING_STATE_0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
+    if ((this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
         phi_a3 = 1;
     } else {
         phi_a3 = 0;
@@ -165,7 +165,7 @@ s32 func_80AA1C68(EnMa2* this) {
     if (this->skelAnime.animation != &gMalonAdultSingAnim) {
         return 0;
     }
-    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E0.talkState != NPC_TALK_STATE_IDLE) {
         return 0;
     }
     this->blinkTimer = 0;
@@ -195,7 +195,7 @@ void EnMa2_ChangeAnim(EnMa2* this, s32 index) {
 
 void func_80AA1DB4(EnMa2* this, PlayState* play) {
     if (this->skelAnime.animation == &gMalonAdultSingAnim) {
-        if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
+        if (this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) {
             if (this->isNotSinging) {
                 // Turn on singing
                 Audio_ToggleMalonSinging(false);
@@ -246,7 +246,7 @@ void EnMa2_Init(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.targetMode = 6;
-    this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+    this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
 }
 
 void EnMa2_Destroy(Actor* thisx, PlayState* play) {
@@ -257,9 +257,9 @@ void EnMa2_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AA2018(EnMa2* this, PlayState* play) {
-    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_1E0.talkState == NPC_TALK_STATE_ACTION) {
         this->actor.flags &= ~ACTOR_FLAG_16;
-        this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+        this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
     }
 }
 
@@ -300,7 +300,7 @@ void func_80AA21C8(EnMa2* this, PlayState* play) {
     if (DECR(this->unk_208)) {
         player->stateFlags2 |= PLAYER_STATE2_23;
     } else {
-        if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
+        if (this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) {
             this->actor.flags |= ACTOR_FLAG_16;
             Message_CloseTextbox(play);
         } else {

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -186,7 +186,7 @@ void func_80AA2E54(EnMa3* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3;
 
-    if ((this->unk_1E0.unk_00 == 0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
+    if ((this->unk_1E0.talkState == 0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
         phi_a3 = 1;
     } else {
         phi_a3 = 0;
@@ -214,7 +214,7 @@ s32 func_80AA2F28(EnMa3* this) {
     if (this->skelAnime.animation != &gMalonAdultSingAnim) {
         return 0;
     }
-    if (this->unk_1E0.unk_00 != 0) {
+    if (this->unk_1E0.talkState != 0) {
         return 0;
     }
     this->blinkTimer = 0;
@@ -268,7 +268,7 @@ void EnMa3_Init(Actor* thisx, PlayState* play) {
 
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     Actor_SetScale(&this->actor, 0.01f);
-    this->unk_1E0.unk_00 = (u16)0;
+    this->unk_1E0.talkState = (u16)0;
 }
 
 void EnMa3_Destroy(Actor* thisx, PlayState* play) {
@@ -279,9 +279,9 @@ void EnMa3_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AA3200(EnMa3* this, PlayState* play) {
-    if (this->unk_1E0.unk_00 == 2) {
+    if (this->unk_1E0.talkState == 2) {
         this->actor.flags &= ~ACTOR_FLAG_16;
-        this->unk_1E0.unk_00 = 0;
+        this->unk_1E0.talkState = 0;
     }
 }
 
@@ -295,9 +295,9 @@ void EnMa3_Update(Actor* thisx, PlayState* play) {
     EnMa3_UpdateEyes(this);
     this->actionFunc(this, play);
     func_80AA2E54(this, play);
-    func_800343CC(play, &this->actor, &this->unk_1E0.unk_00, (f32)this->collider.dim.radius + 150.0f, func_80AA2AA0,
+    func_800343CC(play, &this->actor, &this->unk_1E0.talkState, (f32)this->collider.dim.radius + 150.0f, func_80AA2AA0,
                   func_80AA2BD4);
-    if (this->unk_1E0.unk_00 == 0) {
+    if (this->unk_1E0.talkState == 0) {
         if (this->isNotSinging) {
             // Turn on singing
             Audio_ToggleMalonSinging(false);

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -109,7 +109,7 @@ u16 func_80AA2AA0(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80AA2BD4(PlayState* play, Actor* thisx) {
-    s16 ret = 1;
+    s16 ret = NPC_TALKING_STATE_1;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_EVENT:
@@ -140,7 +140,7 @@ s16 func_80AA2BD4(PlayState* play, Actor* thisx) {
             switch (thisx->textId) {
                 case 0x2000:
                     SET_INFTABLE(INFTABLE_B8);
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
                 case 0x208F:
                     SET_EVENTCHKINF(EVENTCHKINF_1E);
@@ -154,7 +154,7 @@ s16 func_80AA2BD4(PlayState* play, Actor* thisx) {
                 case 0x208E:
                     CLEAR_EVENTINF(EVENTINF_HORSES_0A);
                     thisx->flags &= ~ACTOR_FLAG_16;
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     gSaveContext.timer1State = 0xA;
                     break;
                 case 0x2002:
@@ -162,11 +162,11 @@ s16 func_80AA2BD4(PlayState* play, Actor* thisx) {
                     FALLTHROUGH;
                 case 0x2003:
                     if (!GET_EVENTINF(EVENTINF_HORSES_0A)) {
-                        ret = 0;
+                        ret = NPC_TALKING_STATE_0;
                     }
                     break;
                 default:
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
             }
             break;
@@ -186,7 +186,7 @@ void func_80AA2E54(EnMa3* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3;
 
-    if ((this->unk_1E0.talkState == 0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
+    if ((this->unk_1E0.talkState == NPC_TALKING_STATE_0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
         phi_a3 = 1;
     } else {
         phi_a3 = 0;
@@ -214,7 +214,7 @@ s32 func_80AA2F28(EnMa3* this) {
     if (this->skelAnime.animation != &gMalonAdultSingAnim) {
         return 0;
     }
-    if (this->unk_1E0.talkState != 0) {
+    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
         return 0;
     }
     this->blinkTimer = 0;
@@ -268,7 +268,7 @@ void EnMa3_Init(Actor* thisx, PlayState* play) {
 
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     Actor_SetScale(&this->actor, 0.01f);
-    this->unk_1E0.talkState = (u16)0;
+    this->unk_1E0.talkState = NPC_TALKING_STATE_0;
 }
 
 void EnMa3_Destroy(Actor* thisx, PlayState* play) {
@@ -279,9 +279,9 @@ void EnMa3_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AA3200(EnMa3* this, PlayState* play) {
-    if (this->unk_1E0.talkState == 2) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
         this->actor.flags &= ~ACTOR_FLAG_16;
-        this->unk_1E0.talkState = 0;
+        this->unk_1E0.talkState = NPC_TALKING_STATE_0;
     }
 }
 
@@ -297,7 +297,7 @@ void EnMa3_Update(Actor* thisx, PlayState* play) {
     func_80AA2E54(this, play);
     Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, (f32)this->collider.dim.radius + 150.0f,
                            func_80AA2AA0, func_80AA2BD4);
-    if (this->unk_1E0.talkState == 0) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
         if (this->isNotSinging) {
             // Turn on singing
             Audio_ToggleMalonSinging(false);

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -295,8 +295,8 @@ void EnMa3_Update(Actor* thisx, PlayState* play) {
     EnMa3_UpdateEyes(this);
     this->actionFunc(this, play);
     func_80AA2E54(this, play);
-    func_800343CC(play, &this->actor, &this->unk_1E0.talkState, (f32)this->collider.dim.radius + 150.0f, func_80AA2AA0,
-                  func_80AA2BD4);
+    Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, (f32)this->collider.dim.radius + 150.0f,
+                           func_80AA2AA0, func_80AA2BD4);
     if (this->unk_1E0.talkState == 0) {
         if (this->isNotSinging) {
             // Turn on singing

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -109,7 +109,7 @@ u16 func_80AA2AA0(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80AA2BD4(PlayState* play, Actor* thisx) {
-    s16 ret = NPC_TALKING_STATE_1;
+    s16 ret = NPC_TALK_STATE_TALKING;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_EVENT:
@@ -140,7 +140,7 @@ s16 func_80AA2BD4(PlayState* play, Actor* thisx) {
             switch (thisx->textId) {
                 case 0x2000:
                     SET_INFTABLE(INFTABLE_B8);
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x208F:
                     SET_EVENTCHKINF(EVENTCHKINF_1E);
@@ -154,7 +154,7 @@ s16 func_80AA2BD4(PlayState* play, Actor* thisx) {
                 case 0x208E:
                     CLEAR_EVENTINF(EVENTINF_HORSES_0A);
                     thisx->flags &= ~ACTOR_FLAG_16;
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     gSaveContext.timer1State = 0xA;
                     break;
                 case 0x2002:
@@ -162,11 +162,11 @@ s16 func_80AA2BD4(PlayState* play, Actor* thisx) {
                     FALLTHROUGH;
                 case 0x2003:
                     if (!GET_EVENTINF(EVENTINF_HORSES_0A)) {
-                        ret = NPC_TALKING_STATE_0;
+                        ret = NPC_TALK_STATE_IDLE;
                     }
                     break;
                 default:
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
             }
             break;
@@ -186,7 +186,7 @@ void func_80AA2E54(EnMa3* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 phi_a3;
 
-    if ((this->unk_1E0.talkState == NPC_TALKING_STATE_0) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
+    if ((this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) && (this->skelAnime.animation == &gMalonAdultSingAnim)) {
         phi_a3 = 1;
     } else {
         phi_a3 = 0;
@@ -214,7 +214,7 @@ s32 func_80AA2F28(EnMa3* this) {
     if (this->skelAnime.animation != &gMalonAdultSingAnim) {
         return 0;
     }
-    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E0.talkState != NPC_TALK_STATE_IDLE) {
         return 0;
     }
     this->blinkTimer = 0;
@@ -268,7 +268,7 @@ void EnMa3_Init(Actor* thisx, PlayState* play) {
 
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     Actor_SetScale(&this->actor, 0.01f);
-    this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+    this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
 }
 
 void EnMa3_Destroy(Actor* thisx, PlayState* play) {
@@ -279,9 +279,9 @@ void EnMa3_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80AA3200(EnMa3* this, PlayState* play) {
-    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_1E0.talkState == NPC_TALK_STATE_ACTION) {
         this->actor.flags &= ~ACTOR_FLAG_16;
-        this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+        this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
     }
 }
 
@@ -297,7 +297,7 @@ void EnMa3_Update(Actor* thisx, PlayState* play) {
     func_80AA2E54(this, play);
     Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, (f32)this->collider.dim.radius + 150.0f,
                            func_80AA2AA0, func_80AA2BD4);
-    if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) {
         if (this->isNotSinging) {
             // Turn on singing
             Audio_ToggleMalonSinging(false);

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -319,7 +319,7 @@ void func_80AAA93C(EnMd* this) {
 }
 
 void func_80AAAA24(EnMd* this) {
-    if (this->unk_1E0.talkState != 0) {
+    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
         switch (this->actor.textId) {
             case 0x102F:
                 if ((this->unk_208 == 0) && (this->unk_20B != 1)) {
@@ -473,7 +473,7 @@ s16 func_80AAAF04(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            return 1;
+            return NPC_TALKING_STATE_1;
         case TEXT_STATE_CLOSING:
             switch (this->actor.textId) {
                 case 0x1028:
@@ -491,16 +491,16 @@ s16 func_80AAAF04(PlayState* play, Actor* thisx) {
                     break;
                 case 0x1033:
                 case 0x1067:
-                    return 2;
+                    return NPC_TALKING_STATE_2;
             }
-            return 0;
+            return NPC_TALKING_STATE_0;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
-                return 2;
+                return NPC_TALKING_STATE_2;
             }
             FALLTHROUGH;
         default:
-            return 1;
+            return NPC_TALKING_STATE_1;
     }
 }
 
@@ -554,7 +554,7 @@ void func_80AAB158(EnMd* this, PlayState* play) {
         temp2 = 0;
     }
 
-    if (this->unk_1E0.talkState != 0) {
+    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
         temp = 4;
     }
 
@@ -695,7 +695,7 @@ void EnMd_Destroy(Actor* thisx, PlayState* play) {
 void func_80AAB874(EnMd* this, PlayState* play) {
     if (this->skelAnime.animation == &gMidoHandsOnHipsIdleAnim) {
         func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
-    } else if ((this->unk_1E0.talkState == 0) && (this->unk_20B != 7)) {
+    } else if ((this->unk_1E0.talkState == NPC_TALKING_STATE_0) && (this->unk_20B != 7)) {
         func_80AAA92C(this, 7);
     }
 
@@ -717,7 +717,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
 
     func_80AAAA24(this);
 
-    if (this->unk_1E0.talkState == 0) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
         this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
 
@@ -733,7 +733,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         this->skelAnime.playSpeed = CLAMP(temp, 1.0f, 3.0f);
     }
 
-    if (this->unk_1E0.talkState == 2) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
         if (CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD) && !GET_EVENTCHKINF(EVENTCHKINF_1C) &&
             (play->sceneId == SCENE_SPOT04)) {
             play->msgCtx.msgMode = MSGMODE_PAUSED;
@@ -749,7 +749,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         func_80AAA92C(this, 3);
         func_80AAA93C(this);
         this->waypoint = 1;
-        this->unk_1E0.talkState = 0;
+        this->unk_1E0.talkState = NPC_TALKING_STATE_0;
         this->actionFunc = func_80AABD0C;
         this->actor.speedXZ = 1.5f;
         return;
@@ -759,7 +759,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
     }
 
-    if ((this->unk_1E0.talkState == 0) && (play->sceneId == SCENE_SPOT10)) {
+    if ((this->unk_1E0.talkState == NPC_TALKING_STATE_0) && (play->sceneId == SCENE_SPOT10)) {
         if (player->stateFlags2 & PLAYER_STATE2_24) {
             player->stateFlags2 |= PLAYER_STATE2_25;
             player->unk_6A8 = &this->actor;

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -579,8 +579,8 @@ void func_80AAB158(EnMd* this, PlayState* play) {
     func_80034A14(&this->actor, &this->unk_1E0, 2, temp);
     if (this->actionFunc != func_80AABC10) {
         if (temp2) {
-            func_800343CC(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 30.0f, EnMd_GetText,
-                          func_80AAAF04);
+            Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 30.0f,
+                                   EnMd_GetText, func_80AAAF04);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -319,7 +319,7 @@ void func_80AAA93C(EnMd* this) {
 }
 
 void func_80AAAA24(EnMd* this) {
-    if (this->unk_1E0.unk_00 != 0) {
+    if (this->unk_1E0.talkState != 0) {
         switch (this->actor.textId) {
             case 0x102F:
                 if ((this->unk_208 == 0) && (this->unk_20B != 1)) {
@@ -554,7 +554,7 @@ void func_80AAB158(EnMd* this, PlayState* play) {
         temp2 = 0;
     }
 
-    if (this->unk_1E0.unk_00 != 0) {
+    if (this->unk_1E0.talkState != 0) {
         temp = 4;
     }
 
@@ -579,7 +579,7 @@ void func_80AAB158(EnMd* this, PlayState* play) {
     func_80034A14(&this->actor, &this->unk_1E0, 2, temp);
     if (this->actionFunc != func_80AABC10) {
         if (temp2) {
-            func_800343CC(play, &this->actor, &this->unk_1E0.unk_00, this->collider.dim.radius + 30.0f, EnMd_GetText,
+            func_800343CC(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 30.0f, EnMd_GetText,
                           func_80AAAF04);
         }
     }
@@ -695,7 +695,7 @@ void EnMd_Destroy(Actor* thisx, PlayState* play) {
 void func_80AAB874(EnMd* this, PlayState* play) {
     if (this->skelAnime.animation == &gMidoHandsOnHipsIdleAnim) {
         func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
-    } else if ((this->unk_1E0.unk_00 == 0) && (this->unk_20B != 7)) {
+    } else if ((this->unk_1E0.talkState == 0) && (this->unk_20B != 7)) {
         func_80AAA92C(this, 7);
     }
 
@@ -717,7 +717,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
 
     func_80AAAA24(this);
 
-    if (this->unk_1E0.unk_00 == 0) {
+    if (this->unk_1E0.talkState == 0) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
         this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
 
@@ -733,7 +733,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         this->skelAnime.playSpeed = CLAMP(temp, 1.0f, 3.0f);
     }
 
-    if (this->unk_1E0.unk_00 == 2) {
+    if (this->unk_1E0.talkState == 2) {
         if (CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD) && !GET_EVENTCHKINF(EVENTCHKINF_1C) &&
             (play->sceneId == SCENE_SPOT04)) {
             play->msgCtx.msgMode = MSGMODE_PAUSED;
@@ -749,7 +749,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         func_80AAA92C(this, 3);
         func_80AAA93C(this);
         this->waypoint = 1;
-        this->unk_1E0.unk_00 = 0;
+        this->unk_1E0.talkState = 0;
         this->actionFunc = func_80AABD0C;
         this->actor.speedXZ = 1.5f;
         return;
@@ -759,7 +759,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
     }
 
-    if ((this->unk_1E0.unk_00 == 0) && (play->sceneId == SCENE_SPOT10)) {
+    if ((this->unk_1E0.talkState == 0) && (play->sceneId == SCENE_SPOT10)) {
         if (player->stateFlags2 & PLAYER_STATE2_24) {
             player->stateFlags2 |= PLAYER_STATE2_25;
             player->unk_6A8 = &this->actor;

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -319,7 +319,7 @@ void func_80AAA93C(EnMd* this) {
 }
 
 void func_80AAAA24(EnMd* this) {
-    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E0.talkState != NPC_TALK_STATE_IDLE) {
         switch (this->actor.textId) {
             case 0x102F:
                 if ((this->unk_208 == 0) && (this->unk_20B != 1)) {
@@ -473,7 +473,7 @@ s16 func_80AAAF04(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
         case TEXT_STATE_CLOSING:
             switch (this->actor.textId) {
                 case 0x1028:
@@ -491,16 +491,16 @@ s16 func_80AAAF04(PlayState* play, Actor* thisx) {
                     break;
                 case 0x1033:
                 case 0x1067:
-                    return NPC_TALKING_STATE_2;
+                    return NPC_TALK_STATE_ACTION;
             }
-            return NPC_TALKING_STATE_0;
+            return NPC_TALK_STATE_IDLE;
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
-                return NPC_TALKING_STATE_2;
+                return NPC_TALK_STATE_ACTION;
             }
             FALLTHROUGH;
         default:
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
     }
 }
 
@@ -554,7 +554,7 @@ void func_80AAB158(EnMd* this, PlayState* play) {
         temp2 = 0;
     }
 
-    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E0.talkState != NPC_TALK_STATE_IDLE) {
         temp = 4;
     }
 
@@ -695,7 +695,7 @@ void EnMd_Destroy(Actor* thisx, PlayState* play) {
 void func_80AAB874(EnMd* this, PlayState* play) {
     if (this->skelAnime.animation == &gMidoHandsOnHipsIdleAnim) {
         func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
-    } else if ((this->unk_1E0.talkState == NPC_TALKING_STATE_0) && (this->unk_20B != 7)) {
+    } else if ((this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) && (this->unk_20B != 7)) {
         func_80AAA92C(this, 7);
     }
 
@@ -717,7 +717,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
 
     func_80AAAA24(this);
 
-    if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
         this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
 
@@ -733,7 +733,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         this->skelAnime.playSpeed = CLAMP(temp, 1.0f, 3.0f);
     }
 
-    if (this->unk_1E0.talkState == NPC_TALKING_STATE_2) {
+    if (this->unk_1E0.talkState == NPC_TALK_STATE_ACTION) {
         if (CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD) && !GET_EVENTCHKINF(EVENTCHKINF_1C) &&
             (play->sceneId == SCENE_SPOT04)) {
             play->msgCtx.msgMode = MSGMODE_PAUSED;
@@ -749,7 +749,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         func_80AAA92C(this, 3);
         func_80AAA93C(this);
         this->waypoint = 1;
-        this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+        this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
         this->actionFunc = func_80AABD0C;
         this->actor.speedXZ = 1.5f;
         return;
@@ -759,7 +759,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
     }
 
-    if ((this->unk_1E0.talkState == NPC_TALKING_STATE_0) && (play->sceneId == SCENE_SPOT10)) {
+    if ((this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) && (play->sceneId == SCENE_SPOT10)) {
         if (player->stateFlags2 & PLAYER_STATE2_24) {
             player->stateFlags2 |= PLAYER_STATE2_25;
             player->unk_6A8 = &this->actor;

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.c
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.c
@@ -121,12 +121,12 @@ s16 EnMu_CheckDialogState(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
         case TEXT_STATE_CLOSING:
             EnMu_Interact(this, play);
-            return NPC_TALKING_STATE_0;
+            return NPC_TALK_STATE_IDLE;
         default:
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
     }
 }
 

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.c
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.c
@@ -172,7 +172,8 @@ void EnMu_Update(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     this->actionFunc(this, play);
     talkDist = this->collider.dim.radius + 30.0f;
-    func_800343CC(play, &this->actor, &this->npcInfo.talkState, talkDist, EnMu_GetFaceReaction, EnMu_CheckDialogState);
+    Actor_NpcUpdateTalking(play, &this->actor, &this->npcInfo.talkState, talkDist, EnMu_GetFaceReaction,
+                           EnMu_CheckDialogState);
 
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.focus.pos.y += 60.0f;

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.c
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.c
@@ -121,12 +121,12 @@ s16 EnMu_CheckDialogState(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            return 1;
+            return NPC_TALKING_STATE_1;
         case TEXT_STATE_CLOSING:
             EnMu_Interact(this, play);
-            return 0;
+            return NPC_TALKING_STATE_0;
         default:
-            return 1;
+            return NPC_TALKING_STATE_1;
     }
 }
 

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.c
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.c
@@ -172,7 +172,7 @@ void EnMu_Update(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     this->actionFunc(this, play);
     talkDist = this->collider.dim.radius + 30.0f;
-    func_800343CC(play, &this->actor, &this->npcInfo.unk_00, talkDist, EnMu_GetFaceReaction, EnMu_CheckDialogState);
+    func_800343CC(play, &this->actor, &this->npcInfo.talkState, talkDist, EnMu_GetFaceReaction, EnMu_CheckDialogState);
 
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.focus.pos.y += 60.0f;

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -179,7 +179,7 @@ u16 func_80AF55E0(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80AF56F4(PlayState* play, Actor* thisx) {
-    s16 ret = NPC_TALKING_STATE_1;
+    s16 ret = NPC_TALK_STATE_TALKING;
     EnSa* this = (EnSa*)thisx;
 
     switch (func_80AF5560(this, play)) {
@@ -187,19 +187,19 @@ s16 func_80AF56F4(PlayState* play, Actor* thisx) {
             switch (this->actor.textId) {
                 case 0x1002:
                     SET_INFTABLE(INFTABLE_01);
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x1031:
                     SET_EVENTCHKINF(EVENTCHKINF_03);
                     SET_INFTABLE(INFTABLE_03);
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
                 case 0x1047:
                     SET_INFTABLE(INFTABLE_05);
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
                 default:
-                    ret = NPC_TALKING_STATE_0;
+                    ret = NPC_TALK_STATE_IDLE;
                     break;
             }
             break;
@@ -218,7 +218,7 @@ s16 func_80AF56F4(PlayState* play, Actor* thisx) {
 
 void func_80AF57D8(EnSa* this, PlayState* play) {
     if (play->sceneId != SCENE_SPOT05 || ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) < 0x1555 ||
-        this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
+        this->unk_1E0.talkState != NPC_TALK_STATE_IDLE) {
         Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 30.0f,
                                func_80AF55E0, func_80AF56F4);
     }
@@ -432,7 +432,7 @@ s32 func_80AF603C(EnSa* this) {
         this->skelAnime.animation != &gSariaOcarinaToMouthAnim) {
         return 0;
     }
-    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_1E0.talkState != NPC_TALK_STATE_IDLE) {
         return 0;
     }
     this->unk_20E = 0;
@@ -523,7 +523,7 @@ void EnSa_Init(Actor* thisx, PlayState* play) {
     Actor_SetScale(&this->actor, 0.01f);
 
     this->actor.targetMode = 6;
-    this->unk_1E0.talkState = NPC_TALKING_STATE_0;
+    this->unk_1E0.talkState = NPC_TALK_STATE_IDLE;
     this->alpha = 255;
     this->unk_21A = this->actor.shape.rot;
 
@@ -539,7 +539,7 @@ void EnSa_Destroy(Actor* thisx, PlayState* play) {
 
 void func_80AF6448(EnSa* this, PlayState* play) {
     if (play->sceneId == SCENE_SPOT04) {
-        if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
+        if (this->unk_1E0.talkState != NPC_TALK_STATE_IDLE) {
             switch (this->actor.textId) {
                 case 0x1002:
                     if (this->unk_208 == 0 && this->unk_20B != 1) {
@@ -607,14 +607,14 @@ void func_80AF6448(EnSa* this, PlayState* play) {
             EnSa_ChangeAnim(this, ENSA_ANIM1_6);
         }
     }
-    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0 && play->sceneId == SCENE_SPOT05) {
+    if (this->unk_1E0.talkState != NPC_TALK_STATE_IDLE && play->sceneId == SCENE_SPOT05) {
         Animation_Change(&this->skelAnime, &gSariaStopPlayingOcarinaAnim, 1.0f, 0.0f, 10.0f, ANIMMODE_ONCE, -10.0f);
         this->actionFunc = func_80AF67D0;
     }
 }
 
 void func_80AF67D0(EnSa* this, PlayState* play) {
-    if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
+    if (this->unk_1E0.talkState == NPC_TALK_STATE_IDLE) {
         Animation_Change(&this->skelAnime, &gSariaStopPlayingOcarinaAnim, 0.0f, 10.0f, 0.0f, ANIMMODE_ONCE, -10.0f);
         this->actionFunc = func_80AF6448;
     }

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -219,8 +219,8 @@ s16 func_80AF56F4(PlayState* play, Actor* thisx) {
 void func_80AF57D8(EnSa* this, PlayState* play) {
     if (play->sceneId != SCENE_SPOT05 || ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) < 0x1555 ||
         this->unk_1E0.talkState != 0) {
-        func_800343CC(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 30.0f, func_80AF55E0,
-                      func_80AF56F4);
+        Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 30.0f,
+                               func_80AF55E0, func_80AF56F4);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -218,8 +218,8 @@ s16 func_80AF56F4(PlayState* play, Actor* thisx) {
 
 void func_80AF57D8(EnSa* this, PlayState* play) {
     if (play->sceneId != SCENE_SPOT05 || ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) < 0x1555 ||
-        this->unk_1E0.unk_00 != 0) {
-        func_800343CC(play, &this->actor, &this->unk_1E0.unk_00, this->collider.dim.radius + 30.0f, func_80AF55E0,
+        this->unk_1E0.talkState != 0) {
+        func_800343CC(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 30.0f, func_80AF55E0,
                       func_80AF56F4);
     }
 }
@@ -432,7 +432,7 @@ s32 func_80AF603C(EnSa* this) {
         this->skelAnime.animation != &gSariaOcarinaToMouthAnim) {
         return 0;
     }
-    if (this->unk_1E0.unk_00 != 0) {
+    if (this->unk_1E0.talkState != 0) {
         return 0;
     }
     this->unk_20E = 0;
@@ -523,7 +523,7 @@ void EnSa_Init(Actor* thisx, PlayState* play) {
     Actor_SetScale(&this->actor, 0.01f);
 
     this->actor.targetMode = 6;
-    this->unk_1E0.unk_00 = 0;
+    this->unk_1E0.talkState = 0;
     this->alpha = 255;
     this->unk_21A = this->actor.shape.rot;
 
@@ -539,7 +539,7 @@ void EnSa_Destroy(Actor* thisx, PlayState* play) {
 
 void func_80AF6448(EnSa* this, PlayState* play) {
     if (play->sceneId == SCENE_SPOT04) {
-        if (this->unk_1E0.unk_00 != 0) {
+        if (this->unk_1E0.talkState != 0) {
             switch (this->actor.textId) {
                 case 0x1002:
                     if (this->unk_208 == 0 && this->unk_20B != 1) {
@@ -607,14 +607,14 @@ void func_80AF6448(EnSa* this, PlayState* play) {
             EnSa_ChangeAnim(this, ENSA_ANIM1_6);
         }
     }
-    if (this->unk_1E0.unk_00 != 0 && play->sceneId == SCENE_SPOT05) {
+    if (this->unk_1E0.talkState != 0 && play->sceneId == SCENE_SPOT05) {
         Animation_Change(&this->skelAnime, &gSariaStopPlayingOcarinaAnim, 1.0f, 0.0f, 10.0f, ANIMMODE_ONCE, -10.0f);
         this->actionFunc = func_80AF67D0;
     }
 }
 
 void func_80AF67D0(EnSa* this, PlayState* play) {
-    if (this->unk_1E0.unk_00 == 0) {
+    if (this->unk_1E0.talkState == 0) {
         Animation_Change(&this->skelAnime, &gSariaStopPlayingOcarinaAnim, 0.0f, 10.0f, 0.0f, ANIMMODE_ONCE, -10.0f);
         this->actionFunc = func_80AF6448;
     }

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -179,7 +179,7 @@ u16 func_80AF55E0(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80AF56F4(PlayState* play, Actor* thisx) {
-    s16 ret = 1;
+    s16 ret = NPC_TALKING_STATE_1;
     EnSa* this = (EnSa*)thisx;
 
     switch (func_80AF5560(this, play)) {
@@ -187,19 +187,19 @@ s16 func_80AF56F4(PlayState* play, Actor* thisx) {
             switch (this->actor.textId) {
                 case 0x1002:
                     SET_INFTABLE(INFTABLE_01);
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
                 case 0x1031:
                     SET_EVENTCHKINF(EVENTCHKINF_03);
                     SET_INFTABLE(INFTABLE_03);
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
                 case 0x1047:
                     SET_INFTABLE(INFTABLE_05);
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
                 default:
-                    ret = 0;
+                    ret = NPC_TALKING_STATE_0;
                     break;
             }
             break;
@@ -218,7 +218,7 @@ s16 func_80AF56F4(PlayState* play, Actor* thisx) {
 
 void func_80AF57D8(EnSa* this, PlayState* play) {
     if (play->sceneId != SCENE_SPOT05 || ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) < 0x1555 ||
-        this->unk_1E0.talkState != 0) {
+        this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
         Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 30.0f,
                                func_80AF55E0, func_80AF56F4);
     }
@@ -432,7 +432,7 @@ s32 func_80AF603C(EnSa* this) {
         this->skelAnime.animation != &gSariaOcarinaToMouthAnim) {
         return 0;
     }
-    if (this->unk_1E0.talkState != 0) {
+    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
         return 0;
     }
     this->unk_20E = 0;
@@ -523,7 +523,7 @@ void EnSa_Init(Actor* thisx, PlayState* play) {
     Actor_SetScale(&this->actor, 0.01f);
 
     this->actor.targetMode = 6;
-    this->unk_1E0.talkState = 0;
+    this->unk_1E0.talkState = NPC_TALKING_STATE_0;
     this->alpha = 255;
     this->unk_21A = this->actor.shape.rot;
 
@@ -539,7 +539,7 @@ void EnSa_Destroy(Actor* thisx, PlayState* play) {
 
 void func_80AF6448(EnSa* this, PlayState* play) {
     if (play->sceneId == SCENE_SPOT04) {
-        if (this->unk_1E0.talkState != 0) {
+        if (this->unk_1E0.talkState != NPC_TALKING_STATE_0) {
             switch (this->actor.textId) {
                 case 0x1002:
                     if (this->unk_208 == 0 && this->unk_20B != 1) {
@@ -607,14 +607,14 @@ void func_80AF6448(EnSa* this, PlayState* play) {
             EnSa_ChangeAnim(this, ENSA_ANIM1_6);
         }
     }
-    if (this->unk_1E0.talkState != 0 && play->sceneId == SCENE_SPOT05) {
+    if (this->unk_1E0.talkState != NPC_TALKING_STATE_0 && play->sceneId == SCENE_SPOT05) {
         Animation_Change(&this->skelAnime, &gSariaStopPlayingOcarinaAnim, 1.0f, 0.0f, 10.0f, ANIMMODE_ONCE, -10.0f);
         this->actionFunc = func_80AF67D0;
     }
 }
 
 void func_80AF67D0(EnSa* this, PlayState* play) {
-    if (this->unk_1E0.talkState == 0) {
+    if (this->unk_1E0.talkState == NPC_TALKING_STATE_0) {
         Animation_Change(&this->skelAnime, &gSariaStopPlayingOcarinaAnim, 0.0f, 10.0f, 0.0f, ANIMMODE_ONCE, -10.0f);
         this->actionFunc = func_80AF6448;
     }

--- a/src/overlays/actors/ovl_En_Tg/z_en_tg.c
+++ b/src/overlays/actors/ovl_En_Tg/z_en_tg.c
@@ -152,7 +152,7 @@ void EnTg_Update(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     this->actionFunc(this, play);
     temp = this->collider.dim.radius + 30.0f;
-    func_800343CC(play, &this->actor, &this->isTalking, temp, EnTg_GetTextId, EnTg_OnTextComplete);
+    Actor_NpcUpdateTalking(play, &this->actor, &this->isTalking, temp, EnTg_GetTextId, EnTg_OnTextComplete);
 }
 
 s32 EnTg_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {

--- a/src/overlays/actors/ovl_En_Tg/z_en_tg.c
+++ b/src/overlays/actors/ovl_En_Tg/z_en_tg.c
@@ -132,7 +132,7 @@ void EnTg_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnTg_SpinIfNotTalking(EnTg* this, PlayState* play) {
-    if (!this->isTalking) {
+    if (!this->npcInfo.talkState) {
         this->actor.shape.rot.y += 0x800;
     }
 }
@@ -152,7 +152,7 @@ void EnTg_Update(Actor* thisx, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     this->actionFunc(this, play);
     temp = this->collider.dim.radius + 30.0f;
-    Actor_NpcUpdateTalking(play, &this->actor, &this->isTalking, temp, EnTg_GetTextId, EnTg_OnTextComplete);
+    Actor_NpcUpdateTalking(play, &this->actor, &this->npcInfo.talkState, temp, EnTg_GetTextId, EnTg_OnTextComplete);
 }
 
 s32 EnTg_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {

--- a/src/overlays/actors/ovl_En_Tg/z_en_tg.h
+++ b/src/overlays/actors/ovl_En_Tg/z_en_tg.h
@@ -13,8 +13,7 @@ typedef struct EnTg {
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ EnTgActionFunc actionFunc;
     /* 0x0194 */ ColliderCylinder collider;
-    /* 0x01E0 */ s16 isTalking;
-    /* 0x01E2 */ char unk_1E2[0x26];
+    /* 0x01E0 */ struct_80034A14_arg1 npcInfo;
     /* 0x0208 */ u8 nextDialogue;
 } EnTg; // size = 0x020C
 

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -528,16 +528,16 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
             return;
         }
 
-        func_800343CC(play, &this->actor, &this->npcInfo.talkState, this->collider.dim.radius + 30.0f, func_80B1C54C,
-                      func_80B1C5A0);
+        Actor_NpcUpdateTalking(play, &this->actor, &this->npcInfo.talkState, this->collider.dim.radius + 30.0f,
+                               func_80B1C54C, func_80B1C5A0);
     } else if (EnTk_CheckFacingPlayer(this)) {
         v1 = this->actor.shape.rot.y;
         v1 -= this->h_21E;
         v1 = this->actor.yawTowardsPlayer - v1;
 
         this->actionCountdown = 0;
-        func_800343CC(play, &this->actor, &this->npcInfo.talkState, this->collider.dim.radius + 30.0f, func_80B1C54C,
-                      func_80B1C5A0);
+        Actor_NpcUpdateTalking(play, &this->actor, &this->npcInfo.talkState, this->collider.dim.radius + 30.0f,
+                               func_80B1C54C, func_80B1C5A0);
     } else if (Actor_ProcessTalkRequest(&this->actor, play)) {
         v1 = this->actor.shape.rot.y;
         v1 -= this->h_21E;

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -348,7 +348,7 @@ u16 func_80B1C54C(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80B1C5A0(PlayState* play, Actor* thisx) {
-    s32 ret = 1;
+    s32 ret = NPC_TALKING_STATE_1;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_NONE:
@@ -359,7 +359,7 @@ s16 func_80B1C5A0(PlayState* play, Actor* thisx) {
             if (thisx->textId == 0x5028) {
                 SET_INFTABLE(INFTABLE_D8);
             }
-            ret = 0;
+            ret = NPC_TALKING_STATE_0;
             break;
         case TEXT_STATE_DONE_FADING:
             break;
@@ -375,7 +375,7 @@ s16 func_80B1C5A0(PlayState* play, Actor* thisx) {
                     play->msgCtx.msgMode = MSGMODE_PAUSED;
                     Rupees_ChangeBy(-10);
                     SET_INFTABLE(INFTABLE_D9);
-                    return 2;
+                    return NPC_TALKING_STATE_2;
                 }
                 Message_ContinueTextbox(play, thisx->textId);
                 SET_INFTABLE(INFTABLE_D9);
@@ -384,7 +384,7 @@ s16 func_80B1C5A0(PlayState* play, Actor* thisx) {
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play) && (thisx->textId == 0x0084 || thisx->textId == 0x0085)) {
                 Message_CloseTextbox(play);
-                ret = 0;
+                ret = NPC_TALKING_STATE_0;
             }
             break;
         case TEXT_STATE_DONE:
@@ -516,14 +516,14 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
     s16 v1;
     s16 a1_;
 
-    if (this->npcInfo.talkState != 0) {
+    if (this->npcInfo.talkState != NPC_TALKING_STATE_0) {
         v1 = this->actor.shape.rot.y;
         v1 -= this->h_21E;
         v1 = this->actor.yawTowardsPlayer - v1;
 
-        if (this->npcInfo.talkState == 2) {
+        if (this->npcInfo.talkState == NPC_TALKING_STATE_2) {
             EnTk_DigAnim(this, play);
-            this->npcInfo.talkState = 0;
+            this->npcInfo.talkState = NPC_TALKING_STATE_0;
             this->actionFunc = EnTk_Dig;
             return;
         }
@@ -544,7 +544,7 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
         v1 = this->actor.yawTowardsPlayer - v1;
 
         this->actionCountdown = 0;
-        this->npcInfo.talkState = 1;
+        this->npcInfo.talkState = NPC_TALKING_STATE_1;
     } else if (DECR(this->actionCountdown) == 0) {
         EnTk_WalkAnim(this, play);
         this->actionFunc = EnTk_Walk;
@@ -559,9 +559,9 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
 }
 
 void EnTk_Walk(EnTk* this, PlayState* play) {
-    if (this->npcInfo.talkState == 2) {
+    if (this->npcInfo.talkState == NPC_TALKING_STATE_2) {
         EnTk_DigAnim(this, play);
-        this->npcInfo.talkState = 0;
+        this->npcInfo.talkState = NPC_TALKING_STATE_0;
         this->actionFunc = EnTk_Dig;
     } else {
         this->actor.speedXZ = EnTk_Step(this, play);

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -516,19 +516,19 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
     s16 v1;
     s16 a1_;
 
-    if (this->h_1E0 != 0) {
+    if (this->npcInfo.talkState != 0) {
         v1 = this->actor.shape.rot.y;
         v1 -= this->h_21E;
         v1 = this->actor.yawTowardsPlayer - v1;
 
-        if (this->h_1E0 == 2) {
+        if (this->npcInfo.talkState == 2) {
             EnTk_DigAnim(this, play);
-            this->h_1E0 = 0;
+            this->npcInfo.talkState = 0;
             this->actionFunc = EnTk_Dig;
             return;
         }
 
-        func_800343CC(play, &this->actor, &this->h_1E0, this->collider.dim.radius + 30.0f, func_80B1C54C,
+        func_800343CC(play, &this->actor, &this->npcInfo.talkState, this->collider.dim.radius + 30.0f, func_80B1C54C,
                       func_80B1C5A0);
     } else if (EnTk_CheckFacingPlayer(this)) {
         v1 = this->actor.shape.rot.y;
@@ -536,7 +536,7 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
         v1 = this->actor.yawTowardsPlayer - v1;
 
         this->actionCountdown = 0;
-        func_800343CC(play, &this->actor, &this->h_1E0, this->collider.dim.radius + 30.0f, func_80B1C54C,
+        func_800343CC(play, &this->actor, &this->npcInfo.talkState, this->collider.dim.radius + 30.0f, func_80B1C54C,
                       func_80B1C5A0);
     } else if (Actor_ProcessTalkRequest(&this->actor, play)) {
         v1 = this->actor.shape.rot.y;
@@ -544,7 +544,7 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
         v1 = this->actor.yawTowardsPlayer - v1;
 
         this->actionCountdown = 0;
-        this->h_1E0 = 1;
+        this->npcInfo.talkState = 1;
     } else if (DECR(this->actionCountdown) == 0) {
         EnTk_WalkAnim(this, play);
         this->actionFunc = EnTk_Walk;
@@ -559,9 +559,9 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
 }
 
 void EnTk_Walk(EnTk* this, PlayState* play) {
-    if (this->h_1E0 == 2) {
+    if (this->npcInfo.talkState == 2) {
         EnTk_DigAnim(this, play);
-        this->h_1E0 = 0;
+        this->npcInfo.talkState = 0;
         this->actionFunc = EnTk_Dig;
     } else {
         this->actor.speedXZ = EnTk_Step(this, play);

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -348,7 +348,7 @@ u16 func_80B1C54C(PlayState* play, Actor* thisx) {
 }
 
 s16 func_80B1C5A0(PlayState* play, Actor* thisx) {
-    s32 ret = NPC_TALKING_STATE_1;
+    s32 ret = NPC_TALK_STATE_TALKING;
 
     switch (Message_GetState(&play->msgCtx)) {
         case TEXT_STATE_NONE:
@@ -359,7 +359,7 @@ s16 func_80B1C5A0(PlayState* play, Actor* thisx) {
             if (thisx->textId == 0x5028) {
                 SET_INFTABLE(INFTABLE_D8);
             }
-            ret = NPC_TALKING_STATE_0;
+            ret = NPC_TALK_STATE_IDLE;
             break;
         case TEXT_STATE_DONE_FADING:
             break;
@@ -375,7 +375,7 @@ s16 func_80B1C5A0(PlayState* play, Actor* thisx) {
                     play->msgCtx.msgMode = MSGMODE_PAUSED;
                     Rupees_ChangeBy(-10);
                     SET_INFTABLE(INFTABLE_D9);
-                    return NPC_TALKING_STATE_2;
+                    return NPC_TALK_STATE_ACTION;
                 }
                 Message_ContinueTextbox(play, thisx->textId);
                 SET_INFTABLE(INFTABLE_D9);
@@ -384,7 +384,7 @@ s16 func_80B1C5A0(PlayState* play, Actor* thisx) {
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play) && (thisx->textId == 0x0084 || thisx->textId == 0x0085)) {
                 Message_CloseTextbox(play);
-                ret = NPC_TALKING_STATE_0;
+                ret = NPC_TALK_STATE_IDLE;
             }
             break;
         case TEXT_STATE_DONE:
@@ -516,14 +516,14 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
     s16 v1;
     s16 a1_;
 
-    if (this->npcInfo.talkState != NPC_TALKING_STATE_0) {
+    if (this->npcInfo.talkState != NPC_TALK_STATE_IDLE) {
         v1 = this->actor.shape.rot.y;
         v1 -= this->h_21E;
         v1 = this->actor.yawTowardsPlayer - v1;
 
-        if (this->npcInfo.talkState == NPC_TALKING_STATE_2) {
+        if (this->npcInfo.talkState == NPC_TALK_STATE_ACTION) {
             EnTk_DigAnim(this, play);
-            this->npcInfo.talkState = NPC_TALKING_STATE_0;
+            this->npcInfo.talkState = NPC_TALK_STATE_IDLE;
             this->actionFunc = EnTk_Dig;
             return;
         }
@@ -544,7 +544,7 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
         v1 = this->actor.yawTowardsPlayer - v1;
 
         this->actionCountdown = 0;
-        this->npcInfo.talkState = NPC_TALKING_STATE_1;
+        this->npcInfo.talkState = NPC_TALK_STATE_TALKING;
     } else if (DECR(this->actionCountdown) == 0) {
         EnTk_WalkAnim(this, play);
         this->actionFunc = EnTk_Walk;
@@ -559,9 +559,9 @@ void EnTk_Rest(EnTk* this, PlayState* play) {
 }
 
 void EnTk_Walk(EnTk* this, PlayState* play) {
-    if (this->npcInfo.talkState == NPC_TALKING_STATE_2) {
+    if (this->npcInfo.talkState == NPC_TALK_STATE_ACTION) {
         EnTk_DigAnim(this, play);
-        this->npcInfo.talkState = NPC_TALKING_STATE_0;
+        this->npcInfo.talkState = NPC_TALK_STATE_IDLE;
         this->actionFunc = EnTk_Dig;
     } else {
         this->actor.speedXZ = EnTk_Step(this, play);

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.h
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.h
@@ -3,6 +3,7 @@
 
 #include "ultra64.h"
 #include "global.h"
+#include "z64.h"
 
 /* Dirt particle effect */
 struct EnTkEff;
@@ -28,8 +29,7 @@ typedef struct EnTk {
     /* 0x014C */ SkelAnime  skelAnime;
     /* 0x0190 */ EnTkActionFunc actionFunc;
     /* 0x0194 */ ColliderCylinder collider;
-    /* 0x01E0 */ s16        h_1E0;
-    /* 0x01E2 */ char       unk_1E2[0x26];
+    /* 0x01E0 */ struct_80034A14_arg1 npcInfo;
     /* 0x0208 */ u8         validDigHere;
     /* 0x0209 */ u8         rewardCount[4];
     /* 0x0210 */ Actor*     currentSpot;

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -228,9 +228,9 @@ u16 EnZl4_GetText(PlayState* play, Actor* thisx) {
 
 s16 func_80B5B9B0(PlayState* play, Actor* thisx) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-        return NPC_TALKING_STATE_0;
+        return NPC_TALK_STATE_IDLE;
     }
-    return NPC_TALKING_STATE_1;
+    return NPC_TALK_STATE_TALKING;
 }
 
 void EnZl4_UpdateFace(EnZl4* this) {

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -1208,8 +1208,8 @@ void EnZl4_Cutscene(EnZl4* this, PlayState* play) {
 }
 
 void EnZl4_Idle(EnZl4* this, PlayState* play) {
-    func_800343CC(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 60.0f, EnZl4_GetText,
-                  func_80B5B9B0);
+    Actor_NpcUpdateTalking(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 60.0f,
+                           EnZl4_GetText, func_80B5B9B0);
     func_80B5BB78(this, play);
 }
 

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -228,9 +228,9 @@ u16 EnZl4_GetText(PlayState* play, Actor* thisx) {
 
 s16 func_80B5B9B0(PlayState* play, Actor* thisx) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-        return false;
+        return NPC_TALKING_STATE_0;
     }
-    return true;
+    return NPC_TALKING_STATE_1;
 }
 
 void EnZl4_UpdateFace(EnZl4* this) {

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -1208,7 +1208,7 @@ void EnZl4_Cutscene(EnZl4* this, PlayState* play) {
 }
 
 void EnZl4_Idle(EnZl4* this, PlayState* play) {
-    func_800343CC(play, &this->actor, &this->unk_1E0.unk_00, this->collider.dim.radius + 60.0f, EnZl4_GetText,
+    func_800343CC(play, &this->actor, &this->unk_1E0.talkState, this->collider.dim.radius + 60.0f, EnZl4_GetText,
                   func_80B5B9B0);
     func_80B5BB78(this, play);
 }

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -449,13 +449,13 @@ s16 func_80B61298(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            return 1;
+            return NPC_TALKING_STATE_1;
 
         case TEXT_STATE_CLOSING:
             switch (thisx->textId) {
                 case 0x4020:
                 case 0x4021:
-                    return 0;
+                    return NPC_TALKING_STATE_0;
                 case 0x4008:
                     SET_INFTABLE(INFTABLE_124);
                     break;
@@ -464,12 +464,12 @@ s16 func_80B61298(PlayState* play, Actor* thisx) {
                     break;
             }
             SET_EVENTCHKINF(EVENTCHKINF_30);
-            return 0;
+            return NPC_TALKING_STATE_0;
 
         case TEXT_STATE_CHOICE:
             switch (Message_ShouldAdvance(play)) {
                 case 0:
-                    return 1;
+                    return NPC_TALKING_STATE_1;
                 default:
                     if (thisx->textId == 0x400C) {
                         thisx->textId = (play->msgCtx.choiceIndex == 0) ? 0x400D : 0x400E;
@@ -482,13 +482,13 @@ s16 func_80B61298(PlayState* play, Actor* thisx) {
         case TEXT_STATE_EVENT:
             switch (Message_ShouldAdvance(play)) {
                 case 0:
-                    return 1;
+                    return NPC_TALKING_STATE_1;
                 default:
-                    return 2;
+                    return NPC_TALKING_STATE_2;
             }
     }
 
-    return 1;
+    return NPC_TALKING_STATE_1;
 }
 
 void EnZo_Blink(EnZo* this) {
@@ -542,7 +542,7 @@ void EnZo_SetAnimation(EnZo* this) {
 
     if (this->skelAnime.animation == &gZoraHandsOnHipsTappingFootAnim ||
         this->skelAnime.animation == &gZoraOpenArmsAnim) {
-        if (this->unk_194.talkState == 0) {
+        if (this->unk_194.talkState == NPC_TALKING_STATE_0) {
             if (this->actionFunc == EnZo_Standing) {
                 animId = ENZO_ANIM_0;
             } else {
@@ -551,12 +551,12 @@ void EnZo_SetAnimation(EnZo* this) {
         }
     }
 
-    if (this->unk_194.talkState != 0 && this->actor.textId == 0x4006 &&
+    if (this->unk_194.talkState != NPC_TALKING_STATE_0 && this->actor.textId == 0x4006 &&
         this->skelAnime.animation != &gZoraHandsOnHipsTappingFootAnim) {
         animId = ENZO_ANIM_6;
     }
 
-    if (this->unk_194.talkState != 0 && this->actor.textId == 0x4007 &&
+    if (this->unk_194.talkState != NPC_TALKING_STATE_0 && this->actor.textId == 0x4007 &&
         this->skelAnime.animation != &gZoraOpenArmsAnim) {
         animId = ENZO_ANIM_7;
     }
@@ -590,7 +590,7 @@ void EnZo_Init(Actor* thisx, PlayState* play) {
     this->dialogRadius = this->collider.dim.radius + 30.0f;
     this->unk_64C = 1;
     this->canSpeak = false;
-    this->unk_194.talkState = 0;
+    this->unk_194.talkState = NPC_TALKING_STATE_0;
     Actor_UpdateBgCheckInfo(play, &this->actor, this->collider.dim.height * 0.5f, this->collider.dim.radius, 0.0f,
                             UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
 
@@ -615,7 +615,7 @@ void EnZo_Standing(EnZo* this, PlayState* play) {
 
     func_80034F54(play, this->unk_656, this->unk_67E, 20);
     EnZo_SetAnimation(this);
-    if (this->unk_194.talkState != 0) {
+    if (this->unk_194.talkState != NPC_TALKING_STATE_0) {
         this->unk_64C = 4;
         return;
     }

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -436,7 +436,7 @@ u16 func_80B61024(PlayState* play, Actor* thisx) {
                 return 0x4011;
             }
             break;
-    }
+
     return 0x4006;
 }
 
@@ -513,7 +513,8 @@ void EnZo_Dialog(EnZo* this, PlayState* play) {
     }
     func_80034A14(&this->actor, &this->unk_194, 11, this->unk_64C);
     if (this->canSpeak == true) {
-        func_800343CC(play, &this->actor, &this->unk_194.talkState, this->dialogRadius, func_80B61024, func_80B61298);
+        Actor_NpcUpdateTalking(play, &this->actor, &this->unk_194.talkState, this->dialogRadius, func_80B61024,
+                               func_80B61298);
     }
 }
 
@@ -555,7 +556,8 @@ void EnZo_SetAnimation(EnZo* this) {
         animId = ENZO_ANIM_6;
     }
 
-    if (this->unk_194.talkState != 0 && this->actor.textId == 0x4007 && this->skelAnime.animation != &gZoraOpenArmsAnim) {
+    if (this->unk_194.talkState != 0 && this->actor.textId == 0x4007 &&
+        this->skelAnime.animation != &gZoraOpenArmsAnim) {
         animId = ENZO_ANIM_7;
     }
 

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -436,7 +436,7 @@ u16 func_80B61024(PlayState* play, Actor* thisx) {
                 return 0x4011;
             }
             break;
-
+    }
     return 0x4006;
 }
 
@@ -449,13 +449,13 @@ s16 func_80B61298(PlayState* play, Actor* thisx) {
         case TEXT_STATE_SONG_DEMO_DONE:
         case TEXT_STATE_8:
         case TEXT_STATE_9:
-            return NPC_TALKING_STATE_1;
+            return NPC_TALK_STATE_TALKING;
 
         case TEXT_STATE_CLOSING:
             switch (thisx->textId) {
                 case 0x4020:
                 case 0x4021:
-                    return NPC_TALKING_STATE_0;
+                    return NPC_TALK_STATE_IDLE;
                 case 0x4008:
                     SET_INFTABLE(INFTABLE_124);
                     break;
@@ -464,12 +464,12 @@ s16 func_80B61298(PlayState* play, Actor* thisx) {
                     break;
             }
             SET_EVENTCHKINF(EVENTCHKINF_30);
-            return NPC_TALKING_STATE_0;
+            return NPC_TALK_STATE_IDLE;
 
         case TEXT_STATE_CHOICE:
             switch (Message_ShouldAdvance(play)) {
                 case 0:
-                    return NPC_TALKING_STATE_1;
+                    return NPC_TALK_STATE_TALKING;
                 default:
                     if (thisx->textId == 0x400C) {
                         thisx->textId = (play->msgCtx.choiceIndex == 0) ? 0x400D : 0x400E;
@@ -477,18 +477,19 @@ s16 func_80B61298(PlayState* play, Actor* thisx) {
                     }
                     break;
             }
-            return 1;
+            return NPC_TALK_STATE_TALKING;
 
         case TEXT_STATE_EVENT:
             switch (Message_ShouldAdvance(play)) {
                 case 0:
-                    return NPC_TALKING_STATE_1;
+                    return NPC_TALK_STATE_TALKING;
                 default:
-                    return NPC_TALKING_STATE_2;
+                    return NPC_TALK_STATE_ACTION;
             }
+            return NPC_TALK_STATE_TALKING;
     }
 
-    return NPC_TALKING_STATE_1;
+    return NPC_TALK_STATE_TALKING;
 }
 
 void EnZo_Blink(EnZo* this) {
@@ -542,7 +543,7 @@ void EnZo_SetAnimation(EnZo* this) {
 
     if (this->skelAnime.animation == &gZoraHandsOnHipsTappingFootAnim ||
         this->skelAnime.animation == &gZoraOpenArmsAnim) {
-        if (this->unk_194.talkState == NPC_TALKING_STATE_0) {
+        if (this->unk_194.talkState == NPC_TALK_STATE_IDLE) {
             if (this->actionFunc == EnZo_Standing) {
                 animId = ENZO_ANIM_0;
             } else {
@@ -551,12 +552,12 @@ void EnZo_SetAnimation(EnZo* this) {
         }
     }
 
-    if (this->unk_194.talkState != NPC_TALKING_STATE_0 && this->actor.textId == 0x4006 &&
+    if (this->unk_194.talkState != NPC_TALK_STATE_IDLE && this->actor.textId == 0x4006 &&
         this->skelAnime.animation != &gZoraHandsOnHipsTappingFootAnim) {
         animId = ENZO_ANIM_6;
     }
 
-    if (this->unk_194.talkState != NPC_TALKING_STATE_0 && this->actor.textId == 0x4007 &&
+    if (this->unk_194.talkState != NPC_TALK_STATE_IDLE && this->actor.textId == 0x4007 &&
         this->skelAnime.animation != &gZoraOpenArmsAnim) {
         animId = ENZO_ANIM_7;
     }
@@ -590,7 +591,7 @@ void EnZo_Init(Actor* thisx, PlayState* play) {
     this->dialogRadius = this->collider.dim.radius + 30.0f;
     this->unk_64C = 1;
     this->canSpeak = false;
-    this->unk_194.talkState = NPC_TALKING_STATE_0;
+    this->unk_194.talkState = NPC_TALK_STATE_IDLE;
     Actor_UpdateBgCheckInfo(play, &this->actor, this->collider.dim.height * 0.5f, this->collider.dim.radius, 0.0f,
                             UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
 
@@ -615,7 +616,7 @@ void EnZo_Standing(EnZo* this, PlayState* play) {
 
     func_80034F54(play, this->unk_656, this->unk_67E, 20);
     EnZo_SetAnimation(this);
-    if (this->unk_194.talkState != NPC_TALKING_STATE_0) {
+    if (this->unk_194.talkState != NPC_TALK_STATE_IDLE) {
         this->unk_64C = 4;
         return;
     }

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -513,7 +513,7 @@ void EnZo_Dialog(EnZo* this, PlayState* play) {
     }
     func_80034A14(&this->actor, &this->unk_194, 11, this->unk_64C);
     if (this->canSpeak == true) {
-        func_800343CC(play, &this->actor, &this->unk_194.unk_00, this->dialogRadius, func_80B61024, func_80B61298);
+        func_800343CC(play, &this->actor, &this->unk_194.talkState, this->dialogRadius, func_80B61024, func_80B61298);
     }
 }
 
@@ -541,7 +541,7 @@ void EnZo_SetAnimation(EnZo* this) {
 
     if (this->skelAnime.animation == &gZoraHandsOnHipsTappingFootAnim ||
         this->skelAnime.animation == &gZoraOpenArmsAnim) {
-        if (this->unk_194.unk_00 == 0) {
+        if (this->unk_194.talkState == 0) {
             if (this->actionFunc == EnZo_Standing) {
                 animId = ENZO_ANIM_0;
             } else {
@@ -550,12 +550,12 @@ void EnZo_SetAnimation(EnZo* this) {
         }
     }
 
-    if (this->unk_194.unk_00 != 0 && this->actor.textId == 0x4006 &&
+    if (this->unk_194.talkState != 0 && this->actor.textId == 0x4006 &&
         this->skelAnime.animation != &gZoraHandsOnHipsTappingFootAnim) {
         animId = ENZO_ANIM_6;
     }
 
-    if (this->unk_194.unk_00 != 0 && this->actor.textId == 0x4007 && this->skelAnime.animation != &gZoraOpenArmsAnim) {
+    if (this->unk_194.talkState != 0 && this->actor.textId == 0x4007 && this->skelAnime.animation != &gZoraOpenArmsAnim) {
         animId = ENZO_ANIM_7;
     }
 
@@ -588,7 +588,7 @@ void EnZo_Init(Actor* thisx, PlayState* play) {
     this->dialogRadius = this->collider.dim.radius + 30.0f;
     this->unk_64C = 1;
     this->canSpeak = false;
-    this->unk_194.unk_00 = 0;
+    this->unk_194.talkState = 0;
     Actor_UpdateBgCheckInfo(play, &this->actor, this->collider.dim.height * 0.5f, this->collider.dim.radius, 0.0f,
                             UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
 
@@ -613,7 +613,7 @@ void EnZo_Standing(EnZo* this, PlayState* play) {
 
     func_80034F54(play, this->unk_656, this->unk_67E, 20);
     EnZo_SetAnimation(this);
-    if (this->unk_194.unk_00 != 0) {
+    if (this->unk_194.talkState != 0) {
         this->unk_64C = 4;
         return;
     }


### PR DESCRIPTION
I've been looking at documenting more NPCs and ran into this system that some NPCs use to handle talking to the player. More specifically I just renamed and cleaned up the "talkState" field that indicates the "state" of the NPC dialog, and documented the function that NPCs use to update the state.

This field has four possible values that it gets set to in the game. Shared functions in `z_actor` only care about 0 / 1, the other values are checked and used only by the NPC actors themselves.
- 0: not talking / idle
- 1: talking
- 2: "action": some NPC actors use this state to indicate some triggered action during the dialog (e.g. giving an item, running an animation or setting some flags)
- 3: "item given": used in a few places to indicate that an item was given to the player and the "get item" textbox is done

Suggestions for better names are more than welcome! 😅 


 <details>
 <summary>A list of the uses for the "action" state (2). This is likely incomplete or even incorrect, I just quickly skimmed over these trying to understand how the state gets used:</summary>
 
- EnMd: Move away from blocking a path
- EnMa3: Unused (copied from EnMa2)
- EnMa2: Unset auto-talk actor flag after playing Epona's song
- EnMa1: Give weird egg, teach Epona's song
- EnHy: Not used (only set, but never checked)
- EnZo: Not used (only set, but never checked)
- EnTk (dampe): Dig
- EnKz (King zora):
	- Give tunic
	- GIve bottle back, mweep
	- Give frog
- EnKo: Fado giving saw
- EnIn: set flags / transition in/out of riding / continue to next animation / ...
- EnGo2:
	- Biggoron:
		- Using eyedrops
		- Giving BGS, Prescription
	- Big rolling
		* End talk, continue rolling
	* Bomb flower goron
		* Continue animation
	* Link
		* Give tunic
		* "Ask about..."
- EnGo:
	* Giving out item, etc
- EnDu (Darunia): give bracelet, set cutscene mode
 </details>