### PR TITLE
Name `Actor_PlaySfx` and `Player_PlaySfx`

### DIFF
--- a/docs/tutorial/other_functions.md
+++ b/docs/tutorial/other_functions.md
@@ -502,7 +502,7 @@ void EnJj_Update(EnJj *this, PlayState *play) {
     } else {
         this->actionFunc(this);
         if (this->skelAnime.curFrame == 41.0f) {
-            Audio_PlayActorSfx2((Actor *) this, (u16)0x28B6U);
+            Actor_PlaySfx((Actor *) this, (u16)0x28B6U);
         }
     }
     func_80A87B1C(this);
@@ -526,7 +526,7 @@ void EnJj_Update(Actor *thisx, PlayState *play) {
     } else {
         this->actionFunc(this, play);
         if (this->skelAnime.curFrame == 41.0f) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_JABJAB_GROAN);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_JABJAB_GROAN);
         }
     }
     func_80A87B1C(this);
@@ -687,7 +687,7 @@ void func_80A87D94(EnJj *this, PlayState *play) {
         }
     }
     if ((phi_v1 & 1) != 0) {
-        Audio_PlayActorSfx2((Actor *) this, (u16)0x206DU);
+        Actor_PlaySfx((Actor *) this, (u16)0x206DU);
         temp_v0_2 = this->unk_308;
         if ((s32) temp_v0_2 >= -0x1450) {
             this->unk_308 = temp_v0_2 - 0x66;
@@ -763,7 +763,7 @@ void func_80A87D94(EnJj *this, PlayState *play) {
             break;
     }
     if ((phi_v1 & 1) != 0) {
-        Audio_PlayActorSfx2((Actor *) this, (u16)0x206DU);
+        Actor_PlaySfx((Actor *) this, (u16)0x206DU);
         temp_v0_2 = this->unk_308;
         if ((s32) temp_v0_2 >= -0x1450) {
             this->unk_308 = temp_v0_2 - 0x66;
@@ -771,9 +771,9 @@ void func_80A87D94(EnJj *this, PlayState *play) {
     }
 }
 ```
-(notice that this time we need a `default` to deal with the innermost if contents). If you try to replace `0x206D` in the `Audio_PlayActorSfx2`, you will find there is no such sfxId in the list: this is because some sound effects have an extra offset of `0x800` to do with setting flags. Adding `0x800` to the sfxId shows that this sound effect is `NA_SE_EV_JABJAB_BREATHE`. To correct this to the id in the function, we have a macro `SFX_FLAG`, and it should therefore be
+(notice that this time we need a `default` to deal with the innermost if contents). If you try to replace `0x206D` in the `Actor_PlaySfx`, you will find there is no such sfxId in the list: this is because some sound effects have an extra offset of `0x800` to do with setting flags. Adding `0x800` to the sfxId shows that this sound effect is `NA_SE_EV_JABJAB_BREATHE`. To correct this to the id in the function, we have a macro `SFX_FLAG`, and it should therefore be
 ```C
-Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_JABJAB_BREATHE - SFX_FLAG);
+Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_JABJAB_BREATHE - SFX_FLAG);
 ```
 
 As usual, most of the remaining temps look fake. The only one that does not is possibly `phi_v1`. However, the way in which they are used here makes it hard to tell if they are fake, and if so, how to replace them. I encourage you to try this yourself, with the aid of the diff script; the final, matching result, with other cleanup, is hidden below
@@ -814,7 +814,7 @@ void func_80A87D94(EnJj* this, PlayState* play) {
             break;
     }
     if ((this->unk_30A & 1) != 0) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_JABJAB_BREATHE - SFX_FLAG);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_JABJAB_BREATHE - SFX_FLAG);
         if (this->unk_308 >= -5200) {
             this->unk_308 -= 102;
         }

--- a/include/functions.h
+++ b/include/functions.h
@@ -428,8 +428,8 @@ void func_8002F6D4(PlayState* play, Actor* actor, f32 arg2, s16 arg3, f32 arg4, 
 void func_8002F71C(PlayState* play, Actor* actor, f32 arg2, s16 arg3, f32 arg4);
 void func_8002F758(PlayState* play, Actor* actor, f32 arg2, s16 arg3, f32 arg4, u32 arg5);
 void func_8002F7A0(PlayState* play, Actor* actor, f32 arg2, s16 arg3, f32 arg4);
-void func_8002F7DC(Actor* actor, u16 sfxId);
-void Audio_PlayActorSfx2(Actor* actor, u16 sfxId);
+void Player_PlaySfx(Player* player, u16 sfxId);
+void Actor_PlaySfx(Actor* actor, u16 sfxId);
 void func_8002F850(PlayState* play, Actor* actor);
 void func_8002F8F0(Actor* actor, u16 sfxId);
 void func_8002F91C(Actor* actor, u16 sfxId);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -1715,7 +1715,7 @@ void func_8002F7A0(PlayState* play, Actor* actor, f32 arg2, s16 arg3, f32 arg4) 
 }
 
 /**
- * Play a sound effect at the players' position
+ * Play a sound effect at the player's position
  */
 void Player_PlaySfx(Player* player, u16 sfxId) {
     Audio_PlaySfxGeneral(sfxId, &player->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
@@ -1723,7 +1723,7 @@ void Player_PlaySfx(Player* player, u16 sfxId) {
 }
 
 /**
- * Play a sound effect at the actors' position
+ * Play a sound effect at the actor's position
  */
 void Actor_PlaySfx(Actor* actor, u16 sfxId) {
     func_80078914(&actor->projectedPos, sfxId);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -1715,7 +1715,7 @@ void func_8002F7A0(PlayState* play, Actor* actor, f32 arg2, s16 arg3, f32 arg4) 
 }
 
 /**
- * Play a sfx at player's position
+ * Play a sound effect at the players's position
  */
 void Player_PlaySfx(Player* player, u16 sfxId) {
     Audio_PlaySfxGeneral(sfxId, &player->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
@@ -1723,7 +1723,7 @@ void Player_PlaySfx(Player* player, u16 sfxId) {
 }
 
 /**
- * Play a sfx at actor's position
+ * Play a sound effect at the actor's position
  */
 void Actor_PlaySfx(Actor* actor, u16 sfxId) {
     func_80078914(&actor->projectedPos, sfxId);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -1714,12 +1714,18 @@ void func_8002F7A0(PlayState* play, Actor* actor, f32 arg2, s16 arg3, f32 arg4) 
     func_8002F758(play, actor, arg2, arg3, arg4, 0);
 }
 
-void func_8002F7DC(Actor* actor, u16 sfxId) {
-    Audio_PlaySfxGeneral(sfxId, &actor->projectedPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
-                         &gSfxDefaultReverb);
+/**
+ * Play a sfx at player's position
+ */
+void Player_PlaySfx(Player* player, u16 sfxId) {
+    Audio_PlaySfxGeneral(sfxId, &player->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
+                         &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
 }
 
-void Audio_PlayActorSfx2(Actor* actor, u16 sfxId) {
+/**
+ * Play a sfx at actor's position
+ */
+void Actor_PlaySfx(Actor* actor, u16 sfxId) {
     func_80078914(&actor->projectedPos, sfxId);
 }
 
@@ -1783,7 +1789,7 @@ s32 func_8002F9EC(PlayState* play, Actor* actor, CollisionPoly* poly, s32 bgId, 
     if (SurfaceType_GetFloorType(&play->colCtx, poly, bgId) == FLOOR_TYPE_8) {
         play->roomCtx.unk_74[0] = 1;
         CollisionCheck_BlueBlood(play, NULL, pos);
-        Audio_PlayActorSfx2(actor, NA_SE_IT_WALL_HIT_BUYO);
+        Actor_PlaySfx(actor, NA_SE_IT_WALL_HIT_BUYO);
         return true;
     }
 
@@ -3664,7 +3670,7 @@ void func_8003424C(PlayState* play, Vec3f* arg1) {
 
 void Actor_SetColorFilter(Actor* actor, s16 colorFlag, s16 colorIntensityMax, s16 bufFlag, s16 duration) {
     if ((colorFlag == COLORFILTER_COLORFLAG_GRAY) && !(colorIntensityMax & COLORFILTER_INTENSITY_FLAG)) {
-        Audio_PlayActorSfx2(actor, NA_SE_EN_LIGHT_ARROW_HIT);
+        Actor_PlaySfx(actor, NA_SE_EN_LIGHT_ARROW_HIT);
     }
 
     actor->colorFilterParams = colorFlag | bufFlag | ((colorIntensityMax & 0xF8) << 5) | duration;

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -1715,7 +1715,7 @@ void func_8002F7A0(PlayState* play, Actor* actor, f32 arg2, s16 arg3, f32 arg4) 
 }
 
 /**
- * Play a sound effect at the players's position
+ * Play a sound effect at the players' position
  */
 void Player_PlaySfx(Player* player, u16 sfxId) {
     Audio_PlaySfxGeneral(sfxId, &player->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
@@ -1723,7 +1723,7 @@ void Player_PlaySfx(Player* player, u16 sfxId) {
 }
 
 /**
- * Play a sound effect at the actor's position
+ * Play a sound effect at the actors' position
  */
 void Actor_PlaySfx(Actor* actor, u16 sfxId) {
     func_80078914(&actor->projectedPos, sfxId);

--- a/src/code/z_effect_soft_sprite_old_init.c
+++ b/src/code/z_effect_soft_sprite_old_init.c
@@ -888,7 +888,7 @@ void EffectSsEnIce_SpawnFlyingVec3f(PlayState* play, Actor* actor, Vec3f* pos, s
     initParams.scale = scale;
 
     if (actor != NULL) {
-        Audio_PlayActorSfx2(actor, NA_SE_PL_FREEZE_S);
+        Actor_PlaySfx(actor, NA_SE_PL_FREEZE_S);
     }
 
     EffectSs_Spawn(play, EFFECT_SS_EN_ICE, 80, &initParams);
@@ -914,7 +914,7 @@ void EffectSsEnIce_SpawnFlyingVec3s(PlayState* play, Actor* actor, Vec3s* pos, s
     initParams.scale = scale;
 
     if (actor != NULL) {
-        Audio_PlayActorSfx2(actor, NA_SE_PL_FREEZE_S);
+        Actor_PlaySfx(actor, NA_SE_PL_FREEZE_S);
     }
 
     EffectSs_Spawn(play, EFFECT_SS_EN_ICE, 80, &initParams);
@@ -993,7 +993,7 @@ void EffectSsEnFire_SpawnVec3f(PlayState* play, Actor* actor, Vec3f* pos, s16 sc
     initParams.bodyPart = bodyPart;
 
     if (actor != NULL) {
-        Audio_PlayActorSfx2(actor, NA_SE_EV_FLAME_IGNITION);
+        Actor_PlaySfx(actor, NA_SE_EV_FLAME_IGNITION);
     }
 
     EffectSs_Spawn(play, EFFECT_SS_EN_FIRE, 128, &initParams);
@@ -1014,7 +1014,7 @@ void EffectSsEnFire_SpawnVec3s(PlayState* play, Actor* actor, Vec3s* pos, s16 sc
     initParams.bodyPart = bodyPart;
 
     if (actor != NULL) {
-        Audio_PlayActorSfx2(actor, NA_SE_EV_FLAME_IGNITION);
+        Actor_PlaySfx(actor, NA_SE_EV_FLAME_IGNITION);
     }
 
     EffectSs_Spawn(play, EFFECT_SS_EN_FIRE, 128, &initParams);

--- a/src/code/z_en_a_keep.c
+++ b/src/code/z_en_a_keep.c
@@ -301,7 +301,7 @@ void EnAObj_Block(EnAObj* this, PlayState* play) {
     Math_SmoothStepToF(&this->dyna.actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
 
     if (this->dyna.actor.speedXZ != 0.0f) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
     }
 
     this->dyna.unk_154 = 0.0f;

--- a/src/code/z_scene_table.c
+++ b/src/code/z_scene_table.c
@@ -1244,7 +1244,7 @@ void Scene_DrawConfigLostWoods(PlayState* play) {
 
     if ((play->roomCtx.unk_74[0] == 0) && (INV_CONTENT(ITEM_COJIRO) == ITEM_COJIRO)) {
         if (play->roomCtx.unk_74[1] == 50) {
-            func_8002F7DC(&GET_PLAYER(play)->actor, NA_SE_EV_CHICKEN_CRY_M);
+            Player_PlaySfx(GET_PLAYER(play), NA_SE_EV_CHICKEN_CRY_M);
             play->roomCtx.unk_74[0] = 1;
         }
         play->roomCtx.unk_74[1]++;

--- a/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
+++ b/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
@@ -164,7 +164,7 @@ void ArrowFire_Fly(ArrowFire* this, PlayState* play) {
     func_80865ECC(&this->unkPos, &this->actor.world.pos, 0.05f);
 
     if (arrow->hitFlags & 1) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_EXPLOSION_FRAME);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_EXPLOSION_FRAME);
         ArrowFire_SetupAction(this, ArrowFire_Hit);
         this->timer = 32;
         this->alpha = 255;

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
@@ -165,7 +165,7 @@ void ArrowIce_Fly(ArrowIce* this, PlayState* play) {
     func_80867E8C(&this->unkPos, &this->actor.world.pos, 0.05f);
 
     if (arrow->hitFlags & 1) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_EXPLOSION_ICE);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_EXPLOSION_ICE);
         ArrowIce_SetupAction(this, ArrowIce_Hit);
         this->timer = 32;
         this->alpha = 255;

--- a/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
+++ b/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
@@ -163,7 +163,7 @@ void ArrowLight_Fly(ArrowLight* this, PlayState* play) {
     func_80869E6C(&this->unkPos, &this->actor.world.pos, 0.05f);
 
     if (arrow->hitFlags & 1) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_EXPLOSION_LIGHT);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_EXPLOSION_LIGHT);
         ArrowLight_SetupAction(this, ArrowLight_Hit);
         this->timer = 32;
         this->alpha = 255;

--- a/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
@@ -204,7 +204,7 @@ void func_8086C054(BgBdanObjects* this, PlayState* play) {
 void func_8086C1A0(BgBdanObjects* this, PlayState* play) {
     if (Math_SmoothStepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 500.0f, 0.5f, 7.5f, 1.0f) <
         0.1f) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_A);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_A);
         this->actionFunc = func_8086C29C;
         this->timer = 30;
         BgBdanObjects_SetContactRu1(this, 2);
@@ -253,7 +253,7 @@ void func_8086C3D8(BgBdanObjects* this, PlayState* play) {
                      this->dyna.actor.velocity.y)) {
         this->dyna.actor.world.rot.y = 0;
         this->timer = 60;
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_U);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_U);
         this->dyna.actor.child->world.pos.y = this->dyna.actor.world.pos.y + 140.0f;
         this->actionFunc = func_8086C5BC;
         OnePointCutscene_Init(play, 3080, -99, this->dyna.actor.child, CAM_ID_MAIN);
@@ -337,7 +337,7 @@ void func_8086C76C(BgBdanObjects* this, PlayState* play) {
 void func_8086C7D0(BgBdanObjects* this, PlayState* play) {
     if (Math_SmoothStepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 965.0f, 0.5f, 15.0f, 0.2f) <
         0.01f) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_A);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_A);
         this->actionFunc = BgBdanObjects_DoNothing;
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_BUYOSTAND_RISING - SFX_FLAG);
@@ -429,7 +429,7 @@ void func_8086CB8C(BgBdanObjects* this, PlayState* play) {
     this->dyna.actor.world.pos.y = this->dyna.actor.home.pos.y - (cosf(this->timer * (M_PI / 50.0f)) * 200.0f);
 
     if (this->timer == 0) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_U);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_U);
         this->actionFunc = BgBdanObjects_DoNothing;
         // Using `CAM_ID_NONE` here defaults to the active camera
         Play_CopyCamera(play, CAM_ID_MAIN, CAM_ID_NONE);

--- a/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.c
@@ -272,7 +272,7 @@ void func_8086D694(BgBdanSwitch* this, PlayState* play) {
         this->unk_1C8 -= 0.2f;
         if (this->unk_1C8 <= 0.1f) {
             func_8086D730(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
             Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 120, 20, 10);
         }
     }
@@ -312,7 +312,7 @@ void func_8086D80C(BgBdanSwitch* this, PlayState* play) {
     this->unk_1C8 += 0.2f;
     if (this->unk_1C8 >= 1.0f) {
         func_8086D5C4(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
     }
 }
 
@@ -335,7 +335,7 @@ void func_8086D8CC(BgBdanSwitch* this, PlayState* play) {
     this->unk_1C8 -= 0.2f;
     if (this->unk_1C8 <= 0.6f) {
         func_8086D9F8(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
         Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 120, 20, 10);
     }
 }
@@ -350,7 +350,7 @@ void func_8086D95C(BgBdanSwitch* this, PlayState* play) {
         this->unk_1C8 -= 0.2f;
         if (this->unk_1C8 <= 0.1f) {
             func_8086DB24(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
             Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 120, 20, 10);
         }
     }
@@ -389,7 +389,7 @@ void func_8086DAC4(BgBdanSwitch* this, PlayState* play) {
     this->unk_1C8 += 0.2f;
     if (this->unk_1C8 >= 1.0f) {
         func_8086D86C(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
     }
 }
 
@@ -437,7 +437,7 @@ void func_8086DC48(BgBdanSwitch* this, PlayState* play) {
         this->unk_1C8 -= 0.3f;
         if (this->unk_1C8 <= 1.0f) {
             func_8086DCCC(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
         }
     }
 }
@@ -475,7 +475,7 @@ void func_8086DDC0(BgBdanSwitch* this, PlayState* play) {
         this->unk_1C8 += 0.3f;
         if (this->unk_1C8 >= 2.0f) {
             func_8086DB4C(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
         }
     }
 }

--- a/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.c
+++ b/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.c
@@ -150,7 +150,7 @@ void BgBowlWall_FallDoEffects(BgBowlWall* this, PlayState* play) {
             EffectSsBomb2_SpawnLayered(play, &effectPos, &effectVelocity, &effectAccel, 100, 30);
             effectPos.y = -50.0f;
             EffectSsHahen_SpawnBurst(play, &effectPos, 10.0f, 0, 50, 15, 3, HAHEN_OBJECT_DEFAULT, 10, NULL);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_IT_BOMB_EXPLOSION);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_IT_BOMB_EXPLOSION);
         }
         quakeIndex = Quake_Request(GET_ACTIVE_CAM(play), QUAKE_TYPE_1);
         Quake_SetSpeed(quakeIndex, 0x7FFF);

--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -243,9 +243,9 @@ void BgBreakwall_Wait(BgBreakwall* this, PlayState* play) {
         Flags_SetSwitch(play, this->dyna.actor.params & 0x3F);
 
         if (wallType == BWALL_KD_FLOOR) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_EXPLOSION);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_EXPLOSION);
         } else {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_WALL_BROKEN);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_WALL_BROKEN);
         }
 
         if ((wallType == BWALL_DC_ENTRANCE) && !Flags_GetEventChkInf(EVENTCHKINF_B0)) {

--- a/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.c
+++ b/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.c
@@ -162,7 +162,7 @@ void BgDdanJd_Move(BgDdanJd* this, PlayState* play) {
         this->actionFunc = BgDdanJd_Idle;
         OnePointCutscene_Init(play, 3060, -99, &this->dyna.actor, CAM_ID_MAIN);
     } else if (Math_StepToF(&this->dyna.actor.world.pos.y, this->targetY, this->ySpeed)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_PILLAR_MOVE_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_PILLAR_MOVE_STOP);
         this->actionFunc = BgDdanJd_Idle;
     }
     BgDdanJd_MoveEffects(this, play);

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -297,7 +297,7 @@ void BgDyYoseizo_ChooseType(BgDyYoseizo* this, PlayState* play) {
         OnePointCutscene_Init(play, 8604, -99, NULL, CAM_ID_MAIN);
     };
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GREAT_FAIRY_APPEAR);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_GREAT_FAIRY_APPEAR);
     this->actor.draw = BgDyYoseizo_Draw;
     this->actionFunc = BgDyYoseizo_SetupSpinGrow_NoReward;
 }
@@ -314,7 +314,7 @@ void BgDyYoseizo_SetupSpinGrow_NoReward(BgDyYoseizo* this, PlayState* play) {
                          ANIMMODE_ONCE, -10.0f);
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_VO_FR_LAUGH_0);
+    Actor_PlaySfx(&this->actor, NA_SE_VO_FR_LAUGH_0);
     func_8002DF54(play, &this->actor, PLAYER_CSMODE_1);
     this->actionFunc = BgDyYoseizo_SpinGrow_NoReward;
 }
@@ -410,7 +410,7 @@ void BgDyYoseizo_SetupHealPlayer_NoReward(BgDyYoseizo* this, PlayState* play) {
                          -10.0f);
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_VO_FR_SMILE_0);
+    Actor_PlaySfx(&this->actor, NA_SE_VO_FR_SMILE_0);
     this->mouthState = 1;
     this->actionFunc = BgDyYoseizo_HealPlayer_NoReward;
 }
@@ -521,8 +521,8 @@ void BgDyYoseizo_SetupSpinShrink(BgDyYoseizo* this, PlayState* play) {
     this->vanishTimer = 5;
     this->scaleFraction = 0.0f;
     this->heightFraction = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_VO_FR_LAUGH_0);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GREAT_FAIRY_VANISH);
+    Actor_PlaySfx(&this->actor, NA_SE_VO_FR_LAUGH_0);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_GREAT_FAIRY_VANISH);
     this->actionFunc = BgDyYoseizo_SpinShrink;
 }
 
@@ -582,7 +582,7 @@ void BgDyYoseizo_SetupSpinGrow_Reward(BgDyYoseizo* this, PlayState* play) {
                                  ANIMMODE_ONCE, -10.0f);
             }
 
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GREAT_FAIRY_APPEAR);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_GREAT_FAIRY_APPEAR);
             this->actionFunc = BgDyYoseizo_SpinGrowSetupGive_Reward;
         }
     }
@@ -839,10 +839,10 @@ void BgDyYoseizo_Update(Actor* thisx, PlayState* play2) {
         }
 
         if (sfx == 1) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_VO_FR_SMILE_0);
+            Actor_PlaySfx(&this->actor, NA_SE_VO_FR_SMILE_0);
         }
         if (sfx == 2) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_VO_FR_LAUGH_0);
+            Actor_PlaySfx(&this->actor, NA_SE_VO_FR_LAUGH_0);
         }
     }
 
@@ -958,7 +958,7 @@ void BgDyYoseizo_UpdateEffects(BgDyYoseizo* this, PlayState* play) {
                 effect->velocity.y += effect->accel.y;
                 effect->velocity.z += effect->accel.z;
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_HEALING - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_HEALING - SFX_FLAG);
 
                 sp94 = player->actor.world.pos;
                 sp94.y = player->actor.world.pos.y - 150.0f;

--- a/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.c
@@ -78,11 +78,11 @@ void func_80878300(BgGateShutter* this, PlayState* play) {
     Actor* thisx = &this->dyna.actor;
 
     if (this->unk_178 == 0) {
-        Audio_PlayActorSfx2(thisx, NA_SE_EV_METALGATE_OPEN - SFX_FLAG);
+        Actor_PlaySfx(thisx, NA_SE_EV_METALGATE_OPEN - SFX_FLAG);
         thisx->world.pos.x -= 2.0f;
         Math_ApproachF(&thisx->world.pos.z, -1375.0f, 0.8f, 0.3f);
         if (thisx->world.pos.x < -89.0f) {
-            Audio_PlayActorSfx2(thisx, NA_SE_EV_BRIDGE_OPEN_STOP);
+            Actor_PlaySfx(thisx, NA_SE_EV_BRIDGE_OPEN_STOP);
             this->unk_178 = 0x1E;
             this->actionFunc = func_808783AC;
         }
@@ -100,12 +100,12 @@ void func_808783D4(BgGateShutter* this, PlayState* play) {
     Actor* thisx = &this->dyna.actor;
 
     if (this->unk_178 == 0) {
-        Audio_PlayActorSfx2(thisx, NA_SE_EV_METALGATE_OPEN - SFX_FLAG);
+        Actor_PlaySfx(thisx, NA_SE_EV_METALGATE_OPEN - SFX_FLAG);
         thisx->world.pos.x += 2.0f;
         Math_ApproachF(&thisx->world.pos.z, -1350.0f, 0.8f, 0.3f);
         if (thisx->world.pos.x > 90.0f) {
             thisx->world.pos.x = 91.0f;
-            Audio_PlayActorSfx2(thisx, NA_SE_EV_BRIDGE_OPEN_STOP);
+            Actor_PlaySfx(thisx, NA_SE_EV_BRIDGE_OPEN_STOP);
             this->unk_178 = 30;
             this->actionFunc = func_808783AC;
         }

--- a/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.c
@@ -97,7 +97,7 @@ void BgGndFiremeiro_Shake(BgGndFiremeiro* this, PlayState* play) {
             this->dyna.actor.world.pos.y += Math_CosS(this->timer * 0x7FFF);
 
             if (!(this->timer % 4)) {
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
             }
         } else {
             this->timer = 10;

--- a/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
@@ -313,7 +313,7 @@ void BgGndIceblock_Slide(BgGndIceblock* this, PlayState* play) {
         thisx->speedXZ = 0.0f;
         this->targetPos.x = thisx->world.pos.x;
         this->targetPos.z = thisx->world.pos.z;
-        Audio_PlayActorSfx2(thisx, NA_SE_EV_BLOCK_BOUND);
+        Actor_PlaySfx(thisx, NA_SE_EV_BLOCK_BOUND);
         switch (BgGndIceblock_NextAction(this)) {
             case GNDICE_IDLE:
                 this->actionFunc = BgGndIceblock_Idle;

--- a/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
@@ -241,7 +241,7 @@ void BgHakaGate_FloorClosed(BgHakaGate* this, PlayState* play) {
                 this->actionFunc = BgHakaGate_DoNothing;
             } else {
                 func_80078884(NA_SE_SY_ERROR);
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_GROUND_GATE_OPEN);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_GROUND_GATE_OPEN);
                 DynaPoly_DisableCollision(play, &play->colCtx.dyna, this->dyna.bgId);
                 this->vTimer = 60;
                 this->actionFunc = BgHakaGate_FloorOpen;
@@ -273,7 +273,7 @@ void BgHakaGate_GateWait(BgHakaGate* this, PlayState* play) {
 
 void BgHakaGate_GateOpen(BgHakaGate* this, PlayState* play) {
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 80.0f, 1.0f)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
         this->dyna.actor.flags &= ~ACTOR_FLAG_4;
         this->actionFunc = BgHakaGate_DoNothing;
     } else {

--- a/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.c
@@ -177,7 +177,7 @@ void BgHakaShip_CrashFall(BgHakaShip* this, PlayState* play) {
             Actor_Kill(child);
         }
     } else {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCKSINK - SFX_FLAG);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCKSINK - SFX_FLAG);
         if ((this->dyna.actor.home.pos.y - this->dyna.actor.world.pos.y > 500.0f) &&
             DynaPolyActor_IsPlayerOnTop(&this->dyna)) {
             Play_TriggerVoidOut(play);

--- a/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
@@ -301,13 +301,13 @@ void func_80880484(BgHakaTrap* this, PlayState* play) {
     timer = this->timer;
 
     if ((timer == 10 && !this->unk_16A) || (timer == 13 && this->unk_16A)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_GUILLOTINE_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_GUILLOTINE_BOUND);
     }
 
     if (this->timer == 0) {
         this->dyna.actor.velocity.y = 0.0f;
         this->timer = (this->unk_16A) ? 10 : 40;
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_GUILLOTINE_UP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_GUILLOTINE_UP);
         this->actionFunc = func_808805C0;
     }
 
@@ -333,7 +333,7 @@ void func_808805C0(BgHakaTrap* this, PlayState* play) {
         }
 
         if (this->timer == 20) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_GUILLOTINE_UP);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_GUILLOTINE_UP);
         }
     }
 
@@ -380,7 +380,7 @@ void func_808806BC(BgHakaTrap* this, PlayState* play) {
 
     if (Math_StepToF(&this->dyna.actor.world.pos.y, floorHeight, this->dyna.actor.velocity.y)) {
         if (this->dyna.actor.velocity.y > 0.01f) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_TRAP_BOUND);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_TRAP_BOUND);
         }
         this->dyna.actor.velocity.y = 0.0f;
     }

--- a/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.c
@@ -278,12 +278,12 @@ void func_80883000(BgHakaZou* this, PlayState* play) {
             func_80882E54(this, play);
             this->dyna.actor.draw = NULL;
             this->timer = 1;
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_EXPLOSION);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_EXPLOSION);
             this->actionFunc = func_80883104;
         } else {
             func_80882CC4(this, play);
             this->timer = 1;
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_WALL_BROKEN);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_WALL_BROKEN);
             this->actionFunc = func_80883104;
         }
     } else {
@@ -314,7 +314,7 @@ void func_80883144(BgHakaZou* this, PlayState* play) {
         explosionPos.z = Rand_CenteredFloat(200.0f) + (this->dyna.actor.world.pos.z + 56.0f);
 
         EffectSsBomb2_SpawnLayered(play, &explosionPos, &sZeroVec, &sZeroVec, 150, 70);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_IT_BOMB_EXPLOSION);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_IT_BOMB_EXPLOSION);
     }
 
     if (this->timer == 0) {
@@ -365,7 +365,7 @@ void func_80883328(BgHakaZou* this, PlayState* play) {
             effectPos.x -= 112.0f;
         }
 
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
         this->timer = 25;
         this->actionFunc = func_808834D8;
     }

--- a/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.c
+++ b/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.c
@@ -189,7 +189,7 @@ void BgHeavyBlock_MovePiece(BgHeavyBlock* this, PlayState* play) {
             thisx->velocity.x = Rand_CenteredFloat(8.0f);
             thisx->velocity.z = Rand_CenteredFloat(8.0f);
             BgHeavyBlock_SetPieceRandRot(this, 1.0f);
-            Audio_PlayActorSfx2(thisx, NA_SE_EV_ROCK_BROKEN);
+            Actor_PlaySfx(thisx, NA_SE_EV_ROCK_BROKEN);
             Rumble_Request(thisx->xzDistToPlayer, 150, 10, 8);
         }
     }
@@ -350,7 +350,7 @@ void BgHeavyBlock_LiftedUp(BgHeavyBlock* this, PlayState* play) {
 
     if (this->timer == 11) {
         Rumble_Request(0.0f, 255, 20, 20);
-        func_8002F7DC(&player->actor, NA_SE_PL_PULL_UP_BIGROCK);
+        Player_PlaySfx(player, NA_SE_PL_PULL_UP_BIGROCK);
         LOG_STRING("NA_SE_PL_PULL_UP_BIGROCK", "../z_bg_heavy_block.c", 691);
     }
 
@@ -371,7 +371,7 @@ void BgHeavyBlock_LiftedUp(BgHeavyBlock* this, PlayState* play) {
 
     // if parent is NULL, link threw it
     if (Actor_HasNoParent(&this->dyna.actor, play)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_HEAVY_THROW);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_HEAVY_THROW);
         this->actionFunc = BgHeavyBlock_Fly;
     }
 }
@@ -412,7 +412,7 @@ void BgHeavyBlock_Fly(BgHeavyBlock* this, PlayState* play) {
                 SfxSource_PlaySfxAtFixedWorldPos(play, &this->dyna.actor.world.pos, 30, NA_SE_EV_ELECTRIC_EXPLOSION);
                 return;
             case HEAVYBLOCK_UNBREAKABLE_OUTSIDE_CASTLE:
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
 
                 quakeIndex = Quake_Request(GET_ACTIVE_CAM(play), QUAKE_TYPE_3);
                 Quake_SetSpeed(quakeIndex, 28000);
@@ -423,7 +423,7 @@ void BgHeavyBlock_Fly(BgHeavyBlock* this, PlayState* play) {
                 Flags_SetSwitch(play, (this->dyna.actor.params >> 8) & 0x3F);
                 break;
             case HEAVYBLOCK_UNBREAKABLE:
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_U);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYOSTAND_STOP_U);
 
                 quakeIndex = Quake_Request(GET_ACTIVE_CAM(play), QUAKE_TYPE_3);
                 Quake_SetSpeed(quakeIndex, 28000);

--- a/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
@@ -145,8 +145,8 @@ void BgHidanDalm_Wait(BgHidanDalm* this, PlayState* play) {
         this->dyna.actor.bgCheckFlags &= ~BGCHECKFLAG_WALL;
         this->dyna.actor.speedXZ = 10.0f;
         Flags_SetSwitch(play, this->switchFlag);
-        func_8002F7DC(&GET_PLAYER(play)->actor, NA_SE_IT_HAMMER_HIT);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_DARUMA_VANISH);
+        Player_PlaySfx(GET_PLAYER(play), NA_SE_IT_HAMMER_HIT);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_DARUMA_VANISH);
     } else {
         CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
     }

--- a/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.c
@@ -99,7 +99,7 @@ void func_80886FCC(BgHidanFslift* this, PlayState* play) {
 
 void func_8088706C(BgHidanFslift* this, PlayState* play) {
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y, 4.0f)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
         func_80886FB4(this);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_ELEVATOR_MOVE3 - SFX_FLAG);
@@ -110,7 +110,7 @@ void func_8088706C(BgHidanFslift* this, PlayState* play) {
 void func_808870D8(BgHidanFslift* this, PlayState* play) {
     if (DynaPolyActor_IsPlayerAbove(&this->dyna)) {
         if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 790.0f, 4.0f)) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
             func_80886FB4(this);
         } else {
             func_8002F974(&this->dyna.actor, NA_SE_EV_ELEVATOR_MOVE3 - SFX_FLAG);

--- a/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.c
@@ -280,7 +280,7 @@ void func_80888734(BgHidanHamstep* this) {
 void func_808887C4(BgHidanHamstep* this, PlayState* play) {
     if (this->collider.base.acFlags & AC_HIT) {
         OnePointCutscene_Init(play, 3310, 100, &this->dyna.actor, CAM_ID_MAIN);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_HAMMER_SWITCH);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_HAMMER_SWITCH);
         this->collider.base.acFlags = AC_NONE;
         BgHidanHamstep_SetupAction(this, 1);
         Flags_SetSwitch(play, (this->dyna.actor.params >> 8) & 0xFF);
@@ -313,7 +313,7 @@ void func_80888860(BgHidanHamstep* this, PlayState* play) {
                 Quake_SetSpeed(quakeIndex, -15536);
                 Quake_SetPerturbations(quakeIndex, 0, 0, 500, 0);
                 Quake_SetDuration(quakeIndex, 20);
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
                 Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 255, 20, 150);
                 func_80888638(this, play);
                 osSyncPrintf("A(%d)\n", this->dyna.actor.params);
@@ -373,7 +373,7 @@ void func_80888A58(BgHidanHamstep* this, PlayState* play) {
                 Quake_SetPerturbations(quakeIndex, 20, 1, 0, 0);
                 Quake_SetDuration(quakeIndex, 7);
 
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
                 Rumble_Request(SQ(100.0f), 255, 20, 150);
                 func_808884C8(this, play);
 

--- a/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.c
@@ -162,7 +162,7 @@ void func_808894B0(BgHidanHrock* this, PlayState* play) {
 
     if (!(this->unk_168 % 4)) {
         Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 180, 10, 100);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
     }
 
     if (this->unk_168 == 0) {
@@ -185,7 +185,7 @@ void func_8088960C(BgHidanHrock* this, PlayState* play) {
 
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y, this->dyna.actor.velocity.y)) {
         this->dyna.actor.flags &= ~(ACTOR_FLAG_4 | ACTOR_FLAG_5);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
 
         if (this->dyna.actor.params == 0) {
             if (play->roomCtx.curRoom.num == 10) {

--- a/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.c
@@ -134,7 +134,7 @@ void func_80889C90(BgHidanKousi* this, PlayState* play) {
         Math_Vec3f_DistXYZ(&this->dyna.actor.home.pos, &this->dyna.actor.world.pos)) {
         func_80889ACC(this);
         BgHidanKousi_SetupAction(this, func_80889D28);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_METALDOOR_SLIDE - SFX_FLAG);
     }

--- a/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
@@ -234,7 +234,7 @@ void func_8088B69C(BgHidanRock* this, PlayState* play) {
 
     if (!(this->timer % 4)) {
         Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 180, 10, 100);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
     }
 }
 
@@ -250,10 +250,10 @@ void func_8088B79C(BgHidanRock* this, PlayState* play) {
             this->dyna.actor.flags &= ~(ACTOR_FLAG_4 | ACTOR_FLAG_5);
         }
 
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
-        Audio_PlayActorSfx2(&this->dyna.actor,
-                            NA_SE_PL_WALK_GROUND + SurfaceType_GetSfxOffset(&play->colCtx, this->dyna.actor.floorPoly,
-                                                                            this->dyna.actor.floorBgId));
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+        Actor_PlaySfx(&this->dyna.actor,
+                      NA_SE_PL_WALK_GROUND + SurfaceType_GetSfxOffset(&play->colCtx, this->dyna.actor.floorPoly,
+                                                                      this->dyna.actor.floorBgId));
     }
 
     this->unk_16C -= 0.5f;
@@ -305,7 +305,7 @@ void func_8088B990(BgHidanRock* this, PlayState* play) {
         ((this->type != 0) && (Math_SmoothStepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 480.0,
                                                   0.25f, 20.0f, 0.5f) < 0.1f))) {
         if (this->type == 0) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
         }
         this->timer = 20;
         this->actionFunc = func_8088B954;

--- a/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
@@ -144,7 +144,7 @@ void func_8088E5D0(BgHidanSima* this, PlayState* play) {
     }
     if (!(this->timer % 4)) {
         Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 180, 10, 100);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
     }
 }
 

--- a/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.c
@@ -55,7 +55,7 @@ void BgHidanSyoku_Destroy(Actor* thisx, PlayState* play) {
 
 void func_8088F47C(BgHidanSyoku* this) {
     this->timer = 60;
-    Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+    Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
     this->actionFunc = func_8088F62C;
 }
 

--- a/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.c
@@ -173,7 +173,7 @@ void BgIceObjects_Slide(BgIceObjects* this, PlayState* play) {
         }
         thisx->params = 0;
         func_8002DF54(play, thisx, PLAYER_CSMODE_7);
-        Audio_PlayActorSfx2(thisx, NA_SE_EV_BLOCK_BOUND);
+        Actor_PlaySfx(thisx, NA_SE_EV_BLOCK_BOUND);
         if ((fabsf(thisx->world.pos.x + 1387.0f) < 1.0f) && (fabsf(thisx->world.pos.z + 260.0f) < 1.0f)) {
             this->actionFunc = BgIceObjects_Stuck;
         } else {

--- a/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
@@ -349,7 +349,7 @@ void BgIceShelter_Idle(BgIceShelter* this, PlayState* play) {
             }
 
             BgIceShelter_SetupMelt(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ICE_MELT);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ICE_MELT);
         }
     }
 

--- a/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.c
@@ -137,7 +137,7 @@ void BgIceTurara_Shiver(BgIceTurara* this, PlayState* play) {
         this->shiverTimer--;
     }
     if (!(this->shiverTimer % 4)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ICE_SWING);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ICE_SWING);
     }
     if (this->shiverTimer == 0) {
         this->dyna.actor.world.pos.x = this->dyna.actor.home.pos.x;

--- a/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.c
+++ b/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.c
@@ -160,7 +160,7 @@ void BgJya1flift_Move(BgJya1flift* this, PlayState* play) {
                                  tempVelocity, 1.0f)) < 0.001f) {
         this->dyna.actor.world.pos.y = sFinalPositions[this->isMovingDown];
         BgJya1flift_ResetMoveDelay(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_ELEVATOR_MOVE3 - SFX_FLAG);
     }

--- a/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.c
@@ -87,7 +87,7 @@ void func_80893428(BgJyaAmishutter* this) {
 void func_80893438(BgJyaAmishutter* this) {
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 100.0f, 3.0f)) {
         func_808934B0(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_METALDOOR_SLIDE - SFX_FLAG);
     }
@@ -110,7 +110,7 @@ void func_808934FC(BgJyaAmishutter* this) {
 void func_8089350C(BgJyaAmishutter* this) {
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y, 3.0f)) {
         BgJyaAmishutter_SetupWaitForPlayer(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_METALDOOR_SLIDE - SFX_FLAG);
     }

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
@@ -153,7 +153,7 @@ void BgJyaGoroiwa_Move(BgJyaGoroiwa* this, PlayState* play) {
         }
 
         func_8002F6D4(play, thisx, 2.0f, thisx->yawTowardsPlayer, 0.0f, 0);
-        func_8002F7DC(&GET_PLAYER(play)->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(GET_PLAYER(play), NA_SE_PL_BODY_HIT);
 
         this->yOffsetSpeed = 10.0f;
         this->speedFactor = 0.5f;
@@ -177,7 +177,7 @@ void BgJyaGoroiwa_Move(BgJyaGoroiwa* this, PlayState* play) {
         thisx->world.rot.y = 0x4000;
     }
 
-    Audio_PlayActorSfx2(thisx, NA_SE_EV_BIGBALL_ROLL - SFX_FLAG);
+    Actor_PlaySfx(thisx, NA_SE_EV_BIGBALL_ROLL - SFX_FLAG);
 }
 
 void BgJyaGoroiwa_SetupWait(BgJyaGoroiwa* this) {

--- a/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.c
@@ -102,7 +102,7 @@ void func_80899950(BgJyaKanaami* this, PlayState* play) {
     this->unk_168 += 0x20;
     if (Math_ScaledStepToS(&this->dyna.actor.world.rot.x, 0x4000, this->unk_168)) {
         func_80899A08(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_TRAP_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_TRAP_BOUND);
 
         quakeIndex = Quake_Request(GET_ACTIVE_CAM(play), QUAKE_TYPE_3);
         Quake_SetSpeed(quakeIndex, 25000);

--- a/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
@@ -117,7 +117,7 @@ void BgJyaLift_Move(BgJyaLift* this, PlayState* play) {
     }
     if (fabsf(distFromBottom) < 0.001f) {
         BgJyaLift_SetFinalPosY(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ELEVATOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ELEVATOR_STOP);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN - SFX_FLAG);
     }

--- a/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
@@ -101,7 +101,7 @@ void BgMenkuriEye_Update(Actor* thisx, PlayState* play) {
         (ABS((s16)(this->collider.base.ac->world.rot.y - this->actor.shape.rot.y)) > 0x5000)) {
         this->collider.base.acFlags &= ~AC_HIT;
         if (this->framesUntilDisable == -1) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_AMOS_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_AMOS_DAMAGE);
             D_8089C1A0 += 1;
             D_8089C1A0 = CLAMP_MAX(D_8089C1A0, 4);
         }

--- a/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
@@ -470,7 +470,7 @@ void BgMizuBwall_Idle(BgMizuBwall* this, PlayState* play) {
         DynaPoly_DisableCollision(play, &play->colCtx.dyna, this->dyna.bgId);
         this->dList = NULL;
         BgMizuBwall_SpawnDebris(this, play);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_WALL_BROKEN);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_WALL_BROKEN);
         Audio_PlaySfxGeneral(NA_SE_SY_CORRECT_CHIME, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         this->actionFunc = BgMizuBwall_Break;

--- a/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.c
@@ -105,7 +105,7 @@ void BgMizuShutter_WaitForSwitch(BgMizuShutter* this, PlayState* play) {
 
 void BgMizuShutter_WaitForCutscene(BgMizuShutter* this, PlayState* play) {
     if (this->timer-- == 0) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_OPEN);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_OPEN);
         this->actionFunc = BgMizuShutter_Move;
     }
 }
@@ -129,7 +129,7 @@ void BgMizuShutter_Move(BgMizuShutter* this, PlayState* play) {
             (this->dyna.actor.world.pos.y == this->closedPos.y) &&
             (this->dyna.actor.world.pos.z == this->closedPos.z)) {
             Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 120, 20, 10);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
             this->actionFunc = BgMizuShutter_WaitForSwitch;
         }
     }
@@ -140,7 +140,7 @@ void BgMizuShutter_WaitForTimer(BgMizuShutter* this, PlayState* play) {
         this->timer--;
         func_8002F994(&this->dyna.actor, this->timer);
         if (this->timer == 0) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_CLOSE);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_CLOSE);
             Flags_UnsetSwitch(play, BGMIZUSHUTTER_SWITCH_PARAM(&this->dyna.actor));
             this->actionFunc = BgMizuShutter_Move;
         }

--- a/src/overlays/actors/ovl_Bg_Mizu_Uzu/z_bg_mizu_uzu.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Uzu/z_bg_mizu_uzu.c
@@ -61,7 +61,7 @@ void func_8089F788(BgMizuUzu* this, PlayState* play) {
     } else {
         DynaPoly_EnableCollision(play, &play->colCtx.dyna, this->dyna.bgId);
     }
-    Audio_PlayActorSfx2(thisx, NA_SE_EV_WATER_CONVECTION - SFX_FLAG);
+    Actor_PlaySfx(thisx, NA_SE_EV_WATER_CONVECTION - SFX_FLAG);
     thisx->shape.rot.y += 0x1C0;
 }
 

--- a/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.c
@@ -162,7 +162,7 @@ void BgMoriBigst_Fall(BgMoriBigst* this, PlayState* play) {
     if (this->dyna.actor.world.pos.y <= this->dyna.actor.home.pos.y) {
         this->dyna.actor.world.pos.y = this->dyna.actor.home.pos.y;
         BgMoriBigst_SetupLanding(this, play);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
         OnePointCutscene_Init(play, 1020, 8, &this->dyna.actor, CAM_ID_MAIN);
         func_8002DF38(play, NULL, PLAYER_CSMODE_60);
     }

--- a/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.c
@@ -161,7 +161,7 @@ void BgMoriElevator_MoveIntoGround(BgMoriElevator* this, PlayState* play) {
     distToTarget = func_808A1800(&this->dyna.actor.world.pos.y, 73.0f, 0.08f, this->dyna.actor.velocity.y, 1.5f);
     if (fabsf(distToTarget) < 0.001f) {
         BgMoriElevator_SetupSetPosition(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ELEVATOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ELEVATOR_STOP);
     } else {
         func_808A18FC(this, distToTarget);
     }
@@ -180,7 +180,7 @@ void BgMoriElevator_MoveAboveGround(BgMoriElevator* this, PlayState* play) {
     distToTarget = func_808A1800(&this->dyna.actor.world.pos.y, 233.0f, 0.08f, this->dyna.actor.velocity.y, 1.5f);
     if (fabsf(distToTarget) < 0.001f) {
         BgMoriElevator_SetupSetPosition(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ELEVATOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ELEVATOR_STOP);
     } else {
         func_808A18FC(this, distToTarget);
     }
@@ -233,7 +233,7 @@ void func_808A2008(BgMoriElevator* this, PlayState* play) {
     distTo = func_808A1800(&this->dyna.actor.world.pos.y, this->targetY, 0.1f, this->dyna.actor.velocity.y, 0.3f);
     if (fabsf(distTo) < 0.001f) {
         BgMoriElevator_SetupSetPosition(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ELEVATOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ELEVATOR_STOP);
 
     } else {
         func_808A18FC(this, distTo);

--- a/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.c
@@ -126,14 +126,14 @@ void BgMoriHashira4_SetupPillarsRotate(BgMoriHashira4* this) {
 
 void BgMoriHashira4_PillarsRotate(BgMoriHashira4* this, PlayState* play) {
     this->dyna.actor.shape.rot.y = this->dyna.actor.world.rot.y += 0x96;
-    Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ROLL_STAND_2 - SFX_FLAG);
+    Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ROLL_STAND_2 - SFX_FLAG);
 }
 
 void BgMoriHashira4_GateWait(BgMoriHashira4* this, PlayState* play) {
     if (Flags_GetSwitch(play, this->switchFlag) || (this->gateTimer != 0)) {
         this->gateTimer++;
         if (this->gateTimer > 30) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_OPEN);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_OPEN);
             BgMoriHashira4_SetupAction(this, BgMoriHashira4_GateOpen);
             OnePointCutscene_Init(play, 6010, 20, &this->dyna.actor, CAM_ID_MAIN);
             sUnkTimer++;

--- a/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
+++ b/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
@@ -258,7 +258,7 @@ void BgPoEvent_BlockShake(BgPoEvent* this, PlayState* play) {
     if (this->timer < 15) {
         this->dyna.actor.world.pos.x = this->dyna.actor.home.pos.x + 2.0f * ((this->timer % 3) - 1);
         if (!(this->timer % 4)) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_SHAKE);
         }
     }
     if (this->timer == 0) {
@@ -314,7 +314,7 @@ void BgPoEvent_BlockFall(BgPoEvent* this, PlayState* play) {
         if (this->type != 1) {
             BgPoEvent_CheckBlock(this);
         } else {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
             Actor_RequestQuakeAndRumble(&this->dyna.actor, play, 5, 5);
             Interface_SetTimer(this->timer);
             if (firstFall == 0) {
@@ -355,7 +355,7 @@ void BgPoEvent_BlockIdle(BgPoEvent* this, PlayState* play) {
             this->actionFunc = BgPoEvent_BlockReset;
             if (sPuzzleState == 0x10) {
                 sPuzzleState = 0x40;
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_RISING);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_RISING);
                 func_8002DF54(play, &player->actor, PLAYER_CSMODE_8);
             }
         } else if (this->dyna.unk_150 != 0.0f) {
@@ -394,7 +394,7 @@ void BgPoEvent_BlockPush(BgPoEvent* this, PlayState* play) {
     if (blockStop) {
         player->stateFlags2 &= ~PLAYER_STATE2_4;
         if ((this->dyna.unk_150 > 0.0f) && (func_800435D8(play, &this->dyna, 0x1E, 0x32, -0x14) == 0)) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
         }
         this->dyna.unk_150 = 0.0f;
         this->dyna.actor.home.pos.x = this->dyna.actor.world.pos.x;
@@ -450,7 +450,7 @@ void BgPoEvent_AmyWait(BgPoEvent* this, PlayState* play) {
         sPuzzleState |= 0x20;
         this->timer = 5;
         Actor_SetColorFilter(&this->dyna.actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 5);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_PO_LAUGH2);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_PO_LAUGH2);
         this->actionFunc = BgPoEvent_AmyPuzzle;
     }
 }
@@ -528,7 +528,7 @@ void BgPoEvent_PaintingPresent(BgPoEvent* this, PlayState* play) {
                under the balcony allows him to be closer.
             4) Link is within 45 degrees of facing the painting. */
         this->timer = 0;
-        Audio_PlayActorSfx2(thisx, NA_SE_EN_PO_LAUGH);
+        Actor_PlaySfx(thisx, NA_SE_EN_PO_LAUGH);
         this->actionFunc = BgPoEvent_PaintingVanish;
     } else if (this->collider.base.acFlags & AC_HIT) {
         if (!BgPoEvent_NextPainting(this)) {
@@ -538,7 +538,7 @@ void BgPoEvent_PaintingPresent(BgPoEvent* this, PlayState* play) {
             func_80078884(NA_SE_SY_CORRECT_CHIME);
 
         } else {
-            Audio_PlayActorSfx2(thisx, NA_SE_EN_PO_LAUGH2);
+            Actor_PlaySfx(thisx, NA_SE_EN_PO_LAUGH2);
             OnePointCutscene_Init(play, 3160, 35, thisx, CAM_ID_MAIN);
         }
         if (thisx->parent != NULL) {

--- a/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
+++ b/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
@@ -116,7 +116,7 @@ void BgRelayObjects_Destroy(Actor* thisx, PlayState* play) {
 void func_808A90F4(BgRelayObjects* this, PlayState* play) {
     if (Flags_GetSwitch(play, this->switchFlag)) {
         if (this->timer != 0) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_OPEN);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_OPEN);
             if (INV_CONTENT(ITEM_HOOKSHOT) != ITEM_NONE) {
                 this->timer = 120;
             } else {
@@ -137,7 +137,7 @@ void func_808A91AC(BgRelayObjects* this, PlayState* play) {
         func_8002F994(&this->dyna.actor, this->timer);
     }
     if ((this->timer == 0) || (this->unk_169 == play->roomCtx.curRoom.num)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_CLOSE);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_CLOSE);
         this->actionFunc = func_808A9234;
     }
 }
@@ -146,7 +146,7 @@ void func_808A9234(BgRelayObjects* this, PlayState* play) {
     this->dyna.actor.velocity.y += this->dyna.actor.gravity;
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y, this->dyna.actor.velocity.y)) {
         Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 180, 20, 100);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
         if (this->unk_169 != play->roomCtx.curRoom.num) {
             func_800788CC(NA_SE_EN_PO_LAUGH);
             this->timer = 5;

--- a/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
+++ b/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
@@ -179,13 +179,13 @@ void BgSpot00Hanebasi_DrawbridgeRiseAndFall(BgSpot00Hanebasi* this, PlayState* p
 
     if (this->destAngle < 0) {
         if (this->actionFunc == BgSpot00Hanebasi_DrawbridgeWait) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BRIDGE_CLOSE_STOP);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BRIDGE_CLOSE_STOP);
         } else {
             func_8002F974(&this->dyna.actor, NA_SE_EV_BRIDGE_CLOSE - SFX_FLAG);
         }
     } else {
         if (this->actionFunc == BgSpot00Hanebasi_DrawbridgeWait) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN_STOP);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN_STOP);
         } else {
             func_8002F974(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN - SFX_FLAG);
         }

--- a/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.c
+++ b/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.c
@@ -129,7 +129,7 @@ void func_808AC908(BgSpot02Objects* this, PlayState* play) {
 
     if (play->csCtx.state != 0) {
         if (play->csCtx.npcActions[3] != NULL && play->csCtx.npcActions[3]->action == 2) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_GRAVE_EXPLOSION);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_GRAVE_EXPLOSION);
             SET_EVENTCHKINF(EVENTCHKINF_1D);
             this->timer = 25;
             pos.x = (Math_SinS(this->dyna.actor.shape.rot.y) * 50.0f) + this->dyna.actor.world.pos.x;
@@ -158,9 +158,9 @@ void func_808ACA08(BgSpot02Objects* this, PlayState* play) {
 
     if (play->csCtx.frames == 402) {
         if (!LINK_IS_ADULT) {
-            func_8002F7DC(&player->actor, NA_SE_VO_LI_DEMO_DAMAGE_KID);
+            Player_PlaySfx(player, NA_SE_VO_LI_DEMO_DAMAGE_KID);
         } else {
-            func_8002F7DC(&player->actor, NA_SE_VO_LI_DEMO_DAMAGE);
+            Player_PlaySfx(player, NA_SE_VO_LI_DEMO_DAMAGE);
         }
     }
 }
@@ -175,7 +175,7 @@ void func_808ACAFC(BgSpot02Objects* this, PlayState* play) {
 
 void func_808ACB58(BgSpot02Objects* this, PlayState* play) {
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 255.0f, 1.0f)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONEDOOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONEDOOR_STOP);
         this->actionFunc = func_808AC8FC;
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_WALL_MOVE_SP - SFX_FLAG);
@@ -267,7 +267,7 @@ void func_808ACCB8(Actor* thisx, PlayState* play) {
 void func_808AD3D4(BgSpot02Objects* this, PlayState* play) {
     if (play->csCtx.state != 0 && play->csCtx.npcActions[2] != NULL && play->csCtx.npcActions[2]->action == 2) {
         if (this->timer == 2) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_IT_EXPLOSION_ICE);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_IT_EXPLOSION_ICE);
         }
 
         if (this->timer < 32) {

--- a/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
+++ b/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
@@ -253,7 +253,7 @@ void BgSpot06Objects_GateOpen(BgSpot06Objects* this, PlayState* play) {
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 120.0f, 0.6f)) {
         this->actionFunc = BgSpot06Objects_DoNothing;
         this->timer = 0;
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_STOP);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_METALDOOR_SLIDE - SFX_FLAG);
     }

--- a/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.c
+++ b/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.c
@@ -117,7 +117,7 @@ void func_808B318C(BgSpot12Gate* this, PlayState* play) {
         Quake_SetPerturbations(quakeIndex, 3, 0, 0, 0);
         Quake_SetDuration(quakeIndex, 12);
 
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN_STOP);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_METALGATE_OPEN - SFX_FLAG);
     }

--- a/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.c
+++ b/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.c
@@ -103,7 +103,7 @@ void func_808B3604(BgSpot12Saku* this, PlayState* play) {
         this->dyna.actor.home.pos.z - (Math_CosS(this->dyna.actor.shape.rot.y + 0x4000) * temp_f18);
     if (fabsf(temp_ret) < 0.0001f) {
         func_808B3714(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN_STOP);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_METALGATE_OPEN - SFX_FLAG);
     }

--- a/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.c
+++ b/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.c
@@ -283,7 +283,7 @@ void func_808B4194(BgSpot15Rrbox* this, PlayState* play) {
     } else if (approxFResult) {
         player = GET_PLAYER(play);
         if (func_808B4010(this, play)) {
-            Audio_PlayActorSfx2(actor, NA_SE_EV_WOOD_BOUND);
+            Actor_PlaySfx(actor, NA_SE_EV_WOOD_BOUND);
         }
         if (func_808B3A40(this, play)) {
             func_80078884(NA_SE_SY_CORRECT_CHIME);
@@ -297,7 +297,7 @@ void func_808B4194(BgSpot15Rrbox* this, PlayState* play) {
         this->unk_168 = 10;
         func_808B4084(this, play);
     }
-    Audio_PlayActorSfx2(actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
+    Actor_PlaySfx(actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
 }
 
 void func_808B4380(BgSpot15Rrbox* this, PlayState* play) {
@@ -336,7 +336,7 @@ void func_808B43D0(BgSpot15Rrbox* this, PlayState* play) {
     if ((floorHeight - actor->world.pos.y) >= -0.001f) {
         actor->world.pos.y = floorHeight;
         func_808B4084(this, play);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_WOOD_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_WOOD_BOUND);
     }
 }
 

--- a/src/overlays/actors/ovl_Bg_Spot15_Saku/z_bg_spot15_saku.c
+++ b/src/overlays/actors/ovl_Bg_Spot15_Saku/z_bg_spot15_saku.c
@@ -66,10 +66,10 @@ void func_808B4930(BgSpot15Saku* this, PlayState* play) {
 
 void func_808B4978(BgSpot15Saku* this, PlayState* play) {
     if (this->timer == 0) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALGATE_OPEN - SFX_FLAG);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALGATE_OPEN - SFX_FLAG);
         this->dyna.actor.world.pos.z -= 2.0f;
         if (this->dyna.actor.world.pos.z < 2660.0f) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN_STOP);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BRIDGE_OPEN_STOP);
             this->timer = 30;
             this->actionFunc = func_808B4A04;
         }

--- a/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.c
@@ -259,7 +259,7 @@ void func_808B8F08(BgSpot18Obj* this, PlayState* play) {
         player->stateFlags2 &= ~PLAYER_STATE2_4;
         Flags_SetSwitch(play, (this->dyna.actor.params >> 8) & 0x3F);
         func_80078884(NA_SE_SY_CORRECT_CHIME);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
     }

--- a/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.c
@@ -106,7 +106,7 @@ void func_808B9618(BgSpot18Shutter* this, PlayState* play) {
 
 void func_808B9698(BgSpot18Shutter* this, PlayState* play) {
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 180.0f, 1.44f)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONEDOOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONEDOOR_STOP);
         this->actionFunc = func_808B95AC;
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_STONE_STATUE_OPEN - SFX_FLAG);
@@ -122,7 +122,7 @@ void func_808B971C(BgSpot18Shutter* this, PlayState* play) {
     flag &= Math_StepToF(&this->dyna.actor.world.pos.z, this->dyna.actor.home.pos.z - (125.0f * sin), fabsf(sin));
 
     if (flag) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONEDOOR_STOP);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONEDOOR_STOP);
         this->actionFunc = func_808B95AC;
     } else {
         func_8002F974(&this->dyna.actor, NA_SE_EV_STONE_STATUE_OPEN - SFX_FLAG);

--- a/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.c
+++ b/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.c
@@ -68,7 +68,7 @@ void BgSstFloor_Update(Actor* thisx, PlayState* play) {
 
     if (DynaPolyActor_IsPlayerOnTop(&this->dyna) && (player->fallDistance > 1000.0f)) {
         this->dyna.actor.params = 1;
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
     }
 
     if (this->dyna.actor.params == BONGOFLOOR_HIT) {

--- a/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -133,7 +133,7 @@ void func_808BB0AC(BgTokiSwd* this, PlayState* play) {
     // if sword has a parent it has been pulled/placed from the pedestal
     if (Actor_HasParent(&this->actor, play)) {
         if (!LINK_IS_ADULT) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_SWORD_PUTAWAY_STN);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_SWORD_PUTAWAY_STN);
             this->actor.draw = NULL; // sword has been pulled, don't draw sword
         } else {
             this->actor.draw = BgTokiSwd_Draw; // sword has been placed, draw the master sword

--- a/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.c
@@ -184,7 +184,7 @@ void func_808BF108(BgYdanMaruta* this, PlayState* play) {
 void func_808BF1EC(BgYdanMaruta* this, PlayState* play) {
     this->dyna.actor.velocity.y += 1.0f;
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y, this->dyna.actor.velocity.y)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_LADDER_DOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_LADDER_DOUND);
         this->actionFunc = BgYdanMaruta_DoNothing;
     }
 }

--- a/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
@@ -296,7 +296,7 @@ void BgYdanSp_FloorWebIdle(BgYdanSp* this, PlayState* play) {
                 this->dyna.actor.room = -1;
                 this->dyna.actor.flags |= ACTOR_FLAG_4;
                 this->timer = 40;
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_WEB_BROKEN);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_WEB_BROKEN);
                 this->actionFunc = BgYdanSp_FloorWebBreaking;
                 return;
             }
@@ -329,7 +329,7 @@ void BgYdanSp_FloorWebIdle(BgYdanSp* this, PlayState* play) {
     Math_ApproachZeroF(&this->unk_16C, 1.0f, 0.8f);
     if (this->timer == 13) {
         if (this->unk_16C > 3.0f) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_WEB_VIBRATION);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_WEB_VIBRATION);
         } else {
             Audio_StopSfxById(NA_SE_EV_WEB_VIBRATION);
         }

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -398,7 +398,7 @@ void BossDodongo_IntroCutscene(BossDodongo* this, PlayState* play) {
             }
 
             if (this->unk_198 == 0x64) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_OTAKEBI);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_OTAKEBI);
             }
 
             if (this->unk_198 == 0x5A) {
@@ -550,8 +550,8 @@ void BossDodongo_Explode(BossDodongo* this, PlayState* play) {
         Animation_Change(&this->skelAnime, &object_kingdodongo_Anim_004E0C, 1.0f, 0.0f,
                          Animation_GetLastFrame(&object_kingdodongo_Anim_004E0C), ANIMMODE_ONCE, -5.0f);
         this->actionFunc = BossDodongo_LayDown;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_DAMAGE);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_DAMAGE);
         Actor_RequestQuakeAndRumble(&this->actor, play, 4, 10);
         this->health -= 2;
 
@@ -576,7 +576,7 @@ void BossDodongo_LayDown(BossDodongo* this, PlayState* play) {
 }
 
 void BossDodongo_Vulnerable(BossDodongo* this, PlayState* play) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_DOWN - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_DOWN - SFX_FLAG);
     this->unk_1BE = 10;
     Math_SmoothStepToF(&this->unk_1F8, 1.0f, 0.5f, 0.02f, 0.001f);
     Math_SmoothStepToF(&this->unk_208, 0.05f, 1.0f, 0.005f, 0.0f);
@@ -605,7 +605,7 @@ void BossDodongo_BlowFire(BossDodongo* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (Animation_OnFrame(&this->skelAnime, 12.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_CRY);
     }
 
     if (Animation_OnFrame(&this->skelAnime, 17.0f)) {
@@ -627,7 +627,7 @@ void BossDodongo_Inhale(BossDodongo* this, PlayState* play) {
     this->unk_1E2 = 1;
 
     if (this->unk_1AC > 20) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_BREATH - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_BREATH - SFX_FLAG);
     }
 
     Math_SmoothStepToF(&this->unk_208, 0.05f, 1.0f, 0.005f, 0.0f);
@@ -639,7 +639,7 @@ void BossDodongo_Inhale(BossDodongo* this, PlayState* play) {
         this->unk_1AC++;
 
         if ((this->unk_1AC > 20) && (this->unk_1AC < 82) && BossDodongo_AteExplosive(this, play)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_DRINK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_DRINK);
             BossDodongo_SetupExplode(this);
         }
     }
@@ -673,7 +673,7 @@ void BossDodongo_Walk(BossDodongo* this, PlayState* play) {
             if (this->unk_1BC != 0) {
                 func_80078884(NA_SE_EN_DODO_K_WALK);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_WALK);
             }
 
             if (this->subCamId == SUB_CAM_ID_DONE) {
@@ -737,11 +737,11 @@ void BossDodongo_Roll(BossDodongo* this, PlayState* play) {
 
     if (this->unk_1DA == 10) {
         this->actor.velocity.y = 15.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_CRY);
     }
 
     if (this->unk_1DA == 1) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_COLI2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_COLI2);
     }
 
     sp5C = &sCornerPositions[this->unk_1A0];
@@ -755,7 +755,7 @@ void BossDodongo_Roll(BossDodongo* this, PlayState* play) {
 
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
             this->unk_228 = 7700.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_ROLL - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_ROLL - SFX_FLAG);
 
             if ((this->unk_19E & 7) == 0) {
                 Camera_RequestQuake(&play->mainCamera, 2, 1, 8);
@@ -786,7 +786,7 @@ void BossDodongo_Roll(BossDodongo* this, PlayState* play) {
             BossDodongo_SetupWalk(this);
             this->unk_228 = 9200.0f;
             this->actor.velocity.y = 20.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_COLI);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_COLI);
             Camera_RequestQuake(&play->mainCamera, 2, 6, 8);
             sp50.x = this->actor.world.pos.x;
             sp50.y = this->actor.world.pos.y + 60.0f;
@@ -795,7 +795,7 @@ void BossDodongo_Roll(BossDodongo* this, PlayState* play) {
             Actor_RequestQuakeAndRumble(&this->actor, play, 6, 15);
         } else {
             this->actor.velocity.y = 15.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_COLI2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_COLI2);
         }
 
         if (this->unk_1A2 == 0) {
@@ -1263,7 +1263,7 @@ void BossDodongo_UpdateDamage(BossDodongo* this, PlayState* play) {
                 swordDamage = damage = CollisionCheck_GetSwordDamage(item1->toucher.dmgFlags);
 
                 if (damage != 0) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_DAMAGE);
                     BossDodongo_SetupDamaged(this);
                     this->unk_1C0 = 5;
                     this->health -= swordDamage;
@@ -1279,7 +1279,7 @@ void BossDodongo_SetupDeathCutscene(BossDodongo* this) {
     Animation_Change(&this->skelAnime, &object_kingdodongo_Anim_002D0C, 1.0f, 0.0f,
                      Animation_GetLastFrame(&object_kingdodongo_Anim_002D0C), ANIMMODE_ONCE, -5.0f);
     this->actionFunc = BossDodongo_DeathCutscene;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_DEAD);
     this->unk_1DA = 0;
     this->csState = 0;
     this->actor.flags &= ~(ACTOR_FLAG_0 | ACTOR_FLAG_2);
@@ -1393,7 +1393,7 @@ void BossDodongo_DeathCutscene(BossDodongo* this, PlayState* play) {
 
                 Math_SmoothStepToF(&this->actor.world.pos.x, cornerPos->x + sp184.x, 1.0f, this->unk_1E4, 0.0f);
                 Math_SmoothStepToF(&this->actor.world.pos.z, cornerPos->z + sp184.z, 1.0f, this->unk_1E4, 0.0f);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_ROLL - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_ROLL - SFX_FLAG);
                 if ((this->unk_19E & 7) == 0) {
                     Camera_RequestQuake(&play->mainCamera, 2, 1, 8);
                 }
@@ -1411,7 +1411,7 @@ void BossDodongo_DeathCutscene(BossDodongo* this, PlayState* play) {
                     Vec3f dustPos;
 
                     this->actor.velocity.y = 15.0f;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_COLI2);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_COLI2);
                     if (this->unk_1A2 == 0) {
                         this->unk_1A0 = this->unk_1A0 + 1;
                         if (this->unk_1A0 >= 4) {
@@ -1455,13 +1455,13 @@ void BossDodongo_DeathCutscene(BossDodongo* this, PlayState* play) {
                 Math_SmoothStepToS(&this->unk_1C4, -0x4000, 0xA, 0x12C, 0);
             }
             if (this->unk_1DA == 904) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_END);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_END);
             }
             if (this->unk_1DA < 854) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_LAST - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_LAST - SFX_FLAG);
             }
             if (this->unk_1DA == 960) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_LAVA);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_LAVA);
             }
             if (this->unk_1DA < 960) {
                 Math_SmoothStepToF(&this->actor.shape.shadowScale, 0.0f, 1.0f, 10.0f, 0.0f);
@@ -1521,7 +1521,7 @@ void BossDodongo_DeathCutscene(BossDodongo* this, PlayState* play) {
                     }
                 }
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_ROLL - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_ROLL - SFX_FLAG);
                 if (!(this->unk_19E & 1)) {
                     Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 40.0f, 3, 8.0f, 500, 10,
                                              false);

--- a/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
+++ b/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
@@ -277,7 +277,7 @@ void BossFd2_Emerge(BossFd2* this, PlayState* play) {
                     this->skelAnime.playSpeed = 1.0f;
                     this->fwork[FD2_END_FRAME] = Animation_GetLastFrame(&gHoleVolvagiaEmergeAnim);
                     this->work[FD2_ACTION_STATE] = 2;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_ROAR);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_ROAR);
                     this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
                     this->timers[0] = 15;
                     this->actor.world.pos.y = 150.0f;
@@ -295,7 +295,7 @@ void BossFd2_Emerge(BossFd2* this, PlayState* play) {
             Math_ApproachS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 3, 0x7D0);
             if ((this->timers[0] == 1) && (this->actor.xzDistToPlayer < 120.0f)) {
                 func_8002F6D4(play, &this->actor, 3.0f, this->actor.yawTowardsPlayer, 2.0f, 0x20);
-                Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+                Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
             }
             if (Animation_OnFrame(&this->skelAnime, this->fwork[FD2_END_FRAME])) {
                 BossFd2_SetupIdle(this, play);
@@ -413,7 +413,7 @@ void BossFd2_BreatheFire(BossFd2* this, PlayState* play) {
         if (this->skelAnime.curFrame == 25.0f) {
             play->envCtx.lightBlend = 0.0f;
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_FIRE - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_FIRE - SFX_FLAG);
         if (this->skelAnime.curFrame > 50) {
             breathOpacity = (70.0f - this->skelAnime.curFrame) * 12.0f;
         } else {
@@ -503,8 +503,8 @@ void BossFd2_SetupClawSwipe(BossFd2* this, PlayState* play) {
 void BossFd2_ClawSwipe(BossFd2* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 5.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_ROAR);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_SW_NAIL);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_ROAR);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_SW_NAIL);
     }
     if (Animation_OnFrame(&this->skelAnime, this->fwork[FD2_END_FRAME])) {
         BossFd2_SetupBurrow(this, play);
@@ -528,7 +528,7 @@ void BossFd2_Vulnerable(BossFd2* this, PlayState* play) {
     switch (this->work[FD2_ACTION_STATE]) {
         case 0:
             if (Animation_OnFrame(&this->skelAnime, 13.0f)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_MAHI2);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_MAHI2);
             }
             if (Animation_OnFrame(&this->skelAnime, this->fwork[FD2_END_FRAME] - 3.0f)) {
                 for (i = 0; i < 25; i++) {
@@ -549,7 +549,7 @@ void BossFd2_Vulnerable(BossFd2* this, PlayState* play) {
                     BossFd2_SpawnDust(bossFd->effects, &spawnPos, &spawnVel, &spawnAccel,
                                       Rand_ZeroFloat(100.0f) + 300.0f);
                 }
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_LAND);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_LAND);
             }
             if (Animation_OnFrame(&this->skelAnime, this->fwork[FD2_END_FRAME])) {
                 Animation_MorphToLoop(&this->skelAnime, &gHoleVolvagiaVulnerableAnim, -5.0f);
@@ -559,7 +559,7 @@ void BossFd2_Vulnerable(BossFd2* this, PlayState* play) {
             break;
         case 1:
             if ((this->work[FD2_VAR_TIMER] & 0xF) == 0xF) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_KNOCKOUT);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_KNOCKOUT);
             }
             if (this->timers[0] == 0) {
                 BossFd2_SetupBurrow(this, play);
@@ -588,7 +588,7 @@ void BossFd2_Damaged(BossFd2* this, PlayState* play) {
         }
     } else if (this->work[FD2_ACTION_STATE] == 1) {
         if (Animation_OnFrame(&this->skelAnime, 6.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_DAMAGE2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_DAMAGE2);
         }
         if (Animation_OnFrame(&this->skelAnime, 20.0f)) {
             bossFd->timers[4] = 30;
@@ -690,7 +690,7 @@ void BossFd2_Death(BossFd2* this, PlayState* play) {
                     Audio_StopSfxById(NA_SE_EN_VALVAISA_DEAD);
                 }
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_DAMAGE2);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_DAMAGE2);
             }
             Math_ApproachF(&this->skelAnime.playSpeed, retreatSpeed, 1.0f, 1.0f);
             Matrix_RotateY(BINANG_TO_RAD_ALT(this->actor.yawTowardsPlayer) + 0.2f, MTXMODE_NEW);
@@ -815,7 +815,7 @@ void BossFd2_CollisionCheck(BossFd2* this, PlayState* play) {
         for (i = 0; i < ARRAY_COUNT(this->elements); i++) {
             if (this->collider.elements[i].info.toucherFlags & TOUCH_HIT) {
                 this->collider.elements[i].info.toucherFlags &= ~TOUCH_HIT;
-                Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+                Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
             }
         }
     }
@@ -841,7 +841,7 @@ void BossFd2_CollisionCheck(BossFd2* this, PlayState* play) {
                 BossFd2_SetupVulnerable(this, play);
                 this->work[FD2_INVINC_TIMER] = 30;
                 this->work[FD2_DAMAGE_FLASH_TIMER] = 5;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_MAHI1);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_MAHI1);
                 for (i = 0; i < 30; i++) {
                     Vec3f debrisVel = { 0.0f, 0.0f, 0.0f };
                     Vec3f debrisAccel = { 0.0f, -1.0f, 0.0f };
@@ -885,13 +885,13 @@ void BossFd2_CollisionCheck(BossFd2* this, PlayState* play) {
                 this->work[FD2_DAMAGE_FLASH_TIMER] = 10;
                 this->work[FD2_INVINC_TIMER] = 30000;
                 SEQCMD_STOP_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 1);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_DEAD);
                 Enemy_StartFinishingBlow(play, &this->actor);
             } else if (damage) {
                 BossFd2_SetupDamaged(this, play);
                 this->work[FD2_DAMAGE_FLASH_TIMER] = 10;
                 this->work[FD2_INVINC_TIMER] = 100;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_DAMAGE1);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_DAMAGE1);
             }
             if (damage) {
                 for (i = 0; i < 30; i++) {

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -604,7 +604,7 @@ void BossGanon_IntroCutscene(BossGanon* this, PlayState* play) {
             }
 
             if (this->csTimer == 13) {
-                func_8002F7DC(&player->actor, player->ageProperties->unk_92 + NA_SE_VO_LI_SURPRISE);
+                Player_PlaySfx(player, player->ageProperties->unk_92 + NA_SE_VO_LI_SURPRISE);
             }
 
             if (this->csTimer != 35) {
@@ -883,7 +883,7 @@ void BossGanon_IntroCutscene(BossGanon* this, PlayState* play) {
                 }
 
                 if (this->csTimer == 57) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
                 }
 
                 Math_ApproachF(&this->csCamFov, 110.0f, 0.1f, this->csCamMaxStepScale * 2.0f);
@@ -981,7 +981,7 @@ void BossGanon_IntroCutscene(BossGanon* this, PlayState* play) {
                 this->fwork[GDF_VORTEX_ALPHA] = 0.0f;
                 this->fwork[GDF_VORTEX_SCALE] = 0.1f;
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DARKWAVE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DARKWAVE);
             }
             break;
 
@@ -996,7 +996,7 @@ void BossGanon_IntroCutscene(BossGanon* this, PlayState* play) {
             }
 
             if (this->csTimer > 20) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DARKWAVE_M - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DARKWAVE_M - SFX_FLAG);
             }
 
             if (this->csTimer > 20) {
@@ -1020,7 +1020,7 @@ void BossGanon_IntroCutscene(BossGanon* this, PlayState* play) {
 
         case 21: // purple vortex
             this->envLightMode = 11;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DARKWAVE_M - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DARKWAVE_M - SFX_FLAG);
             BossGanonEff_SpawnShock(play, 700.0f, GDF_SHOCK_PLAYER_PURPLE);
             BossGanonEff_SpawnShock(play, 700.0f, GDF_SHOCK_PLAYER_PURPLE);
 
@@ -1073,7 +1073,7 @@ void BossGanon_IntroCutscene(BossGanon* this, PlayState* play) {
                 SkelAnime_Update(&this->skelAnime);
                 this->actor.shape.yOffset = 0.0f;
                 sCape->attachShouldersTimer = 18.0f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
                 this->unk_198 = 0;
                 SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_GANONDORF_BOSS);
             }
@@ -1092,7 +1092,7 @@ void BossGanon_IntroCutscene(BossGanon* this, PlayState* play) {
 
             if (this->csTimer >= 20) {
                 this->legSwayEnabled = true;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_FLOAT - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_FLOAT - SFX_FLAG);
 
                 Math_ApproachF(&this->actor.world.pos.y, 228.0f, 0.05f, 2.0f);
                 Math_ApproachF(&this->actor.world.pos.z, -230.0f, 0.05f, 4.0f);
@@ -1301,7 +1301,7 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
             }
 
             if ((this->unk_1A2 % 32) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_BREATH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_BREATH);
             }
             break;
 
@@ -1309,7 +1309,7 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
             this->envLightMode = 14;
 
             if ((this->fwork[GDF_FWORK_1] > 100.0f) && ((this->unk_1A2 % 32) == 0)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_BREATH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_BREATH);
             }
 
             this->csCamEye.x = 7.0f;
@@ -1324,7 +1324,7 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
                 (Message_GetState(&play->msgCtx) == TEXT_STATE_NONE)) {
                 Animation_MorphToPlayOnce(&this->skelAnime, &gGanondorfVomitStartAnim, 0.0f);
                 this->fwork[GDF_FWORK_1] = Animation_GetLastFrame(&gGanondorfVomitStartAnim);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_TOKETU);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_TOKETU);
             } else {
                 if (Animation_OnFrame(&this->skelAnime, this->fwork[GDF_FWORK_1] - 16.0f)) {
                     for (i = 0; i < 40; i++) {
@@ -1391,7 +1391,7 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
                 this->csCamAtMaxStep.y = fabsf(this->csCamAt.y - this->csCamTargetAt.y);
                 this->csCamAtMaxStep.z = fabsf(this->csCamAt.z - this->csCamTargetAt.z);
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_CASBREAK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_CASBREAK);
             }
             break;
 
@@ -1439,7 +1439,7 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
 
         skip_cam_and_quake:
             this->envLightMode = 15;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_BODY_SPARK - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_BODY_SPARK - SFX_FLAG);
 
             for (i = 1; i < 15; i++) {
                 this->unk_4E4[i] = 0xA;
@@ -1466,7 +1466,7 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
             break;
 
         case 9:
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_BODY_SPARK - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_BODY_SPARK - SFX_FLAG);
 
             if (this->csTimer == 2) {
                 func_8002DF54(play, &this->actor, PLAYER_CSMODE_57);
@@ -1558,15 +1558,15 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
                 }
 
                 if (this->csTimer == 160) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_PL_BOUND_NOWEAPON);
+                    Actor_PlaySfx(&this->actor, NA_SE_PL_BOUND_NOWEAPON);
                 }
 
                 if (this->csTimer == 187) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_PL_BODY_HIT);
+                    Actor_PlaySfx(&this->actor, NA_SE_PL_BODY_HIT);
                 }
 
                 if (this->csTimer == 180) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
                 }
 
                 if (this->csTimer == 190) {
@@ -1612,7 +1612,7 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
             break;
 
         case 103:
-            Audio_PlayActorSfx2(&sZelda->actor, NA_SE_EV_DOWN_TO_GROUND - SFX_FLAG);
+            Actor_PlaySfx(&sZelda->actor, NA_SE_EV_DOWN_TO_GROUND - SFX_FLAG);
             Math_ApproachF(&sZelda->actor.world.pos.y, 4102.0f, 0.05f, 1.5f);
 
             this->csCamEye.x = -242.0f;
@@ -1861,7 +1861,7 @@ void BossGanon_PoundFloor(BossGanon* this, PlayState* play) {
             Math_ApproachF(&this->fwork[GDF_CENTER_POS], 0.0f, 1, 1.5f);
 
             if (this->timers[0] == 5) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_HIT_GND);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_HIT_GND);
             }
 
             if (this->timers[0] < 14) {
@@ -1901,7 +1901,7 @@ void BossGanon_PoundFloor(BossGanon* this, PlayState* play) {
                 Actor_RequestQuakeAndRumble(&this->actor, play, 10, 20);
                 this->unk_19C = 35;
                 this->unk_19E = 0;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_HIT_GND_IMP);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_HIT_GND_IMP);
                 this->handLightBallScale = 0.0f;
                 sp60 = this->unk_260;
                 sp60.y = 0.0f;
@@ -1937,7 +1937,7 @@ void BossGanon_PoundFloor(BossGanon* this, PlayState* play) {
                 Animation_MorphToPlayOnce(&this->skelAnime, &gGanondorfGetUp3Anim, 0.0f);
                 SkelAnime_Update(&this->skelAnime);
                 sCape->attachShouldersTimer = 18.0f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
                 this->unk_1C2 = 4;
             }
             break;
@@ -2020,7 +2020,7 @@ void BossGanon_ChargeBigMagic(BossGanon* this, PlayState* play) {
 
         case 2:
             this->envLightMode = 2;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_CHARGE_MASIC - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_CHARGE_MASIC - SFX_FLAG);
             this->unk_278.x = this->unk_2EC[0].x;
             this->unk_278.y = this->unk_2EC[0].y + 50.0f + 30.0f;
             this->unk_278.z = this->unk_2EC[0].z;
@@ -2039,7 +2039,7 @@ void BossGanon_ChargeBigMagic(BossGanon* this, PlayState* play) {
                 this->unk_1C2 = 3;
                 this->timers[0] = 6;
                 this->timers[1] = 15;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DARKWAVE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DARKWAVE);
                 break;
             }
 
@@ -2121,7 +2121,7 @@ void BossGanon_ChargeBigMagic(BossGanon* this, PlayState* play) {
 
             if (this->timers[0] == 1) {
                 sCape->attachLeftArmTimer = 15.0f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
             }
 
             if (this->timers[0] == 0) {
@@ -2153,13 +2153,13 @@ void BossGanon_ChargeBigMagic(BossGanon* this, PlayState* play) {
                                        this->unk_1FC.y, this->unk_1FC.z, 0, this->actor.yawTowardsPlayer, 0, 0x104 + i);
                 }
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_BIGMASIC);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_THROW_BIG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_BIGMASIC);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_THROW_BIG);
             }
 
             if (Animation_OnFrame(&this->skelAnime, 3.0f)) {
                 sCape->attachShouldersTimer = 26.0f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
             }
 
             if (Animation_OnFrame(&this->skelAnime, this->fwork[GDF_FWORK_1])) {
@@ -2267,7 +2267,7 @@ void BossGanon_ChargeLightBall(BossGanon* this, PlayState* play) {
     if (this->timers[0] == 17) {
         this->unk_26C = 10;
         this->unk_270 = Rand_ZeroFloat(M_PI);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_SPARK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_SPARK);
     }
 
     if (this->timers[0] < 10) {
@@ -2327,8 +2327,8 @@ void BossGanon_PlayTennis(BossGanon* this, PlayState* play) {
 
             if (Animation_OnFrame(&this->skelAnime, 11.0f)) {
                 this->unk_25C = 1;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_THROW);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_THROW_MASIC);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_THROW);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_THROW_MASIC);
                 Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_BOSS_GANON, this->unk_260.x,
                                    this->unk_260.y, this->unk_260.z, 0, 0, 0, 0x64);
             }
@@ -2340,7 +2340,7 @@ void BossGanon_PlayTennis(BossGanon* this, PlayState* play) {
                 this->fwork[GDF_FWORK_1] = Animation_GetLastFrame(volleyAnims[rand]);
                 Animation_MorphToPlayOnce(&this->skelAnime, volleyAnims[rand], 0.0f);
                 sCape->attachRightArmTimer = capeRightArmDurations[rand];
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
                 this->startVolley = false;
             }
             break;
@@ -2368,7 +2368,7 @@ void BossGanon_SetupBlock(BossGanon* this, PlayState* play) {
 
     this->unk_1C2 = 0;
     sCape->attachLeftArmTimer = this->timers[0] = 10;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
     this->handLightBallScale = 0.0f;
 }
 
@@ -2387,7 +2387,7 @@ void BossGanon_Block(BossGanon* this, PlayState* play) {
             this->fwork[GDF_FWORK_1] = Animation_GetLastFrame(&gGanondorfBlockReleaseAnim);
             SkelAnime_Update(&this->skelAnime);
             sCape->attachShouldersTimer = 15.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
         }
     } else {
         sCape->sideSwayMagnitude = -13.0f;
@@ -2451,8 +2451,8 @@ void BossGanon_HitByLightBall(BossGanon* this, PlayState* play) {
             this->unk_1C2 = 2;
             SkelAnime_Update(&this->skelAnime);
             sCape->attachShouldersTimer = 18.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_RESTORE);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_RESTORE);
             this->timers[2] = 130;
         }
     } else {
@@ -2465,7 +2465,7 @@ void BossGanon_HitByLightBall(BossGanon* this, PlayState* play) {
                 BossGanonEff_SpawnSparkle(play, &this->unk_1FC, &sp50, &sZeroVec, Rand_ZeroFloat(200.0f) + 500.0f,
                                           0x14);
             }
-            Audio_PlayActorSfx2(&this->actor, NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_TALL_GRASS);
+            Actor_PlaySfx(&this->actor, NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_TALL_GRASS);
         }
 
         if (Animation_OnFrame(&this->skelAnime, this->fwork[GDF_FWORK_1])) {
@@ -2583,7 +2583,7 @@ void BossGanon_Vulnerable(BossGanon* this, PlayState* play) {
 
         case 4:
             if (Animation_OnFrame(&this->skelAnime, 5.0f)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DOWN);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DOWN);
             }
 
             if (this->timers[0] == 0) {
@@ -2631,8 +2631,8 @@ void BossGanon_Vulnerable(BossGanon* this, PlayState* play) {
             this->unk_1C2 = 8;
             SkelAnime_Update(&this->skelAnime);
             sCape->attachShouldersTimer = 18.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_MANTLE);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_RESTORE);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_MANTLE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_RESTORE);
             break;
 
         case 8:
@@ -2647,7 +2647,7 @@ void BossGanon_Vulnerable(BossGanon* this, PlayState* play) {
                                               0x14);
                 }
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_TALL_GRASS);
+                Actor_PlaySfx(&this->actor, NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_TALL_GRASS);
                 this->timers[3] = 50;
             }
 
@@ -2697,7 +2697,7 @@ void BossGanon_UpdateDamage(BossGanon* this, PlayState* play) {
             if (acHitInfo->toucher.dmgFlags & DMG_ARROW_LIGHT) {
                 BossGanon_SetupVulnerable(this, play);
                 this->timers[2] = 0;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DAMAGE1);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DAMAGE1);
                 this->unk_1A6 = 15;
             }
         } else if ((this->actionFunc == BossGanon_Vulnerable) && (this->unk_1C2 >= 3)) {
@@ -2736,21 +2736,21 @@ void BossGanon_UpdateDamage(BossGanon* this, PlayState* play) {
 
                 if ((s8)this->actor.colChkInfo.health <= 0) {
                     BossGanon_SetupDeathCutscene(this, play);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DEAD);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DD_THUNDER);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DEAD);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DD_THUNDER);
                     func_80078914(&sZeroVec, NA_SE_EN_LAST_DAMAGE);
                     SEQCMD_STOP_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 1);
                     this->screenFlashTimer = 4;
                 } else {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_DAMAGE2);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_CUTBODY);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_DAMAGE2);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_CUTBODY);
                     BossGanon_SetupDamaged(this, play);
                     this->unk_1A6 = 15;
                     sCape->tearTimer = 1;
                 }
             }
         } else if (acHitInfo->toucher.dmgFlags & DMG_RANGED) {
-            Audio_PlayActorSfx2(&this->actor, 0);
+            Actor_PlaySfx(&this->actor, 0);
 
             for (i = 0; i < ARRAY_COUNT(sCape->strands); i++) {
                 for (j = 1; j < 12; j++) {
@@ -2899,11 +2899,11 @@ void BossGanon_Update(Actor* thisx, PlayState* play2) {
     Math_SmoothStepToF(&this->legRot.z, legRotZ, 1.0f, 100.0f, 0.0f);
 
     if (this->timers[2] == 1) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_LAUGH);
     }
 
     if (this->timers[2] == 100) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_ST_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_ST_LAUGH);
         this->timers[2] = 0;
     }
 
@@ -3897,7 +3897,7 @@ void BossGanon_LightBall_Update(Actor* thisx, PlayState* play2) {
             Actor_Kill(&this->actor);
         }
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_FIRE - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_FIRE - SFX_FLAG);
 
         if ((this->unk_1A2 % 2) != 0) {
             Actor_SetScale(&this->actor, 6.0f);
@@ -4017,8 +4017,8 @@ void BossGanon_LightBall_Update(Actor* thisx, PlayState* play2) {
                     this->actor.world.rot.y = Math_Atan2S(zDistFromLink, xDistFromLink);
                     this->actor.world.rot.x = Math_Atan2S(sqrtf(SQ(xDistFromLink) + SQ(zDistFromLink)), yDistFromLink);
                     this->timers[1] = 2;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_IT_SWORD_REFLECT_MG);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_AT_RETURN);
+                    Actor_PlaySfx(&this->actor, NA_SE_IT_SWORD_REFLECT_MG);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_AT_RETURN);
                     this->unk_1C2 = 0;
                     break;
                 }

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -169,7 +169,7 @@ void func_808FD4D4(BossGanon2* this, PlayState* play, s16 arg2, s16 arg3) {
         Actor_SpawnFloorDustRing(play, &this->actor, &this->unk_1DC, 25.0f, arg3, 8.0f, 500, 10, true);
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_WALK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_WALK);
     Actor_RequestQuakeAndRumble(&this->actor, play, 2, 10);
 }
 
@@ -483,12 +483,12 @@ void func_808FD5F4(BossGanon2* this, PlayState* play) {
                 this->subCamAt.x = this->actor.world.pos.x;
             }
             if ((play->gameplayFrames % 32) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_BREATH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_BREATH);
             }
             break;
         case 15:
             if (((play->gameplayFrames % 32) == 0) && (this->unk_398 < 100)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_BREATH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_BREATH);
             }
             SkelAnime_Update(&this->skelAnime);
             Math_ApproachF(&this->subCamAt.y, this->actor.world.pos.y + 77.0f, 0.05f, 5.0f);
@@ -513,7 +513,7 @@ void func_808FD5F4(BossGanon2* this, PlayState* play) {
                 this->unk_194 = Animation_GetLastFrame(&gGanondorfTransformStartAnim);
                 this->unk_339 = 55;
                 play->envCtx.lightBlend = 1.0f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_CASBREAK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_CASBREAK);
             } else {
                 break;
             }
@@ -539,8 +539,8 @@ void func_808FD5F4(BossGanon2* this, PlayState* play) {
             Math_ApproachF(&this->subCamEye.y, ((this->actor.world.pos.y + 60.0f) - 60.0f) - 70.0f, 0.1f, 13.0f);
             Math_ApproachF(&this->subCamAt.y, this->actor.world.pos.y + 40.0f, 0.1f, 3.6999998f);
             if (this->unk_398 == 30) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_BIGMASIC);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_THROW_BIG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_BIGMASIC);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_THROW_BIG);
             }
             if (this->unk_398 <= 50) {
                 sp8D = true;
@@ -866,7 +866,7 @@ void func_808FD5F4(BossGanon2* this, PlayState* play) {
             player->actor.world.pos.x = 140.0f;
             player->actor.world.pos.z = -196.0f;
             if (this->unk_398 == 50) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_ROAR);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_ROAR);
             }
             if (Animation_OnFrame(&this->skelAnime, this->unk_194)) {
                 Camera* camera = Play_GetCamera(play, CAM_ID_MAIN);
@@ -889,7 +889,7 @@ void func_808FD5F4(BossGanon2* this, PlayState* play) {
     }
 
     if ((this->unk_30C > 4.0f) && !sp8D) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_BODY_SPARK - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_BODY_SPARK - SFX_FLAG);
     }
 
     if (this->subCamId != SUB_CAM_ID_DONE) {
@@ -1065,7 +1065,7 @@ void func_808FFDB0(BossGanon2* this, PlayState* play) {
 void func_808FFEBC(BossGanon2* this, PlayState* play) {
     if (this->unk_390 == 0) {
         this->unk_390 = (s16)Rand_ZeroFloat(50.0f) + 30;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_UNARI);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_UNARI);
     }
 
     SkelAnime_Update(&this->skelAnime);
@@ -1168,7 +1168,7 @@ void func_80900344(BossGanon2* this, PlayState* play) {
 
     if (this->unk_390 == 0) {
         this->unk_390 = (s16)Rand_ZeroFloat(50.0f) + 30;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_UNARI);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_UNARI);
     }
 
     Math_ApproachF(&this->unk_324, 255.0f, 1.0f, 10.0f);
@@ -1231,8 +1231,8 @@ void func_80900650(BossGanon2* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (Animation_OnFrame(&this->skelAnime, this->unk_198)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_SWORD);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_ROAR);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_SWORD);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_ROAR);
     }
 
     if (this->unk_311 == 0) {
@@ -1272,7 +1272,7 @@ void func_80900818(BossGanon2* this, PlayState* play) {
     this->actionFunc = func_80900890;
     this->unk_1AC = 0;
     this->unk_39C = 0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DEAD1);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_DEAD1);
     this->unk_336 = 0;
 }
 
@@ -1399,7 +1399,7 @@ void func_80900890(BossGanon2* this, PlayState* play) {
             break;
         case 1:
             if ((play->gameplayFrames % 32) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_BREATH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_BREATH);
             }
 
             if ((this->unk_1A2[0] == 0) || (this->unk_334 != 0)) {
@@ -1411,7 +1411,7 @@ void func_80900890(BossGanon2* this, PlayState* play) {
                     this->unk_194 = Animation_GetLastFrame(&gGanonGetUpAnim);
                     this->unk_1AC = 2;
                     this->unk_1A2[0] = 40;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_ROAR);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_ROAR);
                 }
             }
             break;
@@ -1437,7 +1437,7 @@ void func_80901020(BossGanon2* this, PlayState* play) {
     this->actionFunc = func_8090120C;
     this->unk_1AC = 0;
     this->unk_39C = 0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DEAD1);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_DEAD1);
     this->unk_314 = 4;
 }
 
@@ -1515,8 +1515,8 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
             }
             if (this->unk_398 >= 110) {
                 if (this->unk_398 == 110) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_HIT_THUNDER);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_HIT_THUNDER);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_DAMAGE);
                 }
                 Math_ApproachF(&this->unk_30C, 10.0f, 0.2f, 5.0f);
                 this->skelAnime.playSpeed = 3.0f;
@@ -1719,7 +1719,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
             break;
         case 8:
             if (this->unk_398 == 1025) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_STAND);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_STAND);
             }
             if (this->unk_398 >= 1000) {
                 if (this->unk_398 < 1040) {
@@ -1728,7 +1728,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
                 }
             }
             if (this->unk_398 == 1040) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DEAD2);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_DEAD2);
                 this->unk_336 = 2;
                 this->unk_339 = 0;
                 play->envCtx.prevLightSetting = 0;
@@ -1746,7 +1746,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
             this->subCamAt.y = this->unk_1B8.y;
             this->subCamAt.z = this->unk_1B8.z;
             if ((this->unk_398 < 1000) && ((this->unk_398 % 16) == 0)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_SWORD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_SWORD);
             }
             if (this->unk_398 == 40) {
                 this->unk_39C = 9;
@@ -1779,7 +1779,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
             if ((this->unk_398 >= 40) && (this->unk_398 <= 110)) {
                 Math_ApproachF(&play->envCtx.lightBlend, 1.0f, 1.0f, 0.02f);
                 Math_ApproachF(&this->unk_384, 10.0f, 0.1f, 0.2f);
-                Audio_PlayActorSfx2(&sZelda->actor, NA_SE_EV_GOD_LIGHTBALL_2 - SFX_FLAG);
+                Actor_PlaySfx(&sZelda->actor, NA_SE_EV_GOD_LIGHTBALL_2 - SFX_FLAG);
             } else {
                 Math_ApproachZeroF(&this->unk_384, 1.0f, 0.2f);
             }
@@ -1798,7 +1798,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
                 sZelda->unk_3C8 = 13;
             }
             if (this->unk_398 == 140) {
-                Audio_PlayActorSfx2(&sZelda->actor, NA_SE_EV_HUMAN_BOUND);
+                Actor_PlaySfx(&sZelda->actor, NA_SE_EV_HUMAN_BOUND);
             }
             if (this->unk_398 < 160) {
                 break;
@@ -1826,7 +1826,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
             break;
         case 1:
             if ((this->unk_39C < 7) && ((play->gameplayFrames % 32) == 0)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_BREATH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_BREATH);
             }
             break;
     }
@@ -1899,14 +1899,14 @@ void func_80902524(BossGanon2* this, PlayState* play) {
                 acHitInfo = this->unk_424.elements[0].info.acHitInfo;
                 if ((acHitInfo->toucher.dmgFlags & DMG_ARROW_LIGHT) && (this->actionFunc != func_80900890)) {
                     func_809000A0(this, play);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_HIT_THUNDER);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_HIT_THUNDER);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_DAMAGE);
                     Audio_StopSfxById(NA_SE_EN_MGANON_UNARI);
                 } else if ((this->actionFunc == func_80900890) &&
                            (acHitInfo->toucher.dmgFlags & (DMG_JUMP_MASTER | DMG_SPIN_MASTER | DMG_SLASH_MASTER))) {
                     this->unk_316 = 60;
                     this->unk_342 = 5;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_DAMAGE);
                     Audio_StopSfxById(NA_SE_EN_MGANON_UNARI);
                     this->actor.colChkInfo.health -= 2;
                     temp_v0_4 = this->actor.colChkInfo.health;
@@ -1921,7 +1921,7 @@ void func_80902524(BossGanon2* this, PlayState* play) {
                     }
                 } else if (this->actionFunc != func_80900890) {
                     func_808FFF90(this, play);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_IT_HOOKSHOT_REFLECT);
+                    Actor_PlaySfx(&this->actor, NA_SE_IT_HOOKSHOT_REFLECT);
                 }
             }
         }
@@ -1932,7 +1932,7 @@ void func_80902524(BossGanon2* this, PlayState* play) {
             this->unk_316 = 60;
             this->unk_344 = 0x32;
             this->unk_342 = 5;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MGANON_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MGANON_DAMAGE);
             Audio_StopSfxById(NA_SE_EN_MGANON_UNARI);
             phi_v1_2 = 1;
             if (acHitInfo->toucher.dmgFlags & (DMG_JUMP_MASTER | DMG_SPIN_MASTER | DMG_SLASH_MASTER)) {

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -462,7 +462,7 @@ void BossGanondrof_Paintings(BossGanondrof* this, PlayState* play) {
         this->colliderBody.dim.radius = 20;
         this->colliderBody.dim.height = 60;
         this->colliderBody.dim.yShift = -33;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_LAUGH);
         this->actor.naviEnemyId = NAVI_ENEMY_PHANTOM_GANON_PHASE_2;
     } else {
         horse->bossGndSignal = FHG_NO_SIGNAL;
@@ -504,12 +504,12 @@ void BossGanondrof_Neutral(BossGanondrof* this, PlayState* play) {
                         this->flyMode = GND_FLY_CHARGE;
                         this->timers[0] = 60;
                         this->fwork[GND_FLOAT_SPEED] = 0.0f;
-                        Audio_PlayActorSfx2(thisx, NA_SE_EN_FANTOM_LAUGH);
+                        Actor_PlaySfx(thisx, NA_SE_EN_FANTOM_LAUGH);
                     } else {
                         this->flyMode = GND_FLY_VOLLEY;
                         this->timers[0] = 60;
                         this->fwork[GND_FLOAT_SPEED] = 0.0f;
-                        Audio_PlayActorSfx2(thisx, NA_SE_EN_FANTOM_LAUGH);
+                        Actor_PlaySfx(thisx, NA_SE_EN_FANTOM_LAUGH);
                     }
                 } else if ((rand01 < 0.5f) || (this->work[GND_THROW_COUNT] < 5)) {
                     BossGanondrof_SetupThrow(this, play);
@@ -517,7 +517,7 @@ void BossGanondrof_Neutral(BossGanondrof* this, PlayState* play) {
                     this->flyMode = GND_FLY_VOLLEY;
                     this->timers[0] = 60;
                     this->fwork[GND_FLOAT_SPEED] = 0.0f;
-                    Audio_PlayActorSfx2(thisx, NA_SE_EN_FANTOM_LAUGH);
+                    Actor_PlaySfx(thisx, NA_SE_EN_FANTOM_LAUGH);
                 }
             }
 
@@ -613,7 +613,7 @@ void BossGanondrof_Neutral(BossGanondrof* this, PlayState* play) {
         BossGanondrof_SetupBlock(this, play);
     }
 
-    Audio_PlayActorSfx2(thisx, NA_SE_EN_FANTOM_FLOAT - SFX_FLAG);
+    Actor_PlaySfx(thisx, NA_SE_EN_FANTOM_FLOAT - SFX_FLAG);
 }
 
 void BossGanondrof_SetupThrow(BossGanondrof* this, PlayState* play) {
@@ -638,7 +638,7 @@ void BossGanondrof_SetupThrow(BossGanondrof* this, PlayState* play) {
                        this->spearTip.z, lightTime, FHGFIRE_LIGHT_GREEN, 0, FHGFIRE_SPEAR_LIGHT);
     this->actor.child = &horseTemp->actor;
     this->work[GND_THROW_COUNT]++;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_STICK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_STICK);
 }
 
 void BossGanondrof_Throw(BossGanondrof* this, PlayState* play) {
@@ -657,12 +657,12 @@ void BossGanondrof_Throw(BossGanondrof* this, PlayState* play) {
 
     if (Animation_OnFrame(&this->skelAnime, this->work[GND_THROW_FRAME])) {
         if (this->flyMode <= GND_FLY_NEUTRAL) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_MASIC2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_MASIC2);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_MASIC1);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_MASIC1);
         }
 
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_VOICE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_VOICE);
     }
 
     if (Animation_OnFrame(&this->skelAnime, this->work[GND_THROW_FRAME])) {
@@ -693,7 +693,7 @@ void BossGanondrof_SetupReturn(BossGanondrof* this, PlayState* play) {
 void BossGanondrof_Return(BossGanondrof* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 5.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_VOICE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_VOICE);
         osSyncPrintf("VOISE               2  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
         osSyncPrintf("VOISE               2  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
     }
@@ -745,7 +745,7 @@ void BossGanondrof_Stunned(BossGanondrof* this, PlayState* play) {
         this->actor.velocity.y = 0.0f;
         this->actor.gravity = 0.0f;
         if (Animation_OnFrame(&this->skelAnime, this->fwork[GND_END_FRAME])) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_DAMAGE2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_DAMAGE2);
         }
 
         this->actor.flags |= ACTOR_FLAG_10;
@@ -769,7 +769,7 @@ void BossGanondrof_SetupBlock(BossGanondrof* this, PlayState* play) {
     Animation_MorphToLoop(&this->skelAnime, &gPhantomGanonBlockAnim, -3.0f);
     this->actionFunc = BossGanondrof_Block;
     this->timers[0] = 10;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_STICK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_STICK);
 }
 
 void BossGanondrof_Block(BossGanondrof* this, PlayState* play) {
@@ -807,11 +807,11 @@ void BossGanondrof_Charge(BossGanondrof* this, PlayState* play) {
     switch (this->work[GND_ACTION_STATE]) {
         case CHARGE_WINDUP:
             if (this->timers[0] == 218) {
-                Audio_PlayActorSfx2(thisx, NA_SE_EN_FANTOM_STICK);
+                Actor_PlaySfx(thisx, NA_SE_EN_FANTOM_STICK);
             }
 
             if (this->timers[0] == 19) {
-                Audio_PlayActorSfx2(thisx, NA_SE_EN_FANTOM_ATTACK);
+                Actor_PlaySfx(thisx, NA_SE_EN_FANTOM_ATTACK);
             }
 
             thisx->world.pos.x += thisx->velocity.x;
@@ -929,7 +929,7 @@ void BossGanondrof_SetupDeath(BossGanondrof* this, PlayState* play) {
     this->fwork[GND_END_FRAME] = Animation_GetLastFrame(&gPhantomGanonDeathBlowAnim);
     this->actionFunc = BossGanondrof_Death;
     SEQCMD_STOP_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 1);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_DEAD);
     this->deathState = DEATH_START;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->work[GND_VARIANCE_TIMER] = 0;
@@ -950,7 +950,7 @@ void BossGanondrof_Death(BossGanondrof* this, PlayState* play) {
     this->work[GND_DEATH_SFX_TIMER]++;
     if (((60 < this->work[GND_DEATH_SFX_TIMER]) && (this->work[GND_DEATH_SFX_TIMER] < 500)) ||
         ((501 < this->work[GND_DEATH_SFX_TIMER]) && (this->work[GND_DEATH_SFX_TIMER] < 620))) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_LAST - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_LAST - SFX_FLAG);
     }
 
     switch (this->deathState) {
@@ -1063,7 +1063,7 @@ void BossGanondrof_Death(BossGanondrof* this, PlayState* play) {
                 this->actor.world.pos.z = GND_BOSSROOM_CENTER_Z;
                 this->actor.shape.rot.y = 0;
                 this->work[GND_BODY_DECAY_INDEX] = 0;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_LAST);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_LAST);
             }
 
             holdCamera = true;
@@ -1239,7 +1239,7 @@ void BossGanondrof_CollisionCheck(BossGanondrof* this, PlayState* play) {
             }
             if (this->flyMode != GND_FLY_PAINTING) {
                 if (acHit && (this->actionFunc != BossGanondrof_Stunned) && (hurtbox->toucher.dmgFlags & DMG_RANGED)) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_NONE);
+                    Actor_PlaySfx(&this->actor, NA_SE_NONE);
                     osSyncPrintf("hit != 0 \n");
                 } else if (this->actionFunc != BossGanondrof_Charge) {
                     if (this->returnCount == 0) {
@@ -1268,15 +1268,15 @@ void BossGanondrof_CollisionCheck(BossGanondrof* this, PlayState* play) {
                     }
                     this->work[GND_INVINC_TIMER] = 10;
                     horse->hitTimer = 20;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_DAMAGE);
                 } else {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_NONE);
+                    Actor_PlaySfx(&this->actor, NA_SE_NONE);
                 }
             } else if (acHit && (hurtbox->toucher.dmgFlags & DMG_RANGED)) {
                 this->work[GND_INVINC_TIMER] = 10;
                 this->actor.colChkInfo.health -= 2;
                 horse->hitTimer = 20;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_DAMAGE);
             }
             this->returnCount = 0;
         }

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -379,9 +379,9 @@ void BossGoma_PlayEffectsAndSfx(BossGoma* this, PlayState* play, s16 arg2, s16 a
     }
 
     if (arg2 == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_DOWN);
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_WALK);
     }
 }
 
@@ -408,7 +408,7 @@ void BossGoma_SetupDefeated(BossGoma* this, PlayState* play) {
     this->actor.speedXZ = 0.0f;
     this->actor.shape.shadowScale = 0.0f;
     SEQCMD_STOP_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 1);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_DEAD);
 }
 
 /**
@@ -617,7 +617,7 @@ void BossGoma_UpdateCeilingMovement(BossGoma* this, PlayState* play, f32 dz, f32
             pos.z = Rand_CenteredFloat(70.0f) + basePos->z;
             EffectSsHahen_Spawn(play, &pos, &vel, &accel, 0, (s16)(Rand_ZeroOne() * 5.0f) + 10, -1, 10, NULL);
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_HIGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_HIGH);
     }
 }
 
@@ -793,7 +793,7 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
 
         case 4: // focus Gohma on the ceiling
             if (Animation_OnFrame(&this->skelanime, 15.0f)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_DEMO_EYE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_DEMO_EYE);
             }
 
             if (this->framesUntilNextAction <= 40) {
@@ -917,7 +917,7 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
             }
 
             if (Animation_OnFrame(&this->skelanime, 40.0f)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_CRY1);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_CRY1);
 
                 if (!GET_EVENTCHKINF(EVENTCHKINF_70)) {
                     TitleCard_InitBossName(play, &play->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex),
@@ -1021,7 +1021,7 @@ void BossGoma_Defeated(BossGoma* this, PlayState* play) {
 
     if (this->framesUntilNextAction < 1080 && this->actionState < 3) {
         if (this->framesUntilNextAction < 1070) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_LAST - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_LAST - SFX_FLAG);
         }
 
         for (i = 0; i < 4; i++) {
@@ -1282,7 +1282,7 @@ void BossGoma_FloorPrepareAttack(BossGoma* this, PlayState* play) {
 
     if (this->framesUntilNextAction == 0) {
         BossGoma_SetupFloorAttack(this);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_CRY1);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_CRY1);
     }
 
     this->eyeState = EYESTATE_IRIS_FOLLOW_NO_IFRAMES;
@@ -1325,7 +1325,7 @@ void BossGoma_FloorAttack(BossGoma* this, PlayState* play) {
 
         case 1:
             if (Animation_OnFrame(&this->skelanime, 3.0f)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_UNARI2);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_UNARI2);
             }
 
             if (this->timer == 0) {
@@ -1398,7 +1398,7 @@ void BossGoma_FloorLand(BossGoma* this, PlayState* play) {
  */
 void BossGoma_FloorStunned(BossGoma* this, PlayState* play) {
     if (this->sfxFaintTimer <= 90) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_FAINT - 0x800);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_FAINT - 0x800);
     }
     SkelAnime_Update(&this->skelanime);
 
@@ -1452,7 +1452,7 @@ void BossGoma_FallStruckDown(BossGoma* this, PlayState* play) {
         this->actor.velocity.y = 0.0f;
         BossGoma_PlayEffectsAndSfx(this, play, 0, 8);
         Actor_RequestQuakeAndRumble(&this->actor, play, 10, 15);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_DAM1);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_DAM1);
     }
 }
 
@@ -1465,7 +1465,7 @@ void BossGoma_CeilingSpawnGohmas(BossGoma* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
 
     if (this->frameCount % 16 == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_UNARI);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_UNARI);
     }
 
     Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
@@ -1600,7 +1600,7 @@ void BossGoma_FloorMain(BossGoma* this, PlayState* play) {
     }
 
     if (this->frameCount % 64 == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_CRY2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_CRY2);
     }
 
     if (!this->doNotMoveThisFrame) {
@@ -1654,7 +1654,7 @@ void BossGoma_WallClimb(BossGoma* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
 
     if (this->frameCount % 8 == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_CLIM);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_CLIM);
     }
 
     Math_ApproachF(&this->actor.velocity.y, 5.0f, 0.5f, 2.0f);
@@ -1679,7 +1679,7 @@ void BossGoma_CeilingMoveToCenter(BossGoma* this, PlayState* play) {
     BossGoma_UpdateCeilingMovement(this, play, 0.0f, -5.0f, true);
 
     if (this->frameCount % 64 == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_CRY2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_CRY2);
     }
 
     Math_ApproachS(&this->actor.shape.rot.x, -0x8000, 3, 0x3E8);
@@ -1817,13 +1817,13 @@ void BossGoma_UpdateHit(BossGoma* this, PlayState* play) {
             if (this->actionFunc == BossGoma_CeilingMoveToCenter || this->actionFunc == BossGoma_CeilingIdle ||
                 this->actionFunc == BossGoma_CeilingPrepareSpawnGohmas) {
                 BossGoma_SetupFallStruckDown(this);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_DAM2);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_DAM2);
             } else if (this->actionFunc == BossGoma_FloorStunned &&
                        (damage = CollisionCheck_GetSwordDamage(acHitInfo->toucher.dmgFlags)) != 0) {
                 this->actor.colChkInfo.health -= damage;
 
                 if ((s8)this->actor.colChkInfo.health > 0) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_DAM1);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_DAM1);
                     BossGoma_SetupFloorDamaged(this);
                     EffectSsSibuki_SpawnBurst(play, &this->actor.focus.pos);
                 } else {
@@ -1834,7 +1834,7 @@ void BossGoma_UpdateHit(BossGoma* this, PlayState* play) {
                 this->invincibilityFrames = 10;
             } else if (this->actionFunc != BossGoma_FloorStunned && this->patienceTimer != 0 &&
                        (acHitInfo->toucher.dmgFlags & (DMG_SLINGSHOT | DMG_DEKU_NUT))) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_DAM2);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_DAM2);
                 Audio_StopSfxById(NA_SE_EN_GOMA_CRY1);
                 this->invincibilityFrames = 10;
                 BossGoma_SetupFloorStunned(this);

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -505,7 +505,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 if ((this->sfxTimer % 32) == 0) {
                     Audio_PlaySfxIncreasinglyTransposed(&this->tentTipPos, NA_SE_EN_MOFER_WAVE, gMorphaTransposeTable);
                     Rumble_Request(0, 100, 5, 2);
-                    func_8002F7DC(&player->actor, NA_SE_VO_LI_FREEZE + player->ageProperties->unk_92);
+                    Player_PlaySfx(player, NA_SE_VO_LI_FREEZE + player->ageProperties->unk_92);
                 }
             } else {
                 maxSwingRateX = 2000.0f;
@@ -519,7 +519,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 if ((this->sfxTimer % 16) == 0) {
                     Audio_PlaySfxIncreasinglyTransposed(&this->tentTipPos, NA_SE_EN_MOFER_WAVE, gMorphaTransposeTable);
                     Rumble_Request(0, 160, 5, 4);
-                    func_8002F7DC(&player->actor, NA_SE_VO_LI_FREEZE + player->ageProperties->unk_92);
+                    Player_PlaySfx(player, NA_SE_VO_LI_FREEZE + player->ageProperties->unk_92);
                 }
             }
         } else if (this->work[MO_TENT_ACTION_STATE] == MO_TENT_RETREAT) {
@@ -1546,7 +1546,7 @@ void BossMo_DeathCs(BossMo* this, PlayState* play) {
             Math_ApproachF(&this->subCamEye.y, 100.0f, 0.05f, 2.0f);
             this->subCamAt = this->subCamAtNext = this->actor.world.pos;
             if (this->timers[0] > 20) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MOFER_DEAD - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MOFER_DEAD - SFX_FLAG);
             }
             if (this->timers[0] == 20) {
                 for (i = 0; i < 300; i++) {
@@ -1562,7 +1562,7 @@ void BossMo_DeathCs(BossMo* this, PlayState* play) {
                 }
                 this->drawActor = false;
                 this->actor.flags &= ~ACTOR_FLAG_0;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MOFER_CORE_JUMP);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MOFER_CORE_JUMP);
                 SfxSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, 70, NA_SE_EN_MOFER_LASTVOICE);
             }
             if (this->timers[0] == 0) {
@@ -1767,7 +1767,7 @@ void BossMo_CoreCollisionCheck(BossMo* this, PlayState* play) {
 
                 this->actor.world.rot.y = this->actor.yawTowardsPlayer + 0x8000;
                 this->work[MO_CORE_DMG_FLASH_TIMER] = 15;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MOFER_CORE_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MOFER_CORE_DAMAGE);
                 this->actor.colChkInfo.health -= damage;
                 this->hitCount++;
                 if ((s8)this->actor.colChkInfo.health <= 0) {
@@ -2067,7 +2067,7 @@ void BossMo_Core(BossMo* this, PlayState* play) {
                         }
                     } else {
                         this->timers[1] = 2;
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MOFER_CORE_LAND);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_MOFER_CORE_LAND);
                         for (i = 0; i < 10; i++) {
                             effectVelocity.x = Rand_CenteredFloat(4.0f);
                             effectVelocity.y = Rand_ZeroFloat(2.0f) + 3.0f;
@@ -2088,7 +2088,7 @@ void BossMo_Core(BossMo* this, PlayState* play) {
             } else if (this->actor.world.pos.y < MO_WATER_LEVEL(play)) {
                 this->actor.velocity.y = BossMo_NearLand(&this->actor.world.pos, 40.0f) ? 15.0f : 6.0f;
                 if ((this->actor.world.pos.y + 15.0f) >= MO_WATER_LEVEL(play)) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MOFER_CORE_JUMP);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_MOFER_CORE_JUMP);
                 }
             }
         } else if (this->work[MO_TENT_ACTION_STATE] >= MO_CORE_MOVE) {
@@ -2122,7 +2122,7 @@ void BossMo_Core(BossMo* this, PlayState* play) {
                             if (this->timers[0] == 0) {
                                 this->work[MO_CORE_WAIT_IN_WATER] = false;
                                 this->timers[0] = (s16)Rand_ZeroFloat(20.0f) + 20;
-                                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MOFER_CORE_MOVE_WT);
+                                Actor_PlaySfx(&this->actor, NA_SE_EN_MOFER_CORE_MOVE_WT);
                             }
                             break;
                     }
@@ -2154,9 +2154,9 @@ void BossMo_Core(BossMo* this, PlayState* play) {
     }
     if ((this->actor.world.pos.y < MO_WATER_LEVEL(play)) && (MO_WATER_LEVEL(play) <= this->actor.prevPos.y)) {
         if (this->actor.velocity.y < -5.0f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MOFER_CORE_JUMP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MOFER_CORE_JUMP);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MOFER_CORE_SMJUMP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MOFER_CORE_SMJUMP);
         }
         if ((this->timers[3] != 0) || ((sMorphaTent1->fwork[MO_TENT_MAX_STRETCH] > 0.2f) &&
                                        (fabsf(this->actor.world.pos.x - sMorphaTent1->actor.world.pos.x) < 30.0f) &&

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -434,7 +434,7 @@ void BossSst_HeadIntro(BossSst* this, PlayState* play) {
                 sFloor->dyna.actor.params = BONGOFLOOR_HIT;
                 this->ready = true;
                 Rumble_Request(this->actor.xyzDistToPlayerSq, 255, 20, 150);
-                Audio_PlayActorSfx2(&sFloor->dyna.actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
+                Actor_PlaySfx(&sFloor->dyna.actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
             } else if (GET_EVENTCHKINF(EVENTCHKINF_77)) {
                 //! @bug This condition assumes that the second bounce on the ground will occur before frame 545 on the
                 //! timer. However, it is possible to delay Player's descent to the ground by, for example, jumpslashing
@@ -764,7 +764,7 @@ void BossSst_HeadCharge(BossSst* this, PlayState* play) {
         sHands[LEFT]->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
         sHands[RIGHT]->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
         func_8002F71C(play, &this->actor, 10.0f, this->actor.shape.rot.y, 5.0f);
-        func_8002F7DC(&GET_PLAYER(play)->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(GET_PLAYER(play), NA_SE_PL_BODY_HIT);
     }
 }
 
@@ -1293,7 +1293,7 @@ void BossSst_HandDownbeat(BossSst* this, PlayState* play) {
                 BossSst_HandSetupDownbeatEnd(this);
             }
             Rumble_Request(this->actor.xyzDistToPlayerSq, 255, 20, 150);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
         }
     }
 }
@@ -1345,7 +1345,7 @@ void BossSst_HandOffbeat(BossSst* this, PlayState* play) {
         }
 
         if (this->timer == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_TAIKO_LOW);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_TAIKO_LOW);
             BossSst_HandSetupOffbeatEnd(this);
         }
     }
@@ -1473,7 +1473,7 @@ void BossSst_HandSetupSlam(BossSst* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, sHandFlatPoses[this->actor.params], 10.0f);
     BossSst_HandSetDamage(this, 0x20);
     this->ready = false;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_FLY_ATTACK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_FLY_ATTACK);
     this->actionFunc = BossSst_HandSlam;
 }
 
@@ -1503,7 +1503,7 @@ void BossSst_HandSlam(BossSst* this, PlayState* play) {
             this->actor.velocity.y *= 1.5f;
             if (Math_StepToF(&this->actor.world.pos.y, this->actor.floorHeight, this->actor.velocity.y)) {
                 this->ready = true;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_TAIKO_LOW);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_TAIKO_LOW);
                 BossSst_SpawnShockwave(this);
                 this->colliderCyl.base.atFlags |= AT_ON;
                 Collider_UpdateCylinder(&this->actor, &this->colliderCyl);
@@ -1559,7 +1559,7 @@ void BossSst_HandSetupSweep(BossSst* this) {
     this->handMaxSpeed = 0x300;
     this->handAngSpeed = 0;
     this->ready = false;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_FLY_ATTACK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_FLY_ATTACK);
     this->actionFunc = BossSst_HandSweep;
 }
 
@@ -1578,7 +1578,7 @@ void BossSst_HandSweep(BossSst* this, PlayState* play) {
         this->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
         this->ready = true;
         func_8002F71C(play, &this->actor, 5.0f, this->actor.shape.rot.y - (this->vParity * 0x3800), 0.0f);
-        func_8002F7DC(&player->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(player, NA_SE_PL_BODY_HIT);
         newTargetYaw = this->actor.shape.rot.y - (this->vParity * 0x1400);
         if (((s16)(newTargetYaw - this->targetYaw) * this->vParity) > 0) {
             this->targetYaw = newTargetYaw;
@@ -1635,7 +1635,7 @@ void BossSst_HandPunch(BossSst* this, PlayState* play) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
         BossSst_HandSetupRetreat(this);
     } else if (this->colliderJntSph.base.atFlags & AT_HIT) {
-        func_8002F7DC(&GET_PLAYER(play)->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(GET_PLAYER(play), NA_SE_PL_BODY_HIT);
         func_8002F71C(play, &this->actor, 10.0f, this->actor.shape.rot.y, 5.0f);
         BossSst_HandSetupRetreat(this);
     }
@@ -1736,7 +1736,7 @@ void BossSst_HandClap(BossSst* this, PlayState* play) {
 
             if (Math_ScaledStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, this->handAngSpeed)) {
                 if (this->actor.params == BONGO_LEFT_HAND) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_CLAP);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_CLAP);
                 }
                 this->ready = true;
             } else {
@@ -1836,7 +1836,7 @@ void BossSst_HandGrab(BossSst* this, PlayState* play) {
 
     if (this->colliderJntSph.base.atFlags & AT_HIT) {
         this->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_CATCH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_CATCH);
         BossSst_HandGrabPlayer(this, play);
         this->timer = CLAMP_MAX(this->timer, 5);
     }
@@ -1872,15 +1872,15 @@ void BossSst_HandCrush(BossSst* this, PlayState* play) {
         if (this->timer == 0) {
             this->timer = 20;
             if (!LINK_IS_ADULT) {
-                func_8002F7DC(&player->actor, NA_SE_VO_LI_DAMAGE_S_KID);
+                Player_PlaySfx(player, NA_SE_VO_LI_DAMAGE_S_KID);
             } else {
-                func_8002F7DC(&player->actor, NA_SE_VO_LI_DAMAGE_S);
+                Player_PlaySfx(player, NA_SE_VO_LI_DAMAGE_S);
             }
 
             play->damagePlayer(play, -8);
         }
         if (Animation_OnFrame(&this->skelAnime, 0.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_CATCH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_CATCH);
         }
     }
 }
@@ -1955,7 +1955,7 @@ void BossSst_HandSwing(BossSst* this, PlayState* play) {
         player->actor.world.pos.x += 70.0f * Math_SinS(this->actor.shape.rot.y);
         player->actor.world.pos.z += 70.0f * Math_CosS(this->actor.shape.rot.y);
         func_8002F71C(play, &this->actor, 15.0f, this->actor.shape.rot.y, 2.0f);
-        func_8002F7DC(&player->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(player, NA_SE_PL_BODY_HIT);
     }
 
     func_8002F974(&this->actor, NA_SE_EN_SHADEST_HAND_FLY - SFX_FLAG);
@@ -2038,7 +2038,7 @@ void BossSst_HandShake(BossSst* this, PlayState* play) {
     this->handYRotMod = (this->vParity * -0x2000) + (sinf(this->timer * (M_PI / 4)) * 0x2800);
 
     if (!(this->timer % 8)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_SHAKEHAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_SHAKEHAND);
     }
 
     if (HAND_STATE(OTHER_HAND(this)) == HAND_DAMAGED) {
@@ -2077,7 +2077,7 @@ void BossSst_HandReadyCharge(BossSst* this, PlayState* play) {
         OTHER_HAND(this)->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
         sHead->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
         func_8002F71C(play, &this->actor, 10.0f, this->actor.shape.rot.y, 5.0f);
-        func_8002F7DC(&GET_PLAYER(play)->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(GET_PLAYER(play), NA_SE_PL_BODY_HIT);
     }
 }
 
@@ -2139,7 +2139,7 @@ void BossSst_HandDamage(BossSst* this, PlayState* play) {
 
     if (this->timer == 0) {
         if (this->actor.floorHeight >= 0.0f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
         }
         BossSst_HandSetupStunned(this);
     }
@@ -2176,7 +2176,7 @@ void BossSst_HandThrash(BossSst* this, PlayState* play) {
             this->amplitude = 0;
             Animation_MorphToPlayOnce(&this->skelAnime, sHandFlatPoses[this->actor.params], 5.0f);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_TAIKO_HIGH);
             this->amplitude = -0x800;
             Animation_MorphToPlayOnce(&this->skelAnime, sHandOpenPoses[this->actor.params], 5.0f);
         }
@@ -2377,7 +2377,7 @@ void BossSst_HandBreakIce(BossSst* this, PlayState* play) {
             }
 
             if (this->timer != 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_ICE_BROKEN);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_ICE_BROKEN);
             }
 
             OTHER_HAND(this)->handAngSpeed = 5;
@@ -2543,7 +2543,7 @@ void BossSst_HandCollisionCheck(BossSst* this, PlayState* play) {
             BossSst_HeadSetupDamagedHand(sHead, bothHands);
             Item_DropCollectible(play, &this->actor.world.pos,
                                  (Rand_ZeroOne() < 0.5f) ? ITEM00_ARROWS_SMALL : ITEM00_MAGIC_SMALL);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_DAMAGE_HAND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_DAMAGE_HAND);
         }
     }
 }
@@ -2984,7 +2984,7 @@ void BossSst_SpawnShockwave(BossSst* this) {
     s32 scale = 120;
     s32 alpha = 250;
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHADEST_HAND_WAVE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_HAND_WAVE);
     this->effectMode = BONGO_SHOCKWAVE;
 
     for (i = 0; i < 3; i++) {
@@ -3041,7 +3041,7 @@ void BossSst_SpawnIceCrystal(BossSst* this, s32 index) {
     ice->scale = 4000;
 
     if ((index % 2) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_PL_FREEZE_S);
+        Actor_PlaySfx(&this->actor, NA_SE_PL_FREEZE_S);
     }
 }
 
@@ -3080,7 +3080,7 @@ void BossSst_IceShatter(BossSst* this) {
     s32 i;
 
     this->effects[0].status = 1;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_PL_ICE_BROKEN);
+    Actor_PlaySfx(&this->actor, NA_SE_PL_ICE_BROKEN);
 
     for (i = 0; i < 18; i++) {
         BossSstEffect* ice = &this->effects[i];

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -680,7 +680,7 @@ void BossTw_FlyTo(BossTw* this, PlayState* play) {
     f32 yawTarget;
     f32 xzDist;
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
     Math_ApproachF(&this->scepterAlpha, 0.0f, 1.0f, 10.0f);
     SkelAnime_Update(&this->skelAnime);
 
@@ -817,7 +817,7 @@ s32 BossTw_BeamHitPlayerCheck(BossTw* this, PlayState* play) {
                 }
 
                 player->isBurning = true;
-                func_8002F7DC(&player->actor, player->ageProperties->unk_92 + NA_SE_VO_LI_DEMO_DAMAGE);
+                Player_PlaySfx(player, player->ageProperties->unk_92 + NA_SE_VO_LI_DEMO_DAMAGE);
             }
         }
 
@@ -1002,7 +1002,7 @@ void BossTw_ShootBeam(BossTw* this, PlayState* play) {
                 if (this->timers[1] == 9) {
                     play->envCtx.lightBlend = 0.5f;
                     play->envCtx.lightSetting = 3 - this->actor.params;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_MASIC_SET);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_MASIC_SET);
                 }
 
                 if (this->timers[1] == 5) {
@@ -1039,9 +1039,9 @@ void BossTw_ShootBeam(BossTw* this, PlayState* play) {
             } else {
                 Math_ApproachF(&this->flameAlpha, 255.0f, 1.0f, 10.0f);
                 if (this->actor.params == TW_KOUME) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_MS_FIRE - SFX_FLAG);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_MS_FIRE - SFX_FLAG);
                 } else {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_MS_FREEZE - SFX_FLAG);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_MS_FREEZE - SFX_FLAG);
                 }
             }
 
@@ -1075,8 +1075,8 @@ void BossTw_ShootBeam(BossTw* this, PlayState* play) {
         }
 
         if (Animation_OnFrame(&this->skelAnime, this->workf[ANIM_SW_TGT] - 13.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_THROW_MASIC);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_SHOOT_VOICE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_THROW_MASIC);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_SHOOT_VOICE);
         }
 
         xDiff = this->targetPos.x - this->beamOrigin.x;
@@ -1310,7 +1310,7 @@ void BossTw_ShootBeam(BossTw* this, PlayState* play) {
             }
 
             BossTw_SetupHitByBeam(otherTw, play);
-            Audio_PlayActorSfx2(&otherTw->actor, NA_SE_EN_TWINROBA_DAMAGE_VOICE);
+            Actor_PlaySfx(&otherTw->actor, NA_SE_EN_TWINROBA_DAMAGE_VOICE);
             play->envCtx.lightBlend = 1.0f;
             otherTw->actor.colChkInfo.health++;
         }
@@ -1415,9 +1415,9 @@ void BossTw_Laugh(BossTw* this, PlayState* play) {
 
     if (Animation_OnFrame(&this->skelAnime, 10.0f)) {
         if (this->actor.params == TW_KOUME) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_LAUGH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_LAUGH);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_LAUGH2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_LAUGH2);
         }
     }
 
@@ -1441,7 +1441,7 @@ void BossTw_Spin(BossTw* this, PlayState* play) {
         this->actor.shape.rot.y -= 0x3000;
 
         if ((this->timers[0] % 4) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_ROLL);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_ROLL);
         }
     } else {
         SkelAnime_Update(&this->skelAnime);
@@ -1569,8 +1569,8 @@ void BossTw_TwinrovaMergeCS(BossTw* this, PlayState* play) {
 
     switch (this->csState1) {
         case 0:
-            Audio_PlayActorSfx2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
-            Audio_PlayActorSfx2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
+            Actor_PlaySfx(&sKotakePtr->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
+            Actor_PlaySfx(&sKoumePtr->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
             spB0.x = this->workf[UNK_F11];
             spB0.y = 400.0f;
             spB0.z = 0.0f;
@@ -1589,7 +1589,7 @@ void BossTw_TwinrovaMergeCS(BossTw* this, PlayState* play) {
             Math_ApproachF(&this->workf[UNK_F10], 0.5f, 1, 0.0039999997f);
             if (this->workf[UNK_F11] < 10.0f) {
                 if (!this->work[PLAYED_CHRG_SFX]) {
-                    Audio_PlayActorSfx2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_POWERUP);
+                    Actor_PlaySfx(&sKoumePtr->actor, NA_SE_EN_TWINROBA_POWERUP);
                     this->work[PLAYED_CHRG_SFX] = true;
                 }
 
@@ -1640,7 +1640,7 @@ void BossTw_TwinrovaMergeCS(BossTw* this, PlayState* play) {
                     this->workf[ANIM_SW_TGT] = Animation_GetLastFrame(&gTwinrovaIntroAnim);
                     this->timers[0] = 50;
                     func_8002DF54(play, &this->actor, PLAYER_CSMODE_2);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_TRANSFORM);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_TRANSFORM);
                     SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_BOSS);
                 }
             }
@@ -1686,7 +1686,7 @@ void BossTw_TwinrovaMergeCS(BossTw* this, PlayState* play) {
             }
 
             if (this->timers[3] == 16) {
-                func_8002F7DC(&player->actor, player->ageProperties->unk_92 + NA_SE_VO_LI_SURPRISE);
+                Player_PlaySfx(player, player->ageProperties->unk_92 + NA_SE_VO_LI_SURPRISE);
             }
 
             if ((this->timers[3] != 0) && (this->timers[3] < 20)) {
@@ -1969,7 +1969,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
                         BossTw_AddFlameEffect(play, &pos, &velocity, &sZeroVector, Rand_ZeroFloat(10.0f) + 25.0f, 1);
                     }
 
-                    Audio_PlayActorSfx2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_TRANSFORM);
+                    Actor_PlaySfx(&sKoumePtr->actor, NA_SE_EN_TWINROBA_TRANSFORM);
                     play->envCtx.lightBlend = 0;
                 }
 
@@ -1985,7 +1985,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
                         }
 
                         if (this->work[CS_TIMER_1] == 60) {
-                            Audio_PlayActorSfx2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_LAUGH);
+                            Actor_PlaySfx(&sKoumePtr->actor, NA_SE_EN_TWINROBA_LAUGH);
                         }
 
                         if (Animation_OnFrame(&sKoumePtr->skelAnime, this->workf[ANIM_SW_TGT])) {
@@ -2026,7 +2026,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
                 }
             } else {
                 if ((this->work[CS_TIMER_1] % 8) == 0) {
-                    Audio_PlayActorSfx2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_ROLL);
+                    Actor_PlaySfx(&sKoumePtr->actor, NA_SE_EN_TWINROBA_ROLL);
                 }
 
                 sKoumePtr->actor.shape.rot.y = sKoumePtr->actor.shape.rot.y + (s16)this->subCamYawStep;
@@ -2130,7 +2130,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
                         BossTw_AddFlameEffect(play, &pos, &velocity, &sZeroVector, Rand_ZeroFloat(10.f) + 25.0f, 0);
                     }
 
-                    Audio_PlayActorSfx2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_TRANSFORM);
+                    Actor_PlaySfx(&sKotakePtr->actor, NA_SE_EN_TWINROBA_TRANSFORM);
                     play->envCtx.lightBlend = 0.0f;
                 }
 
@@ -2146,7 +2146,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
                         }
 
                         if (this->work[CS_TIMER_1] == 60) {
-                            Audio_PlayActorSfx2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_LAUGH2);
+                            Actor_PlaySfx(&sKotakePtr->actor, NA_SE_EN_TWINROBA_LAUGH2);
                         }
 
                         if (Animation_OnFrame(&sKotakePtr->skelAnime, this->workf[ANIM_SW_TGT])) {
@@ -2186,7 +2186,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
                 }
             } else {
                 if ((this->work[CS_TIMER_1] % 8) == 0) {
-                    Audio_PlayActorSfx2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_ROLL);
+                    Actor_PlaySfx(&sKotakePtr->actor, NA_SE_EN_TWINROBA_ROLL);
                 }
 
                 sKotakePtr->actor.shape.rot.y = sKotakePtr->actor.shape.rot.y + (s16)this->subCamYawStep;
@@ -2233,8 +2233,8 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
             }
 
             if (this->work[CS_TIMER_1] < 200) {
-                Audio_PlayActorSfx2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
-                Audio_PlayActorSfx2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
+                Actor_PlaySfx(&sKoumePtr->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
+                Actor_PlaySfx(&sKotakePtr->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
                 sp90.x = this->workf[UNK_F11];
                 sp90.y = 400.0f;
                 sp90.z = 0.0f;
@@ -2313,7 +2313,7 @@ void BossTw_DeathBall(BossTw* this, PlayState* play) {
     s16 yaw;
 
     if ((this->work[CS_TIMER_1] % 16) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_FB_FLY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_FB_FLY);
     }
 
     if (sTwinrovaPtr->csState2 < 2) {
@@ -2414,7 +2414,7 @@ void BossTw_DeathCSMsgSfx(BossTw* this, PlayState* play) {
         kotakeAnim = 3;
         sKotakePtr->work[YAW_TGT] = -0x4000;
         sKotakePtr->rotateSpeed = 0.0f;
-        Audio_PlayActorSfx2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_SENSE);
+        Actor_PlaySfx(&sKotakePtr->actor, NA_SE_EN_TWINROBA_SENSE);
         msgId2 = 0x604C;
     }
 
@@ -2426,7 +2426,7 @@ void BossTw_DeathCSMsgSfx(BossTw* this, PlayState* play) {
         koumeAnim = 3;
         sKoumePtr->work[YAW_TGT] = 0x4000;
         sKoumePtr->rotateSpeed = 0.0f;
-        Audio_PlayActorSfx2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_SENSE);
+        Actor_PlaySfx(&sKoumePtr->actor, NA_SE_EN_TWINROBA_SENSE);
     }
 
     if (this->work[CS_TIMER_2] == 290) {
@@ -2520,8 +2520,8 @@ void BossTw_DeathCSMsgSfx(BossTw* this, PlayState* play) {
     }
 
     if (this->work[CS_TIMER_2] == 900) {
-        Audio_PlayActorSfx2(&sKoumePtr->actor, NA_SE_EN_TWINROBA_DIE);
-        Audio_PlayActorSfx2(&sKotakePtr->actor, NA_SE_EN_TWINROBA_DIE);
+        Actor_PlaySfx(&sKoumePtr->actor, NA_SE_EN_TWINROBA_DIE);
+        Actor_PlaySfx(&sKotakePtr->actor, NA_SE_EN_TWINROBA_DIE);
     }
 
     if (this->work[CS_TIMER_2] == 930) {
@@ -2592,7 +2592,7 @@ void BossTw_DeathCSMsgSfx(BossTw* this, PlayState* play) {
                 Math_ApproachF(&this->workf[UNK_F18], 0.0f, 1.0f, 3.0f);
             }
 
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GOTO_HEAVEN - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_GOTO_HEAVEN - SFX_FLAG);
         } else {
             f32 yTarget = Math_CosS(this->work[CS_TIMER_2] * 1700) * 4.0f;
             Math_ApproachF(&sKotakePtr->actor.world.pos.y, 20.0f + (263.0f + yTarget), 0.1f, this->actor.speedXZ);
@@ -2643,7 +2643,7 @@ void BossTw_TwinrovaDeathCS(BossTw* this, PlayState* play) {
                 this->workf[UNK_F13] += this->actor.speedXZ;
                 if (this->workf[UNK_F13] > 65536.0f) {
                     this->workf[UNK_F13] -= 65536.0f;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_ROLL);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_ROLL);
                 }
                 Math_ApproachF(&this->actor.speedXZ, 12288.0f, 1.0f, 256.0f);
                 if (this->work[CS_TIMER_1] == 135) {
@@ -3089,7 +3089,7 @@ void BossTw_TwinrovaUpdate(Actor* thisx, PlayState* play2) {
                 this->twinrovaStun = 0;
                 this->work[FOG_TIMER] = 10;
                 BossTw_TwinrovaDamage(this, play, 0);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_YOUNG_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_YOUNG_DAMAGE);
             } else if (this->collider.base.acFlags & AC_HIT) {
                 ColliderInfo* info = this->collider.info.acHitInfo;
 
@@ -3938,7 +3938,7 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
                     if (this->timers[0] == 0) {
                         func_8002D908(&this->actor);
                         func_8002D7EC(&this->actor);
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_SHOOT_FIRE & ~SFX_FLAG);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_SHOOT_FIRE & ~SFX_FLAG);
                     } else {
                         Vec3f velocity;
                         Vec3f velDir;
@@ -3960,8 +3960,8 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
                         }
 
                         if (this->timers[0] <= 50) {
-                            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_SHOOT_FIRE & ~SFX_FLAG);
-                            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_REFL_FIRE & ~SFX_FLAG);
+                            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_SHOOT_FIRE & ~SFX_FLAG);
+                            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_REFL_FIRE & ~SFX_FLAG);
                             Matrix_RotateY((this->magicDir.y / 32678.0f) * M_PI, MTXMODE_NEW);
                             Matrix_RotateX((this->magicDir.x / 32678.0f) * M_PI, MTXMODE_APPLY);
                             velDir.x = 0.0f;
@@ -4047,7 +4047,7 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
                     this->timers[0] = 0;
                 }
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_FIRE_EXP - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_FIRE_EXP - SFX_FLAG);
 
                 xDiff = sKoumePtr->groundBlastPos2.x - player->actor.world.pos.x;
                 yDiff = sKoumePtr->groundBlastPos2.y - player->actor.world.pos.y;
@@ -4064,7 +4064,7 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
                     player->isBurning = 1;
 
                     if (this->work[BURN_TMR] == 0) {
-                        func_8002F7DC(&player->actor, player->ageProperties->unk_92 + NA_SE_VO_LI_DEMO_DAMAGE);
+                        Player_PlaySfx(player, player->ageProperties->unk_92 + NA_SE_VO_LI_DEMO_DAMAGE);
                         this->work[BURN_TMR] = 40;
                     }
 
@@ -4127,7 +4127,7 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
                     if (this->timers[0] == 0) {
                         func_8002D908(&this->actor);
                         func_8002D7EC(&this->actor);
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_SHOOT_FREEZE - SFX_FLAG);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_SHOOT_FREEZE - SFX_FLAG);
                     } else {
                         Vec3f velocity;
                         Vec3f spF4;
@@ -4149,8 +4149,8 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
                         }
 
                         if (this->timers[0] <= 50) {
-                            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_SHOOT_FREEZE - SFX_FLAG);
-                            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_REFL_FREEZE - SFX_FLAG);
+                            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_SHOOT_FREEZE - SFX_FLAG);
+                            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_REFL_FREEZE - SFX_FLAG);
                             Matrix_RotateY((this->magicDir.y / 32678.0f) * M_PI, MTXMODE_NEW);
                             Matrix_RotateX((this->magicDir.x / 32678.0f) * M_PI, MTXMODE_APPLY);
                             spF4.x = 0.0f;
@@ -4237,7 +4237,7 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
                     this->timers[0] = 0;
                 }
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_ICE_FREEZE - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_ICE_FREEZE - SFX_FLAG);
 
                 if (this->timers[0] > (sTwinrovaPtr->actionFunc == BossTw_Wait ? 70 : 20)) {
                     s32 pad;
@@ -5180,8 +5180,8 @@ void BossTw_TwinrovaShootBlast(BossTw* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (Animation_OnFrame(&this->skelAnime, 8.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_THROW_MASIC);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_YOUNG_SHOOTVC);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_THROW_MASIC);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_YOUNG_SHOOTVC);
     }
 
     if (Animation_OnFrame(&this->skelAnime, 12.0f)) {
@@ -5265,12 +5265,12 @@ void BossTw_TwinrovaDamage(BossTw* this, PlayState* play, u8 damage) {
         if ((s8)this->actor.colChkInfo.health <= 0) {
             BossTw_TwinrovaSetupDeathCS(this, play);
             Enemy_StartFinishingBlow(play, &this->actor);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_YOUNG_DEAD);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_YOUNG_DEAD);
             return;
         }
 
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_YOUNG_DAMAGE2);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_CUTBODY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_YOUNG_DAMAGE2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_CUTBODY);
     }
 
     this->actionFunc = BossTw_TwinrovaStun;
@@ -5392,7 +5392,7 @@ void BossTw_TwinrovaFly(BossTw* this, PlayState* play) {
     f32 yaw;
     f32 xzDist;
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_FLY - SFX_FLAG);
     SkelAnime_Update(&this->skelAnime);
     xDiff = this->targetPos.x - this->actor.world.pos.x;
     yDiff = this->targetPos.y - this->actor.world.pos.y;
@@ -5429,7 +5429,7 @@ void BossTw_TwinrovaSpin(BossTw* this, PlayState* play) {
         this->actor.shape.rot.y -= 0x3000;
 
         if ((this->timers[0] % 4) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_ROLL);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_ROLL);
         }
     } else {
         BossTw_TwinrovaSetupFly(this, play);
@@ -5447,7 +5447,7 @@ void BossTw_TwinrovaLaugh(BossTw* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (Animation_OnFrame(&this->skelAnime, 10.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_YOUNG_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_YOUNG_LAUGH);
     }
 
     if (Animation_OnFrame(&this->skelAnime, this->workf[ANIM_SW_TGT])) {

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -820,7 +820,7 @@ void BossVa_BodyIntro(BossVa* this, PlayState* play) {
                 sCsState++;
             }
             if (Rand_ZeroOne() < 0.1f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
             }
             break;
         case INTRO_CRACKLE:
@@ -935,7 +935,7 @@ void BossVa_BodyIntro(BossVa* this, PlayState* play) {
             for (i = 10; i >= 1; i--) {
                 if (sBodyBari[i - 1]) {
                     if (sBodyBari[i - 1] == 1) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_STICK);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_STICK);
                         BossVa_SetSparkEnv(play);
                         if (this->onCeiling == 0) {
                             this->onCeiling = 2; // Not used by body
@@ -978,7 +978,7 @@ void BossVa_BodyIntro(BossVa* this, PlayState* play) {
                 }
 
                 if (Rand_ZeroOne() < 0.1f) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
                 }
 
                 this->timer = 40;
@@ -1076,7 +1076,7 @@ void BossVa_BodyPhase1(BossVa* this, PlayState* play) {
     if (sBodyState & 0x7F) {
         this->skelAnime.curFrame = 0.0f;
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 12);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_DAMAGE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_DAMAGE);
     }
 
     if (SkelAnime_Update(&this->skelAnime) && (sFightPhase >= PHASE_2)) {
@@ -1093,7 +1093,7 @@ void BossVa_BodyPhase1(BossVa* this, PlayState* play) {
     }
 
     if (Rand_ZeroOne() < 0.1f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
     Collider_UpdateCylinder(&this->actor, &this->colliderBody);
@@ -1152,7 +1152,7 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
             Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 12);
         }
 
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_FAINT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_FAINT);
     }
 
     if (this->colliderBody.base.atFlags & AT_HIT) {
@@ -1161,7 +1161,7 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
         sPhase2Timer = (sPhase2Timer + 0x18) & 0xFFF0;
         if (this->colliderBody.base.at == &player->actor) {
             func_8002F71C(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
-            Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+            Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
         }
     }
 
@@ -1174,7 +1174,7 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
     }
 
     if (Rand_ZeroOne() < 0.1f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
     Math_SmoothStepToS(&this->actor.shape.rot.x, this->actor.world.rot.x, 1, 0xC8, 0);
@@ -1237,14 +1237,14 @@ void BossVa_BodyPhase3(BossVa* this, PlayState* play) {
         if (this->colliderBody.base.at == &player->actor) {
             func_8002F71C(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             this->actor.world.rot.y += (s16)Rand_CenteredFloat(0x2EE0) + 0x8000;
-            Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+            Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
         }
     }
 
     if (this->colliderBody.base.acFlags & AC_HIT) {
         this->skelAnime.curFrame = 0.0f;
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 12);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_FAINT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_FAINT);
         sBodyState = 1;
         this->timer = 131;
         this->actor.flags &= ~ACTOR_FLAG_0;
@@ -1316,7 +1316,7 @@ void BossVa_BodyPhase3(BossVa* this, PlayState* play) {
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.focus.pos.y += 20.0f;
     if (Rand_ZeroOne() < 0.1f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
     Collider_UpdateCylinder(&this->actor, &this->colliderBody);
@@ -1358,11 +1358,11 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
         if (this->colliderBody.base.at == &player->actor) {
             func_8002F71C(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             this->actor.world.rot.y += (s16)Rand_CenteredFloat(0x2EE0) + 0x8000;
-            Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+            Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
         }
     }
     if (Rand_ZeroOne() < 0.1f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
     if (this->colliderBody.base.acFlags & AC_HIT) {
@@ -1373,7 +1373,7 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
                 this->invincibilityTimer = 8;
                 if (this->actor.colChkInfo.damageEffect != 1) {
                     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_DAMAGE);
                     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 12);
                     sPhase4HP -= this->actor.colChkInfo.damage;
                     if (sPhase4HP <= 0) {
@@ -1393,7 +1393,7 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
                     this->vaBodySpinRate = 0;
                     this->actor.speedXZ = 0.0f;
                     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 125, COLORFILTER_BUFFLAG_OPA, 255);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_FAINT);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_FAINT);
                 }
             }
         } else if (this->colliderBody.base.ac->id == ACTOR_EN_BOOM) {
@@ -1401,7 +1401,7 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
             boomerang->returnTimer = 0;
             boomerang->moveTo = &player->actor;
             boomerang->actor.world.rot.y = boomerang->actor.yawTowardsPlayer;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
         }
     } else if ((this->timer2 == 0) && (this->actor.shape.yOffset == 0.0f)) {
         this->timer = -220 - (s16)(Rand_ZeroOne() * 200.0f);
@@ -1703,7 +1703,7 @@ void BossVa_SupportIntro(BossVa* this, PlayState* play) {
         SkelAnime_Update(&this->skelAnime);
         Math_SmoothStepToF(&this->skelAnime.playSpeed, 1.0f, 1.0f, 0.05f, 0.0f);
         if (Rand_ZeroOne() < 0.1f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
         }
     }
 }
@@ -1735,7 +1735,7 @@ void BossVa_SupportAttached(BossVa* this, PlayState* play) {
 
     BossVa_AttachToBody(this);
     if (Rand_ZeroOne() < 0.1f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
     if (this->colliderSph.base.acFlags & AC_HIT) {
@@ -1834,7 +1834,7 @@ void BossVa_SupportCut(BossVa* this, PlayState* play) {
                 if (this->timer2 >= 32) {
                     this->burst++;
                     this->isDead = true;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BREAK2);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BREAK2);
                     if (this->actor.params == BOSSVA_SUPPORT_3) {
                         sCsState++;
                     }
@@ -2045,7 +2045,7 @@ void BossVa_ZapperAttack(BossVa* this, PlayState* play) {
                 }
 
                 if (Rand_ZeroOne() < 0.1f) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
                 }
             }
         }
@@ -2053,7 +2053,7 @@ void BossVa_ZapperAttack(BossVa* this, PlayState* play) {
         if (this->burst || (this->timer2 < 0)) {
             if (this->colliderLightning.base.atFlags & AT_HIT) {
                 if (this->timer2 > 0) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_HIT_RINK);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_HIT_RINK);
                     BossVa_SetSparkEnv(play);
                     this->timer2 = -1;
                     GET_BODY(this)->onCeiling = 6; // not used by body
@@ -2079,7 +2079,7 @@ void BossVa_ZapperAttack(BossVa* this, PlayState* play) {
     if (this->burst && (this->burst != 2)) { // burst can never be 2
         if (this->timer2 >= 32) {
             if (this->timer2 == 32) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_THUNDER);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_THUNDER);
             }
             BossVa_Spark(play, this, 2, 110, 15.0f, 15.0f, SPARK_BLAST, 5.0f, true);
             BossVa_Spark(play, this, 2, 110, 15.0f, 15.0f, SPARK_BLAST, 6.0f, true);
@@ -2196,7 +2196,7 @@ void BossVa_ZapperDeath(BossVa* this, PlayState* play) {
                         this->burst++;
                         this->isDead = true;
                         BossVa_SetDeathEnv(play);
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BREAK2);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BREAK2);
                     }
                 } else {
                     this->burst++;
@@ -2304,7 +2304,7 @@ void BossVa_ZapperEnraged(BossVa* this, PlayState* play) {
                 this->burst++;
                 this->unk_1D8 = sp54;
                 if (Rand_ZeroOne() < 0.1f) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
                 }
             }
         }
@@ -2312,7 +2312,7 @@ void BossVa_ZapperEnraged(BossVa* this, PlayState* play) {
         if (this->burst || (this->timer2 < 0)) {
             if (this->colliderLightning.base.atFlags & AT_HIT) {
                 if (this->timer2 > 0) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_HIT_RINK);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_HIT_RINK);
                     BossVa_SetSparkEnv(play);
                     this->timer2 = -1;
                     GET_BODY(this)->onCeiling = 6; // not used by body
@@ -2338,7 +2338,7 @@ void BossVa_ZapperEnraged(BossVa* this, PlayState* play) {
     if (this->burst && (this->burst != 2)) { // burst can never be 2
         if (this->timer2 >= 16) {
             if (this->timer2 == 18) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_THUNDER);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_THUNDER);
             }
 
             BossVa_Spark(play, this, 2, 110, 15.0f, 15.0f, SPARK_BLAST, 5.0f, true);
@@ -2509,7 +2509,7 @@ void BossVa_BariIntro(BossVa* this, PlayState* play) {
     }
 
     if (Rand_ZeroOne() < 0.1f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 }
 
@@ -2543,7 +2543,7 @@ void BossVa_BariPhase3Attack(BossVa* this, PlayState* play) {
     if ((this->colliderLightning.base.atFlags & AT_HIT) || (this->colliderSph.base.atFlags & AT_HIT)) {
         if ((this->colliderLightning.base.at == &player->actor) || (this->colliderSph.base.at == &player->actor)) {
             func_8002F71C(play, &this->actor, 8.0f, GET_BODY(this)->actor.yawTowardsPlayer, 8.0f);
-            Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+            Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
             this->colliderSph.base.at = NULL;
             this->colliderLightning.base.at = NULL;
         }
@@ -2559,7 +2559,7 @@ void BossVa_BariPhase3Attack(BossVa* this, PlayState* play) {
             boomerang->returnTimer = 0;
             boomerang->moveTo = &player->actor;
             boomerang->actor.world.rot.y = boomerang->actor.yawTowardsPlayer;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
         }
     }
 
@@ -2591,7 +2591,7 @@ void BossVa_BariPhase3Attack(BossVa* this, PlayState* play) {
     }
 
     if (Rand_ZeroOne() < 0.1f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
     this->actor.world.rot.y += this->unk_1AC;
@@ -2638,7 +2638,7 @@ void BossVa_BariPhase2Attack(BossVa* this, PlayState* play) {
     if ((this->colliderLightning.base.atFlags & AT_HIT) || (this->colliderSph.base.atFlags & AT_HIT)) {
         if ((this->colliderLightning.base.at == &player->actor) || (this->colliderSph.base.at == &player->actor)) {
             func_8002F71C(play, &this->actor, 8.0f, GET_BODY(this)->actor.yawTowardsPlayer, 8.0f);
-            Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+            Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
             this->colliderSph.base.at = NULL;
             this->colliderLightning.base.at = NULL;
         }
@@ -2673,7 +2673,7 @@ void BossVa_BariPhase2Attack(BossVa* this, PlayState* play) {
                 boomerang->returnTimer = 0;
                 boomerang->moveTo = &player->actor;
                 boomerang->actor.world.rot.y = boomerang->actor.yawTowardsPlayer;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
+                Actor_PlaySfx(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
             }
         }
 
@@ -2705,7 +2705,7 @@ void BossVa_BariPhase2Attack(BossVa* this, PlayState* play) {
     }
 
     if (Rand_ZeroOne() < 0.1f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
     if (GET_BODY(this)->actor.colorFilterTimer == 0) {
@@ -2765,7 +2765,7 @@ void BossVa_BariPhase3Stunned(BossVa* this, PlayState* play) {
 void BossVa_SetupBariDeath(BossVa* this) {
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->timer = 30;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_BL_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_DEAD);
     this->isDead++;
     BossVa_SetupAction(this, BossVa_BariDeath);
 }
@@ -2787,7 +2787,7 @@ void BossVa_SetupDoor(BossVa* this, PlayState* play) {
 
 void BossVa_Door(BossVa* this, PlayState* play) {
     if (sDoorState == 29) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BUYODOOR_CLOSE);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_BUYODOOR_CLOSE);
     }
 
     if (sCsState <= INTRO_DOOR_SHUT) {

--- a/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
+++ b/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
@@ -142,7 +142,7 @@ void Demo6K_Init(Actor* thisx, PlayState* play) {
             Actor_SetScale(&this->actor, 0.0f);
             this->initActionFunc = func_8096784C;
             this->actor.velocity.x = this->actor.velocity.y = this->actor.velocity.z = 0.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_NABALL_VANISH);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_NABALL_VANISH);
             break;
         case 12:
             Actor_SetScale(&this->actor, 0.0f);
@@ -388,7 +388,7 @@ void func_809674E0(Demo6K* this, PlayState* play) {
         this->actor.world.pos.y += (19.0f - this->actor.world.pos.y) * temp;
         this->actor.world.pos.z += (1613.0f - this->actor.world.pos.z) * temp;
 
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_FIRE - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_FIRE - SFX_FLAG);
     }
 
     Lights_PointNoGlowSetInfo(&this->lightInfo, this->actor.world.pos.x, this->actor.world.pos.y,
@@ -506,7 +506,7 @@ void func_80967BF8(Player* player, PlayState* play) {
 }
 
 void func_80967DBC(Demo6K* this, PlayState* play) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_ATTACK_DEMO - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_ATTACK_DEMO - SFX_FLAG);
 
     this->timer2++;
 
@@ -520,13 +520,13 @@ void func_80967DBC(Demo6K* this, PlayState* play) {
         if (this->timer2 > 104) {
             func_80967BF8(GET_PLAYER(play), play);
             Actor_Kill(&this->actor);
-            Audio_PlayActorSfx2(&GET_PLAYER(play)->actor, NA_SE_EN_FANTOM_HIT_THUNDER);
+            Actor_PlaySfx(&GET_PLAYER(play)->actor, NA_SE_EN_FANTOM_HIT_THUNDER);
         } else if (this->timer2 > 94) {
             Actor_SetScale(&this->actor, this->actor.scale.x + 0.03f);
 
             if (this->timer2 == 95) {
                 osSyncPrintf(VT_FGCOL(CYAN) "  NA_SE_EN_GANON_FIRE_DEMO\n" VT_RST);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_FIRE_DEMO);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_FIRE_DEMO);
             }
         }
 

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -644,7 +644,7 @@ void DemoEffect_UpdateGetItem(DemoEffect* this, PlayState* play) {
         switch (play->csCtx.npcActions[this->csActionId]->action) {
             case 2:
                 if (gSaveContext.entranceIndex == ENTR_TEMPLE_OF_TIME_0) {
-                    Audio_PlayActorSfx2(thisx, NA_SE_EV_MEDAL_APPEAR_L - SFX_FLAG);
+                    Actor_PlaySfx(thisx, NA_SE_EV_MEDAL_APPEAR_L - SFX_FLAG);
                 } else {
                     func_800788CC(NA_SE_EV_MEDAL_APPEAR_S - SFX_FLAG);
                 }
@@ -659,13 +659,13 @@ void DemoEffect_UpdateGetItem(DemoEffect* this, PlayState* play) {
                     this->actor.shape.rot.y += this->getItem.rotation;
                 }
                 if (gSaveContext.entranceIndex == ENTR_TEMPLE_OF_TIME_0) {
-                    Audio_PlayActorSfx2(thisx, NA_SE_EV_MEDAL_APPEAR_L - SFX_FLAG);
+                    Actor_PlaySfx(thisx, NA_SE_EV_MEDAL_APPEAR_L - SFX_FLAG);
                 } else {
                     func_800788CC(NA_SE_EV_MEDAL_APPEAR_S - SFX_FLAG);
                 }
                 break;
             case 4:
-                Audio_PlayActorSfx2(thisx, NA_SE_EV_MEDAL_APPEAR_S - SFX_FLAG);
+                Actor_PlaySfx(thisx, NA_SE_EV_MEDAL_APPEAR_S - SFX_FLAG);
                 break;
         }
     }
@@ -854,7 +854,7 @@ void DemoEffect_UpdateTriforceSpot(DemoEffect* this, PlayState* play) {
 
         if (gSaveContext.entranceIndex == ENTR_CUTSCENE_MAP_0 && gSaveContext.sceneLayer == 6 &&
             play->csCtx.frames == 143) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_RING_EXPLOSION);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_DM_RING_EXPLOSION);
         }
     }
 }
@@ -1069,15 +1069,15 @@ void DemoEffect_UpdateLightEffect(DemoEffect* this, PlayState* play) {
         }
 
         if (play->sceneId == SCENE_KOKIRI_FOREST && gSaveContext.sceneLayer == 6 && play->csCtx.frames == 197) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WHITE_OUT);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_WHITE_OUT);
         }
 
         if (play->sceneId == SCENE_DEATH_MOUNTAIN_TRAIL && gSaveContext.sceneLayer == 5) {
             if (!DemoEffect_CheckCsAction(this, play, 1)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
             }
             if (play->csCtx.frames == 640) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WHITE_OUT);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_WHITE_OUT);
             }
 
             if (0) {}
@@ -1085,10 +1085,10 @@ void DemoEffect_UpdateLightEffect(DemoEffect* this, PlayState* play) {
 
         if (play->sceneId == SCENE_ZORAS_FOUNTAIN && gSaveContext.sceneLayer == 4) {
             if (!DemoEffect_CheckCsAction(this, play, 1)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
             }
             if (play->csCtx.frames == 648) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WHITE_OUT);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_WHITE_OUT);
             }
 
             // Necessary to match
@@ -1099,13 +1099,13 @@ void DemoEffect_UpdateLightEffect(DemoEffect* this, PlayState* play) {
             if (1) {}
 
             if (play->csCtx.npcActions[this->csActionId]->action == 2) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
             }
         }
 
         if (play->sceneId == SCENE_GREAT_FAIRYS_FOUNTAIN_MAGIC || play->sceneId == SCENE_GREAT_FAIRYS_FOUNTAIN_SPELLS) {
             if (play->csCtx.npcActions[this->csActionId]->action == 2) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_LIGHT_GATHER - SFX_FLAG);
             }
         }
     }
@@ -1155,22 +1155,22 @@ void DemoEffect_UpdateGodLgtDin(DemoEffect* this, PlayState* play) {
             switch (gSaveContext.sceneLayer) {
                 case 4:
                     if (play->csCtx.frames == 288) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_PASS);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_PASS);
                     }
                     if (play->csCtx.frames == 635) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_PASS);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_PASS);
                     }
                     break;
 
                 case 6:
                     if (play->csCtx.frames == 55) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
                     }
                     break;
 
                 case 11:
                     if (play->csCtx.frames == 350) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
                     }
                     break;
             }
@@ -1210,19 +1210,19 @@ void DemoEffect_UpdateGodLgtNayru(DemoEffect* this, PlayState* play) {
             switch (gSaveContext.sceneLayer) {
                 case 4:
                     if (play->csCtx.frames == 298) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_PASS);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_PASS);
                     }
                     break;
 
                 case 6:
                     if (play->csCtx.frames == 105) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
                     }
                     break;
 
                 case 11:
                     if (play->csCtx.frames == 360) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
                     }
                     break;
             }
@@ -1230,7 +1230,7 @@ void DemoEffect_UpdateGodLgtNayru(DemoEffect* this, PlayState* play) {
 
         if (gSaveContext.entranceIndex == ENTR_DEATH_MOUNTAIN_TRAIL_0 && gSaveContext.sceneLayer == 4) {
             if (play->csCtx.frames == 72) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
+                Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
             }
             if (play->csCtx.frames == 80) {
                 Audio_PlayCutsceneEffectsSequence(SEQ_CS_EFFECTS_NAYRU_MAGIC);
@@ -1262,7 +1262,7 @@ void DemoEffect_UpdateGodLgtFarore(DemoEffect* this, PlayState* play) {
                 lgtShower->actor.scale.z = 0.23f;
             }
 
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
             Audio_PlayCutsceneEffectsSequence(SEQ_CS_EFFECTS_FARORE_MAGIC);
         }
 
@@ -1270,19 +1270,19 @@ void DemoEffect_UpdateGodLgtFarore(DemoEffect* this, PlayState* play) {
             switch (gSaveContext.sceneLayer) {
                 case 4:
                     if (play->csCtx.frames == 315) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_PASS);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_PASS);
                     }
                     break;
 
                 case 6:
                     if (play->csCtx.frames == 80) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
                     }
                     break;
 
                 case 11:
                     if (play->csCtx.frames == 370) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
+                        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_FLYING_GOD_DASH);
                     }
                     break;
             }
@@ -1970,7 +1970,7 @@ void DemoEffect_DrawTriforceSpot(Actor* thisx, PlayState* play) {
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
 
         if (this->triforceSpot.lightColumnOpacity > 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_AURORA - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_AURORA - SFX_FLAG);
             Matrix_Push();
             Matrix_Scale(1.0f, 2.4f, 1.0f, MTXMODE_APPLY);
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx, "../z_demo_effect.c", 3011),
@@ -1987,7 +1987,7 @@ void DemoEffect_DrawTriforceSpot(Actor* thisx, PlayState* play) {
         }
 
         if (this->triforceSpot.triforceSpotOpacity != 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_TRIFORCE - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_TRIFORCE - SFX_FLAG);
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx, "../z_demo_effect.c", 3042),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -406,10 +406,10 @@ void DemoKankyo_UpdateClouds(DemoKankyo* this, PlayState* play) {
 }
 
 void DemoKankyo_UpdateDoorOfTime(DemoKankyo* this, PlayState* play) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_STONE_STATUE_OPEN - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_STONE_STATUE_OPEN - SFX_FLAG);
     this->unk_150[0].unk_18 += 1.0f;
     if (this->unk_150[0].unk_18 >= 102.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_STONEDOOR_STOP);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_STONEDOOR_STOP);
         SET_EVENTCHKINF(EVENTCHKINF_4B);
         Actor_Kill(this->actor.child);
         DemoKankyo_SetupAction(this, DemoKankyo_KillDoorOfTimeCollision);

--- a/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.c
+++ b/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.c
@@ -220,7 +220,7 @@ void DemoKekkai_TrialBarrierDispel(Actor* thisx, PlayState* play) {
     } else if (this->timer < 50) {
         this->orbScale = 2.0f;
     } else if (this->timer == 50) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_DM_RING_EXPLOSION);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_DM_RING_EXPLOSION);
         DemoKekkai_SpawnParticles(this, play);
     } else {
         this->orbScale = 0.0f;

--- a/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.c
+++ b/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.c
@@ -101,7 +101,7 @@ void func_8099485C(DoorGerudo* this, PlayState* play) {
         this->actionFunc = func_8099496C;
         gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex] -= 1;
         Flags_SetSwitch(play, this->dyna.actor.params & 0x3F);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_CHAIN_KEY_UNLOCK);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_CHAIN_KEY_UNLOCK);
     } else {
         s32 direction = func_80994750(this, play);
 
@@ -124,7 +124,7 @@ void func_8099485C(DoorGerudo* this, PlayState* play) {
 
 void func_8099496C(DoorGerudo* this, PlayState* play) {
     if (DECR(this->unk_166) == 0) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_OPEN);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_OPEN);
         this->actionFunc = func_809949C8;
     }
 }

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -353,13 +353,13 @@ void DoorKiller_FallOver(DoorKiller* this, PlayState* play) {
             (playerPosRelToDoor.z < 100.0f) && (playerPosRelToDoor.z > 0.0f)) {
             this->hasHitPlayerOrGround |= 1;
             func_8002F6D4(play, &this->actor, 6.0f, this->actor.yawTowardsPlayer, 6.0f, 16);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_KDOOR_HIT);
-            func_8002F7DC(&player->actor, NA_SE_PL_BODY_HIT);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_KDOOR_HIT);
+            Player_PlaySfx(player, NA_SE_PL_BODY_HIT);
         }
     }
     if (!(this->hasHitPlayerOrGround & 1) && (this->timer == 2)) {
         this->hasHitPlayerOrGround |= 1;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_KDOOR_HIT_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_KDOOR_HIT_GND);
     }
 }
 
@@ -371,7 +371,7 @@ void DoorKiller_Wobble(DoorKiller* this, PlayState* play) {
     s32 i;
 
     if ((this->timer == 16) || (this->timer == 8)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_KDOOR_WAVE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_KDOOR_WAVE);
     }
 
     if (this->timer > 0) {

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -470,7 +470,7 @@ void DoorShutter_WaitForObject(DoorShutter* this, PlayState* play) {
             if (this->doorType == SHUTTER_GOHMA_BLOCK) {
                 this->dyna.actor.velocity.y = 0.0f;
                 this->dyna.actor.gravity = -2.0f;
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_CLOSE);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_CLOSE);
                 DoorShutter_SetupAction(this, DoorShutter_GohmaBlockFall);
             } else {
                 DoorShutter_SetupAction(this, DoorShutter_PhantomGanonBarsRaise);
@@ -564,9 +564,9 @@ void func_80996B0C(DoorShutter* this, PlayState* play) {
             Flags_SetSwitch(play, this->dyna.actor.params & 0x3F);
             if (this->doorType != SHUTTER_BOSS) {
                 gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex]--;
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_CHAIN_KEY_UNLOCK);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_CHAIN_KEY_UNLOCK);
             } else {
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_CHAIN_KEY_UNLOCK_B);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_CHAIN_KEY_UNLOCK_B);
             }
         }
     } else {
@@ -614,7 +614,7 @@ void func_80996C60(DoorShutter* this, PlayState* play) {
 s32 DoorShutter_UpdateOpening(DoorShutter* this, PlayState* play) {
     if (this->gfxType != DOORSHUTTER_GFX_JABU_JABU) {
         if (this->dyna.actor.velocity.y == 0.0f) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_OPEN);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_OPEN);
             func_80996C60(this, play);
         }
         Math_StepToF(&this->dyna.actor.velocity.y, 15.0f, 3.0f);
@@ -624,7 +624,7 @@ s32 DoorShutter_UpdateOpening(DoorShutter* this, PlayState* play) {
         }
     } else {
         if (this->jabuDoorClosedAmount == 100) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYODOOR_OPEN);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYODOOR_OPEN);
             func_80996C60(this, play);
         }
         if (Math_StepToS(&this->jabuDoorClosedAmount, 0, 10)) {
@@ -638,15 +638,15 @@ s32 DoorShutter_UpdateBarsClosed(DoorShutter* this, PlayState* play, f32 barsClo
     if (this->barsClosedAmount == (1.0f - barsClosedAmountTarget)) {
         if (this->gfxType != DOORSHUTTER_GFX_JABU_JABU) {
             if (barsClosedAmountTarget == 1.0f) {
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_CLOSE);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_CLOSE);
             } else {
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_METALDOOR_OPEN);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_METALDOOR_OPEN);
             }
         } else {
             if (barsClosedAmountTarget == 1.0f) {
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYOSHUTTER_CLOSE);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYOSHUTTER_CLOSE);
             } else {
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYOSHUTTER_OPEN);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYOSHUTTER_OPEN);
             }
         }
     }
@@ -689,13 +689,13 @@ void func_80997004(DoorShutter* this, PlayState* play) {
                 this->dyna.actor.velocity.y = 30.0f;
             }
             if (this->gfxType != DOORSHUTTER_GFX_JABU_JABU) {
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_CLOSE);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_SLIDE_DOOR_CLOSE);
                 DoorShutter_SetupAction(this, func_809973E8);
             } else {
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYODOOR_CLOSE);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYODOOR_CLOSE);
                 if ((this->doorType == SHUTTER_FRONT_SWITCH || this->doorType == SHUTTER_FRONT_SWITCH_BACK_CLEAR) &&
                     !Flags_GetSwitch(play, this->dyna.actor.params & 0x3F)) {
-                    Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUYOSHUTTER_CLOSE);
+                    Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUYOSHUTTER_CLOSE);
                 }
                 DoorShutter_SetupAction(this, DoorShutter_JabuDoorClose);
             }
@@ -766,7 +766,7 @@ void func_809973E8(DoorShutter* this, PlayState* play) {
             Actor_SpawnFloorDustRing(play, &this->dyna.actor, &this->dyna.actor.world.pos, 45.0f, 10, 8.0f, 500, 10,
                                      false);
         }
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
         quakeIndex = Quake_Request(Play_GetCamera(play, CAM_ID_MAIN), 3);
         Quake_SetSpeed(quakeIndex, -32536);
         Quake_SetPerturbations(quakeIndex, 2, 0, 0, 0);
@@ -798,7 +798,7 @@ void DoorShutter_GohmaBlockFall(DoorShutter* this, PlayState* play) {
             BossGoma* parent = (BossGoma*)this->dyna.actor.parent;
 
             this->unk_164 = 10;
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_STONE_BOUND);
             DoorShutter_RequestQuakeAndRumble(play, 2, 10, parent->subCamId);
             Actor_SpawnFloorDustRing(play, &this->dyna.actor, &this->dyna.actor.world.pos, 70.0f, 20, 8.0f, 500, 10,
                                      true);

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -267,7 +267,7 @@ void DoorWarp1_SetupPurpleCrystal(DoorWarp1* this, PlayState* play) {
         this->actor.scale.z = 0.09f;
         this->crystalAlpha = 255.0f;
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_SHUT_BY_CRYSTAL);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_SHUT_BY_CRYSTAL);
     }
     DoorWarp1_SetupAction(this, DoorWarp1_PurpleCrystal);
 }
@@ -400,7 +400,7 @@ void func_809995D4(DoorWarp1* this, PlayState* play) {
 }
 
 void DoorWarp1_WarpAppear(DoorWarp1* this, PlayState* play) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
     Math_SmoothStepToF(&this->lightRayAlpha, 255.0f, 0.4f, 10.0f, 0.01f);
     Math_SmoothStepToF(&this->warpAlpha, 255.0f, 0.4f, 10.0f, 0.01f);
 
@@ -435,7 +435,7 @@ void DoorWarp1_WarpAppear(DoorWarp1* this, PlayState* play) {
 
 void func_809998A4(DoorWarp1* this, PlayState* play) {
     if (this->lightRayAlpha != 0.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
     }
     Math_SmoothStepToF(&this->lightRayAlpha, 0.0f, 0.1f, 2.0f, 0.01f);
     Math_SmoothStepToF(&this->warpAlpha, 0.0f, 0.1f, 2.0f, 0.01f);
@@ -458,7 +458,7 @@ s32 DoorWarp1_PlayerInRange(DoorWarp1* this, PlayState* play) {
 void DoorWarp1_ChildWarpIdle(DoorWarp1* this, PlayState* play) {
     Player* player;
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
 
     if (DoorWarp1_PlayerInRange(this, play)) {
         player = GET_PLAYER(play);
@@ -538,7 +538,7 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
 }
 
 void DoorWarp1_RutoWarpIdle(DoorWarp1* this, PlayState* play) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
 
     if (this->rutoWarpState != WARP_BLUE_RUTO_STATE_INITIAL && DoorWarp1_PlayerInRange(this, play)) {
         this->rutoWarpState = WARP_BLUE_RUTO_STATE_ENTERED;
@@ -624,7 +624,7 @@ void DoorWarp1_RutoWarpOut(DoorWarp1* this, PlayState* play) {
 }
 
 void func_8099A3A4(DoorWarp1* this, PlayState* play) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
     Math_SmoothStepToF(&this->lightRayAlpha, 255.0f, 0.2f, 2.0f, 0.1f);
     Math_SmoothStepToF(&this->warpAlpha, 255.0f, 0.2f, 2.0f, 0.1f);
 
@@ -644,7 +644,7 @@ void func_8099A3A4(DoorWarp1* this, PlayState* play) {
 void DoorWarp1_AdultWarpIdle(DoorWarp1* this, PlayState* play) {
     Player* player;
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
 
     if (DoorWarp1_PlayerInRange(this, play)) {
         player = GET_PLAYER(play);
@@ -849,7 +849,7 @@ void DoorWarp1_Destination(DoorWarp1* this, PlayState* play) {
         this->warpAlpha = 0.0f;
         DoorWarp1_SetupAction(this, DoorWarp1_DoNothing);
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
 }
 
 void DoorWarp1_DoNothing(DoorWarp1* this, PlayState* play) {
@@ -863,7 +863,7 @@ void func_8099B020(DoorWarp1* this, PlayState* play) {
         Math_StepToF(&this->unk_194, 2.0f, 0.01f);
         Math_StepToF(&this->unk_198, 10.0f, 0.02f);
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_WARP_HOLE - SFX_FLAG);
 }
 
 void DoorWarp1_Update(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Am/z_en_am.c
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.c
@@ -266,7 +266,7 @@ void EnAm_SpawnEffects(EnAm* this, PlayState* play) {
         EffectSsKiraKira_SpawnSmall(play, &pos, &velocity, &accel, &primColor, &envColor);
     }
 
-    Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_AMOS_WALK);
+    Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_AMOS_WALK);
     Actor_SpawnFloorDustRing(play, &this->dyna.actor, &this->dyna.actor.world.pos, 4.0f, 3, 8.0f, 300, 15, false);
 }
 
@@ -338,7 +338,7 @@ void EnAm_SetupRecoilFromDamage(EnAm* this, PlayState* play) {
                      Animation_GetLastFrame(&gArmosDamagedAnim) - 6.0f, ANIMMODE_ONCE, 0.0f);
     this->behavior = AM_BEHAVIOR_DAMAGED;
     this->dyna.actor.world.rot.y = this->dyna.actor.yawTowardsPlayer;
-    Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_AMOS_DAMAGE);
+    Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_AMOS_DAMAGE);
 
     if (EnAm_CanMove(this, play, -6.0f, this->dyna.actor.world.rot.y)) {
         this->dyna.actor.speedXZ = -6.0f;
@@ -377,8 +377,8 @@ void EnAm_Sleep(EnAm* this, PlayState* play) {
         this->hurtCollider.base.acFlags &= ~AC_HIT;
 
         if (this->textureBlend == 0) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_AMOS_WAVE);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_AMOS_VOICE);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_AMOS_WAVE);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_AMOS_VOICE);
             Actor_SetColorFilter(&this->dyna.actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
         }
 
@@ -419,7 +419,7 @@ void EnAm_Sleep(EnAm* this, PlayState* play) {
             Math_SmoothStepToF(&this->dyna.actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
 
             if (this->dyna.actor.speedXZ != 0.0f) {
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
             }
 
             this->dyna.unk_154 = 0.0f;
@@ -588,7 +588,7 @@ void EnAm_Cooldown(EnAm* this, PlayState* play) {
 
         if (this->unk_258 == 0) {
             EnAm_SetupLunge(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_AMOS_VOICE);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_AMOS_VOICE);
         }
 
         this->dyna.actor.shape.rot.y = this->dyna.actor.world.rot.y;
@@ -672,7 +672,7 @@ void EnAm_Statue(EnAm* this, PlayState* play) {
         }
     } else {
         this->unk_258 -= 0x800;
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
 
         if (this->dyna.unk_150 < 0.0f) {
             temp158f = this->dyna.unk_158 + 0x8000;
@@ -699,7 +699,7 @@ void EnAm_Statue(EnAm* this, PlayState* play) {
     }
 
     if (this->dyna.actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
     }
 
     this->dyna.unk_150 = this->dyna.unk_154 = 0.0f;
@@ -724,7 +724,7 @@ void EnAm_SetupStunned(EnAm* this, PlayState* play) {
     }
 
     this->behavior = AM_BEHAVIOR_STUNNED;
-    Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_GOMA_JR_FREEZE);
     EnAm_SetupAction(this, EnAm_Stunned);
 }
 
@@ -864,7 +864,7 @@ void EnAm_Update(Actor* thisx, PlayState* play) {
                     bomb->timer = 0;
                 }
 
-                Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_AMOS_DEAD);
+                Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_AMOS_DEAD);
                 Item_DropCollectibleRandom(play, &this->dyna.actor, &this->dyna.actor.world.pos, 0xA0);
 
                 for (i = 9; i >= 0; i--) {
@@ -910,7 +910,7 @@ void EnAm_Update(Actor* thisx, PlayState* play) {
                     Player* player = GET_PLAYER(play);
 
                     if (this->hitCollider.base.at == &player->actor) {
-                        Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+                        Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
                     }
                 }
                 CollisionCheck_SetAT(play, &play->colChkCtx, &this->hitCollider.base);

--- a/src/overlays/actors/ovl_En_Anubice/z_en_anubice.c
+++ b/src/overlays/actors/ovl_En_Anubice/z_en_anubice.c
@@ -376,7 +376,7 @@ void EnAnubice_Update(Actor* thisx, PlayState* play) {
                 Actor_ChangeCategory(play, &play->actorCtx, &this->actor, ACTORCAT_PROP);
                 this->actor.flags &= ~ACTOR_FLAG_0;
                 Enemy_StartFinishingBlow(play, &this->actor);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_ANUBIS_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_ANUBIS_DEAD);
                 this->actionFunc = EnAnubice_SetupDie;
                 return;
             }
@@ -388,7 +388,7 @@ void EnAnubice_Update(Actor* thisx, PlayState* play) {
                 Actor_ChangeCategory(play, &play->actorCtx, &this->actor, ACTORCAT_PROP);
                 this->actor.flags &= ~ACTOR_FLAG_0;
                 Enemy_StartFinishingBlow(play, &this->actor);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_ANUBIS_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_ANUBIS_DEAD);
                 this->actionFunc = EnAnubice_SetupDie;
                 return;
             }
@@ -412,7 +412,7 @@ void EnAnubice_Update(Actor* thisx, PlayState* play) {
                 this->knockbackRecoveryVelocity.x = -rotatedKnockbackVelocity.x;
                 this->knockbackRecoveryVelocity.z = -rotatedKnockbackVelocity.z;
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_CUTBODY);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_CUTBODY);
             }
         }
 

--- a/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
+++ b/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
@@ -110,7 +110,7 @@ void func_809B27D8(EnAnubiceFire* this, PlayState* play) {
         Actor_Kill(&this->actor);
     } else if ((this->actor.params == 0) && (this->cylinder.base.atFlags & AT_BOUNCED)) {
         if (Player_HasMirrorShieldEquipped(play)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
             this->cylinder.base.atFlags &= ~(AT_HIT | AT_BOUNCED | AT_TYPE_ENEMY);
             this->cylinder.base.atFlags |= AT_TYPE_PLAYER;
             this->cylinder.info.toucher.dmgFlags = DMG_DEKU_STICK;
@@ -123,7 +123,7 @@ void func_809B27D8(EnAnubiceFire* this, PlayState* play) {
             this->unk_15A = 0;
             EffectSsBomb2_SpawnLayered(play, &this->actor.world.pos, &sp78, &sp84, 10, 5);
             this->actor.velocity.x = this->actor.velocity.y = this->actor.velocity.z = 0.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_ANUBIS_FIREBOMB);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_ANUBIS_FIREBOMB);
             this->actionFunc = func_809B2B48;
         }
     } else if (!(this->scale < .4f)) {
@@ -137,7 +137,7 @@ void func_809B27D8(EnAnubiceFire* this, PlayState* play) {
             pos.z = this->actor.world.pos.z;
             EffectSsKiraKira_SpawnDispersed(play, &pos, &velocity, &accel, &primColor, &envColor, scale, life);
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_ANUBIS_FIRE - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_ANUBIS_FIRE - SFX_FLAG);
     }
 }
 
@@ -207,7 +207,7 @@ void EnAnubiceFire_Update(Actor* thisx, PlayState* play) {
 
         if (BgCheck_SphVsFirstPoly(&play->colCtx, &this->actor.world.pos, 30.0f)) {
             this->actor.velocity.x = this->actor.velocity.y = this->actor.velocity.z = 0.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_ANUBIS_FIREBOMB);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_ANUBIS_FIREBOMB);
             this->actionFunc = func_809B2B48;
         }
     }

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -163,19 +163,19 @@ void EnArrow_Shoot(EnArrow* this, PlayState* play) {
 
         switch (this->actor.params) {
             case ARROW_SEED:
-                func_8002F7DC(&player->actor, NA_SE_IT_SLING_SHOT);
+                Player_PlaySfx(player, NA_SE_IT_SLING_SHOT);
                 break;
 
             case ARROW_NORMAL_LIT:
             case ARROW_NORMAL_HORSE:
             case ARROW_NORMAL:
-                func_8002F7DC(&player->actor, NA_SE_IT_ARROW_SHOT);
+                Player_PlaySfx(player, NA_SE_IT_ARROW_SHOT);
                 break;
 
             case ARROW_FIRE:
             case ARROW_ICE:
             case ARROW_LIGHT:
-                func_8002F7DC(&player->actor, NA_SE_IT_MAGIC_ARROW_SHOT);
+                Player_PlaySfx(player, NA_SE_IT_MAGIC_ARROW_SHOT);
                 break;
         }
 
@@ -307,7 +307,7 @@ void EnArrow_Fly(EnArrow* this, PlayState* play) {
                     }
 
                     func_809B3CEC(play, this);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_IT_ARROW_STICK_CRE);
+                    Actor_PlaySfx(&this->actor, NA_SE_IT_ARROW_STICK_CRE);
                 }
             } else if (this->touchedPoly) {
                 EnArrow_SetupAction(this, func_809B45E0);
@@ -319,7 +319,7 @@ void EnArrow_Fly(EnArrow* this, PlayState* play) {
                     this->timer = 20;
                 }
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_IT_ARROW_STICK_OBJ);
+                Actor_PlaySfx(&this->actor, NA_SE_IT_ARROW_STICK_OBJ);
                 this->hitFlags |= 1;
             }
         }

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -365,11 +365,11 @@ void EnAttackNiw_Update(Actor* thisx, PlayState* play) {
     }
     if (this->unk_25E == 0) {
         this->unk_25E = 30;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
     }
     if (this->unk_260 == 0) {
         this->unk_260 = 7;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_WAKEUP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_WAKEUP);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.c
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.c
@@ -237,7 +237,7 @@ void EnBa_SwingAtPlayer(EnBa* this, PlayState* play) {
     Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.home.pos.y + 60.0f, 1.0f, 10.0f, 0.0f);
     if ((this->actor.xzDistToPlayer <= 175.0f) || (this->unk_31A != 0)) {
         if (this->unk_318 == 20) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_HAND_UP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_HAND_UP);
             this->unk_31C = 1500;
         }
         if (this->unk_318 != 0) {
@@ -267,7 +267,7 @@ void EnBa_SwingAtPlayer(EnBa* this, PlayState* play) {
             }
         } else {
             if (this->unk_31A == 10) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_HAND_DOWN);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_HAND_DOWN);
             }
             if (this->unk_31A != 0) {
                 this->unk_31C = 8000;
@@ -324,7 +324,7 @@ void func_809B7174(EnBa* this) {
     this->unk_318 = 20;
     this->actor.colChkInfo.mass = MASS_IMMOVABLE;
     this->actor.speedXZ = 10.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BALINADE_HAND_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_HAND_DAMAGE);
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 12);
     EnBa_SetupAction(this, EnBa_RecoilFromDamage);
 }

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -505,7 +505,7 @@ void EnBb_Death(EnBb* this, PlayState* play) {
 
 void EnBb_SetupDamage(EnBb* this) {
     this->action = BB_DAMAGE;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_DAMAGE);
     if (this->actor.params > ENBB_GREEN) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
         if (!(this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
@@ -640,7 +640,7 @@ void EnBb_Blue(EnBb* this, PlayState* play) {
             afterHitAngle = -0x8000;
         } else {
             afterHitAngle = 0x4000;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_BITE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_BITE);
             if (play->gameplayFrames & 1) {
                 afterHitAngle = -0x4000;
             }
@@ -652,17 +652,17 @@ void EnBb_Blue(EnBb* this, PlayState* play) {
 
     if (this->maxSpeed >= 6.0f) {
         if ((s32)this->skelAnime.curFrame == 0 || (s32)this->skelAnime.curFrame == 5) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_MOUTH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_MOUTH);
         } else if ((s32)this->skelAnime.curFrame == 2 || (s32)this->skelAnime.curFrame == 7) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_WING);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_WING);
         }
     } else {
         if ((s32)this->skelAnime.curFrame == 5) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_WING);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_WING);
         }
     }
     if (((s32)this->skelAnime.curFrame == 0) && (Rand_ZeroOne() < 0.1f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_LAUGH);
     }
     this->actor.shape.rot.y = this->actor.world.rot.y;
 }
@@ -677,7 +677,7 @@ void EnBb_SetupDown(EnBb* this) {
     this->flameScaleX = 0.0f;
     this->flameScaleY = 0.0f;
     this->actor.gravity = -2.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_DOWN);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_DOWN);
     EnBb_SetupAction(this, EnBb_Down);
 }
 
@@ -705,7 +705,7 @@ void EnBb_Down(EnBb* this, PlayState* play) {
                 return;
             }
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         if (this->actor.velocity.y < -14.0f) {
             this->actor.velocity.y *= -0.7f;
         } else {
@@ -717,10 +717,10 @@ void EnBb_Down(EnBb* this, PlayState* play) {
     }
     this->actor.shape.rot.y = this->actor.world.rot.y;
     if ((s32)this->skelAnime.curFrame == 5) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_WING);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_WING);
     }
     if (this->timer == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_UP);
         switch (this->actor.params) {
             case ENBB_BLUE:
                 this->actor.velocity.y = 0.0f;
@@ -847,9 +847,9 @@ void EnBb_Red(EnBb* this, PlayState* play) {
     }
     if (this->actionState != BBRED_WAIT) {
         if (((s32)this->skelAnime.curFrame == 0) || ((s32)this->skelAnime.curFrame == 5)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_MOUTH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_MOUTH);
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLEFALL_FIRE - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEFALL_FIRE - SFX_FLAG);
     }
 }
 
@@ -919,7 +919,7 @@ void EnBb_White(EnBb* this, PlayState* play) {
             this->maxSpeed = 10.0f;
         }
         if (this->collider.base.atFlags & AT_HIT) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_BITE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_BITE);
             this->collider.base.atFlags &= ~AT_HIT;
         }
         this->actor.shape.rot.y = this->actor.world.rot.y;
@@ -928,13 +928,13 @@ void EnBb_White(EnBb* this, PlayState* play) {
     }
     SkelAnime_Update(&this->skelAnime);
     if (((s32)this->skelAnime.curFrame == 0) && (Rand_ZeroOne() <= 0.1f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_LAUGH);
     }
 
     if ((this->maxSpeed != 0.0f) && (((s32)this->skelAnime.curFrame == 0) || ((s32)this->skelAnime.curFrame == 5))) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_MOUTH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_MOUTH);
     } else if (((s32)this->skelAnime.curFrame == 2) || ((s32)this->skelAnime.curFrame == 7)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_WING);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_WING);
     }
 }
 
@@ -1005,7 +1005,7 @@ void EnBb_Green(EnBb* this, PlayState* play) {
             this->moveMode = BBMOVE_NOCLIP;
             this->maxSpeed = 10.0f;
             if (this->collider.base.atFlags & AT_HIT) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_BITE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_BITE);
                 this->collider.base.atFlags &= ~AT_HIT;
             }
             if (Math_CosF(this->bobPhase) == 0.0f) {
@@ -1013,7 +1013,7 @@ void EnBb_Green(EnBb* this, PlayState* play) {
                     this->bobSpeedMod = Rand_ZeroOne();
                 } else {
                     this->bobSpeedMod = Rand_ZeroOne() * 3.0f;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_LAUGH);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_LAUGH);
                 }
             }
             this->actor.shape.rot.y = this->actor.world.rot.y;
@@ -1043,14 +1043,14 @@ void EnBb_Green(EnBb* this, PlayState* play) {
         if (this->vFlameTimer != 0) {
             this->collider.base.acFlags &= ~AC_HIT;
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_DOWN);
     }
     if (this->actionState != BBGREEN_FLAME_ON) {
         this->timer--;
         if (this->timer == 0) {
             this->actionState = BBGREEN_FLAME_ON;
             this->vFlameTimer = (Rand_ZeroOne() * 30.0f) + 180.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_UP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_UP);
         }
         Math_SmoothStepToF(&this->flameScaleY, 0.0f, 1.0f, 10.0f, 0.0f);
         Math_SmoothStepToF(&this->flameScaleX, 0.0f, 1.0f, 10.0f, 0.0f);
@@ -1059,10 +1059,10 @@ void EnBb_Green(EnBb* this, PlayState* play) {
         Math_SmoothStepToF(&this->flameScaleX, 100.0f, 1.0f, 10.0f, 0.0f);
     }
     if ((s32)this->skelAnime.curFrame == 5) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_WING);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_WING);
     }
     if (((s32)this->skelAnime.curFrame == 0) && (Rand_ZeroOne() < 0.1f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_LAUGH);
     }
 }
 
@@ -1089,7 +1089,7 @@ void EnBb_SetupStunned(EnBb* this) {
             this->fireIceTimer = 0x30;
             FALLTHROUGH;
         case 15:
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
             Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 180, COLORFILTER_BUFFLAG_OPA, 80);
             break;
     }
@@ -1107,7 +1107,7 @@ void EnBb_Stunned(EnBb* this, PlayState* play) {
         this->actor.bgCheckFlags &= ~BGCHECKFLAG_WALL;
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         if (this->actor.velocity.y < -14.0f) {
             this->actor.velocity.y *= -0.4f;
         } else {
@@ -1209,7 +1209,7 @@ void EnBb_CollisionCheck(EnBb* this, PlayState* play) {
                     this->actor.speedXZ = -8.0f;
                     this->maxSpeed = 0.0f;
                     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_DAMAGE);
                 } else if (((this->action == BB_DOWN) && (this->timer < 190)) ||
                            ((this->actor.params != ENBB_WHITE) && (this->flameScaleX < 20.0f))) {
                     EnBb_SetupDamage(this);

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -260,8 +260,8 @@ void func_809BD1C8(EnBigokuta* this, PlayState* play) {
         EffectSsGSplash_Spawn(play, &effectPos, NULL, NULL, 1, 2000);
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_LAND_WATER);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOLON_LAND_BIG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_LAND_WATER);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_LAND_BIG);
     Actor_RequestQuakeAndRumble(&this->actor, play, 10, 8);
 }
 
@@ -283,7 +283,7 @@ void func_809BD318(EnBigokuta* this) {
 
 void func_809BD370(EnBigokuta* this) {
     this->unk_196 = 21;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actionFunc = func_809BD8DC;
 }
 
@@ -332,7 +332,7 @@ void func_809BD524(EnBigokuta* this) {
     this->unk_196 = 80;
     this->unk_19A = 0;
     this->cylinder[0].base.atFlags |= AT_ON;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_MAHI);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_MAHI);
     if (this->collider.elements->info.acHitInfo->toucher.dmgFlags & DMG_DEKU_NUT) {
         this->unk_195 = true;
         this->unk_196 = 20;
@@ -355,7 +355,7 @@ void func_809BD5E0(EnBigokuta* this) {
 void func_809BD658(EnBigokuta* this) {
 
     Animation_MorphToPlayOnce(&this->skelAnime, &object_bigokuta_Anim_000A74, -5.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_DEAD2);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_DEAD2);
     this->unk_196 = 38;
     this->unk_198 = 10;
     this->actionFunc = func_809BE26C;
@@ -385,7 +385,7 @@ void func_809BD768(EnBigokuta* this) {
     this->unk_19A = 0;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->cylinder[0].base.atFlags &= ~AT_ON;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_SINK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_SINK);
     this->actionFunc = func_809BE4A4;
 }
 
@@ -402,7 +402,7 @@ void func_809BD84C(EnBigokuta* this, PlayState* play) {
     this->unk_196--;
 
     if (this->unk_196 == 13 || this->unk_196 == -20) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_VOICE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_VOICE);
     }
     if (this->unk_196 == 1) {
         func_800F5ACC(NA_BGM_MINI_BOSS);
@@ -433,8 +433,8 @@ void func_809BD8DC(EnBigokuta* this, PlayState* play) {
             EffectSsGSplash_Spawn(play, &effectPos, NULL, NULL, 1, 2000);
             effectPos.x = this->actor.world.pos.x - 40.0f;
             EffectSsGSplash_Spawn(play, &effectPos, NULL, NULL, 1, 2000);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_LAND_WATER);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOLON_LAND_BIG);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_LAND_WATER);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_LAND_BIG);
             Rumble_Request(0.0f, 255, 20, 150);
         }
     } else if (this->unk_196 < -1) {
@@ -455,7 +455,7 @@ void func_809BDAE8(EnBigokuta* this, PlayState* play) {
             this->actor.home.pos.y = this->actor.world.pos.y;
             Actor_ChangeCategory(play, &play->actorCtx, &this->actor, ACTORCAT_ENEMY);
             this->actor.params = 2;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_VOICE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_VOICE);
             func_809BD3E0(this);
         }
     }
@@ -483,7 +483,7 @@ void func_809BDC08(EnBigokuta* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 0.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_BUBLE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_BUBLE);
     }
 
     if (this->unk_196 < 0) {
@@ -562,7 +562,7 @@ void func_809BDFC8(EnBigokuta* this, PlayState* play) {
         this->unk_196--;
     }
     if (this->unk_196 == 20) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_VOICE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_VOICE);
     }
     if ((this->unk_196 == 0) && Math_ScaledStepToS(&this->actor.shape.rot.y, this->actor.world.rot.x, 0x800)) {
         this->unk_194 = -this->unk_194;
@@ -636,7 +636,7 @@ void func_809BE26C(EnBigokuta* this, PlayState* play) {
             effectPos.z = this->actor.world.pos.z;
             func_8002829C(play, &effectPos, &sEffectPosAccel, &sEffectPosAccel, &sEffectPrimColor, &sEffectEnvColor,
                           1200, 20);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_DEAD2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_DEAD2);
         }
         if (this->unk_198 == 0 && Math_StepToF(&this->actor.scale.y, 0.0f, 0.001f)) {
             Flags_SetClear(play, this->actor.room);
@@ -756,10 +756,10 @@ void EnBigokuta_UpdateDamage(EnBigokuta* this, PlayState* play) {
                 func_809BD47C(this);
             } else if (!Actor_IsFacingPlayer(&this->actor, 0x4000)) {
                 if (Actor_ApplyDamage(&this->actor) == 0) { // Dead
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_DEAD);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_DEAD);
                     Enemy_StartFinishingBlow(play, &this->actor);
                 } else {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DAIOCTA_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_DAMAGE);
                 }
                 func_809BD5E0(this);
             }

--- a/src/overlays/actors/ovl_En_Bili/z_en_bili.c
+++ b/src/overlays/actors/ovl_En_Bili/z_en_bili.c
@@ -241,7 +241,7 @@ void EnBili_SetupStunned(EnBili* this) {
     this->actor.gravity = -1.0f;
     this->actor.speedXZ = 0.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 150, COLORFILTER_BUFFLAG_XLU, 80);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->collider.base.atFlags &= ~AT_ON;
     this->actionFunc = EnBili_Stunned;
 }
@@ -396,7 +396,7 @@ void EnBili_Climb(EnBili* this, PlayState* play) {
     f32 curFrame = this->skelAnime.curFrame;
 
     if (Animation_OnFrame(&this->skelAnime, 9.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BIRI_JUMP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BIRI_JUMP);
     }
 
     if (curFrame > 9.0f) {
@@ -519,7 +519,7 @@ void EnBili_Stunned(EnBili* this, PlayState* play) {
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
     }
 
     if (this->timer == 0) {
@@ -553,7 +553,7 @@ void EnBili_UpdateDamage(EnBili* this, PlayState* play) {
 
         if ((this->actor.colChkInfo.damageEffect != 0) || (this->actor.colChkInfo.damage != 0)) {
             if (Actor_ApplyDamage(&this->actor) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BIRI_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_BIRI_DEAD);
                 Enemy_StartFinishingBlow(play, &this->actor);
                 this->actor.flags &= ~ACTOR_FLAG_0;
             }
@@ -611,7 +611,7 @@ void EnBili_Update(Actor* thisx, PlayState* play2) {
             if ((this->actionFunc == EnBili_FloatIdle) || (this->actionFunc == EnBili_SetNewHomeHeight) ||
                 (this->actionFunc == EnBili_ApproachPlayer) || (this->actionFunc == EnBili_Recoil)) {
                 if (this->playFlySfx) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BIRI_FLY);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_BIRI_FLY);
                     this->playFlySfx = false;
                 } else {
                     this->playFlySfx = true;

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -135,7 +135,7 @@ void EnBom_Move(EnBom* this, PlayState* play) {
         if (ABS((s16)(this->actor.wallYaw - this->actor.world.rot.y)) > 0x4000) {
             this->actor.world.rot.y = ((this->actor.wallYaw - this->actor.world.rot.y) + this->actor.wallYaw) - 0x8000;
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BOMB_BOUND);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_BOMB_BOUND);
         Actor_MoveForward(&this->actor);
         this->actor.speedXZ *= 0.7f;
         this->actor.bgCheckFlags &= ~BGCHECKFLAG_WALL;
@@ -235,7 +235,7 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
     }
 
     if (this->timer == 67) {
-        Audio_PlayActorSfx2(thisx, NA_SE_PL_TAKE_OUT_SHIELD);
+        Actor_PlaySfx(thisx, NA_SE_PL_TAKE_OUT_SHIELD);
         Actor_SetScale(thisx, 0.01f);
     }
 
@@ -260,7 +260,7 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
                 EffectSsGSpk_SpawnFuse(play, thisx, &effPos, &effVelocity, &effAccel);
             }
 
-            Audio_PlayActorSfx2(thisx, NA_SE_IT_BOMB_IGNIT - SFX_FLAG);
+            Actor_PlaySfx(thisx, NA_SE_IT_BOMB_IGNIT - SFX_FLAG);
 
             effPos.y += 3.0f;
             func_8002829C(play, &effPos, &effVelocity, &dustAccel, &dustColor, &dustColor, 50, 5);
@@ -313,7 +313,7 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
                 EffectSsBlast_SpawnWhiteShockwave(play, &effPos, &effVelocity, &effAccel);
             }
 
-            Audio_PlayActorSfx2(thisx, NA_SE_IT_BOMB_EXPLOSION);
+            Actor_PlaySfx(thisx, NA_SE_IT_BOMB_EXPLOSION);
 
             play->envCtx.adjLight1Color[0] = play->envCtx.adjLight1Color[1] = play->envCtx.adjLight1Color[2] = 250;
 
@@ -349,7 +349,7 @@ void EnBom_Update(Actor* thisx, PlayState* play2) {
         }
         if (thisx->bgCheckFlags & BGCHECKFLAG_WATER_TOUCH) {
             thisx->bgCheckFlags &= ~BGCHECKFLAG_WATER_TOUCH;
-            Audio_PlayActorSfx2(thisx, NA_SE_EV_BOMB_DROP_WATER);
+            Actor_PlaySfx(thisx, NA_SE_EV_BOMB_DROP_WATER);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -366,7 +366,7 @@ void EnBomBowMan_SetupChooseShowPrize(EnBomBowlMan* this, PlayState* play) {
         pos.y = 40.0f;
         pos.z = 300.0f;
         EffectSsBomb2_SpawnLayered(play, &pos, &velocity, &accel, 50, 15);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_GOODS_APPEAR);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_GOODS_APPEAR);
         this->prizeRevealTimer = 10;
         this->actionFunc = EnBomBowMan_ChooseShowPrize;
     }

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -156,7 +156,7 @@ void EnBombf_GrowBomb(EnBombf* this, PlayState* play) {
                 func_8002F5C4(&this->actor, &bombFlower->actor, play);
                 this->timer = 180;
                 this->flowerBombScale = 0.0f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_PL_PULL_UP_ROCK);
+                Actor_PlaySfx(&this->actor, NA_SE_PL_PULL_UP_ROCK);
                 this->actor.flags &= ~ACTOR_FLAG_0;
             } else {
                 player->actor.child = NULL;
@@ -356,7 +356,7 @@ void EnBombf_Update(Actor* thisx, PlayState* play) {
                 if (1) {}
                 thisx->world.rot.y = ((thisx->wallYaw - thisx->world.rot.y) + thisx->wallYaw) - 0x8000;
             }
-            Audio_PlayActorSfx2(thisx, NA_SE_EV_BOMB_BOUND);
+            Actor_PlaySfx(thisx, NA_SE_EV_BOMB_BOUND);
             Actor_MoveForward(thisx);
             DREG(6) = 1;
             Actor_UpdateBgCheckInfo(play, thisx, 5.0f, 10.0f, 0.0f,
@@ -387,7 +387,7 @@ void EnBombf_Update(Actor* thisx, PlayState* play) {
                 if ((play->gameplayFrames % 2) == 0) {
                     EffectSsGSpk_SpawnFuse(play, thisx, &effPos, &effVelocity, &effAccel);
                 }
-                Audio_PlayActorSfx2(thisx, NA_SE_IT_BOMB_IGNIT - SFX_FLAG);
+                Actor_PlaySfx(thisx, NA_SE_IT_BOMB_IGNIT - SFX_FLAG);
 
                 effPos.y += 3.0f;
                 func_8002829C(play, &effPos, &effVelocity, &dustAccel, &dustColor, &dustColor, 50, 5);
@@ -424,7 +424,7 @@ void EnBombf_Update(Actor* thisx, PlayState* play) {
                     EffectSsBlast_SpawnWhiteShockwave(play, &effPos, &effVelocity, &effAccel);
                 }
 
-                Audio_PlayActorSfx2(thisx, NA_SE_IT_BOMB_EXPLOSION);
+                Actor_PlaySfx(thisx, NA_SE_IT_BOMB_EXPLOSION);
                 play->envCtx.adjLight1Color[0] = play->envCtx.adjLight1Color[1] = play->envCtx.adjLight1Color[2] = 250;
                 play->envCtx.adjAmbientColor[0] = play->envCtx.adjAmbientColor[1] = play->envCtx.adjAmbientColor[2] =
                     250;
@@ -460,7 +460,7 @@ void EnBombf_Update(Actor* thisx, PlayState* play) {
         }
         if (thisx->bgCheckFlags & BGCHECKFLAG_WATER_TOUCH) {
             thisx->bgCheckFlags &= ~BGCHECKFLAG_WATER_TOUCH;
-            Audio_PlayActorSfx2(thisx, NA_SE_EV_BOMB_DROP_WATER);
+            Actor_PlaySfx(thisx, NA_SE_EV_BOMB_DROP_WATER);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Brob/z_en_brob.c
+++ b/src/overlays/actors/ovl_En_Brob/z_en_brob.c
@@ -128,7 +128,7 @@ void func_809CAEF4(EnBrob* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &object_brob_Anim_000290, -5.0f);
     this->unk_1AE -= 125.0f;
     Actor_SetColorFilter(&this->dyna.actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 80);
-    Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->actionFunc = func_809CB2B8;
 }
 
@@ -181,7 +181,7 @@ void func_809CB114(EnBrob* this, PlayState* play) {
 void func_809CB218(EnBrob* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 6.0f) || Animation_OnFrame(&this->skelAnime, 15.0f)) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EN_BROB_WAVE);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_BROB_WAVE);
     }
     if (this->timer != 0) {
         this->timer--;

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -250,7 +250,7 @@ void EnBubble_Fly(EnBubble* this, PlayState* play) {
         this->velocityFromBounce.y = (this->bounceDirection.y * bounceSpeed);
         this->velocityFromBounce.z = (this->bounceDirection.z * bounceSpeed);
         this->sinkSpeed = 0.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_AWA_BOUND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_AWA_BOUND);
         this->graphicRotSpeed = 128.0f;
         this->graphicEccentricity = 0.48f;
     } else if ((this->actor.bgCheckFlags & BGCHECKFLAG_WATER) && sp54.y < 0.0f) {
@@ -269,7 +269,7 @@ void EnBubble_Fly(EnBubble* this, PlayState* play) {
         this->velocityFromBounce.y = (this->bounceDirection.y * bounceSpeed);
         this->velocityFromBounce.z = (this->bounceDirection.z * bounceSpeed);
         this->sinkSpeed = 0.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_AWA_BOUND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_AWA_BOUND);
         this->graphicRotSpeed = 128.0f;
         this->graphicEccentricity = 0.48f;
     }

--- a/src/overlays/actors/ovl_En_Bw/z_en_bw.c
+++ b/src/overlays/actors/ovl_En_Bw/z_en_bw.c
@@ -210,7 +210,7 @@ void func_809CEA24(EnBw* this, PlayState* play) {
         }
     } else {
         if (ABS(sp58) > ABS(sp5C)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLEWALK_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEWALK_WALK);
             this->unk_232 = 0;
         }
     }
@@ -400,7 +400,7 @@ void func_809CF72C(EnBw* this) {
     this->unk_222 = 20;
     this->unk_224 = 0xBB8;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLEWALK_AIM);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEWALK_AIM);
     EnBw_SetupAction(this, func_809CF7AC);
 }
 
@@ -431,7 +431,7 @@ void func_809CF8F0(EnBw* this) {
     this->unk_220 = 4;
     this->unk_222 = 1000;
     this->actor.velocity.y = 11.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.flags |= ACTOR_FLAG_24;
     EnBw_SetupAction(this, func_809CF984);
 }
@@ -450,7 +450,7 @@ void func_809CF984(EnBw* this, PlayState* play) {
         this->actor.speedXZ = -6.0f;
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
         if ((&player->actor == this->collider1.base.at) && !(this->collider1.base.atFlags & AT_BOUNCED)) {
-            Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+            Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
         }
     }
     SkelAnime_Update(&this->skelAnime);
@@ -464,7 +464,7 @@ void func_809CF984(EnBw* this, PlayState* play) {
         this->unk_222 = 3000;
         this->actor.flags &= ~ACTOR_FLAG_24;
         this->actor.speedXZ = 0.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         EnBw_SetupAction(this, func_809CE884);
     }
 }
@@ -478,7 +478,7 @@ void func_809CFBA8(EnBw* this) {
     this->actor.velocity.y = 11.0f;
     this->unk_25C = Rand_ZeroOne() * 0.25f + 1.0f;
     this->unk_224 = 0xBB8;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLEWALK_REVERSE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEWALK_REVERSE);
     EnBw_SetupAction(this, func_809CFC4C);
 }
 
@@ -495,7 +495,7 @@ void func_809CFC4C(EnBw* this, PlayState* play) {
         Math_SmoothStepToF(&this->unk_260, 0.075f, 1.0f, 0.005f, 0.0f);
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
             Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 30.0f, 11, 4.0f, 0, 0, false);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
         if (this->unk_224 != 0) {
             this->unk_224 -= 250;
@@ -534,7 +534,7 @@ void func_809CFF10(EnBw* this) {
     this->unk_221 = 3;
     this->actor.speedXZ = 0.0f;
     this->actor.velocity.y = 11.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLEWALK_REVERSE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEWALK_REVERSE);
     this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND;
     EnBw_SetupAction(this, func_809CFF98);
 }
@@ -547,7 +547,7 @@ void func_809CFF98(EnBw* this, PlayState* play) {
         Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 30.0f, 11, 4.0f, 0, 0, false);
         this->unk_222 = 0xBB8;
         this->unk_250 = 0.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         EnBw_SetupAction(this, func_809CE884);
     }
     if (this->color1.r < 247) {
@@ -575,7 +575,7 @@ void func_809D00F4(EnBw* this) {
     this->unk_222 = 40;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLEWALK_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEWALK_DEAD);
     EnBw_SetupAction(this, func_809D014C);
 }
 
@@ -642,7 +642,7 @@ void func_809D03CC(EnBw* this) {
         this->iceTimer = 32;
     }
     this->unk_23C = this->actor.colorFilterTimer;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     EnBw_SetupAction(this, func_809D0424);
 }
 
@@ -718,7 +718,7 @@ void func_809D0584(EnBw* this, PlayState* play) {
                     func_809D00F4(this);
                 }
             } else if ((this->unk_220 != 1) && (this->unk_220 != 6)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLEWALK_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEWALK_DAMAGE);
                 Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
                 if (this->unk_220 != 5) {
                     func_809D01CC(this);

--- a/src/overlays/actors/ovl_En_Bx/z_en_bx.c
+++ b/src/overlays/actors/ovl_En_Bx/z_en_bx.c
@@ -183,7 +183,7 @@ void EnBx_Update(Actor* thisx, PlayState* play) {
             }
         }
 
-        Audio_PlayActorSfx2(thisx, NA_SE_EN_BIRI_SPARK - SFX_FLAG);
+        Actor_PlaySfx(thisx, NA_SE_EN_BIRI_SPARK - SFX_FLAG);
     }
     thisx->focus.pos = thisx->world.pos;
     Collider_UpdateCylinder(thisx, &this->collider);

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -248,7 +248,7 @@ void EnClearTag_Init(Actor* thisx, PlayState* play) {
 
         func_8002D908(&this->actor);
         Collider_SetCylinder(play, &this->collider, &this->actor, &sLaserCylinderInit);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_SWORD_REFLECT_MG);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_SWORD_REFLECT_MG);
     } else { // Initialize the Arwing.
         this->actor.flags |= ACTOR_FLAG_0;
         this->actor.targetMode = 5;
@@ -353,7 +353,7 @@ void EnClearTag_Update(Actor* thisx, PlayState* play2) {
                     this->acceleration.y = Rand_CenteredFloat(15.0f);
                     this->acceleration.z = Rand_CenteredFloat(15.0f);
 
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_THUNDER_GND);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_THUNDER_GND);
                     this->actor.colChkInfo.health--;
                     if ((s8)this->actor.colChkInfo.health <= 0) {
                         this->state = CLEAR_TAG_STATE_CRASHING;
@@ -524,7 +524,7 @@ void EnClearTag_Update(Actor* thisx, PlayState* play2) {
                     this->actor.velocity.y -= 0.2f;
                     this->actor.shape.rot.x += 0x10;
 
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_BREATH - SFX_FLAG);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_BREATH - SFX_FLAG);
 
                     // Check if the Arwing has hit the ground or a wall.
                     if (this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_WALL)) {

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -305,7 +305,7 @@ void EnCow_Update(Actor* thisx, PlayState* play2) {
     Actor_UpdateBgCheckInfo(play, thisx, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     if (SkelAnime_Update(&this->skelAnime)) {
         if (this->skelAnime.animation == &gCowBodyChewAnim) {
-            Audio_PlayActorSfx2(thisx, NA_SE_EV_COW_CRY);
+            Actor_PlaySfx(thisx, NA_SE_EV_COW_CRY);
             Animation_Change(&this->skelAnime, &gCowBodyMoveHeadAnim, 1.0f, 0.0f,
                              Animation_GetLastFrame(&gCowBodyMoveHeadAnim), ANIMMODE_ONCE, 1.0f);
         } else {

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -154,7 +154,7 @@ void EnCrow_SetupDamaged(EnCrow* this, PlayState* play) {
     this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND;
     this->actor.shape.yOffset = 0.0f;
     this->actor.targetArrowOffset = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_KAICHO_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_KAICHO_DEAD);
 
     if (this->actor.colChkInfo.damageEffect == 3) { // Ice arrows
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 40);
@@ -197,7 +197,7 @@ void EnCrow_SetupTurnAway(EnCrow* this) {
     this->aimRotY = this->actor.yawTowardsPlayer + 0x8000;
     this->skelAnime.playSpeed = 2.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 5);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->actionFunc = EnCrow_TurnAway;
 }
 
@@ -248,7 +248,7 @@ void EnCrow_FlyIdle(EnCrow* this, PlayState* play) {
         } else {
             this->aimRotY -= 0x1000 + (0x1000 * Rand_ZeroOne());
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_KAICHO_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_KAICHO_CRY);
     }
 
     if (this->actor.yDistToWater > -40.0f) {
@@ -317,7 +317,7 @@ void EnCrow_DiveAttack(EnCrow* this, PlayState* play) {
         (player->stateFlags1 & PLAYER_STATE1_23) || (this->actor.yDistToWater > -40.0f)) {
         if (this->collider.base.atFlags & AT_HIT) {
             this->collider.base.atFlags &= ~AT_HIT;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_KAICHO_ATTACK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_KAICHO_ATTACK);
         }
 
         EnCrow_SetupFlyIdle(this);
@@ -470,7 +470,7 @@ void EnCrow_Update(Actor* thisx, PlayState* play) {
     Actor_SetFocus(&this->actor, height);
 
     if (this->actor.colChkInfo.health != 0 && Animation_OnFrame(&this->skelAnime, 3.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_KAICHO_FLUTTER);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_KAICHO_FLUTTER);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Cs/z_en_cs.c
+++ b/src/overlays/actors/ovl_En_Cs/z_en_cs.c
@@ -422,14 +422,14 @@ void EnCs_Update(Actor* thisx, PlayState* play) {
 
     if (this->currentAnimIndex == 0) {
         if (((s32)this->skelAnime.curFrame == 9) || ((s32)this->skelAnime.curFrame == 23)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHIBI_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHIBI_WALK);
         }
     } else if (this->currentAnimIndex == 1) {
         if (((s32)this->skelAnime.curFrame == 10) || ((s32)this->skelAnime.curFrame == 25)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHIBI_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHIBI_WALK);
         }
     } else if ((this->currentAnimIndex == 2) && ((s32)this->skelAnime.curFrame == 20)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHIBI_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_CHIBI_WALK);
     }
 
     Collider_UpdateCylinder(&this->actor, &this->collider);

--- a/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
+++ b/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
@@ -563,7 +563,7 @@ void EnDaiku_Update(Actor* thisx, PlayState* play) {
     if (this->currentAnimIndex == ENDAIKU_ANIM_RUN) {
         curFrame = this->skelAnime.curFrame;
         if (curFrame == 6 || curFrame == 15) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_WALK);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
+++ b/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
@@ -458,7 +458,7 @@ void EnDaikuKakariko_Update(Actor* thisx, PlayState* play) {
 
     if (this->currentAnimIndex == 3) {
         if (((s32)this->skelAnime.curFrame == 6) || ((s32)this->skelAnime.curFrame == 15)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_WALK);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
@@ -328,7 +328,7 @@ void EnDekubaba_SetupGrow(EnDekubaba* this) {
 
     this->collider.base.colType = COLTYPE_HIT6;
     this->collider.base.acFlags &= ~AC_HARD;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DUMMY482);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DUMMY482);
     this->actionFunc = EnDekubaba_Grow;
 }
 
@@ -623,9 +623,9 @@ void EnDekubaba_DecideLunge(EnDekubaba* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 12.0f)) {
         if (this->actor.params == DEKUBABA_BIG) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_MOUTH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_MOUTH);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_JR_MOUTH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_JR_MOUTH);
         }
     }
 
@@ -675,9 +675,9 @@ void EnDekubaba_Lunge(EnDekubaba* this, PlayState* play) {
     if (this->timer == 0) {
         if (Animation_OnFrame(&this->skelAnime, 1.0f)) {
             if (this->actor.params == DEKUBABA_BIG) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_ATTACK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_ATTACK);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_JR_ATTACK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_JR_ATTACK);
             }
         }
 
@@ -712,9 +712,9 @@ void EnDekubaba_Lunge(EnDekubaba* this, PlayState* play) {
 
         if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 12.0f)) {
             if (this->actor.params == DEKUBABA_BIG) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_MOUTH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_MOUTH);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_JR_MOUTH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_JR_MOUTH);
             }
         }
     }
@@ -816,7 +816,7 @@ void EnDekubaba_PullBack(EnDekubaba* this, PlayState* play) {
         this->timer++;
 
         if (this->timer == 10) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_SCRAPE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_SCRAPE);
         }
 
         if (this->timer >= 12) {
@@ -961,7 +961,7 @@ void EnDekubaba_PrunedSomersault(EnDekubaba* this, PlayState* play) {
         }
 
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
             this->timer = 1;
         }
     } else if (this->timer == 1) {
@@ -1094,16 +1094,16 @@ void EnDekubaba_UpdateDamage(EnDekubaba* this, PlayState* play) {
 
     if (this->actor.colChkInfo.health != 0) {
         if (this->timer == 2) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_DAMAGE);
         }
     } else {
         Enemy_StartFinishingBlow(play, &this->actor);
         if (this->actor.params == DEKUBABA_BIG) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_DEAD);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_DEAD);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_JR_DEAD);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_JR_DEAD);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
+++ b/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
@@ -171,7 +171,7 @@ void EnDekunuts_SetupStand(EnDekunuts* this) {
 
 void EnDekunuts_SetupBurrow(EnDekunuts* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gDekuNutsBurrowAnim, -5.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DOWN);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DOWN);
     this->actionFunc = EnDekunuts_Burrow;
 }
 
@@ -179,7 +179,7 @@ void EnDekunuts_SetupBeginRun(EnDekunuts* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gDekuNutsUnburrowAnim, -3.0f);
     this->collider.dim.height = 37;
     this->actor.colChkInfo.mass = 0x32;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DAMAGE);
     this->collider.base.acFlags &= ~AC_ON;
     this->actionFunc = EnDekunuts_BeginRun;
 }
@@ -212,8 +212,8 @@ void EnDekunuts_SetupBeDamaged(EnDekunuts* this) {
     this->collider.base.acFlags &= ~AC_ON;
     this->actionFunc = EnDekunuts_BeDamaged;
     this->actor.speedXZ = 10.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DAMAGE);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_CUTBODY);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_CUTBODY);
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA,
                          Animation_GetLastFrame(&gDekuNutsDamageAnim));
 }
@@ -223,7 +223,7 @@ void EnDekunuts_SetupBeStunned(EnDekunuts* this) {
     this->animFlagAndTimer = 5;
     this->actionFunc = EnDekunuts_BeStunned;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA,
                          Animation_GetLastFrame(&gDekuNutsDamageAnim) * this->animFlagAndTimer);
 }
@@ -232,7 +232,7 @@ void EnDekunuts_SetupDie(EnDekunuts* this) {
     Animation_PlayOnce(&this->skelAnime, &gDekuNutsDieAnim);
     this->actionFunc = EnDekunuts_Die;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DEAD);
 }
 
 void EnDekunuts_Wait(EnDekunuts* this, PlayState* play) {
@@ -247,7 +247,7 @@ void EnDekunuts_Wait(EnDekunuts* this, PlayState* play) {
     if (Animation_OnFrame(&this->skelAnime, 9.0f)) {
         this->collider.base.acFlags |= AC_ON;
     } else if (Animation_OnFrame(&this->skelAnime, 8.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
     }
 
     this->collider.dim.height = ((CLAMP(this->skelAnime.curFrame, 9.0f, 12.0f) - 9.0f) * 9.0f) + 5.0f;
@@ -310,7 +310,7 @@ void EnDekunuts_ThrowNut(EnDekunuts* this, PlayState* play) {
         spawnPos.z = this->actor.world.pos.z + (Math_CosS(this->actor.shape.rot.y) * 23.0f);
         if (Actor_Spawn(&play->actorCtx, play, ACTOR_EN_NUTSBALL, spawnPos.x, spawnPos.y, spawnPos.z,
                         this->actor.shape.rot.x, this->actor.shape.rot.y, this->actor.shape.rot.z, 0) != NULL) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_THROW);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_THROW);
         }
     } else if ((this->animFlagAndTimer > 1) && Animation_OnFrame(&this->skelAnime, 12.0f)) {
         Animation_MorphToPlayOnce(&this->skelAnime, &gDekuNutsSpitAnim, -3.0f);
@@ -352,7 +352,7 @@ void EnDekunuts_Run(EnDekunuts* this, PlayState* play) {
         this->animFlagAndTimer--;
     }
     if (this->playWalkSfx) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
         this->playWalkSfx = false;
     } else {
         this->playWalkSfx = true;
@@ -415,7 +415,7 @@ void EnDekunuts_BeStunned(EnDekunuts* this, PlayState* play) {
         if (this->animFlagAndTimer == 0) {
             EnDekunuts_SetupRun(this);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_FAINT);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_FAINT);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.c
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.c
@@ -211,7 +211,7 @@ void EnDh_Wait(EnDh* this, PlayState* play) {
                 this->actor.flags &= ~ACTOR_FLAG_7;
                 this->actionState++;
                 this->drawDirtWave++;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_HIDE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_HIDE);
                 FALLTHROUGH;
             case 1:
                 this->dirtWavePhase += 0x3A7;
@@ -252,10 +252,10 @@ void EnDh_Walk(EnDh* this, PlayState* play) {
     this->actor.world.rot.y = this->actor.shape.rot.y;
     SkelAnime_Update(&this->skelAnime);
     if (((s32)this->skelAnime.curFrame % 8) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_WALK);
     }
     if ((play->gameplayFrames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_LAUGH);
     }
     if (this->actor.xzDistToPlayer <= 100.0f) {
         this->actor.speedXZ = 0.0f;
@@ -311,7 +311,7 @@ void EnDh_Attack(EnDh* this, PlayState* play) {
         case 1:
             Animation_PlayOnce(&this->skelAnime, &object_dh_Anim_001A3C);
             this->actionState++;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_BITE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_BITE);
             FALLTHROUGH;
         case 0:
             Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 0x5DC, 0);
@@ -365,7 +365,7 @@ void EnDh_SetupBurrow(EnDh* this) {
     this->dirtWavePhase = 0;
     this->actionState = 0;
     this->actor.flags &= ~ACTOR_FLAG_0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_HIDE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_HIDE);
     EnDh_SetupAction(this, EnDh_Burrow);
 }
 
@@ -405,7 +405,7 @@ void EnDh_SetupDamage(EnDh* this) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
         this->actor.speedXZ = -1.0f;
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_DAMAGE);
     this->curAction = DH_DAMAGE;
     EnDh_SetupAction(this, EnDh_Damage);
 }
@@ -439,7 +439,7 @@ void EnDh_SetupDeath(EnDh* this) {
     this->actor.speedXZ = 0.0f;
     func_800F5B58();
     this->actor.params = ENDH_DEATH;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_DEAD);
     EnDh_SetupAction(this, EnDh_Death);
 }
 
@@ -461,7 +461,7 @@ void EnDh_Death(EnDh* this, PlayState* play) {
     } else {
         if (((s32)this->skelAnime.curFrame == 53) || ((s32)this->skelAnime.curFrame == 56) ||
             ((s32)this->skelAnime.curFrame == 61)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
         }
         if ((s32)this->skelAnime.curFrame == 61) {
             Actor_ChangeCategory(play, &play->actorCtx, &this->actor, ACTORCAT_PROP);

--- a/src/overlays/actors/ovl_En_Dha/z_en_dha.c
+++ b/src/overlays/actors/ovl_En_Dha/z_en_dha.c
@@ -221,7 +221,7 @@ void EnDha_Wait(EnDha* this, PlayState* play) {
                         this->actor.parent->params = ENDH_START_ATTACK_GRAB;
                     }
 
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_GRIP);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_GRIP);
                 }
             } else {
                 this->timer += 0x1194;
@@ -234,7 +234,7 @@ void EnDha_Wait(EnDha* this, PlayState* play) {
                 }
 
                 if (this->timer < -0x6E6B) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_GRIP);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_GRIP);
                 }
             }
 
@@ -249,7 +249,7 @@ void EnDha_Wait(EnDha* this, PlayState* play) {
             }
 
             if (this->actor.home.rot.z != 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_HAND_AT);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_HAND_AT);
                 this->actor.home.rot.z = 0;
             }
         }
@@ -326,7 +326,7 @@ void EnDha_SetupDeath(EnDha* this) {
 
     if (this->actor.parent != NULL) {
         if (this->actor.parent->params != ENDH_DEATH) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_HAND_DEAD);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_HAND_DEAD);
         }
         if (this->actor.parent->params <= ENDH_WAIT_UNDERGROUND) {
             this->actor.parent->params--;
@@ -389,7 +389,7 @@ void EnDha_UpdateHealth(EnDha* this, PlayState* play) {
                 this->actor.colChkInfo.health = 8;
                 Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos, 0xE0);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEADHAND_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_DAMAGE);
                 this->unk_1C0 = 9;
                 EnDha_SetupTakeDamage(this);
             }

--- a/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -437,7 +437,7 @@ void EnDns_SetupBurrow(EnDns* this, PlayState* play) {
     f32 frameCount = Animation_GetLastFrame(&gBusinessScrubAnim_4404);
 
     if (this->skelAnime.curFrame == frameCount) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_AKINDONUTS_HIDE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_AKINDONUTS_HIDE);
         this->actionFunc = EnDns_Burrow;
         this->standOnGround = 0;
         this->yInitPos = this->actor.world.pos.y;

--- a/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
+++ b/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
@@ -128,7 +128,7 @@ void EnDntJiji_SetupUp(EnDntJiji* this, PlayState* play) {
     this->endFrame = (f32)Animation_GetLastFrame(&gDntJijiUpAnim);
     Animation_Change(&this->skelAnime, &gDntJijiUpAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_ONCE, -10.0f);
     EffectSsHahen_SpawnBurst(play, &this->actor.world.pos, 6.0f, 0, 15, 5, 20, HAHEN_OBJECT_DEFAULT, 10, NULL);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
     this->actionFunc = EnDntJiji_Up;
 }
 
@@ -144,7 +144,7 @@ void EnDntJiji_SetupUnburrow(EnDntJiji* this, PlayState* play) {
     this->endFrame = (f32)Animation_GetLastFrame(&gDntJijiUnburrowAnim);
     Animation_Change(&this->skelAnime, &gDntJijiUnburrowAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_ONCE, -10.0f);
     EffectSsHahen_SpawnBurst(play, &this->actor.world.pos, 6.0f, 0, 15, 5, 20, HAHEN_OBJECT_DEFAULT, 10, NULL);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
     this->actionFunc = EnDntJiji_Unburrow;
 }
 
@@ -177,7 +177,7 @@ void EnDntJiji_Walk(EnDntJiji* this, PlayState* play) {
     Math_ApproachF(&this->actor.speedXZ, 1.0f, 0.2f, 0.4f);
     if (this->sfxTimer == 0) {
         this->sfxTimer = 5;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         this->actor.velocity.y = 9.0f;
@@ -201,8 +201,8 @@ void EnDntJiji_SetupBurrow(EnDntJiji* this, PlayState* play) {
     this->endFrame = (f32)Animation_GetLastFrame(&gDntJijiBurrowAnim);
     Animation_Change(&this->skelAnime, &gDntJijiBurrowAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_ONCE, -10.0f);
     EffectSsHahen_SpawnBurst(play, &this->actor.world.pos, 6.0f, 0, 15, 5, 20, HAHEN_OBJECT_DEFAULT, 10, NULL);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DOWN);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DOWN);
     this->actionFunc = EnDntJiji_Burrow;
 }
 
@@ -214,7 +214,7 @@ void EnDntJiji_SetupCower(EnDntJiji* this, PlayState* play) {
     this->endFrame = (f32)Animation_GetLastFrame(&gDntJijiCowerAnim);
     Animation_Change(&this->skelAnime, &gDntJijiCowerAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_ONCE, -10.0f);
     EffectSsHahen_SpawnBurst(play, &this->actor.world.pos, 3.0f, 0, 9, 3, 10, HAHEN_OBJECT_DEFAULT, 10, NULL);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
 
     if ((CUR_UPG_VALUE(UPG_DEKU_NUTS) == 1) || (CUR_UPG_VALUE(UPG_DEKU_NUTS) == 0)) {
         this->getItemId = GI_DEKU_NUT_UPGRADE_30;
@@ -349,7 +349,7 @@ void EnDntJiji_Return(EnDntJiji* this, PlayState* play) {
     }
     if (this->sfxTimer == 0) {
         this->sfxTimer = 3;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     if ((fabsf(dx) < 5.0f) && (fabsf(dz) < 5.0f)) {
         this->actor.world.pos.x = this->flowerPos.x;

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -274,7 +274,7 @@ void EnDntNomal_SetupTargetUnburrow(EnDntNomal* this, PlayState* play) {
         spawnPos = this->actor.world.pos;
         spawnPos.y = this->actor.world.pos.y + 50.0f;
         EffectSsHahen_SpawnBurst(play, &spawnPos, 4.0f, 0, 10, 3, 15, HAHEN_OBJECT_DEFAULT, 10, NULL);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
         this->actionFunc = EnDntNomal_TargetUnburrow;
     }
 }
@@ -306,7 +306,7 @@ void EnDntNomal_TargetWalk(EnDntNomal* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, RAD_TO_BINANG(Math_FAtan2F(dx, dz)), 0x32, 0xBB8, 0);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 6.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     if (this->actor.world.pos.z > -30.0f) {
         this->actor.speedXZ = 0.0f;
@@ -318,7 +318,7 @@ void EnDntNomal_TargetFacePlayer(EnDntNomal* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 3, 0x1388, 0);
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 6.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     if (fabsf(this->actor.shape.rot.y - this->actor.yawTowardsPlayer) < 30.0f) {
         this->actionFunc = EnDntNomal_SetupTargetTalk;
@@ -365,7 +365,7 @@ void EnDntNomal_TargetGivePrize(EnDntNomal* this, PlayState* play) {
             Actor_Kill(&this->actor);
         }
         this->spawnedItem = true;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_THROW);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_THROW);
     }
     if (frame >= this->endFrame) {
         this->endFrame = (f32)Animation_GetLastFrame(&gHintNutsRunAnim);
@@ -387,7 +387,7 @@ void EnDntNomal_TargetReturn(EnDntNomal* this, PlayState* play) {
         this->actor.speedXZ = 1.0f;
     }
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 6.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     this->actor.world.rot.y = this->actor.shape.rot.y;
     if (this->actor.world.pos.z < -172.0f) {
@@ -430,7 +430,7 @@ void EnDntNomal_SetupStageUp(EnDntNomal* this, PlayState* play) {
             this->rotDirection = -1;
         }
         EffectSsHahen_SpawnBurst(play, &this->actor.world.pos, 4.0f, 0, 10, 3, 15, HAHEN_OBJECT_DEFAULT, 10, NULL);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
         this->isSolid = true;
         this->actionFunc = EnDntNomal_StageUp;
     }
@@ -485,7 +485,7 @@ void EnDntNomal_SetupStageUnburrow(EnDntNomal* this, PlayState* play) {
         Animation_Change(&this->skelAnime, &gDntStageUnburrowAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_ONCE, -10.0f);
         this->isSolid = false;
         EffectSsHahen_SpawnBurst(play, &this->actor.world.pos, 4.0f, 0, 10, 3, 15, HAHEN_OBJECT_DEFAULT, 10, NULL);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
         this->actionFunc = EnDntNomal_StageUnburrow;
     }
 }
@@ -537,10 +537,10 @@ void EnDntNomal_StageCelebrate(EnDntNomal* this, PlayState* play) {
     if (this->timer5 == 0) {
         this->timer5 = 20;
         if ((this->type & 1) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DAMAGE);
         }
     } else if ((this->timer5 & 3) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         this->actor.velocity.y = 7.5f;
@@ -592,7 +592,7 @@ void EnDntNomal_SetupStageHide(EnDntNomal* this, PlayState* play) {
         this->endFrame = (f32)Animation_GetLastFrame(&gDntStageHideAnim);
         Animation_Change(&this->skelAnime, &gDntStageHideAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_ONCE, -10.0f);
         this->isSolid = false;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DOWN);
         this->actionFunc = EnDntNomal_StageHide;
     }
 }
@@ -605,7 +605,7 @@ void EnDntNomal_StageHide(EnDntNomal* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (frame >= this->endFrame) {
         EffectSsHahen_SpawnBurst(play, &this->actor.world.pos, 4.0f, 0, 10, 3, 15, HAHEN_OBJECT_DEFAULT, 10, NULL);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
         switch (this->action) {
             case DNT_ACTION_NONE:
                 this->actionFunc = EnDntNomal_SetupStageWait;
@@ -700,7 +700,7 @@ void EnDntNomal_StageAttack(EnDntNomal* this, PlayState* play) {
         if (nut != NULL) {
             nut->velocity.y = spawnOffset.y * 0.5f;
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_THROW);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_THROW);
         this->spawnedItem = true;
     }
 }
@@ -724,7 +724,7 @@ void EnDntNomal_StageReturn(EnDntNomal* this, PlayState* play) {
     if (this->timer5 == 0) {
         this->timer5 = 10;
     } else if (!(this->timer5 & 1)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     if ((fabsf(sp2C) < 7.0f) && (fabsf(sp28) < 7.0f)) {
         this->actor.world.pos.x = this->flowerPos.x;

--- a/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
+++ b/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
@@ -90,7 +90,7 @@ void EnDodojr_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnDodojr_DoSwallowedBombEffects(EnDodojr* this) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
+    Actor_PlaySfx(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 200, COLORFILTER_BUFFLAG_OPA, 8);
 }
 
@@ -145,7 +145,7 @@ s32 EnDodojr_UpdateBounces(EnDodojr* this, PlayState* play) {
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         this->dustPos = this->actor.world.pos;
         EnDodojr_SpawnLargeDust(this, play, 10);
         this->actor.velocity.y = 10.0f / (4 - this->counter);
@@ -213,7 +213,7 @@ void EnDodojr_SetupDespawn(EnDodojr* this) {
 
 void EnDodojr_SetupEatBomb(EnDodojr* this) {
     Animation_Change(&this->skelAnime, &object_dodojr_Anim_000724, 1.0f, 8.0f, 12.0f, ANIMMODE_ONCE, 0.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_EAT);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_EAT);
     this->actor.speedXZ = 0.0f;
     this->actor.velocity.x = 0.0f;
     this->actor.velocity.z = 0.0f;
@@ -314,7 +314,7 @@ s32 EnDodojr_IsPlayerWithinAttackRange(EnDodojr* this) {
 }
 
 void EnDodojr_SetupStandardDeathBounce(EnDodojr* this) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_DEAD);
     this->actor.flags &= ~ACTOR_FLAG_0;
     EnDodojr_SetupFlipBounce(this);
     this->actionFunc = EnDodojr_StandardDeathBounce;
@@ -357,7 +357,7 @@ s32 EnDodojr_CheckDamaged(EnDodojr* this, PlayState* play) {
 
         if ((this->actor.colChkInfo.damageEffect == 1) && (this->actionFunc != EnDodojr_Stunned) &&
             (this->actionFunc != EnDodojr_StunnedBounce)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
             this->stunTimer = 120;
             Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 200, COLORFILTER_BUFFLAG_OPA, 120);
             EnDodojr_SetupFlipBounce(this);
@@ -398,7 +398,7 @@ void EnDodojr_WaitUnderground(EnDodojr* this, PlayState* play) {
         if (!(dist >= 40.0f)) {
             Animation_Change(&this->skelAnime, &object_dodojr_Anim_000860, 1.8f, 0.0f, lastFrame, ANIMMODE_LOOP_INTERP,
                              -10.0f);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_UP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_UP);
             this->actor.world.pos.y -= 60.0f;
             this->actor.flags |= ACTOR_FLAG_0;
             this->actor.world.rot.x -= 0x4000;
@@ -433,7 +433,7 @@ void EnDodojr_CrawlTowardsTarget(EnDodojr* this, PlayState* play) {
     EnDodojr_SpawnSmallDust(this, play, &this->actor.world.pos);
 
     if (DECR(this->crawlSfxTimer) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_MOVE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_MOVE);
         this->crawlSfxTimer = 5;
     }
 
@@ -446,13 +446,13 @@ void EnDodojr_CrawlTowardsTarget(EnDodojr* this, PlayState* play) {
     EnDodojr_UpdateCrawl(this, play);
 
     if (EnDodojr_IsPlayerWithinAttackRange(this)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_CRY);
         EnDodojr_SetupJumpAttackBounce(this);
         this->actionFunc = EnDodojr_JumpAttackBounce;
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_DOWN);
         EnDodojr_SetupDespawn(this);
         this->actionFunc = EnDodojr_Despawn;
     }
@@ -466,7 +466,7 @@ void EnDodojr_EatBomb(EnDodojr* this, PlayState* play) {
         bomb->timer++;
         this->bomb->world.pos = this->headPos;
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_K_DRINK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_K_DRINK);
         Actor_Kill(this->bomb);
         this->timer = 24;
         this->counter = 0;

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -403,7 +403,7 @@ void EnDodongo_SetupStunned(EnDodongo* this) {
     if (this->damageEffect == 0xF) {
         this->iceTimer = 36;
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     EnDodongo_SetupAction(this, EnDodongo_Stunned);
 }
 
@@ -430,10 +430,10 @@ void EnDodongo_BreatheFire(EnDodongo* this, PlayState* play) {
     s16 fireFrame;
 
     if ((s32)this->skelAnime.curFrame == 24) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_J_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_CRY);
     }
     if ((29.0f <= this->skelAnime.curFrame) && (this->skelAnime.curFrame <= 43.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_J_FIRE - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_FIRE - SFX_FLAG);
         fireFrame = this->skelAnime.curFrame - 29.0f;
         pos = this->actor.world.pos;
         pos.y += 35.0f;
@@ -441,7 +441,7 @@ void EnDodongo_BreatheFire(EnDodongo* this, PlayState* play) {
         EnDodongo_ShiftVecRadial(this->actor.world.rot.y, 2.5f, &accel);
         EffectSsDFire_SpawnFixedScale(play, &pos, &velocity, &accel, 255 - (fireFrame * 10), fireFrame + 3);
     } else if ((2.0f <= this->skelAnime.curFrame) && (this->skelAnime.curFrame <= 20.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_J_BREATH - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_BREATH - SFX_FLAG);
     }
     if (SkelAnime_Update(&this->skelAnime)) {
         EnDodongo_SetupEndBreatheFire(this);
@@ -470,7 +470,7 @@ void EnDodongo_SwallowBomb(EnDodongo* this, PlayState* play) {
     }
 
     if ((s32)this->skelAnime.curFrame == 28) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_J_EAT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_EAT);
         if (this->actor.child != NULL) {
             Actor_Kill(this->actor.child);
             this->actor.child = NULL;
@@ -496,7 +496,7 @@ void EnDodongo_SwallowBomb(EnDodongo* this, PlayState* play) {
                     func_8002836C(play, &pos, &deathFireVel, &deathFireAccel, &this->bombSmokePrimColor,
                                   &this->bombSmokeEnvColor, 400, 10, 10);
                 }
-                Audio_PlayActorSfx2(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
+                Actor_PlaySfx(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
                 Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 120, COLORFILTER_BUFFLAG_OPA, 8);
             }
         }
@@ -549,13 +549,13 @@ void EnDodongo_Walk(EnDodongo* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if ((s32)this->skelAnime.curFrame < 21) {
         if (!this->rightFootStep) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_J_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_WALK);
             Actor_SpawnFloorDustRing(play, &this->actor, &this->leftFootPos, 10.0f, 3, 2.0f, 200, 15, false);
             this->rightFootStep = true;
         }
     } else {
         if (this->rightFootStep) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_J_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_WALK);
             Actor_SpawnFloorDustRing(play, &this->actor, &this->rightFootPos, 10.0f, 3, 2.0f, 200, 15, false);
             this->rightFootStep = false;
         }
@@ -593,7 +593,7 @@ void EnDodongo_Walk(EnDodongo* this, PlayState* play) {
 
 void EnDodongo_SetupSweepTail(EnDodongo* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gDodongoDamageAnim, -4.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_J_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_DAMAGE);
     this->actionState = DODONGO_SWEEP_TAIL;
     this->timer = 0;
     this->actor.speedXZ = 0.0f;
@@ -625,7 +625,7 @@ void EnDodongo_SweepTail(EnDodongo* this, PlayState* play) {
             } else {
                 animation = &gDodongoSweepTailRightAnim;
             }
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_J_TAIL);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_TAIL);
             Animation_PlayOnceSetSpeed(&this->skelAnime, animation, 2.0f);
             this->timer = 18;
             this->colliderBody.base.atFlags = this->sphElements[1].info.toucherFlags =
@@ -651,7 +651,7 @@ void EnDodongo_SweepTail(EnDodongo* this, PlayState* play) {
             Player* player = GET_PLAYER(play);
 
             if (this->colliderBody.base.at == &player->actor) {
-                Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+                Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
             }
         }
         CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderBody.base);
@@ -661,7 +661,7 @@ void EnDodongo_SweepTail(EnDodongo* this, PlayState* play) {
 void EnDodongo_SetupDeath(EnDodongo* this, PlayState* play) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gDodongoDieAnim, -8.0f);
     this->timer = 0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_J_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_DEAD);
     this->actionState = DODONGO_DEATH;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actor.speedXZ = 0.0f;
@@ -688,7 +688,7 @@ void EnDodongo_Death(EnDodongo* this, PlayState* play) {
             }
         }
     } else if ((s32)this->skelAnime.curFrame == 52) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
     }
     if (this->timer != 0) {
         this->timer--;
@@ -774,7 +774,7 @@ void EnDodongo_Update(Actor* thisx, PlayState* play) {
                                 UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2 | UPDBGCHECKINFO_FLAG_3 |
                                     UPDBGCHECKINFO_FLAG_4);
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
         }
     }
     CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderBody.base);

--- a/src/overlays/actors/ovl_En_Dog/z_en_dog.c
+++ b/src/overlays/actors/ovl_En_Dog/z_en_dog.c
@@ -92,7 +92,7 @@ void EnDog_PlayWalkSFX(EnDog* this) {
 
     if (this->skelAnime.animation == walk) {
         if ((this->skelAnime.curFrame == 1.0f) || (this->skelAnime.curFrame == 7.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHIBI_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHIBI_WALK);
         }
     }
 }
@@ -102,7 +102,7 @@ void EnDog_PlayRunSFX(EnDog* this) {
 
     if (this->skelAnime.animation == run) {
         if ((this->skelAnime.curFrame == 2.0f) || (this->skelAnime.curFrame == 4.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHIBI_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHIBI_WALK);
         }
     }
 }
@@ -112,7 +112,7 @@ void EnDog_PlayBarkSFX(EnDog* this) {
 
     if (this->skelAnime.animation == bark) {
         if ((this->skelAnime.curFrame == 13.0f) || (this->skelAnime.curFrame == 19.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_SMALL_DOG_BARK);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_SMALL_DOG_BARK);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Door/z_en_door.c
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.c
@@ -228,7 +228,7 @@ void EnDoor_Idle(EnDoor* this, PlayState* play) {
         if (this->lockTimer != 0) {
             gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex]--;
             Flags_SetSwitch(play, ENDOOR_GET_LOCKED_SWITCH_FLAG(&this->actor));
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHAIN_KEY_UNLOCK);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHAIN_KEY_UNLOCK);
         }
     } else if (!Player_InCsMode(play)) {
         if (fabsf(playerPosRelToDoor.y) < 20.0f && fabsf(playerPosRelToDoor.x) < 20.0f &&
@@ -301,11 +301,11 @@ void EnDoor_Open(EnDoor* this, PlayState* play) {
             this->actionFunc = EnDoor_Idle;
             this->playerIsOpening = false;
         } else if (Animation_OnFrame(&this->skelAnime, sDoorAnimOpenFrames[this->openAnim])) {
-            Audio_PlayActorSfx2(&this->actor,
-                                (play->sceneId == SCENE_SHADOW_TEMPLE || play->sceneId == SCENE_BOTTOM_OF_THE_WELL ||
-                                 play->sceneId == SCENE_FIRE_TEMPLE)
-                                    ? NA_SE_EV_IRON_DOOR_OPEN
-                                    : NA_SE_OC_DOOR_OPEN);
+            Actor_PlaySfx(&this->actor,
+                          (play->sceneId == SCENE_SHADOW_TEMPLE || play->sceneId == SCENE_BOTTOM_OF_THE_WELL ||
+                           play->sceneId == SCENE_FIRE_TEMPLE)
+                              ? NA_SE_EV_IRON_DOOR_OPEN
+                              : NA_SE_OC_DOOR_OPEN);
             if (this->skelAnime.playSpeed < 1.5f) {
                 numEffects = (s32)(Rand_ZeroOne() * 30.0f) + 50;
                 for (i = 0; i < numEffects; i++) {
@@ -313,11 +313,11 @@ void EnDoor_Open(EnDoor* this, PlayState* play) {
                 }
             }
         } else if (Animation_OnFrame(&this->skelAnime, sDoorAnimCloseFrames[this->openAnim])) {
-            Audio_PlayActorSfx2(&this->actor,
-                                (play->sceneId == SCENE_SHADOW_TEMPLE || play->sceneId == SCENE_BOTTOM_OF_THE_WELL ||
-                                 play->sceneId == SCENE_FIRE_TEMPLE)
-                                    ? NA_SE_EV_IRON_DOOR_CLOSE
-                                    : NA_SE_EV_DOOR_CLOSE);
+            Actor_PlaySfx(&this->actor,
+                          (play->sceneId == SCENE_SHADOW_TEMPLE || play->sceneId == SCENE_BOTTOM_OF_THE_WELL ||
+                           play->sceneId == SCENE_FIRE_TEMPLE)
+                              ? NA_SE_EV_IRON_DOOR_CLOSE
+                              : NA_SE_EV_DOOR_CLOSE);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -394,16 +394,16 @@ void func_809FE798(EnDu* this, PlayState* play) {
     if (DECR(this->unk_1E2) != 0) {
         switch (this->unk_1E2) {
             case 0x50:
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHAIN_KEY_UNLOCK_B);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_CHAIN_KEY_UNLOCK_B);
                 break;
             case 0x3C:
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_SLIDE_DOOR_OPEN);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_SLIDE_DOOR_OPEN);
                 break;
             case 0xF:
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_SLIDE_DOOR_CLOSE);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_SLIDE_DOOR_CLOSE);
                 break;
             case 5:
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_STONE_BOUND);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_STONE_BOUND);
                 break;
         }
         if (this->unk_1E2 >= 0x3D) {

--- a/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.c
+++ b/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.c
@@ -82,7 +82,7 @@ void EnDyExtra_Update(Actor* thisx, PlayState* play) {
     this->actor.scale.x = this->scale.x;
     this->actor.scale.y = this->scale.y;
     this->actor.scale.z = this->scale.z;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_PL_SPIRAL_HEAL_BEAM - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_PL_SPIRAL_HEAL_BEAM - SFX_FLAG);
     this->actionFunc(this, play);
     Actor_MoveForward(&this->actor);
 }

--- a/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
+++ b/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
@@ -235,7 +235,7 @@ void EnEiyer_SetupAmbush(EnEiyer* this, PlayState* play) {
     this->collider.base.acFlags &= ~AC_ON;
     this->actor.shape.shadowScale = 65.0f;
     this->actor.shape.yOffset = 600.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_JUMP);
     EffectSsGSplash_Spawn(play, &this->actor.world.pos, NULL, NULL, 1, 700);
     this->actionFunc = EnEiyer_Ambush;
 }
@@ -319,7 +319,7 @@ void EnEiyer_SetupStunned(EnEiyer* this) {
     this->collider.dim.height = sColCylInit.dim.height + 8;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 200, COLORFILTER_BUFFLAG_OPA, 80);
     this->collider.base.atFlags &= ~AT_ON;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->actionFunc = EnEiyer_Stunned;
 }
 
@@ -584,11 +584,11 @@ void EnEiyer_Stunned(EnEiyer* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
 
     if (Animation_OnFrame(&this->skelanime, 0.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EIER_FLUTTER);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_EIER_FLUTTER);
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
     }
 
     if (this->timer == 0) {
@@ -607,7 +607,7 @@ void EnEiyer_UpdateDamage(EnEiyer* this, PlayState* play) {
         if (this->actor.colChkInfo.damageEffect != 0 || this->actor.colChkInfo.damage != 0) {
             if (Actor_ApplyDamage(&this->actor) == 0) {
                 Enemy_StartFinishingBlow(play, &this->actor);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EIER_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_EIER_DEAD);
                 this->actor.flags &= ~ACTOR_FLAG_0;
             }
 
@@ -623,7 +623,7 @@ void EnEiyer_UpdateDamage(EnEiyer* this, PlayState* play) {
                     EnEiyer_SetupStunned(this);
                 }
             } else if (this->actor.colChkInfo.health != 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EIER_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_EIER_DAMAGE);
                 EnEiyer_SetupHurt(this);
             } else {
                 this->collider.dim.height = sColCylInit.dim.height;

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -728,7 +728,7 @@ void func_80A03610(EnElf* this, PlayState* play) {
 
     this->unk_2BC = Math_Atan2S(this->actor.velocity.z, this->actor.velocity.x);
     EnElf_SpawnSparkles(this, play, 32);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
 }
 
 void func_80A03814(EnElf* this, PlayState* play) {
@@ -763,7 +763,7 @@ void func_80A03814(EnElf* this, PlayState* play) {
     func_80A02E30(this, &player->bodyPartsPos[PLAYER_BODYPART_WAIST]);
     this->unk_2BC = Math_Atan2S(this->actor.velocity.z, this->actor.velocity.x);
     EnElf_SpawnSparkles(this, play, 32);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
 }
 
 void func_80A03990(EnElf* this, PlayState* play) {
@@ -788,7 +788,7 @@ void func_80A03990(EnElf* this, PlayState* play) {
     Actor_SetScale(&this->actor, (1.0f - (SQ(this->unk_2B4) * SQ(1.0f / 9.0f))) * 0.008f);
     this->unk_2BC = Math_Atan2S(this->actor.velocity.z, this->actor.velocity.x);
     EnElf_SpawnSparkles(this, play, 32);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
 }
 
 void func_80A03AB0(EnElf* this, PlayState* play) {
@@ -866,7 +866,7 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
             // play dash sound effect as Navi enters Links house in the intro
             if (1) {}
             if (play->csCtx.frames == 55) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_FAIRY_DASH);
             }
 
             // play dash sound effect in intervals as Navi is waking up Link in the intro
@@ -878,7 +878,7 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
                 } else {
                     if (this->actor.world.pos.y < prevPos.y) {
                         this->fairyFlags |= 0x40;
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                        Actor_PlaySfx(&this->actor, NA_SE_EV_FAIRY_DASH);
                     }
                 }
             }
@@ -961,7 +961,7 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
                             this->fairyFlags |= 2;
 
                             if (this->unk_2C7 == 0) {
-                                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                                Actor_PlaySfx(&this->actor, NA_SE_EV_FAIRY_DASH);
                             }
 
                             this->unk_2C0 = 0x64;
@@ -1009,7 +1009,7 @@ void func_80A04414(EnElf* this, PlayState* play) {
         this->unk_29C = 1.0f;
 
         if (this->unk_2C7 == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FAIRY_DASH);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FAIRY_DASH);
         }
 
     } else {
@@ -1045,7 +1045,7 @@ void func_80A04414(EnElf* this, PlayState* play) {
             }
 
             if (this->unk_2C7 == 0) {
-                Audio_PlayActorSfx2(&this->actor, sfxId);
+                Actor_PlaySfx(&this->actor, sfxId);
             }
 
             this->fairyFlags |= 1;
@@ -1104,7 +1104,7 @@ void func_80A0461C(EnElf* this, PlayState* play) {
                             temp = 0;
                         } else {
                             if (this->unk_2C7 == 0) {
-                                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_NAVY_VANISH);
+                                Actor_PlaySfx(&this->actor, NA_SE_EV_NAVY_VANISH);
                             }
                             temp = 7;
                         }
@@ -1148,7 +1148,7 @@ void func_80A0461C(EnElf* this, PlayState* play) {
                 if (!(player->stateFlags2 & PLAYER_STATE2_20)) {
                     temp = 7;
                     if (this->unk_2C7 == 0) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_NAVY_VANISH);
+                        Actor_PlaySfx(&this->actor, NA_SE_EV_NAVY_VANISH);
                     }
                 }
                 break;
@@ -1158,7 +1158,7 @@ void func_80A0461C(EnElf* this, PlayState* play) {
                     this->unk_2C0 = 42;
                     temp = 11;
                     if (this->unk_2C7 == 0) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FAIRY_DASH);
+                        Actor_PlaySfx(&this->actor, NA_SE_EV_FAIRY_DASH);
                     }
                 }
                 break;

--- a/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
+++ b/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
@@ -152,7 +152,7 @@ void EnEncount2_SpawnRocks(EnEncount2* this, PlayState* play) {
             spawnerState = ENCOUNT2_ACTIVE_DEATH_MOUNTAIN;
         }
 
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_VOLCANO - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_VOLCANO - SFX_FLAG);
     } else if ((this->actor.xzDistToPlayer < 700.0f) && (Flags_GetSwitch(play, 0x37) != 0)) {
         s16 sceneId = play->sceneId;
 

--- a/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
+++ b/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
@@ -338,7 +338,7 @@ void EnExRuppy_WaitToBlowUp(EnExRuppy* this, PlayState* play) {
         }
         EffectSsBomb2_SpawnLayered(play, &this->actor.world.pos, &velocity, &accel, explosionScale, explosionScaleStep);
         func_8002F71C(play, &this->actor, 2.0f, this->actor.yawTowardsPlayer, 0.0f);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
         Actor_Kill(&this->actor);
     }
 }

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -292,7 +292,7 @@ s32 EnFd_ColliderCheck(EnFd* this, PlayState* play) {
         }
         this->invincibilityTimer = 30;
         this->actor.flags &= ~ACTOR_FLAG_0;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLAME_DAMAGE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_DAMAGE);
         Enemy_StartFinishingBlow(play, &this->actor);
         return true;
     } else if (DECR(this->attackTimer) == 0 && this->collider.base.atFlags & AT_HIT) {
@@ -305,7 +305,7 @@ s32 EnFd_ColliderCheck(EnFd* this, PlayState* play) {
             return false;
         }
         this->attackTimer = 30;
-        Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+        Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
         func_8002F71C(play, &this->actor, this->actor.speedXZ + 2.0f, this->actor.yawTowardsPlayer, 6.0f);
     }
     return false;
@@ -479,7 +479,7 @@ void EnFd_Reappear(EnFd* this, PlayState* play) {
     this->actor.scale.y = 0.0f;
     this->fadeAlpha = 255.0f;
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENFD_ANIM_0);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLAME_LAUGH);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_LAUGH);
     this->actionFunc = EnFd_SpinAndGrow;
 }
 
@@ -622,7 +622,7 @@ void EnFd_Run(EnFd* this, PlayState* play) {
     this->actor.world.rot = this->actor.shape.rot;
     func_8002F974(&this->actor, NA_SE_EN_FLAME_RUN - SFX_FLAG);
     if (this->skelAnime.curFrame == 6.0f || this->skelAnime.curFrame == 13.0f || this->skelAnime.curFrame == 28.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLAME_KICK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_KICK);
     }
     Math_SmoothStepToF(&this->actor.speedXZ, 8.0f, 0.1f, 1.0f, 0.0f);
 }
@@ -665,7 +665,7 @@ void EnFd_Update(Actor* thisx, PlayState* play) {
         if (EnFd_SpawnCore(this, play)) {
             this->actor.flags &= ~ACTOR_FLAG_0;
             this->invincibilityTimer = 30;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLAME_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_DAMAGE);
             Enemy_StartFinishingBlow(play, &this->actor);
         } else {
             this->actor.flags &= ~ACTOR_FLAG_13;

--- a/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
+++ b/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
@@ -96,7 +96,7 @@ void EnFhgFire_Init(Actor* thisx, PlayState* play) {
 
     if (this->actor.params == FHGFIRE_LIGHTNING_STRIKE) {
         EnFhgFire_SetUpdate(this, EnFhgFire_LightningStrike);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_THUNDER);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_THUNDER);
     } else if (this->actor.params >= FHGFIRE_LIGHTNING_TRAIL) {
         EnFhgFire_SetUpdate(this, EnFhgFire_LightningTrail);
         this->actor.shape.rot = this->actor.world.rot;
@@ -105,7 +105,7 @@ void EnFhgFire_Init(Actor* thisx, PlayState* play) {
         this->actor.draw = NULL;
         EnFhgFire_SetUpdate(this, EnFhgFire_LightningShock);
         this->actor.speedXZ = 30.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_SPARK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_SPARK);
     } else if (this->actor.params == FHGFIRE_LIGHTNING_BURST) {
         EnFhgFire_SetUpdate(this, EnFhgFire_LightningBurst);
         this->fwork[FHGFIRE_ALPHA] = 255.0f;
@@ -132,8 +132,8 @@ void EnFhgFire_Init(Actor* thisx, PlayState* play) {
             this->actor.scale.z = 1.0f;
         } else {
             this->work[FHGFIRE_TIMER] = 76;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FANTOM_WARP_S);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FANTOM_WARP_S2);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FANTOM_WARP_S);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FANTOM_WARP_S2);
         }
     } else if (this->actor.params == FHGFIRE_ENERGY_BALL) {
         f32 dxL;
@@ -287,7 +287,7 @@ void EnFhgFire_LightningShock(EnFhgFire* this, PlayState* play) {
 
     if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~AT_HIT;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_HIT_THUNDER);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_HIT_THUNDER);
     }
 
     if (Rand_ZeroOne() < 0.5f) {
@@ -529,9 +529,9 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
                     }
                 } else if (sqrtf(SQ(dxL) + SQ(dyL) + SQ(dzL)) <= 25.0f) {
                     killMode = BALL_BURST;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_HIT_THUNDER);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_HIT_THUNDER);
                     if ((bossGnd->flyMode >= GND_FLY_VOLLEY) && (this->work[FHGFIRE_RETURN_COUNT] >= 2)) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_LAUGH);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_LAUGH);
                     }
                     func_8002F698(play, &this->actor, 3.0f, this->actor.world.rot.y, 0.0f, 3, 0x10);
                 }
@@ -581,7 +581,7 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
                     dxzL = sqrtf(SQ(dxL) + SQ(dzL));
                     this->actor.world.rot.x = RAD_TO_BINANG(Math_FAtan2F(dyL, dxzL));
                     this->work[FHGFIRE_FIRE_MODE] = FHGFIRE_LIGHT_GREEN;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_IT_SWORD_REFLECT_MG);
+                    Actor_PlaySfx(&this->actor, NA_SE_IT_SWORD_REFLECT_MG);
                     this->actor.speedXZ += 2.0f;
                 }
                 break;
@@ -619,7 +619,7 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
                 this->work[FHGFIRE_KILL_TIMER] = 30;
                 this->actor.draw = NULL;
                 if (killMode == BALL_FIZZLE) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_THUNDER_GND);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_THUNDER_GND);
                 }
                 return;
             } else {
@@ -634,7 +634,7 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
         if (this->actor.speedXZ > 20.0f) {
             this->actor.speedXZ = 20.0f;
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_FIRE - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_FIRE - SFX_FLAG);
         // "Why ah ah ah ah"
         osSyncPrintf("なぜだああああああああ      %d\n", this->work[FHGFIRE_VARIANCE_TIMER]);
     }
@@ -651,13 +651,13 @@ void EnFhgFire_PhantomWarp(EnFhgFire* this, PlayState* play) {
 
     if (this->actor.params == FHGFIRE_WARP_DEATH) {
         if (this->work[FHGFIRE_TIMER] > 70) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FANTOM_WARP_L - SFX_FLAG);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FANTOM_WARP_L2 - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FANTOM_WARP_L - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FANTOM_WARP_L2 - SFX_FLAG);
         }
 
         if (this->work[FHGFIRE_TIMER] == 70) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FANTOM_WARP_S);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FANTOM_WARP_S2);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FANTOM_WARP_S);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FANTOM_WARP_S2);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -190,7 +190,7 @@ void EnFireRock_Fall(EnFireRock* this, PlayState* play) {
             break;
         case FIRE_ROCK_BROKEN_PIECE1:
             if ((play->gameplayFrames & 3) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_ROCK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_ROCK);
             }
             break;
     }
@@ -258,7 +258,7 @@ void EnFireRock_SpawnMoreBrokenPieces(EnFireRock* this, PlayState* play) {
                 osSyncPrintf(VT_FGCOL(YELLOW) "☆☆☆☆☆ イッパイデッス ☆☆☆☆☆ \n" VT_RST);
             }
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_VALVAISA_ROCK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_VALVAISA_ROCK);
     }
     Actor_Kill(&this->actor);
 }
@@ -350,7 +350,7 @@ void EnFireRock_Update(Actor* thisx, PlayState* play) {
                 (this->type == FIRE_ROCK_BROKEN_PIECE1)) {
                 if (this->collider.base.atFlags & AT_BOUNCED) {
                     this->collider.base.atFlags &= ~AT_BOUNCED;
-                    Audio_PlayActorSfx2(thisx, NA_SE_EV_BRIDGE_OPEN_STOP);
+                    Actor_PlaySfx(thisx, NA_SE_EV_BRIDGE_OPEN_STOP);
                     thisx->velocity.y = 0.0f;
                     thisx->speedXZ = 0.0f;
                     this->actionFunc = EnFireRock_SpawnMoreBrokenPieces;

--- a/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
+++ b/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
@@ -212,7 +212,7 @@ void EnFirefly_SetupFall(EnFirefly* this) {
     this->timer = 40;
     this->actor.velocity.y = 0.0f;
     Animation_Change(&this->skelAnime, &gKeeseFlyAnim, 0.5f, 0.0f, 0.0f, ANIMMODE_LOOP_INTERP, -3.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FFLY_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_FFLY_DEAD);
     this->actor.flags |= ACTOR_FLAG_4;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 40);
     this->actionFunc = EnFirefly_Fall;
@@ -252,7 +252,7 @@ void EnFirefly_SetupStunned(EnFirefly* this) {
     this->auraType = KEESE_AURA_NONE;
     this->actor.velocity.y = 0.0f;
     this->skelAnime.playSpeed = 3.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->actionFunc = EnFirefly_Stunned;
 }
 
@@ -264,7 +264,7 @@ void EnFirefly_SetupFrozenFall(EnFirefly* this, PlayState* play) {
     this->auraType = KEESE_AURA_NONE;
     this->actor.speedXZ = 0.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 255);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FFLY_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_FFLY_DEAD);
 
     for (i = 0; i <= 7; i++) {
         iceParticlePos.x = (i & 1 ? 7.0f : -7.0f) + this->actor.world.pos.x;
@@ -668,7 +668,7 @@ void EnFirefly_Update(Actor* thisx, PlayState* play2) {
 
     if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~AT_HIT;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FFLY_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FFLY_ATTACK);
         if (this->onFire) {
             EnFirefly_Extinguish(this);
         }
@@ -706,7 +706,7 @@ void EnFirefly_Update(Actor* thisx, PlayState* play2) {
         CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
         this->actor.world.rot.y = this->actor.shape.rot.y;
         if (Animation_OnFrame(&this->skelAnime, 5.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FFLY_FLY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FFLY_FLY);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -426,7 +426,7 @@ void EnFish_Dropped_SetupFlopOnGround(EnFish* this) {
     this->unk_250 = UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2;
 
     if (playSfx && (this->actor.draw != NULL)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FISH_LEAP);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_FISH_LEAP);
     }
 }
 
@@ -591,7 +591,7 @@ void EnFish_Cutscene_FlopOnGround(EnFish* this, PlayState* play) {
 
         if (Rand_ZeroOne() < 0.1f) {
             D_80A17018 = (Rand_ZeroOne() * 3.0f) + 2.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FISH_LEAP);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FISH_LEAP);
         } else {
             D_80A17018 = 0.0f;
         }

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -255,7 +255,7 @@ void EnFloormas_SetupHover(EnFloormas* this, PlayState* play) {
     this->actor.gravity = 0.0f;
     EnFloormas_MakeInvulnerable(this);
     Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 15.0f, 6, 20.0f, 300, 100, true);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_ATTACK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_ATTACK);
     this->actionFunc = EnFloormas_Hover;
 }
 
@@ -416,9 +416,9 @@ void EnFloormas_SetupFreeze(EnFloormas* this) {
     } else {
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 80);
         if (this->actor.scale.x > 0.004f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
         }
     }
     this->actionTimer = 80;
@@ -432,7 +432,7 @@ void EnFloormas_Die(EnFloormas* this, PlayState* play) {
         EnFloormas_SetupSplit((EnFloormas*)this->actor.child);
         EnFloormas_SetupSplit((EnFloormas*)this->actor.parent);
         EnFloormas_SetupSplit(this);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SPLIT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SPLIT);
     } else {
         // Die
         Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos, 0x90);
@@ -480,7 +480,7 @@ void EnFloormas_BigWalk(EnFloormas* this, PlayState* play) {
     if (((animPastFrame || (Animation_OnFrame(&this->skelAnime, 12.0f))) ||
          (Animation_OnFrame(&this->skelAnime, 24.0f) != 0)) ||
         (Animation_OnFrame(&this->skelAnime, 36.0f) != 0)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_WALK);
     }
 
     if ((this->actor.xzDistToPlayer < 320.0f) && (Actor_IsFacingPlayer(&this->actor, 0x4000))) {
@@ -508,7 +508,7 @@ void EnFloormas_Run(EnFloormas* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 12.0f) ||
         Animation_OnFrame(&this->skelAnime, 24.0f) || Animation_OnFrame(&this->skelAnime, 36.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_WALK);
     }
 
     Math_ApproachS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 3, 0x71C);
@@ -533,9 +533,9 @@ void EnFloormas_Turn(EnFloormas* this, PlayState* play) {
     if (((this->skelAnime.playSpeed > 0.0f) && Animation_OnFrame(&this->skelAnime, 21.0f)) ||
         ((this->skelAnime.playSpeed < 0.0f) && Animation_OnFrame(&this->skelAnime, 6.0f))) {
         if (this->actor.scale.x > 0.004f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_WALK);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_WALK);
         }
     }
     // Needed to match
@@ -621,9 +621,9 @@ void EnFloormas_Land(EnFloormas* this, PlayState* play) {
 
         if (this->actor.velocity.y < -4.0f) {
             if (this->actor.scale.x > 0.004f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_LAND);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_LAND);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
             }
         }
     }
@@ -671,7 +671,7 @@ void EnFloormas_Split(EnFloormas* this, PlayState* play) {
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
     }
 }
 
@@ -680,7 +680,7 @@ void EnFloormas_SmWalk(EnFloormas* this, PlayState* play) {
     DECR(this->smActionTimer);
 
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 18.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_WALK);
     }
 
     if (this->smActionTimer == 0) {
@@ -699,7 +699,7 @@ void EnFloormas_SmDecideAction(EnFloormas* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 18.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_WALK);
     }
     isAgainstWall = this->actor.bgCheckFlags & BGCHECKFLAG_WALL;
     if (isAgainstWall) {
@@ -750,7 +750,7 @@ void EnFloormas_JumpAtLink(EnFloormas* this, PlayState* play) {
     } else if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
         this->actionTimer = 0x32;
         this->actor.speedXZ = 0.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
         EnFloormas_SetupLand(this);
     } else if ((this->actor.yDistToPlayer < -10.0f) && (this->collider.base.ocFlags1 & OC1_HIT) &&
                (&player->actor == this->collider.base.oc)) {
@@ -812,15 +812,15 @@ void EnFloormas_GrabLink(EnFloormas* this, PlayState* play) {
         // Damage link every 20 frames
         if ((this->actionTarget % 20) == 0) {
             if (!LINK_IS_ADULT) {
-                func_8002F7DC(&player->actor, NA_SE_VO_LI_DAMAGE_S_KID);
+                Player_PlaySfx(player, NA_SE_VO_LI_DAMAGE_S_KID);
             } else {
-                func_8002F7DC(&player->actor, NA_SE_VO_LI_DAMAGE_S);
+                Player_PlaySfx(player, NA_SE_VO_LI_DAMAGE_S);
             }
             play->damagePlayer(play, -8);
         }
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_STICK - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_STICK - SFX_FLAG);
 }
 
 void EnFloormas_SmSlaveJumpAtMaster(EnFloormas* this, PlayState* play) {
@@ -850,7 +850,7 @@ void EnFloormas_SmSlaveJumpAtMaster(EnFloormas* this, PlayState* play) {
         this->collider.base.ocFlags1 |= OC1_ON;
     } else if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
         this->actor.speedXZ = 0.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
         EnFloormas_SetupLand(this);
     }
 
@@ -904,7 +904,7 @@ void EnFloormas_Merge(EnFloormas* this, PlayState* play) {
     this->actor.scale.y = this->actor.scale.z = curScale;
 
     if (((prevScale == 0.007f) || (prevScale == 0.004f)) && (prevScale != this->actor.scale.x)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_EXPAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_EXPAND);
     }
 
     this->collider.dim.radius = (sCylinderInit.dim.radius * 100.0f) * this->actor.scale.x;
@@ -945,9 +945,9 @@ void EnFloormas_TakeDamage(EnFloormas* this, PlayState* play) {
 
     if (Animation_OnFrame(&this->skelAnime, 13.0f)) {
         if (this->actor.scale.x > 0.004f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
     }
     Math_StepToF(&this->actor.speedXZ, 0.0f, 0.2f);
@@ -992,14 +992,14 @@ void EnFloormas_ColliderCheck(EnFloormas* this, PlayState* play) {
                 }
                 if (Actor_ApplyDamage(&this->actor) == 0) {
                     if (isSmall) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLOORMASTER_SM_DEAD);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_DEAD);
                     } else {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_DEAD);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_DEAD);
                     }
                     Enemy_StartFinishingBlow(play, &this->actor);
                     this->actor.flags &= ~ACTOR_FLAG_0;
                 } else if (this->actor.colChkInfo.damage != 0) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_DAMAGE);
                 }
 
                 if ((this->actor.colChkInfo.damageEffect == 4) || (this->actor.colChkInfo.damageEffect == 1)) {

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -353,9 +353,9 @@ void EnFr_DivingIntoWater(EnFr* this, PlayState* play) {
         EffectSsGSplash_Spawn(play, &vec, NULL, NULL, 1, 1);
 
         if (this->isBelowWaterSurfaceCurrent == false) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_DIVE_INTO_WATER_L);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_DIVE_INTO_WATER_L);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BOMB_DROP_WATER);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_BOMB_DROP_WATER);
         }
     }
 }
@@ -479,7 +479,7 @@ void EnFr_JumpingUp(EnFr* this, PlayState* play) {
         this->actor.velocity.y = 25.0f;
         if (this->isJumpingToFrogSong) {
             this->isJumpingToFrogSong = false;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_EAT);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_EAT);
         }
     }
 
@@ -741,7 +741,7 @@ void EnFr_ChildSong(EnFr* this, PlayState* play) {
             if (frog->actionFunc == EnFr_ChooseJumpFromLogSpot) {
                 frog->isJumpingUp = true;
                 frog->isActive = true;
-                Audio_PlayActorSfx2(&frog->actor, NA_SE_EV_FROG_GROW_UP);
+                Actor_PlaySfx(&frog->actor, NA_SE_EV_FROG_GROW_UP);
                 this->actionFunc = EnFr_ChildSongFirstTime;
             } else {
                 this->jumpCounter = 48;
@@ -1008,7 +1008,7 @@ void EnFr_Deactivate(EnFr* this, PlayState* play) {
     }
 
     play->msgCtx.ocarinaMode = OCARINA_MODE_04;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FROG_CRY_0);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_FROG_CRY_0);
     if (this->reward == GI_NONE) {
         this->actionFunc = EnFr_Idle;
     } else {

--- a/src/overlays/actors/ovl_En_Fw/z_en_fw.c
+++ b/src/overlays/actors/ovl_En_Fw/z_en_fw.c
@@ -83,7 +83,7 @@ s32 EnFw_DoBounce(EnFw* this, s32 totalBounces, f32 yVelocity) {
         return false;
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
     this->bounceCnt--;
     if (this->bounceCnt <= 0) {
         if (this->bounceCnt == 0) {
@@ -233,10 +233,10 @@ void EnFw_Run(EnFw* this, PlayState* play) {
             if (!this->lastDmgHook) {
                 this->actor.velocity.y = 6.0f;
             }
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLAME_MAN_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_MAN_DAMAGE);
             this->damageTimer = 20;
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLAME_MAN_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_MAN_DAMAGE);
             this->explosionTimer = 6;
         }
         this->actor.speedXZ = 0.0f;
@@ -302,14 +302,14 @@ void EnFw_Run(EnFw* this, PlayState* play) {
         this->actor.world.rot = this->actor.shape.rot;
 
         if (this->slideTimer == 0 && EnFw_PlayerInRange(this, play)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLAME_MAN_SURP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_MAN_SURP);
             this->slideSfxTimer = 8;
             this->slideTimer = 8;
         }
 
         if (this->slideTimer != 0) {
             if (DECR(this->slideSfxTimer) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLAME_MAN_SLIDE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_MAN_SLIDE);
                 this->slideSfxTimer = 4;
             }
             Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.1f, 1.0f, 0.0f);
@@ -324,7 +324,7 @@ void EnFw_Run(EnFw* this, PlayState* play) {
             Math_SmoothStepToF(&this->actor.speedXZ, 6.0f, 0.1f, 1.0f, 0.0f);
             curFrame = this->skelAnime.curFrame;
             if (curFrame == 1 || curFrame == 4) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FLAME_MAN_RUN);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_MAN_RUN);
                 EnFw_SpawnDust(this, 8, 0.16f, 0.1f, 1, 0.0f, 20.0f, 0.0f);
             }
         }
@@ -341,7 +341,7 @@ void EnFw_TurnToParentInitPos(EnFw* this, PlayState* play) {
         this->actor.world.rot = this->actor.shape.rot;
         this->actor.velocity.y = 14.0f;
         this->actor.home.pos = this->actor.world.pos;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENFW_ANIM_1);
         this->actionFunc = EnFw_JumpToParentInitPos;
     }

--- a/src/overlays/actors/ovl_En_Fz/z_en_fz.c
+++ b/src/overlays/actors/ovl_En_Fz/z_en_fz.c
@@ -346,15 +346,15 @@ void EnFz_ApplyDamage(EnFz* this, PlayState* play) {
                     Actor_ApplyDamage(&this->actor);
                     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_XLU, 8);
                     if (this->actor.colChkInfo.health != 0) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FREEZAD_DAMAGE);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_FREEZAD_DAMAGE);
                         vec.x = this->actor.world.pos.x;
                         vec.y = this->actor.world.pos.y;
                         vec.z = this->actor.world.pos.z;
                         EnFz_Damaged(this, play, &vec, 10, 0.0f);
                         this->unusedCounter++;
                     } else {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FREEZAD_DEAD);
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_ICE_BROKEN);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_FREEZAD_DEAD);
+                        Actor_PlaySfx(&this->actor, NA_SE_EV_ICE_BROKEN);
                         vec.x = this->actor.world.pos.x;
                         vec.y = this->actor.world.pos.y;
                         vec.z = this->actor.world.pos.z;
@@ -367,10 +367,10 @@ void EnFz_ApplyDamage(EnFz* this, PlayState* play) {
                     Actor_ApplyDamage(&this->actor);
                     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_XLU, 8);
                     if (this->actor.colChkInfo.health == 0) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FREEZAD_DEAD);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_FREEZAD_DEAD);
                         EnFz_SetupMelt(this);
                     } else {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FREEZAD_DAMAGE);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_FREEZAD_DAMAGE);
                     }
                     break;
 

--- a/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -264,7 +264,7 @@ s32 func_80A2F760(EnGb* this) {
 void func_80A2F7C0(EnGb* this) {
     Animation_Change(&this->skelAnime, &gPoeSellerSwingStickAnim, 1.0f, 0.0f,
                      Animation_GetLastFrame(&gPoeSellerSwingStickAnim), ANIMMODE_ONCE, 0.0f);
-    Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_NALE_MAGIC);
+    Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_NALE_MAGIC);
     this->actionFunc = func_80A2FC70;
 }
 
@@ -389,7 +389,7 @@ void func_80A2FC70(EnGb* this, PlayState* play) {
         this->cagedSouls[0].unk_3 = 1;
         if (this->actionFunc) {}
         this->actionTimer = (s16)Rand_ZeroFloat(600.0f) + 600;
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_WOOD_HIT);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_WOOD_HIT);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -333,7 +333,7 @@ void EnGe1_Open_GTGGuard(EnGe1* this, PlayState* play) {
         this->cutsceneTimer = 50;
         Message_CloseTextbox(play);
     } else if ((this->skelAnime.curFrame == 15.0f) || (this->skelAnime.curFrame == 19.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_HAND_CLAP);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_HAND_CLAP);
     }
 }
 
@@ -426,7 +426,7 @@ void EnGe1_OpenGate_GateOp(EnGe1* this, PlayState* play) {
         this->cutsceneTimer = 50;
         Message_CloseTextbox(play);
     } else if ((this->skelAnime.curFrame == 15.0f) || (this->skelAnime.curFrame == 19.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_HAND_CLAP);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_HAND_CLAP);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -567,7 +567,7 @@ void EnGe2_Update(Actor* thisx, PlayState* play) {
         this->timer = 100;
         this->stateFlags |= GE2_STATE_KO;
         this->actor.speedXZ = 0.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_SK_CRASH);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_SK_CRASH);
     } else {
         this->actionFunc(this, play);
 
@@ -613,7 +613,7 @@ void EnGe2_UpdateStunned(Actor* thisx, PlayState* play2) {
         this->timer = 100;
         this->stateFlags |= GE2_STATE_KO;
         this->actor.speedXZ = 0.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_SK_CRASH);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_SK_CRASH);
     }
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
 

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -363,7 +363,7 @@ void EnGeldB_Wait(EnGeldB* this, PlayState* play) {
         func_800F5ACC(NA_BGM_MINI_BOSS);
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
         this->skelAnime.playSpeed = 1.0f;
         this->actor.world.pos.y = this->actor.floorHeight;
         this->actor.flags |= ACTOR_FLAG_0;
@@ -391,7 +391,7 @@ void EnGeldB_SetupFlee(EnGeldB* this) {
 
 void EnGeldB_Flee(EnGeldB* this, PlayState* play) {
     if (this->skelAnime.curFrame == 10.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     }
     if (this->skelAnime.curFrame == 2.0f) {
         this->actor.gravity = 0.0f;
@@ -465,7 +465,7 @@ void EnGeldB_Ready(EnGeldB* this, PlayState* play) {
                 EnGeldB_SetupPivot(this);
             }
             if ((play->gameplayFrames & 0x5F) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
             }
         }
     }
@@ -543,13 +543,13 @@ void EnGeldB_Advance(EnGeldB* this, PlayState* play) {
                 }
             }
             if ((play->gameplayFrames & 0x5F) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
             }
             if (prevFrame != (s32)this->skelAnime.curFrame) {
                 s32 afterPrevFrame = absPlaySpeed + prevFrame;
 
                 if (((beforeCurFrame < 0) && (afterPrevFrame > 0)) || ((beforeCurFrame < 4) && (afterPrevFrame > 4))) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MUSI_LAND);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_MUSI_LAND);
                 }
             }
         }
@@ -565,7 +565,7 @@ void EnGeldB_SetupRollForward(EnGeldB* this) {
     this->action = GELDB_ROLL_FORWARD;
     this->actor.world.rot.y = this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
     this->actor.speedXZ = 10.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     EnGeldB_SetupAction(this, EnGeldB_RollForward);
 }
 
@@ -590,7 +590,7 @@ void EnGeldB_RollForward(EnGeldB* this, PlayState* play) {
         }
     }
     if ((play->gameplayFrames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
     }
 }
 
@@ -626,7 +626,7 @@ void EnGeldB_Pivot(EnGeldB* this, PlayState* play) {
             }
         }
         if ((play->gameplayFrames & 0x5F) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
         }
     }
 }
@@ -715,11 +715,11 @@ void EnGeldB_Circle(EnGeldB* this, PlayState* play) {
 
         if ((prevFrame != (s32)this->skelAnime.curFrame) &&
             (((beforeCurFrame < 0) && (afterPrevFrame > 0)) || ((beforeCurFrame < 5) && (afterPrevFrame > 5)))) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MUSI_LAND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MUSI_LAND);
         }
 
         if ((play->gameplayFrames & 0x5F) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
         }
         if ((Math_CosS(angleBehindLink - this->actor.shape.rot.y) < -0.85f) &&
             !Actor_OtherIsTargeted(play, &this->actor) && (this->actor.xzDistToPlayer <= 45.0f)) {
@@ -811,11 +811,11 @@ void EnGeldB_SpinDodge(EnGeldB* this, PlayState* play) {
 
     if ((prevFrame != (s32)this->skelAnime.curFrame) &&
         (((beforeCurFrame < 0) && (afterPrevFrame > 0)) || ((beforeCurFrame < 5) && (afterPrevFrame > 5)))) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MUSI_LAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MUSI_LAND);
     }
 
     if ((play->gameplayFrames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
     }
     this->timer--;
     if (this->timer == 0) {
@@ -856,7 +856,7 @@ void EnGeldB_Slash(EnGeldB* this, PlayState* play) {
 
     this->actor.speedXZ = 0.0f;
     if ((s32)this->skelAnime.curFrame == 1) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_ATTACK);
         this->swordState = 1;
     } else if ((s32)this->skelAnime.curFrame == 6) {
         this->swordState = -1;
@@ -923,7 +923,7 @@ void EnGeldB_SpinAttack(EnGeldB* this, PlayState* play) {
                 Message_StartTextbox(play, 0x6003, &this->actor);
                 this->timer = 30;
                 this->actor.speedXZ = 0.0f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_YOUNG_LAUGH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_YOUNG_LAUGH);
                 return;
             }
         }
@@ -935,7 +935,7 @@ void EnGeldB_SpinAttack(EnGeldB* this, PlayState* play) {
         Actor_SpawnFloorDustRing(play, &this->actor, &this->rightFootPos, 3.0f, 2, 2.0f, 0, 0, false);
         this->swordState = 1;
         this->actor.speedXZ = 10.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_ATTACK);
     } else if ((s32)this->skelAnime.curFrame == 21) {
         this->actor.speedXZ = 0.0f;
     } else if ((s32)this->skelAnime.curFrame == 24) {
@@ -981,7 +981,7 @@ void EnGeldB_SetupRollBack(EnGeldB* this) {
     this->invisible = true;
     this->action = GELDB_ROLL_BACK;
     this->actor.speedXZ = -8.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.shape.rot.y = this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     EnGeldB_SetupAction(this, EnGeldB_RollBack);
 }
@@ -998,7 +998,7 @@ void EnGeldB_RollBack(EnGeldB* this, PlayState* play) {
         }
     }
     if ((play->state.frames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
     }
 }
 
@@ -1012,7 +1012,7 @@ void EnGeldB_SetupStunned(EnGeldB* this) {
     if (this->damageEffect == GELDB_DMG_FREEZE) {
         this->iceTimer = 36;
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->action = GELDB_STUNNED;
     EnGeldB_SetupAction(this, EnGeldB_Stunned);
 }
@@ -1046,7 +1046,7 @@ void EnGeldB_SetupDamaged(EnGeldB* this) {
     }
     this->lookTimer = 0;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_DAMAGE);
     this->action = GELDB_DAMAGED;
     EnGeldB_SetupAction(this, EnGeldB_Damaged);
 }
@@ -1090,7 +1090,7 @@ void EnGeldB_SetupJump(EnGeldB* this) {
     this->action = GELDB_JUMP;
     this->actor.speedXZ = 6.5f;
     this->actor.velocity.y = 15.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnGeldB_SetupAction(this, EnGeldB_Jump);
 }
@@ -1304,10 +1304,10 @@ void EnGeldB_Sidestep(EnGeldB* this, PlayState* play) {
         if ((prevFrame != (s32)this->skelAnime.curFrame) &&
             (((beforeCurFrame < 0) && (((s32)absPlaySpeed + prevFrame) > 0)) ||
              ((beforeCurFrame < 5) && (((s32)absPlaySpeed + prevFrame) > 5)))) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MUSI_LAND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MUSI_LAND);
         }
         if ((play->gameplayFrames & 0x5F) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_BREATH);
         }
     }
 }
@@ -1323,7 +1323,7 @@ void EnGeldB_SetupDefeated(EnGeldB* this) {
     }
     this->action = GELDB_DEFEAT;
     this->actor.flags &= ~ACTOR_FLAG_0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GERUDOFT_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_DEAD);
     EnGeldB_SetupAction(this, EnGeldB_Defeated);
 }
 
@@ -1338,7 +1338,7 @@ void EnGeldB_Defeated(EnGeldB* this, PlayState* play) {
     if (SkelAnime_Update(&this->skelAnime)) {
         EnGeldB_SetupFlee(this);
     } else if ((s32)this->skelAnime.curFrame == 10) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
         func_800F5B58();
     }
 }

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -910,7 +910,7 @@ s32 func_80A44AB0(EnGo2* this, PlayState* play) {
 
                 play->damagePlayer(play, -4);
                 func_8002F71C(play, &this->actor, arg2, this->actor.yawTowardsPlayer, 6.0f);
-                Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+                Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
                 this->collider.base.ocFlags1 &= ~OC1_TYPE_PLAYER;
             }
         }
@@ -998,15 +998,14 @@ s32 EnGo2_IsRollingOnGround(EnGo2* this, s16 arg1, f32 arg2, s16 arg3) {
         } else {
             this->actor.world.pos.y =
                 (this->unk_590 & 1) ? this->actor.world.pos.y + 1.5f : this->actor.world.pos.y - 1.5f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BIGBALL_ROLL - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_BIGBALL_ROLL - SFX_FLAG);
             return true;
         }
     }
 
     if (this->unk_59C >= 2) {
-        Audio_PlayActorSfx2(&this->actor, (this->actor.params & 0x1F) == GORON_CITY_ROLLING_BIG
-                                              ? NA_SE_EN_GOLON_LAND_BIG
-                                              : NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, (this->actor.params & 0x1F) == GORON_CITY_ROLLING_BIG ? NA_SE_EN_GOLON_LAND_BIG
+                                                                                          : NA_SE_EN_DODO_M_GND);
     }
 
     this->unk_59C--;
@@ -1275,17 +1274,17 @@ void EnGo2_SitDownAnimation(EnGo2* this) {
     if ((this->skelAnime.playSpeed != 0.0f) && (this->skelAnime.animation == &gGoronAnim_004930)) {
         if (this->skelAnime.playSpeed > 0.0f && this->skelAnime.curFrame == 14.0f) {
             if ((this->actor.params & 0x1F) != GORON_DMT_BIGGORON) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOLON_SIT_DOWN);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_SIT_DOWN);
             } else {
                 func_800F4524(&gSfxDefaultPos, NA_SE_EN_GOLON_SIT_DOWN, 60);
             }
         }
         if (this->skelAnime.playSpeed < 0.0f) {
             if (this->skelAnime.curFrame == 1.0f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
             }
             if (this->skelAnime.curFrame == 40.0f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOLON_SIT_DOWN);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_SIT_DOWN);
             }
         }
     }
@@ -1318,7 +1317,7 @@ void EnGo2_RollingAnimation(EnGo2* this, PlayState* play) {
 void EnGo2_WakeUp(EnGo2* this, PlayState* play) {
     if (this->skelAnime.playSpeed == 0.0f) {
         if ((this->actor.params & 0x1F) != GORON_DMT_BIGGORON) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOLON_WAKE_UP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_WAKE_UP);
         } else {
             func_800F4524(&gSfxDefaultPos, NA_SE_EN_GOLON_WAKE_UP, 60);
         }
@@ -1468,7 +1467,7 @@ void EnGo2_GoronLinkAnimation(EnGo2* this, PlayState* play) {
 
         if (this->skelAnime.animation == &gGoronAnim_000750) {
             if (this->skelAnime.curFrame == 20.0f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOLON_CRY);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_CRY);
             }
         }
 
@@ -1931,7 +1930,7 @@ void EnGo2_GoronFireGenericAction(EnGo2* this, PlayState* play) {
         case 2: // Walking away
             if (DECR(this->animTimer)) {
                 if (!(this->animTimer % 8)) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_WALK);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_WALK);
                 }
                 Actor_MoveForward(&this->actor);
             } else {
@@ -1948,10 +1947,10 @@ void EnGo2_GoronFireGenericAction(EnGo2* this, PlayState* play) {
         case 3: // Walking away
             this->animTimer++;
             if (!(this->animTimer % 8) && (this->animTimer < 10)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_WALK);
             }
             if (this->animTimer == 10) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_IRON_DOOR_OPEN);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_IRON_DOOR_OPEN);
             }
             if (this->animTimer > 44) {
                 SfxSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, 20, NA_SE_EV_IRON_DOOR_CLOSE);

--- a/src/overlays/actors/ovl_En_Goma/z_en_goma.c
+++ b/src/overlays/actors/ovl_En_Goma/z_en_goma.c
@@ -185,9 +185,9 @@ void EnGoma_SetupFlee(EnGoma* this) {
     this->actionTimer = 20;
 
     if (this->actor.params < 6) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_BJR_DAM2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_DAM2);
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_DAM2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_DAM2);
     }
 }
 
@@ -214,9 +214,9 @@ void EnGoma_EggFallToGround(EnGoma* this, PlayState* play) {
         case 0:
             if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
                 if (this->actor.params < 6) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_BJR_EGG1);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_EGG1);
                 } else {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_EGG1);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_EGG1);
                 }
 
                 if (this->actor.params > 5) {
@@ -331,9 +331,9 @@ void EnGoma_SetupHurt(EnGoma* this, PlayState* play) {
     this->actor.speedXZ = 20.0f;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer + 0x8000;
     if (this->actor.params < 6) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_BJR_DAM1);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_DAM1);
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_DAM1);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_DAM1);
     }
 }
 
@@ -360,9 +360,9 @@ void EnGoma_SetupDie(EnGoma* this) {
     this->actionTimer = 30;
 
     if (this->actor.params < 6) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_BJR_DEAD);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_DEAD);
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_DEAD);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_DEAD);
     }
 
     this->invincibilityTimer = 100;
@@ -378,9 +378,9 @@ void EnGoma_Die(EnGoma* this, PlayState* play) {
 
     if (this->actionTimer == 17) {
         if (this->actor.params < 6) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_BJR_LAND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_LAND);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_LAND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_LAND);
         }
     }
 
@@ -491,9 +491,9 @@ void EnGoma_SetupJump(EnGoma* this) {
     this->actor.velocity.y = 8.0f;
 
     if (this->actor.params < 6) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_BJR_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_CRY);
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_CRY);
     }
 }
 
@@ -505,9 +505,9 @@ void EnGoma_Jump(EnGoma* this, PlayState* play) {
     if (this->actor.velocity.y <= 0.0f && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         EnGoma_SetupLand(this);
         if (this->actor.params < 6) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_BJR_LAND2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_LAND2);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_LAND2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_LAND2);
         }
     }
     this->visualState = 0;
@@ -529,9 +529,9 @@ void EnGoma_ChasePlayer(EnGoma* this, PlayState* play) {
 
     if (Animation_OnFrame(&this->skelanime, 1.0f) || Animation_OnFrame(&this->skelanime, 5.0f)) {
         if (this->actor.params < 6) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_BJR_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_WALK);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_WALK);
         }
     }
 
@@ -554,9 +554,9 @@ void EnGoma_SetupStunned(EnGoma* this, PlayState* play) {
     this->actionTimer = (s16)Rand_ZeroFloat(15.0f) + 3;
 
     if (this->actor.params < 6) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_BJR_FREEZE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_FREEZE);
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
@@ -601,7 +601,7 @@ void EnGoroiwa_Roll(EnGoroiwa* this, PlayState* play) {
         osSyncPrintf("Player ぶっ飛ばし\n"); // "Player knocked down"
         osSyncPrintf(VT_RST);
         onHitSetupFuncs[(this->actor.params >> 10) & 1](this);
-        func_8002F7DC(&GET_PLAYER(play)->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(GET_PLAYER(play), NA_SE_PL_BODY_HIT);
         if ((this->actor.home.rot.z & 1) == 1) {
             this->collisionDisabledTimer = 50;
         }
@@ -629,7 +629,7 @@ void EnGoroiwa_Roll(EnGoroiwa* this, PlayState* play) {
             EnGoroiwa_SetupRoll(this);
         }
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BIGBALL_ROLL - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_BIGBALL_ROLL - SFX_FLAG);
 }
 
 void EnGoroiwa_SetupMoveAndFallToGround(EnGoroiwa* this) {
@@ -683,7 +683,7 @@ void EnGoroiwa_MoveUp(EnGoroiwa* this, PlayState* play) {
     if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~AT_HIT;
         func_8002F6D4(play, &this->actor, 2.0f, this->actor.yawTowardsPlayer, 0.0f, 4);
-        func_8002F7DC(&GET_PLAYER(play)->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(GET_PLAYER(play), NA_SE_PL_BODY_HIT);
         if ((this->actor.home.rot.z & 1) == 1) {
             this->collisionDisabledTimer = 50;
         }
@@ -708,7 +708,7 @@ void EnGoroiwa_MoveDown(EnGoroiwa* this, PlayState* play) {
     if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~AT_HIT;
         func_8002F6D4(play, &this->actor, 2.0f, this->actor.yawTowardsPlayer, 0.0f, 4);
-        func_8002F7DC(&GET_PLAYER(play)->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(GET_PLAYER(play), NA_SE_PL_BODY_HIT);
         if ((this->actor.home.rot.z & 1) == 1) {
             this->collisionDisabledTimer = 50;
         }

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.c
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.c
@@ -156,11 +156,11 @@ void func_80A4E470(EnGs* this, PlayState* play) {
                     (play->msgCtx.unk_E3F2 == OCARINA_SONG_TIME)) {
                     Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ELF, this->actor.world.pos.x,
                                 this->actor.world.pos.y + 40.0f, this->actor.world.pos.z, 0, 0, 0, FAIRY_HEAL_TIMED);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BUTTERFRY_TO_FAIRY);
+                    Actor_PlaySfx(&this->actor, NA_SE_EV_BUTTERFRY_TO_FAIRY);
                 } else if (play->msgCtx.unk_E3F2 == OCARINA_SONG_STORMS) {
                     Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ELF, this->actor.world.pos.x,
                                 this->actor.world.pos.y + 40.0f, this->actor.world.pos.z, 0, 0, 0, FAIRY_HEAL_BIG);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BUTTERFRY_TO_FAIRY);
+                    Actor_PlaySfx(&this->actor, NA_SE_EV_BUTTERFRY_TO_FAIRY);
                 }
                 this->unk_19D = 0;
                 Flags_SetSwitch(play, (this->actor.params >> 8) & 0x3F);
@@ -211,7 +211,7 @@ f32 func_80A4E754(EnGs* this, PlayState* play, f32* arg2, f32* arg3, u16* arg4, 
 
 void func_80A4E910(EnGs* this, PlayState* play) {
     if (this->unk_19F == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALKID_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALKID_ATTACK);
         this->unk_200 = 0;
         this->unk_19F = 1;
         this->unk_1E8 = 0.5f;
@@ -228,7 +228,7 @@ void func_80A4E910(EnGs* this, PlayState* play) {
 
 void func_80A4EA08(EnGs* this, PlayState* play) {
     if (this->unk_19F == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALKID_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALKID_ATTACK);
         this->unk_1E8 = 0.3f;
         this->unk_1EC = 0.0f;
         this->unk_200 = 0;
@@ -272,7 +272,7 @@ void func_80A4EB3C(EnGs* this, PlayState* play) {
             this->unk_1E8 = 0.5f;
             this->unk_1EC = 0.0f;
             this->unk_200 = 0;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALKID_ATTACK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STALKID_ATTACK);
             this->unk_19F++;
         }
     } else if (this->unk_19F == 4) {
@@ -365,7 +365,7 @@ void func_80A4ED34(EnGs* this, PlayState* play) {
             bomb2Pos.x = this->actor.world.pos.x;
             bomb2Pos.y = this->actor.world.pos.y;
             bomb2Pos.z = this->actor.world.pos.z;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
             EffectSsBomb2_SpawnLayered(play, &bomb2Pos, &bomb2Velocity, &bomb2Accel, 100, 20);
             this->unk_200 = 10;
             this->unk_19E |= 8;
@@ -412,7 +412,7 @@ void func_80A4F13C(EnGs* this, PlayState* play) {
             this->unk_1EC = 1.5f;
             this->unk_1F0 = this->unk_1B4[1].y - 1.0f;
             this->unk_1F4 = -0.3f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_STONE_GROW_UP);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_STONE_GROW_UP);
             this->unk_19F = 3;
         }
     }
@@ -460,7 +460,7 @@ void func_80A4F13C(EnGs* this, PlayState* play) {
             this->unk_1F4 = 0;
             this->unk_1F8 = 0.5f;
             this->unk_1FC = 0;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALKID_ATTACK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STALKID_ATTACK);
             this->unk_19F = 6;
         }
     }
@@ -479,7 +479,7 @@ void func_80A4F13C(EnGs* this, PlayState* play) {
         }
     }
     if ((u16)this->unk_1A0[0].y < (u16)tmp2) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_STONE_ROLLING);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_STONE_ROLLING);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
+++ b/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
@@ -149,7 +149,7 @@ void EnHeishi1_Walk(EnHeishi1* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (Animation_OnFrame(&this->skelAnime, 1.0f) || Animation_OnFrame(&this->skelAnime, 17.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_KNIGHT_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_KNIGHT_WALK);
     }
 
     if (!sPlayerIsCaught) {

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -284,7 +284,7 @@ void func_80A53638(EnHeishi2* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
     if ((frameCount >= 12.0f) && (!this->audioFlag)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_SPEAR_HIT);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_SPEAR_HIT);
         this->audioFlag = 1;
     }
     if (this->unk_2EC <= frameCount) {
@@ -447,7 +447,7 @@ void func_80A53D0C(EnHeishi2* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (12.0f <= frameCount) {
         if (this->audioFlag == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_SPEAR_HIT);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_SPEAR_HIT);
             this->audioFlag = 1;
         }
     }
@@ -605,7 +605,7 @@ void func_80A543A0(EnHeishi2* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if ((frameCount >= 12.0f) && (!this->audioFlag)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_SPEAR_HIT);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_SPEAR_HIT);
         this->audioFlag = 1;
     }
 

--- a/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
+++ b/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
@@ -179,7 +179,7 @@ void func_80A55BD4(EnHeishi3* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 1.0f) || Animation_OnFrame(&this->skelAnime, 17.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_KNIGHT_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_KNIGHT_WALK);
     }
     if (this->caughtTimer == 0) {
         this->actionFunc = EnHeishi3_ResetAnimationToIdle;

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
@@ -148,14 +148,14 @@ void EnHintnuts_SetupStand(EnHintnuts* this) {
 
 void EnHintnuts_SetupBurrow(EnHintnuts* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gHintNutsBurrowAnim, -5.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DOWN);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DOWN);
     this->actionFunc = EnHintnuts_Burrow;
 }
 
 void EnHintnuts_HitByScrubProjectile2(EnHintnuts* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gHintNutsUnburrowAnim, -3.0f);
     this->collider.dim.height = 37;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DAMAGE);
     this->collider.base.acFlags &= ~AC_ON;
 
     if (this->actor.params > 0 && this->actor.params < 4 && this->actor.category == ACTORCAT_ENEMY) {
@@ -196,7 +196,7 @@ void EnHintnuts_SetupLeave(EnHintnuts* this, PlayState* play) {
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->collider.base.ocFlags1 &= ~OC1_ON;
     this->actor.flags |= ACTOR_FLAG_4;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DAMAGE);
     Actor_Spawn(&play->actorCtx, play, ACTOR_EN_ITEM00, this->actor.world.pos.x, this->actor.world.pos.y,
                 this->actor.world.pos.z, 0x0, 0x0, 0x0, 0x3); // recovery heart
     this->actionFunc = EnHintnuts_Leave;
@@ -208,7 +208,7 @@ void EnHintnuts_SetupFreeze(EnHintnuts* this) {
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 100);
     this->actor.colorFilterTimer = 1;
     this->animFlagAndTimer = 0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_FAINT);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_FAINT);
     if (sPuzzleCounter == -3) {
         func_80078884(NA_SE_SY_ERROR);
         sPuzzleCounter = -4;
@@ -228,7 +228,7 @@ void EnHintnuts_Wait(EnHintnuts* this, PlayState* play) {
     if (Animation_OnFrame(&this->skelAnime, 9.0f)) {
         this->collider.base.acFlags |= AC_ON;
     } else if (Animation_OnFrame(&this->skelAnime, 8.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
     }
 
     this->collider.dim.height = 5.0f + ((CLAMP(this->skelAnime.curFrame, 9.0f, 12.0f) - 9.0f) * 9.0f);
@@ -288,7 +288,7 @@ void EnHintnuts_ThrowNut(EnHintnuts* this, PlayState* play) {
         nutPos.z = this->actor.world.pos.z + (Math_CosS(this->actor.shape.rot.y) * 23.0f);
         if (Actor_Spawn(&play->actorCtx, play, ACTOR_EN_NUTSBALL, nutPos.x, nutPos.y, nutPos.z, this->actor.shape.rot.x,
                         this->actor.shape.rot.y, this->actor.shape.rot.z, 1) != NULL) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_THROW);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_THROW);
         }
     }
 }
@@ -347,7 +347,7 @@ void EnHintnuts_Run(EnHintnuts* this, PlayState* play) {
         this->animFlagAndTimer--;
     }
     if ((temp_ret != 0) || (Animation_OnFrame(&this->skelAnime, 6.0f))) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
 
     Math_StepToF(&this->actor.speedXZ, 7.5f, 1.0f);
@@ -403,7 +403,7 @@ void EnHintnuts_Leave(EnHintnuts* this, PlayState* play) {
         this->animFlagAndTimer--;
     }
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 6.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
         temp_a1 = this->actor.wallYaw;
@@ -434,7 +434,7 @@ void EnHintnuts_Freeze(EnHintnuts* this, PlayState* play) {
     this->actor.colorFilterTimer = 1;
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 0.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_FAINT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_FAINT);
     }
     if (this->animFlagAndTimer == 0) {
         if (sPuzzleCounter == 3) {

--- a/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
+++ b/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
@@ -199,7 +199,7 @@ void EnHonotrap_InitFlame(Actor* thisx, PlayState* play) {
     this->targetPos.y += 10.0f;
     this->flameScroll = Rand_ZeroOne() * 511.0f;
     EnHonotrap_SetupFlame(this);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FLAME_IGNITION);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_FLAME_IGNITION);
     if (this->actor.params == HONOTRAP_FLAME_DROP) {
         this->actor.room = -1;
         this->collider.cyl.dim.radius = 12;
@@ -248,7 +248,7 @@ void EnHonotrap_SetupEyeOpen(EnHonotrap* this) {
     this->actionFunc = EnHonotrap_EyeOpen;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 40);
     this->timer = 30;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_RED_EYE);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_RED_EYE);
 }
 
 void EnHonotrap_EyeOpen(EnHonotrap* this, PlayState* play) {
@@ -478,7 +478,7 @@ void EnHonotrap_Update(Actor* thisx, PlayState* play) {
         this->bobPhase += 0x640;
         this->actor.shape.yOffset = (Math_SinS(this->bobPhase) * 1000.0f) + 600.0f;
         Actor_SetFocus(&this->actor, 5.0f);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BURN_OUT - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_BURN_OUT - SFX_FLAG);
     }
     this->actionFunc(this, play);
     if (this->actor.params == HONOTRAP_EYE) {

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -194,7 +194,7 @@ void func_80A6E8CC(EnHs* this, PlayState* play) {
     if (this->unk_2AA > 0) {
         this->unk_2AA--;
         if (this->unk_2AA == 0) {
-            func_8002F7DC(&player->actor, NA_SE_EV_CHICKEN_CRY_M);
+            Player_PlaySfx(player, NA_SE_EV_CHICKEN_CRY_M);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -301,7 +301,7 @@ void EnIk_StandUp(EnIk* this, PlayState* play) {
 
     if (this->bodyCollider.base.acFlags & AC_HIT) {
         sparksPos = this->actor.world.pos;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_ARMOR_HIT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_ARMOR_HIT);
         sparksPos.y += 30.0f;
         func_8003424C(play, &sparksPos);
         this->skelAnime.playSpeed = 1.0f;
@@ -309,7 +309,7 @@ void EnIk_StandUp(EnIk* this, PlayState* play) {
     }
 
     if (this->skelAnime.curFrame == 5.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_WAKEUP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_WAKEUP);
     }
 
     if (SkelAnime_Update(&this->skelAnime)) {
@@ -359,7 +359,7 @@ void EnIk_SetupWalkOrRun(EnIk* this) {
     } else {
         Animation_Change(&this->skelAnime, &gIronKnuckleRunAnim, 1.0f, 0.0f,
                          Animation_GetLastFrame(&gIronKnuckleRunAnim), ANIMMODE_LOOP, -4.0f);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_DASH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_DASH);
         this->actor.speedXZ = 2.5f;
     }
 
@@ -430,7 +430,7 @@ void EnIk_WalkOrRun(EnIk* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (((s16)this->skelAnime.curFrame == footstepFrame1) || ((s16)this->skelAnime.curFrame == footstepFrame2)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_WALK);
     }
 }
 
@@ -448,13 +448,13 @@ void EnIk_VerticalAttack(EnIk* this, PlayState* play) {
     Vec3f sparksPos;
 
     if (this->skelAnime.curFrame == 15.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_SWING_AXE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_SWING_AXE);
     } else if (this->skelAnime.curFrame == 21.0f) {
         sparksPos.x = this->actor.world.pos.x + Math_SinS(this->actor.shape.rot.y + 0x6A4) * 70.0f;
         sparksPos.z = this->actor.world.pos.z + Math_CosS(this->actor.shape.rot.y + 0x6A4) * 70.0f;
         sparksPos.y = this->actor.world.pos.y;
 
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_HIT_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_HIT_GND);
         Camera_RequestQuake(&play->mainCamera, 2, 25, 5);
         Rumble_Request(this->actor.xzDistToPlayer, 255, 20, 150);
         CollisionCheck_SpawnShieldParticles(play, &sparksPos);
@@ -483,7 +483,7 @@ void EnIk_SetupPullOutAxe(EnIk* this) {
     this->unk_2F8 = 7;
     this->unk_2FF = this->unk_2FE;
     Animation_Change(&this->skelAnime, &gIronKnuckleAxeStuckAnim, 1.0f, 0.0f, endFrame, ANIMMODE_LOOP, -4.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_PULLOUT);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_PULLOUT);
     EnIk_SetupAction(this, EnIk_PullOutAxe);
 }
 
@@ -535,7 +535,7 @@ void EnIk_DoubleHorizontalAttack(EnIk* this, PlayState* play) {
         }
 
         if (this->unk_2FE < 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_SWING_AXE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_SWING_AXE);
         }
 
         this->unk_2FE = 1;
@@ -583,7 +583,7 @@ void EnIk_SingleHorizontalAttack(EnIk* this, PlayState* play) {
 
     if ((this->skelAnime.curFrame > 13.0f) && (this->skelAnime.curFrame < 18.0f)) {
         if (this->unk_2FE < 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_SWING_AXE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_SWING_AXE);
         }
         this->unk_2FE = 1;
     } else {
@@ -670,8 +670,8 @@ void EnIk_SetupDie(EnIk* this) {
     this->actor.speedXZ = 0.0f;
     Animation_Change(&this->skelAnime, &gIronKnuckleDeathAnim, 1.0f, 0.0f, endFrame, ANIMMODE_ONCE, -4.0f);
     this->animationTimer = 24;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_DEAD);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_CUTBODY);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_CUTBODY);
     EnIk_SetupAction(this, EnIk_Die);
 }
 
@@ -703,7 +703,7 @@ void EnIk_Die(EnIk* this, PlayState* play) {
             }
         }
     } else if (this->skelAnime.curFrame == 23.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_WALK);
     }
 }
 
@@ -782,16 +782,16 @@ void EnIk_UpdateDamage(EnIk* this, PlayState* play) {
 
         if ((this->actor.params != IK_TYPE_NABOORU) && (this->armorStatusFlag != 0)) {
             if ((prevHealth > 10) && (this->actor.colChkInfo.health <= 10)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_ARMOR_OFF_DEMO);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_ARMOR_OFF_DEMO);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_DAMAGE);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_CUTBODY);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_CUTBODY);
             }
 
             EnIk_SetupReactToAttack(this);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_ARMOR_HIT);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_IRONNACK_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_ARMOR_HIT);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_DAMAGE);
             CollisionCheck_SpawnShieldParticles(play, &sparksPos);
         }
     }

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -615,7 +615,7 @@ void func_80A7A304(EnIn* this, PlayState* play) {
         }
     }
     if (this->skelAnime.animation == &object_in_Anim_018C38 && this->skelAnime.curFrame == 20.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_IN_CRY_0);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_IN_CRY_0);
     }
     if (SkelAnime_Update(&this->skelAnime)) {
         this->animationIdx %= 8;
@@ -741,7 +741,7 @@ void func_80A7A940(EnIn* this, PlayState* play) {
     if (this->unk_1EC != 0) {
         this->unk_1EC--;
         if (this->unk_1EC == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_VO_IN_LOST);
+            Actor_PlaySfx(&this->actor, NA_SE_VO_IN_LOST);
         }
     }
     if (this->interactInfo.talkState == NPC_TALK_STATE_ACTION) {
@@ -809,7 +809,7 @@ void func_80A7ABD4(EnIn* this, PlayState* play) {
         if (this->unk_1EC != 0) {
             this->unk_1EC--;
             if (this->unk_1EC == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_VO_IN_LOST);
+                Actor_PlaySfx(&this->actor, NA_SE_VO_IN_LOST);
             }
         }
     }
@@ -831,7 +831,7 @@ void func_80A7ABD4(EnIn* this, PlayState* play) {
             return;
         }
         if (play->csCtx.frames == 44) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_RONRON_DOOR_CLOSE);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_RONRON_DOOR_CLOSE);
         }
         Math_SmoothStepToF(&this->subCamAtOffset.x, 0.0f, 0.06f, 10000.0f, 0.0f);
         Math_SmoothStepToF(&this->subCamAtOffset.y, 50.0f, 0.06f, 10000.0f, 0.0f);

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -169,7 +169,7 @@ void EnInsect_UpdateCrawlSfx(EnInsect* this) {
         return;
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MUSI_WALK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MUSI_WALK);
 
     this->crawlSoundDelay = 3.0f / CLAMP_MIN(this->skelAnime.playSpeed, 0.1f);
     if (this->crawlSoundDelay < 2) {
@@ -413,7 +413,7 @@ void EnInsect_SetupDig(EnInsect* this) {
     this->actionTimer = 60;
     EnInsect_SetCrawlAnim(this);
     this->skelAnime.playSpeed = 1.9f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MUSI_SINK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MUSI_SINK);
     Math_Vec3f_Copy(&this->actor.home.pos, &this->actor.world.pos);
     this->actionFunc = EnInsect_Dig;
     this->insectFlags &= ~INSECT_FLAG_CRAWLING;
@@ -664,7 +664,7 @@ void EnInsect_Dropped(EnInsect* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (!(this->insectFlags & INSECT_FLAG_DROPPED_HAS_LANDED) && (this->insectFlags & INSECT_FLAG_0) &&
         (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MUSI_LAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MUSI_LAND);
         this->insectFlags |= INSECT_FLAG_DROPPED_HAS_LANDED;
     }
 

--- a/src/overlays/actors/ovl_En_Jj/z_en_jj.c
+++ b/src/overlays/actors/ovl_En_Jj/z_en_jj.c
@@ -258,7 +258,7 @@ void EnJj_CutsceneUpdate(EnJj* this, PlayState* play) {
     }
 
     if (this->unk_30A & 1) {
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_JABJAB_BREATHE - SFX_FLAG);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_JABJAB_BREATHE - SFX_FLAG);
 
         if (this->mouthOpenAngle >= -5200) {
             this->mouthOpenAngle -= 102;
@@ -292,7 +292,7 @@ void EnJj_Update(Actor* thisx, PlayState* play) {
         this->actionFunc(this, play);
 
         if (this->skelAnime.curFrame == 41.0f) {
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_JABJAB_GROAN);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_JABJAB_GROAN);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
+++ b/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
@@ -109,7 +109,7 @@ void func_80A8F320(EnKakasi* this, PlayState* play, s16 arg) {
             this->unk_19A++;
             if (this->unk_1A4 == 0) {
                 this->unk_1A4 = 1;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_KAKASHI_ROLL);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_KAKASHI_ROLL);
             }
             break;
         case OCARINA_BTN_C_DOWN:
@@ -142,7 +142,7 @@ void func_80A8F320(EnKakasi* this, PlayState* play, s16 arg) {
         this->actor.gravity = -1.0f;
         if (this->unk_19A == 8 && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
             this->actor.velocity.y = 3.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_KAKASHI_JUMP);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_KAKASHI_JUMP);
         }
         Math_ApproachF(&this->skelanime.playSpeed, this->unk_1B8, 0.1f, 0.2f);
         Math_SmoothStepToS(&this->actor.shape.rot.x, this->unk_1A8, 5, 0x3E8, 0);
@@ -163,7 +163,7 @@ void func_80A8F320(EnKakasi* this, PlayState* play, s16 arg) {
         }
         currentFrame = this->skelanime.curFrame;
         if (currentFrame == 11 || currentFrame == 17) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_KAKASHI_SWING);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_KAKASHI_SWING);
         }
         SkelAnime_Update(&this->skelanime);
     }

--- a/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
+++ b/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
@@ -161,7 +161,7 @@ void func_80A904D8(EnKakasi2* this, PlayState* play) {
     f32 frameCount = Animation_GetLastFrame(&object_ka_Anim_000214);
 
     Animation_Change(&this->skelAnime, &object_ka_Anim_000214, 1.0f, 0.0f, (s16)frameCount, ANIMMODE_LOOP, -10.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_COME_UP_DEKU_JR);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_COME_UP_DEKU_JR);
     this->actionFunc = func_80A90578;
 }
 
@@ -172,7 +172,7 @@ void func_80A90578(EnKakasi2* this, PlayState* play) {
 
     currentFrame = this->skelAnime.curFrame;
     if (currentFrame == 11 || currentFrame == 17) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_KAKASHI_SWING);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_KAKASHI_SWING);
     }
 
     this->actor.shape.rot.y += 0x800;

--- a/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.c
+++ b/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.c
@@ -112,7 +112,7 @@ void func_80A90EBC(EnKakasi3* this, PlayState* play, s32 arg) {
             this->unk_19A++;
             if (this->unk_1A4 == 0) {
                 this->unk_1A4 = 1;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_KAKASHI_ROLL);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_KAKASHI_ROLL);
             }
             break;
         case OCARINA_BTN_C_DOWN:
@@ -145,7 +145,7 @@ void func_80A90EBC(EnKakasi3* this, PlayState* play, s32 arg) {
         this->actor.gravity = -1.0f;
         if (this->unk_19A == 8 && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
             this->actor.velocity.y = 3.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_KAKASHI_JUMP);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_KAKASHI_JUMP);
         }
         Math_ApproachF(&this->skelAnime.playSpeed, this->unk_1B8, 0.1f, 0.2f);
         Math_SmoothStepToS(&this->actor.shape.rot.x, this->unk_1AA, 0x5, 0x3E8, 0);
@@ -166,7 +166,7 @@ void func_80A90EBC(EnKakasi3* this, PlayState* play, s32 arg) {
         }
         currentFrame = this->skelAnime.curFrame;
         if (currentFrame == 11 || currentFrame == 17) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_KAKASHI_SWING);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_KAKASHI_SWING);
         }
         SkelAnime_Update(&this->skelAnime);
     }

--- a/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
+++ b/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
@@ -403,7 +403,7 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                     piece->actor.flags &= ~ACTOR_FLAG_0;
                     piece->actor.flags |= ACTOR_FLAG_25;
                     this->cutMarkTimer = 5;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_IT_SWORD_STRIKE);
+                    Actor_PlaySfx(&this->actor, NA_SE_IT_SWORD_STRIKE);
                 }
             }
             this->actor.focus.pos = this->actor.world.pos;
@@ -499,11 +499,11 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
             }
             if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
                 this->actor.speedXZ *= -0.5f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WOODPLATE_BOUND);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_WOODPLATE_BOUND);
             }
             if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER_TOUCH) {
                 this->actionState = ENKANBAN_WATER;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BOMB_DROP_WATER);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_BOMB_DROP_WATER);
                 this->bounceX = this->bounceZ = 0;
                 this->actor.world.pos.y += this->actor.yDistToWater;
                 EffectSsGSplash_Spawn(play, &this->actor.world.pos, NULL, NULL, 0, (this->partCount * 20) + 300);
@@ -568,7 +568,7 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                 Vec3f accel;
                 Vec3f pos;
 
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_WOODPLATE_BOUND);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_WOODPLATE_BOUND);
                 accel.x = 0.0f;
                 accel.y = 0.1f;
                 accel.z = 0.0f;

--- a/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
+++ b/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
@@ -146,7 +146,7 @@ void EnKarebaba_SetupIdle(EnKarebaba* this) {
 void EnKarebaba_SetupAwaken(EnKarebaba* this) {
     Animation_Change(&this->skelAnime, &gDekuBabaFastChompAnim, 4.0f, 0.0f,
                      Animation_GetLastFrame(&gDekuBabaFastChompAnim), ANIMMODE_LOOP, -3.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DUMMY482);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DUMMY482);
     this->actionFunc = EnKarebaba_Awaken;
 }
 
@@ -177,7 +177,7 @@ void EnKarebaba_SetupDying(EnKarebaba* this) {
     this->actor.velocity.y = 4.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x8000;
     this->actor.speedXZ = 3.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_JR_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_JR_DEAD);
     this->actor.flags |= ACTOR_FLAG_4 | ACTOR_FLAG_5;
     this->actionFunc = EnKarebaba_Dying;
 }
@@ -260,7 +260,7 @@ void EnKarebaba_Upright(EnKarebaba* this, PlayState* play) {
     }
 
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 12.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_JR_MOUTH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_JR_MOUTH);
     }
 
     if (this->bodyCollider.base.acFlags & AC_HIT) {
@@ -284,7 +284,7 @@ void EnKarebaba_Spin(EnKarebaba* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 12.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_JR_MOUTH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_JR_MOUTH);
     }
 
     value = 20 - this->actor.params;
@@ -333,7 +333,7 @@ void EnKarebaba_Dying(EnKarebaba* this, PlayState* play) {
         }
 
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
             this->actor.params = 1;
         }
     } else if (this->actor.params == 1) {

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -401,7 +401,7 @@ void EnKz_Mweep(EnKz* this, PlayState* play) {
         this->actionFunc = EnKz_StopMweep;
     }
     if (this->skelanime.curFrame == 13.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_KZ_MOVE);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_KZ_MOVE);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Light/z_en_light.c
+++ b/src/overlays/actors/ovl_En_Light/z_en_light.c
@@ -101,7 +101,7 @@ void EnLight_Update(Actor* thisx, PlayState* play) {
     EnLight_UpdatePosRot(this, play);
 
     if (this->actor.params >= 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_TORCH - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_TORCH - SFX_FLAG);
     }
 }
 
@@ -144,7 +144,7 @@ void EnLight_UpdateSwitch(Actor* thisx, PlayState* play) {
     EnLight_UpdatePosRot(this, play);
 
     if (this->actor.params >= 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_TORCH - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_TORCH - SFX_FLAG);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -484,7 +484,7 @@ void EnMb_SetupSpearPrepareAndCharge(EnMb* this) {
     this->state = ENMB_STATE_ATTACK;
     this->actor.speedXZ = 0.0f;
     this->timer3 = (s16)frameCount + 6;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_SPEAR_AT);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_SPEAR_AT);
     if (this->actor.params == ENMB_TYPE_SPEAR_GUARD) {
         EnMb_SetupAction(this, EnMb_SpearGuardPrepareAndCharge);
     } else {
@@ -494,7 +494,7 @@ void EnMb_SetupSpearPrepareAndCharge(EnMb* this) {
 
 void EnMb_SetupSpearPatrolImmediateCharge(EnMb* this) {
     Animation_PlayLoop(&this->skelAnime, &gEnMbSpearChargeAnim);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_ATTACK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_ATTACK);
     this->attack = ENMB_ATTACK_SPEAR;
     this->state = ENMB_STATE_ATTACK;
     this->timer3 = 3;
@@ -527,7 +527,7 @@ void EnMb_SetupSpearEndChargeQuick(EnMb* this) {
     this->state = ENMB_STATE_ATTACK_END;
     this->timer1 = 0;
     this->timer3 = 5;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_SLIDE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_SLIDE);
     EnMb_SetupAction(this, EnMb_SpearEndChargeQuick);
 }
 
@@ -539,7 +539,7 @@ void EnMb_SetupSpearPatrolEndCharge(EnMb* this) {
     this->timer3 = 50;
     this->actor.speedXZ = -8.0f;
     this->actor.velocity.y = 6.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_SLIDE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_SLIDE);
     EnMb_SetupAction(this, EnMb_SpearPatrolEndCharge);
 }
 
@@ -557,7 +557,7 @@ void EnMb_SetupClubDamaged(EnMb* this) {
     this->state = ENMB_STATE_CLUB_KNEELING;
     this->timer1 = 0;
     this->timer3 = 20;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_DEAD);
     EnMb_SetupAction(this, EnMb_ClubDamaged);
 }
 
@@ -579,7 +579,7 @@ void EnMb_SetupClubDead(EnMb* this) {
     this->hitbox.dim.radius = 95;
     this->timer1 = 30;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_DEAD);
     EnMb_SetupAction(this, EnMb_ClubDead);
 }
 
@@ -593,7 +593,7 @@ void EnMb_SetupStunned(EnMb* this) {
         if (this->actor.params != ENMB_TYPE_CLUB) {
             Animation_PlayOnceSetSpeed(&this->skelAnime, &gEnMbSpearDamagedFromFrontAnim, 0.0f);
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     }
     EnMb_SetupAction(this, EnMb_Stunned);
 }
@@ -664,7 +664,7 @@ void EnMb_SpearPatrolTurnTowardsWaypoint(EnMb* this, PlayState* play) {
         relYawFromPlayer = this->actor.shape.rot.y - this->actor.yawTowardsPlayer;
         if (ABS(relYawFromPlayer) <= 0x4000 || (func_8002DDE4(play) && this->actor.xzDistToPlayer < 160.0f)) {
             EnMb_FindWaypointTowardsPlayer(this, play);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_VOICE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_VOICE);
             EnMb_SetupSpearPrepareAndCharge(this);
         }
     }
@@ -689,7 +689,7 @@ void EnMb_SpearEndChargeQuick(EnMb* this, PlayState* play) {
                                  Animation_GetLastFrame(&gEnMbSpearPrepareChargeAnim), 0.0f, ANIMMODE_ONCE, 0.0f);
                 this->timer1 = 1;
                 this->actor.speedXZ = 0.0f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_SPEAR_NORM);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_SPEAR_NORM);
             }
         } else {
             if (this->actor.params <= ENMB_TYPE_SPEAR_GUARD) {
@@ -746,7 +746,7 @@ void EnMb_SpearPatrolEndCharge(EnMb* this, PlayState* play) {
                     Animation_Change(&this->skelAnime, &gEnMbSpearPrepareChargeAnim, -1.0f, lastFrame, 0.0f,
                                      ANIMMODE_ONCE, 0.0f);
                     this->actor.speedXZ = 0.0f;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_SPEAR_NORM);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_SPEAR_NORM);
                 }
             } else {
                 if (this->actor.xzDistToPlayer <= 160.0f) {
@@ -792,7 +792,7 @@ void EnMb_SpearGuardPrepareAndCharge(EnMb* this, PlayState* play) {
 
     if (SkelAnime_Update(&this->skelAnime)) {
         Animation_PlayLoop(&this->skelAnime, &gEnMbSpearChargeAnim);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_ATTACK);
     }
 
     if (this->timer3 != 0) {
@@ -804,7 +804,7 @@ void EnMb_SpearGuardPrepareAndCharge(EnMb* this, PlayState* play) {
         Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 5.0f, 3, 4.0f, 100, 15, false);
         if (prevFrame != (s32)this->skelAnime.curFrame &&
             ((s32)this->skelAnime.curFrame == 2 || (s32)this->skelAnime.curFrame == 6)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_DASH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_DASH);
         }
     }
 
@@ -857,7 +857,7 @@ void EnMb_ClubAttack(EnMb* this, PlayState* play) {
         } else {
             effSpawnPos = this->effSpawnPos;
             effSpawnPos.y = this->actor.floorHeight;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MONBLIN_HAM_LAND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MONBLIN_HAM_LAND);
             Rumble_Request(this->actor.xzDistToPlayer, 255, 20, 150);
             EffectSsBlast_SpawnWhiteShockwave(play, &effSpawnPos, &effWhiteShockwaveDynamics,
                                               &effWhiteShockwaveDynamics);
@@ -869,10 +869,10 @@ void EnMb_ClubAttack(EnMb* this, PlayState* play) {
         }
     } else {
         if (this->timer3 != 0 && this->skelAnime.curFrame == 6.0f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MONBLIN_HAM_UP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MONBLIN_HAM_UP);
 
         } else if (this->timer3 == 0 && this->skelAnime.curFrame == 3.0f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MONBLIN_HAM_DOWN);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MONBLIN_HAM_DOWN);
         }
     }
 }
@@ -889,7 +889,7 @@ void EnMb_SpearPatrolPrepareAndCharge(EnMb* this, PlayState* play) {
     prevFrame = (s32)this->skelAnime.curFrame;
     if (SkelAnime_Update(&this->skelAnime)) {
         Animation_PlayLoop(&this->skelAnime, &gEnMbSpearChargeAnim);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_ATTACK);
     }
 
     if (this->timer3 != 0) {
@@ -902,7 +902,7 @@ void EnMb_SpearPatrolPrepareAndCharge(EnMb* this, PlayState* play) {
         Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 5.0f, 3, 4.0f, 100, 15, false);
         if (prevFrame != (s32)this->skelAnime.curFrame &&
             ((s32)this->skelAnime.curFrame == 2 || (s32)this->skelAnime.curFrame == 6)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_DASH);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_DASH);
         }
     }
 
@@ -918,7 +918,7 @@ void EnMb_SpearPatrolPrepareAndCharge(EnMb* this, PlayState* play) {
                     }
                 }
                 if (!(this->attackCollider.base.atFlags & AT_BOUNCED)) {
-                    Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+                    Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
                 }
                 if (play->grabPlayer(play, player)) {
                     player->actor.parent = &this->actor;
@@ -972,7 +972,7 @@ void EnMb_SpearPatrolImmediateCharge(EnMb* this, PlayState* play) {
     Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 5.0f, 3, 4.0f, 100, 15, false);
     if (prevFrame != (s32)this->skelAnime.curFrame &&
         ((s32)this->skelAnime.curFrame == 2 || (s32)this->skelAnime.curFrame == 6)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_DASH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_DASH);
     }
 
     if (this->attackCollider.base.atFlags & AT_HIT) {
@@ -987,7 +987,7 @@ void EnMb_SpearPatrolImmediateCharge(EnMb* this, PlayState* play) {
                     }
                 }
                 if (!(this->attackCollider.base.atFlags & AT_BOUNCED)) {
-                    Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+                    Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
                 }
                 if (play->grabPlayer(play, player)) {
                     player->actor.parent = &this->actor;
@@ -1104,7 +1104,7 @@ void EnMb_ClubDead(EnMb* this, PlayState* play) {
     } else if ((s32)this->skelAnime.curFrame == 15 || (s32)this->skelAnime.curFrame == 22) {
         Rumble_Request(this->actor.xzDistToPlayer, 255, 20, 150);
         Actor_SpawnFloorDustRing(play, &this->actor, &effPos, 50.0f, 10, 3.0f, 400, 60, false);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
         Camera_RequestQuake(&play->mainCamera, 2, 25, 5);
     }
 }
@@ -1151,7 +1151,7 @@ void EnMb_SpearGuardWalk(EnMb* this, PlayState* play) {
             this->timer3--;
         }
         if (this->timer2 == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_VOICE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_VOICE);
         }
         this->timer1--;
         if (this->timer1 == 0) {
@@ -1167,7 +1167,7 @@ void EnMb_SpearGuardWalk(EnMb* this, PlayState* play) {
     if (prevFrame != (s32)this->skelAnime.curFrame) {
         if ((beforeCurFrame <= 1 && prevFrame + (s32)playSpeedAbs >= 1) ||
             (beforeCurFrame <= 20 && prevFrame + (s32)playSpeedAbs >= 20)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_WALK);
         }
     }
 
@@ -1197,7 +1197,7 @@ void EnMb_SpearPatrolWalkTowardsWaypoint(EnMb* this, PlayState* play) {
         relYawTowardsPlayer = (this->actor.shape.rot.y - this->actor.yawTowardsPlayer);
         if (ABS(relYawTowardsPlayer) <= 0x4000 || (func_8002DDE4(play) && this->actor.xzDistToPlayer < 160.0f)) {
             EnMb_FindWaypointTowardsPlayer(this, play);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_VOICE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_VOICE);
             EnMb_SetupSpearPrepareAndCharge(this);
             return;
         }
@@ -1210,7 +1210,7 @@ void EnMb_SpearPatrolWalkTowardsWaypoint(EnMb* this, PlayState* play) {
         this->timer3--;
     }
     if (this->timer2 == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_VOICE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_VOICE);
         this->timer2 = Rand_S16Offset(30, 70);
     }
 
@@ -1222,7 +1222,7 @@ void EnMb_SpearPatrolWalkTowardsWaypoint(EnMb* this, PlayState* play) {
     if (prevFrame != (s32)this->skelAnime.curFrame) {
         if ((beforeCurFrame <= 1 && (s32)playSpeedABS + prevFrame >= 1) ||
             (beforeCurFrame <= 20 && (s32)playSpeedABS + prevFrame >= 20)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_WALK);
         }
     }
 
@@ -1255,7 +1255,7 @@ void EnMb_SetupSpearDamaged(EnMb* this) {
     this->timer1 = 30;
     this->state = ENMB_STATE_SPEAR_SPEARPATH_DAMAGED;
     this->actor.shape.rot.y = this->actor.world.rot.y;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_DEAD);
     EnMb_SetupAction(this, EnMb_SpearDamaged);
 }
 
@@ -1285,7 +1285,7 @@ void EnMb_SetupSpearDead(EnMb* this) {
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->timer1 = 30;
     this->state = ENMB_STATE_SPEAR_SPEARPATH_DAMAGED;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_DEAD);
     this->actor.flags &= ~ACTOR_FLAG_0;
     EnMb_SetupAction(this, EnMb_SpearDead);
 }

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -415,7 +415,7 @@ void func_80AAE294(EnMm* this, PlayState* play) {
 
         if (this->curAnimIndex == 0) {
             if (((s32)this->skelAnime.curFrame == 1) || ((s32)this->skelAnime.curFrame == 6)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_PL_WALK_GROUND);
+                Actor_PlaySfx(&this->actor, NA_SE_PL_WALK_GROUND);
             }
         }
 
@@ -423,7 +423,7 @@ void func_80AAE294(EnMm* this, PlayState* play) {
             if (((this->skelAnime.curFrame - this->skelAnime.playSpeed < 9.0f) && (this->skelAnime.curFrame >= 9.0f)) ||
                 ((this->skelAnime.curFrame - this->skelAnime.playSpeed < 19.0f) &&
                  (this->skelAnime.curFrame >= 19.0f))) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_WALK);
             }
         }
 

--- a/src/overlays/actors/ovl_En_Niw/z_en_niw.c
+++ b/src/overlays/actors/ovl_En_Niw/z_en_niw.c
@@ -456,7 +456,7 @@ void func_80AB6450(EnNiw* this, PlayState* play) {
         this->actionFunc = func_80AB7290;
     } else if (Actor_HasParent(&this->actor, play)) {
         this->actor.gravity = -2.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
         this->sfxTimer1 = 30;
         this->path = 0;
         this->timer4 = 30;
@@ -478,7 +478,7 @@ void func_80AB6570(EnNiw* this, PlayState* play) {
 
     if (this->actor.params != 0xA) {
         if (Actor_HasParent(&this->actor, play)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
             this->sfxTimer1 = 30;
             this->path = 0;
             this->timer4 = 30;
@@ -492,7 +492,7 @@ void func_80AB6570(EnNiw* this, PlayState* play) {
         if (this->path != 0) {
             this->unk_2A6 = 1;
             if (this->sfxTimer3 == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
                 this->sfxTimer3 = 100;
             }
             this->unk_2A0 = Rand_ZeroFloat(1.99f);
@@ -687,7 +687,7 @@ void func_80AB6D08(EnNiw* this, PlayState* play) {
     }
 
     if (Actor_HasParent(&this->actor, play)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
         this->sfxTimer1 = 30;
         this->path = 0;
         this->timer4 = 30;
@@ -793,7 +793,7 @@ void func_80AB714C(EnNiw* this, PlayState* play) {
         this->unk_26C[1] = 0.0f;
         this->unk_26C[2] = 0.0f;
         this->timer1 = 10;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
     }
     if (this->timer5 == 0) {
         this->timer7 = 10;
@@ -865,7 +865,7 @@ void func_80AB747C(EnNiw* this, PlayState* play) {
             this->unk_2A4--;
         }
         this->unk_2A6 = 1;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
         this->timer6 = 100;
         this->path = 0;
         this->actionFunc = func_80AB7290;
@@ -1086,15 +1086,15 @@ void EnNiw_Update(Actor* thisx, PlayState* play) {
 
     if (this->sfxTimer2 == 0 && this->actionFunc == func_80AB6BF8) {
         this->sfxTimer2 = 7;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DEKU_WAKEUP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_WAKEUP);
     }
     if (this->sfxTimer1 == 0) {
         if (this->actionFunc != func_80AB6570) {
             this->sfxTimer1 = 30;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
         } else {
             this->sfxTimer1 = 300;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_N);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_N);
         }
     }
     if (this->unk_2A8 == 0) {

--- a/src/overlays/actors/ovl_En_Ny/z_en_ny.c
+++ b/src/overlays/actors/ovl_En_Ny/z_en_ny.c
@@ -177,7 +177,7 @@ void func_80ABCDBC(EnNy* this) {
 }
 
 void EnNy_SetupTurnToStone(EnNy* this) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NYU_HIT_STOP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NYU_HIT_STOP);
     this->actionFunc = EnNy_TurnToStone;
     this->unk_1E8 = 0.0f;
 }
@@ -253,7 +253,7 @@ void EnNy_TurnToStone(EnNy* this, PlayState* play) {
         phi_f0 = 0.25f;
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
             if (!(this->unk_1F0 < this->actor.yDistToWater)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
             }
             this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND_TOUCH;
             this->actor.speedXZ = 0.0f;
@@ -444,7 +444,7 @@ void EnNy_SetupDie(EnNy* this, PlayState* play) {
         } else {
             Item_DropCollectible(play, &this->actor.world.pos, ITEM00_ARROWS_SMALL);
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NYU_DEAD);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NYU_DEAD);
         this->actionFunc = EnNy_Die;
     }
 }

--- a/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
+++ b/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
@@ -233,7 +233,7 @@ void EnOkuta_SetupShoot(EnOkuta* this, PlayState* play) {
         EnOkuta_SpawnSplash(this, play);
     }
     if (this->jumpHeight > 50.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_JUMP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_JUMP);
     }
     this->actionFunc = EnOkuta_Shoot;
 }
@@ -243,7 +243,7 @@ void EnOkuta_SetupWaitToDie(EnOkuta* this) {
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 11);
     this->collider.base.acFlags &= ~AC_HIT;
     Actor_SetScale(&this->actor, 0.01f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_DEAD1);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_DEAD1);
     this->actionFunc = EnOkuta_WaitToDie;
 }
 
@@ -278,7 +278,7 @@ void EnOkuta_SpawnProjectile(EnOkuta* this, PlayState* play) {
         velocity.z = 1.5f * cosY;
         EnOkuta_SpawnDust(&pos, &velocity, 20, play);
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_THROW);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_THROW);
 }
 
 void EnOkuta_WaitToAppear(EnOkuta* this, PlayState* play) {
@@ -303,10 +303,10 @@ void EnOkuta_Appear(EnOkuta* this, PlayState* play) {
         Actor_SetScale(&this->actor, 0.01f);
     }
     if (Animation_OnFrame(&this->skelAnime, 2.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_JUMP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_JUMP);
     }
     if (Animation_OnFrame(&this->skelAnime, 12.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_LAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_LAND);
     }
     if (Animation_OnFrame(&this->skelAnime, 3.0f) || Animation_OnFrame(&this->skelAnime, 15.0f)) {
         EnOkuta_SpawnSplash(this, play);
@@ -318,14 +318,14 @@ void EnOkuta_Hide(EnOkuta* this, PlayState* play) {
 
     Math_ApproachF(&this->actor.world.pos.y, this->actor.home.pos.y, 0.5f, 30.0f);
     if (SkelAnime_Update(&this->skelAnime)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_BUBLE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_BUBLE);
         EnOkuta_SpawnBubbles(this, play);
         EnOkuta_SetupWaitToAppear(this);
     } else if (this->skelAnime.curFrame >= 4.0f) {
         Actor_SetScale(&this->actor, (6.0f - this->skelAnime.curFrame) * 0.5f * 0.01f);
     }
     if (Animation_OnFrame(&this->skelAnime, 2.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_SINK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_SINK);
     }
     if (Animation_OnFrame(&this->skelAnime, 4.0f)) {
         EnOkuta_SpawnSplash(this, play);
@@ -344,7 +344,7 @@ void EnOkuta_WaitToShoot(EnOkuta* this, PlayState* play) {
         }
     }
     if (Animation_OnFrame(&this->skelAnime, 0.5f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_FLOAT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_FLOAT);
     }
     if (this->actor.xzDistToPlayer < 160.0f || this->actor.xzDistToPlayer > 560.0f) {
         EnOkuta_SetupHide(this);
@@ -381,7 +381,7 @@ void EnOkuta_Shoot(EnOkuta* this, PlayState* play) {
             EnOkuta_SpawnSplash(this, play);
         }
         if ((this->jumpHeight > 50.0f) && Animation_OnFrame(&this->skelAnime, 13.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_LAND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_LAND);
         }
     }
     if (this->actor.xzDistToPlayer < 160.0f) {
@@ -416,11 +416,11 @@ void EnOkuta_Die(EnOkuta* this, PlayState* play) {
         velocity.y = -0.5f;
         velocity.z = 0.0f;
         EnOkuta_SpawnDust(&pos, &velocity, -0x14, play);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_DEAD2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_DEAD2);
     }
     if (Animation_OnFrame(&this->skelAnime, 15.0f)) {
         EnOkuta_SpawnSplash(this, play);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_LAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_LAND);
     }
     if (this->timer < 3) {
         Actor_SetScale(&this->actor, ((this->timer * 0.25f) + 1.0f) * 0.01f);

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -1095,7 +1095,7 @@ void EnOwl_Update(Actor* thisx, PlayState* play) {
               this->skelAnime.curFrame == 23.0f || this->skelAnime.curFrame == 40.0f ||
               this->skelAnime.curFrame == 58.0f)) ||
             (this->skelAnime.animation == &gOwlFlyAnim && this->skelAnime.curFrame == 4.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OWL_FLUTTER);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_OWL_FLUTTER);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -206,7 +206,7 @@ void func_80ACE5C8(EnPart* this, PlayState* play) {
         velocity.x = Rand_CenteredFloat(16.0f);
         EffectSsHahen_Spawn(play, &this->actor.world.pos, &velocity, &accel, 20,
                             (s32)((Rand_ZeroOne() * 5.0f + 12.0f) * 2), -1, 10, NULL);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MONBLIN_GNDWAVE - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MONBLIN_GNDWAVE - SFX_FLAG);
     }
 }
 
@@ -229,7 +229,7 @@ void func_80ACE7E8(EnPart* this, PlayState* play) {
         if (diffsSum == 0.0f) {
             this->actor.parent->home.rot.x--;
             this->timer--;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_DAMAGE);
         }
     } else if (this->timer > 0) {
         this->timer--;

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -306,7 +306,7 @@ void EnPeehat_HitWhenGrounded(EnPeehat* this, PlayState* play) {
         }
         this->unk_2D4 = 8;
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_DAMAGE);
 }
 
 void EnPeehat_Ground_SetStateGround(EnPeehat* this) {
@@ -384,7 +384,7 @@ void EnPeehat_Flying_SetStateFly(EnPeehat* this) {
 }
 
 void EnPeehat_Flying_StateFly(EnPeehat* this, PlayState* play) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
     SkelAnime_Update(&this->skelAnime);
     if (!IS_DAY || this->xzDistToRise < this->actor.xzDistToPlayer) {
         EnPeehat_Flying_SetStateLanding(this);
@@ -411,7 +411,7 @@ void EnPeehat_Ground_SetStateRise(EnPeehat* this) {
     }
     this->state = PEAHAT_STATE_8;
     this->animTimer = lastFrame;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_UP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_UP);
     EnPeehat_SetupAction(this, EnPeehat_Ground_StateRise);
 }
 
@@ -452,7 +452,7 @@ void EnPeehat_Flying_SetStateRise(EnPeehat* this) {
     }
     this->state = PEAHAT_STATE_9;
     this->animTimer = lastFrame;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_UP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_UP);
     EnPeehat_SetupAction(this, EnPeehat_Flying_StateRise);
 }
 
@@ -518,7 +518,7 @@ void EnPeehat_Ground_StateSeekPlayer(EnPeehat* this, PlayState* play) {
     Math_SmoothStepToS(&this->bladeRotVel, 4000, 1, 500, 0);
     this->bladeRot += this->bladeRotVel;
     Math_SmoothStepToF(&this->scaleShift, 0.075f, 1.0f, 0.005f, 0.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
 }
 
 void EnPeehat_Larva_SetStateSeekPlayer(EnPeehat* this) {
@@ -553,7 +553,7 @@ void EnPeehat_Larva_StateSeekPlayer(EnPeehat* this, PlayState* play) {
     Math_SmoothStepToS(&this->bladeRotVel, 4000, 1, 500, 0);
     this->bladeRot += this->bladeRotVel;
     Math_SmoothStepToF(&this->scaleShift, 0.075f, 1.0f, 0.005f, 0.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_SM_FLY - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_SM_FLY - SFX_FLAG);
     if (this->colQuad.base.atFlags & AT_BOUNCED) {
         this->actor.colChkInfo.health = 0;
         this->colQuad.base.acFlags = this->colQuad.base.acFlags & ~AC_BOUNCED;
@@ -603,7 +603,7 @@ void EnPeehat_Ground_StateLanding(EnPeehat* this, PlayState* play) {
     if (SkelAnime_Update(&this->skelAnime)) {
         EnPeehat_Ground_SetStateGround(this);
         this->actor.world.pos.y = this->actor.floorHeight;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_LAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_LAND);
     } else if (this->actor.floorHeight < this->actor.world.pos.y) {
         Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.floorHeight, 0.3f, 3.5f, 0.25f);
         if (this->actor.world.pos.y - this->actor.floorHeight < 60.0f) {
@@ -629,7 +629,7 @@ void EnPeehat_Flying_StateLanding(EnPeehat* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.x, 0, 1, 50, 0);
     if (SkelAnime_Update(&this->skelAnime)) {
         EnPeehat_Flying_SetStateGround(this);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_LAND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_LAND);
         this->actor.world.pos.y = this->actor.floorHeight;
     } else if (this->actor.floorHeight < this->actor.world.pos.y) {
         Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.floorHeight, 0.3f, 13.5f, 0.25f);
@@ -689,7 +689,7 @@ void EnPeehat_Ground_StateHover(EnPeehat* this, PlayState* play) {
     Math_SmoothStepToS(&this->bladeRotVel, 4000, 1, 500, 0);
     this->bladeRot += this->bladeRotVel;
     Math_SmoothStepToF(&this->scaleShift, 0.075f, 1.0f, 0.005f, 0.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
 }
 
 void EnPeehat_Ground_SetStateReturnHome(EnPeehat* this) {
@@ -726,7 +726,7 @@ void EnPeehat_Ground_StateReturnHome(EnPeehat* this, PlayState* play) {
         EnPeehat_Ground_SetStateSeekPlayer(this);
         this->unk_2FA = (play->gameplayFrames & 1);
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
 }
 
 void EnPeehat_SetStateAttackRecoil(EnPeehat* this) {
@@ -762,7 +762,7 @@ void EnPeehat_StateAttackRecoil(EnPeehat* this, PlayState* play) {
             }
         }
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_FLY - SFX_FLAG);
 }
 
 void EnPeehat_SetStateBoomerangStunned(EnPeehat* this) {
@@ -773,7 +773,7 @@ void EnPeehat_SetStateBoomerangStunned(EnPeehat* this) {
     this->bladeRotVel = 0;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 200, COLORFILTER_BUFFLAG_OPA, 80);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     EnPeehat_SetupAction(this, EnPeehat_StateBoomerangStunned);
 }
 
@@ -895,7 +895,7 @@ void EnPeehat_Adult_CollisionCheck(EnPeehat* this, PlayState* play) {
         } else {
             Actor_ApplyDamage(&this->actor);
             Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PIHAT_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_DAMAGE);
         }
 
         if (this->actor.colChkInfo.damageEffect == PEAHAT_DMG_EFF_FIRE) {

--- a/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
+++ b/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
@@ -115,7 +115,7 @@ void EnPoDesert_SetupDisappear(EnPoDesert* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gPoeFieldDisappearAnim, -6.0f);
     this->actionTimer = 16;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DISAPPEAR);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DISAPPEAR);
     this->actionFunc = EnPoDesert_Disappear;
 }
 

--- a/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
+++ b/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
@@ -210,7 +210,7 @@ void EnPoField_SetupAppear(EnPoField* this) {
     this->lightColor.a = 0;
     this->actor.shape.shadowAlpha = 0;
     this->actor.shape.yOffset = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_APPEAR);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
     this->actor.home.pos.y = this->actor.world.pos.y;
     if (this->actor.params == EN_PO_FIELD_BIG) {
         this->actor.speedXZ = 12.0f;
@@ -291,8 +291,8 @@ void EnPoField_SetupDisappear(EnPoField* this) {
     this->actionTimer = 16;
     this->collider.base.acFlags &= ~(AC_HIT | AC_ON);
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DISAPPEAR);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DISAPPEAR);
     this->actionFunc = EnPoField_Disappear;
 }
 
@@ -322,7 +322,7 @@ void func_80AD42B0(EnPoField* this) {
     this->actor.home.pos.y = this->actor.world.pos.y;
     this->actor.scale.x = 0.0f;
     this->actor.scale.y = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_METAL_BOX_BOUND);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_METAL_BOX_BOUND);
     if (this->actor.params == EN_PO_FIELD_BIG) {
         func_80078884(NA_SE_SY_TRE_BOX_APPEAR);
     }
@@ -568,7 +568,7 @@ void EnPoField_Death(EnPoField* this, PlayState* play) {
         EffectSsDeadDb_Spawn(play, &sp6C, &D_80AD7114, &D_80AD7120, this->actionTimer * 10 + 80, 0, 255, 255, 255, 255,
                              0, 0, 255, 1, 9, 1);
         if (this->actionTimer == 1) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EXTINCT);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_EXTINCT);
         }
     } else if (this->actionTimer == 28) {
         EnPoField_SetupSoulIdle(this, play);
@@ -580,7 +580,7 @@ void EnPoField_Death(EnPoField* this, PlayState* play) {
         this->actor.scale.x = temp_f0;
     }
     if (this->actionTimer == 18) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DEAD2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DEAD2);
     }
 }
 
@@ -651,7 +651,7 @@ void func_80AD58D4(EnPoField* this, PlayState* play) {
         return;
     }
     if (this->actionTimer == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
         this->actor.flags &= ~ACTOR_FLAG_16;
         EnPoField_SetupSoulDisappear(this);
         return;
@@ -696,7 +696,7 @@ void EnPoField_SoulInteract(EnPoField* this, PlayState* play) {
             Audio_StopSfxByPosAndId(&this->actor.projectedPos, NA_SE_EN_PO_BIG_CRY - SFX_FLAG);
             if (play->msgCtx.choiceIndex == 0) {
                 if (Inventory_HasEmptyBottle()) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_BIG_GET);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_BIG_GET);
                     if (this->actor.params == 0) {
                         Item_Give(play, ITEM_BOTTLE_POE);
                         this->actor.textId = 0x5008;
@@ -706,12 +706,12 @@ void EnPoField_SoulInteract(EnPoField* this, PlayState* play) {
                         Flags_SetSwitch(play, sSpawnSwitchFlags[this->spawnFlagIndex]);
                     }
                 } else {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
                     this->actor.textId = 0x5006;
                 }
             } else {
                 this->actor.textId = 0x5007;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
             }
             Message_ContinueTextbox(play, this->actor.textId);
             return;
@@ -727,9 +727,9 @@ void EnPoField_TestForDamage(EnPoField* this, PlayState* play) {
         if (this->actor.colChkInfo.damageEffect != 0 || this->actor.colChkInfo.damage != 0) {
             if (Actor_ApplyDamage(&this->actor) == 0) {
                 Enemy_StartFinishingBlow(play, &this->actor);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DEAD);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DAMAGE);
             }
             EnPoField_SetupDamage(this);
         }

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -141,7 +141,7 @@ void EnPoRelay_SetupRace(EnPoRelay* this) {
     this->hookshotSlotFull = INV_CONTENT(ITEM_HOOKSHOT) != ITEM_NONE;
     this->unk_19A = Actor_WorldYawTowardPoint(&this->actor, &vec);
     this->actor.flags |= ACTOR_FLAG_27;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
     this->actionFunc = EnPoRelay_Race;
 }
 
@@ -318,7 +318,7 @@ void EnPoRelay_DisappearAndReward(EnPoRelay* this, PlayState* play) {
         EffectSsDeadDb_Spawn(play, &vec, &D_80AD8D30, &D_80AD8D3C, this->actionTimer * 10 + 80, 0, 255, 255, 255, 255,
                              0, 0, 255, 1, 9, true);
         if (this->actionTimer == 1) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EXTINCT);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_EXTINCT);
         }
     }
     if (Math_StepToF(&this->actor.scale.x, 0.0f, 0.001f) != 0) {

--- a/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
+++ b/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
@@ -329,8 +329,8 @@ void func_80AD9718(EnPoSisters* this) {
     this->unk_19C = 100;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->unk_199 &= ~5;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DISAPPEAR);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH2);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DISAPPEAR);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH2);
     this->actionFunc = func_80ADAD54;
 }
 
@@ -366,7 +366,7 @@ void func_80AD98F4(EnPoSisters* this, PlayState* play) {
     }
     this->unk_19A = 15;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_APPEAR);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
     this->unk_199 &= ~1;
     this->actionFunc = func_80ADAE6C;
 }
@@ -445,7 +445,7 @@ void func_80AD9C24(EnPoSisters* this, PlayState* play) {
 void func_80AD9D44(EnPoSisters* this) {
     if (this->unk_194 == 3) {
         Animation_PlayOnce(&this->skelAnime, &gPoeSistersAppearDisappearAnim);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_APPEAR);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
     } else {
         Animation_Change(&this->skelAnime, &gPoeSistersAppearDisappearAnim, 0.5f, 0.0f,
                          Animation_GetLastFrame(&gPoeSistersAppearDisappearAnim), ANIMMODE_ONCE_INTERP, 0.0f);
@@ -474,7 +474,7 @@ void func_80AD9E60(EnPoSisters* this) {
         this->unk_19A++;
     }
     if (this->unk_195 == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH2);
     }
     this->actionFunc = func_80ADB51C;
 }
@@ -564,7 +564,7 @@ void func_80ADA2BC(EnPoSisters* this, PlayState* play) {
     if (this->unk_194 == 0) {
         Flags_SetSwitch(play, 0x1B);
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FLAME_IGNITION);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_FLAME_IGNITION);
     this->actionFunc = func_80ADBF58;
 }
 
@@ -654,7 +654,7 @@ void func_80ADA7F0(EnPoSisters* this, PlayState* play) {
     }
     this->actor.shape.rot.y += 384.0f * ((this->skelAnime.endFrame + 1.0f) * 3.0f - this->unk_19A);
     if (this->unk_19A == 18 || this->unk_19A == 7) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_ROLL);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_ROLL);
     }
     if (this->unk_19A == 0) {
         func_80AD94E0(this);
@@ -675,12 +675,12 @@ void func_80ADA8C0(EnPoSisters* this, PlayState* play) {
             this->collider.base.acFlags &= ~AC_HARD;
             func_80AD93C4(this);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH2);
             func_80AD9C24(this, play);
         }
     }
     if (Animation_OnFrame(&this->skelAnime, 1.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_ROLL);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_ROLL);
     }
 }
 
@@ -692,7 +692,7 @@ void func_80ADA9E8(EnPoSisters* this, PlayState* play) {
         if (this->unk_194 != 0) {
             func_80AD93C4(this);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH2);
             func_80AD9C24(this, play);
         }
     }
@@ -804,7 +804,7 @@ void func_80ADAFC0(EnPoSisters* this, PlayState* play) {
         }
     }
     if (this->unk_19A == 16) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DEAD2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DEAD2);
     }
 }
 
@@ -837,7 +837,7 @@ void func_80ADB2B8(EnPoSisters* this, PlayState* play) {
         func_80AD9DF0(this, play);
     }
     if (Animation_OnFrame(&this->skelAnime, 0.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_CRY);
     }
     this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
 }
@@ -926,7 +926,7 @@ void func_80ADB51C(EnPoSisters* this, PlayState* play) {
             Math_ScaledStepToS(&this->actor.shape.rot.y,
                                this->actor.parent->shape.rot.y + (this->unk_195 * 0x4000) * phi_v0, phi_a2);
         } else if (this->unk_19A == 70 || this->unk_19A == 40) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH2);
         }
     }
     func_80AD97C8(this, play);
@@ -1010,7 +1010,7 @@ void func_80ADB9F0(EnPoSisters* this, PlayState* play) {
         this->unk_22E.a = 255.0f * div;
     }
     if (this->unk_194 != 3 && Animation_OnFrame(&this->skelAnime, 1.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_APPEAR);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
     }
     Actor_SetFocus(&this->actor, 40.0f);
 }
@@ -1062,7 +1062,7 @@ void func_80ADBD38(EnPoSisters* this, PlayState* play) {
 void func_80ADBD8C(EnPoSisters* this, PlayState* play) {
     this->unk_19A--;
     if (this->unk_19A == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_APPEAR);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
         this->unk_199 &= ~0x80;
     }
     if (this->unk_19A <= 0) {
@@ -1137,7 +1137,7 @@ void func_80ADC10C(EnPoSisters* this, PlayState* play) {
         Actor_SetDropFlag(&this->actor, &this->collider.info, true);
         if (this->unk_195 != 0) {
             ((EnPoSisters*)this->actor.parent)->unk_19C--;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH2);
             func_80AD9C24(this, play);
             if (Rand_ZeroOne() < 0.2f) {
                 sp24.x = this->actor.world.pos.x;
@@ -1161,10 +1161,10 @@ void func_80ADC10C(EnPoSisters* this, PlayState* play) {
             }
         } else {
             if (Actor_ApplyDamage(&this->actor) != 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DAMAGE);
             } else {
                 Enemy_StartFinishingBlow(play, &this->actor);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_SISTER_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_PO_SISTER_DEAD);
             }
             func_80AD95D8(this);
         }

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -283,7 +283,7 @@ void EnPoh_SetupAttack(EnPoh* this) {
     }
     this->unk_198 = 12;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
     this->actionFunc = EnPoh_Attack;
 }
 
@@ -322,8 +322,8 @@ void EnPoh_SetupInitialAction(EnPoh* this) {
     } else {
         Animation_PlayOnceSetSpeed(&this->skelAnime, &gPoeComposerAppearAnim, 1.0f);
         this->actor.world.pos.y = this->actor.home.pos.y + 20.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_APPEAR);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
         this->actionFunc = EnPoh_ComposerAppear;
     }
 }
@@ -354,16 +354,16 @@ void EnPoh_SetupDisappear(EnPoh* this) {
     this->unk_194 = 32;
     this->actor.speedXZ = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DISAPPEAR);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DISAPPEAR);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
     this->actionFunc = EnPoh_Disappear;
 }
 
 void EnPoh_SetupAppear(EnPoh* this) {
     this->unk_194 = 0;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_APPEAR);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
     this->actionFunc = EnPoh_Appear;
 }
 
@@ -405,7 +405,7 @@ void func_80ADE6D4(EnPoh* this) {
     this->actor.scale.y = 0.0f;
     this->actor.shape.rot.x = 0;
     this->actor.home.pos.y = this->actor.world.pos.y;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_METAL_BOX_BOUND);
+    Actor_PlaySfx(&this->actor, NA_SE_EV_METAL_BOX_BOUND);
     this->actionFunc = func_80ADFE28;
 }
 
@@ -442,7 +442,7 @@ void EnPoh_Talk(EnPoh* this, PlayState* play) {
 void func_80ADE950(EnPoh* this, s32 arg1) {
     if (arg1) {
         Audio_StopSfxByPosAndId(&this->actor.projectedPos, NA_SE_EN_PO_BIG_CRY - SFX_FLAG);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
     }
     this->actionFunc = func_80AE009C;
 }
@@ -546,7 +546,7 @@ void func_80ADEC9C(EnPoh* this, PlayState* play) {
 void EnPoh_Attack(EnPoh* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (Animation_OnFrame(&this->skelAnime, 0.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_KANTERA);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_KANTERA);
         if (this->unk_198 != 0) {
             this->unk_198--;
         }
@@ -584,7 +584,7 @@ void func_80ADEF38(EnPoh* this, PlayState* play) {
         this->lightColor.a = ((this->skelAnime.curFrame - 10.0f) * 0.05f) * 255.0f;
     }
     if (this->skelAnime.playSpeed < 0.5f && this->actor.xzDistToPlayer < 280.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_APPEAR);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
         this->skelAnime.playSpeed = 1.0f;
     }
 }
@@ -632,7 +632,7 @@ void func_80ADF15C(EnPoh* this, PlayState* play) {
         EffectSsDeadDb_Spawn(play, &vec, &D_80AE1B60, &D_80AE1B6C, this->unk_198 * 10 + 80, 0, 255, 255, 255, 255, 0, 0,
                              255, 1, 9, 1);
         if (this->unk_198 == 1) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EXTINCT);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_EXTINCT);
         }
     } else if (this->unk_198 == 28) {
         EnPoh_SetupDeath(this, play);
@@ -644,7 +644,7 @@ void func_80ADF15C(EnPoh* this, PlayState* play) {
         this->actor.scale.x = newScale;
     }
     if (this->unk_198 == 18) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DEAD2);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DEAD2);
     }
 }
 
@@ -817,14 +817,14 @@ void EnPoh_TalkRegular(EnPoh* this, PlayState* play) {
                 if (Inventory_HasEmptyBottle()) {
                     this->actor.textId = 0x5008;
                     Item_Give(play, ITEM_BOTTLE_POE);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_BIG_GET);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_BIG_GET);
                 } else {
                     this->actor.textId = 0x5006;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
                 }
             } else {
                 this->actor.textId = 0x5007;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_LAUGH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
             }
             Message_ContinueTextbox(play, this->actor.textId);
         }
@@ -867,9 +867,9 @@ void func_80AE032C(EnPoh* this, PlayState* play) {
         if (this->actor.colChkInfo.damageEffect != 0 || this->actor.colChkInfo.damage != 0) {
             if (Actor_ApplyDamage(&this->actor) == 0) {
                 Enemy_StartFinishingBlow(play, &this->actor);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DEAD);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DAMAGE);
             }
             func_80ADE28C(this);
         }

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -288,7 +288,7 @@ void EnRd_Idle(EnRd* this, PlayState* play) {
     }
 
     if ((play->gameplayFrames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_CRY);
     }
 }
 
@@ -313,7 +313,7 @@ void EnRd_RiseFromCoffin(EnRd* this, PlayState* play) {
         }
     } else {
         if (this->actor.world.pos.y == this->actor.home.pos.y) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_CRY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_CRY);
         }
 
         if (Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.home.pos.y + 50.0f, 0.3f, 2.0f, 0.3f) == 0.0f) {
@@ -367,7 +367,7 @@ void EnRd_WalkToPlayer(EnRd* this, PlayState* play) {
                 }
 
                 this->playerStunWaitTimer = 60;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_AIM);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_AIM);
             }
         } else {
             EnRd_SetupWalkToHome(this, play);
@@ -394,9 +394,9 @@ void EnRd_WalkToPlayer(EnRd* this, PlayState* play) {
     }
 
     if ((this->skelAnime.curFrame == 10.0f) || (this->skelAnime.curFrame == 22.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_WALK);
     } else if ((play->gameplayFrames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_CRY);
     }
 }
 
@@ -445,9 +445,9 @@ void EnRd_WalkToHome(EnRd* this, PlayState* play) {
     }
 
     if (this->skelAnime.curFrame == 10.0f || this->skelAnime.curFrame == 22.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_WALK);
     } else if ((play->gameplayFrames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_CRY);
     }
 }
 
@@ -497,9 +497,9 @@ void EnRd_WalkToParent(EnRd* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (this->skelAnime.curFrame == 10.0f || this->skelAnime.curFrame == 22.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_WALK);
     } else if ((play->gameplayFrames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_CRY);
     }
 }
 
@@ -555,7 +555,7 @@ void EnRd_Grab(EnRd* this, PlayState* play) {
             Math_SmoothStepToS(&this->actor.shape.rot.y, player->actor.shape.rot.y, 1, 0x1770, 0);
 
             if (this->skelAnime.curFrame == 0.0f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_ATTACK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_ATTACK);
             }
 
             this->grabDamageTimer--;
@@ -563,7 +563,7 @@ void EnRd_Grab(EnRd* this, PlayState* play) {
                 play->damagePlayer(play, -8);
                 Rumble_Request(this->actor.xzDistToPlayer, 240, 1, 12);
                 this->grabDamageTimer = 20;
-                func_8002F7DC(&player->actor, NA_SE_VO_LI_DAMAGE_S + player->ageProperties->unk_92);
+                Player_PlaySfx(player, NA_SE_VO_LI_DAMAGE_S + player->ageProperties->unk_92);
             }
             break;
 
@@ -607,7 +607,7 @@ void EnRd_AttemptPlayerFreeze(EnRd* this, PlayState* play) {
             func_8008EEAC(play, &this->actor);
         }
 
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_AIM);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_AIM);
         EnRd_SetupWalkToPlayer(this, play);
     }
 }
@@ -649,7 +649,7 @@ void EnRd_SetupDamaged(EnRd* this) {
     }
 
     this->actor.flags |= ACTOR_FLAG_0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_DAMAGE);
     this->action = REDEAD_ACTION_DAMAGED;
     EnRd_SetupAction(this, EnRd_Damaged);
 }
@@ -685,7 +685,7 @@ void EnRd_SetupDead(EnRd* this) {
     this->timer = 300;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_REDEAD_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_DEAD);
     EnRd_SetupAction(this, EnRd_Dead);
 }
 
@@ -717,7 +717,7 @@ void EnRd_Dead(EnRd* this, PlayState* play) {
             this->timer--;
         }
     } else if (((s32)this->skelAnime.curFrame == 33) || ((s32)this->skelAnime.curFrame == 40)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
     }
 }
 
@@ -728,13 +728,13 @@ void EnRd_SetupStunned(EnRd* this) {
     if (gSaveContext.sunsSongState != SUNSSONG_INACTIVE) {
         this->stunnedBySunsSong = true;
         this->sunsSongStunTimer = 600;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_LIGHT_ARROW_HIT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_LIGHT_ARROW_HIT);
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_GRAY, COLORFILTER_INTENSITY_FLAG | 200,
                              COLORFILTER_BUFFLAG_OPA, 255);
     } else if (this->damageEffect == REDEAD_DMGEFF_HOOKSHOT) {
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 200, COLORFILTER_BUFFLAG_OPA, 80);
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_LIGHT_ARROW_HIT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_LIGHT_ARROW_HIT);
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_GRAY, 200, COLORFILTER_BUFFLAG_OPA, 80);
     }
 

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -184,9 +184,9 @@ void func_80AE4F40(EnReeba* this, PlayState* play) {
     this->actor.world.pos.y = this->actor.floorHeight;
 
     if (this->isBig) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIVA_BIG_APPEAR);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIVA_BIG_APPEAR);
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIVA_APPEAR);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIVA_APPEAR);
     }
 
     this->actionfunc = func_80AE5054;
@@ -260,7 +260,7 @@ void func_80AE5270(EnReeba* this, PlayState* play) {
                (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
         this->actionfunc = func_80AE5688;
     } else if (this->unk_274 == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIVA_MOVE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIVA_MOVE);
         this->unk_274 = 10;
     }
 }
@@ -307,7 +307,7 @@ void func_80AE53AC(EnReeba* this, PlayState* play) {
         this->actor.world.rot.y += yaw * 2.0f;
 
         if (this->unk_274 == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIVA_MOVE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIVA_MOVE);
             this->unk_274 = 20;
         }
     }
@@ -327,7 +327,7 @@ void func_80AE561C(EnReeba* this, PlayState* play) {
 
 void func_80AE5688(EnReeba* this, PlayState* play) {
     this->unk_27E = 0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_AKINDONUTS_HIDE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_AKINDONUTS_HIDE);
     this->actor.flags |= ACTOR_FLAG_27;
     this->actor.flags &= ~(ACTOR_FLAG_0 | ACTOR_FLAG_2);
     this->actionfunc = func_80AE56E0;
@@ -437,7 +437,7 @@ void func_80AE5A9C(EnReeba* this, PlayState* play) {
             EffectSsEnIce_SpawnFlyingVec3f(play, &this->actor, &pos, 150, 150, 150, 250, 235, 245, 255, scale);
         }
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIVA_DEAD);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIVA_DEAD);
         Enemy_StartFinishingBlow(play, &this->actor);
         this->actionfunc = func_80AE5C38;
     }
@@ -527,7 +527,7 @@ void func_80AE5EDC(EnReeba* this, PlayState* play) {
                 case 12: // boomerang
                     if ((this->actor.colChkInfo.health > 1) && (this->unk_27E != 4)) {
                         this->unk_27E = 4;
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
                         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA,
                                              80);
                         this->actionfunc = func_80AE58EC;
@@ -539,7 +539,7 @@ void func_80AE5EDC(EnReeba* this, PlayState* play) {
                         this->unk_27E = 4;
                         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA,
                                              80);
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
                         this->actionfunc = func_80AE58EC;
                         break;
                     }
@@ -548,14 +548,14 @@ void func_80AE5EDC(EnReeba* this, PlayState* play) {
                     this->unk_27C = 6;
                     Actor_ApplyDamage(&this->actor);
                     if (this->actor.colChkInfo.health == 0) {
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIVA_DEAD);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_RIVA_DEAD);
                         Enemy_StartFinishingBlow(play, &this->actor);
                         this->actionfunc = func_80AE5BC4;
                     } else {
                         if (this->actionfunc == func_80AE5E48) {
                             this->actor.shape.rot.x = this->actor.shape.rot.z = 0;
                         }
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIVA_DAMAGE);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_RIVA_DAMAGE);
                         this->actionfunc = func_80AE57F0;
                     }
                     break;

--- a/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
+++ b/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
@@ -292,6 +292,6 @@ void EnRiverSound_Draw(Actor* thisx, PlayState* play) {
         func_800788CC(soundEffects[this->actor.params]);
     } else {
         // Play sfx at the location of riverSounds projected position
-        Audio_PlayActorSfx2(&this->actor, soundEffects[this->actor.params]);
+        Actor_PlaySfx(&this->actor, soundEffects[this->actor.params]);
     }
 }

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -207,7 +207,7 @@ void EnRr_Destroy(Actor* thisx, PlayState* play) {
 
 void EnRr_SetSpeed(EnRr* this, f32 speed) {
     this->actor.speedXZ = speed;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_LIKE_WALK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_LIKE_WALK);
 }
 
 void EnRr_SetupReach(EnRr* this) {
@@ -225,7 +225,7 @@ void EnRr_SetupReach(EnRr* this) {
         this->bodySegs[i].rotTarget.z = 0.0f;
     }
     this->actionFunc = EnRr_Reach;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_LIKE_UNARI);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_LIKE_UNARI);
 }
 
 void EnRr_SetupNeutral(EnRr* this) {
@@ -266,7 +266,7 @@ void EnRr_SetupGrabPlayer(EnRr* this, Player* player) {
         this->bodySegs[i].scaleTarget.x = this->bodySegs[i].scaleTarget.z = 1.0f;
     }
     this->actionFunc = EnRr_GrabPlayer;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_LIKE_DRINK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_LIKE_DRINK);
 }
 
 u8 EnRr_GetMessage(u8 shield, u8 tunic) {
@@ -325,7 +325,7 @@ void EnRr_SetupReleasePlayer(EnRr* this, PlayState* play) {
     func_8002F6D4(play, &this->actor, 4.0f, this->actor.shape.rot.y, 12.0f, 8);
     if (this->actor.colorFilterTimer == 0) {
         this->actionFunc = EnRr_Approach;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_LIKE_THROW);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_LIKE_THROW);
     } else if (this->actor.colChkInfo.health != 0) {
         EnRr_SetupDamage(this);
     } else {
@@ -348,7 +348,7 @@ void EnRr_SetupDamage(EnRr* this) {
         this->bodySegs[i].scaleTarget.x = this->bodySegs[i].scaleTarget.z = 1.0f;
     }
     this->actionFunc = EnRr_Damage;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_LIKE_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_LIKE_DAMAGE);
 }
 
 void EnRr_SetupApproach(EnRr* this) {
@@ -378,7 +378,7 @@ void EnRr_SetupDeath(EnRr* this) {
         this->bodySegs[i].rotTarget.x = this->bodySegs[i].rotTarget.z = 0.0f;
     }
     this->actionFunc = EnRr_Death;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_LIKE_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_LIKE_DEAD);
     this->actor.flags &= ~ACTOR_FLAG_0;
 }
 
@@ -494,7 +494,7 @@ void EnRr_CollisionCheck(EnRr* this, PlayState* play) {
                     EnRr_SetupStunned(this);
                     return;
                 case RR_DMG_STUN: // Boomerang and Hookshot
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
                     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_XLU, 80);
                     EnRr_SetupStunned(this);
                     return;
@@ -626,7 +626,7 @@ void EnRr_GrabPlayer(EnRr* this, PlayState* play) {
 
     Rumble_Request(this->actor.xyzDistToPlayerSq, 120, 2, 120);
     if ((this->frameCount % 8) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_LIKE_EAT);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_LIKE_EAT);
     }
     this->ocTimer = 8;
     if ((this->grabTimer == 0) || !(player->stateFlags2 & PLAYER_STATE2_7)) {

--- a/src/overlays/actors/ovl_En_Sb/z_en_sb.c
+++ b/src/overlays/actors/ovl_En_Sb/z_en_sb.c
@@ -154,7 +154,7 @@ void EnSb_SetupOpen(EnSb* this) {
                      ANIMMODE_ONCE, 0.0f);
     this->behavior = SHELLBLADE_OPEN;
     this->actionFunc = EnSb_Open;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHELL_MOUTH);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_SHELL_MOUTH);
 }
 
 void EnSb_SetupWaitOpen(EnSb* this) {
@@ -171,7 +171,7 @@ void EnSb_SetupLunge(EnSb* this) {
     Animation_Change(&this->skelAnime, &object_sb_Anim_000124, playbackSpeed, 0.0f, frameCount, ANIMMODE_ONCE, 0);
     this->behavior = SHELLBLADE_LUNGE;
     this->actionFunc = EnSb_Lunge;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_SHELL_MOUTH);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_SHELL_MOUTH);
 }
 
 void EnSb_SetupBounce(EnSb* this) {
@@ -275,7 +275,7 @@ void EnSb_Lunge(EnSb* this, PlayState* play) {
     Math_StepToF(&this->actor.speedXZ, 0.0f, 0.2f);
     if ((this->actor.velocity.y <= -0.1f) || (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH)) {
         if (!(this->actor.yDistToWater > 0.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
         this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND_TOUCH;
         EnSb_SetupBounce(this);

--- a/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
+++ b/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
@@ -114,13 +114,13 @@ void EnShopnuts_SetupStand(EnShopnuts* this) {
 
 void EnShopnuts_SetupBurrow(EnShopnuts* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gBusinessScrubAnim_39C, -5.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DOWN);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DOWN);
     this->actionFunc = EnShopnuts_Burrow;
 }
 
 void EnShopnuts_SetupSpawnSalesman(EnShopnuts* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gBusinessScrubRotateAnim, -3.0f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DAMAGE);
     this->collider.base.acFlags &= ~AC_ON;
     this->actionFunc = EnShopnuts_SpawnSalesman;
 }
@@ -137,7 +137,7 @@ void EnShopnuts_Wait(EnShopnuts* this, PlayState* play) {
     if (Animation_OnFrame(&this->skelAnime, 9.0f)) {
         this->collider.base.acFlags |= AC_ON;
     } else if (Animation_OnFrame(&this->skelAnime, 8.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_UP);
     }
 
     this->collider.dim.height = ((CLAMP(this->skelAnime.curFrame, 9.0f, 13.0f) - 9.0f) * 9.0f) + 5.0f;
@@ -198,7 +198,7 @@ void EnShopnuts_ThrowNut(EnShopnuts* this, PlayState* play) {
         spawnPos.z = this->actor.world.pos.z + (Math_CosS(this->actor.shape.rot.y) * 23.0f);
         if (Actor_Spawn(&play->actorCtx, play, ACTOR_EN_NUTSBALL, spawnPos.x, spawnPos.y, spawnPos.z,
                         this->actor.shape.rot.x, this->actor.shape.rot.y, this->actor.shape.rot.z, 2) != NULL) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_NUTS_THROW);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_THROW);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.c
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.c
@@ -211,7 +211,7 @@ void EnSkb_SetupRiseFromGround(EnSkb* this) {
     Animation_PlayOnceSetSpeed(&this->skelAnime, &gStalchildUncurlingAnim, 1.0f);
     this->actionState = SKB_BEHAVIOR_BURIED;
     this->actor.flags &= ~ACTOR_FLAG_0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIVA_APPEAR);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_RIVA_APPEAR);
     EnSkb_SetupAction(this, EnSkb_RiseFromGround);
 }
 
@@ -239,7 +239,7 @@ void EnSkb_SetupDespawn(EnSkb* this) {
     this->setColliderAT = false;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actor.speedXZ = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_AKINDONUTS_HIDE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_AKINDONUTS_HIDE);
     EnSkb_SetupAction(this, EnSkb_Despawn);
 }
 
@@ -291,7 +291,7 @@ void EnSkb_WalkForward(EnSkb* this, PlayState* play) {
         if (((prevKeyFrame < 9) && (((s32)playSpeed + thisKeyFrame) >= 8)) ||
             !((prevKeyFrame >= 16) || (((s32)playSpeed + thisKeyFrame) < 15))) {
 
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALKID_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STALKID_WALK);
         }
     }
     if (Math_Vec3f_DistXZ(&this->actor.home.pos, &player->actor.world.pos) > 800.0f || IS_DAY) {
@@ -316,7 +316,7 @@ void EnSkb_Attack(EnSkb* this, PlayState* play) {
 
     frameData = this->skelAnime.curFrame;
     if (frameData == 3) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALKID_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALKID_ATTACK);
         this->setColliderAT = true;
     } else if (frameData == 6) {
         this->setColliderAT = false;
@@ -348,7 +348,7 @@ void EnSkb_SetupStunned(EnSkb* this) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
         this->actor.speedXZ = 0.0f;
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->setColliderAT = false;
     this->actionState = SKB_BEHAVIOR_STUNNED;
     EnSkb_SetupAction(this, EnSkb_Stunned);
@@ -378,7 +378,7 @@ void EnSkb_SetupTakeDamage(EnSkb* this) {
         this->actor.speedXZ = -4.0f;
     }
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALKID_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STALKID_DAMAGE);
     this->actionState = SKB_BEHAVIOR_DAMAGED;
     EnSkb_SetupAction(this, EnSkb_TakeDamage);
 }

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -238,7 +238,7 @@ void EnSsh_SetWaitAnimation(EnSsh* this) {
 }
 
 void EnSsh_SetReturnAnimation(EnSsh* this) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_UP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_UP);
     EnSsh_SetAnimation(this, SSH_ANIM_UP);
 }
 
@@ -303,8 +303,8 @@ s32 EnSsh_Damaged(EnSsh* this) {
         if (this->swayTimer == 0) {
             this->spinTimer = 30;
         }
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_ROLL);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_ST_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_ROLL);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_ST_ATTACK);
         return true;
     }
 }
@@ -468,8 +468,8 @@ s32 EnSsh_CheckHitPlayer(EnSsh* this, PlayState* play) {
     if (this->swayTimer == 0) {
         this->spinTimer = this->hitTimer;
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_ROLL);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_VO_ST_ATTACK);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_ROLL);
+    Actor_PlaySfx(&this->actor, NA_SE_VO_ST_ATTACK);
     play->damagePlayer(play, -8);
     func_8002F71C(play, &this->actor, 4.0f, this->actor.yawTowardsPlayer, 6.0f);
     this->hitCount--;
@@ -515,8 +515,8 @@ s32 EnSsh_CheckHitBack(EnSsh* this, PlayState* play) {
         this->hitCount++;
     }
     if (this->stunTimer == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_ST_DAMAGE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_ST_DAMAGE);
     }
     EnSsh_SetStunned(this);
     this->stateFlags |= SSH_STATE_STUNNED;
@@ -532,8 +532,8 @@ s32 EnSsh_CollisionCheck(EnSsh* this, PlayState* play) {
     } else if (play->actorCtx.unk_02 != 0) {
         this->invincibilityTimer = 8;
         if (this->stunTimer == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_VO_ST_DAMAGE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+            Actor_PlaySfx(&this->actor, NA_SE_VO_ST_DAMAGE);
         }
         EnSsh_SetStunned(this);
         this->stateFlags |= SSH_STATE_STUNNED;
@@ -689,7 +689,7 @@ void EnSsh_Idle(EnSsh* this, PlayState* play) {
             EnSsh_SetupAction(this, EnSsh_Return);
         } else {
             if (DECR(this->sfxTimer) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_LAUGH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_LAUGH);
                 this->sfxTimer = 64;
             }
             EnSsh_Bob(this, play);
@@ -748,7 +748,7 @@ void EnSsh_Drop(EnSsh* this, PlayState* play) {
         EnSsh_SetLandAnimation(this);
         EnSsh_SetupAction(this, EnSsh_Land);
     } else if (DECR(this->sfxTimer) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_DOWN);
         this->sfxTimer = 3;
     }
 }

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -249,7 +249,7 @@ void EnSt_SetWaitingAnimation(EnSt* this) {
 }
 
 void EnSt_SetReturnToCeilingAnimation(EnSt* this) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_UP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_UP);
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENST_ANIM_2);
 }
 
@@ -398,12 +398,12 @@ s32 EnSt_CheckHitPlayer(EnSt* this, PlayState* play) {
     }
 
     if (this->swayTimer == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_ROLL);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_ROLL);
     }
 
     this->gaveDamageSpinTimer = 30;
     play->damagePlayer(play, -8);
-    Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+    Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
     func_8002F71C(play, &this->actor, 4.0f, this->actor.yawTowardsPlayer, 6.0f);
     return true;
 }
@@ -448,7 +448,7 @@ s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
     this->invulnerableTimer = 8;
     if (this->actor.colChkInfo.damageEffect == 1) {
         if (this->stunTimer == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
             this->stunTimer = 120;
             Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 200, COLORFILTER_BUFFLAG_OPA,
                                  this->stunTimer);
@@ -463,7 +463,7 @@ s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 200, COLORFILTER_BUFFLAG_OPA,
                          this->takeDamageSpinTimer);
     if (Actor_ApplyDamage(&this->actor)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_DAMAGE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_DAMAGE);
         return false;
     }
     Enemy_StartFinishingBlow(play, &this->actor);
@@ -471,7 +471,7 @@ s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
     this->groundBounces = 3;
     this->deathTimer = 20;
     this->actor.gravity = -1.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALWALL_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STALWALL_DEAD);
 
     if (flags & DMG_ARROW) {
         EnSt_SetupAction(this, EnSt_Die);
@@ -608,14 +608,14 @@ void EnSt_UpdateYaw(EnSt* this, PlayState* play) {
             // turn away from the player
             this->rotAwayTimer--;
             if (this->rotAwayTimer == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_ROLL);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_ROLL);
                 this->rotTowardsTimer = 30;
             }
         } else if (this->rotTowardsTimer != 0) {
             // turn towards the player
             this->rotTowardsTimer--;
             if (this->rotTowardsTimer == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_ROLL);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_ROLL);
                 this->rotAwayTimer = 30;
             }
             yawDir = 0x8000;
@@ -665,7 +665,7 @@ s32 EnSt_IsDoneBouncing(EnSt* this, PlayState* play) {
         return false;
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
     EnSt_SpawnDust(this, play, 10);
     // creates an elastic bouncing effect, boucing up less for each hit on the ground.
     this->actor.velocity.y = 6.0f / (4 - this->groundBounces);
@@ -757,7 +757,7 @@ void EnSt_Sway(EnSt* this) {
         rotAngle = Math_SinS(this->swayAngle) * (swayAmt * (65536.0f / 360.0f));
 
         if (this->absPrevSwayAngle >= ABS(rotAngle) && this->playSwayFlag == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_WAVE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_WAVE);
             this->playSwayFlag = 1;
         }
 
@@ -854,7 +854,7 @@ void EnSt_WaitOnGround(EnSt* this, PlayState* play) {
 
     if (DECR(this->sfxTimer) == 0) {
         // play the "laugh" sfx every 64 frames.
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_LAUGH);
         this->sfxTimer = 64;
     }
 
@@ -880,7 +880,7 @@ void EnSt_LandOnGround(EnSt* this, PlayState* play) {
     this->sfxTimer++;
     if (this->sfxTimer == 14) {
         // play the sound effect of the Skulltula hitting the ground.
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_DOWN_SET);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_DOWN_SET);
     }
 
     if ((this->actor.floorHeight + this->floorHeightOffset) < this->actor.world.pos.y) {
@@ -910,7 +910,7 @@ void EnSt_MoveToGround(EnSt* this, PlayState* play) {
         EnSt_SetLandAnimation(this);
         EnSt_SetupAction(this, EnSt_LandOnGround);
     } else if (DECR(this->sfxTimer) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_DOWN);
         this->sfxTimer = 3;
     }
 }

--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -331,7 +331,7 @@ s32 func_80B0C9F0(EnSw* this, PlayState* play) {
             this->unk_392 = 0x10;
             Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 200, COLORFILTER_BUFFLAG_OPA, this->unk_392);
             if (Actor_ApplyDamage(&this->actor) != 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALTU_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_STALTU_DAMAGE);
                 return true;
             }
             Enemy_StartFinishingBlow(play, &this->actor);
@@ -356,7 +356,7 @@ s32 func_80B0C9F0(EnSw* this, PlayState* play) {
                 this->actionFunc = func_80B0DB00;
             }
 
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALWALL_DEAD);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STALWALL_DEAD);
             return true;
         }
     }
@@ -437,8 +437,8 @@ void func_80B0CEA8(EnSw* this, PlayState* play) {
         Camera* activeCam = GET_ACTIVE_CAM(play);
 
         if (!(Math_Vec3f_DistXYZ(&this->actor.world.pos, &activeCam->eye) >= 380.0f)) {
-            Audio_PlayActorSfx2(&this->actor, ((this->actor.params & 0xE000) >> 0xD) > 0 ? NA_SE_EN_STALGOLD_ROLL
-                                                                                         : NA_SE_EN_STALWALL_ROLL);
+            Actor_PlaySfx(&this->actor,
+                          ((this->actor.params & 0xE000) >> 0xD) > 0 ? NA_SE_EN_STALGOLD_ROLL : NA_SE_EN_STALWALL_ROLL);
         }
     }
 }
@@ -521,7 +521,7 @@ void func_80B0D3AC(EnSw* this, PlayState* play) {
     }
 
     if (func_80B0C0CC(this, play, 1) == 1) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         func_80B0D14C(this, play, 8);
         this->actor.scale.x = 0.02f;
         Actor_SetScale(&this->actor, 0.02f);
@@ -657,7 +657,7 @@ void func_80B0DB00(EnSw* this, PlayState* play) {
             this->actor.velocity.y = ((this->unk_38A--) * 8.0f) * 0.5f;
         }
 
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 16.0f, 12, 2.0f, 120, 10, false);
     }
 }
@@ -801,7 +801,7 @@ s32 func_80B0E430(EnSw* this, f32 arg1, s16 arg2, s32 arg3, PlayState* play) {
 
     if (Math_Vec3f_DistXYZ(&this->actor.world.pos, &activeCam->eye) < 380.0f) {
         if (DECR(this->unk_440) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALWALL_ROLL);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STALWALL_ROLL);
             this->unk_440 = 4;
         }
     } else {
@@ -827,7 +827,7 @@ void func_80B0E5E0(EnSw* this, PlayState* play) {
     }
 
     if ((DECR(this->unk_442) == 0) && (func_80B0DEA8(this, play, 1))) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALWALL_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STALWALL_LAUGH);
         this->unk_442 = 20;
         this->actionFunc = func_80B0E728;
     }
@@ -856,7 +856,7 @@ void func_80B0E728(EnSw* this, PlayState* play) {
             func_80B0E314(this, this->unk_448, 8.0f);
 
             if (DECR(this->unk_440) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STALWALL_DASH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_STALWALL_DASH);
                 this->unk_440 = 4;
             }
 

--- a/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
+++ b/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
@@ -437,7 +437,7 @@ void func_80B12460(EnSyatekiNiw* this, PlayState* play) {
                 this->unk_27C = 0.0f;
                 this->unk_280 = 14000.0f;
                 this->unk_278 = 14000.0f;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
                 this->unk_254 = this->unk_256 = this->unk_25A = 0x1E;
                 this->unk_29A = 5;
             }
@@ -549,7 +549,7 @@ void func_80B12BA4(EnSyatekiNiw* this, PlayState* play) {
             case 0:
                 if (this->unk_29C == 0) {
                     this->unk_262 = 0x1E;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
+                    Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
                     this->unk_29C = 1;
                     this->unk_2A0 = 1;
                     this->actionFunc = func_80B123A8;
@@ -560,7 +560,7 @@ void func_80B12BA4(EnSyatekiNiw* this, PlayState* play) {
             case 1:
                 this->unk_262 = 0x1E;
                 this->unk_2F8 = 1;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
                 this->unk_260 = 100;
                 this->unk_2A0 = 1;
                 this->unk_25E = this->unk_260;
@@ -642,10 +642,10 @@ void EnSyatekiNiw_Update(Actor* thisx, PlayState* play) {
     if (this->unk_262 == 0) {
         if (this->actionFunc == func_80B11E78) {
             this->unk_262 = 0x12C;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_N);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_N);
         } else {
             this->unk_262 = 0x1E;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_CHICKEN_CRY_A);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -356,7 +356,7 @@ void EnTa_WakeUp(EnTa* this, PlayState* play) {
         this->timer = 60;
         Animation_PlayOnce(&this->skelAnime, &gTalonWakeUpAnim);
         this->currentAnimation = &gTalonStandAnim;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_TA_SURPRISE);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_TA_SURPRISE);
     }
 }
 
@@ -431,7 +431,7 @@ void EnTa_RunWithAccelerationAndSfx(EnTa* this, PlayState* play) {
     s32 framesMod12 = (s32)play->state.frames % 12;
 
     if (framesMod12 == 0 || framesMod12 == 6) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_DIRT);
+        Actor_PlaySfx(&this->actor, NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_DIRT);
     }
     if (this->actor.speedXZ < 6.0f) {
         this->actor.speedXZ += 0.4f;
@@ -500,7 +500,7 @@ void EnTa_RunAwayStart(EnTa* this, PlayState* play) {
     this->actor.shape.rot.y -= 0xC00;
 
     if (this->timer == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_TA_CRY_1);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_TA_CRY_1);
         EnTa_SetupAction(this, EnTa_RunAwayRunSouth, EnTa_AnimRepeatCurrent);
         this->timer = 65;
         this->actor.flags |= ACTOR_FLAG_4;
@@ -774,13 +774,13 @@ void EnTa_RunCuccoGame(EnTa* this, PlayState* play) {
                         case 2:
                             // One cucco remaining
                             this->actor.textId = 0x2083;
-                            Audio_PlayActorSfx2(&this->actor, NA_SE_VO_TA_CRY_1);
+                            Actor_PlaySfx(&this->actor, NA_SE_VO_TA_CRY_1);
                             break;
 
                         case 3:
                             // Two cuccos remaining
                             this->actor.textId = 0x2082;
-                            Audio_PlayActorSfx2(&this->actor, NA_SE_VO_TA_SURPRISE);
+                            Actor_PlaySfx(&this->actor, NA_SE_VO_TA_SURPRISE);
                             break;
                     }
                     this->actionFunc = EnTa_IdleFoundSuperCucco;
@@ -1091,7 +1091,7 @@ void EnTa_IdleSittingInLonLonHouse(EnTa* this, PlayState* play) {
     EnTa_SetTextForTalkInLonLonHouse(this, play);
 
     if (EnTa_RequestTalk(this, play, this->actor.textId)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_TA_SURPRISE);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_TA_SURPRISE);
 
         if (faceReaction != 0) {
             EnTa_SetupActionWithWakeUpAnimation(this, EnTa_TalkGeneralInLonLonHouse);
@@ -1188,7 +1188,7 @@ void EnTa_AnimRepeatCurrent(EnTa* this) {
 void EnTa_AnimSleeping(EnTa* this) {
     if (SkelAnime_Update(&this->skelAnime)) {
         Animation_PlayOnce(&this->skelAnime, this->currentAnimation);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_VO_TA_SLEEP);
+        Actor_PlaySfx(&this->actor, NA_SE_VO_TA_SLEEP);
     }
     this->stateFlags |= TALON_STATE_FLAG_SUPPRESS_ROCKING_ANIM | TALON_STATE_FLAG_SUPPRESS_BLINK;
 }

--- a/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -543,7 +543,7 @@ void EnTest_Fall(EnTest* this, PlayState* play) {
         this->skelAnime.playSpeed = 1.0f;
         this->unk_7C8 = 0xC;
         this->timer = this->unk_7E4 * 0.15f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
         EnTest_SetupAction(this, EnTest_Land);
     }
 }
@@ -647,12 +647,12 @@ void EnTest_WalkAndBlock(EnTest* this, PlayState* play) {
             s32 afterPrevFrame = absPlaySpeed + prevFrame;
 
             if (((afterPrevFrame > 1) && (beforeCurFrame < 1)) || ((beforeCurFrame < 7) && (afterPrevFrame > 7))) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_WALK);
             }
         }
 
         if ((this->timer % 32) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_WARAU);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_WARAU);
             this->timer += (s16)(Rand_ZeroOne() * 5.0f);
         }
 
@@ -757,7 +757,7 @@ void func_80860C24(EnTest* this, PlayState* play) {
             afterPrevFrame = absPlaySpeed + prevFrame;
 
             if (((afterPrevFrame > 2) && (beforeCurFrame <= 0)) || ((beforeCurFrame < 7) && (afterPrevFrame >= 9))) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_WALK);
             }
         }
 
@@ -872,12 +872,12 @@ void func_80860F84(EnTest* this, PlayState* play) {
             s32 afterPrevFrame = absPlaySpeed + prevFrame;
 
             if (((afterPrevFrame > 1) && (beforeCurFrame < 1)) || ((beforeCurFrame < 7) && (afterPrevFrame > 7))) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_WALK);
             }
         }
 
         if ((play->gameplayFrames & 95) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_WARAU);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_WARAU);
         }
 
         yawDiff = playerYaw180 - this->actor.shape.rot.y;
@@ -913,7 +913,7 @@ void EnTest_SlashDown(EnTest* this, PlayState* play) {
     }
 
     if ((s32)this->skelAnime.curFrame == 7) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_SAKEBI);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_SAKEBI);
     }
 
     if ((this->skelAnime.curFrame > 7.0f) && (this->skelAnime.curFrame < 11.0f)) {
@@ -1008,7 +1008,7 @@ void EnTest_SlashUp(EnTest* this, PlayState* play) {
     this->actor.speedXZ = 0.0f;
 
     if ((s32)this->skelAnime.curFrame == 2) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_SAKEBI);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_SAKEBI);
     }
 
     if ((this->skelAnime.curFrame > 1.0f) && (this->skelAnime.curFrame < 8.0f)) {
@@ -1024,7 +1024,7 @@ void EnTest_SlashUp(EnTest* this, PlayState* play) {
 
 void EnTest_SetupJumpBack(EnTest* this) {
     Animation_PlayOnce(&this->skelAnime, &gStalfosJumpBackwardsAnim);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->unk_7C8 = 0x14;
     this->timer = 5;
     EnTest_SetupAction(this, EnTest_JumpBack);
@@ -1044,7 +1044,7 @@ void EnTest_JumpBack(EnTest* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 0xBB8, 1);
 
     if (this->timer == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_WARAU);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_WARAU);
     } else {
         this->timer--;
     }
@@ -1069,7 +1069,7 @@ void EnTest_JumpBack(EnTest* this, PlayState* play) {
             this->actor.flags |= ACTOR_FLAG_0;
         }
     } else if (this->skelAnime.curFrame == (this->skelAnime.endFrame - 4.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
     }
 }
 
@@ -1080,7 +1080,7 @@ void EnTest_SetupJumpslash(EnTest* this) {
     this->unk_7C8 = 0x17;
     this->actor.velocity.y = 10.0f;
     this->actor.speedXZ = 8.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->swordCollider.base.atFlags &= ~AT_BOUNCED;
     EnTest_SetupAction(this, EnTest_Jumpslash);
@@ -1097,8 +1097,8 @@ void EnTest_Jumpslash(EnTest* this, PlayState* play) {
             Animation_PlayOnce(&this->skelAnime, &gStalfosJumpslashAnim);
             this->timer = 1;
             this->swordState = 1;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_SAKEBI);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_SAKEBI);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
         } else {
             this->actor.speedXZ = 0.0f;
             EnTest_SetupIdle(this);
@@ -1111,7 +1111,7 @@ void EnTest_Jumpslash(EnTest* this, PlayState* play) {
 
     if (this->actor.world.pos.y <= this->actor.floorHeight) {
         if (this->actor.speedXZ != 0.0f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
 
         this->actor.world.pos.y = this->actor.floorHeight;
@@ -1126,7 +1126,7 @@ void EnTest_SetupJumpUp(EnTest* this) {
     this->unk_7C8 = 4;
     this->actor.velocity.y = 14.0f;
     this->actor.speedXZ = 6.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnTest_SetupAction(this, EnTest_JumpUp);
 }
@@ -1136,7 +1136,7 @@ void EnTest_JumpUp(EnTest* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (this->actor.world.pos.y <= this->actor.floorHeight) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
         this->actor.world.pos.y = this->actor.floorHeight;
         this->unk_7E4 = -(s32)this->actor.velocity.y;
@@ -1208,7 +1208,7 @@ void EnTest_IdleFromBlock(EnTest* this, PlayState* play) {
 
 void func_80862154(EnTest* this) {
     Animation_PlayOnce(&this->skelAnime, &gStalfosFlinchFromHitFrontAnim);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_DAMAGE);
     this->unk_7C8 = 8;
     this->actor.speedXZ = -2.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
@@ -1252,7 +1252,7 @@ void func_808621D4(EnTest* this, PlayState* play) {
 
 void func_80862398(EnTest* this) {
     Animation_PlayOnce(&this->skelAnime, &gStalfosFlinchFromHitBehindAnim);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_DAMAGE);
     this->unk_7C8 = 9;
     this->actor.speedXZ = -2.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
@@ -1309,7 +1309,7 @@ void EnTest_SetupStunned(EnTest* this) {
         }
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     EnTest_SetupAction(this, EnTest_Stunned);
 }
 
@@ -1445,13 +1445,13 @@ void func_808628C8(EnTest* this, PlayState* play) {
     absPlaySpeed = ABS(this->skelAnime.playSpeed);
 
     if ((this->timer % 32) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_WARAU);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_WARAU);
     }
     if ((s32)this->skelAnime.curFrame != prevFrame) {
         s32 afterPrevFrame = (s32)absPlaySpeed + prevFrame;
 
         if (((afterPrevFrame > 1) && (beforeCurFrame < 1)) || ((beforeCurFrame < 7) && (afterPrevFrame > 7))) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_WALK);
         }
     }
 
@@ -1478,7 +1478,7 @@ void func_808628C8(EnTest* this, PlayState* play) {
 }
 
 void func_80862DBC(EnTest* this, PlayState* play) {
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_DAMAGE);
     this->unk_7C8 = 2;
     BodyBreak_Alloc(&this->bodyBreak, 60, play);
     this->actor.home.rot.x = 0;
@@ -1534,7 +1534,7 @@ void func_80862E6C(EnTest* this, PlayState* play) {
 
 void func_80862FA8(EnTest* this, PlayState* play) {
     Animation_PlayOnce(&this->skelAnime, &gStalfosFallOverBackwardsAnim);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_DEAD);
     this->unk_7DE = 0;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actor.colorFilterTimer = 0;
@@ -1557,13 +1557,13 @@ void func_80863044(EnTest* this, PlayState* play) {
     }
 
     if ((s32)this->skelAnime.curFrame == 15) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
     }
 }
 
 void func_808630F0(EnTest* this, PlayState* play) {
     Animation_PlayOnce(&this->skelAnime, &gStalfosFallOverForwardsAnim);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_DEAD);
     this->unk_7C8 = 6;
     this->actor.colorFilterTimer = 0;
     this->unk_7DE = 0;
@@ -1586,7 +1586,7 @@ void func_8086318C(EnTest* this, PlayState* play) {
     }
 
     if (((s32)this->skelAnime.curFrame == 10) || ((s32)this->skelAnime.curFrame == 25)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -277,10 +277,10 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
                     if (this->actor.floorHeight > BGCHECK_Y_MIN) {
                         this->actor.world.pos.y = this->actor.floorHeight;
                     }
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
                 } else {
                     this->actor.world.pos.y += this->actor.yDistToWater;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_JUMP_WATER);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_JUMP_WATER);
                 }
                 this->actor.velocity.y = 8.0f;
                 this->actor.gravity = -1.0f;
@@ -374,7 +374,7 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
                 this->actor.world.rot.y = this->actor.yawTowardsPlayer;
                 if (&player->actor == this->collider.base.at) {
                     if (!(this->collider.base.atFlags & AT_BOUNCED)) {
-                        Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+                        Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
                     }
                 }
                 EnTite_SetupAction(this, EnTite_Recoil);
@@ -406,17 +406,17 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER_TOUCH) {
             this->actor.speedXZ = 0.0f;
             if (this->vAttackState == TEKTITE_SUBMERGED) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_LAND_WATER);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_LAND_WATER);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_LAND_WATER2);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_LAND_WATER2);
             }
             this->actor.bgCheckFlags &= ~BGCHECKFLAG_WATER_TOUCH;
         } else if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
     } else if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
         this->actor.speedXZ = 0.0f;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
     }
 }
 
@@ -469,9 +469,9 @@ void EnTite_TurnTowardPlayer(EnTite* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (((s16)this->skelAnime.curFrame & 7) == 0) {
         if ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_WALK_WATER);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_WALK_WATER);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_WALK);
         }
     }
 
@@ -496,9 +496,9 @@ void EnTite_SetupMoveTowardPlayer(EnTite* this) {
     this->actor.speedXZ = 4.0f;
     this->vQueuedJumps = Rand_S16Offset(1, 3);
     if ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_JUMP_WATER);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_JUMP_WATER);
     } else {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     }
     EnTite_SetupAction(this, EnTite_MoveTowardPlayer);
 }
@@ -516,9 +516,9 @@ void EnTite_MoveTowardPlayer(EnTite* this, PlayState* play) {
             func_80033480(play, &this->frontRightFootPos, 1.0f, 2, 80, 15, 1);
             func_80033480(play, &this->backRightFootPos, 1.0f, 2, 80, 15, 1);
             func_80033480(play, &this->backLeftFootPos, 1.0f, 2, 80, 15, 1);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         } else {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_LAND_WATER);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_LAND_WATER);
         }
     }
 
@@ -574,9 +574,9 @@ void EnTite_MoveTowardPlayer(EnTite* this, PlayState* play) {
                 this->actor.flags |= ACTOR_FLAG_24;
                 this->actor.gravity = -1.0f;
                 if ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_JUMP_WATER);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_JUMP_WATER);
                 } else {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
                 }
             }
         } else {
@@ -585,9 +585,9 @@ void EnTite_MoveTowardPlayer(EnTite* this, PlayState* play) {
             this->actor.flags |= ACTOR_FLAG_24;
             this->actor.gravity = -1.0f;
             if ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_JUMP_WATER);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_JUMP_WATER);
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
             }
         }
         // If in midair:
@@ -644,10 +644,10 @@ void EnTite_Recoil(EnTite* this, PlayState* play) {
             func_80033480(play, &this->frontRightFootPos, 1.0f, 2, 80, 15, 1);
             func_80033480(play, &this->backRightFootPos, 1.0f, 2, 80, 15, 1);
             func_80033480(play, &this->backLeftFootPos, 1.0f, 2, 80, 15, 1);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         } else {
             this->actor.bgCheckFlags &= ~BGCHECKFLAG_WATER_TOUCH;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_LAND_WATER2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_LAND_WATER2);
         }
     }
 
@@ -682,7 +682,7 @@ void EnTite_SetupStunned(EnTite* this) {
     if (this->damageEffect == 0xF) {
         this->spawnIceTimer = 48;
     }
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     EnTite_SetupAction(this, EnTite_Stunned);
 }
 
@@ -714,10 +714,10 @@ void EnTite_Stunned(EnTite* this, PlayState* play) {
             func_80033480(play, &this->frontRightFootPos, 1.0f, 2, 80, 15, 1);
             func_80033480(play, &this->backRightFootPos, 1.0f, 2, 80, 15, 1);
             func_80033480(play, &this->backLeftFootPos, 1.0f, 2, 80, 15, 1);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         } else {
             this->actor.bgCheckFlags &= ~BGCHECKFLAG_WATER_TOUCH;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_LAND_WATER2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_LAND_WATER2);
         }
     }
     // Decide on next action based on health, flip state and player distance
@@ -780,7 +780,7 @@ void EnTite_FallApart(EnTite* this, PlayState* play) {
 void EnTite_SetupFlipOnBack(EnTite* this) {
 
     Animation_PlayLoopSetSpeed(&this->skelAnime, &object_tite_Anim_000A14, 1.5f);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_REVERSE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_REVERSE);
     this->flipState = TEKTITE_FLIPPED;
     this->vOnBackTimer = 500;
     this->actor.speedXZ = 0.0f;
@@ -806,7 +806,7 @@ void EnTite_FlipOnBack(EnTite* this, PlayState* play) {
         // Upon landing, spawn dust and make noise
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
             Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 20.0f, 11, 4.0f, 0, 0, false);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
         this->vOnBackTimer--;
         if (this->vOnBackTimer == 0) {
@@ -825,7 +825,7 @@ void EnTite_SetupFlipUpright(EnTite* this) {
     this->actionVar1 = 1000; // value unused here and overwritten in SetupIdle
     //! @bug flying tektite: water sets gravity to 0 so y velocity will never decrease from 13
     this->actor.velocity.y = 13.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TEKU_REVERSE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_REVERSE);
     EnTite_SetupAction(this, EnTite_FlipUpright);
 }
 
@@ -840,7 +840,7 @@ void EnTite_FlipUpright(EnTite* this, PlayState* play) {
         func_80033480(play, &this->backLeftFootPos, 1.0f, 2, 80, 15, 1);
         this->actor.shape.yOffset = 0.0f;
         this->actor.world.pos.y = this->actor.floorHeight;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         EnTite_SetupIdle(this);
     }
 }
@@ -870,7 +870,7 @@ void EnTite_CheckDamage(Actor* thisx, PlayState* play) {
                     EnTite_SetupDeathCry(this);
                 } else {
                     // Flip tektite back up if it's on its back
-                    Audio_PlayActorSfx2(thisx, NA_SE_EN_TEKU_DAMAGE);
+                    Actor_PlaySfx(thisx, NA_SE_EN_TEKU_DAMAGE);
                     if (this->flipState != TEKTITE_FLIPPED) {
                         EnTite_SetupRecoil(this);
                     } else {

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -277,7 +277,7 @@ f32 EnTk_Step(EnTk* this, PlayState* play) {
     s32 i;
 
     if (this->skelAnime.curFrame == 0.0f || this->skelAnime.curFrame == 25.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_MORIBLIN_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_WALK);
     }
 
     if (this->skelAnime.animation != &gDampeWalkAnim) {
@@ -588,7 +588,7 @@ void EnTk_Dig(EnTk* this, PlayState* play) {
 
     if (this->skelAnime.curFrame == 32.0f) {
         /* What's gonna come out? */
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_DIG_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_DIG_UP);
 
         this->rewardTimer = 0;
 
@@ -624,14 +624,14 @@ void EnTk_Dig(EnTk* this, PlayState* play) {
         /* Play a reward sound effect shortly after digging */
         if (this->validDigHere == 0) {
             /* Bad dig spot */
-            Audio_PlayActorSfx2(&this->actor, NA_SE_SY_ERROR);
+            Actor_PlaySfx(&this->actor, NA_SE_SY_ERROR);
         } else if (this->currentReward == 4) {
             /* Heart piece */
             Audio_PlaySfxGeneral(NA_SE_SY_CORRECT_CHIME, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         } else {
             /* Rupee */
-            Audio_PlayActorSfx2(&this->actor, NA_SE_SY_TRE_BOX_APPEAR);
+            Actor_PlaySfx(&this->actor, NA_SE_SY_TRE_BOX_APPEAR);
         }
     }
     this->rewardTimer++;

--- a/src/overlays/actors/ovl_En_Tp/z_en_tp.c
+++ b/src/overlays/actors/ovl_En_Tp/z_en_tp.c
@@ -286,7 +286,7 @@ void EnTp_SetupDie(EnTp* this) {
         }
 
         this->timer = 13;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TAIL_DEAD);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_TAIL_DEAD);
     }
     this->actionIndex = TAILPASARAN_ACTION_DIE;
     EnTp_SetupAction(this, EnTp_Die);
@@ -605,7 +605,7 @@ void EnTp_UpdateDamage(EnTp* this, PlayState* play) {
             } else {
                 if (phi_s4 != 0) {
                     this->actor.freezeTimer = 80;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
                     if (phi_s2 != 0) {
                         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA,
                                              80);
@@ -620,7 +620,7 @@ void EnTp_UpdateDamage(EnTp* this, PlayState* play) {
 
                     if (phi_s4 != 0) {
                         now->actor.freezeTimer = 80;
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
 
                         if (phi_s2 != 0) {
                             Actor_SetColorFilter(&now->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA,

--- a/src/overlays/actors/ovl_En_Tr/z_en_tr.c
+++ b/src/overlays/actors/ovl_En_Tr/z_en_tr.c
@@ -150,7 +150,7 @@ void EnTr_ChooseAction2(EnTr* this, PlayState* play) {
                     Actor_SetScale(&this->actor, 0.01f);
                     EnTr_SetupAction(this, EnTr_ShrinkVanish);
                     this->timer = 24;
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_PO_DEAD2);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DEAD2);
                     break;
 
                 case 6:
@@ -162,7 +162,7 @@ void EnTr_ChooseAction2(EnTr* this, PlayState* play) {
                     Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_DEMO_6K, this->actor.world.pos.x,
                                        this->actor.world.pos.y, this->actor.world.pos.z, 0, 0, 0,
                                        this->actor.params + 9);
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_MASIC1);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_MASIC1);
                     break;
 
                 default:
@@ -261,7 +261,7 @@ void EnTr_ShrinkVanish(EnTr* this, PlayState* play) {
     }
 
     if (this->timer == 4) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BUBLE_DOWN);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_DOWN);
     }
 
     if (this->timer > 0) {
@@ -297,7 +297,7 @@ void EnTr_WaitToReappear(EnTr* this, PlayState* play) {
         if ((play->csCtx.npcActions[this->actionIndex] != NULL) &&
             ((play->csCtx.npcActions[this->actionIndex]->action == 3) ||
              (play->csCtx.npcActions[this->actionIndex]->action == 5))) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_TRANSFORM);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_TRANSFORM);
             this->timer = 34;
             EnTr_SetStartPosRot(this, play, this->actionIndex);
             EnTr_SetupAction(this, EnTr_Reappear);
@@ -383,9 +383,9 @@ void EnTr_Update(Actor* thisx, PlayState* play) {
             if ((this->animation == &gKotakeKoumeLookingOverLeftShoulderAnim) ||
                 (this->animation == &gKotakeKoumeLookingOverRightShoulderAnim)) {
                 if (this->actor.params != TR_KOUME) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_LAUGH2);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_LAUGH2);
                 } else {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TWINROBA_LAUGH);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_LAUGH);
                 }
                 Animation_PlayLoop(&this->skelAnime, this->animation);
             } else if (this->animation == &gKotakeKoumeFlyAnim) {

--- a/src/overlays/actors/ovl_En_Trap/z_en_trap.c
+++ b/src/overlays/actors/ovl_En_Trap/z_en_trap.c
@@ -73,7 +73,7 @@ void EnTrap_Init(Actor* thisx, PlayState* play) {
     thisx->gravity = -2.0f;
     if (thisx->params & SPIKETRAP_MODE_LINEAR) {
         thisx->speedXZ = this->moveSpeedForwardBack.z = this->upperParams & 0xF;
-        Audio_PlayActorSfx2(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
+        Actor_PlaySfx(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
     } else if (thisx->params & SPIKETRAP_MODE_CIRCULAR) {
         this->vRadius = (this->upperParams & 0xF) * 40.0f;
         this->vAngularVel = ((this->upperParams & 0xF0) + 0x10) << 5;
@@ -206,14 +206,14 @@ void EnTrap_Update(Actor* thisx, PlayState* play) {
             // If any of the above three conditions are met, turn around
             if (this->vContinue == 0.0f) {
                 thisx->world.rot.y += 0x8000;
-                Audio_PlayActorSfx2(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
+                Actor_PlaySfx(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
             }
         } else if (thisx->params & SPIKETRAP_MODE_CIRCULAR) {
             temp_cond = Math_SinS(this->vAngularPos);
             this->vAngularPos += this->vAngularVel;
             // Every full circle make a sound:
             if ((temp_cond < 0.0f) && (Math_SinS(this->vAngularPos) >= 0.0f)) {
-                Audio_PlayActorSfx2(thisx, NA_SE_EV_ROUND_TRAP_MOVE);
+                Actor_PlaySfx(thisx, NA_SE_EV_ROUND_TRAP_MOVE);
             }
             thisx->world.pos.x = (this->vRadius * Math_SinS(this->vAngularPos)) + thisx->home.pos.x;
             thisx->world.pos.z = (this->vRadius * Math_CosS(this->vAngularPos)) + thisx->home.pos.z;
@@ -234,7 +234,7 @@ void EnTrap_Update(Actor* thisx, PlayState* play) {
                         }
                         if (this->vMovementMetric != 0.0f) {
                             if (this->vMovementMetric == BEGIN_MOVE_OUT) {
-                                Audio_PlayActorSfx2(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
+                                Actor_PlaySfx(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
                             }
                             this->vMovementMetric = Math_SmoothStepToF(&thisx->world.pos.z, this->targetPosFwd.z, 1.0f,
                                                                        this->moveSpeedForwardBack.z, 0.0f);
@@ -257,7 +257,7 @@ void EnTrap_Update(Actor* thisx, PlayState* play) {
                         }
                         if (this->vMovementMetric != 0.0f) {
                             if (this->vMovementMetric == BEGIN_MOVE_OUT) {
-                                Audio_PlayActorSfx2(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
+                                Actor_PlaySfx(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
                             }
                             this->vMovementMetric = Math_SmoothStepToF(&thisx->world.pos.x, this->targetPosLeft.x, 1.0f,
                                                                        this->moveSpeedLeftRight.x, 0.0f);
@@ -278,7 +278,7 @@ void EnTrap_Update(Actor* thisx, PlayState* play) {
                         }
                         if (this->vMovementMetric != 0.0f) {
                             if (this->vMovementMetric == BEGIN_MOVE_OUT) {
-                                Audio_PlayActorSfx2(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
+                                Actor_PlaySfx(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
                             }
                             this->vMovementMetric = Math_SmoothStepToF(&thisx->world.pos.z, this->targetPosBack.z, 1.0f,
                                                                        this->moveSpeedForwardBack.z, 0.0f);
@@ -301,7 +301,7 @@ void EnTrap_Update(Actor* thisx, PlayState* play) {
                         }
                         if (this->vMovementMetric != 0.0f) {
                             if (this->vMovementMetric == BEGIN_MOVE_OUT) {
-                                Audio_PlayActorSfx2(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
+                                Actor_PlaySfx(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
                             }
                             this->vMovementMetric = Math_SmoothStepToF(&thisx->world.pos.x, this->targetPosRight.x,
                                                                        1.0f, this->moveSpeedLeftRight.x, 0.0f);

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
@@ -238,7 +238,7 @@ void EnTuboTrap_WaitForProximity(EnTuboTrap* this, PlayState* play) {
         }
 
         this->originPos = this->actor.world.pos;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_POT_MOVE_START);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_POT_MOVE_START);
         this->actionFunc = EnTuboTrap_Levitate;
     }
 }
@@ -259,7 +259,7 @@ void EnTuboTrap_Fly(EnTuboTrap* this, PlayState* play) {
     f32 dy = this->originPos.y - this->actor.world.pos.y;
     f32 dz = this->originPos.z - this->actor.world.pos.z;
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_TUBOOCK_FLY - SFX_FLAG);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_TUBOOCK_FLY - SFX_FLAG);
 
     if (240.0f < sqrtf(SQ(dx) + SQ(dy) + SQ(dz))) {
         Math_ApproachF(&this->actor.gravity, -3.0f, 0.2f, 0.5f);

--- a/src/overlays/actors/ovl_En_Vali/z_en_vali.c
+++ b/src/overlays/actors/ovl_En_Vali/z_en_vali.c
@@ -259,7 +259,7 @@ void EnVali_SetupStunned(EnVali* this) {
     this->actor.velocity.y = 0.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_XLU, 80);
     this->bodyCollider.info.bumper.effect = 0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->actor.velocity.y = 1.0f;
     this->actionFunc = EnVali_Stunned;
 }
@@ -316,7 +316,7 @@ void EnVali_DropAppear(EnVali* this, PlayState* play) {
     this->actor.velocity.y = CLAMP_MAX(this->actor.velocity.y, 40.0f);
 
     if (Math_StepToF(&this->actor.world.pos.y, this->actor.floorHeight, this->actor.velocity.y)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         EnVali_SetupFloatIdle(this);
     }
 }
@@ -339,10 +339,10 @@ void EnVali_FloatIdle(EnVali* this, PlayState* play) {
         this->actor.shape.rot.y += 0x800;
 
         if (((this->slingshotReactionTimer % 6) == 0) && (curFrame > 15) && (curFrame <= 55)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BARI_ROLL);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BARI_ROLL);
         }
     } else if ((curFrame == 16) || (curFrame == 30) || (curFrame == 42) || (curFrame == 55)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BARI_ROLL);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BARI_ROLL);
     }
 
     curFrame = ((curFrame > 40) ? (80 - curFrame) : curFrame);
@@ -441,7 +441,7 @@ void EnVali_Stunned(EnVali* this, PlayState* play) {
     if (this->actor.velocity.y != 0.0f) {
         if (Math_StepToF(&this->actor.world.pos.y, this->actor.floorHeight, this->actor.velocity.y)) {
             this->actor.velocity.y = 0.0f;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         } else {
             this->actor.velocity.y += 1.0f;
         }
@@ -500,12 +500,12 @@ void EnVali_UpdateDamage(EnVali* this, PlayState* play) {
 
         if ((this->actor.colChkInfo.damageEffect != BARI_DMGEFF_NONE) || (this->actor.colChkInfo.damage != 0)) {
             if (Actor_ApplyDamage(&this->actor) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BARI_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_BARI_DEAD);
                 Enemy_StartFinishingBlow(play, &this->actor);
                 this->actor.flags &= ~ACTOR_FLAG_0;
             } else if ((this->actor.colChkInfo.damageEffect != BARI_DMGEFF_STUN) &&
                        (this->actor.colChkInfo.damageEffect != BARI_DMGEFF_SLINGSHOT)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BARI_DAMAGE);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_BARI_DAMAGE);
             }
 
             if (this->actor.colChkInfo.damageEffect == BARI_DMGEFF_STUN) {

--- a/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.c
+++ b/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.c
@@ -289,7 +289,7 @@ void EnVbBall_Update(Actor* thisx, PlayState* play2) {
             Player* player = GET_PLAYER(play);
 
             this->collider.base.atFlags &= ~AT_HIT;
-            Audio_PlayActorSfx2(&player->actor, NA_SE_PL_BODY_HIT);
+            Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
         }
         Collider_UpdateCylinder(&this->actor, &this->collider);
         CollisionCheck_SetAT(play, &play->colChkCtx, &this->collider.base);

--- a/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
+++ b/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
@@ -202,9 +202,9 @@ void EnViewer_UpdateImpl(EnViewer* this, PlayState* play) {
         if (gSaveContext.sceneLayer == 5) {
             csFrames = play->csCtx.frames;
             if (csFrames == 792) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_VO_Z0_SURPRISE);
+                Actor_PlaySfx(&this->actor, NA_SE_VO_Z0_SURPRISE);
             } else if (csFrames == 845) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_VO_Z0_THROW);
+                Actor_PlaySfx(&this->actor, NA_SE_VO_Z0_THROW);
             }
         }
     } else if (type == ENVIEWER_TYPE_7_GANONDORF) {
@@ -233,7 +233,7 @@ void EnViewer_UpdateImpl(EnViewer* this, PlayState* play) {
         }
         if (gSaveContext.sceneLayer == 5) {
             if (play->csCtx.frames == 1508) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_ST_LAUGH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_ST_LAUGH);
             }
             if (play->csCtx.frames == 1545) {
                 Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_DEMO_6K, 32.0f, 101.0f, 1226.0f, 0, 0, 0,
@@ -249,24 +249,24 @@ void EnViewer_UpdateImpl(EnViewer* this, PlayState* play) {
         }
     } else if (type == ENVIEWER_TYPE_6_HORSE_GANONDORF) {
         if (gSaveContext.sceneLayer == 5 || gSaveContext.sceneLayer == 10) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_HORSE_RUN_LEVEL - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_HORSE_RUN_LEVEL - SFX_FLAG);
         }
     } else if (type == ENVIEWER_TYPE_4_HORSE_GANONDORF) {
         s16 curFrame = this->skin.skelAnime.curFrame;
 
         if (this->skin.skelAnime.animation == &gHorseGanonRearingAnim) {
             if (curFrame == 8) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_HORSE_NEIGH);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_HORSE_NEIGH);
             }
             if (curFrame == 30) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_HORSE_LAND2);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_HORSE_LAND2);
             }
         } else if (this->skin.skelAnime.animation == &gHorseGanonIdleAnim) {
             if (curFrame == 25) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_HORSE_SANDDUST);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_HORSE_SANDDUST);
             }
         } else if (this->skin.skelAnime.animation == &gHorseGanonGallopingAnim) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_HORSE_RUN_LEVEL - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_HORSE_RUN_LEVEL - SFX_FLAG);
         }
     }
 
@@ -342,7 +342,7 @@ void EnViewer_UpdateImpl(EnViewer* this, PlayState* play) {
                         break;
                     case 6:
                         if (play->csCtx.npcActions[1]->action == 12) {
-                            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GANON_VOICE_DEMO);
+                            Actor_PlaySfx(&this->actor, NA_SE_EN_GANON_VOICE_DEMO);
                             Animation_PlayLoopSetSpeed(&this->skin.skelAnime, &gYoungGanondorfHorsebackRideAnim, 3.0f);
                             this->state++;
                         }
@@ -732,7 +732,7 @@ void EnViewer_UpdatePosition(EnViewer* this, PlayState* play) {
                     Audio_PlaySfxGeneral(NA_SE_EV_HORSE_NEIGH, &this->actor.projectedPos, 4,
                                          &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                 }
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_HORSE_RUN_LEVEL - SFX_FLAG);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_HORSE_RUN_LEVEL - SFX_FLAG);
             }
 
             startPos.x = play->csCtx.npcActions[0]->startPos.x;

--- a/src/overlays/actors/ovl_En_Vm/z_en_vm.c
+++ b/src/overlays/actors/ovl_En_Vm/z_en_vm.c
@@ -203,7 +203,7 @@ void EnVm_Wait(EnVm* this, PlayState* play) {
                         this->skelAnime.curFrame = 0.0f;
                         this->skelAnime.startFrame = 0.0f;
                         this->skelAnime.playSpeed = 2.0f;
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BIMOS_AIM);
+                        Actor_PlaySfx(&this->actor, NA_SE_EN_BIMOS_AIM);
                     }
                 }
             } else {
@@ -301,7 +301,7 @@ void EnVm_Attack(EnVm* this, PlayState* play) {
         dist = Math_Vec3f_DistXYZ(&this->beamPos1, &playerPos);
         Math_SmoothStepToF(&this->beamScale.z, dist, 1.0f, this->beamSpeed, 0.0f);
         Math_SmoothStepToF(&this->beamScale.x, 0.1f, 1.0f, 0.12f, 0.0f);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BIMOS_LAZER - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BIMOS_LAZER - SFX_FLAG);
 
         if (this->unk_260 > 2) {
             CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderQuad1.base);
@@ -324,7 +324,7 @@ void EnVm_SetupStun(EnVm* this) {
     this->unk_21C = 2;
     this->beamScale.z = 0.0f;
     this->beamScale.y = 0.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     EnVm_SetupAction(this, EnVm_Stun);
 }
 
@@ -426,14 +426,14 @@ void EnVm_Update(Actor* thisx, PlayState* play) {
     if (this->unk_260 == 4) {
         EffectSsDeadDs_SpawnStationary(play, &this->beamPos3, 20, -1, 255, 20);
         func_80033480(play, &this->beamPos3, 6.0f, 1, 120, 20, 1);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BIMOS_LAZER_GND - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BIMOS_LAZER_GND - SFX_FLAG);
     }
 
     this->actionFunc(this, play);
     this->beamTexScroll += 3 << 2;
 
     if (this->actor.colChkInfo.health != 0 && this->unk_21C != 2) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BIMOS_ROLL_HEAD - SFX_FLAG);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_BIMOS_ROLL_HEAD - SFX_FLAG);
     }
 
     Collider_UpdateCylinder(&this->actor, &this->colliderCylinder);

--- a/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
+++ b/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
@@ -118,7 +118,7 @@ void EnWallTubo_SetWallFall(EnWallTubo* this, PlayState* play) {
         effPos.z = this->explosionCenter.z;
         EffectSsBomb2_SpawnLayered(play, &effPos, &effVelocity, &effAccel, 100, 30);
         EffectSsHahen_SpawnBurst(play, &effPos, 10.0f, 0, 50, 15, 3, HAHEN_OBJECT_DEFAULT, 10, NULL);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
+        Actor_PlaySfx(&this->actor, NA_SE_IT_BOMB_EXPLOSION);
     }
 
     if (this->timer == 0) {

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -423,10 +423,10 @@ void EnWallmas_TakePlayer(EnWallmas* this, PlayState* play) {
 
     if (Animation_OnFrame(&this->skelAnime, 1.0f) != 0) {
         if (!LINK_IS_ADULT) {
-            //! @bug: This is an unsafe cast, although the sfx will still play
+            //! @bug: This is an unsafe cast, although the sound effect will still play
             Player_PlaySfx((Player*)&this->actor, NA_SE_VO_LI_DAMAGE_S_KID);
         } else {
-            //! @bug: This is an unsafe cast, although the sfx will still play
+            //! @bug: This is an unsafe cast, although the sound effect will still play
             Player_PlaySfx((Player*)&this->actor, NA_SE_VO_LI_DAMAGE_S);
         }
 
@@ -450,10 +450,10 @@ void EnWallmas_TakePlayer(EnWallmas* this, PlayState* play) {
 
         if (this->timer == -0x1E) {
             if (!LINK_IS_ADULT) {
-                //! @bug: This is an unsafe cast, although the sfx will still play
+                //! @bug: This is an unsafe cast, although the sound effect will still play
                 Player_PlaySfx((Player*)&this->actor, NA_SE_VO_LI_TAKEN_AWAY_KID);
             } else {
-                //! @bug: This is an unsafe cast, although the sfx will still play
+                //! @bug: This is an unsafe cast, although the sound effect will still play
                 Player_PlaySfx((Player*)&this->actor, NA_SE_VO_LI_TAKEN_AWAY);
             }
         }

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -184,7 +184,7 @@ void EnWallmas_SetupLand(EnWallmas* this, PlayState* play) {
                      ANIMMODE_ONCE, -3.0f);
 
     Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 15.0f, 6, 20.0f, 300, 100, true);
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_LAND);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_LAND);
     this->actionFunc = EnWallmas_Land;
 }
 
@@ -282,7 +282,7 @@ void EnWallmas_SetupStun(EnWallmas* this) {
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_GRAY, 255, COLORFILTER_BUFFLAG_OPA, 80);
     } else {
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 80);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     }
 
     this->timer = 0x50;
@@ -309,7 +309,7 @@ void EnWallmas_WaitToDrop(EnWallmas* this, PlayState* play) {
     }
 
     if (this->timer == 0x50) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_AIM);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_AIM);
     }
 
     if (this->timer == 0) {
@@ -350,7 +350,7 @@ void EnWallmas_Walk(EnWallmas* this, PlayState* play) {
 
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 12.0f) ||
         Animation_OnFrame(&this->skelAnime, 24.0f) || Animation_OnFrame(&this->skelAnime, 36.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_WALK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_WALK);
     }
 }
 
@@ -369,7 +369,7 @@ void EnWallmas_ReturnToCeiling(EnWallmas* this, PlayState* play) {
     }
 
     if (Animation_OnFrame(&this->skelAnime, 20.0f) != 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_UP);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_UP);
     }
 
     if (this->actor.yDistToPlayer < -900.0f) {
@@ -396,7 +396,7 @@ void EnWallmas_TakeDamage(EnWallmas* this, PlayState* play) {
         }
     }
     if (Animation_OnFrame(&this->skelAnime, 13.0f) != 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
     }
 
     Math_StepToF(&this->actor.speedXZ, 0.0f, 0.2f);
@@ -423,12 +423,14 @@ void EnWallmas_TakePlayer(EnWallmas* this, PlayState* play) {
 
     if (Animation_OnFrame(&this->skelAnime, 1.0f) != 0) {
         if (!LINK_IS_ADULT) {
-            func_8002F7DC(&this->actor, NA_SE_VO_LI_DAMAGE_S_KID);
+            //! @bug: This is an unsafe cast, although the sfx will still play
+            Player_PlaySfx((Player*)&this->actor, NA_SE_VO_LI_DAMAGE_S_KID);
         } else {
-            func_8002F7DC(&this->actor, NA_SE_VO_LI_DAMAGE_S);
+            //! @bug: This is an unsafe cast, although the sfx will still play
+            Player_PlaySfx((Player*)&this->actor, NA_SE_VO_LI_DAMAGE_S);
         }
 
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_CATCH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_CATCH);
     }
     if (SkelAnime_Update(&this->skelAnime)) {
         player->actor.world.pos.x = this->actor.world.pos.x;
@@ -448,13 +450,15 @@ void EnWallmas_TakePlayer(EnWallmas* this, PlayState* play) {
 
         if (this->timer == -0x1E) {
             if (!LINK_IS_ADULT) {
-                func_8002F7DC(&this->actor, NA_SE_VO_LI_TAKEN_AWAY_KID);
+                //! @bug: This is an unsafe cast, although the sfx will still play
+                Player_PlaySfx((Player*)&this->actor, NA_SE_VO_LI_TAKEN_AWAY_KID);
             } else {
-                func_8002F7DC(&this->actor, NA_SE_VO_LI_TAKEN_AWAY);
+                //! @bug: This is an unsafe cast, although the sfx will still play
+                Player_PlaySfx((Player*)&this->actor, NA_SE_VO_LI_TAKEN_AWAY);
             }
         }
         if (this->timer == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_UP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_UP);
         }
 
         this->timer = this->timer + 2;
@@ -507,11 +511,11 @@ void EnWallmas_ColUpdate(EnWallmas* this, PlayState* play) {
         if ((this->actor.colChkInfo.damageEffect != 0) || (this->actor.colChkInfo.damage != 0)) {
             if (Actor_ApplyDamage(&this->actor) == 0) {
                 Enemy_StartFinishingBlow(play, &this->actor);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_DEAD);
                 this->actor.flags &= ~ACTOR_FLAG_0;
             } else {
                 if (this->actor.colChkInfo.damage != 0) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FALL_DAMAGE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_FALL_DAMAGE);
                 }
             }
 

--- a/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
+++ b/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
@@ -184,7 +184,7 @@ void func_80B32660(EnWeiyer* this) {
     this->collider.dim.height = sCylinderInit.dim.height + 15;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 200, COLORFILTER_BUFFLAG_OPA, 80);
     this->collider.base.atFlags &= ~AT_ON;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->actionFunc = func_80B333B8;
 }
 
@@ -264,7 +264,7 @@ void func_80B328E8(EnWeiyer* this, PlayState* play) {
             this->unk_194 = 30;
 
             if (Rand_ZeroOne() < 0.3333f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EIER_CRY);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_EIER_CRY);
             }
         }
     }
@@ -312,7 +312,7 @@ void func_80B32C2C(EnWeiyer* this, PlayState* play) {
         if (this->actor.world.pos.y < this->actor.home.pos.y) {
             if (this->actor.shape.rot.x > 0) {
                 EffectSsGSplash_Spawn(play, &this->actor.world.pos, NULL, NULL, 1, 400);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_SINK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_SINK);
             }
 
             func_80B32538(this);
@@ -326,7 +326,7 @@ void func_80B32D30(EnWeiyer* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
     if (Animation_OnFrame(&this->skelAnime, 0.0f)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EIER_FLUTTER);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_EIER_FLUTTER);
     }
 
     Math_ScaledStepToS(&this->actor.shape.rot.x, 0, 0x800);
@@ -495,11 +495,11 @@ void func_80B333B8(EnWeiyer* this, PlayState* play) {
 
     if (this->actor.home.pos.y < this->actor.floorHeight) {
         if (Animation_OnFrame(&this->skelAnime, 0.0f)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EIER_FLUTTER);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_EIER_FLUTTER);
         }
 
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
     }
 
@@ -526,7 +526,7 @@ void func_80B3349C(EnWeiyer* this, PlayState* play) {
         } else if (this->actor.yDistToWater < 0.0f) {
             this->unk_194 = 10;
             EffectSsGSplash_Spawn(play, &this->actor.world.pos, NULL, NULL, 1, 400);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_JUMP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_JUMP);
         }
     } else {
         if (phi_a0 || (this->collider.base.atFlags & AT_HIT)) {
@@ -550,7 +550,7 @@ void func_80B3349C(EnWeiyer* this, PlayState* play) {
             func_80B32434(this);
         } else if ((this->actor.bgCheckFlags & BGCHECKFLAG_WATER) && (this->actor.shape.rot.x > 0)) {
             EffectSsGSplash_Spawn(play, &this->actor.world.pos, NULL, NULL, 1, 400);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_OCTAROCK_SINK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_OCTAROCK_SINK);
             func_80B32538(this);
         } else {
             Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 8, 0x100, 0x80);
@@ -570,7 +570,7 @@ void func_80B3368C(EnWeiyer* this, PlayState* play) {
                 }
             } else if (Actor_ApplyDamage(&this->actor) == 0) {
                 Enemy_StartFinishingBlow(play, &this->actor);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EIER_DEAD);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_EIER_DEAD);
                 this->actor.flags &= ~ACTOR_FLAG_0;
                 func_80B32724(this);
             } else {
@@ -602,7 +602,7 @@ void EnWeiyer_Update(Actor* thisx, PlayState* play) {
 
     if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~(AT_ON | AT_HIT);
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_EIER_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_EIER_ATTACK);
     }
 
     Collider_UpdateCylinder(&this->actor, &this->collider);

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -397,7 +397,7 @@ void EnWf_WaitToAppear(EnWf* this, PlayState* play) {
         this->actionTimer--;
 
         if (this->actionTimer == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_APPEAR);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_APPEAR);
         }
     } else { // actionTimer == 0
         if (SkelAnime_Update(&this->skelAnime)) {
@@ -474,7 +474,7 @@ void EnWf_Wait(EnWf* this, PlayState* play) {
                     EnWf_SetupSearchForPlayer(this);
                 }
                 if ((play->gameplayFrames & 95) == 0) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_CRY);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_CRY);
                 }
             }
         }
@@ -554,11 +554,11 @@ void EnWf_RunAtPlayer(EnWf* this, PlayState* play) {
 
         if (!EnWf_ChangeAction(play, this, false)) {
             if ((play->gameplayFrames & 95) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_CRY);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_CRY);
             }
             if ((prevFrame != (s32)this->skelAnime.curFrame) && (beforeCurFrame <= 0) &&
                 ((absPlaySpeed + prevFrame) > 0)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_WALK);
                 Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 20.0f, 3, 3.0f, 50, 50, true);
             }
         }
@@ -602,7 +602,7 @@ void EnWf_SearchForPlayer(EnWf* this, PlayState* play) {
         }
 
         if ((play->gameplayFrames & 95) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_CRY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_CRY);
         }
     }
 }
@@ -688,12 +688,12 @@ void EnWf_RunAroundPlayer(EnWf* this, PlayState* play) {
         absPlaySpeed = (s32)(f32)ABS(this->skelAnime.playSpeed);
 
         if ((prevFrame != (s32)this->skelAnime.curFrame) && (beforeCurFrame <= 0) && (absPlaySpeed + prevFrame > 0)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_WALK);
             Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 20.0f, 3, 3.0f, 50, 50, true);
         }
 
         if ((play->gameplayFrames & 95) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_CRY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_CRY);
         }
 
         if ((Math_CosS(angle1 - this->actor.shape.rot.y) < -0.85f) && !Actor_OtherIsTargeted(play, &this->actor) &&
@@ -739,7 +739,7 @@ void EnWf_Slash(EnWf* this, PlayState* play) {
 
     if (((curFrame >= 9) && (curFrame <= 12)) || ((curFrame >= 17) && (curFrame <= 19))) {
         if (this->slashStatus == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_ATTACK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_ATTACK);
         }
 
         this->slashStatus = 1;
@@ -844,7 +844,7 @@ void EnWf_SetupBackflipAway(EnWf* this) {
     this->actionTimer = 0;
     this->unk_300 = true;
     this->action = WOLFOS_ACTION_BACKFLIP_AWAY;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     EnWf_SetupAction(this, EnWf_BackflipAway);
 }
 
@@ -860,7 +860,7 @@ void EnWf_BackflipAway(EnWf* this, PlayState* play) {
         }
     }
     if ((play->state.frames & 95) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_CRY);
     }
 }
 
@@ -869,7 +869,7 @@ void EnWf_SetupStunned(EnWf* this) {
         this->actor.speedXZ = 0.0f;
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     Animation_PlayOnceSetSpeed(&this->skelAnime, &gWolfosDamagedAnim, 0.0f);
     this->action = WOLFOS_ACTION_STUNNED;
     EnWf_SetupAction(this, EnWf_Stunned);
@@ -909,7 +909,7 @@ void EnWf_SetupDamaged(EnWf* this) {
 
     this->unk_2E2 = 0;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_DAMAGE);
     this->action = WOLFOS_ACTION_DAMAGED;
     EnWf_SetupAction(this, EnWf_Damaged);
 }
@@ -964,7 +964,7 @@ void EnWf_SetupSomersaultAndAttack(EnWf* this) {
     this->action = WOLFOS_ACTION_TURN_TOWARDS_PLAYER;
     this->actor.speedXZ = 6.5f;
     this->actor.velocity.y = 15.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_STAL_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnWf_SetupAction(this, EnWf_SomersaultAndAttack);
 }
@@ -1169,12 +1169,12 @@ void EnWf_Sidestep(EnWf* this, PlayState* play) {
         }
 
         if ((prevFrame != (s32)this->skelAnime.curFrame) && (beforeCurFrame <= 0) && ((absPlaySpeed + prevFrame) > 0)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_WALK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_WALK);
             Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 20.0f, 3, 3.0f, 50, 50, true);
         }
 
         if ((play->gameplayFrames & 95) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_CRY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_CRY);
         }
     }
 }
@@ -1193,7 +1193,7 @@ void EnWf_SetupDie(EnWf* this) {
     this->action = WOLFOS_ACTION_DIE;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actionTimer = this->skelAnime.animLength;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_WOLFOS_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_WOLFOS_DEAD);
     EnWf_SetupAction(this, EnWf_Die);
 }
 

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -334,7 +334,7 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
     if (this->actor.params <= WOOD_TREE_KAKARIKO_ADULT) {
         if (this->collider.base.acFlags & AC_HIT) {
             this->collider.base.acFlags &= ~AC_HIT;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_IT_REFLECTION_WOOD);
+            Actor_PlaySfx(&this->actor, NA_SE_IT_REFLECTION_WOOD);
         }
 
         if (this->actor.home.rot.y != 0) {
@@ -361,7 +361,7 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
                     (this->actor.params == WOOD_TREE_OVAL_YELLOW_SPAWNED)) {
                     leavesParams = WOOD_LEAF_YELLOW;
                 }
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_TREE_SWING);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_TREE_SWING);
 
                 for (i = 3; i >= 0; i--) {
                     Actor_Spawn(&play->actorCtx, play, ACTOR_EN_WOOD02, dropsSpawnPt.x, dropsSpawnPt.y, dropsSpawnPt.z,
@@ -390,7 +390,7 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
                                                ((this->unk_14C << 4) | 0x8000));
                 }
                 this->unk_14C = -0x15;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_TREE_SWING);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_TREE_SWING);
             }
         }
     } else { // Leaves

--- a/src/overlays/actors/ovl_En_Zf/z_en_zf.c
+++ b/src/overlays/actors/ovl_En_Zf/z_en_zf.c
@@ -648,7 +648,7 @@ void EnZf_SetupDropIn(EnZf* this) {
 
 void EnZf_DropIn(EnZf* this, PlayState* play) {
     if (this->unk_3F0 == 1) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
         this->actor.flags |= ACTOR_FLAG_0;
 
         if (this->actor.params == ENZF_TYPE_LIZALFOS_MINIBOSS_A) {
@@ -662,7 +662,7 @@ void EnZf_DropIn(EnZf* this, PlayState* play) {
         } else if (this->actor.xzDistToPlayer <= 160.0f) {
             this->unk_3F0 = 0;
             this->actor.flags |= ACTOR_FLAG_0;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
         }
 
         this->actor.world.pos.y = this->actor.floorHeight + 300.0f;
@@ -671,7 +671,7 @@ void EnZf_DropIn(EnZf* this, PlayState* play) {
     }
 
     if ((this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH)) && (this->hopAnimIndex != 0)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_ONGND);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_ONGND);
         Animation_Change(&this->skelAnime, &gZfLandingAnim, 1.0f, 0.0f, 17.0f, ANIMMODE_ONCE, 0.0f);
         this->hopAnimIndex = 0;
         this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND_TOUCH;
@@ -752,7 +752,7 @@ void func_80B4543C(EnZf* this, PlayState* play) {
             }
 
             if ((play->gameplayFrames & 0x5F) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
             }
         }
     }
@@ -904,14 +904,14 @@ void EnZf_ApproachPlayer(EnZf* this, PlayState* play) {
         }
 
         if ((play->gameplayFrames & 0x5F) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
         }
 
         if (prevFrame != (s32)this->skelAnime.curFrame) {
             afterPrevFrame = absPlaySpeed + prevFrame;
 
             if (((beforeCurFrame < 2) && (afterPrevFrame >= 4)) || ((beforeCurFrame < 32) && (afterPrevFrame >= 34))) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_WALK);
             }
         }
     }
@@ -930,7 +930,7 @@ void EnZf_SetupJumpForward(EnZf* this) {
     }
 
     this->action = ENZF_ACTION_JUMP_FORWARD;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_JUMP);
     EnZf_SetupAction(this, EnZf_JumpForward);
 }
 
@@ -946,7 +946,7 @@ void EnZf_JumpForward(EnZf* this, PlayState* play) {
         if (this->unk_3F0 == 0) {
             Animation_Change(&this->skelAnime, &gZfLandingAnim, 3.0f, 0.0f, 17.0f, ANIMMODE_ONCE, -3.0f);
             this->unk_3F0 = 10;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_JUMP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_JUMP);
         } else {
             this->actor.speedXZ = 0.0f;
             this->hopAnimIndex = 0;
@@ -954,7 +954,7 @@ void EnZf_JumpForward(EnZf* this, PlayState* play) {
         }
     }
     if ((play->gameplayFrames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
     }
 
     if ((this->actor.params == ENZF_TYPE_DINOLFOS) &&
@@ -1024,7 +1024,7 @@ void func_80B46098(EnZf* this, PlayState* play) {
                 }
             }
             if ((play->gameplayFrames & 0x5F) == 0) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
             }
         }
     }
@@ -1141,12 +1141,12 @@ void func_80B463E4(EnZf* this, PlayState* play) {
 
             if (((beforeCurFrame < 14) && (afterPrevFrame >= 16)) ||
                 ((beforeCurFrame < 27) && (afterPrevFrame >= 29))) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_WALK);
             }
         }
 
         if ((play->gameplayFrames & 0x5F) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
         }
 
         if ((Math_CosS(angleBehindPlayer - this->actor.shape.rot.y) < -0.85f) || (this->unk_3F0 == 0)) {
@@ -1174,7 +1174,7 @@ void EnZf_SetupSlash(EnZf* this) {
 
     this->swordCollider.base.atFlags &= ~AT_BOUNCED;
     this->action = ENZF_ACTION_SLASH;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
     this->actor.speedXZ = 0.0f;
     EnZf_SetupAction(this, EnZf_Slash);
 }
@@ -1187,7 +1187,7 @@ void EnZf_Slash(EnZf* this, PlayState* play) {
     this->actor.speedXZ = 0.0f;
 
     if ((s32)this->skelAnime.curFrame == 10) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_ATTACK);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_ATTACK);
     }
 
     if (SkelAnime_Update(&this->skelAnime)) {
@@ -1260,7 +1260,7 @@ void EnZf_SetupJumpBack(EnZf* this) {
     this->action = ENZF_ACTION_JUMP_BACK;
     this->actor.velocity.y = 15.0f;
     this->actor.speedXZ = -15.0f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_JUMP);
     EnZf_SetupAction(this, EnZf_JumpBack);
 }
 
@@ -1276,7 +1276,7 @@ void EnZf_JumpBack(EnZf* this, PlayState* play) {
         if (this->unk_3F0 == 0) {
             Animation_Change(&this->skelAnime, &gZfLandingAnim, 3.0f, 0.0f, 17.0f, ANIMMODE_ONCE, -3.0f);
             this->unk_3F0 = 10;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_JUMP);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_JUMP);
         } else if ((play->gameplayFrames % 2) != 0) {
             func_80B483E4(this, play);
         } else {
@@ -1285,7 +1285,7 @@ void EnZf_JumpBack(EnZf* this, PlayState* play) {
     }
 
     if ((play->state.frames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
     }
 }
 
@@ -1304,7 +1304,7 @@ void EnZf_SetupStunned(EnZf* this) {
         Animation_PlayOnceSetSpeed(&this->skelAnime, &gZfKnockedBackAnim, 0.0f);
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->action = ENZF_ACTION_STUNNED;
     EnZf_SetupAction(this, EnZf_Stunned);
 }
@@ -1455,7 +1455,7 @@ void EnZf_HopAndTaunt(EnZf* this, PlayState* play) {
         }
 
         if ((play->gameplayFrames & 0x5F) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
         }
     }
 }
@@ -1487,7 +1487,7 @@ void EnZf_HopAway(EnZf* this, PlayState* play) {
     sp54 = this->hopAnimIndex;
 
     if ((play->gameplayFrames & 0x5F) == 0) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
     }
 
     // Upstairs
@@ -1546,7 +1546,7 @@ void EnZf_HopAway(EnZf* this, PlayState* play) {
         case 1:
             if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) ||
                 (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_ONGND);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_ONGND);
                 this->actor.velocity.y = 0.0f;
                 this->actor.world.pos.y = this->actor.floorHeight;
                 this->actor.speedXZ = 0.0f;
@@ -1603,7 +1603,7 @@ void EnZf_DrawSword(EnZf* this, PlayState* play) {
     }
 
     if (SkelAnime_Update(&this->skelAnime)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
         this->actor.world.rot.y = yawTowardsPlayer;
         this->hopAnimIndex = -1;
         func_80B45384(this);
@@ -1634,7 +1634,7 @@ void EnZf_SetupDamaged(EnZf* this) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     }
 
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DAMAGE);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DAMAGE);
     this->action = ENZF_ACTION_DAMAGED;
     EnZf_SetupAction(this, EnZf_Damaged);
 }
@@ -1709,7 +1709,7 @@ void EnZf_SetupJumpUp(EnZf* this) {
     this->action = ENZF_ACTION_JUMP_UP;
     this->actor.velocity.y = 22.0f;
     this->actor.speedXZ = 7.5f;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_JUMP);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnZf_SetupAction(this, EnZf_JumpUp);
 }
@@ -1731,7 +1731,7 @@ void EnZf_JumpUp(EnZf* this, PlayState* play) {
             this->actor.speedXZ = 0.0f;
             this->actor.world.pos.y = this->actor.floorHeight;
             EnZf_SetupSlash(this);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_ATTACK);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_ATTACK);
             this->skelAnime.curFrame = 13.0f;
         }
     }
@@ -1893,11 +1893,11 @@ void EnZf_CircleAroundPlayer(EnZf* this, PlayState* play) {
 
             if (((beforeCurFrame < 14) && (afterPrevFrame >= 16)) ||
                 ((beforeCurFrame < 27) && (afterPrevFrame >= 29))) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_WALK);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_WALK);
             }
         }
         if ((play->gameplayFrames & 0x5F) == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
         }
     }
 }
@@ -1934,7 +1934,7 @@ void EnZf_SetupDie(EnZf* this) {
     }
 
     D_80B4A1B0 = 0;
-    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DEAD);
+    Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DEAD);
     EnZf_SetupAction(this, EnZf_Die);
 }
 
@@ -1970,7 +1970,7 @@ void EnZf_Die(EnZf* this, PlayState* play) {
         s32 curFrame = this->skelAnime.curFrame;
 
         if ((curFrame == 10) || (curFrame == 18)) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_DOWN);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
         }
     }
 }
@@ -2010,7 +2010,7 @@ void EnZf_UpdateDamage(EnZf* this, PlayState* play) {
                     EnZf_SetupStunned(this);
                 }
             } else {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_RIZA_CRY);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
                 Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
 
                 if (Actor_ApplyDamage(&this->actor) == 0) {

--- a/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
+++ b/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
@@ -423,7 +423,7 @@ void func_80B4BBC4(EnZl1* this, PlayState* play) {
 
     Animation_Change(&this->skelAnime, &gChildZelda1Anim_00438, 1.0f, 0.0f, frameCount, ANIMMODE_LOOP, 0.0f);
     func_8002DF54(play, &this->actor, PLAYER_CSMODE_1);
-    func_8002F7DC(&player->actor, NA_SE_VO_LI_SURPRISE_KID);
+    Player_PlaySfx(player, NA_SE_VO_LI_SURPRISE_KID);
     this->actor.textId = 0x7039;
     Message_StartTextbox(play, this->actor.textId, NULL);
     this->unk_1E2 = 0;

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -446,7 +446,7 @@ s32 EnZl4_CsMeetPlayer(EnZl4* this, PlayState* play) {
     switch (this->talkState) {
         case 0:
             if (this->skelAnime.curFrame == 50.0f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_VO_Z0_MEET);
+                Actor_PlaySfx(&this->actor, NA_SE_VO_Z0_MEET);
             }
             if (!EnZl4_SetNextAnim(this, ZL4_ANIM_4)) {
                 break;
@@ -551,7 +551,7 @@ s32 EnZl4_CsAskStone(EnZl4* this, PlayState* play) {
             break;
         case 4:
             if (this->skelAnime.curFrame == 16.0f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_VO_Z0_QUESTION);
+                Actor_PlaySfx(&this->actor, NA_SE_VO_Z0_QUESTION);
             }
             if (EnZl4_SetNextAnim(this, ZL4_ANIM_10)) {
                 this->talkState++;
@@ -598,7 +598,7 @@ s32 EnZl4_CsAskStone(EnZl4* this, PlayState* play) {
             break;
         case 7:
             if (this->skelAnime.curFrame == 17.0f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_VO_Z0_SMILE_0);
+                Actor_PlaySfx(&this->actor, NA_SE_VO_Z0_SMILE_0);
             }
             if (EnZl4_SetNextAnim(this, ZL4_ANIM_29)) {
                 this->talkState++;
@@ -739,7 +739,7 @@ s32 EnZl4_CsAskName(EnZl4* this, PlayState* play) {
             break;
         case 12:
             if (this->skelAnime.curFrame == 5.0f) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_VO_Z0_SIGH_0);
+                Actor_PlaySfx(&this->actor, NA_SE_VO_Z0_SIGH_0);
             }
             if (EnZl4_SetNextAnim(this, ZL4_ANIM_12)) {
                 this->talkState++;
@@ -834,7 +834,7 @@ s32 EnZl4_CsTellLegend(EnZl4* this, PlayState* play) {
                 this->mouthExpression = ZL4_MOUTH_SURPRISED;
                 Message_StartTextbox(play, 0x7038, NULL);
                 this->talkState++;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_VO_Z0_HURRY);
+                Actor_PlaySfx(&this->actor, NA_SE_VO_Z0_HURRY);
             }
             break;
         case 5:

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -642,7 +642,7 @@ void EnZo_Submerged(EnZo* this, PlayState* play) {
 
 void EnZo_Surface(EnZo* this, PlayState* play) {
     if (this->actor.yDistToWater < 54.0f) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_OUT_OF_WATER);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_OUT_OF_WATER);
         EnZo_SpawnSplashes(this);
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENZO_ANIM_3);
         this->actor.flags |= ACTOR_FLAG_0;
@@ -693,7 +693,7 @@ void EnZo_TreadWater(EnZo* this, PlayState* play) {
 
 void EnZo_Dive(EnZo* this, PlayState* play) {
     if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_DIVE_WATER);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_DIVE_WATER);
         EnZo_SpawnSplashes(this);
         this->actor.flags &= ~ACTOR_FLAG_0;
         this->actor.velocity.y = -4.0f;

--- a/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
+++ b/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
@@ -141,7 +141,7 @@ void EnfHG_Intro(EnfHG* this, PlayState* play) {
                                        GND_BOSSROOM_CENTER_Z + 308.0f, 0, 0, 0, (SHUTTER_PG_BARS << 6));
                 }
                 if (this->timers[0] == 51) {
-                    Audio_PlayActorSfx2(this->actor.child, NA_SE_EV_SPEAR_FENCE);
+                    Actor_PlaySfx(this->actor.child, NA_SE_EV_SPEAR_FENCE);
                     SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_BOSS);
                 }
                 if (this->timers[0] == 0) {
@@ -180,7 +180,7 @@ void EnfHG_Intro(EnfHG* this, PlayState* play) {
                                    GND_BOSSROOM_CENTER_Z + 308.0f, 0, 0, 0, (SHUTTER_PG_BARS << 6));
             }
             if (this->timers[0] == 21) {
-                Audio_PlayActorSfx2(this->actor.child, NA_SE_EV_SPEAR_FENCE);
+                Actor_PlaySfx(this->actor.child, NA_SE_EV_SPEAR_FENCE);
             }
             if (this->timers[0] == 0) {
                 this->cutsceneState = INTRO_BACK;
@@ -189,7 +189,7 @@ void EnfHG_Intro(EnfHG* this, PlayState* play) {
             break;
         case INTRO_BACK:
             if (this->timers[0] == 25) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_HORSE_GROAN);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_HORSE_GROAN);
             }
             if (this->timers[0] == 20) {
                 func_8002DF54(play, &this->actor, PLAYER_CSMODE_9);
@@ -219,7 +219,7 @@ void EnfHG_Intro(EnfHG* this, PlayState* play) {
             Math_ApproachF(&this->subCamAt.z, GND_BOSSROOM_CENTER_Z - 65.0f, 0.1f, this->subCamVelFactor * 40.0f);
             Math_ApproachF(&this->subCamVelFactor, 1.0f, 1.0f, 0.05f);
             if (this->timers[0] == 5) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_HORSE_SANDDUST);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_HORSE_SANDDUST);
             }
             if (this->timers[0] == 0) {
                 this->cutsceneState = INTRO_CUT;
@@ -260,16 +260,16 @@ void EnfHG_Intro(EnfHG* this, PlayState* play) {
             if ((this->timers[0] == 245) || (this->timers[0] == 3)) {
                 Animation_MorphToPlayOnce(&this->skin.skelAnime, &gPhantomHorseRearingAnim, -8.0f);
                 this->bossGndSignal = FHG_REAR;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_HORSE_NEIGH);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_HORSE_NEIGH);
                 if (this->timers[0] == 3) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_VOICE);
+                    Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_VOICE);
                 }
             }
             if (this->timers[0] == 192) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_HORSE_SANDDUST);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_HORSE_SANDDUST);
             }
             if (this->timers[0] == 212) {
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_HORSE_LAND2);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_HORSE_LAND2);
                 Animation_Change(&this->skin.skelAnime, &gPhantomHorseIdleAnim, 0.3f, 0.0f, 5.0f, ANIMMODE_LOOP_INTERP,
                                  -10.0f);
             }
@@ -343,8 +343,8 @@ void EnfHG_Intro(EnfHG* this, PlayState* play) {
                 Animation_Change(&this->skin.skelAnime, &gPhantomHorseLeapAnim, 1.0f, 0.0f,
                                  Animation_GetLastFrame(&gPhantomHorseLeapAnim), ANIMMODE_ONCE_INTERP, -4.0f);
                 this->bossGndSignal = FHG_SPUR;
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_VOICE);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_HORSE_NEIGH);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_VOICE);
+                Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_HORSE_NEIGH);
             }
             break;
         case INTRO_RETREAT:
@@ -355,7 +355,7 @@ void EnfHG_Intro(EnfHG* this, PlayState* play) {
             }
             if (this->timers[0] == 170) {
                 func_8002DF54(play, &this->actor, PLAYER_CSMODE_8);
-                Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_MASIC2);
+                Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_MASIC2);
             }
             Math_ApproachF(&this->subCamEye.z, this->subCamPanZ + (GND_BOSSROOM_CENTER_Z + 100.0f), 0.1f,
                            this->subCamVelFactor * 1.5f);
@@ -484,7 +484,7 @@ void EnfHG_Approach(EnfHG* this, PlayState* play) {
             this->turnTarget = -0x8000;
         } else {
             this->actionFunc = EnfHG_Attack;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_GANON_HORSE_NEIGH);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_GANON_HORSE_NEIGH);
             this->timers[0] = 40;
             Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_EN_FHG_FIRE, this->actor.world.pos.x,
                                this->actor.world.pos.y + 50.0f, this->actor.world.pos.z, 0,
@@ -515,8 +515,8 @@ void EnfHG_Attack(EnfHG* this, PlayState* play) {
         Math_ApproachF(&this->warpColorFilterB, play->lightCtx.fogColor[0], 1.0f, 10.0f);
         Math_ApproachF(&this->warpColorFilterUnk1, 0.0f, 1.0f, 5.0f);
         if (this->timers[1] == 29) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_MASIC2);
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_VOICE);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_MASIC2);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_VOICE);
         }
         if (this->hitTimer == 0) {
             if (this->timers[1] == 24) {
@@ -645,7 +645,7 @@ void EnfHG_Retreat(EnfHG* this, PlayState* play) {
     Math_ApproachF(&this->actor.world.pos.y, 200.0f, 0.05f, 1.0f);
     this->actor.scale.y = this->actor.scale.x;
     if ((this->timers[0] == 80) && (this->actor.params == GND_REAL_BOSS)) {
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EN_FANTOM_LAUGH);
+        Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_LAUGH);
     }
     if (this->timers[0] == 0) {
         BossGanondrof* bossGnd = (BossGanondrof*)this->actor.parent;

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -2820,7 +2820,7 @@ void func_80B71278(Fishing* this, u8 arg1) {
         }
     }
 
-    Audio_PlayActorSfx2(&this->actor, sfxId);
+    Actor_PlaySfx(&this->actor, sfxId);
 }
 
 void Fishing_HandleAquariumDialog(Fishing* this, PlayState* play) {
@@ -3248,7 +3248,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                         Fishing_SpawnRipple(&this->actor.projectedPos, play->specialEffects, &spB8, 30.0f, 400.0f, 150,
                                             90);
 
-                        Audio_PlayActorSfx2(&this->actor, NA_SE_PL_CATCH_BOOMERANG);
+                        Actor_PlaySfx(&this->actor, NA_SE_PL_CATCH_BOOMERANG);
                         break;
                     }
                 }
@@ -3522,7 +3522,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                 this->unk_194 = 2000.0f;
             } else if (sp124 < 10.0f) {
                 if (sLurePos.y > (WATER_SURFACE_Y(play) - 10.0f)) {
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_JUMP_OUT_WATER);
+                    Actor_PlaySfx(&this->actor, NA_SE_EV_JUMP_OUT_WATER);
                     func_80078884(NA_SE_PL_CATCH_BOOMERANG);
                 }
 
@@ -4150,7 +4150,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                     this->actor.velocity.x = this->actor.world.pos.x * -0.003f;
                     this->actor.velocity.z = this->actor.world.pos.z * -0.003f;
 
-                    Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FISH_LEAP);
+                    Actor_PlaySfx(&this->actor, NA_SE_EV_FISH_LEAP);
                     func_80B70CF0(this, play);
 
                     if (Rand_ZeroOne() < 0.5f) {

--- a/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
+++ b/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
@@ -108,7 +108,7 @@ void ItemOcarina_Fly(ItemOcarina* this, PlayState* play) {
         this->actor.gravity = -0.1f;
         this->actor.minVelocityY = -0.5f;
         this->spinRotOffset = 0;
-        Audio_PlayActorSfx2(&this->actor, NA_SE_EV_BOMB_DROP_WATER);
+        Actor_PlaySfx(&this->actor, NA_SE_EV_BOMB_DROP_WATER);
     }
 
     // landed in water

--- a/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.c
+++ b/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.c
@@ -111,7 +111,7 @@ void MagicFire_UpdateBeforeCast(Actor* thisx, PlayState* play) {
         this->actionTimer--;
     } else {
         this->actor.update = MagicFire_Update;
-        func_8002F7DC(&player->actor, NA_SE_PL_MAGIC_FIRE);
+        Player_PlaySfx(player, NA_SE_PL_MAGIC_FIRE);
     }
     this->actor.world.pos = player->actor.world.pos;
 }

--- a/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.c
+++ b/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.c
@@ -61,7 +61,7 @@ void MagicWind_Init(Actor* thisx, PlayState* play) {
             MagicWind_SetupAction(this, MagicWind_Shrink);
             // "Means start"
             LOG_STRING("表示開始", "../z_magic_wind.c", 486);
-            func_8002F7DC(&player->actor, NA_SE_PL_MAGIC_WIND_WARP);
+            Player_PlaySfx(player, NA_SE_PL_MAGIC_WIND_WARP);
             break;
     }
 }
@@ -92,7 +92,7 @@ void MagicWind_WaitForTimer(MagicWind* this, PlayState* play) {
 
     // "Means start"
     LOG_STRING("表示開始", "../z_magic_wind.c", 539);
-    func_8002F7DC(&player->actor, NA_SE_PL_MAGIC_WIND_NORMAL);
+    Player_PlaySfx(player, NA_SE_PL_MAGIC_WIND_NORMAL);
     MagicWind_UpdateAlpha(1.0f);
     MagicWind_SetupAction(this, MagicWind_Grow);
     SkelCurve_Update(play, &this->skelCurve);

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -703,7 +703,7 @@ void ObjBean_GrowWaterPhase3(ObjBean* this, PlayState* play) {
                 Item_DropCollectible(play, &itemDropPos, ITEM00_FLEXIBLE);
             }
             this->stateFlags |= BEAN_STATE_BEEN_WATERED;
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BUTTERFRY_TO_FAIRY);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BUTTERFRY_TO_FAIRY);
             func_80078884(NA_SE_SY_TRE_BOX_APPEAR);
         }
     } else if (this->timer <= 0) {

--- a/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
+++ b/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
@@ -96,7 +96,7 @@ void ObjDekujr_ComeUp(ObjDekujr* this, PlayState* play) {
         this->unk_19B = 0;
     } else {
         if (play->csCtx.frames == 351) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_COME_UP_DEKU_JR);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_COME_UP_DEKU_JR);
         }
         csCmdNPCAction = play->csCtx.npcActions[1];
         if (csCmdNPCAction != NULL) {

--- a/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.c
+++ b/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.c
@@ -104,10 +104,10 @@ void func_80B92D44(ObjElevator* this, PlayState* play) {
     Actor* thisx = &this->dyna.actor;
 
     if (fabsf(Math_SmoothStepToF(&thisx->world.pos.y, this->unk_168, 1.0f, this->unk_16C, 0.0f)) < 0.001f) {
-        Audio_PlayActorSfx2(thisx, NA_SE_EV_FOOT_SWITCH);
+        Actor_PlaySfx(thisx, NA_SE_EV_FOOT_SWITCH);
         func_80B92C5C(this);
     } else {
-        Audio_PlayActorSfx2(thisx, NA_SE_EV_STONE_STATUE_OPEN - SFX_FLAG);
+        Actor_PlaySfx(thisx, NA_SE_EV_STONE_STATUE_OPEN - SFX_FLAG);
     }
 }
 

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
@@ -167,7 +167,7 @@ void ObjIcePoly_Melt(ObjIcePoly* this, PlayState* play) {
         this->meltTimer++;
         if (this->meltTimer == 0) {
             this->meltTimer = 40;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_ICE_MELT);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_ICE_MELT);
         }
     } else {
         if (this->meltTimer != 0) {

--- a/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
+++ b/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
@@ -219,7 +219,7 @@ void ObjKibako_Idle(ObjKibako* this, PlayState* play) {
 void ObjKibako_SetupHeld(ObjKibako* this) {
     this->actionFunc = ObjKibako_Held;
     this->actor.room = -1;
-    //! @bug: This is an unsafe cast, although the sfx will still play
+    //! @bug: This is an unsafe cast, although the sound effect will still play
     Player_PlaySfx((Player*)&this->actor, NA_SE_PL_PULL_UP_WOODBOX);
 }
 

--- a/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
+++ b/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
@@ -219,14 +219,15 @@ void ObjKibako_Idle(ObjKibako* this, PlayState* play) {
 void ObjKibako_SetupHeld(ObjKibako* this) {
     this->actionFunc = ObjKibako_Held;
     this->actor.room = -1;
-    func_8002F7DC(&this->actor, NA_SE_PL_PULL_UP_WOODBOX);
+    //! @bug: This is an unsafe cast, although the sfx will still play
+    Player_PlaySfx((Player*)&this->actor, NA_SE_PL_PULL_UP_WOODBOX);
 }
 
 void ObjKibako_Held(ObjKibako* this, PlayState* play) {
     if (Actor_HasNoParent(&this->actor, play)) {
         this->actor.room = play->roomCtx.curRoom.num;
         if (fabsf(this->actor.speedXZ) < 0.1f) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_PUT_DOWN_WOODBOX);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_PUT_DOWN_WOODBOX);
             ObjKibako_SetupIdle(this);
             this->collider.base.ocFlags1 &= ~OC1_TYPE_PLAYER;
         } else {

--- a/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
+++ b/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
@@ -255,7 +255,7 @@ void ObjLightswitch_SetupTurnOn(ObjLightswitch* this) {
 void ObjLightswitch_TurnOn(ObjLightswitch* this, PlayState* play) {
     if (func_8005B198() == this->actor.category || this->toggleDelay <= 0) {
         if (this->timer == 0) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_TRIFORCE_FLASH);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_TRIFORCE_FLASH);
         }
 
         this->timer++;
@@ -270,7 +270,7 @@ void ObjLightswitch_TurnOn(ObjLightswitch* this, PlayState* play) {
             ObjLightswitch_SetupOn(this);
         } else if (this->timer == 15) {
             this->faceTextureIndex = FACE_EYES_OPEN;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FOOT_SWITCH);
         }
     }
 }
@@ -339,7 +339,7 @@ void ObjLightswitch_TurnOff(ObjLightswitch* this, PlayState* play) {
             ObjLightswitch_SetupOff(this);
         } else if (this->timer == 15) {
             this->faceTextureIndex = FACE_EYES_CLOSED;
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->actor, NA_SE_EV_FOOT_SWITCH);
         }
     }
 }

--- a/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
+++ b/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
@@ -562,7 +562,7 @@ void ObjOshihiki_Push(ObjOshihiki* this, PlayState* play) {
     } else if (stopFlag) {
         player = GET_PLAYER(play);
         if (ObjOshihiki_CheckWall(play, this->dyna.unk_158, this->dyna.unk_150, this)) {
-            Audio_PlayActorSfx2(thisx, NA_SE_EV_BLOCK_BOUND);
+            Actor_PlaySfx(thisx, NA_SE_EV_BLOCK_BOUND);
         }
 
         thisx->home.pos.x = thisx->world.pos.x;
@@ -578,7 +578,7 @@ void ObjOshihiki_Push(ObjOshihiki* this, PlayState* play) {
             ObjOshihiki_SetupOnActor(this, play);
         }
     }
-    Audio_PlayActorSfx2(thisx, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
+    Actor_PlaySfx(thisx, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
 }
 
 void ObjOshihiki_SetupFall(ObjOshihiki* this, PlayState* play) {
@@ -604,11 +604,10 @@ void ObjOshihiki_Fall(ObjOshihiki* this, PlayState* play) {
         } else {
             ObjOshihiki_SetupOnActor(this, play);
         }
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
-        Audio_PlayActorSfx2(&this->dyna.actor,
-                            NA_SE_PL_WALK_GROUND + SurfaceType_GetSfxOffset(&play->colCtx,
-                                                                            this->floorPolys[this->highestFloor],
-                                                                            this->floorBgIds[this->highestFloor]));
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_BLOCK_BOUND);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_PL_WALK_GROUND + SurfaceType_GetSfxOffset(
+                                                                    &play->colCtx, this->floorPolys[this->highestFloor],
+                                                                    this->floorBgIds[this->highestFloor]));
     }
 }
 

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -436,7 +436,7 @@ void ObjSwitch_FloorPress(ObjSwitch* this, PlayState* play) {
         this->dyna.actor.scale.y -= 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y <= 33.0f / 2000.0f) {
             ObjSwitch_FloorDownInit(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
             Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 120, 20, 10);
         }
     }
@@ -496,7 +496,7 @@ void ObjSwitch_FloorRelease(ObjSwitch* this, PlayState* play) {
         this->dyna.actor.scale.y += 99.0f / 2000.0f;
         if (this->dyna.actor.scale.y >= 33.0f / 200.0f) {
             ObjSwitch_FloorUpInit(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
             if (subType == OBJSWITCH_SUBTYPE_TOGGLE) {
                 Rumble_Request(this->dyna.actor.xyzDistToPlayerSq, 120, 20, 10);
             }
@@ -555,7 +555,7 @@ void ObjSwitch_EyeClosing(ObjSwitch* this, PlayState* play) {
         this->eyeTexIndex++;
         if (this->eyeTexIndex >= 3) {
             ObjSwitch_EyeClosedInit(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
         }
     }
 }
@@ -596,7 +596,7 @@ void ObjSwitch_EyeOpening(ObjSwitch* this, PlayState* play) {
         this->eyeTexIndex--;
         if (this->eyeTexIndex <= 0) {
             ObjSwitch_EyeOpenInit(this);
-            Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
+            Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FOOT_SWITCH);
         }
     }
 }
@@ -652,7 +652,7 @@ void ObjSwitch_CrystalTurnOn(ObjSwitch* this, PlayState* play) {
         if (OBJSWITCH_SUBTYPE(&this->dyna.actor) == OBJSWITCH_SUBTYPE_TOGGLE) {
             ObjSwitch_UpdateTwoTexScrollXY(this);
         }
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_DIAMOND_SWITCH);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_DIAMOND_SWITCH);
     }
 }
 
@@ -696,7 +696,7 @@ void ObjSwitch_CrystalTurnOff(ObjSwitch* this, PlayState* play) {
         func_8005B198() == this->dyna.actor.category || this->cooldownTimer <= 0) {
         ObjSwitch_CrystalOffInit(this);
         ObjSwitch_UpdateTwoTexScrollXY(this);
-        Audio_PlayActorSfx2(&this->dyna.actor, NA_SE_EV_DIAMOND_SWITCH);
+        Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_DIAMOND_SWITCH);
     }
 }
 

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
@@ -275,7 +275,7 @@ void ObjTsubo_Idle(ObjTsubo* this, PlayState* play) {
 void ObjTsubo_SetupLiftedUp(ObjTsubo* this) {
     this->actionFunc = ObjTsubo_LiftedUp;
     this->actor.room = -1;
-    //! @bug: This is an unsafe cast, although the sfx will still play
+    //! @bug: This is an unsafe cast, although the sound effect will still play
     Player_PlaySfx((Player*)&this->actor, NA_SE_PL_PULL_UP_POT);
     this->actor.flags |= ACTOR_FLAG_4;
 }

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
@@ -275,7 +275,8 @@ void ObjTsubo_Idle(ObjTsubo* this, PlayState* play) {
 void ObjTsubo_SetupLiftedUp(ObjTsubo* this) {
     this->actionFunc = ObjTsubo_LiftedUp;
     this->actor.room = -1;
-    func_8002F7DC(&this->actor, NA_SE_PL_PULL_UP_POT);
+    //! @bug: This is an unsafe cast, although the sfx will still play
+    Player_PlaySfx((Player*)&this->actor, NA_SE_PL_PULL_UP_POT);
     this->actor.flags |= ACTOR_FLAG_4;
 }
 

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -799,7 +799,7 @@ void ObjectKankyo_WaitForSunGraveSparkObject(ObjectKankyo* this, PlayState* play
 void ObjectKankyo_SunGraveSpark(ObjectKankyo* this, PlayState* play) {
     if (play->csCtx.state != 0) {
         if (play->csCtx.npcActions[1] != NULL && play->csCtx.npcActions[1]->action == 2) {
-            Audio_PlayActorSfx2(&this->actor, NA_SE_EN_BIRI_SPARK - SFX_FLAG);
+            Actor_PlaySfx(&this->actor, NA_SE_EN_BIRI_SPARK - SFX_FLAG);
             if ((s16)this->effects[0].alpha + 20 > 255) {
                 this->effects[0].alpha = 255;
             } else {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1715,7 +1715,7 @@ void Player_RequestRumble(Player* this, s32 sourceStrength, s32 duration, s32 de
 
 void func_80832698(Player* this, u16 sfxId) {
     if (this->actor.category == ACTORCAT_PLAYER) {
-        func_8002F7DC(&this->actor, sfxId + this->ageProperties->unk_92);
+        Player_PlaySfx(this, sfxId + this->ageProperties->unk_92);
     } else {
         func_800F4190(&this->actor.projectedPos, sfxId);
     }
@@ -1736,7 +1736,7 @@ u16 func_8083275C(Player* this, u16 sfxId) {
 }
 
 void func_80832770(Player* this, u16 sfxId) {
-    func_8002F7DC(&this->actor, func_8083275C(this, sfxId));
+    Player_PlaySfx(this, func_8083275C(this, sfxId));
 }
 
 u16 func_808327A4(Player* this, u16 sfxId) {
@@ -1744,7 +1744,7 @@ u16 func_808327A4(Player* this, u16 sfxId) {
 }
 
 void func_808327C4(Player* this, u16 sfxId) {
-    func_8002F7DC(&this->actor, func_808327A4(this, sfxId));
+    Player_PlaySfx(this, func_808327A4(this, sfxId));
 }
 
 void func_808327F8(Player* this, f32 arg1) {
@@ -1768,7 +1768,7 @@ void func_80832854(Player* this) {
         sfxId = func_808327A4(this, NA_SE_PL_JUMP);
     }
 
-    func_8002F7DC(&this->actor, sfxId);
+    Player_PlaySfx(this, sfxId);
 }
 
 void func_808328A0(Player* this) {
@@ -1780,11 +1780,11 @@ void func_808328A0(Player* this) {
         sfxId = func_808327A4(this, NA_SE_PL_LAND);
     }
 
-    func_8002F7DC(&this->actor, sfxId);
+    Player_PlaySfx(this, sfxId);
 }
 
 void func_808328EC(Player* this, u16 sfxId) {
-    func_8002F7DC(&this->actor, sfxId);
+    Player_PlaySfx(this, sfxId);
     this->stateFlags2 |= PLAYER_STATE2_3;
 }
 
@@ -1799,7 +1799,7 @@ void func_80832924(Player* this, struct_80832924* entry) {
         flags = data & 0x7800;
         if (LinkAnimation_OnFrame(&this->skelAnime, fabsf(data & 0x7FF))) {
             if (flags == 0x800) {
-                func_8002F7DC(&this->actor, entry->sfxId);
+                Player_PlaySfx(this, entry->sfxId);
             } else if (flags == 0x1000) {
                 func_80832770(this, entry->sfxId);
             } else if (flags == 0x1800) {
@@ -2458,7 +2458,7 @@ s32 func_8083442C(Player* this, PlayState* play) {
         this->unk_834 = 14;
 
         if (this->unk_860 >= 0) {
-            func_8002F7DC(&this->actor, D_80854398[ABS(this->unk_860) - 1]);
+            Player_PlaySfx(this, D_80854398[ABS(this->unk_860) - 1]);
 
             if (!Player_HoldsHookshot(this) && (func_80834380(play, this, &item, &arrowType) > 0)) {
                 magicArrowType = arrowType - ARROW_FIRE;
@@ -2535,7 +2535,7 @@ s32 func_80834758(PlayState* play, Player* this) {
         anim = func_808346C4(play, this);
         frame = Animation_GetLastFrame(anim);
         LinkAnimation_Change(play, &this->skelAnime2, anim, 1.0f, frame, frame, ANIMMODE_ONCE, 0.0f);
-        func_8002F7DC(&this->actor, NA_SE_IT_SHIELD_POSTURE);
+        Player_PlaySfx(this, NA_SE_IT_SHIELD_POSTURE);
 
         return 1;
     } else {
@@ -2559,7 +2559,7 @@ void func_80834894(Player* this) {
     }
 
     Animation_Reverse(&this->skelAnime2);
-    func_8002F7DC(&this->actor, NA_SE_IT_SHIELD_REMOVE);
+    Player_PlaySfx(this, NA_SE_IT_SHIELD_REMOVE);
 }
 
 void func_808348EC(PlayState* play, Player* this) {
@@ -2728,7 +2728,7 @@ s32 func_80834FBC(Player* this) {
         if (this->heldActor == NULL) {
             this->heldActor = this->actor.child;
             Player_RequestRumble(this, 255, 10, 250, 0);
-            func_8002F7DC(&this->actor, NA_SE_IT_HOOKSHOT_RECEIVE);
+            Player_PlaySfx(this, NA_SE_IT_HOOKSHOT_RECEIVE);
         }
 
         return 1;
@@ -2822,7 +2822,7 @@ s32 func_808351D4(Player* this, PlayState* play) {
         if (this->unk_860 >= 0) {
             if (sp2C == 0) {
                 if (!func_808350A4(play, this)) {
-                    func_8002F7DC(&this->actor, D_808543DC[ABS(this->unk_860) - 1]);
+                    Player_PlaySfx(this, D_808543DC[ABS(this->unk_860) - 1]);
                 }
             } else if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
                 func_808350A4(play, this);
@@ -3015,7 +3015,7 @@ s32 func_808359FC(Player* this, PlayState* play) {
                 func_808355DC(this);
             }
             this->unk_A73 = 4;
-            func_8002F7DC(&this->actor, NA_SE_IT_BOOMERANG_THROW);
+            Player_PlaySfx(this, NA_SE_IT_BOOMERANG_THROW);
             func_80832698(this, NA_SE_VO_LI_SWORD_N);
         }
     }
@@ -3032,7 +3032,7 @@ s32 func_80835B60(Player* this, PlayState* play) {
         func_80833638(this, func_80835C08);
         LinkAnimation_PlayOnce(play, &this->skelAnime2, &gPlayerAnim_link_boom_catch);
         func_808357E8(this, gPlayerLeftHandBoomerangDLs);
-        func_8002F7DC(&this->actor, NA_SE_PL_CATCH_BOOMERANG);
+        Player_PlaySfx(this, NA_SE_PL_CATCH_BOOMERANG);
         func_80832698(this, NA_SE_VO_LI_SWORD_N);
         return 1;
     }
@@ -3861,7 +3861,7 @@ void func_80837C0C(PlayState* play, Player* this, s32 arg2, f32 arg3, f32 arg4, 
 
     this->unk_890 = 0;
 
-    func_8002F7DC(&this->actor, NA_SE_PL_DAMAGE);
+    Player_PlaySfx(this, NA_SE_PL_DAMAGE);
 
     if (!func_80837B18(play, this, 0 - this->actor.colChkInfo.damage)) {
         this->stateFlags2 &= ~PLAYER_STATE2_7;
@@ -3881,7 +3881,7 @@ void func_80837C0C(PlayState* play, Player* this, s32 arg2, f32 arg3, f32 arg4, 
         func_80832224(this);
         Player_RequestRumble(this, 255, 10, 40, 0);
 
-        func_8002F7DC(&this->actor, NA_SE_PL_FREEZE_S);
+        Player_PlaySfx(this, NA_SE_PL_FREEZE_S);
         func_80832698(this, NA_SE_VO_LI_FREEZE);
     } else if (arg2 == 4) {
         func_80835C58(play, this, func_8084FBF4, 0);
@@ -4155,7 +4155,7 @@ s32 func_808382DC(Player* this, PlayState* play) {
                 s32 sp4C;
 
                 if (ac->flags & ACTOR_FLAG_24) {
-                    func_8002F7DC(&this->actor, NA_SE_PL_BODY_HIT);
+                    Player_PlaySfx(this, NA_SE_PL_BODY_HIT);
                 }
 
                 if (this->stateFlags1 & PLAYER_STATE1_27) {
@@ -5004,7 +5004,7 @@ s32 func_8083A6AC(Player* this, PlayState* play) {
                 this->stateFlags1 &= ~PLAYER_STATE1_17;
             }
 
-            func_8002F7DC(&this->actor, NA_SE_PL_SLIPDOWN);
+            Player_PlaySfx(this, NA_SE_PL_SLIPDOWN);
             func_80832698(this, NA_SE_VO_LI_HANG);
             return 1;
         }
@@ -5520,7 +5520,7 @@ void func_8083BCD0(Player* this, PlayState* play, s32 arg2) {
 
     this->stateFlags2 |= PLAYER_STATE2_19;
 
-    func_8002F7DC(&this->actor, ((arg2 << 0xE) == 0x8000) ? NA_SE_PL_ROLL : NA_SE_PL_SKIP);
+    Player_PlaySfx(this, ((arg2 << 0xE) == 0x8000) ? NA_SE_PL_ROLL : NA_SE_PL_SKIP);
 }
 
 s32 func_8083BDBC(Player* this, PlayState* play) {
@@ -5668,7 +5668,7 @@ s32 func_8083C2B0(Player* this, PlayState* play) {
                 func_80832F54(play, this, 4);
             }
 
-            func_8002F7DC(&this->actor, NA_SE_IT_SHIELD_POSTURE);
+            Player_PlaySfx(this, NA_SE_IT_SHIELD_POSTURE);
         }
 
         return 1;
@@ -5744,7 +5744,7 @@ s32 func_8083C6B8(PlayState* play, Player* this) {
 
             func_808322D0(play, this, D_80854554[this->unk_850].unk_00);
 
-            func_8002F7DC(&this->actor, NA_SE_IT_SWORD_SWING);
+            Player_PlaySfx(this, NA_SE_IT_SWORD_SWING);
             func_80832698(this, NA_SE_VO_LI_AUTO_JUMP);
             return 1;
         }
@@ -5953,7 +5953,7 @@ void func_8083D0A8(PlayState* play, Player* this, f32 arg2) {
 
     func_80832340(play, this);
     if (func_8083CFA8(play, this, arg2, 500)) {
-        func_8002F7DC(&this->actor, NA_SE_EV_JUMP_OUT_WATER);
+        Player_PlaySfx(this, NA_SE_EV_JUMP_OUT_WATER);
     }
 
     Player_SetBootData(play, this);
@@ -5973,7 +5973,7 @@ s32 func_8083D12C(PlayState* play, Player* this, Input* arg2) {
 
             if (arg2 != NULL) {
                 this->stateFlags2 |= PLAYER_STATE2_11;
-                func_8002F7DC(&this->actor, NA_SE_PL_DIVE_BUBBLE);
+                Player_PlaySfx(this, NA_SE_PL_DIVE_BUBBLE);
             }
 
             return 1;
@@ -6002,7 +6002,7 @@ s32 func_8083D12C(PlayState* play, Player* this, Input* arg2) {
                                                                      : &gPlayerAnim_link_swimer_swim_deep_end);
 
                 if (func_8083CFA8(play, this, this->actor.velocity.y, 500)) {
-                    func_8002F7DC(&this->actor, NA_SE_PL_FACE_UP);
+                    Player_PlaySfx(this, NA_SE_PL_FACE_UP);
                 }
 
                 return 1;
@@ -6040,7 +6040,7 @@ void func_8083D36C(PlayState* play, Player* this) {
 
     if (!(this->stateFlags1 & PLAYER_STATE1_27) || (this->actor.yDistToWater < this->ageProperties->unk_2C)) {
         if (func_8083CFA8(play, this, this->actor.velocity.y, 500)) {
-            func_8002F7DC(&this->actor, NA_SE_EV_DIVE_INTO_WATER);
+            Player_PlaySfx(this, NA_SE_EV_DIVE_INTO_WATER);
 
             if (this->fallDistance > 800.0f) {
                 func_80832698(this, NA_SE_VO_LI_CLIMB_END);
@@ -7990,7 +7990,7 @@ void func_80842A28(PlayState* play, Player* this) {
     Player_RequestQuake(play, 27767, 7, 20);
     play->actorCtx.unk_02 = 4;
     Player_RequestRumble(this, 255, 20, 150, 0);
-    func_8002F7DC(&this->actor, NA_SE_IT_HAMMER_HIT);
+    Player_PlaySfx(this, NA_SE_IT_HAMMER_HIT);
 }
 
 void func_80842A88(PlayState* play, Player* this) {
@@ -8004,7 +8004,7 @@ s32 func_80842AC4(PlayState* play, Player* this) {
             EffectSsStick_Spawn(play, &this->bodyPartsPos[PLAYER_BODYPART_R_HAND], this->actor.shape.rot.y + 0x8000);
             this->unk_85C = 0.5f;
             func_80842A88(play, this);
-            func_8002F7DC(&this->actor, NA_SE_IT_WOODSTICK_BROKEN);
+            Player_PlaySfx(this, NA_SE_IT_WOODSTICK_BROKEN);
         }
 
         return 1;
@@ -8020,7 +8020,7 @@ s32 func_80842B7C(PlayState* play, Player* this) {
                 EffectSsStick_Spawn(play, &this->bodyPartsPos[PLAYER_BODYPART_R_HAND],
                                     this->actor.shape.rot.y + 0x8000);
                 func_800849EC(play);
-                func_8002F7DC(&this->actor, NA_SE_IT_MAJIN_SWORD_BROKEN);
+                Player_PlaySfx(this, NA_SE_IT_MAJIN_SWORD_BROKEN);
             }
         }
 
@@ -8111,9 +8111,9 @@ s32 func_80842DF4(PlayState* play, Player* this) {
                             } else {
                                 CollisionCheck_SpawnShieldParticles(play, &sp5C);
                                 if (surfaceMaterial == SURFACE_MATERIAL_DIRT_SOFT) {
-                                    func_8002F7DC(&this->actor, NA_SE_IT_WALL_HIT_SOFT);
+                                    Player_PlaySfx(this, NA_SE_IT_WALL_HIT_SOFT);
                                 } else {
-                                    func_8002F7DC(&this->actor, NA_SE_IT_WALL_HIT_HARD);
+                                    Player_PlaySfx(this, NA_SE_IT_WALL_HIT_HARD);
                                 }
                             }
 
@@ -8239,7 +8239,7 @@ void func_80843188(Player* this, PlayState* play) {
                     func_8083A098(this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_defense_end, this->modelAnimType), play);
                 }
 
-                func_8002F7DC(&this->actor, NA_SE_IT_SHIELD_REMOVE);
+                Player_PlaySfx(this, NA_SE_IT_SHIELD_REMOVE);
                 return;
             }
         } else {
@@ -8413,7 +8413,7 @@ void func_80843AE8(PlayState* play, Player* this) {
     } else if (this->unk_84F != 0) {
         this->unk_850 = 60;
         Player_SpawnFairy(play, this, &this->actor.world.pos, &D_808545E4, FAIRY_REVIVE_DEATH);
-        func_8002F7DC(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
+        Player_PlaySfx(this, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
         OnePointCutscene_Init(play, 9908, 125, &this->actor, CAM_ID_MAIN);
     } else if (play->gameOverCtx.state == GAMEOVER_DEATH_WAIT_GROUND) {
         play->gameOverCtx.state = GAMEOVER_DEATH_DELAY_MENU;
@@ -8458,7 +8458,7 @@ void func_80843E14(Player* this, u16 sfxId) {
     func_80832698(this, sfxId);
 
     if ((this->heldActor != NULL) && (this->heldActor->id == ACTOR_EN_RU1)) {
-        Audio_PlayActorSfx2(this->heldActor, NA_SE_VO_RT_FALL);
+        Actor_PlaySfx(this->heldActor, NA_SE_VO_RT_FALL);
     }
 }
 
@@ -8500,7 +8500,7 @@ s32 func_80843E64(PlayState* play, Player* this) {
         Player_RequestQuake(play, 32967, 2, 30);
         Player_RequestRumble(this, impactInfo->rumbleStrength, impactInfo->rumbleDuration,
                              impactInfo->rumbleDecreaseRate, 0);
-        func_8002F7DC(&this->actor, NA_SE_PL_BODY_HIT);
+        Player_PlaySfx(this, NA_SE_PL_BODY_HIT);
         func_80832698(this, impactInfo->sfxId);
 
         return impactIndex + 1;
@@ -8533,7 +8533,7 @@ void func_8084409C(PlayState* play, Player* this, f32 speedXZ, f32 velocityY) {
         heldActor->speedXZ = speedXZ;
         heldActor->velocity.y = velocityY;
         func_80834644(play, this);
-        func_8002F7DC(&this->actor, NA_SE_PL_THROW);
+        Player_PlaySfx(this, NA_SE_PL_THROW);
         func_80832698(this, NA_SE_VO_LI_SWORD_N);
     }
 }
@@ -8705,7 +8705,7 @@ void func_80844708(Player* this, PlayState* play) {
                     this->linearVelocity = -this->linearVelocity;
                     Player_RequestQuake(play, 33267, 3, 12);
                     Player_RequestRumble(this, 255, 20, 150, 0);
-                    func_8002F7DC(&this->actor, NA_SE_PL_BODY_HIT);
+                    Player_PlaySfx(this, NA_SE_PL_BODY_HIT);
                     func_80832698(this, NA_SE_VO_LI_CLIMB_END);
                     this->unk_850 = 1;
                     return;
@@ -9361,7 +9361,7 @@ void func_80846358(Player* this, PlayState* play) {
         heldActor->speedXZ = 10.0f;
         heldActor->velocity.y = 20.0f;
         func_80834644(play, this);
-        func_8002F7DC(&this->actor, NA_SE_PL_THROW);
+        Player_PlaySfx(this, NA_SE_PL_THROW);
         func_80832698(this, NA_SE_VO_LI_SWORD_N);
     }
 }
@@ -9517,7 +9517,7 @@ void func_80846720(PlayState* play, Player* this, s32 arg2) {
     func_80834644(play, this);
 
     if (arg2 != 0) {
-        func_8002F7DC(&this->actor, NA_SE_IT_SWORD_PICKOUT);
+        Player_PlaySfx(this, NA_SE_IT_SWORD_PICKOUT);
     }
 }
 
@@ -9728,7 +9728,7 @@ void Player_Init(Actor* thisx, PlayState* play2) {
     }
 
     if (gSaveContext.entranceSound != 0) {
-        Audio_PlayActorSfx2(&this->actor, ((void)0, gSaveContext.entranceSound));
+        Actor_PlaySfx(&this->actor, ((void)0, gSaveContext.entranceSound));
         gSaveContext.entranceSound = 0;
     }
 
@@ -10413,7 +10413,7 @@ void func_80848C74(PlayState* play, Player* this) {
     }
 
     if (spawnedFlame) {
-        func_8002F7DC(&this->actor, NA_SE_EV_TORCH - SFX_FLAG);
+        Player_PlaySfx(this, NA_SE_EV_TORCH - SFX_FLAG);
 
         if (play->sceneId == SCENE_SPIRIT_TEMPLE_BOSS) {
             dmgCooldown = 0;
@@ -11572,14 +11572,14 @@ void func_8084BDFC(Player* this, PlayState* play) {
         func_808328A0(this);
     } else if (LinkAnimation_OnFrame(&this->skelAnime, this->skelAnime.endFrame - 34.0f)) {
         this->stateFlags1 &= ~(PLAYER_STATE1_13 | PLAYER_STATE1_14);
-        func_8002F7DC(&this->actor, NA_SE_PL_CLIMB_CLIFF);
+        Player_PlaySfx(this, NA_SE_PL_CLIMB_CLIFF);
         func_80832698(this, NA_SE_VO_LI_CLIMB_END);
     }
 }
 
 void func_8084BEE4(Player* this) {
-    func_8002F7DC(&this->actor, (this->unk_84F != 0) ? NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_VINE
-                                                     : NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD);
+    Player_PlaySfx(this, (this->unk_84F != 0) ? NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_VINE
+                                              : NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD);
 }
 
 void func_8084BF1C(Player* this, PlayState* play) {
@@ -11983,13 +11983,13 @@ void func_8084CC98(Player* this, PlayState* play) {
         arr = D_80854998[(this->mountSide < 0) ? 0 : 1];
 
         if (LinkAnimation_OnFrame(&this->skelAnime, arr[0])) {
-            func_8002F7DC(&this->actor, NA_SE_PL_CLIMB_CLIFF);
+            Player_PlaySfx(this, NA_SE_PL_CLIMB_CLIFF);
             return;
         }
 
         if (LinkAnimation_OnFrame(&this->skelAnime, arr[1])) {
             func_8002DE74(play, this);
-            func_8002F7DC(&this->actor, NA_SE_PL_SIT_ON_HORSE);
+            Player_PlaySfx(this, NA_SE_PL_SIT_ON_HORSE);
             return;
         }
 
@@ -12069,7 +12069,7 @@ void func_8084CC98(Player* this, PlayState* play) {
 
                 if (this->skelAnime2.animation == &gPlayerAnim_link_uma_stop_muti) {
                     if (LinkAnimation_OnFrame(&this->skelAnime2, 23.0f)) {
-                        func_8002F7DC(&this->actor, NA_SE_IT_LASH);
+                        Player_PlaySfx(this, NA_SE_IT_LASH);
                         func_80832698(this, NA_SE_VO_LI_LASH);
                     }
 
@@ -12077,7 +12077,7 @@ void func_8084CC98(Player* this, PlayState* play) {
                                                 this->skelAnime2.jointTable);
                 } else {
                     if (LinkAnimation_OnFrame(&this->skelAnime2, 10.0f)) {
-                        func_8002F7DC(&this->actor, NA_SE_IT_LASH);
+                        Player_PlaySfx(this, NA_SE_IT_LASH);
                         func_80832698(this, NA_SE_VO_LI_LASH);
                     }
 
@@ -12800,7 +12800,7 @@ void func_8084ECA4(Player* this, PlayState* play) {
                 if (sp24->unk_09 >= temp) {
                     if (this->unk_850 != 0) {
                         if (temp == 0) {
-                            func_8002F7DC(&this->actor, NA_SE_IT_SCOOP_UP_WATER);
+                            Player_PlaySfx(this, NA_SE_IT_SCOOP_UP_WATER);
                         }
                     }
 
@@ -12847,8 +12847,8 @@ void func_8084EED8(Player* this, PlayState* play) {
     if (LinkAnimation_OnFrame(&this->skelAnime, 37.0f)) {
         Player_SpawnFairy(play, this, &this->leftHandPos, &D_80854A1C, FAIRY_REVIVE_BOTTLE);
         Player_UpdateBottleHeld(play, this, ITEM_BOTTLE_EMPTY, PLAYER_IA_BOTTLE);
-        func_8002F7DC(&this->actor, NA_SE_EV_BOTTLE_CAP_OPEN);
-        func_8002F7DC(&this->actor, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
+        Player_PlaySfx(this, NA_SE_EV_BOTTLE_CAP_OPEN);
+        Player_PlaySfx(this, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
     } else if (LinkAnimation_OnFrame(&this->skelAnime, 47.0f)) {
         gSaveContext.healthAccumulator = 0x140;
     }
@@ -12919,7 +12919,7 @@ void func_8084F104(Player* this, PlayState* play) {
                 Message_StartTextbox(play, this->actor.textId, &this->actor);
 
                 if ((this->itemAction == PLAYER_IA_CHICKEN) || (this->itemAction == PLAYER_IA_POCKET_CUCCO)) {
-                    func_8002F7DC(&this->actor, NA_SE_EV_CHICKEN_CRY_M);
+                    Player_PlaySfx(this, NA_SE_EV_CHICKEN_CRY_M);
                 }
 
                 this->unk_850 = 1;
@@ -13142,7 +13142,7 @@ void func_8084FB10(Player* this, PlayState* play) {
         if (func_80832594(this, 1, 100)) {
             this->unk_84F = -1;
             EffectSsIcePiece_SpawnBurst(play, &this->actor.world.pos, this->actor.scale.x);
-            func_8002F7DC(&this->actor, NA_SE_PL_ICE_BROKEN);
+            Player_PlaySfx(this, NA_SE_PL_ICE_BROKEN);
         } else {
             this->stateFlags2 |= PLAYER_STATE2_14;
         }
@@ -14198,7 +14198,7 @@ void func_80851A50(PlayState* play, Player* this, CsCmdActorAction* arg2) {
         }
         this->leftHandDLists = dLists + gSaveContext.linkAge;
 
-        func_8002F7DC(&this->actor, sp2C->unk_00);
+        Player_PlaySfx(this, sp2C->unk_00);
         if (!LINK_IS_ADULT) {
             func_80832698(this, sp2C->unk_02);
         }


### PR DESCRIPTION
These two functions from `z_actor.c` seem to be the primary functions to play a sound effect at the actor and player position respectively. There is nothing explicitly checking for `Player*` in `Player_PlaySfx`, but it's dependence on player is inferred by usage and its extension in MM. There are 6 uses of `Player_PlaySfx` where `Player` is not used as an argument, although it always appears it should be `PLAYER` that's used:
- z_obj_kibako.c (1 use)
- z_obj_tsubo.c (1 use)
- z_en_wallmas.c (4 uses)

Currently there's a bug tag: `//! @bug: This is an unsafe cast, although the sfx will still play` although this could use improvement I think, and might not even warrant a bug tag
