### PR TITLE
Cleanup `z_collision_check` 2: Rename fields pertaining to "other" colliders

### DIFF
--- a/include/z64collision_check.h
+++ b/include/z64collision_check.h
@@ -10,10 +10,10 @@
 struct Actor;
 
 typedef struct {
-    /* 0x00 */ struct Actor* actor; // Attached actor
-    /* 0x04 */ struct Actor* at; // Actor attached to what it collided with as an AT collider.
-    /* 0x08 */ struct Actor* ac; // Actor attached to what it collided with as an AC collider.
-    /* 0x0C */ struct Actor* oc; // Actor attached to what it collided with as an OC collider.
+    /* 0x00 */ struct Actor* self; // Actor owning this collider.
+    /* 0x04 */ struct Actor* otherAC; // Other actor owning the AC collider that collided with this AT collider.
+    /* 0x08 */ struct Actor* otherAT; // Other actor owning the AT collider that collided with this AC collider.
+    /* 0x0C */ struct Actor* otherOC; // Other actor owning the OC collider that collided with this OC collider.
     /* 0x10 */ u8 atFlags; // Information flags for AT collisions.
     /* 0x11 */ u8 acFlags; // Information flags for AC collisions.
     /* 0x12 */ u8 ocFlags1; // Information flags for OC collisions.
@@ -73,10 +73,10 @@ typedef struct ColliderInfo {
     /* 0x15 */ u8 toucherFlags; // Information flags for AT collisions
     /* 0x16 */ u8 bumperFlags; // Information flags for AC collisions
     /* 0x17 */ u8 ocElemFlags; // Information flags for OC collisions
-    /* 0x18 */ Collider* atHit;                // object touching this element's AT collider
-    /* 0x1C */ Collider* acHit;                // object touching this element's AC collider
-    /* 0x20 */ struct ColliderInfo* atHitInfo; // element that hit the AT collider
-    /* 0x24 */ struct ColliderInfo* acHitInfo; // element that hit the AC collider
+    /* 0x18 */ Collider* otherColAC; // AC collider that collided with this AT element
+    /* 0x1C */ Collider* otherColAT; // AT collider that collided with this AC element
+    /* 0x20 */ struct ColliderInfo* otherElemAC; // AC element that collided with this AT element
+    /* 0x24 */ struct ColliderInfo* otherElemAT; // AT element that collided with this AC element
 } ColliderInfo; // size = 0x28
 
 typedef struct {

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -3235,9 +3235,9 @@ void func_80033480(PlayState* play, Vec3f* posBase, f32 randRangeDiameter, s32 a
 }
 
 Actor* Actor_GetCollidedExplosive(PlayState* play, Collider* collider) {
-    if ((collider->acFlags & AC_HIT) && (collider->ac->category == ACTORCAT_EXPLOSIVE)) {
+    if ((collider->acFlags & AC_HIT) && (collider->otherAT->category == ACTORCAT_EXPLOSIVE)) {
         collider->acFlags &= ~AC_HIT;
-        return collider->ac;
+        return collider->otherAT;
     }
 
     return NULL;
@@ -4065,27 +4065,27 @@ u8 Actor_ApplyDamage(Actor* actor) {
 }
 
 void Actor_SetDropFlag(Actor* actor, ColliderInfo* colInfo, s32 freezeFlag) {
-    if (colInfo->acHitInfo == NULL) {
+    if (colInfo->otherElemAT == NULL) {
         actor->dropFlag = 0x00;
     } else if (freezeFlag &&
-               (colInfo->acHitInfo->toucher.dmgFlags & (DMG_UNKNOWN_1 | DMG_MAGIC_ICE | DMG_MAGIC_FIRE))) {
-        actor->freezeTimer = colInfo->acHitInfo->toucher.damage;
+               (colInfo->otherElemAT->toucher.dmgFlags & (DMG_UNKNOWN_1 | DMG_MAGIC_ICE | DMG_MAGIC_FIRE))) {
+        actor->freezeTimer = colInfo->otherElemAT->toucher.damage;
         actor->dropFlag = 0x00;
-    } else if (colInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_FIRE) {
+    } else if (colInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_FIRE) {
         actor->dropFlag = 0x01;
-    } else if (colInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_ICE) {
+    } else if (colInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_ICE) {
         actor->dropFlag = 0x02;
-    } else if (colInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_UNK1) {
+    } else if (colInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_UNK1) {
         actor->dropFlag = 0x04;
-    } else if (colInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_UNK2) {
+    } else if (colInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_UNK2) {
         actor->dropFlag = 0x08;
-    } else if (colInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_UNK3) {
+    } else if (colInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_UNK3) {
         actor->dropFlag = 0x10;
-    } else if (colInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_LIGHT) {
+    } else if (colInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_LIGHT) {
         actor->dropFlag = 0x20;
-    } else if (colInfo->acHitInfo->toucher.dmgFlags & DMG_MAGIC_LIGHT) {
+    } else if (colInfo->otherElemAT->toucher.dmgFlags & DMG_MAGIC_LIGHT) {
         if (freezeFlag) {
-            actor->freezeTimer = colInfo->acHitInfo->toucher.damage;
+            actor->freezeTimer = colInfo->otherElemAT->toucher.damage;
         }
         actor->dropFlag = 0x40;
     } else {
@@ -4102,27 +4102,27 @@ void Actor_SetDropFlagJntSph(Actor* actor, ColliderJntSph* jntSph, s32 freezeFla
 
     for (i = jntSph->count - 1; i >= 0; i--) {
         curColInfo = &jntSph->elements[i].info;
-        if (curColInfo->acHitInfo == NULL) {
+        if (curColInfo->otherElemAT == NULL) {
             flag = 0x00;
         } else if (freezeFlag &&
-                   (curColInfo->acHitInfo->toucher.dmgFlags & (DMG_UNKNOWN_1 | DMG_MAGIC_ICE | DMG_MAGIC_FIRE))) {
-            actor->freezeTimer = curColInfo->acHitInfo->toucher.damage;
+                   (curColInfo->otherElemAT->toucher.dmgFlags & (DMG_UNKNOWN_1 | DMG_MAGIC_ICE | DMG_MAGIC_FIRE))) {
+            actor->freezeTimer = curColInfo->otherElemAT->toucher.damage;
             flag = 0x00;
-        } else if (curColInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_FIRE) {
+        } else if (curColInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_FIRE) {
             flag = 0x01;
-        } else if (curColInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_ICE) {
+        } else if (curColInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_ICE) {
             flag = 0x02;
-        } else if (curColInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_UNK1) {
+        } else if (curColInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_UNK1) {
             flag = 0x04;
-        } else if (curColInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_UNK2) {
+        } else if (curColInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_UNK2) {
             flag = 0x08;
-        } else if (curColInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_UNK3) {
+        } else if (curColInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_UNK3) {
             flag = 0x10;
-        } else if (curColInfo->acHitInfo->toucher.dmgFlags & DMG_ARROW_LIGHT) {
+        } else if (curColInfo->otherElemAT->toucher.dmgFlags & DMG_ARROW_LIGHT) {
             flag = 0x20;
-        } else if (curColInfo->acHitInfo->toucher.dmgFlags & DMG_MAGIC_LIGHT) {
+        } else if (curColInfo->otherElemAT->toucher.dmgFlags & DMG_MAGIC_LIGHT) {
             if (freezeFlag) {
-                actor->freezeTimer = curColInfo->acHitInfo->toucher.damage;
+                actor->freezeTimer = curColInfo->otherElemAT->toucher.damage;
             }
             flag = 0x40;
         } else {

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -169,10 +169,10 @@ void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
     ArmsHook_CheckForCancel(this);
 
     if ((this->timer != 0) && (this->collider.base.atFlags & AT_HIT) &&
-        (this->collider.info.atHitInfo->elemType != ELEMTYPE_UNK4)) {
-        touchedActor = this->collider.base.at;
+        (this->collider.info.otherElemAC->elemType != ELEMTYPE_UNK4)) {
+        touchedActor = this->collider.base.otherAC;
         if ((touchedActor->update != NULL) && (touchedActor->flags & (ACTOR_FLAG_9 | ACTOR_FLAG_10))) {
-            if (this->collider.info.atHitInfo->bumperFlags & BUMP_HOOKABLE) {
+            if (this->collider.info.otherElemAC->bumperFlags & BUMP_HOOKABLE) {
                 ArmsHook_AttachHookToActor(this, touchedActor);
                 if (CHECK_FLAG_ALL(touchedActor->flags, ACTOR_FLAG_10)) {
                     func_80865044(this);

--- a/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
+++ b/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
@@ -278,9 +278,9 @@ void BgDodoago_Update(Actor* thisx, PlayState* play) {
         if ((this->colliderLeft.base.ocFlags1 & OC1_HIT) || (this->colliderRight.base.ocFlags1 & OC1_HIT)) {
 
             if (this->colliderLeft.base.ocFlags1 & OC1_HIT) {
-                actor = this->colliderLeft.base.oc;
+                actor = this->colliderLeft.base.otherOC;
             } else {
-                actor = this->colliderRight.base.oc;
+                actor = this->colliderRight.base.otherOC;
             }
             this->colliderLeft.base.ocFlags1 &= ~OC1_HIT;
             this->colliderRight.base.ocFlags1 &= ~OC1_HIT;

--- a/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.c
@@ -121,8 +121,8 @@ void BgHakaTubo_Idle(BgHakaTubo* this, PlayState* play) {
         this->potCollider.base.acFlags &= ~AC_HIT;
         // If the colliding actor is within a 50 unit radius and 50 unit height cylinder centered
         // on the actor's position, break the pot
-        if (Actor_WorldDistXZToPoint(&this->dyna.actor, &this->potCollider.base.ac->world.pos) < 50.0f &&
-            (this->potCollider.base.ac->world.pos.y - this->dyna.actor.world.pos.y) < 50.0f) {
+        if (Actor_WorldDistXZToPoint(&this->dyna.actor, &this->potCollider.base.otherAT->world.pos) < 50.0f &&
+            (this->potCollider.base.otherAT->world.pos.y - this->dyna.actor.world.pos.y) < 50.0f) {
             pos.x = this->dyna.actor.world.pos.x;
             pos.z = this->dyna.actor.world.pos.z;
             pos.y = this->dyna.actor.world.pos.y + 80.0f;

--- a/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
@@ -341,7 +341,7 @@ void BgIceShelter_Idle(BgIceShelter* this, PlayState* play) {
     if (this->cylinder1.base.acFlags & AC_HIT) {
         this->cylinder1.base.acFlags &= ~AC_HIT;
 
-        if ((this->cylinder1.base.ac != NULL) && (this->cylinder1.base.ac->id == ACTOR_EN_ICE_HONO)) {
+        if ((this->cylinder1.base.otherAT != NULL) && (this->cylinder1.base.otherAT->id == ACTOR_EN_ICE_HONO)) {
             if (type == RED_ICE_KING_ZORA) {
                 if (this->dyna.actor.parent != NULL) {
                     this->dyna.actor.parent->freezeTimer = 50;

--- a/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.c
@@ -152,8 +152,8 @@ void BgJyaHaheniron_ChairCrumble(BgJyaHaheniron* this, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 5.0f, 8.0f, 0.0f,
                             UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2 | UPDBGCHECKINFO_FLAG_7);
     if ((this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_WALL)) ||
-        ((this->collider.base.atFlags & AT_HIT) && (this->collider.base.at != NULL) &&
-         (this->collider.base.at->category == ACTORCAT_PLAYER))) {
+        ((this->collider.base.atFlags & AT_HIT) && (this->collider.base.otherAC != NULL) &&
+         (this->collider.base.otherAC->category == ACTORCAT_PLAYER))) {
         vec.x = -Rand_ZeroOne() * this->actor.velocity.x;
         vec.y = -Rand_ZeroOne() * this->actor.velocity.y;
         vec.z = -Rand_ZeroOne() * this->actor.velocity.z;

--- a/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
@@ -244,7 +244,7 @@ void func_808992E8(BgJyaIronobj* this, PlayState* play) {
     s32 i;
 
     if (this->colCylinder.base.acFlags & AC_HIT) {
-        actor = this->colCylinder.base.ac;
+        actor = this->colCylinder.base.otherAT;
         this->colCylinder.base.acFlags &= ~AC_HIT;
         if (actor != NULL && actor->id == ACTOR_EN_IK) {
             particleFunc[this->dyna.actor.params & 1](this, play, (EnIk*)actor);

--- a/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
@@ -98,7 +98,7 @@ void BgMenkuriEye_Update(Actor* thisx, PlayState* play) {
         }
     }
     if ((this->collider.base.acFlags & AC_HIT) &&
-        (ABS((s16)(this->collider.base.ac->world.rot.y - this->actor.shape.rot.y)) > 0x5000)) {
+        (ABS((s16)(this->collider.base.otherAT->world.rot.y - this->actor.shape.rot.y)) > 0x5000)) {
         this->collider.base.acFlags &= ~AC_HIT;
         if (this->framesUntilDisable == -1) {
             Audio_PlayActorSfx2(&this->actor, NA_SE_EN_AMOS_DAMAGE);

--- a/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
@@ -215,13 +215,13 @@ void func_808B7BCC(BgSpot18Basket* this, PlayState* play) {
     this->dyna.actor.world.pos.z = (Math_CosS(this->unk_20E) * this->unk_208) + this->dyna.actor.home.pos.z;
 
     if (this->colliderJntSph.base.acFlags & AC_HIT) {
-        colliderBaseAc = this->colliderJntSph.base.ac;
+        colliderBaseAc = this->colliderJntSph.base.otherAT;
 
         if (colliderBaseAc != NULL) {
             positionDiff = colliderBaseAc->world.pos.y - this->dyna.actor.world.pos.y;
 
             if (positionDiff > 120.0f && positionDiff < 200.0f) {
-                if (Math3D_Dist2DSq(colliderBaseAc->world.pos.z, this->colliderJntSph.base.ac->world.pos.x,
+                if (Math3D_Dist2DSq(colliderBaseAc->world.pos.z, this->colliderJntSph.base.otherAT->world.pos.x,
                                     this->dyna.actor.world.pos.z, this->dyna.actor.world.pos.x) < SQ(32.0f)) {
                     OnePointCutscene_Init(play, 4210, 240, &this->dyna.actor, CAM_ID_MAIN);
                     func_808B7D38(this);

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -1242,7 +1242,7 @@ void BossDodongo_UpdateDamage(BossDodongo* this, PlayState* play) {
         if (this->actionFunc == BossDodongo_Inhale) {
             for (i = 0; i < 19; i++) {
                 if (this->collider.elements[i].info.bumperFlags & BUMP_HIT) {
-                    item1 = this->collider.elements[i].info.acHitInfo;
+                    item1 = this->collider.elements[i].info.otherElemAT;
                     item2 = item1;
 
                     if ((item2->toucher.dmgFlags & DMG_BOOMERANG) || (item2->toucher.dmgFlags & DMG_SLINGSHOT)) {
@@ -1258,7 +1258,7 @@ void BossDodongo_UpdateDamage(BossDodongo* this, PlayState* play) {
 
         if (this->collider.elements->info.bumperFlags & BUMP_HIT) {
             this->collider.elements->info.bumperFlags &= ~BUMP_HIT;
-            item1 = this->collider.elements[0].info.acHitInfo;
+            item1 = this->collider.elements[0].info.otherElemAT;
             if ((this->actionFunc == BossDodongo_Vulnerable) || (this->actionFunc == BossDodongo_LayDown)) {
                 swordDamage = damage = CollisionCheck_GetSwordDamage(item1->toucher.dmgFlags);
 

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -1283,7 +1283,7 @@ void BossFd_CollisionCheck(BossFd* this, PlayState* play) {
 
     if (headCollider->info.bumperFlags & BUMP_HIT) {
         headCollider->info.bumperFlags &= ~BUMP_HIT;
-        hurtbox = headCollider->info.acHitInfo;
+        hurtbox = headCollider->info.otherElemAT;
         this->actor.colChkInfo.health -= 2;
         if (hurtbox->toucher.dmgFlags & DMG_ARROW_ICE) {
             this->actor.colChkInfo.health -= 2;

--- a/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
+++ b/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
@@ -830,7 +830,7 @@ void BossFd2_CollisionCheck(BossFd2* this, PlayState* play) {
     if (this->collider.elements[0].info.bumperFlags & BUMP_HIT) {
         this->collider.elements[0].info.bumperFlags &= ~BUMP_HIT;
 
-        hurtbox = this->collider.elements[0].info.acHitInfo;
+        hurtbox = this->collider.elements[0].info.otherElemAT;
         if (!bossFd->faceExposed) {
             if (hurtbox->toucher.dmgFlags & DMG_HAMMER) {
                 bossFd->actor.colChkInfo.health -= 2;

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -2685,22 +2685,22 @@ void BossGanon_Damaged(BossGanon* this, PlayState* play) {
 void BossGanon_UpdateDamage(BossGanon* this, PlayState* play) {
     s16 i;
     s16 j;
-    ColliderInfo* acHitInfo;
+    ColliderInfo* otherElemAT;
 
     if (this->collider.base.acFlags & AC_HIT) {
         this->unk_2D4 = 2;
         this->collider.base.acFlags &= ~AC_HIT;
-        acHitInfo = this->collider.info.acHitInfo;
+        otherElemAT = this->collider.info.otherElemAT;
 
         if ((this->actionFunc == BossGanon_HitByLightBall) || (this->actionFunc == BossGanon_ChargeBigMagic)) {
-            if (acHitInfo->toucher.dmgFlags & DMG_ARROW_LIGHT) {
+            if (otherElemAT->toucher.dmgFlags & DMG_ARROW_LIGHT) {
                 BossGanon_SetupVulnerable(this, play);
                 this->timers[2] = 0;
                 Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DAMAGE1);
                 this->unk_1A6 = 15;
             }
         } else if ((this->actionFunc == BossGanon_Vulnerable) && (this->unk_1C2 >= 3)) {
-            if (!(acHitInfo->toucher.dmgFlags & DMG_HOOKSHOT)) {
+            if (!(otherElemAT->toucher.dmgFlags & DMG_HOOKSHOT)) {
                 u8 hitWithSword = false;
                 u8 damage;
                 Vec3f sp50;
@@ -2714,7 +2714,7 @@ void BossGanon_UpdateDamage(BossGanon* this, PlayState* play) {
                                               0x1E);
                 }
 
-                damage = flags = CollisionCheck_GetSwordDamage(acHitInfo->toucher.dmgFlags);
+                damage = flags = CollisionCheck_GetSwordDamage(otherElemAT->toucher.dmgFlags);
 
                 if (flags == 0) {
                     damage = 2;
@@ -2748,7 +2748,7 @@ void BossGanon_UpdateDamage(BossGanon* this, PlayState* play) {
                     sCape->tearTimer = 1;
                 }
             }
-        } else if (acHitInfo->toucher.dmgFlags & DMG_RANGED) {
+        } else if (otherElemAT->toucher.dmgFlags & DMG_RANGED) {
             Audio_PlayActorSfx2(&this->actor, 0);
 
             for (i = 0; i < ARRAY_COUNT(sCape->strands); i++) {
@@ -3935,11 +3935,11 @@ void BossGanon_LightBall_Update(Actor* thisx, PlayState* play2) {
                 }
 
                 if ((this->collider.base.acFlags & AC_HIT) || hitWithBottle) {
-                    ColliderInfo* acHitInfo = this->collider.info.acHitInfo;
+                    ColliderInfo* otherElemAT = this->collider.info.otherElemAT;
 
                     this->collider.base.acFlags &= ~AC_HIT;
 
-                    if ((hitWithBottle == false) && (acHitInfo->toucher.dmgFlags & DMG_SHIELD)) {
+                    if ((hitWithBottle == false) && (otherElemAT->toucher.dmgFlags & DMG_SHIELD)) {
                         spBA = 2;
                         Audio_PlaySfxGeneral(NA_SE_IT_SHIELD_REFLECT_MG, &player->actor.projectedPos, 4,
                                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
@@ -4309,7 +4309,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
     BossGanon* dorf = (BossGanon*)this->actor.parent;
     s32 pad;
     Player* player = GET_PLAYER(play);
-    ColliderInfo* acHitInfo;
+    ColliderInfo* otherElemAT;
     Vec3f sp60;
 
     this->unk_1A2++;
@@ -4419,11 +4419,11 @@ void func_808E2544(Actor* thisx, PlayState* play) {
             }
 
             if (this->collider.base.acFlags & AC_HIT) {
-                acHitInfo = this->collider.info.acHitInfo;
+                otherElemAT = this->collider.info.otherElemAT;
 
                 this->collider.base.acFlags &= ~AC_HIT;
 
-                if (!(acHitInfo->toucher.dmgFlags & DMG_SHIELD) || Player_HasMirrorShieldEquipped(play)) {
+                if (!(otherElemAT->toucher.dmgFlags & DMG_SHIELD) || Player_HasMirrorShieldEquipped(play)) {
                     Rumble_Request(this->actor.xyzDistToPlayerSq, 180, 20, 100);
                     this->unk_1C2 = 0xC;
                     this->actor.speedXZ = -30.0f;

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -1880,7 +1880,7 @@ void func_80902348(BossGanon2* this, PlayState* play) {
 
 void func_80902524(BossGanon2* this, PlayState* play) {
     s8 temp_v0_4;
-    ColliderInfo* acHitInfo;
+    ColliderInfo* otherElemAT;
     s16 i;
     u8 phi_v1_2;
 
@@ -1896,14 +1896,14 @@ void func_80902524(BossGanon2* this, PlayState* play) {
         if (this->actionFunc != func_808FFFE0) {
             if (this->unk_424.elements[0].info.bumperFlags & BUMP_HIT) {
                 this->unk_424.elements[0].info.bumperFlags &= ~BUMP_HIT;
-                acHitInfo = this->unk_424.elements[0].info.acHitInfo;
-                if ((acHitInfo->toucher.dmgFlags & DMG_ARROW_LIGHT) && (this->actionFunc != func_80900890)) {
+                otherElemAT = this->unk_424.elements[0].info.otherElemAT;
+                if ((otherElemAT->toucher.dmgFlags & DMG_ARROW_LIGHT) && (this->actionFunc != func_80900890)) {
                     func_809000A0(this, play);
                     Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_HIT_THUNDER);
                     Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DAMAGE);
                     Audio_StopSfxById(NA_SE_EN_MGANON_UNARI);
                 } else if ((this->actionFunc == func_80900890) &&
-                           (acHitInfo->toucher.dmgFlags & (DMG_JUMP_MASTER | DMG_SPIN_MASTER | DMG_SLASH_MASTER))) {
+                           (otherElemAT->toucher.dmgFlags & (DMG_JUMP_MASTER | DMG_SPIN_MASTER | DMG_SLASH_MASTER))) {
                     this->unk_316 = 60;
                     this->unk_342 = 5;
                     Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DAMAGE);
@@ -1928,15 +1928,15 @@ void func_80902524(BossGanon2* this, PlayState* play) {
     } else {
         if (this->unk_424.elements[15].info.bumperFlags & BUMP_HIT) {
             this->unk_424.elements[15].info.bumperFlags &= ~BUMP_HIT;
-            acHitInfo = this->unk_424.elements[15].info.acHitInfo;
+            otherElemAT = this->unk_424.elements[15].info.otherElemAT;
             this->unk_316 = 60;
             this->unk_344 = 0x32;
             this->unk_342 = 5;
             Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DAMAGE);
             Audio_StopSfxById(NA_SE_EN_MGANON_UNARI);
             phi_v1_2 = 1;
-            if (acHitInfo->toucher.dmgFlags & (DMG_JUMP_MASTER | DMG_SPIN_MASTER | DMG_SLASH_MASTER)) {
-                if (acHitInfo->toucher.dmgFlags & DMG_JUMP_MASTER) {
+            if (otherElemAT->toucher.dmgFlags & (DMG_JUMP_MASTER | DMG_SPIN_MASTER | DMG_SLASH_MASTER)) {
+                if (otherElemAT->toucher.dmgFlags & DMG_JUMP_MASTER) {
                     phi_v1_2 = 4;
                 } else {
                     phi_v1_2 = 2;

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -1235,7 +1235,7 @@ void BossGanondrof_CollisionCheck(BossGanondrof* this, PlayState* play) {
         if ((acHit && ((s8)this->actor.colChkInfo.health > 0)) || (this->returnCount != 0)) {
             if (acHit) {
                 this->colliderBody.base.acFlags &= ~AC_HIT;
-                hurtbox = this->colliderBody.info.acHitInfo;
+                hurtbox = this->colliderBody.info.otherElemAT;
             }
             if (this->flyMode != GND_FLY_PAINTING) {
                 if (acHit && (this->actionFunc != BossGanondrof_Stunned) && (hurtbox->toucher.dmgFlags & DMG_RANGED)) {

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -1807,7 +1807,7 @@ void BossGoma_UpdateHit(BossGoma* this, PlayState* play) {
     if (this->invincibilityFrames != 0) {
         this->invincibilityFrames--;
     } else {
-        ColliderInfo* acHitInfo = this->collider.elements[0].info.acHitInfo;
+        ColliderInfo* otherElemAT = this->collider.elements[0].info.otherElemAT;
         s32 damage;
 
         if (this->eyeClosedTimer == 0 && this->actionFunc != BossGoma_CeilingSpawnGohmas &&
@@ -1819,7 +1819,7 @@ void BossGoma_UpdateHit(BossGoma* this, PlayState* play) {
                 BossGoma_SetupFallStruckDown(this);
                 Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_DAM2);
             } else if (this->actionFunc == BossGoma_FloorStunned &&
-                       (damage = CollisionCheck_GetSwordDamage(acHitInfo->toucher.dmgFlags)) != 0) {
+                       (damage = CollisionCheck_GetSwordDamage(otherElemAT->toucher.dmgFlags)) != 0) {
                 this->actor.colChkInfo.health -= damage;
 
                 if ((s8)this->actor.colChkInfo.health > 0) {
@@ -1833,14 +1833,14 @@ void BossGoma_UpdateHit(BossGoma* this, PlayState* play) {
 
                 this->invincibilityFrames = 10;
             } else if (this->actionFunc != BossGoma_FloorStunned && this->patienceTimer != 0 &&
-                       (acHitInfo->toucher.dmgFlags & (DMG_SLINGSHOT | DMG_DEKU_NUT))) {
+                       (otherElemAT->toucher.dmgFlags & (DMG_SLINGSHOT | DMG_DEKU_NUT))) {
                 Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_DAM2);
                 Audio_StopSfxById(NA_SE_EN_GOMA_CRY1);
                 this->invincibilityFrames = 10;
                 BossGoma_SetupFloorStunned(this);
                 this->sfxFaintTimer = 100;
 
-                if (acHitInfo->toucher.dmgFlags & DMG_DEKU_NUT) {
+                if (otherElemAT->toucher.dmgFlags & DMG_DEKU_NUT) {
                     this->framesUntilNextAction = 40;
                 } else {
                     this->framesUntilNextAction = 90;

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -1147,7 +1147,7 @@ void BossMo_TentCollisionCheck(BossMo* this, PlayState* play) {
                 this->tentCollider.elements[i2].info.bumperFlags &= ~BUMP_HIT;
                 this->tentCollider.elements[i2].info.toucherFlags &= ~TOUCH_HIT;
             }
-            hurtbox = this->tentCollider.elements[i1].info.acHitInfo;
+            hurtbox = this->tentCollider.elements[i1].info.otherElemAT;
             this->work[MO_TENT_INVINC_TIMER] = 5;
             if (hurtbox->toucher.dmgFlags & DMG_MAGIC_FIRE) {
                 func_80078914(&this->tentTipPos, NA_SE_EN_MOFER_CUT);
@@ -1745,7 +1745,7 @@ void BossMo_CoreCollisionCheck(BossMo* this, PlayState* play) {
         }
     }
     if (this->coreCollider.base.acFlags & AC_HIT) {
-        ColliderInfo* hurtbox = this->coreCollider.info.acHitInfo;
+        ColliderInfo* hurtbox = this->coreCollider.info.otherElemAT;
         // "hit!!"
         osSyncPrintf("Core_Damage_check 当り！！\n");
         this->coreCollider.base.acFlags &= ~AC_HIT;

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -3091,7 +3091,7 @@ void BossTw_TwinrovaUpdate(Actor* thisx, PlayState* play2) {
                 BossTw_TwinrovaDamage(this, play, 0);
                 Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_YOUNG_DAMAGE);
             } else if (this->collider.base.acFlags & AC_HIT) {
-                ColliderInfo* info = this->collider.info.acHitInfo;
+                ColliderInfo* info = this->collider.info.otherElemAT;
 
                 this->collider.base.acFlags &= ~AC_HIT;
                 if (info->toucher.dmgFlags & (DMG_SLINGSHOT | DMG_ARROW)) {}
@@ -3099,7 +3099,7 @@ void BossTw_TwinrovaUpdate(Actor* thisx, PlayState* play2) {
         } else if (this->collider.base.acFlags & AC_HIT) {
             u8 damage;
             u8 swordDamage;
-            ColliderInfo* info = this->collider.info.acHitInfo;
+            ColliderInfo* info = this->collider.info.otherElemAT;
 
             this->collider.base.acFlags &= ~AC_HIT;
             swordDamage = false;
@@ -4326,7 +4326,7 @@ s32 BossTw_BlastShieldCheck(BossTw* this, PlayState* play) {
         if (this->collider.base.acFlags & AC_HIT) {
             this->collider.base.acFlags &= ~AC_HIT;
             this->collider.base.atFlags &= ~AT_HIT;
-            info = this->collider.info.acHitInfo;
+            info = this->collider.info.otherElemAT;
 
             if (info->toucher.dmgFlags & DMG_SHIELD) {
                 this->work[INVINC_TIMER] = 7;

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -1068,7 +1068,7 @@ void BossVa_BodyPhase1(BossVa* this, PlayState* play) {
 
     if (this->colliderBody.base.atFlags & AT_HIT) {
         this->colliderBody.base.atFlags &= ~AT_HIT;
-        if (this->colliderBody.base.at == &player->actor) {
+        if (this->colliderBody.base.otherAC == &player->actor) {
             func_8002F71C(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
         }
     }
@@ -1136,7 +1136,7 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
     if (this->colliderBody.base.acFlags & AC_HIT) {
         this->colliderBody.base.acFlags &= ~AC_HIT;
 
-        if (this->colliderBody.base.ac->id == ACTOR_EN_BOOM) {
+        if (this->colliderBody.base.otherAT->id == ACTOR_EN_BOOM) {
             sPhase2Timer &= 0xFE00;
             Actor_SetColorFilter(&this->actor, 0, 255, 0, 160);
             this->colliderBody.info.bumper.dmgFlags = DMG_SWORD | DMG_BOOMERANG | DMG_DEKU_STICK;
@@ -1159,7 +1159,7 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
         this->colliderBody.base.atFlags &= ~AT_HIT;
 
         sPhase2Timer = (sPhase2Timer + 0x18) & 0xFFF0;
-        if (this->colliderBody.base.at == &player->actor) {
+        if (this->colliderBody.base.otherAC == &player->actor) {
             func_8002F71C(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
         }
@@ -1234,7 +1234,7 @@ void BossVa_BodyPhase3(BossVa* this, PlayState* play) {
     this->bodyGlow = (s16)(Math_SinS(this->unk_1B0) * 50.0f) + 150;
     if (this->colliderBody.base.atFlags & AT_HIT) {
         this->colliderBody.base.atFlags &= ~AT_HIT;
-        if (this->colliderBody.base.at == &player->actor) {
+        if (this->colliderBody.base.otherAC == &player->actor) {
             func_8002F71C(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             this->actor.world.rot.y += (s16)Rand_CenteredFloat(0x2EE0) + 0x8000;
             Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
@@ -1355,7 +1355,7 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
     this->bodyGlow = (s16)(Math_SinS(this->unk_1B0) * 50.0f) + 150;
     if (this->colliderBody.base.atFlags & AT_HIT) {
         this->colliderBody.base.atFlags &= ~AT_HIT;
-        if (this->colliderBody.base.at == &player->actor) {
+        if (this->colliderBody.base.otherAC == &player->actor) {
             func_8002F71C(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             this->actor.world.rot.y += (s16)Rand_CenteredFloat(0x2EE0) + 0x8000;
             Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
@@ -1396,8 +1396,8 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
                     Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_FAINT);
                 }
             }
-        } else if (this->colliderBody.base.ac->id == ACTOR_EN_BOOM) {
-            boomerang = (EnBoom*)this->colliderBody.base.ac;
+        } else if (this->colliderBody.base.otherAT->id == ACTOR_EN_BOOM) {
+            boomerang = (EnBoom*)this->colliderBody.base.otherAT;
             boomerang->returnTimer = 0;
             boomerang->moveTo = &player->actor;
             boomerang->actor.world.rot.y = boomerang->actor.yawTowardsPlayer;
@@ -2541,11 +2541,12 @@ void BossVa_BariPhase3Attack(BossVa* this, PlayState* play) {
     Math_SmoothStepToS(&this->vaBariUnused.z, this->vaBariUnused.x, 1, 0x1E, 0);
     this->vaBariUnused.y += this->vaBariUnused.z;
     if ((this->colliderLightning.base.atFlags & AT_HIT) || (this->colliderSph.base.atFlags & AT_HIT)) {
-        if ((this->colliderLightning.base.at == &player->actor) || (this->colliderSph.base.at == &player->actor)) {
+        if ((this->colliderLightning.base.otherAC == &player->actor) ||
+            (this->colliderSph.base.otherAC == &player->actor)) {
             func_8002F71C(play, &this->actor, 8.0f, GET_BODY(this)->actor.yawTowardsPlayer, 8.0f);
             Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
-            this->colliderSph.base.at = NULL;
-            this->colliderLightning.base.at = NULL;
+            this->colliderSph.base.otherAC = NULL;
+            this->colliderLightning.base.otherAC = NULL;
         }
 
         this->colliderLightning.base.atFlags &= ~AT_HIT;
@@ -2554,8 +2555,8 @@ void BossVa_BariPhase3Attack(BossVa* this, PlayState* play) {
 
     if (this->colliderSph.base.acFlags & AC_HIT) {
         this->colliderSph.base.acFlags &= ~AC_HIT;
-        if ((this->colliderSph.base.ac->id == ACTOR_EN_BOOM) && (sp52 >= 128)) {
-            boomerang = (EnBoom*)this->colliderSph.base.ac;
+        if ((this->colliderSph.base.otherAT->id == ACTOR_EN_BOOM) && (sp52 >= 128)) {
+            boomerang = (EnBoom*)this->colliderSph.base.otherAT;
             boomerang->returnTimer = 0;
             boomerang->moveTo = &player->actor;
             boomerang->actor.world.rot.y = boomerang->actor.yawTowardsPlayer;
@@ -2636,11 +2637,12 @@ void BossVa_BariPhase2Attack(BossVa* this, PlayState* play) {
     }
 
     if ((this->colliderLightning.base.atFlags & AT_HIT) || (this->colliderSph.base.atFlags & AT_HIT)) {
-        if ((this->colliderLightning.base.at == &player->actor) || (this->colliderSph.base.at == &player->actor)) {
+        if ((this->colliderLightning.base.otherAC == &player->actor) ||
+            (this->colliderSph.base.otherAC == &player->actor)) {
             func_8002F71C(play, &this->actor, 8.0f, GET_BODY(this)->actor.yawTowardsPlayer, 8.0f);
             Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
-            this->colliderSph.base.at = NULL;
-            this->colliderLightning.base.at = NULL;
+            this->colliderSph.base.otherAC = NULL;
+            this->colliderLightning.base.otherAC = NULL;
         }
 
         this->colliderLightning.base.atFlags &= ~AT_HIT;
@@ -2668,8 +2670,8 @@ void BossVa_BariPhase2Attack(BossVa* this, PlayState* play) {
         if (this->colliderSph.base.acFlags & AC_HIT) {
             this->colliderSph.base.acFlags &= ~AC_HIT;
 
-            if ((this->colliderSph.base.ac->id == ACTOR_EN_BOOM) && (sp52 >= 64)) {
-                boomerang = (EnBoom*)this->colliderSph.base.ac;
+            if ((this->colliderSph.base.otherAT->id == ACTOR_EN_BOOM) && (sp52 >= 64)) {
+                boomerang = (EnBoom*)this->colliderSph.base.otherAT;
                 boomerang->returnTimer = 0;
                 boomerang->moveTo = &player->actor;
                 boomerang->actor.world.rot.y = boomerang->actor.yawTowardsPlayer;
@@ -2810,8 +2812,8 @@ void BossVa_Update(Actor* thisx, PlayState* play2) {
         case BOSSVA_BODY:
             if (this->colliderBody.base.acFlags & AC_HIT) {
                 this->colliderBody.base.acFlags &= ~AC_HIT;
-                if (this->colliderBody.base.ac->id == ACTOR_EN_BOOM) {
-                    boomerang = (EnBoom*)this->colliderBody.base.ac;
+                if (this->colliderBody.base.otherAT->id == ACTOR_EN_BOOM) {
+                    boomerang = (EnBoom*)this->colliderBody.base.otherAT;
                     boomerang->returnTimer = 0;
                 }
             }

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -227,7 +227,7 @@ void DoorKiller_FallAsRubble(DoorKiller* this, PlayState* play) {
 
 s32 DoorKiller_IsHit(Actor* thisx, PlayState* play) {
     DoorKiller* this = (DoorKiller*)thisx;
-    if ((this->colliderCylinder.base.acFlags & AC_HIT) && (this->colliderCylinder.info.acHitInfo != NULL)) {
+    if ((this->colliderCylinder.base.acFlags & AC_HIT) && (this->colliderCylinder.info.otherElemAT != NULL)) {
         return true;
     }
     return false;
@@ -422,10 +422,10 @@ void DoorKiller_Wait(DoorKiller* this, PlayState* play) {
 
     if (DoorKiller_IsHit(&this->actor, play)) {
         // AC cylinder: wobble if hit by most weapons, die if hit by explosives or hammer
-        if (this->colliderCylinder.info.acHitInfo->toucher.dmgFlags & (DMG_RANGED | DMG_SLASH | DMG_DEKU_STICK)) {
+        if (this->colliderCylinder.info.otherElemAT->toucher.dmgFlags & (DMG_RANGED | DMG_SLASH | DMG_DEKU_STICK)) {
             this->timer = 16;
             this->actionFunc = DoorKiller_Wobble;
-        } else if (this->colliderCylinder.info.acHitInfo->toucher.dmgFlags & (DMG_HAMMER_SWING | DMG_EXPLOSIVE)) {
+        } else if (this->colliderCylinder.info.otherElemAT->toucher.dmgFlags & (DMG_HAMMER_SWING | DMG_EXPLOSIVE)) {
             DoorKiller_SpawnRubble(&this->actor, play);
             this->actionFunc = DoorKiller_Die;
             SfxSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, 20, NA_SE_EN_KDOOR_BREAK);

--- a/src/overlays/actors/ovl_En_Am/z_en_am.c
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.c
@@ -372,7 +372,7 @@ void EnAm_Sleep(EnAm* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     if ((this->unk_258 != 0) ||
-        ((this->hurtCollider.base.ocFlags1 & OC1_HIT) && (this->hurtCollider.base.oc == &player->actor)) ||
+        ((this->hurtCollider.base.ocFlags1 & OC1_HIT) && (this->hurtCollider.base.otherOC == &player->actor)) ||
         (this->hurtCollider.base.acFlags & AC_HIT)) {
         this->hurtCollider.base.acFlags &= ~AC_HIT;
 
@@ -679,7 +679,8 @@ void EnAm_Statue(EnAm* this, PlayState* play) {
         }
 
         if (this->hurtCollider.base.ocFlags1 & OC1_HIT) {
-            moveDir = Math_Vec3f_Yaw(&this->dyna.actor.world.pos, &this->hurtCollider.base.oc->world.pos) - temp158f;
+            moveDir =
+                Math_Vec3f_Yaw(&this->dyna.actor.world.pos, &this->hurtCollider.base.otherOC->world.pos) - temp158f;
         }
 
         if ((this->dyna.unk_150 == 0.0f) || (this->unk_258 == 0) ||
@@ -909,14 +910,14 @@ void EnAm_Update(Actor* thisx, PlayState* play) {
                 if (this->hitCollider.base.atFlags & AT_HIT) {
                     Player* player = GET_PLAYER(play);
 
-                    if (this->hitCollider.base.at == &player->actor) {
+                    if (this->hitCollider.base.otherAC == &player->actor) {
                         Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
                     }
                 }
                 CollisionCheck_SetAT(play, &play->colChkCtx, &this->hitCollider.base);
             } else {
                 this->hitCollider.base.atFlags &= ~(AT_HIT | AT_BOUNCED);
-                this->hitCollider.base.at = NULL;
+                this->hitCollider.base.otherAC = NULL;
                 EnAm_SetupRicochet(this, play);
             }
         }

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -284,8 +284,8 @@ void EnArrow_Fly(EnArrow* this, PlayState* play) {
         } else {
             EffectSsHitMark_SpawnCustomScale(play, 0, 150, &this->actor.world.pos);
 
-            if (atTouched && (this->collider.info.atHitInfo->elemType != ELEMTYPE_UNK4)) {
-                hitActor = this->collider.base.at;
+            if (atTouched && (this->collider.info.otherElemAC->elemType != ELEMTYPE_UNK4)) {
+                hitActor = this->collider.base.otherAC;
 
                 if ((hitActor->update != NULL) && !(this->collider.base.atFlags & AT_BOUNCED) &&
                     (hitActor->flags & ACTOR_FLAG_14)) {
@@ -300,10 +300,10 @@ void EnArrow_Fly(EnArrow* this, PlayState* play) {
                     this->hitFlags |= 1;
                     this->hitFlags |= 2;
 
-                    if (this->collider.info.atHitInfo->bumperFlags & BUMP_HIT) {
-                        this->actor.world.pos.x = this->collider.info.atHitInfo->bumper.hitPos.x;
-                        this->actor.world.pos.y = this->collider.info.atHitInfo->bumper.hitPos.y;
-                        this->actor.world.pos.z = this->collider.info.atHitInfo->bumper.hitPos.z;
+                    if (this->collider.info.otherElemAC->bumperFlags & BUMP_HIT) {
+                        this->actor.world.pos.x = this->collider.info.otherElemAC->bumper.hitPos.x;
+                        this->actor.world.pos.y = this->collider.info.otherElemAC->bumper.hitPos.y;
+                        this->actor.world.pos.z = this->collider.info.otherElemAC->bumper.hitPos.z;
                     }
 
                     func_809B3CEC(play, this);

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.c
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.c
@@ -302,7 +302,7 @@ void EnBa_SwingAtPlayer(EnBa* this, PlayState* play) {
         this->unk_2A8[13].y = this->unk_2A8[12].y;
         if (this->collider.base.atFlags & AT_HIT) {
             this->collider.base.atFlags &= ~AT_HIT;
-            if (this->collider.base.at == &player->actor) {
+            if (this->collider.base.otherAC == &player->actor) {
                 func_8002F71C(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             }
         }

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -1154,7 +1154,7 @@ void EnBb_CollisionCheck(EnBb* this, PlayState* play) {
         Actor_SetDropFlag(&this->actor, &this->collider.elements[0].info, false);
         switch (this->dmgEffect) {
             case 7:
-                this->actor.freezeTimer = this->collider.elements[0].info.acHitInfo->toucher.damage;
+                this->actor.freezeTimer = this->collider.elements[0].info.otherElemAT->toucher.damage;
                 FALLTHROUGH;
             case 5:
                 this->fireIceTimer = 0x30;
@@ -1164,7 +1164,7 @@ void EnBb_CollisionCheck(EnBb* this, PlayState* play) {
                 //! Din's Fire on a white bubble will do just that. The mechanism is complex and described below.
                 goto block_15;
             case 6:
-                this->actor.freezeTimer = this->collider.elements[0].info.acHitInfo->toucher.damage;
+                this->actor.freezeTimer = this->collider.elements[0].info.otherElemAT->toucher.damage;
                 break;
             case 8:
             case 9:

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -333,7 +333,7 @@ void func_809BD524(EnBigokuta* this) {
     this->unk_19A = 0;
     this->cylinder[0].base.atFlags |= AT_ON;
     Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_MAHI);
-    if (this->collider.elements->info.acHitInfo->toucher.dmgFlags & DMG_DEKU_NUT) {
+    if (this->collider.elements->info.otherElemAT->toucher.dmgFlags & DMG_DEKU_NUT) {
         this->unk_195 = true;
         this->unk_196 = 20;
     } else {

--- a/src/overlays/actors/ovl_En_Bili/z_en_bili.c
+++ b/src/overlays/actors/ovl_En_Bili/z_en_bili.c
@@ -202,8 +202,8 @@ void EnBili_SetupRecoil(EnBili* this) {
         Animation_PlayLoop(&this->skelAnime, &gBiriDefaultAnim);
     }
 
-    this->actor.world.rot.y = Actor_WorldYawTowardPoint(&this->actor, &this->collider.base.ac->prevPos) + 0x8000;
-    this->actor.world.rot.x = Actor_WorldPitchTowardPoint(&this->actor, &this->collider.base.ac->prevPos);
+    this->actor.world.rot.y = Actor_WorldYawTowardPoint(&this->actor, &this->collider.base.otherAT->prevPos) + 0x8000;
+    this->actor.world.rot.x = Actor_WorldPitchTowardPoint(&this->actor, &this->collider.base.otherAT->prevPos);
     this->actionFunc = EnBili_Recoil;
     this->actor.speedXZ = 5.0f;
 }
@@ -586,7 +586,7 @@ void EnBili_UpdateDamage(EnBili* this, PlayState* play) {
                 EnBili_SetupBurnt(this);
             }
 
-            if (this->collider.info.acHitInfo->toucher.dmgFlags & DMG_ARROW) {
+            if (this->collider.info.otherElemAT->toucher.dmgFlags & DMG_ARROW) {
                 this->actor.flags |= ACTOR_FLAG_4;
             }
         }

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -266,8 +266,9 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
             func_8002829C(play, &effPos, &effVelocity, &dustAccel, &dustColor, &dustColor, 50, 5);
         }
 
-        if ((this->bombCollider.base.acFlags & AC_HIT) || ((this->bombCollider.base.ocFlags1 & OC1_HIT) &&
-                                                           (this->bombCollider.base.oc->category == ACTORCAT_ENEMY))) {
+        if ((this->bombCollider.base.acFlags & AC_HIT) ||
+            ((this->bombCollider.base.ocFlags1 & OC1_HIT) &&
+             (this->bombCollider.base.otherOC->category == ACTORCAT_ENEMY))) {
             this->timer = 0;
             thisx->shape.rot.z = 0;
         } else {

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
@@ -260,7 +260,7 @@ void EnBomChu_Move(EnBomChu* this, PlayState* play) {
     }
 
     if ((this->timer == 0) || (this->collider.base.acFlags & AC_HIT) ||
-        ((this->collider.base.ocFlags1 & OC1_HIT) && (this->collider.base.oc->category != ACTORCAT_PLAYER))) {
+        ((this->collider.base.ocFlags1 & OC1_HIT) && (this->collider.base.otherOC->category != ACTORCAT_PLAYER))) {
         EnBomChu_Explode(this, play);
         return;
     }

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -168,7 +168,7 @@ void EnBombf_GrowBomb(EnBombf* this, PlayState* play) {
         } else if (this->bombCollider.base.acFlags & AC_HIT) {
             this->bombCollider.base.acFlags &= ~AC_HIT;
 
-            if (this->bombCollider.base.ac->category != ACTORCAT_BOSS) {
+            if (this->bombCollider.base.otherAT->category != ACTORCAT_BOSS) {
                 bombFlower = (EnBombf*)Actor_Spawn(&play->actorCtx, play, ACTOR_EN_BOMBF, this->actor.world.pos.x,
                                                    this->actor.world.pos.y, this->actor.world.pos.z, 0, 0, 0, 0);
                 if (bombFlower != NULL) {
@@ -367,8 +367,9 @@ void EnBombf_Update(Actor* thisx, PlayState* play) {
             thisx->bgCheckFlags &= ~BGCHECKFLAG_WALL;
         }
 
-        if ((this->bombCollider.base.acFlags & AC_HIT) || ((this->bombCollider.base.ocFlags1 & OC1_HIT) &&
-                                                           (this->bombCollider.base.oc->category == ACTORCAT_ENEMY))) {
+        if ((this->bombCollider.base.acFlags & AC_HIT) ||
+            ((this->bombCollider.base.ocFlags1 & OC1_HIT) &&
+             (this->bombCollider.base.otherOC->category == ACTORCAT_ENEMY))) {
             this->isFuseEnabled = true;
             this->timer = 0;
         } else {

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -156,10 +156,11 @@ void EnBoom_Fly(EnBoom* this, PlayState* play) {
     collided = this->collider.base.atFlags & AT_HIT;
     collided = !!(collided);
     if (collided) {
-        if (((this->collider.base.at->id == ACTOR_EN_ITEM00) || (this->collider.base.at->id == ACTOR_EN_SI))) {
-            this->grabbed = this->collider.base.at;
-            if (this->collider.base.at->id == ACTOR_EN_SI) {
-                this->collider.base.at->flags |= ACTOR_FLAG_13;
+        if (((this->collider.base.otherAC->id == ACTOR_EN_ITEM00) ||
+             (this->collider.base.otherAC->id == ACTOR_EN_SI))) {
+            this->grabbed = this->collider.base.otherAC;
+            if (this->collider.base.otherAC->id == ACTOR_EN_SI) {
+                this->collider.base.otherAC->flags |= ACTOR_FLAG_13;
             }
         }
     }

--- a/src/overlays/actors/ovl_En_Brob/z_en_brob.c
+++ b/src/overlays/actors/ovl_En_Brob/z_en_brob.c
@@ -262,8 +262,8 @@ void EnBrob_Update(Actor* thisx, PlayState* play2) {
 
     acHits[0] = (this->colliders[0].base.acFlags & AC_HIT) != 0;
     acHits[1] = (this->colliders[1].base.acFlags & AC_HIT) != 0;
-    if ((acHits[0] && (this->colliders[0].info.acHitInfo->toucher.dmgFlags & DMG_BOOMERANG)) ||
-        (acHits[1] && (this->colliders[1].info.acHitInfo->toucher.dmgFlags & DMG_BOOMERANG))) {
+    if ((acHits[0] && (this->colliders[0].info.otherElemAT->toucher.dmgFlags & DMG_BOOMERANG)) ||
+        (acHits[1] && (this->colliders[1].info.otherElemAT->toucher.dmgFlags & DMG_BOOMERANG))) {
 
         for (i = 0; i < 2; i++) {
             this->colliders[i].base.atFlags &= ~(AT_HIT | AT_BOUNCED);
@@ -272,8 +272,8 @@ void EnBrob_Update(Actor* thisx, PlayState* play2) {
 
         func_809CAEF4(this);
     } else if ((this->colliders[0].base.atFlags & AT_HIT) || (this->colliders[1].base.atFlags & AT_HIT) ||
-               (acHits[0] && (this->colliders[0].info.acHitInfo->toucher.dmgFlags & DMG_SLASH_KOKIRI)) ||
-               (acHits[1] && (this->colliders[1].info.acHitInfo->toucher.dmgFlags & DMG_SLASH_KOKIRI))) {
+               (acHits[0] && (this->colliders[0].info.otherElemAT->toucher.dmgFlags & DMG_SLASH_KOKIRI)) ||
+               (acHits[1] && (this->colliders[1].info.otherElemAT->toucher.dmgFlags & DMG_SLASH_KOKIRI))) {
 
         if (this->actionFunc == func_809CB114 && !(this->colliders[0].base.atFlags & AT_BOUNCED) &&
             !(this->colliders[1].base.atFlags & AT_BOUNCED)) {

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -209,7 +209,7 @@ void EnBubble_Fly(EnBubble* this, PlayState* play) {
     u8 bounceCount;
 
     if (this->colliderSphere.elements[1].info.bumperFlags & BUMP_HIT) {
-        bumpActor = this->colliderSphere.base.ac;
+        bumpActor = this->colliderSphere.base.otherAT;
         this->normalizedBumpVelocity = bumpActor->velocity;
         EnBubble_Vec3fNormalize(&this->normalizedBumpVelocity);
         this->velocityFromBump.x += (this->normalizedBumpVelocity.x * 3.0f);
@@ -287,9 +287,9 @@ u32 func_809CC648(EnBubble* this) {
     }
     this->colliderSphere.base.acFlags &= ~AC_HIT;
     if (this->colliderSphere.elements[1].info.bumperFlags & BUMP_HIT) {
-        this->unk_1F0.x = this->colliderSphere.base.ac->velocity.x / 10.0f;
-        this->unk_1F0.y = this->colliderSphere.base.ac->velocity.y / 10.0f;
-        this->unk_1F0.z = this->colliderSphere.base.ac->velocity.z / 10.0f;
+        this->unk_1F0.x = this->colliderSphere.base.otherAT->velocity.x / 10.0f;
+        this->unk_1F0.y = this->colliderSphere.base.otherAT->velocity.y / 10.0f;
+        this->unk_1F0.z = this->colliderSphere.base.otherAT->velocity.z / 10.0f;
         this->graphicRotSpeed = 128.0f;
         this->graphicEccentricity = 0.48f;
         return false;

--- a/src/overlays/actors/ovl_En_Bw/z_en_bw.c
+++ b/src/overlays/actors/ovl_En_Bw/z_en_bw.c
@@ -449,7 +449,7 @@ void func_809CF984(EnBw* this, PlayState* play) {
         this->collider1.base.atFlags &= ~AT_HIT;
         this->actor.speedXZ = -6.0f;
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-        if ((&player->actor == this->collider1.base.at) && !(this->collider1.base.atFlags & AT_BOUNCED)) {
+        if ((&player->actor == this->collider1.base.otherAC) && !(this->collider1.base.atFlags & AT_BOUNCED)) {
             Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
         }
     }

--- a/src/overlays/actors/ovl_En_Bx/z_en_bx.c
+++ b/src/overlays/actors/ovl_En_Bx/z_en_bx.c
@@ -136,15 +136,15 @@ void EnBx_Update(Actor* thisx, PlayState* play) {
 
     if ((thisx->xzDistToPlayer <= 70.0f) || (this->collider.base.atFlags & AT_HIT) ||
         (this->collider.base.acFlags & AC_HIT) || (this->colliderQuad.base.atFlags & AT_HIT)) {
-        if ((thisx->xzDistToPlayer <= 70.0f) || (&player->actor == this->collider.base.at) ||
-            (&player->actor == this->collider.base.ac) || (&player->actor == this->colliderQuad.base.at)) {
+        if ((thisx->xzDistToPlayer <= 70.0f) || (&player->actor == this->collider.base.otherAC) ||
+            (&player->actor == this->collider.base.otherAT) || (&player->actor == this->colliderQuad.base.otherAC)) {
             tmp33 = player->invincibilityTimer & 0xFF;
             tmp32 = thisx->world.rot.y;
             if (!(thisx->params & 0x80)) {
                 tmp32 = thisx->yawTowardsPlayer;
             }
-            if ((&player->actor != this->collider.base.at) && (&player->actor != this->collider.base.ac) &&
-                (&player->actor != this->colliderQuad.base.at) && (player->invincibilityTimer <= 0)) {
+            if ((&player->actor != this->collider.base.otherAC) && (&player->actor != this->collider.base.otherAT) &&
+                (&player->actor != this->colliderQuad.base.otherAC) && (player->invincibilityTimer <= 0)) {
                 if (player->invincibilityTimer < -39) {
                     player->invincibilityTimer = 0;
                 } else {
@@ -159,9 +159,9 @@ void EnBx_Update(Actor* thisx, PlayState* play) {
         this->collider.base.atFlags &= ~AT_HIT;
         this->collider.base.acFlags &= ~AC_HIT;
         this->colliderQuad.base.atFlags &= ~AT_HIT;
-        this->colliderQuad.base.at = NULL;
-        this->collider.base.ac = NULL;
-        this->collider.base.at = NULL;
+        this->colliderQuad.base.otherAC = NULL;
+        this->collider.base.otherAT = NULL;
+        this->collider.base.otherAC = NULL;
         this->unk_14C = 0x14;
     }
 

--- a/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
+++ b/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
@@ -204,10 +204,10 @@ void EnDekunuts_SetupGasp(EnDekunuts* this) {
 
 void EnDekunuts_SetupBeDamaged(EnDekunuts* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gDekuNutsDamageAnim, -3.0f);
-    if (this->collider.info.acHitInfo->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
-        this->actor.world.rot.y = this->collider.base.ac->world.rot.y;
+    if (this->collider.info.otherElemAT->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
+        this->actor.world.rot.y = this->collider.base.otherAT->world.rot.y;
     } else {
-        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->collider.base.ac) + 0x8000;
+        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->collider.base.otherAT) + 0x8000;
     }
     this->collider.base.acFlags &= ~AC_ON;
     this->actionFunc = EnDekunuts_BeDamaged;

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -650,7 +650,7 @@ void EnDodongo_SweepTail(EnDodongo* this, PlayState* play) {
         if (this->colliderBody.base.atFlags & AT_HIT) {
             Player* player = GET_PLAYER(play);
 
-            if (this->colliderBody.base.at == &player->actor) {
+            if (this->colliderBody.base.otherAC == &player->actor) {
                 Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
             }
         }

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -283,7 +283,7 @@ s32 EnFd_ColliderCheck(EnFd* this, PlayState* play) {
             return false;
         }
         info = &this->collider.elements[0].info;
-        if (info->acHitInfo != NULL && (info->acHitInfo->toucher.dmgFlags & DMG_HOOKSHOT)) {
+        if (info->otherElemAT != NULL && (info->otherElemAT->toucher.dmgFlags & DMG_HOOKSHOT)) {
             return false;
         }
 

--- a/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
+++ b/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
@@ -476,7 +476,7 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
                         ? true
                         : false;
                 if ((this->collider.base.acFlags & AC_HIT) || canBottleReflect1) {
-                    ColliderInfo* hurtbox = this->collider.info.acHitInfo;
+                    ColliderInfo* hurtbox = this->collider.info.otherElemAT;
                     s16 i2;
                     Vec3f spA8;
                     Vec3f sp9C = { 0.0f, -0.5f, 0.0f };

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -365,7 +365,7 @@ void EnFireRock_Update(Actor* thisx, PlayState* play) {
         if (this->type == FIRE_ROCK_ON_FLOOR) {
             if (this->collider.base.atFlags & AT_HIT) {
                 this->collider.base.atFlags &= ~AT_HIT;
-                if (this->collider.base.at == playerActor) {
+                if (this->collider.base.otherAC == playerActor) {
                     if (!(player->stateFlags1 & PLAYER_STATE1_26)) {
                         func_8002F758(play, thisx, 2.0f, -player->actor.world.rot.y, 3.0f, 4);
                     }

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -390,10 +390,10 @@ void EnFloormas_SetupSmWait(EnFloormas* this) {
 
 void EnFloormas_SetupTakeDamage(EnFloormas* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gWallmasterDamageAnim, -3.0f);
-    if (this->collider.info.acHitInfo->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
-        this->actor.world.rot.y = this->collider.base.ac->world.rot.y;
+    if (this->collider.info.otherElemAT->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
+        this->actor.world.rot.y = this->collider.base.otherAT->world.rot.y;
     } else {
-        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->collider.base.ac) + 0x8000;
+        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->collider.base.otherAT) + 0x8000;
     }
     Actor_SetColorFilter(&this->actor, 0x4000, 0xFF, 0, 0x14);
     this->actionFunc = EnFloormas_TakeDamage;
@@ -753,7 +753,7 @@ void EnFloormas_JumpAtLink(EnFloormas* this, PlayState* play) {
         Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
         EnFloormas_SetupLand(this);
     } else if ((this->actor.yDistToPlayer < -10.0f) && (this->collider.base.ocFlags1 & OC1_HIT) &&
-               (&player->actor == this->collider.base.oc)) {
+               (&player->actor == this->collider.base.otherOC)) {
         play->grabPlayer(play, player);
         EnFloormas_SetupGrabLink(this, player);
     }
@@ -986,7 +986,7 @@ void EnFloormas_ColliderCheck(EnFloormas* this, PlayState* play) {
                 if (this->actor.scale.x < 0.01f) {
                     isSmall = 1;
                 }
-                if (isSmall && this->collider.info.acHitInfo->toucher.dmgFlags & DMG_HOOKSHOT) {
+                if (isSmall && this->collider.info.otherElemAT->toucher.dmgFlags & DMG_HOOKSHOT) {
                     this->actor.colChkInfo.damage = 2;
                     this->actor.colChkInfo.damageEffect = 0;
                 }

--- a/src/overlays/actors/ovl_En_Fw/z_en_fw.c
+++ b/src/overlays/actors/ovl_En_Fw/z_en_fw.c
@@ -139,7 +139,7 @@ s32 EnFw_CheckCollider(EnFw* this, PlayState* play) {
 
     if (this->collider.base.acFlags & AC_HIT) {
         info = &this->collider.elements[0].info;
-        if (info->acHitInfo->toucher.dmgFlags & DMG_HOOKSHOT) {
+        if (info->otherElemAT->toucher.dmgFlags & DMG_HOOKSHOT) {
             this->lastDmgHook = true;
         } else {
             this->lastDmgHook = false;

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -554,8 +554,8 @@ void EnGe2_Update(Actor* thisx, PlayState* play) {
     if ((this->stateFlags & GE2_STATE_KO) || (this->stateFlags & GE2_STATE_CAPTURING)) {
         this->actionFunc(this, play);
     } else if (this->collider.base.acFlags & AC_HIT) {
-        if ((this->collider.info.acHitInfo != NULL) &&
-            (this->collider.info.acHitInfo->toucher.dmgFlags & DMG_HOOKSHOT)) {
+        if ((this->collider.info.otherElemAT != NULL) &&
+            (this->collider.info.otherElemAT->toucher.dmgFlags & DMG_HOOKSHOT)) {
             Actor_SetColorFilter(&this->actor, 0, 120, 0, 400);
             this->actor.update = EnGe2_UpdateStunned;
             return;
@@ -604,8 +604,9 @@ void EnGe2_UpdateStunned(Actor* thisx, PlayState* play2) {
     CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     Actor_UpdateBgCheckInfo(play, &this->actor, 40.0f, 25.0f, 40.0f, UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
 
-    if ((this->collider.base.acFlags & AC_HIT) && ((this->collider.info.acHitInfo == NULL) ||
-                                                   !(this->collider.info.acHitInfo->toucher.dmgFlags & DMG_HOOKSHOT))) {
+    if ((this->collider.base.acFlags & AC_HIT) &&
+        ((this->collider.info.otherElemAT == NULL) ||
+         !(this->collider.info.otherElemAT->toucher.dmgFlags & DMG_HOOKSHOT))) {
         this->actor.colorFilterTimer = 0;
         EnGe2_ChangeAction(this, GE2_ACTION_KNOCKEDOUT);
         this->timer = 100;

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -916,7 +916,7 @@ void EnGeldB_SpinAttack(EnGeldB* this, PlayState* play) {
             this->skelAnime.playSpeed = 1.5f;
         } else if (this->swordCollider.base.atFlags & AT_HIT) {
             this->swordCollider.base.atFlags &= ~AT_HIT;
-            if (&player->actor == this->swordCollider.base.at) {
+            if (&player->actor == this->swordCollider.base.otherAC) {
                 func_8002F71C(play, &this->actor, 6.0f, this->actor.yawTowardsPlayer, 6.0f);
                 this->spinAttackState = 2;
                 func_8002DF54(play, &this->actor, 0x18);

--- a/src/overlays/actors/ovl_En_Goma/z_en_goma.c
+++ b/src/overlays/actors/ovl_En_Goma/z_en_goma.c
@@ -610,7 +610,7 @@ void EnGoma_UpdateHit(EnGoma* this, PlayState* play) {
     if (this->hurtTimer != 0) {
         this->hurtTimer--;
     } else {
-        ColliderInfo* acHitInfo;
+        ColliderInfo* otherElemAT;
         u8 swordDamage;
 
         if ((this->colCyl1.base.atFlags & AT_HIT) && this->actionFunc == EnGoma_Jump) {
@@ -620,11 +620,11 @@ void EnGoma_UpdateHit(EnGoma* this, PlayState* play) {
         }
 
         if ((this->colCyl2.base.acFlags & AC_HIT) && (s8)this->actor.colChkInfo.health > 0) {
-            acHitInfo = this->colCyl2.info.acHitInfo;
+            otherElemAT = this->colCyl2.info.otherElemAT;
             this->colCyl2.base.acFlags &= ~AC_HIT;
 
             if (this->gomaType == ENGOMA_NORMAL) {
-                u32 dmgFlags = acHitInfo->toucher.dmgFlags;
+                u32 dmgFlags = otherElemAT->toucher.dmgFlags;
 
                 if (dmgFlags & DMG_SHIELD) {
                     if (this->actionFunc == EnGoma_Jump) {

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
@@ -462,7 +462,7 @@ void EnHintnuts_ColliderCheck(EnHintnuts* this, PlayState* play) {
     if (this->collider.base.acFlags & AC_HIT) {
         this->collider.base.acFlags &= ~AC_HIT;
         Actor_SetDropFlag(&this->actor, &this->collider.info, true);
-        if (this->collider.base.ac->id != ACTOR_EN_NUTSBALL) {
+        if (this->collider.base.otherAT->id != ACTOR_EN_NUTSBALL) {
             EnHintnuts_SetupBurrow(this);
         } else {
             EnHintnuts_HitByScrubProjectile1(this, play);

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -586,7 +586,7 @@ void func_80A75790(EnIk* this) {
     s16 yaw;
     s16 yawDiff;
 
-    yaw = Math_Vec3f_Yaw(&this->actor.world.pos, &this->bodyCollider.base.ac->world.pos);
+    yaw = Math_Vec3f_Yaw(&this->actor.world.pos, &this->bodyCollider.base.otherAT->world.pos);
     this->unk_2F8 = 0;
     yawDiff = yaw - this->actor.shape.rot.y;
     if (ABS(yawDiff) <= 0x4000) {
@@ -753,7 +753,7 @@ void func_80A75FA0(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
     if (this->axeCollider.base.atFlags & AT_HIT) {
         this->axeCollider.base.atFlags &= ~AT_HIT;
-        if (&player->actor == this->axeCollider.base.at) {
+        if (&player->actor == this->axeCollider.base.otherAC) {
             prevInvincibilityTimer = player->invincibilityTimer;
             if (player->invincibilityTimer <= 0) {
                 if (player->invincibilityTimer < -39) {

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
@@ -356,7 +356,7 @@ void EnIshi_Wait(EnIshi* this, PlayState* play) {
             EnIshi_SpawnBugs(this, play);
         }
     } else if ((this->collider.base.acFlags & AC_HIT) && (type == ROCK_SMALL) &&
-               this->collider.info.acHitInfo->toucher.dmgFlags & (DMG_HAMMER | DMG_EXPLOSIVE)) {
+               this->collider.info.otherElemAT->toucher.dmgFlags & (DMG_HAMMER | DMG_EXPLOSIVE)) {
         EnIshi_DropCollectible(this, play);
         SfxSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, sBreakSfxDurations[type], sBreakSfxIds[type]);
         sFragmentSpawnFuncs[type](this, play);

--- a/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
+++ b/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
@@ -295,7 +295,7 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                                                       this->actor.world.pos.z, this->actor.shape.rot.x,
                                                       this->actor.shape.rot.y, this->actor.shape.rot.z, ENKANBAN_PIECE);
                 if (piece != NULL) {
-                    ColliderInfo* hitItem = this->collider.info.acHitInfo;
+                    ColliderInfo* hitItem = this->collider.info.otherElemAT;
                     s16 yawDiff = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
                     u8 i;
 

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -827,7 +827,7 @@ void EnMb_ClubAttack(EnMb* this, PlayState* play) {
 
     if (this->attackCollider.base.atFlags & AT_HIT) {
         this->attackCollider.base.atFlags &= ~AT_HIT;
-        if (this->attackCollider.base.at == &player->actor) {
+        if (this->attackCollider.base.otherAC == &player->actor) {
             u8 prevPlayerInvincibilityTimer = player->invincibilityTimer;
 
             if (player->invincibilityTimer < 0) {
@@ -907,7 +907,7 @@ void EnMb_SpearPatrolPrepareAndCharge(EnMb* this, PlayState* play) {
     }
 
     if (this->attackCollider.base.atFlags & AT_HIT) {
-        if (this->attackCollider.base.at == &player->actor) {
+        if (this->attackCollider.base.otherAC == &player->actor) {
             if (!endCharge && !(player->stateFlags2 & PLAYER_STATE2_7)) {
                 if (player->invincibilityTimer < 0) {
                     if (player->invincibilityTimer < -39) {
@@ -976,7 +976,7 @@ void EnMb_SpearPatrolImmediateCharge(EnMb* this, PlayState* play) {
     }
 
     if (this->attackCollider.base.atFlags & AT_HIT) {
-        if (this->attackCollider.base.at == &player->actor) {
+        if (this->attackCollider.base.otherAC == &player->actor) {
             if (!endCharge && !(player->stateFlags2 & PLAYER_STATE2_7)) {
                 if (player->invincibilityTimer < 0) {
                     if (player->invincibilityTimer <= -40) {

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -562,7 +562,7 @@ void EnPeehat_Larva_StateSeekPlayer(EnPeehat* this, PlayState* play) {
                (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         Player* player = GET_PLAYER(play);
         this->colQuad.base.atFlags &= ~AT_HIT;
-        if (!(this->colCylinder.base.acFlags & AC_HIT) && &player->actor == this->colQuad.base.at) {
+        if (!(this->colCylinder.base.acFlags & AC_HIT) && &player->actor == this->colQuad.base.otherAC) {
             if (Rand_ZeroOne() > 0.5f) {
                 this->actor.world.rot.y += 0x2000;
             } else {
@@ -580,7 +580,7 @@ void EnPeehat_Larva_StateSeekPlayer(EnPeehat* this, PlayState* play) {
                 EffectSsDeadDb_Spawn(play, &pos, &zeroVec, &zeroVec, 40, 7, 255, 255, 255, 255, 255, 0, 0, 1, 9, 1);
             }
         }
-        if (&player->actor != this->colQuad.base.at || this->colCylinder.base.acFlags & AC_HIT) {
+        if (&player->actor != this->colQuad.base.otherAC || this->colCylinder.base.acFlags & AC_HIT) {
             if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
                 EffectSsDeadSound_SpawnStationary(play, &this->actor.projectedPos, NA_SE_EN_PIHAT_SM_DEAD, 1, 1, 40);
             }
@@ -964,7 +964,7 @@ void EnPeehat_Update(Actor* thisx, PlayState* play) {
         }
         if (thisx->params != PEAHAT_TYPE_FLYING && this->colQuad.base.atFlags & AT_HIT) {
             this->colQuad.base.atFlags &= ~AT_HIT;
-            if (&player->actor == this->colQuad.base.at) {
+            if (&player->actor == this->colQuad.base.otherAC) {
                 EnPeehat_SetStateAttackRecoil(this);
             }
         }

--- a/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
+++ b/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
@@ -263,10 +263,10 @@ void EnPoField_SetupFlee(EnPoField* this) {
 
 void EnPoField_SetupDamage(EnPoField* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gPoeFieldDamagedAnim, -6.0f);
-    if (this->collider.info.acHitInfo->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
-        this->actor.world.rot.y = this->collider.base.ac->world.rot.y;
+    if (this->collider.info.otherElemAT->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
+        this->actor.world.rot.y = this->collider.base.otherAT->world.rot.y;
     } else {
-        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->collider.base.ac) + 0x8000;
+        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->collider.base.otherAT) + 0x8000;
     }
     this->collider.base.acFlags &= ~(AC_HIT | AC_ON);
     this->actor.speedXZ = 5.0f;

--- a/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
+++ b/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
@@ -300,10 +300,10 @@ void func_80AD9568(EnPoSisters* this) {
 
 void func_80AD95D8(EnPoSisters* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gPoeSistersDamagedAnim, -3.0f);
-    if (this->collider.base.ac != NULL) {
-        this->actor.world.rot.y = (this->collider.info.acHitInfo->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT))
-                                      ? this->collider.base.ac->world.rot.y
-                                      : Actor_WorldYawTowardActor(&this->actor, this->collider.base.ac) + 0x8000;
+    if (this->collider.base.otherAT != NULL) {
+        this->actor.world.rot.y = (this->collider.info.otherElemAT->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT))
+                                      ? this->collider.base.otherAT->world.rot.y
+                                      : Actor_WorldYawTowardActor(&this->actor, this->collider.base.otherAT) + 0x8000;
     }
     if (this->unk_194 != 0) {
         this->actor.speedXZ = 10.0f;

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -293,10 +293,10 @@ void func_80ADE28C(EnPoh* this) {
     } else {
         Animation_PlayOnce(&this->skelAnime, &gPoeComposerDamagedAnim);
     }
-    if (this->colliderCyl.info.acHitInfo->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
-        this->actor.world.rot.y = this->colliderCyl.base.ac->world.rot.y;
+    if (this->colliderCyl.info.otherElemAT->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
+        this->actor.world.rot.y = this->colliderCyl.base.otherAT->world.rot.y;
     } else {
-        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->colliderCyl.base.ac) + 0x8000;
+        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->colliderCyl.base.otherAT) + 0x8000;
     }
     this->colliderCyl.base.acFlags &= ~AC_ON;
     this->actor.speedXZ = 5.0f;

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -624,7 +624,7 @@ void EnReeba_Update(Actor* thisx, PlayState* play2) {
 
     if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~AT_HIT;
-        if ((this->collider.base.at == &player->actor) && !this->isBig && (this->actionfunc != func_80AE56E0)) {
+        if ((this->collider.base.otherAC == &player->actor) && !this->isBig && (this->actionfunc != func_80AE56E0)) {
             this->actionfunc = func_80AE5688;
         }
     }

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -431,14 +431,14 @@ s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
     if (cyl->base.acFlags & AC_HIT) {
         cyl->base.acFlags &= ~AC_HIT;
         hit = true;
-        flags |= cyl->info.acHitInfo->toucher.dmgFlags;
+        flags |= cyl->info.otherElemAT->toucher.dmgFlags;
     }
 
     cyl = &this->colCylinder[1];
     if (cyl->base.acFlags & AC_HIT) {
         cyl->base.acFlags &= ~AC_HIT;
         hit = true;
-        flags |= cyl->info.acHitInfo->toucher.dmgFlags;
+        flags |= cyl->info.otherElemAT->toucher.dmgFlags;
     }
 
     if (!hit) {

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -372,7 +372,7 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
                 Animation_MorphToLoop(&this->skelAnime, &object_tite_Anim_0012E4, 4.0f);
                 this->actor.speedXZ = -6.0f;
                 this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-                if (&player->actor == this->collider.base.at) {
+                if (&player->actor == this->collider.base.otherAC) {
                     if (!(this->collider.base.atFlags & AT_BOUNCED)) {
                         Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
                     }

--- a/src/overlays/actors/ovl_En_Tp/z_en_tp.c
+++ b/src/overlays/actors/ovl_En_Tp/z_en_tp.c
@@ -248,7 +248,7 @@ void EnTp_Head_ApproachPlayer(EnTp* this, PlayState* play) {
 
     if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~AT_HIT;
-        if (&player->actor == this->collider.base.at) {
+        if (&player->actor == this->collider.base.otherAC) {
             this->timer = 1;
         }
     }
@@ -385,7 +385,7 @@ void EnTp_Head_TakeOff(EnTp* this, PlayState* play) {
 
     if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~AT_HIT;
-        if (&player->actor == this->collider.base.at) {
+        if (&player->actor == this->collider.base.otherAC) {
             this->unk_15C = 1;
         }
     }
@@ -439,7 +439,7 @@ void EnTp_Head_Wait(EnTp* this, PlayState* play) {
     if (this->actor.xzDistToPlayer < 200.0f) {
         if (this->collider.base.atFlags & AT_HIT) {
             this->collider.base.atFlags &= ~AT_HIT;
-            if (&player->actor == this->collider.base.at) {
+            if (&player->actor == this->collider.base.otherAC) {
                 this->timer = 0;
             }
         }

--- a/src/overlays/actors/ovl_En_Trap/z_en_trap.c
+++ b/src/overlays/actors/ovl_En_Trap/z_en_trap.c
@@ -143,7 +143,7 @@ void EnTrap_Update(Actor* thisx, PlayState* play) {
     if (this->collider.base.ocFlags1 & OC1_HIT) {
         this->collider.base.ocFlags1 &= ~OC1_HIT;
         angleToCollidedActor =
-            thisx->world.rot.y + Math_Vec3f_Yaw(&this->collider.base.oc->world.pos, &thisx->world.pos);
+            thisx->world.rot.y + Math_Vec3f_Yaw(&this->collider.base.otherOC->world.pos, &thisx->world.pos);
         touchingActor = true;
     }
     // Freeze the trap if hit by ice arrows:
@@ -198,7 +198,7 @@ void EnTrap_Update(Actor* thisx, PlayState* play) {
             // If spike trap is touching an actor which is in the path of the spike trap
             if (touchingActor && (this->vContinue != 0.0f)) {
                 angleToCollidedActor =
-                    Math_Vec3f_Yaw(&thisx->world.pos, &this->collider.base.oc->world.pos) - thisx->world.rot.y;
+                    Math_Vec3f_Yaw(&thisx->world.pos, &this->collider.base.otherOC->world.pos) - thisx->world.rot.y;
                 if (ABS(angleToCollidedActor) < 0x1000) {
                     this->vContinue = 0.0f;
                 }

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
@@ -198,7 +198,7 @@ void EnTuboTrap_HandleImpact(EnTuboTrap* this, PlayState* play) {
 
     if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~AT_HIT;
-        if (this->collider.base.at == &player->actor) {
+        if (this->collider.base.otherAC == &player->actor) {
             EnTuboTrap_SpawnEffectsOnLand(this, play);
             SfxSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, 40, NA_SE_EV_POT_BROKEN);
             SfxSource_PlaySfxAtFixedWorldPos(play, &player2->actor.world.pos, 40, NA_SE_PL_BODY_HIT);

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -219,10 +219,10 @@ void EnWallmas_SetupReturnToCeiling(EnWallmas* this) {
 
 void EnWallmas_SetupTakeDamage(EnWallmas* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gWallmasterDamageAnim, -3.0f);
-    if (this->collider.info.acHitInfo->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
-        this->actor.world.rot.y = this->collider.base.ac->world.rot.y;
+    if (this->collider.info.otherElemAT->toucher.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
+        this->actor.world.rot.y = this->collider.base.otherAT->world.rot.y;
     } else {
-        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->collider.base.ac) + 0x8000;
+        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->collider.base.otherAT) + 0x8000;
     }
 
     Actor_SetColorFilter(&this->actor, 0x4000, 0xFF, 0, 0x14);

--- a/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.c
+++ b/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.c
@@ -117,7 +117,7 @@ void EnYukabyun_Update(Actor* thisx, PlayState* play) {
     s32 pad;
 
     if (((this->collider.base.atFlags & AT_HIT) || (this->collider.base.acFlags & AC_HIT) ||
-         ((this->collider.base.ocFlags1 & OC1_HIT) && !(this->collider.base.oc->id == ACTOR_EN_YUKABYUN))) ||
+         ((this->collider.base.ocFlags1 & OC1_HIT) && !(this->collider.base.otherOC->id == ACTOR_EN_YUKABYUN))) ||
         ((this->actionfunc == func_80B43B6C) && (this->actor.bgCheckFlags & BGCHECKFLAG_WALL))) {
         this->collider.base.atFlags &= ~AT_HIT;
         this->collider.base.acFlags &= ~AC_HIT;

--- a/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
+++ b/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
@@ -125,7 +125,7 @@ void ObjBombiwa_Update(Actor* thisx, PlayState* play) {
     s32 pad;
 
     if ((func_80033684(play, &this->actor) != NULL) ||
-        ((this->collider.base.acFlags & AC_HIT) && (this->collider.info.acHitInfo->toucher.dmgFlags & DMG_HAMMER))) {
+        ((this->collider.base.acFlags & AC_HIT) && (this->collider.info.otherElemAT->toucher.dmgFlags & DMG_HAMMER))) {
         ObjBombiwa_Break(this, play);
         Flags_SetSwitch(play, this->actor.params & 0x3F);
         SfxSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, 80, NA_SE_EV_WALL_BROKEN);

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
@@ -176,7 +176,7 @@ void ObjComb_Wait(ObjComb* this, PlayState* play) {
 
     if (this->collider.base.acFlags & AC_HIT) {
         this->collider.base.acFlags &= ~AC_HIT;
-        dmgFlags = this->collider.elements[0].info.acHitInfo->toucher.dmgFlags;
+        dmgFlags = this->collider.elements[0].info.otherElemAT->toucher.dmgFlags;
         if (dmgFlags & (DMG_HAMMER | DMG_ARROW | DMG_SLINGSHOT | DMG_DEKU_STICK)) {
             this->unk_1B0 = 1500;
         } else {

--- a/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
+++ b/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
@@ -170,7 +170,7 @@ void ObjHamishi_Update(Actor* thisx, PlayState* play) {
 
     ObjHamishi_Shake(this);
 
-    if ((this->collider.base.acFlags & AC_HIT) && (this->collider.info.acHitInfo->toucher.dmgFlags & DMG_HAMMER)) {
+    if ((this->collider.base.acFlags & AC_HIT) && (this->collider.info.otherElemAT->toucher.dmgFlags & DMG_HAMMER)) {
         this->collider.base.acFlags &= ~AC_HIT;
         this->hitCount++;
         if (this->hitCount < 2) {

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
@@ -117,7 +117,7 @@ void ObjIcePoly_Idle(ObjIcePoly* this, PlayState* play) {
     Vec3f pos;
 
     if (this->colliderIce.base.acFlags & AC_HIT) {
-        this->meltTimer = -this->colliderIce.info.acHitInfo->toucher.damage;
+        this->meltTimer = -this->colliderIce.info.otherElemAT->toucher.damage;
         this->actor.focus.rot.y = this->actor.yawTowardsPlayer;
         OnePointCutscene_Init(play, 5120, 40, &this->actor, CAM_ID_MAIN);
         this->actionFunc = ObjIcePoly_Melt;

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -509,7 +509,7 @@ s32 ObjSwitch_EyeIsHit(ObjSwitch* this) {
     s16 yawDiff;
 
     if ((this->tris.col.base.acFlags & AC_HIT) && !(this->prevColFlags & AC_HIT)) {
-        collidingActor = this->tris.col.base.ac;
+        collidingActor = this->tris.col.base.otherAT;
         if (collidingActor != NULL) {
             yawDiff = collidingActor->world.rot.y - this->dyna.actor.shape.rot.y;
             if (ABS(yawDiff) > 0x5000) {

--- a/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
+++ b/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
@@ -171,7 +171,7 @@ void ObjSyokudai_Update(Actor* thisx, PlayState* play2) {
             }
         }
         if (this->colliderFlame.base.acFlags & AC_HIT) {
-            dmgFlags = this->colliderFlame.info.acHitInfo->toucher.dmgFlags;
+            dmgFlags = this->colliderFlame.info.otherElemAT->toucher.dmgFlags;
             if (dmgFlags & (DMG_FIRE | DMG_ARROW_NORMAL)) {
                 interactionType = 1;
             }
@@ -194,7 +194,7 @@ void ObjSyokudai_Update(Actor* thisx, PlayState* play2) {
                         player->unk_860 = 200;
                     }
                 } else if (dmgFlags & DMG_ARROW_NORMAL) {
-                    arrow = (EnArrow*)this->colliderFlame.base.ac;
+                    arrow = (EnArrow*)this->colliderFlame.base.otherAT;
                     if ((arrow->actor.update != NULL) && (arrow->actor.id == ACTOR_EN_ARROW)) {
                         arrow->actor.params = 0;
                         arrow->collider.info.toucher.dmgFlags = DMG_ARROW_FIRE;

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
@@ -246,7 +246,7 @@ void ObjTsubo_Idle(ObjTsubo* this, PlayState* play) {
         ObjTsubo_SpawnCollectible(this, play);
         Actor_Kill(&this->actor);
     } else if ((this->collider.base.acFlags & AC_HIT) &&
-               (this->collider.info.acHitInfo->toucher.dmgFlags &
+               (this->collider.info.otherElemAT->toucher.dmgFlags &
                 (DMG_SWORD | DMG_RANGED | DMG_HAMMER | DMG_BOOMERANG | DMG_EXPLOSIVE))) {
         ObjTsubo_AirBreak(this, play);
         ObjTsubo_SpawnCollectible(this, play);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4099,10 +4099,11 @@ s32 func_808382DC(Player* this, PlayState* play) {
 
             //! @bug The second set of conditions here seems intended as a way for Link to "block" hits by rolling.
             // However, `Collider.atFlags` is a byte so the flag check at the end is incorrect and cannot work.
-            // Additionally, `Collider.atHit` can never be set while already colliding as AC, so it's also bugged.
-            // This behavior was later fixed in MM, most likely by removing both the `atHit` and `atFlags` checks.
-            if (sp64 || ((this->invincibilityTimer < 0) && (this->cylinder.base.acFlags & AC_HIT) &&
-                         (this->cylinder.info.atHit != NULL) && (this->cylinder.info.atHit->atFlags & 0x20000000))) {
+            // Additionally, `Collider.otherColAC` can never be set while already colliding as AC, so it's also bugged.
+            // This behavior was later fixed in MM, most likely by removing both the `otherColAC` and `atFlags` checks.
+            if (sp64 ||
+                ((this->invincibilityTimer < 0) && (this->cylinder.base.acFlags & AC_HIT) &&
+                 (this->cylinder.info.otherColAC != NULL) && (this->cylinder.info.otherColAC->atFlags & 0x20000000))) {
 
                 Player_RequestRumble(this, 180, 20, 100, 0);
 
@@ -4135,7 +4136,7 @@ s32 func_808382DC(Player* this, PlayState* play) {
                     }
                 }
 
-                if (sp64 && (this->shieldQuad.info.acHitInfo->toucher.effect == 1)) {
+                if (sp64 && (this->shieldQuad.info.otherElemAT->toucher.effect == 1)) {
                     func_8083819C(this, play);
                 }
 
@@ -4149,7 +4150,7 @@ s32 func_808382DC(Player* this, PlayState* play) {
             }
 
             if (this->cylinder.base.acFlags & AC_HIT) {
-                Actor* ac = this->cylinder.base.ac;
+                Actor* ac = this->cylinder.base.otherAT;
                 s32 sp4C;
 
                 if (ac->flags & ACTOR_FLAG_24) {
@@ -8129,7 +8130,7 @@ s32 func_80842DF4(PlayState* play, Player* this) {
 
         if (temp1) {
             if (this->meleeWeaponAnimation < PLAYER_MWA_SPIN_ATTACK_1H) {
-                Actor* at = this->meleeWeaponQuads[temp1 ? 1 : 0].base.at;
+                Actor* at = this->meleeWeaponQuads[temp1 ? 1 : 0].base.otherAC;
 
                 if ((at != NULL) && (at->id != ACTOR_EN_KANBAN)) {
                     func_80832630(play);
@@ -8683,7 +8684,7 @@ void func_80844708(Player* this, PlayState* play) {
             if (this->linearVelocity >= 7.0f) {
                 if (((this->actor.bgCheckFlags & BGCHECKFLAG_PLAYER_WALL_INTERACT) && (D_8085360C < 0x2000)) ||
                     ((this->cylinder.base.ocFlags1 & OC1_HIT) &&
-                     (cylinderOc = this->cylinder.base.oc,
+                     (cylinderOc = this->cylinder.base.otherOC,
                       ((cylinderOc->id == ACTOR_EN_WOOD02) &&
                        (ABS((s16)(this->actor.world.rot.y - cylinderOc->yawTowardsPlayer)) > 0x6000))))) {
 


### PR DESCRIPTION
Split from #1427

`Collider.actor` -> `Collider.self`
`Collider.ac` -> `Collider.otherAT`
`Collider.at` -> `Collider.otherAC`
`Collider.oc` -> `Collider.otherOC`

`ColliderInfo.atHit` -> `ColliderInfo.otherColAC`
`ColliderInfo.acHit` -> `ColliderInfo.otherColAT`
`ColliderInfo.atHitInfo` -> `ColliderInfo.otherElemAC`
`ColliderInfo.acHitInfo` -> `ColliderInfo.otherElemAT`
(note: `ColliderInfo` -> `ColliderElement` in #1427)

Relevant comment thread from #1427:
https://github.com/zeldaret/oot/pull/1427#discussion_r1020951184