### PR TITLE
speedXZ -> speed

### DIFF
--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -207,7 +207,7 @@ typedef struct Actor {
     /* 0x04C */ f32 targetArrowOffset; // Height offset of the target arrow relative to `focus` position
     /* 0x050 */ Vec3f scale; // Scale of the actor in each axis
     /* 0x05C */ Vec3f velocity; // Velocity of the actor in each axis
-    /* 0x068 */ f32 speedXZ; // How fast the actor is traveling along the XZ plane
+    /* 0x068 */ f32 speed; // Context dependent speed value. Can be used for XZ or XYZ depending on which move function is used
     /* 0x06C */ f32 gravity; // Acceleration due to gravity. Value is added to Y velocity every frame
     /* 0x070 */ f32 minVelocityY; // Sets the lower bounds cap on velocity along the Y axis
     /* 0x074 */ CollisionPoly* wallPoly; // Wall polygon the actor is touching

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -850,8 +850,8 @@ void func_8002D7EC(Actor* actor) {
 }
 
 void func_8002D868(Actor* actor) {
-    actor->velocity.x = Math_SinS(actor->world.rot.y) * actor->speedXZ;
-    actor->velocity.z = Math_CosS(actor->world.rot.y) * actor->speedXZ;
+    actor->velocity.x = Math_SinS(actor->world.rot.y) * actor->speed;
+    actor->velocity.z = Math_CosS(actor->world.rot.y) * actor->speed;
 
     actor->velocity.y += actor->gravity;
     if (actor->velocity.y < actor->minVelocityY) {
@@ -865,10 +865,10 @@ void Actor_MoveForward(Actor* actor) {
 }
 
 void func_8002D908(Actor* actor) {
-    f32 sp24 = Math_CosS(actor->world.rot.x) * actor->speedXZ;
+    f32 sp24 = Math_CosS(actor->world.rot.x) * actor->speed;
 
     actor->velocity.x = Math_SinS(actor->world.rot.y) * sp24;
-    actor->velocity.y = Math_SinS(actor->world.rot.x) * actor->speedXZ;
+    actor->velocity.y = Math_SinS(actor->world.rot.x) * actor->speed;
     actor->velocity.z = Math_CosS(actor->world.rot.y) * sp24;
 }
 
@@ -878,7 +878,7 @@ void func_8002D97C(Actor* actor) {
 }
 
 void func_8002D9A4(Actor* actor, f32 arg1) {
-    actor->speedXZ = Math_CosS(actor->world.rot.x) * arg1;
+    actor->speed = Math_CosS(actor->world.rot.x) * arg1;
     actor->velocity.y = -Math_SinS(actor->world.rot.x) * arg1;
 }
 
@@ -3350,9 +3350,9 @@ Actor* Actor_GetProjectileActor(PlayState* play, Actor* refActor, f32 radius) {
                 (((ArmsHook*)actor)->timer == 0)) {
                 actor = actor->next;
             } else {
-                deltaX = Math_SinS(actor->world.rot.y) * (actor->speedXZ * 10.0f);
+                deltaX = Math_SinS(actor->world.rot.y) * (actor->speed * 10.0f);
                 deltaY = actor->velocity.y + (actor->gravity * 10.0f);
-                deltaZ = Math_CosS(actor->world.rot.y) * (actor->speedXZ * 10.0f);
+                deltaZ = Math_CosS(actor->world.rot.y) * (actor->speed * 10.0f);
 
                 spA8.x = actor->world.pos.x + deltaX;
                 spA8.y = actor->world.pos.y + deltaY;
@@ -4091,7 +4091,7 @@ s32 func_80035124(Actor* actor, PlayState* play) {
                 actor->params = 1;
             } else if (!(actor->bgCheckFlags & BGCHECKFLAG_GROUND)) {
                 Actor_MoveForward(actor);
-                Math_SmoothStepToF(&actor->speedXZ, 0.0f, 1.0f, 0.1f, 0.0f);
+                Math_SmoothStepToF(&actor->speed, 0.0f, 1.0f, 0.1f, 0.0f);
             } else if ((actor->bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) && (actor->velocity.y < -4.0f)) {
                 ret = 1;
             } else {
@@ -4299,7 +4299,7 @@ Actor* func_800358DC(Actor* actor, Vec3f* spawnPos, Vec3s* spawnRot, f32* arg3, 
                                                 spawnPos->z, spawnRot->x, spawnRot->y, actor->objBankIndex, params);
     if (spawnedEnPart != NULL) {
         spawnedEnPart->actor.scale = actor->scale;
-        spawnedEnPart->actor.speedXZ = arg3[0];
+        spawnedEnPart->actor.speed = arg3[0];
         spawnedEnPart->displayList = dList;
         spawnedEnPart->action = 2;
         spawnedEnPart->timer = timer;

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -865,11 +865,11 @@ void Actor_MoveForward(Actor* actor) {
 }
 
 void func_8002D908(Actor* actor) {
-    f32 sp24 = Math_CosS(actor->world.rot.x) * actor->speed;
+    f32 speedXZ = Math_CosS(actor->world.rot.x) * actor->speed;
 
-    actor->velocity.x = Math_SinS(actor->world.rot.y) * sp24;
+    actor->velocity.x = Math_SinS(actor->world.rot.y) * speedXZ;
     actor->velocity.y = Math_SinS(actor->world.rot.x) * actor->speed;
-    actor->velocity.z = Math_CosS(actor->world.rot.y) * sp24;
+    actor->velocity.z = Math_CosS(actor->world.rot.y) * speedXZ;
 }
 
 void func_8002D97C(Actor* actor) {

--- a/src/code/z_en_a_keep.c
+++ b/src/code/z_en_a_keep.c
@@ -265,11 +265,11 @@ void EnAObj_SetupBoulderFragment(EnAObj* this, s16 type) {
 }
 
 void EnAObj_BoulderFragment(EnAObj* this, PlayState* play) {
-    Math_SmoothStepToF(&this->dyna.actor.speedXZ, 1.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->dyna.actor.speed, 1.0f, 1.0f, 0.5f, 0.0f);
     this->dyna.actor.shape.rot.x += this->dyna.actor.world.rot.x >> 1;
     this->dyna.actor.shape.rot.z += this->dyna.actor.world.rot.z >> 1;
 
-    if (this->dyna.actor.speedXZ != 0.0f && this->dyna.actor.bgCheckFlags & BGCHECKFLAG_WALL) {
+    if (this->dyna.actor.speed != 0.0f && this->dyna.actor.bgCheckFlags & BGCHECKFLAG_WALL) {
         this->dyna.actor.world.rot.y =
             this->dyna.actor.wallYaw - this->dyna.actor.world.rot.y + this->dyna.actor.wallYaw - 0x8000;
         if (1) {}
@@ -279,7 +279,7 @@ void EnAObj_BoulderFragment(EnAObj* this, PlayState* play) {
     if (this->dyna.actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
         if (this->dyna.actor.velocity.y < -8.0f) {
             this->dyna.actor.velocity.y *= -0.6f;
-            this->dyna.actor.speedXZ *= 0.6f;
+            this->dyna.actor.speed *= 0.6f;
             this->dyna.actor.bgCheckFlags &= ~(BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH);
         } else {
             Actor_Kill(&this->dyna.actor);
@@ -294,13 +294,13 @@ void EnAObj_SetupBlock(EnAObj* this, s16 type) {
 }
 
 void EnAObj_Block(EnAObj* this, PlayState* play) {
-    this->dyna.actor.speedXZ += this->dyna.unk_150;
+    this->dyna.actor.speed += this->dyna.unk_150;
     this->dyna.actor.world.rot.y = this->dyna.unk_158;
-    this->dyna.actor.speedXZ = CLAMP(this->dyna.actor.speedXZ, -2.5f, 2.5f);
+    this->dyna.actor.speed = CLAMP(this->dyna.actor.speed, -2.5f, 2.5f);
 
-    Math_SmoothStepToF(&this->dyna.actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->dyna.actor.speed, 0.0f, 1.0f, 1.0f, 0.0f);
 
-    if (this->dyna.actor.speedXZ != 0.0f) {
+    if (this->dyna.actor.speed != 0.0f) {
         Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
     }
 

--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -280,7 +280,7 @@ void EnItem00_Init(Actor* thisx, PlayState* play) {
     this->despawnTimer = 15;
     this->unk_154 = 35;
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = 0.0f;
 
@@ -390,7 +390,7 @@ void func_8001DFC8(EnItem00* this, PlayState* play) {
         this->actor.shape.yOffset = Math_SinS(this->actor.shape.rot.y) * 150.0f + 850.0f;
     }
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
 
     if (this->unk_154 == 0) {
         if ((this->actor.params != ITEM00_SMALL_KEY) && (this->actor.params != ITEM00_HEART_PIECE) &&
@@ -448,7 +448,7 @@ void func_8001E304(EnItem00* this, PlayState* play) {
 
     if (this->actor.params == ITEM00_RECOVERY_HEART) {
         if (this->actor.velocity.y < 0.0f) {
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->actor.gravity = -0.4f;
             if (this->actor.velocity.y < -1.5f) {
                 this->actor.velocity.y = -1.5f;
@@ -489,7 +489,7 @@ void func_8001E304(EnItem00* this, PlayState* play) {
         EnItem00_SetupAction(this, func_8001DFC8);
         this->actor.shape.rot.z = 0;
         this->actor.velocity.y = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 }
 
@@ -733,7 +733,7 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
     this->despawnTimer = 15;
     this->unk_154 = 35;
     this->actor.shape.rot.z = 0;
-    this->actor.speedXZ = 0;
+    this->actor.speed = 0;
     this->actor.velocity.y = 0;
     this->actor.gravity = 0;
 
@@ -969,7 +969,7 @@ EnItem00* Item_DropCollectible(PlayState* play, Vec3f* spawnPos, s16 params) {
                                                   spawnPos->z, 0, 0, 0, params | param8000 | param3F00);
             if ((spawnedActor != NULL) && !param8000) {
                 spawnedActor->actor.velocity.y = !param4000 ? 8.0f : -2.0f;
-                spawnedActor->actor.speedXZ = 2.0f;
+                spawnedActor->actor.speed = 2.0f;
                 spawnedActor->actor.gravity = -0.9f;
                 spawnedActor->actor.world.rot.y = Rand_CenteredFloat(65536.0f);
                 Actor_SetScale(&spawnedActor->actor, 0.0f);
@@ -1009,7 +1009,7 @@ EnItem00* Item_DropCollectible2(PlayState* play, Vec3f* spawnPos, s16 params) {
                                                   spawnPos->z, 0, 0, 0, params | param8000 | param3F00);
             if ((spawnedActor != NULL) && !param8000) {
                 spawnedActor->actor.velocity.y = 0.0f;
-                spawnedActor->actor.speedXZ = 0.0f;
+                spawnedActor->actor.speed = 0.0f;
                 spawnedActor->actor.gravity = param4000 ? 0.0f : -0.9f;
                 spawnedActor->actor.world.rot.y = Rand_CenteredFloat(65536.0f);
                 spawnedActor->actor.flags |= ACTOR_FLAG_4;
@@ -1119,7 +1119,7 @@ void Item_DropCollectibleRandom(PlayState* play, Actor* fromActor, Vec3f* spawnP
                                                           spawnPos->y, spawnPos->z, 0, 0, 0, dropId);
                     if ((spawnedActor != NULL) && (dropId != ITEM00_NONE)) {
                         spawnedActor->actor.velocity.y = 8.0f;
-                        spawnedActor->actor.speedXZ = 2.0f;
+                        spawnedActor->actor.speed = 2.0f;
                         spawnedActor->actor.gravity = -0.9f;
                         spawnedActor->actor.world.rot.y = Rand_ZeroOne() * 40000.0f;
                         Actor_SetScale(&spawnedActor->actor, 0.0f);

--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -1130,7 +1130,7 @@ s32 Player_OverrideLimbDrawGameplayDefault(PlayState* play, s32 limbIndex, Gfx**
             } else if ((sLeftHandType == PLAYER_MODELTYPE_LH_BOOMERANG) && (this->stateFlags1 & PLAYER_STATE1_25)) {
                 dLists = gPlayerLeftHandOpenDLs + gSaveContext.linkAge;
                 sLeftHandType = PLAYER_MODELTYPE_LH_OPEN;
-            } else if ((this->leftHandType == PLAYER_MODELTYPE_LH_OPEN) && (this->actor.speedXZ > 2.0f) &&
+            } else if ((this->leftHandType == PLAYER_MODELTYPE_LH_OPEN) && (this->actor.speed > 2.0f) &&
                        !(this->stateFlags1 & PLAYER_STATE1_27)) {
                 dLists = gPlayerLeftHandClosedDLs + gSaveContext.linkAge;
                 sLeftHandType = PLAYER_MODELTYPE_LH_CLOSED;
@@ -1142,7 +1142,7 @@ s32 Player_OverrideLimbDrawGameplayDefault(PlayState* play, s32 limbIndex, Gfx**
 
             if (sRightHandType == PLAYER_MODELTYPE_RH_SHIELD) {
                 dLists += this->currentShield * 4;
-            } else if ((this->rightHandType == PLAYER_MODELTYPE_RH_OPEN) && (this->actor.speedXZ > 2.0f) &&
+            } else if ((this->rightHandType == PLAYER_MODELTYPE_RH_OPEN) && (this->actor.speed > 2.0f) &&
                        !(this->stateFlags1 & PLAYER_STATE1_27)) {
                 dLists = sPlayerRightHandClosedDLs + gSaveContext.linkAge;
                 sRightHandType = PLAYER_MODELTYPE_RH_CLOSED;

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -253,7 +253,7 @@ void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
         Actor_MoveForward(&this->actor);
         Math_Vec3f_Diff(&this->actor.world.pos, &this->actor.prevPos, &prevFrameDiff);
         Math_Vec3f_Sum(&this->unk_1E8, &prevFrameDiff, &this->unk_1E8);
-        this->actor.shape.rot.x = Math_Atan2S(this->actor.speedXZ, -this->actor.velocity.y);
+        this->actor.shape.rot.x = Math_Atan2S(this->actor.speed, -this->actor.velocity.y);
         sp60.x = this->unk_1F4.x - (this->unk_1E8.x - this->unk_1F4.x);
         sp60.y = this->unk_1F4.y - (this->unk_1E8.y - this->unk_1F4.y);
         sp60.z = this->unk_1F4.z - (this->unk_1E8.z - this->unk_1F4.z);

--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -180,7 +180,7 @@ Actor* BgBreakwall_SpawnFragments(PlayState* play, BgBreakwall* this, Vec3f* pos
                 }
 
                 if (actor != NULL) {
-                    actor->speedXZ = Rand_ZeroOne() + (accel * 0.6f);
+                    actor->speed = Rand_ZeroOne() + (accel * 0.6f);
                     actor->velocity.y = Rand_ZeroOne() + (accel * 0.6f);
                     actor->world.rot.y += (s16)((Rand_ZeroOne() - 0.5f) * 3000.0f);
                     actor->world.rot.x = (s16)(Rand_ZeroOne() * 3500.0f) + 2000;

--- a/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.c
+++ b/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.c
@@ -126,16 +126,15 @@ void BgDdanKd_LowerStairs(BgDdanKd* this, PlayState* play) {
     Vec3f pos2;
     f32 effectStrength;
 
-    Math_SmoothStepToF(&this->dyna.actor.speedXZ, 4.0f, 0.5f, 0.025f, 0.0f);
+    Math_SmoothStepToF(&this->dyna.actor.speed, 4.0f, 0.5f, 0.025f, 0.0f);
     Rumble_Request(500.0f, 120, 20, 10);
 
     if (Math_SmoothStepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y - 200.0f - 20.0f, 0.075f,
-                           this->dyna.actor.speedXZ, 0.0075f) == 0.0f) {
+                           this->dyna.actor.speed, 0.0075f) == 0.0f) {
         Flags_SetSwitch(play, this->dyna.actor.params);
         BgDdanKd_SetupAction(this, BgDdanKd_DoNothing);
     } else {
-        effectStrength =
-            (this->dyna.actor.prevPos.y - this->dyna.actor.world.pos.y) + (this->dyna.actor.speedXZ * 0.25f);
+        effectStrength = (this->dyna.actor.prevPos.y - this->dyna.actor.world.pos.y) + (this->dyna.actor.speed * 0.25f);
 
         if (play->state.frames & 1) {
             pos1 = pos2 = this->dyna.actor.world.pos;

--- a/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
+++ b/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
@@ -290,7 +290,7 @@ void BgDodoago_Update(Actor* thisx, PlayState* play) {
                 // disable the bomb catcher for a few seconds
                 this->dyna.actor.parent = &bomb->actor;
                 bomb->timer = 50;
-                bomb->actor.speedXZ = 0.0f;
+                bomb->actor.speed = 0.0f;
                 sTimer = 0;
             }
         }

--- a/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.c
+++ b/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.c
@@ -183,19 +183,19 @@ void BgGanonOtyuka_Fall(BgGanonOtyuka* this, PlayState* play) {
     }
     if (this->dropTimer == 0) {
         this->flashYScale = 0.0f;
-        Math_ApproachF(&this->dyna.actor.world.pos.y, -1000.0f, 1.0f, this->dyna.actor.speedXZ);
-        Math_ApproachF(&this->dyna.actor.speedXZ, 100.0f, 1.0f, 2.0f);
+        Math_ApproachF(&this->dyna.actor.world.pos.y, -1000.0f, 1.0f, this->dyna.actor.speed);
+        Math_ApproachF(&this->dyna.actor.speed, 100.0f, 1.0f, 2.0f);
         if (!(this->unwalledSides & OTYUKA_SIDE_EAST)) {
-            this->dyna.actor.shape.rot.z -= (s16)(this->dyna.actor.speedXZ * 30.0f);
+            this->dyna.actor.shape.rot.z -= (s16)(this->dyna.actor.speed * 30.0f);
         }
         if (!(this->unwalledSides & OTYUKA_SIDE_WEST)) {
-            this->dyna.actor.shape.rot.z += (s16)(this->dyna.actor.speedXZ * 30.0f);
+            this->dyna.actor.shape.rot.z += (s16)(this->dyna.actor.speed * 30.0f);
         }
         if (!(this->unwalledSides & OTYUKA_SIDE_SOUTH)) {
-            this->dyna.actor.shape.rot.x += (s16)(this->dyna.actor.speedXZ * 30.0f);
+            this->dyna.actor.shape.rot.x += (s16)(this->dyna.actor.speed * 30.0f);
         }
         if (!(this->unwalledSides & OTYUKA_SIDE_NORTH)) {
-            this->dyna.actor.shape.rot.x -= (s16)(this->dyna.actor.speedXZ * 30.0f);
+            this->dyna.actor.shape.rot.x -= (s16)(this->dyna.actor.speed * 30.0f);
         }
         if (this->dyna.actor.world.pos.y < -750.0f) {
             if (player->actor.world.pos.y < -400.0f) {
@@ -224,8 +224,8 @@ void BgGanonOtyuka_Fall(BgGanonOtyuka* this, PlayState* play) {
             Audio_PlaySfxGeneral(NA_SE_EV_BLOCKSINK - SFX_FLAG, &this->dyna.actor.projectedPos, 4,
                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         }
-        Math_ApproachF(&this->dyna.actor.world.pos.y, -1000.0f, 1.0f, this->dyna.actor.speedXZ);
-        Math_ApproachF(&this->dyna.actor.speedXZ, 100.0f, 1.0f, 0.1f);
+        Math_ApproachF(&this->dyna.actor.world.pos.y, -1000.0f, 1.0f, this->dyna.actor.speed);
+        Math_ApproachF(&this->dyna.actor.speed, 100.0f, 1.0f, 0.1f);
     }
     osSyncPrintf("MODE DOWN END\n");
 }

--- a/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
@@ -257,7 +257,7 @@ void BgGndIceblock_Reset(BgGndIceblock* this, PlayState* play) {
     }
     if (Math_StepToF(&thisx->world.pos.y, thisx->home.pos.y, 1.0f)) {
         this->targetPos = thisx->home.pos;
-        thisx->speedXZ = 0.0f;
+        thisx->speed = 0.0f;
         this->actionFunc = BgGndIceblock_Idle;
         switch (thisx->params) {
             case 0:
@@ -306,11 +306,11 @@ void BgGndIceblock_Slide(BgGndIceblock* this, PlayState* play) {
     f32 spread;
     Actor* thisx = &this->dyna.actor;
 
-    Math_StepToF(&thisx->speedXZ, 10.0f, 0.5f);
-    atTarget = Math_StepToF(&thisx->world.pos.x, this->targetPos.x, thisx->speedXZ);
-    atTarget &= Math_StepToF(&thisx->world.pos.z, this->targetPos.z, thisx->speedXZ);
+    Math_StepToF(&thisx->speed, 10.0f, 0.5f);
+    atTarget = Math_StepToF(&thisx->world.pos.x, this->targetPos.x, thisx->speed);
+    atTarget &= Math_StepToF(&thisx->world.pos.z, this->targetPos.z, thisx->speed);
     if (atTarget) {
-        thisx->speedXZ = 0.0f;
+        thisx->speed = 0.0f;
         this->targetPos.x = thisx->world.pos.x;
         this->targetPos.z = thisx->world.pos.z;
         Actor_PlaySfx(thisx, NA_SE_EV_BLOCK_BOUND);
@@ -326,7 +326,7 @@ void BgGndIceblock_Slide(BgGndIceblock* this, PlayState* play) {
                 this->actionFunc = BgGndIceblock_Hole;
                 break;
         }
-    } else if (thisx->speedXZ > 6.0f) {
+    } else if (thisx->speed > 6.0f) {
         spread = Rand_CenteredFloat(120.0f);
         velocity.x = -(1.5f + Rand_ZeroOne()) * Math_SinS(this->dyna.unk_158);
         velocity.y = Rand_ZeroOne() + 1.0f;

--- a/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
+++ b/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
@@ -92,9 +92,9 @@ void func_8087B938(BgHaka* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 sp38;
 
-    this->dyna.actor.speedXZ += 0.05f;
-    this->dyna.actor.speedXZ = CLAMP_MAX(this->dyna.actor.speedXZ, 1.5f);
-    sp38 = Math_StepToF(&this->dyna.actor.minVelocityY, 60.0f, this->dyna.actor.speedXZ);
+    this->dyna.actor.speed += 0.05f;
+    this->dyna.actor.speed = CLAMP_MAX(this->dyna.actor.speed, 1.5f);
+    sp38 = Math_StepToF(&this->dyna.actor.minVelocityY, 60.0f, this->dyna.actor.speed);
     this->dyna.actor.world.pos.x =
         Math_SinS(this->dyna.actor.world.rot.y) * this->dyna.actor.minVelocityY + this->dyna.actor.home.pos.x;
     this->dyna.actor.world.pos.z =

--- a/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.c
+++ b/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.c
@@ -189,9 +189,9 @@ void func_8087E288(BgHakaMeganeBG* this, PlayState* play) {
 }
 
 void func_8087E2D8(BgHakaMeganeBG* this, PlayState* play) {
-    Math_StepToF(&this->dyna.actor.speedXZ, 30.0f, 2.0f);
+    Math_StepToF(&this->dyna.actor.speed, 30.0f, 2.0f);
 
-    if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y, this->dyna.actor.speedXZ)) {
+    if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y, this->dyna.actor.speed)) {
         Actor_SetFocus(&this->dyna.actor, 50.0f);
         this->actionFunc = func_8087E34C;
     } else {

--- a/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.c
@@ -125,19 +125,19 @@ void BgHakaShip_Move(BgHakaShip* this, PlayState* play) {
     distanceFromHome = this->dyna.actor.home.pos.x - this->dyna.actor.world.pos.x;
     if (distanceFromHome > 7650.0f) {
         this->dyna.actor.world.pos.x = this->dyna.actor.home.pos.x - 7650.0f;
-        this->dyna.actor.speedXZ = 0.0f;
+        this->dyna.actor.speed = 0.0f;
     }
     if (distanceFromHome > 7600.0f && !Play_InCsMode(play)) {
         this->counter = 40;
-        this->dyna.actor.speedXZ = 0.0f;
+        this->dyna.actor.speed = 0.0f;
         Message_StartTextbox(play, 0x5071, NULL);
         this->actionFunc = BgHakaShip_SetupCrash;
     } else {
-        Math_StepToF(&this->dyna.actor.speedXZ, 4.0f, 0.2f);
+        Math_StepToF(&this->dyna.actor.speed, 4.0f, 0.2f);
     }
     child = this->dyna.actor.child;
     if (child != NULL && child->update != NULL) {
-        child->shape.rot.z += ((655.0f / 13.0f) * this->dyna.actor.speedXZ);
+        child->shape.rot.z += ((655.0f / 13.0f) * this->dyna.actor.speed);
     } else {
         this->dyna.actor.child = NULL;
     }

--- a/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.c
@@ -83,7 +83,7 @@ void BgHakaZou_Init(Actor* thisx, PlayState* play) {
     if (thisx->params == STA_UNKNOWN) {
         Actor_SetScale(thisx, (Rand_ZeroOne() * 0.005f) + 0.025f);
 
-        thisx->speedXZ = Rand_ZeroOne();
+        thisx->speed = Rand_ZeroOne();
         thisx->world.rot.y = thisx->shape.rot.y * ((Rand_ZeroOne() < 0.5f) ? -1 : 1) + Rand_CenteredFloat(0x1000);
         this->timer = 20;
         thisx->world.rot.x = Rand_S16Offset(0x100, 0x300) * ((Rand_ZeroOne() < 0.5f) ? -1 : 1);
@@ -209,7 +209,7 @@ void func_80882BDC(BgHakaZou* this, PlayState* play) {
             this->dyna.actor.velocity.y *= -0.6f;
             this->dyna.actor.velocity.y = CLAMP_MAX(this->dyna.actor.velocity.y, 10.0f);
             this->dyna.actor.bgCheckFlags &= ~(BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH);
-            this->dyna.actor.speedXZ = 2.0f;
+            this->dyna.actor.speed = 2.0f;
         } else {
             Actor_Kill(&this->dyna.actor);
         }

--- a/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.c
+++ b/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.c
@@ -441,7 +441,7 @@ void BgHeavyBlock_Fly(BgHeavyBlock* this, PlayState* play) {
                 this->actionFunc = BgHeavyBlock_Land;
         }
     }
-    this->dyna.actor.shape.rot.x = Math_Atan2S(this->dyna.actor.velocity.y, this->dyna.actor.speedXZ);
+    this->dyna.actor.shape.rot.x = Math_Atan2S(this->dyna.actor.velocity.y, this->dyna.actor.speed);
 }
 
 void BgHeavyBlock_DoNothing(BgHeavyBlock* this, PlayState* play) {
@@ -451,7 +451,7 @@ void BgHeavyBlock_Land(BgHeavyBlock* this, PlayState* play) {
     s32 pad;
 
     if (Math_SmoothStepToS(&this->dyna.actor.shape.rot.x, 0x8AD0, 6, 2000, 100) != 0) {
-        Math_StepToF(&this->dyna.actor.speedXZ, 0.0f, 20.0f);
+        Math_StepToF(&this->dyna.actor.speed, 0.0f, 20.0f);
         Math_StepToF(&this->dyna.actor.velocity.y, 0.0f, 3.0f);
         this->dyna.actor.gravity = 0.0f;
         this->dyna.actor.world.pos = this->dyna.actor.home.pos;

--- a/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
@@ -143,7 +143,7 @@ void BgHidanDalm_Wait(BgHidanDalm* this, PlayState* play) {
         this->actionFunc = BgHidanDalm_Shrink;
         this->dyna.actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND_TOUCH;
         this->dyna.actor.bgCheckFlags &= ~BGCHECKFLAG_WALL;
-        this->dyna.actor.speedXZ = 10.0f;
+        this->dyna.actor.speed = 10.0f;
         Flags_SetSwitch(play, this->switchFlag);
         Player_PlaySfx(GET_PLAYER(play), NA_SE_IT_HAMMER_HIT);
         Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_DARUMA_VANISH);

--- a/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.c
@@ -119,9 +119,9 @@ void func_80889BC0(BgHidanKousi* this, PlayState* play) {
 }
 
 void func_80889C18(BgHidanKousi* this, PlayState* play) {
-    this->dyna.actor.speedXZ += 0.2f;
-    if (this->dyna.actor.speedXZ > 2.0f) {
-        this->dyna.actor.speedXZ = 2.0f;
+    this->dyna.actor.speed += 0.2f;
+    if (this->dyna.actor.speed > 2.0f) {
+        this->dyna.actor.speed = 2.0f;
         BgHidanKousi_SetupAction(this, func_80889C90);
     }
     Actor_MoveForward(&this->dyna.actor);

--- a/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
@@ -135,13 +135,13 @@ void func_8088B268(BgHidanRock* this, PlayState* play) {
                 }
             }
 
-            this->dyna.actor.speedXZ += 0.05f;
-            this->dyna.actor.speedXZ = CLAMP_MAX(this->dyna.actor.speedXZ, 2.0f);
+            this->dyna.actor.speed += 0.05f;
+            this->dyna.actor.speed = CLAMP_MAX(this->dyna.actor.speed, 2.0f);
 
             if (D_8088BFC0 > 0.0f) {
-                temp_v1 = Math_StepToF(&D_8088BFC0, 20.0f, this->dyna.actor.speedXZ);
+                temp_v1 = Math_StepToF(&D_8088BFC0, 20.0f, this->dyna.actor.speed);
             } else {
-                temp_v1 = Math_StepToF(&D_8088BFC0, -20.0f, this->dyna.actor.speedXZ);
+                temp_v1 = Math_StepToF(&D_8088BFC0, -20.0f, this->dyna.actor.speed);
             }
 
             this->dyna.actor.world.pos.x = (Math_SinS(this->dyna.unk_158) * D_8088BFC0) + this->dyna.actor.home.pos.x;
@@ -153,7 +153,7 @@ void func_8088B268(BgHidanRock* this, PlayState* play) {
                 this->dyna.actor.home.pos.x = this->dyna.actor.world.pos.x;
                 this->dyna.actor.home.pos.z = this->dyna.actor.world.pos.z;
                 D_8088BFC0 = 0.0f;
-                this->dyna.actor.speedXZ = 0.0f;
+                this->dyna.actor.speed = 0.0f;
                 this->timer = 5;
             }
 
@@ -175,7 +175,7 @@ void func_8088B268(BgHidanRock* this, PlayState* play) {
         Math_Vec3f_Copy(&this->dyna.actor.home.pos, &D_8088BF60);
         this->dyna.actor.world.pos.x = D_8088BF60.x;
         this->dyna.actor.world.pos.z = D_8088BF60.z;
-        this->dyna.actor.speedXZ = 0.0f;
+        this->dyna.actor.speed = 0.0f;
         D_8088BFC0 = 0.0f;
         player->stateFlags2 &= ~PLAYER_STATE2_4;
         this->actionFunc = func_8088B79C;
@@ -296,7 +296,7 @@ void func_8088B990(BgHidanRock* this, PlayState* play) {
 
     this->timer++;
     if (this->dyna.unk_150 != 0.0f) {
-        this->dyna.actor.speedXZ = 0.0f;
+        this->dyna.actor.speed = 0.0f;
         player->stateFlags2 &= ~PLAYER_STATE2_4;
     }
 

--- a/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.c
@@ -161,11 +161,11 @@ void BgIceObjects_Slide(BgIceObjects* this, PlayState* play) {
     f32 spread;
     Actor* thisx = &this->dyna.actor;
 
-    Math_StepToF(&thisx->speedXZ, 10.0f, 0.5f);
-    atTarget = Math_StepToF(&thisx->world.pos.x, this->targetPos.x, thisx->speedXZ);
-    atTarget &= Math_StepToF(&thisx->world.pos.z, this->targetPos.z, thisx->speedXZ);
+    Math_StepToF(&thisx->speed, 10.0f, 0.5f);
+    atTarget = Math_StepToF(&thisx->world.pos.x, this->targetPos.x, thisx->speed);
+    atTarget &= Math_StepToF(&thisx->world.pos.z, this->targetPos.z, thisx->speed);
     if (atTarget) {
-        thisx->speedXZ = 0.0f;
+        thisx->speed = 0.0f;
         this->targetPos.x = thisx->world.pos.x;
         this->targetPos.z = thisx->world.pos.z;
         if (thisx->velocity.y <= 0.0f) {
@@ -179,7 +179,7 @@ void BgIceObjects_Slide(BgIceObjects* this, PlayState* play) {
         } else {
             this->actionFunc = BgIceObjects_Idle;
         }
-    } else if ((thisx->speedXZ > 6.0f) && (thisx->world.pos.y >= 0.0f)) {
+    } else if ((thisx->speed > 6.0f) && (thisx->world.pos.y >= 0.0f)) {
         spread = Rand_CenteredFloat(120.0f);
         velocity.x = -(1.5f + Rand_ZeroOne()) * Math_SinS(this->dyna.unk_158);
         velocity.y = Rand_ZeroOne() + 1.0f;
@@ -209,7 +209,7 @@ void BgIceObjects_Reset(BgIceObjects* this, PlayState* play) {
         thisx->flags &= ~ACTOR_FLAG_4;
         Math_Vec3f_Copy(&this->targetPos, &thisx->home.pos);
         this->actionFunc = BgIceObjects_Idle;
-        thisx->speedXZ = 0.0f;
+        thisx->speed = 0.0f;
     }
 }
 

--- a/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.c
@@ -114,8 +114,8 @@ void func_80891D6C(BgIceShutter* this, PlayState* play) {
 }
 
 void func_80891DD4(BgIceShutter* this, PlayState* play) {
-    Math_StepToF(&this->dyna.actor.speedXZ, 30.0f, 2.0f);
-    if (Math_StepToF(&this->dyna.actor.velocity.y, 210.0f, this->dyna.actor.speedXZ)) {
+    Math_StepToF(&this->dyna.actor.speed, 30.0f, 2.0f);
+    if (Math_StepToF(&this->dyna.actor.velocity.y, 210.0f, this->dyna.actor.speed)) {
         Actor_Kill(&this->dyna.actor);
         return;
     }

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
@@ -125,8 +125,8 @@ void BgJyaGoroiwa_Move(BgJyaGoroiwa* this, PlayState* play) {
     f32 speedXZBaseSq = (-100.0f - thisx->world.pos.y) * 2.5f;
     f32 posYfac;
 
-    if (speedXZBaseSq < SQ(0.1f)) {
-        speedXZBaseSq = SQ(0.1f);
+    if (speedXZBaseSq < 0.01f) {
+        speedXZBaseSq = 0.01f;
     }
 
     thisx->speed = sqrtf(speedXZBaseSq) * this->speedFactor;

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
@@ -122,16 +122,16 @@ void BgJyaGoroiwa_SetupMove(BgJyaGoroiwa* this) {
 void BgJyaGoroiwa_Move(BgJyaGoroiwa* this, PlayState* play) {
     Actor* thisx = &this->actor;
     s16 relYawTowardsPlayer;
-    f32 speedXZsqBase = (-100.0f - thisx->world.pos.y) * 2.5f;
+    f32 speedXZBaseSq = (-100.0f - thisx->world.pos.y) * 2.5f;
     f32 posYfac;
 
-    if (speedXZsqBase < 0.01f) {
-        speedXZsqBase = 0.01f;
+    if (speedXZBaseSq < 0.01f) {
+        speedXZBaseSq = 0.01f;
     }
 
-    thisx->speedXZ = sqrtf(speedXZsqBase) * this->speedFactor;
-    thisx->velocity.x = Math_SinS(thisx->world.rot.y) * thisx->speedXZ;
-    thisx->velocity.z = Math_CosS(thisx->world.rot.y) * thisx->speedXZ;
+    thisx->speed = sqrtf(speedXZBaseSq) * this->speedFactor;
+    thisx->velocity.x = Math_SinS(thisx->world.rot.y) * thisx->speed;
+    thisx->velocity.z = Math_CosS(thisx->world.rot.y) * thisx->speed;
 
     thisx->world.pos.x = thisx->world.pos.x + thisx->velocity.x;
     thisx->world.pos.z = thisx->world.pos.z + thisx->velocity.z;

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
@@ -125,8 +125,8 @@ void BgJyaGoroiwa_Move(BgJyaGoroiwa* this, PlayState* play) {
     f32 speedXZBaseSq = (-100.0f - thisx->world.pos.y) * 2.5f;
     f32 posYfac;
 
-    if (speedXZBaseSq < 0.01f) {
-        speedXZBaseSq = 0.01f;
+    if (speedXZBaseSq < SQ(0.1f)) {
+        speedXZBaseSq = SQ(0.1f);
     }
 
     thisx->speed = sqrtf(speedXZBaseSq) * this->speedFactor;

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
@@ -133,8 +133,8 @@ void BgJyaGoroiwa_Move(BgJyaGoroiwa* this, PlayState* play) {
     thisx->velocity.x = Math_SinS(thisx->world.rot.y) * thisx->speed;
     thisx->velocity.z = Math_CosS(thisx->world.rot.y) * thisx->speed;
 
-    thisx->world.pos.x = thisx->world.pos.x + thisx->velocity.x;
-    thisx->world.pos.z = thisx->world.pos.z + thisx->velocity.z;
+    thisx->world.pos.x += thisx->velocity.x;
+    thisx->world.pos.z += thisx->velocity.z;
 
     if ((thisx->world.pos.x > 1466.0f) && (thisx->world.pos.x < 1673.0f)) {
         thisx->world.pos.y = -129.5f;

--- a/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
@@ -119,7 +119,7 @@ void BgJyaIronobj_SpawnPillarParticles(BgJyaIronobj* this, PlayState* play, EnIk
                         Rand_ZeroOne() * 80.0f + this->dyna.actor.world.pos.y + 20.0f, this->dyna.actor.world.pos.z, 0,
                         (s16)(Rand_ZeroOne() * 0x4000) + rotY - 0x2000, 0, 0);
         if (actor != NULL) {
-            actor->speedXZ = Rand_ZeroOne() * 8.0f + 9.0f;
+            actor->speed = Rand_ZeroOne() * 8.0f + 9.0f;
             actor->velocity.y = Rand_ZeroOne() * 10.0f + 6.0f;
         }
     }
@@ -181,7 +181,7 @@ void BgJyaIronobj_SpawnThroneParticles(BgJyaIronobj* this, PlayState* play, EnIk
                         (Rand_ZeroOne() * 80.0f) + this->dyna.actor.world.pos.y + 10.0f, this->dyna.actor.world.pos.z,
                         0, ((s16)(s32)(Rand_ZeroOne() * 0x4000) + rotY) - 0x2000, 0, 0);
         if (actor != NULL) {
-            actor->speedXZ = Rand_ZeroOne() * 8.0f + 9.0f;
+            actor->speed = Rand_ZeroOne() * 8.0f + 9.0f;
             actor->velocity.y = Rand_ZeroOne() * 10.0f + 6.0f;
         }
     }

--- a/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.c
@@ -322,11 +322,11 @@ void func_8089E650(BgMizuMovebg* this, PlayState* play) {
     f32 dy;
     f32 dz;
 
-    this->dyna.actor.speedXZ = MOVEBG_SPEED(this->dyna.actor.params) * 0.1f;
+    this->dyna.actor.speed = MOVEBG_SPEED(this->dyna.actor.params) * 0.1f;
     func_8089E108(play->pathList, &waypoint, MOVEBG_PATH_ID(this->dyna.actor.params), this->waypointId);
     dist = Actor_WorldDistXYZToPoint(&this->dyna.actor, &waypoint);
-    if (dist < this->dyna.actor.speedXZ) {
-        this->dyna.actor.speedXZ = dist;
+    if (dist < this->dyna.actor.speed) {
+        this->dyna.actor.speed = dist;
     }
     func_80035844(&this->dyna.actor.world.pos, &waypoint, &this->dyna.actor.world.rot, 1);
     func_8002D97C(&this->dyna.actor);

--- a/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
+++ b/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
@@ -385,9 +385,9 @@ void BgPoEvent_BlockPush(BgPoEvent* this, PlayState* play) {
     s32 blockStop;
     Player* player = GET_PLAYER(play);
 
-    this->dyna.actor.speedXZ += 0.1f;
-    this->dyna.actor.speedXZ = CLAMP_MAX(this->dyna.actor.speedXZ, 2.0f);
-    blockStop = Math_StepToF(&blockPushDist, 20.0f, this->dyna.actor.speedXZ);
+    this->dyna.actor.speed += 0.1f;
+    this->dyna.actor.speed = CLAMP_MAX(this->dyna.actor.speed, 2.0f);
+    blockStop = Math_StepToF(&blockPushDist, 20.0f, this->dyna.actor.speed);
     displacement = this->direction * blockPushDist;
     this->dyna.actor.world.pos.x = (Math_SinS(this->dyna.unk_158) * displacement) + this->dyna.actor.home.pos.x;
     this->dyna.actor.world.pos.z = (Math_CosS(this->dyna.unk_158) * displacement) + this->dyna.actor.home.pos.z;
@@ -400,7 +400,7 @@ void BgPoEvent_BlockPush(BgPoEvent* this, PlayState* play) {
         this->dyna.actor.home.pos.x = this->dyna.actor.world.pos.x;
         this->dyna.actor.home.pos.z = this->dyna.actor.world.pos.z;
         blockPushDist = 0.0f;
-        this->dyna.actor.speedXZ = 0.0f;
+        this->dyna.actor.speed = 0.0f;
         this->direction = 5;
         sBlocksAtRest++;
         this->actionFunc = BgPoEvent_BlockIdle;

--- a/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
+++ b/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
@@ -58,11 +58,10 @@ void BgPushbox_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void BgPushbox_UpdateImpl(BgPushbox* this, PlayState* play) {
-    this->dyna.actor.speedXZ += this->dyna.unk_150 * 0.2f;
-    this->dyna.actor.speedXZ = (this->dyna.actor.speedXZ < -1.0f)
-                                   ? -1.0f
-                                   : ((this->dyna.actor.speedXZ > 1.0f) ? 1.0f : this->dyna.actor.speedXZ);
-    Math_StepToF(&this->dyna.actor.speedXZ, 0.0f, 0.2f);
+    this->dyna.actor.speed += this->dyna.unk_150 * 0.2f;
+    this->dyna.actor.speed =
+        (this->dyna.actor.speed < -1.0f) ? -1.0f : ((this->dyna.actor.speed > 1.0f) ? 1.0f : this->dyna.actor.speed);
+    Math_StepToF(&this->dyna.actor.speed, 0.0f, 0.2f);
     this->dyna.actor.world.rot.y = this->dyna.unk_158;
     Actor_MoveForward(&this->dyna.actor);
     Actor_UpdateBgCheckInfo(play, &this->dyna.actor, 20.0f, 40.0f, 40.0f,

--- a/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
+++ b/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
@@ -59,8 +59,7 @@ void BgPushbox_Destroy(Actor* thisx, PlayState* play) {
 
 void BgPushbox_UpdateImpl(BgPushbox* this, PlayState* play) {
     this->dyna.actor.speed += this->dyna.unk_150 * 0.2f;
-    this->dyna.actor.speed =
-        (this->dyna.actor.speed < -1.0f) ? -1.0f : ((this->dyna.actor.speed > 1.0f) ? 1.0f : this->dyna.actor.speed);
+    this->dyna.actor.speed = CLAMP(this->dyna.actor.speed, -1.0f, 1.0f);
     Math_StepToF(&this->dyna.actor.speed, 0.0f, 0.2f);
     this->dyna.actor.world.rot.y = this->dyna.unk_158;
     Actor_MoveForward(&this->dyna.actor);

--- a/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.c
+++ b/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.c
@@ -82,13 +82,13 @@ void func_808AE5B4(BgSpot05Soko* this, PlayState* play) {
         Actor_SetFocus(&this->dyna.actor, 50.0f);
         OnePointCutscene_Attention(play, &this->dyna.actor);
         this->actionFunc = func_808AE630;
-        this->dyna.actor.speedXZ = 0.5f;
+        this->dyna.actor.speed = 0.5f;
     }
 }
 
 void func_808AE630(BgSpot05Soko* this, PlayState* play) {
-    this->dyna.actor.speedXZ *= 1.5f;
-    if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y - 120.0f, this->dyna.actor.speedXZ) !=
+    this->dyna.actor.speed *= 1.5f;
+    if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y - 120.0f, this->dyna.actor.speed) !=
         0) {
         Actor_Kill(&this->dyna.actor);
     }

--- a/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.c
+++ b/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.c
@@ -196,7 +196,7 @@ s32 func_808B4E58(BgSpot16Bombstone* this, PlayState* play) {
 
     Actor_ProcessInitChain(actor, sInitChainDebris);
 
-    actor->speedXZ = D_808B5DD8[actor->params][0];
+    actor->speed = D_808B5DD8[actor->params][0];
     actor->velocity.y = D_808B5DD8[actor->params][1];
 
     Actor_SetScale(actor, D_808B5DD8[actor->params][2] * scaleFactor);

--- a/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.c
@@ -236,7 +236,7 @@ void func_808B8E7C(BgSpot18Obj* this, PlayState* play) {
 void func_808B8EE0(BgSpot18Obj* this) {
     this->actionFunc = func_808B8F08;
     this->dyna.actor.world.rot.y = 0;
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     this->dyna.actor.velocity.z = 0.0f;
     this->dyna.actor.velocity.y = 0.0f;
     this->dyna.actor.velocity.x = 0.0f;
@@ -246,7 +246,7 @@ void func_808B8F08(BgSpot18Obj* this, PlayState* play) {
     s32 pad;
     Player* player = GET_PLAYER(play);
 
-    Math_StepToF(&this->dyna.actor.speedXZ, 1.2f, 0.1f);
+    Math_StepToF(&this->dyna.actor.speed, 1.2f, 0.1f);
     Actor_MoveForward(&this->dyna.actor);
     func_808B8DDC(this, play);
 

--- a/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
@@ -308,7 +308,7 @@ void BgYdanSp_FloorWebIdle(BgYdanSp* this, PlayState* play) {
                 this->timer = 14;
             }
         }
-        if (player->actor.speedXZ != 0.0f) {
+        if (player->actor.speed != 0.0f) {
             if (this->unk_16C < 0.1f) {
                 this->timer = 14;
             }

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -285,7 +285,7 @@ void BossDodongo_IntroCutscene(BossDodongo* this, PlayState* play) {
                 player->actor.world.pos.x = -890.0f;
                 player->actor.world.pos.z = -2804.0f;
 
-                player->actor.speedXZ = 0.0f;
+                player->actor.speed = 0.0f;
                 player->actor.shape.rot.y = player->actor.world.rot.y = 0x3FFF;
 
                 this->subCamEye.x = -890.0f;
@@ -489,7 +489,7 @@ void BossDodongo_SetupRoll(BossDodongo* this) {
 }
 
 void BossDodongo_SetupBlowFire(BossDodongo* this) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_1E4 = 0.0f;
     Animation_Change(&this->skelAnime, &object_kingdodongo_Anim_0061D4, 1.0f, 0.0f,
                      Animation_GetLastFrame(&object_kingdodongo_Anim_0061D4), ANIMMODE_ONCE, 0.0f);
@@ -499,7 +499,7 @@ void BossDodongo_SetupBlowFire(BossDodongo* this) {
 }
 
 void BossDodongo_SetupInhale(BossDodongo* this) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_Change(&this->skelAnime, &object_kingdodongo_Anim_008EEC, 1.0f, 0.0f,
                      Animation_GetLastFrame(&object_kingdodongo_Anim_008EEC), ANIMMODE_ONCE, -5.0f);
     this->actionFunc = BossDodongo_Inhale;
@@ -1274,7 +1274,7 @@ void BossDodongo_UpdateDamage(BossDodongo* this, PlayState* play) {
 }
 
 void BossDodongo_SetupDeathCutscene(BossDodongo* this) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_1E4 = 0.0f;
     Animation_Change(&this->skelAnime, &object_kingdodongo_Anim_002D0C, 1.0f, 0.0f,
                      Animation_GetLastFrame(&object_kingdodongo_Anim_002D0C), ANIMMODE_ONCE, -5.0f);
@@ -1364,7 +1364,7 @@ void BossDodongo_DeathCutscene(BossDodongo* this, PlayState* play) {
             Math_SmoothStepToF(&this->unk_204, 1.0f, 1.0f, 0.1f, 0.0f);
             if (this->unk_1DA == 1) {
                 this->csState = 8;
-                this->actor.speedXZ = this->unk_1E4 / 1.5f;
+                this->actor.speed = this->unk_1E4 / 1.5f;
                 if (this->unk_1A2 == 0) {
                     this->unk_238 = 250.0f;
                 } else {
@@ -1527,7 +1527,7 @@ void BossDodongo_DeathCutscene(BossDodongo* this, PlayState* play) {
                                              false);
                 }
             }
-            Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.2f, 0.1f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.2f, 0.1f, 0.0f);
             this->actor.world.rot.y += (s16)this->unk_238;
             this->unk_1C4 += (s16)this->unk_234;
             if (this->unk_1DA >= 0x367) {

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -320,7 +320,7 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
                     player2->actor.world.pos.y = 100.0f;
                     player2->actor.world.pos.z = 0.0f;
                     player2->actor.shape.rot.y = player2->actor.world.rot.y = -0x4000;
-                    player2->actor.speedXZ = 0.0f;
+                    player2->actor.speed = 0.0f;
                     this->subCamEye.x = player2->actor.world.pos.x - 70.0f;
                     this->subCamEye.y = player2->actor.world.pos.y + 40.0f;
                     this->subCamEye.z = player2->actor.world.pos.z + 70.0f;
@@ -377,7 +377,7 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
                 player2->actor.world.pos.x = 380.0f;
                 player2->actor.world.pos.y = 100.0f;
                 player2->actor.world.pos.z = 0.0f;
-                player2->actor.speedXZ = 0.0f;
+                player2->actor.speed = 0.0f;
                 player2->actor.shape.rot.y = player2->actor.world.rot.y = -0x4000;
                 if (this->timers[0] == 50) {
                     this->fogMode = 1;
@@ -824,7 +824,7 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
             }
             break;
         case BOSSFD_SKULL_FALL:
-            this->fwork[BFD_TURN_RATE] = this->fwork[BFD_TURN_RATE_MAX] = this->actor.speedXZ =
+            this->fwork[BFD_TURN_RATE] = this->fwork[BFD_TURN_RATE_MAX] = this->actor.speed =
                 this->fwork[BFD_FLY_SPEED] = 0;
 
             if (this->timers[0] == 1) {
@@ -879,7 +879,7 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
         case BOSSFD_SKULL_BURN:
             this->actor.velocity.y = 0.0f;
             this->actor.world.pos.y = 110.0f;
-            this->fwork[BFD_TURN_RATE] = this->fwork[BFD_TURN_RATE_MAX] = this->actor.speedXZ =
+            this->fwork[BFD_TURN_RATE] = this->fwork[BFD_TURN_RATE_MAX] = this->actor.speed =
                 this->fwork[BFD_FLY_SPEED] = 0.0f;
 
             if ((50 > this->timers[0]) && (this->timers[0] > 0)) {
@@ -937,7 +937,7 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
 
         Math_ApproachS(&this->actor.world.rot.x, pitchToTarget, 0xA, this->fwork[BFD_TURN_RATE]);
         Math_ApproachF(&this->fwork[BFD_TURN_RATE], this->fwork[BFD_TURN_RATE_MAX], 1.0f, 20000.0f);
-        Math_ApproachF(&this->actor.speedXZ, this->fwork[BFD_FLY_SPEED], 1.0f, 0.1f);
+        Math_ApproachF(&this->actor.speed, this->fwork[BFD_FLY_SPEED], 1.0f, 0.1f);
         if (this->work[BFD_ACTION_STATE] < BOSSFD_SKULL_FALL) {
             func_8002D908(&this->actor);
         }
@@ -1930,7 +1930,7 @@ void BossFd_DrawBody(PlayState* play, BossFd* this) {
     gDPSetEnvColor(POLY_OPA_DISP++, 255, 255, 255, (s8)this->fwork[BFD_HEAD_TEX2_ALPHA]);
     Matrix_Push();
     temp_float =
-        (this->work[BFD_ACTION_STATE] >= BOSSFD_SKULL_FALL) ? -20.0f : -10.0f - ((this->actor.speedXZ - 5.0f) * 10.0f);
+        (this->work[BFD_ACTION_STATE] >= BOSSFD_SKULL_FALL) ? -20.0f : -10.0f - ((this->actor.speed - 5.0f) * 10.0f);
     segIndex = (this->work[BFD_LEAD_BODY_SEG] + sBodyIndex[0]) % 100;
     Matrix_Translate(this->bodySegsPos[segIndex].x, this->bodySegsPos[segIndex].y, this->bodySegsPos[segIndex].z,
                      MTXMODE_NEW);

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -423,7 +423,7 @@ void BossGanon_Init(Actor* thisx, PlayState* play2) {
                 thisx->update = func_808E1EB4;
                 thisx->draw = func_808E229C;
                 if (1) {}
-                thisx->speedXZ = 11.0f;
+                thisx->speed = 11.0f;
 
                 if (thisx->params == 0xC8) {
                     this->timers[0] = 7;
@@ -439,7 +439,7 @@ void BossGanon_Init(Actor* thisx, PlayState* play2) {
             // light ball (anything from 0x64 - 0xC7)
             thisx->update = BossGanon_LightBall_Update;
             thisx->draw = BossGanon_LightBall_Draw;
-            thisx->speedXZ = 12.0f;
+            thisx->speed = 12.0f;
 
             xDistFromPlayer = player->actor.world.pos.x - thisx->world.pos.x;
             yDistFromPlayer = (player->actor.world.pos.y + 30.0f) - thisx->world.pos.y;
@@ -3969,7 +3969,7 @@ void BossGanon_LightBall_Update(Actor* thisx, PlayState* play2) {
                             }
 
                             if (player->meleeWeaponAnimation >= PLAYER_MWA_SPIN_ATTACK_1H) {
-                                this->actor.speedXZ = 20.0f;
+                                this->actor.speed = 20.0f;
                             }
                             break;
                         } else {
@@ -4000,7 +4000,7 @@ void BossGanon_LightBall_Update(Actor* thisx, PlayState* play2) {
 
             case 1:
                 if ((ganondorf->actionFunc == BossGanon_PlayTennis) && (ganondorf->unk_1C2 == 1)) {
-                    minReflectDist = (this->actor.speedXZ >= 19.0f) ? 250.0f : 170.0f;
+                    minReflectDist = (this->actor.speed >= 19.0f) ? 250.0f : 170.0f;
 
                     if (sqrtf(SQ(xDistFromGanondorf) + SQ(yDistFromGanondorf) + SQ(zDistFromGanondorf)) <
                         minReflectDist) {
@@ -4226,7 +4226,7 @@ void func_808E1EB4(Actor* thisx, PlayState* play2) {
         if (sqrtf(SQ(xDiff) + SQ(zDiff) + SQ(yDiff)) < 40.0f) {
             this->unk_1C2 = 2;
             this->timers[0] = 30;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
 
             if (this->actor.params == 0xC8) {
                 func_80078884(NA_SE_EN_GANON_DAMAGE2);
@@ -4338,7 +4338,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
     switch (this->unk_1C2) {
         if (1) {}
         case 0:
-            this->actor.speedXZ = 40.0f;
+            this->actor.speed = 40.0f;
             Math_ApproachF(&this->fwork[1], 255.0f, 1.0f, 40.0f);
             xDiff = dorf->unk_278.x - this->actor.world.pos.x;
             yDiff = dorf->unk_278.y - this->actor.world.pos.y;
@@ -4360,7 +4360,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
 
             if (sqrtf(SQ(xDiff) + SQ(zDiff) + SQ(yDiff)) < 45.0f) {
                 this->unk_1C2 = 1;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
             }
             break;
 
@@ -4380,7 +4380,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
             this->collider.dim.height = 20;
             this->collider.dim.yShift = -10;
 
-            this->actor.speedXZ = 20.0f;
+            this->actor.speed = 20.0f;
             this->fwork[1] = 255.0f;
             this->unk_1F0 = player->actor.world.pos;
             new_var = this->unk_1F0.x - this->actor.world.pos.x;
@@ -4411,7 +4411,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
             if ((player->meleeWeaponState != 0) && (player->meleeWeaponAnimation >= PLAYER_MWA_SPIN_ATTACK_1H) &&
                 (this->actor.xzDistToPlayer < 80.0f)) {
                 this->unk_1C2 = 0xC;
-                this->actor.speedXZ = -30.0f;
+                this->actor.speed = -30.0f;
                 func_8002D908(&this->actor);
                 func_8002D7EC(&this->actor);
                 this->unk_1F0 = dorf->unk_1FC;
@@ -4427,7 +4427,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
                 if (!(acHitInfo->toucher.dmgFlags & DMG_SHIELD) || Player_HasMirrorShieldEquipped(play)) {
                     Rumble_Request(this->actor.xyzDistToPlayerSq, 180, 20, 100);
                     this->unk_1C2 = 0xC;
-                    this->actor.speedXZ = -30.0f;
+                    this->actor.speed = -30.0f;
 
                     func_8002D908(&this->actor);
                     func_8002D7EC(&this->actor);
@@ -4457,7 +4457,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
 
             if (sqrtf(SQ(xDiff) + SQ(zDiff) + SQ(yDiff)) < 30.0f) {
                 this->unk_1C2 = 1;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
 
                 if (dorf->timers[2] == 0) {
                     func_8002F6D4(play, &this->actor, 3.0f, this->actor.world.rot.y, 0.0f, 0x50);
@@ -4477,7 +4477,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
             break;
 
         case 12:
-            this->actor.speedXZ = 20.0f;
+            this->actor.speed = 20.0f;
 
             xDiff = this->unk_1F0.x - this->actor.world.pos.x;
             yDiff = this->unk_1F0.y - this->actor.world.pos.y;
@@ -4508,7 +4508,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
                 this->timers[0] = 150;
                 numEffects = 40;
                 this->unk_1C2 = 1;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
             }
             break;
     }
@@ -4520,7 +4520,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
             (fabsf(this->actor.world.pos.z) > (465.0f + xzDist)) || (this->actor.world.pos.y < 0.0f) ||
             (this->actor.world.pos.y > 450.0f)) {
             this->unk_1C2 = 1;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             numEffects = 10;
             BossGanon_CheckFallingPlatforms(this, play, &this->actor.world.pos);
             Actor_SpawnAsChild(&play->actorCtx, &dorf->actor, play, ACTOR_BOSS_GANON, this->actor.world.pos.x,

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -1069,7 +1069,7 @@ void func_808FFEBC(BossGanon2* this, PlayState* play) {
     }
 
     SkelAnime_Update(&this->skelAnime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 1.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 1.0f);
 
     if (this->unk_1A2[0] == 0) {
         func_809002CC(this, play);
@@ -1091,7 +1091,7 @@ void func_808FFFE0(BossGanon2* this, PlayState* play) {
     s16 target;
 
     SkelAnime_Update(&this->skelAnime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 1.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 1.0f);
 
     if (this->unk_1A2[0] == 0) {
         func_809002CC(this, play);
@@ -1115,7 +1115,7 @@ void func_809000A0(BossGanon2* this, PlayState* play) {
 
 void func_80900104(BossGanon2* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 1.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 1.0f);
 
     switch (this->unk_1AC) {
         case 0:
@@ -1148,7 +1148,7 @@ void func_80900210(BossGanon2* this, PlayState* play) {
 
 void func_8090026C(BossGanon2* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
 
     if (Animation_OnFrame(&this->skelAnime, this->unk_194)) {
         func_809002CC(this, play);
@@ -1201,7 +1201,7 @@ void func_80900344(BossGanon2* this, PlayState* play) {
     }
 
     SkelAnime_Update(&this->skelAnime);
-    Math_ApproachF(&this->actor.speedXZ, phi_f0, 0.5f, 1.0f);
+    Math_ApproachF(&this->actor.speed, phi_f0, 0.5f, 1.0f);
 
     if (this->unk_1A2[0] == 0) {
         func_808FFDB0(this, play);
@@ -1245,7 +1245,7 @@ void func_80900650(BossGanon2* this, PlayState* play) {
         this->unk_312 = 2;
     }
 
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 1.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 1.0f);
 
     if (Animation_OnFrame(&this->skelAnime, this->unk_194)) {
         this->unk_311 = 1 - this->unk_311;
@@ -1428,7 +1428,7 @@ void func_80900890(BossGanon2* this, PlayState* play) {
             break;
     }
 
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 1.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 1.0f);
 }
 
 void func_80901020(BossGanon2* this, PlayState* play) {
@@ -1493,7 +1493,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
             this->unk_1A2[2] = 0;
             this->unk_336 = 0;
             this->unk_324 = 0.0f;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->unk_31A = this->unk_31C;
             play->envCtx.lightBlend = 0.0f;
             FALLTHROUGH;

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -821,7 +821,7 @@ void BossGanondrof_Charge(BossGanondrof* this, PlayState* play) {
             if (this->timers[0] == 0) {
                 this->work[GND_ACTION_STATE] = CHARGE_START;
                 this->timers[0] = 10;
-                thisx->speedXZ = 0.0f;
+                thisx->speed = 0.0f;
                 this->fwork[GND_END_FRAME] = Animation_GetLastFrame(&gPhantomGanonChargeStartAnim);
                 Animation_MorphToPlayOnce(&this->skelAnime, &gPhantomGanonChargeStartAnim, 0.0f);
             }
@@ -849,7 +849,7 @@ void BossGanondrof_Charge(BossGanondrof* this, PlayState* play) {
 
             func_8002D908(thisx);
             func_8002D7EC(thisx);
-            Math_ApproachF(&thisx->speedXZ, 10.0f, 1.0f, 0.5f);
+            Math_ApproachF(&thisx->speed, 10.0f, 1.0f, 0.5f);
             if ((sqrtf(SQ(dxCenter) + SQ(dzCenter)) > 280.0f) || (thisx->xyzDistToPlayerSq < SQ(100.0f))) {
                 this->work[GND_ACTION_STATE] = CHARGE_FINISH;
                 this->timers[0] = 20;
@@ -865,15 +865,15 @@ void BossGanondrof_Charge(BossGanondrof* this, PlayState* play) {
             }
 
             if (sqrtf(SQ(dxCenter) + SQ(dzCenter)) > 280.0f) {
-                Math_ApproachZeroF(&thisx->speedXZ, 1.0f, 2.0f);
+                Math_ApproachZeroF(&thisx->speed, 1.0f, 2.0f);
                 this->timers[0] = 0;
             }
 
             if (this->timers[0] == 0) {
-                Math_ApproachZeroF(&thisx->speedXZ, 1.0f, 2.0f);
+                Math_ApproachZeroF(&thisx->speed, 1.0f, 2.0f);
                 Math_ApproachZeroF(&thisx->velocity.y, 1.0f, 2.0f);
                 Math_ApproachS(&thisx->shape.rot.y, thisx->yawTowardsPlayer, 5, 0x7D0);
-                if ((thisx->speedXZ <= 0.5f) && (fabsf(thisx->velocity.y) <= 0.1f)) {
+                if ((thisx->speed <= 0.5f) && (fabsf(thisx->velocity.y) <= 0.1f)) {
                     BossGanondrof_SetupNeutral(this, -10.0f);
                     this->timers[0] = 30;
                     this->flyMode = GND_FLY_NEUTRAL;
@@ -963,7 +963,7 @@ void BossGanondrof_Death(BossGanondrof* this, PlayState* play) {
             Play_ChangeCameraStatus(play, this->subCamId, CAM_STAT_ACTIVE);
             osSyncPrintf("8\n");
             this->deathState = DEATH_THROES;
-            player->actor.speedXZ = 0.0f;
+            player->actor.speed = 0.0f;
             this->timers[0] = 50;
             this->subCamEye = mainCam->eye;
             this->subCamAt = mainCam->at;

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -405,7 +405,7 @@ void BossGoma_SetupDefeated(BossGoma* this, PlayState* play) {
     this->framesUntilNextAction = 1200;
     this->actionState = 0;
     this->actor.flags &= ~(ACTOR_FLAG_0 | ACTOR_FLAG_2);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.shape.shadowScale = 0.0f;
     SEQCMD_STOP_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 1);
     Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_DEAD);
@@ -452,7 +452,7 @@ void BossGoma_SetupCeilingIdle(BossGoma* this) {
 void BossGoma_SetupFallJump(BossGoma* this) {
     Animation_Change(&this->skelanime, &gGohmaLandAnim, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -5.0f);
     this->actionFunc = BossGoma_FallJump;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = -2.0f;
 }
@@ -463,7 +463,7 @@ void BossGoma_SetupFallJump(BossGoma* this) {
 void BossGoma_SetupFallStruckDown(BossGoma* this) {
     Animation_Change(&this->skelanime, &gGohmaCrashAnim, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -5.0f);
     this->actionFunc = BossGoma_FallStruckDown;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = -2.0f;
 }
@@ -486,7 +486,7 @@ void BossGoma_SetupWallClimb(BossGoma* this) {
     Animation_Change(&this->skelanime, &gGohmaClimbAnim, 1.0f, 0.0f, Animation_GetLastFrame(&gGohmaClimbAnim),
                      ANIMMODE_LOOP, -10.0f);
     this->actionFunc = BossGoma_WallClimb;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = 0.0f;
 }
@@ -498,7 +498,7 @@ void BossGoma_SetupCeilingMoveToCenter(BossGoma* this) {
     Animation_Change(&this->skelanime, &gGohmaWalkAnim, 1.0f, 0.0f, Animation_GetLastFrame(&gGohmaWalkAnim),
                      ANIMMODE_LOOP, -5.0f);
     this->actionFunc = BossGoma_CeilingMoveToCenter;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = 0.0f;
     this->framesUntilNextAction = Rand_S16Offset(30, 60);
@@ -595,7 +595,7 @@ void BossGoma_UpdateCeilingMovement(BossGoma* this, PlayState* play, f32 dz, f32
 
     roomCenter.z += dz; // dz is always 0
     SkelAnime_Update(&this->skelanime);
-    Math_ApproachF(&this->actor.speedXZ, targetSpeedXZ, 0.5f, 2.0f);
+    Math_ApproachF(&this->actor.speed, targetSpeedXZ, 0.5f, 2.0f);
 
     if (rotateTowardsCenter) {
         Math_ApproachS(&this->actor.world.rot.y, Math_Vec3f_Yaw(&this->actor.world.pos, &roomCenter) + 0x8000, 3,
@@ -674,7 +674,7 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 pad[2];
 
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
 
     switch (this->actionState) {
         case 0: // wait for the player to enter the room
@@ -725,7 +725,7 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
             player->actor.world.pos.x = 150.0f;
             player->actor.world.pos.z = 300.0f;
             player->actor.world.rot.y = player->actor.shape.rot.y;
-            player->actor.speedXZ = 0.0f;
+            player->actor.speed = 0.0f;
 
             if (this->framesUntilNextAction == 0) {
                 // (-20, 25, -65) is towards room center
@@ -777,7 +777,7 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
             if (fabsf(this->actor.projectedPos.x) < 150.0f && fabsf(this->actor.projectedPos.y) < 250.0f &&
                 this->actor.projectedPos.z < 800.0f && this->actor.projectedPos.z > 0.0f) {
                 this->lookedAtFrames++;
-                Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+                Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
                 Math_ApproachS(&this->actor.world.rot.y,
                                Actor_WorldYawTowardActor(&this->actor, &GET_PLAYER(play)->actor) + 0x8000, 2, 0xBB8);
                 this->eyeLidBottomRotX = this->eyeLidTopRotX = this->eyeIrisRotX = this->eyeIrisRotY = 0;
@@ -845,7 +845,7 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
             if (this->framesUntilNextAction < 0) {
                 //! @bug ? unreachable, timer is >= 0
                 SkelAnime_Update(&this->skelanime);
-                Math_ApproachZeroF(&this->actor.speedXZ, 1.0f, 2.0f);
+                Math_ApproachZeroF(&this->actor.speed, 1.0f, 2.0f);
             } else {
                 BossGoma_UpdateCeilingMovement(this, play, 0.0f, -7.5f, false);
             }
@@ -857,7 +857,7 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
 
             if (this->framesUntilNextAction == 0) {
                 this->actionState = 9;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 this->actor.velocity.y = 0.0f;
                 this->actor.gravity = -2.0f;
                 Animation_Change(&this->skelanime, &gGohmaInitialLandingAnim, 1.0f, 0.0f,
@@ -1255,7 +1255,7 @@ void BossGoma_Defeated(BossGoma* this, PlayState* play) {
  */
 void BossGoma_FloorAttackPosture(BossGoma* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
 
     if (this->skelanime.curFrame >= (19.0f + 1.0f / 3.0f) && this->skelanime.curFrame <= 30.0f) {
         Math_ApproachS(&this->actor.world.rot.y, Actor_WorldYawTowardActor(&this->actor, &GET_PLAYER(play)->actor), 3,
@@ -1406,7 +1406,7 @@ void BossGoma_FloorStunned(BossGoma* this, PlayState* play) {
         Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 55.0f, 4, 8.0f, 500, 10, true);
     }
 
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 1.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 1.0f);
 
     if (this->framesUntilNextAction == 0) {
         BossGoma_SetupFloorMain(this);
@@ -1468,7 +1468,7 @@ void BossGoma_CeilingSpawnGohmas(BossGoma* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_UNARI);
     }
 
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
     this->spawnGohmasActionTimer++;
 
     switch (this->spawnGohmasActionTimer) {
@@ -1530,7 +1530,7 @@ void BossGoma_CeilingPrepareSpawnGohmas(BossGoma* this, PlayState* play) {
  */
 void BossGoma_FloorIdle(BossGoma* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
     Math_ApproachS(&this->actor.shape.rot.x, 0, 2, 0xBB8);
 
     if (this->framesUntilNextAction == 0) {
@@ -1547,7 +1547,7 @@ void BossGoma_CeilingIdle(BossGoma* this, PlayState* play) {
     s16 i;
 
     SkelAnime_Update(&this->skelanime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
 
     if (this->framesUntilNextAction == 0) {
         if (this->childrenGohmaState[0] == 0 && this->childrenGohmaState[1] == 0 && this->childrenGohmaState[2] == 0) {
@@ -1613,19 +1613,19 @@ void BossGoma_FloorMain(BossGoma* this, PlayState* play) {
                 BossGoma_SetupFloorAttackPosture(this);
             }
 
-            Math_ApproachF(&this->actor.speedXZ, 10.0f / 3.0f, 0.5f, 2.0f);
+            Math_ApproachF(&this->actor.speed, 10.0f / 3.0f, 0.5f, 2.0f);
             Math_ApproachS(&this->actor.world.rot.y, rot, 5, 0x3E8);
         } else {
             if (this->timer != 0) {
                 // move away from the player, walking backwards
-                Math_ApproachF(&this->actor.speedXZ, -10.0f, 0.5f, 2.0f);
+                Math_ApproachF(&this->actor.speed, -10.0f, 0.5f, 2.0f);
                 this->skelanime.playSpeed = -3.0f;
                 if (this->timer == 1) {
-                    this->actor.speedXZ = 0.0f;
+                    this->actor.speed = 0.0f;
                 }
             } else {
                 // move away from the player, walking forwards
-                Math_ApproachF(&this->actor.speedXZ, 20.0f / 3.0f, 0.5f, 2.0f);
+                Math_ApproachF(&this->actor.speed, 20.0f / 3.0f, 0.5f, 2.0f);
                 this->skelanime.playSpeed = 2.0f;
                 rot += 0x8000;
             }

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -613,7 +613,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 Math_ApproachS(&this->tentRot[indS1].z, tempf2, 1.0f / this->tentMaxAngle, this->tentSpeed);
             }
             this->targetPos = this->actor.world.pos;
-            Math_ApproachF(&this->actor.speedXZ, 0.75f, 1.0f, 0.04f);
+            Math_ApproachF(&this->actor.speed, 0.75f, 1.0f, 0.04f);
             if (this->work[MO_TENT_ACTION_STATE] == MO_TENT_SWING) {
                 Math_ApproachS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer + this->attackAngleMod, 0xA,
                                0x1F4);
@@ -757,7 +757,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
             }
             if (this->work[MO_TENT_ACTION_STATE] == MO_TENT_GRAB) {
                 player->unk_850 = 0xA;
-                player->actor.speedXZ = player->actor.velocity.y = 0;
+                player->actor.speed = player->actor.velocity.y = 0;
                 Math_ApproachF(&player->actor.world.pos.x, this->grabPosRot.pos.x, 0.5f, 20.0f);
                 Math_ApproachF(&player->actor.world.pos.y, this->grabPosRot.pos.y, 0.5f, 20.0f);
                 Math_ApproachF(&player->actor.world.pos.z, this->grabPosRot.pos.z, 0.5f, 20.0f);
@@ -822,7 +822,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
             player->actor.world.rot.y = player->actor.shape.rot.y = this->grabPosRot.rot.y;
             player->actor.world.rot.z = player->actor.shape.rot.z = this->grabPosRot.rot.z;
             player->actor.velocity.y = 0;
-            player->actor.speedXZ = 0;
+            player->actor.speed = 0;
             Math_ApproachF(&this->fwork[MO_TENT_MAX_STRETCH], 1.0f, 0.5f, 0.01);
             Math_ApproachF(&this->tentMaxAngle, 0.5f, 1.0f, 0.005f);
             Math_ApproachF(&this->tentSpeed, 480.0f, 1.0f, 10.0f);
@@ -999,7 +999,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 Math_ApproachS(&this->tentRot[indS1].x, tempf1, 1.0f / this->tentMaxAngle, this->tentSpeed);
                 Math_ApproachS(&this->tentRot[indS1].z, tempf2, 1.0f / this->tentMaxAngle, this->tentSpeed);
             }
-            this->actor.speedXZ = 0.0;
+            this->actor.speed = 0.0;
             Math_ApproachF(&this->fwork[MO_TENT_MAX_STRETCH], 4.3f, 0.5f, 0.04);
             Math_ApproachF(&this->tentPulse, 1.3f, 0.5f, 0.05f);
             break;
@@ -1018,7 +1018,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 Math_ApproachS(&this->tentRot[indS1].x, tempf1, 1.0f / this->tentMaxAngle, this->tentSpeed);
                 Math_ApproachS(&this->tentRot[indS1].z, tempf2, 1.0f / this->tentMaxAngle, this->tentSpeed);
             }
-            this->actor.speedXZ = 0.0;
+            this->actor.speed = 0.0;
             Math_ApproachF(&this->tentPulse, 1.3f, 0.5f, 0.05f);
             break;
         case MO_TENT_DEATH_2:
@@ -1034,7 +1034,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 Math_ApproachS(&this->tentRot[indS1].x, tempf1, 1.0f / this->tentMaxAngle, this->tentSpeed);
                 Math_ApproachS(&this->tentRot[indS1].z, tempf2, 1.0f / this->tentMaxAngle, this->tentSpeed);
             }
-            this->actor.speedXZ = 0.0;
+            this->actor.speed = 0.0;
             this->noBubbles--;
             Math_ApproachF(&this->fwork[MO_TENT_MAX_STRETCH], 0.1f, 0.1f, 0.03);
             Math_ApproachF(&this->tentPulse, 0.02f, 0.5f, 0.015f);
@@ -1229,7 +1229,7 @@ void BossMo_IntroCs(BossMo* this, PlayState* play) {
                 this->subCamId = Play_CreateSubCamera(play);
                 Play_ChangeCameraStatus(play, CAM_ID_MAIN, CAM_STAT_WAIT);
                 Play_ChangeCameraStatus(play, this->subCamId, CAM_STAT_ACTIVE);
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 this->csState = MO_INTRO_START;
                 this->timers[2] = 50;
                 this->work[MO_TENT_VAR_TIMER] = this->work[MO_TENT_MOVE_TIMER] = 0;
@@ -1245,7 +1245,7 @@ void BossMo_IntroCs(BossMo* this, PlayState* play) {
             player->actor.world.pos.x = 180.0f;
             player->actor.world.pos.z = -130.0f;
             player->actor.shape.rot.y = player->actor.world.rot.y = 0;
-            player->actor.speedXZ = 0.0f;
+            player->actor.speed = 0.0f;
             this->subCamEye.x = -424.0f;
             this->subCamEye.y = -190.0f;
             this->subCamEye.z = 180.0f;
@@ -1330,7 +1330,7 @@ void BossMo_IntroCs(BossMo* this, PlayState* play) {
                 sp80 = 1.5f;
                 sp7C = (f32)0x600;
             }
-            Math_ApproachF(&this->actor.speedXZ, sp80, 1.0f, sp78);
+            Math_ApproachF(&this->actor.speed, sp80, 1.0f, sp78);
             Math_ApproachF(&this->subCamYawRate, sp7C, 1.0f, 128.0f);
             if (this->work[MO_TENT_MOVE_TIMER] == 525) {
                 func_8002DF54(play, &this->actor, PLAYER_CSMODE_2);
@@ -1345,7 +1345,7 @@ void BossMo_IntroCs(BossMo* this, PlayState* play) {
                 player->actor.shape.rot.y = player->actor.world.rot.y;
                 this->subCamYawShake = 0.0f;
                 sMorphaTent1->baseAlpha = 150.0;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 this->timers[2] = 200;
                 this->subCamFov = 60.0f;
                 this->actor.world.pos = sMorphaTent1->actor.world.pos;
@@ -1454,7 +1454,7 @@ void BossMo_IntroCs(BossMo* this, PlayState* play) {
         sMorphaTent1->actor.world.pos.x = 180.0f;
         sMorphaTent1->actor.world.pos.z = -360.0f;
         sMorphaTent1->actor.prevPos = sMorphaTent1->actor.world.pos;
-        sMorphaTent1->actor.speedXZ = 0.0f;
+        sMorphaTent1->actor.speed = 0.0f;
         sMorphaTent1->actor.shape.rot.y = sMorphaTent1->actor.yawTowardsPlayer;
     }
     if (this->subCamId != SUB_CAM_ID_DONE) {
@@ -1763,7 +1763,7 @@ void BossMo_CoreCollisionCheck(BossMo* this, PlayState* play) {
                 this->work[MO_TENT_ACTION_STATE] = MO_CORE_STUNNED;
                 this->timers[0] = 25;
 
-                this->actor.speedXZ = 15.0f;
+                this->actor.speed = 15.0f;
 
                 this->actor.world.rot.y = this->actor.yawTowardsPlayer + 0x8000;
                 this->work[MO_CORE_DMG_FLASH_TIMER] = 15;
@@ -1811,7 +1811,7 @@ void BossMo_CoreCollisionCheck(BossMo* this, PlayState* play) {
                 this->work[MO_TENT_ACTION_STATE] = MO_CORE_STUNNED;
                 this->timers[0] = 30;
                 this->work[MO_TENT_INVINC_TIMER] = 10;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
             }
             for (i = 0; i < 10; i++) {
                 Vec3f pos;
@@ -1903,7 +1903,7 @@ void BossMo_Core(BossMo* this, PlayState* play) {
         ((this->work[MO_TENT_ACTION_STATE] == MO_CORE_MOVE) ||
          (this->work[MO_TENT_ACTION_STATE] == MO_CORE_MAKE_TENT))) {
         this->work[MO_TENT_ACTION_STATE] = MO_CORE_UNDERWATER;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->work[MO_CORE_WAIT_IN_WATER] = 0;
     }
     switch (this->work[MO_TENT_ACTION_STATE]) {
@@ -1913,7 +1913,7 @@ void BossMo_Core(BossMo* this, PlayState* play) {
                 ((sMorphaTent1->work[MO_TENT_ACTION_STATE] == MO_TENT_WAIT) ||
                  (sMorphaTent1->work[MO_TENT_ACTION_STATE] == MO_TENT_READY)) &&
                 (this->actor.world.pos.y < MO_WATER_LEVEL(play))) {
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 this->work[MO_TENT_ACTION_STATE] = MO_CORE_MAKE_TENT;
                 if (sMorphaTent1->work[MO_TENT_ACTION_STATE] == MO_TENT_WAIT) {
                     sMorphaTent1->work[MO_TENT_ACTION_STATE] = MO_TENT_SPAWN;
@@ -1937,13 +1937,13 @@ void BossMo_Core(BossMo* this, PlayState* play) {
                 this->work[MO_TENT_ACTION_STATE] = MO_CORE_ATTACK;
                 this->work[MO_CORE_POS_IN_TENT] = 0;
                 this->timers[0] = 0;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
             }
             break;
         case MO_CORE_UNDERWATER:
             if (player->actor.world.pos.y >= MO_WATER_LEVEL(play)) {
                 this->work[MO_TENT_ACTION_STATE] = MO_CORE_MOVE;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
             }
             break;
         case MO_CORE_STUNNED:
@@ -1955,7 +1955,7 @@ void BossMo_Core(BossMo* this, PlayState* play) {
             if (this->actor.world.pos.y < MO_WATER_LEVEL(play)) {
                 this->work[MO_TENT_ACTION_STATE] = MO_CORE_MAKE_TENT;
                 this->timers[0] = 50;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
             }
             break;
         case MO_CORE_UNUSED:
@@ -1984,7 +1984,7 @@ void BossMo_Core(BossMo* this, PlayState* play) {
                     this->work[MO_TENT_ACTION_STATE] = MO_CORE_MAKE_TENT;
                     this->timers[0] = 100;
                     this->tentSpeed = 0.0f;
-                    this->actor.speedXZ = 0.0f;
+                    this->actor.speed = 0.0f;
                 }
                 this->timers[0] = 0;
                 break;
@@ -2023,22 +2023,22 @@ void BossMo_Core(BossMo* this, PlayState* play) {
         if (this->work[MO_CORE_POS_IN_TENT] <= 1) {
             this->targetPos.y -= 20.0f;
         }
-        Math_ApproachF(&this->actor.world.pos.x, this->targetPos.x, 0.5f, this->actor.speedXZ);
-        Math_ApproachF(&this->actor.world.pos.y, this->targetPos.y, 0.5f, this->actor.speedXZ);
-        Math_ApproachF(&this->actor.world.pos.z, this->targetPos.z, 0.5f, this->actor.speedXZ);
-        Math_ApproachF(&this->actor.speedXZ, 30.0f, 1.0f, 1.0f);
+        Math_ApproachF(&this->actor.world.pos.x, this->targetPos.x, 0.5f, this->actor.speed);
+        Math_ApproachF(&this->actor.world.pos.y, this->targetPos.y, 0.5f, this->actor.speed);
+        Math_ApproachF(&this->actor.world.pos.z, this->targetPos.z, 0.5f, this->actor.speed);
+        Math_ApproachF(&this->actor.speed, 30.0f, 1.0f, 1.0f);
     } else {
         switch (this->work[MO_TENT_ACTION_STATE]) {
             case MO_CORE_MOVE:
                 sp80 = Math_SinS(this->work[MO_TENT_VAR_TIMER] * 0x800) * 100.0f;
                 sp7C = Math_CosS(this->work[MO_TENT_VAR_TIMER] * 0x800) * 100.0f;
-                Math_ApproachF(&this->actor.world.pos.x, sMorphaTent1->targetPos.x + sp80, 0.05f, this->actor.speedXZ);
-                Math_ApproachF(&this->actor.world.pos.z, sMorphaTent1->targetPos.z + sp7C, 0.05f, this->actor.speedXZ);
-                Math_ApproachF(&this->actor.speedXZ, 10.0f, 1.0f, 0.5f);
+                Math_ApproachF(&this->actor.world.pos.x, sMorphaTent1->targetPos.x + sp80, 0.05f, this->actor.speed);
+                Math_ApproachF(&this->actor.world.pos.z, sMorphaTent1->targetPos.z + sp7C, 0.05f, this->actor.speed);
+                Math_ApproachF(&this->actor.speed, 10.0f, 1.0f, 0.5f);
                 break;
             case MO_CORE_STUNNED:
-                this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speedXZ;
-                this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speedXZ;
+                this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speed;
+                this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speed;
                 this->actor.world.pos.x += this->actor.velocity.x;
                 this->actor.world.pos.z += this->actor.velocity.z;
                 break;
@@ -2097,7 +2097,7 @@ void BossMo_Core(BossMo* this, PlayState* play) {
                     this->targetPos.x = sMorphaTent1->targetPos.x;
                     this->targetPos.y = sMorphaTent1->actor.world.pos.y - 40.0f;
                     this->targetPos.z = sMorphaTent1->targetPos.z;
-                    Math_ApproachF(&this->actor.speedXZ, 10.0f, 1.0f, 0.5f);
+                    Math_ApproachF(&this->actor.speed, 10.0f, 1.0f, 0.5f);
                 } else if (this->work[MO_TENT_ACTION_STATE] == MO_CORE_UNDERWATER) {
                     switch (this->work[MO_CORE_WAIT_IN_WATER]) {
                         case false:
@@ -2111,14 +2111,14 @@ void BossMo_Core(BossMo* this, PlayState* play) {
                             this->targetPos.x = player->actor.world.pos.x + sp64.x;
                             this->targetPos.y = player->actor.world.pos.y + 30.0f;
                             this->targetPos.z = player->actor.world.pos.z + sp64.z;
-                            Math_ApproachF(&this->actor.speedXZ, 10.0f, 1.0f, 1.0f);
+                            Math_ApproachF(&this->actor.speed, 10.0f, 1.0f, 1.0f);
                             if (this->timers[0] == 0) {
                                 this->work[MO_CORE_WAIT_IN_WATER] = true;
                                 this->timers[0] = (s16)Rand_ZeroFloat(50.0f) + 50;
                             }
                             break;
                         case true:
-                            Math_ApproachF(&this->actor.speedXZ, 1.0f, 1.0f, 0.5f);
+                            Math_ApproachF(&this->actor.speed, 1.0f, 1.0f, 0.5f);
                             if (this->timers[0] == 0) {
                                 this->work[MO_CORE_WAIT_IN_WATER] = false;
                                 this->timers[0] = (s16)Rand_ZeroFloat(20.0f) + 20;
@@ -2322,7 +2322,7 @@ void BossMo_UpdateTent(Actor* thisx, PlayState* play) {
     }
     Math_ApproachS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 0xA, 0xC8);
     Actor_MoveForward(&this->actor);
-    Math_ApproachF(&this->actor.speedXZ, 0.0, 1.0f, 0.02f);
+    Math_ApproachF(&this->actor.speed, 0.0, 1.0f, 0.02f);
 
     if (BossMo_NearLand(&this->actor.world.pos, 40)) {
         this->actor.world.pos = this->actor.prevPos;

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -695,7 +695,7 @@ void BossSst_HeadDamagedHand(BossSst* this, PlayState* play) {
 
 void BossSst_HeadSetupReadyCharge(BossSst* this) {
     Animation_MorphToLoop(&this->skelAnime, &gBongoHeadEyeOpenIdleAnim, -5.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->colliderCyl.base.acFlags |= AC_ON;
     this->actionFunc = BossSst_HeadReadyCharge;
 }
@@ -716,7 +716,7 @@ void BossSst_HeadSetupCharge(BossSst* this) {
     BossSst_HandSetDamage(sHands[LEFT], 0x20);
     BossSst_HandSetDamage(sHands[RIGHT], 0x20);
     this->colliderJntSph.base.atFlags |= AT_ON;
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
     this->radius = -650.0f;
     this->ready = false;
     this->actionFunc = BossSst_HeadCharge;
@@ -728,15 +728,15 @@ void BossSst_HeadCharge(BossSst* this, PlayState* play) {
 
     if (!this->ready && Animation_OnFrame(&this->skelAnime, 6.0f)) {
         this->ready = true;
-        this->actor.speedXZ = 0.25f;
+        this->actor.speed = 0.25f;
         this->skelAnime.playSpeed = 0.2f;
     }
 
-    this->actor.speedXZ *= 1.25f;
-    this->actor.speedXZ = CLAMP_MAX(this->actor.speedXZ, 45.0f);
+    this->actor.speed *= 1.25f;
+    this->actor.speed = CLAMP_MAX(this->actor.speed, 45.0f);
 
     if (this->ready) {
-        if (Math_SmoothStepToF(&this->radius, 650.0f, 0.4f, this->actor.speedXZ, 1.0f) < 10.0f) {
+        if (Math_SmoothStepToF(&this->radius, 650.0f, 0.4f, this->actor.speed, 1.0f) < 10.0f) {
             this->radius = 650.0f;
             BossSst_HeadSetupEndCharge(this);
         } else {
@@ -753,7 +753,7 @@ void BossSst_HeadCharge(BossSst* this, PlayState* play) {
             sHandOffsets[RIGHT].z += 5.0f;
         }
     } else {
-        Math_ApproachF(&this->radius, -700.0f, 0.4f, this->actor.speedXZ);
+        Math_ApproachF(&this->radius, -700.0f, 0.4f, this->actor.speed);
         Math_StepToF(&this->actor.world.pos.y, this->actor.home.pos.y - 180.0f, 20.0f);
         sHandOffsets[LEFT].y += 5.0f;
         sHandOffsets[RIGHT].y += 5.0f;
@@ -855,8 +855,8 @@ void BossSst_HeadStunned(BossSst* this, PlayState* play) {
     if (this->radius < -500.0f) {
         Math_SmoothStepToF(&this->radius, -500.0f, 1.0f, 50.0f, 5.0f);
     } else {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.5f, 15.0f, 3.0f);
-        this->radius += this->actor.speedXZ;
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.5f, 15.0f, 3.0f);
+        this->radius += this->actor.speed;
     }
 
     this->radius = CLAMP_MAX(this->radius, 400.0f);
@@ -871,7 +871,7 @@ void BossSst_HeadSetupVulnerable(BossSst* this) {
     Animation_MorphToLoop(&this->skelAnime, &gBongoHeadStunnedAnim, -5.0f);
     this->colliderCyl.base.acFlags |= AC_ON;
     this->colliderCyl.info.bumper.dmgFlags = DMG_SWORD | DMG_DEKU_STICK;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->colliderJntSph.elements[10].info.bumperFlags |= (BUMP_ON | BUMP_HOOKABLE);
     this->colliderJntSph.elements[0].info.bumperFlags &= ~BUMP_ON;
     if (this->actionFunc != BossSst_HeadDamage) {
@@ -933,7 +933,7 @@ void BossSst_HeadSetupRecover(BossSst* this) {
     this->colliderJntSph.elements[10].info.bumperFlags &= ~(BUMP_ON | BUMP_HOOKABLE);
     this->colliderJntSph.elements[0].info.bumperFlags |= BUMP_ON;
     this->vVanish = true;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     this->actionFunc = BossSst_HeadRecover;
 }
 
@@ -948,11 +948,11 @@ void BossSst_HeadRecover(BossSst* this, PlayState* play) {
         this->actor.world.pos.y += 10.0f;
         sHandOffsets[LEFT].y -= 10.0f;
         sHandOffsets[RIGHT].y -= 10.0f;
-        Math_SmoothStepToF(&this->radius, -750.0f, 1.0f, this->actor.speedXZ, 2.0f);
+        Math_SmoothStepToF(&this->radius, -750.0f, 1.0f, this->actor.speed, 2.0f);
     } else {
-        this->actor.speedXZ *= 1.25f;
-        this->actor.speedXZ = CLAMP_MAX(this->actor.speedXZ, 50.0f);
-        diff = Math_SmoothStepToF(&this->radius, -650.0f, 1.0f, this->actor.speedXZ, 2.0f);
+        this->actor.speed *= 1.25f;
+        this->actor.speed = CLAMP_MAX(this->actor.speed, 50.0f);
+        diff = Math_SmoothStepToF(&this->radius, -650.0f, 1.0f, this->actor.speed, 2.0f);
         diff += Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.home.pos.y, 0.5f, 30.0f, 3.0f);
     }
     if (animFinish && (diff < 10.0f)) {
@@ -1117,7 +1117,7 @@ void BossSst_HeadDarken(BossSst* this, PlayState* play) {
 }
 
 void BossSst_HeadSetupFall(BossSst* this) {
-    this->actor.speedXZ = 1.0f;
+    this->actor.speed = 1.0f;
     Math_Vec3f_Copy(&sSubCamAt, &sSubCamAtPoints[3]);
     Math_Vec3f_Copy(&sSubCamEye, &sSubCamEyePoints[3]);
     sSubCamAtVel.x = 0.0f;
@@ -1128,8 +1128,8 @@ void BossSst_HeadSetupFall(BossSst* this) {
 }
 
 void BossSst_HeadFall(BossSst* this, PlayState* play) {
-    this->actor.speedXZ *= 1.5f;
-    if (Math_StepToF(&this->actor.world.pos.y, this->actor.home.pos.y - 230.0f, this->actor.speedXZ)) {
+    this->actor.speed *= 1.5f;
+    if (Math_StepToF(&this->actor.world.pos.y, this->actor.home.pos.y - 230.0f, this->actor.speed)) {
         BossSst_HeadSetupMelt(this);
     }
 
@@ -1400,7 +1400,7 @@ void BossSst_HandSetupRetreat(BossSst* this) {
     BossSst_HandSetInvulnerable(this, false);
     this->timer = 0;
     this->actionFunc = BossSst_HandRetreat;
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
 }
 
 void BossSst_HandRetreat(BossSst* this, PlayState* play) {
@@ -1408,11 +1408,11 @@ void BossSst_HandRetreat(BossSst* this, PlayState* play) {
     s32 inPosition;
 
     SkelAnime_Update(&this->skelAnime);
-    this->actor.speedXZ = this->actor.speedXZ * 1.2f;
-    this->actor.speedXZ = CLAMP_MAX(this->actor.speedXZ, 50.0f);
+    this->actor.speed = this->actor.speed * 1.2f;
+    this->actor.speed = CLAMP_MAX(this->actor.speed, 50.0f);
 
-    diff = Math_SmoothStepToF(&this->actor.world.pos.x, this->actor.home.pos.x, 0.3f, this->actor.speedXZ, 1.0f);
-    diff += Math_SmoothStepToF(&this->actor.world.pos.z, this->actor.home.pos.z, 0.3f, this->actor.speedXZ, 1.0f);
+    diff = Math_SmoothStepToF(&this->actor.world.pos.x, this->actor.home.pos.x, 0.3f, this->actor.speed, 1.0f);
+    diff += Math_SmoothStepToF(&this->actor.world.pos.z, this->actor.home.pos.z, 0.3f, this->actor.speed, 1.0f);
     if (this->timer != 0) {
         if (this->timer != 0) {
             this->timer--;
@@ -1612,7 +1612,7 @@ void BossSst_HandReadyPunch(BossSst* this, PlayState* play) {
 }
 
 void BossSst_HandSetupPunch(BossSst* this) {
-    this->actor.speedXZ = 0.5f;
+    this->actor.speed = 0.5f;
     Animation_MorphToPlayOnce(&this->skelAnime, sHandFistPoses[this->actor.params], 5.0f);
     BossSst_HandSetInvulnerable(this, true);
     this->targetRoll = this->vParity * 0x3F00;
@@ -1627,11 +1627,11 @@ void BossSst_HandPunch(BossSst* this, PlayState* play) {
         this->targetRoll *= -1;
     }
 
-    this->actor.speedXZ *= 1.25f;
-    this->actor.speedXZ = CLAMP_MAX(this->actor.speedXZ, 50.0f);
+    this->actor.speed *= 1.25f;
+    this->actor.speed = CLAMP_MAX(this->actor.speed, 50.0f);
 
-    this->actor.world.pos.x += this->actor.speedXZ * Math_SinS(this->actor.shape.rot.y);
-    this->actor.world.pos.z += this->actor.speedXZ * Math_CosS(this->actor.shape.rot.y);
+    this->actor.world.pos.x += this->actor.speed * Math_SinS(this->actor.shape.rot.y);
+    this->actor.world.pos.z += this->actor.speed * Math_CosS(this->actor.shape.rot.y);
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
         BossSst_HandSetupRetreat(this);
     } else if (this->colliderJntSph.base.atFlags & AT_HIT) {
@@ -1796,7 +1796,7 @@ void BossSst_HandSetupGrab(BossSst* this) {
     this->actor.world.rot.y = this->actor.shape.rot.y + (this->vParity * 0x4000);
     this->targetYaw = this->actor.world.rot.y;
     this->timer = 30;
-    this->actor.speedXZ = 0.5f;
+    this->actor.speed = 0.5f;
     BossSst_HandSetDamage(this, 0x20);
     this->actionFunc = BossSst_HandGrab;
 }
@@ -1812,10 +1812,10 @@ void BossSst_HandGrab(BossSst* this, PlayState* play) {
         ((1.0f - sinf(this->timer * (M_PI / 60.0f))) * (this->vParity * 0x2000)) + this->targetYaw;
     this->actor.shape.rot.y = this->actor.world.rot.y - (this->vParity * 0x4000);
     if (this->timer < 5) {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.5f, 25.0f, 5.0f);
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.5f, 25.0f, 5.0f);
         if (SkelAnime_Update(&this->skelAnime)) {
             this->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             if (player->stateFlags2 & PLAYER_STATE2_7) {
                 if (Rand_ZeroOne() < 0.5f) {
                     BossSst_HandSetupCrush(this);
@@ -1829,8 +1829,8 @@ void BossSst_HandGrab(BossSst* this, PlayState* play) {
             }
         }
     } else {
-        this->actor.speedXZ *= 1.26f;
-        this->actor.speedXZ = CLAMP_MAX(this->actor.speedXZ, 70.0f);
+        this->actor.speed *= 1.26f;
+        this->actor.speed = CLAMP_MAX(this->actor.speed, 70.0f);
         func_8002F974(&this->actor, NA_SE_EN_SHADEST_HAND_FLY - SFX_FLAG);
     }
 
@@ -1841,8 +1841,8 @@ void BossSst_HandGrab(BossSst* this, PlayState* play) {
         this->timer = CLAMP_MAX(this->timer, 5);
     }
 
-    this->actor.world.pos.x += this->actor.speedXZ * Math_SinS(this->actor.world.rot.y);
-    this->actor.world.pos.z += this->actor.speedXZ * Math_CosS(this->actor.world.rot.y);
+    this->actor.world.pos.x += this->actor.speed * Math_SinS(this->actor.world.rot.y);
+    this->actor.world.pos.z += this->actor.speed * Math_CosS(this->actor.world.rot.y);
     if (player->stateFlags2 & PLAYER_STATE2_7) {
         player->unk_850 = 0;
         player->actor.world.pos = this->actor.world.pos;
@@ -2362,15 +2362,15 @@ void BossSst_HandReadyBreakIce(BossSst* this, PlayState* play) {
 void BossSst_HandSetupBreakIce(BossSst* this) {
     this->timer = 9;
     this->actionFunc = BossSst_HandBreakIce;
-    this->actor.speedXZ = 0.5f;
+    this->actor.speed = 0.5f;
 }
 
 void BossSst_HandBreakIce(BossSst* this, PlayState* play) {
     if ((this->timer % 2) != 0) {
-        this->actor.speedXZ *= 1.5f;
-        this->actor.speedXZ = CLAMP_MAX(this->actor.speedXZ, 60.0f);
+        this->actor.speed *= 1.5f;
+        this->actor.speed = CLAMP_MAX(this->actor.speed, 60.0f);
 
-        if (Math_StepToF(&this->radius, 100.0f, this->actor.speedXZ)) {
+        if (Math_StepToF(&this->radius, 100.0f, this->actor.speed)) {
             BossSst_SpawnIceShard(this);
             if (this->timer != 0) {
                 this->timer--;
@@ -2383,9 +2383,9 @@ void BossSst_HandBreakIce(BossSst* this, PlayState* play) {
             OTHER_HAND(this)->handAngSpeed = 5;
         }
     } else {
-        this->actor.speedXZ *= 0.8f;
-        Math_StepToF(&this->radius, 500.0f, this->actor.speedXZ);
-        if (this->actor.speedXZ < 2.0f) {
+        this->actor.speed *= 0.8f;
+        Math_StepToF(&this->radius, 500.0f, this->actor.speed);
+        if (this->actor.speed < 2.0f) {
             if (this->timer != 0) {
                 this->timer--;
             }

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -1408,7 +1408,7 @@ void BossSst_HandRetreat(BossSst* this, PlayState* play) {
     s32 inPosition;
 
     SkelAnime_Update(&this->skelAnime);
-    this->actor.speed = this->actor.speed * 1.2f;
+    this->actor.speed *= 1.2f;
     this->actor.speed = CLAMP_MAX(this->actor.speed, 50.0f);
 
     diff = Math_SmoothStepToF(&this->actor.world.pos.x, this->actor.home.pos.x, 0.3f, this->actor.speed, 1.0f);

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -622,7 +622,7 @@ void BossTw_TurnToPlayer(BossTw* this, PlayState* play) {
     BossTw* otherTw = (BossTw*)this->actor.parent;
 
     SkelAnime_Update(&this->skelAnime);
-    Math_ApproachF(&this->actor.speedXZ, 0.0f, 1.0f, 1.0f);
+    Math_ApproachF(&this->actor.speed, 0.0f, 1.0f, 1.0f);
     Math_ApproachS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 5, this->rotateSpeed);
     Math_ApproachS(&this->actor.shape.rot.x, 0, 5, this->rotateSpeed);
     Math_ApproachF(&this->rotateSpeed, 4096.0f, 1.0f, 200.0f);
@@ -632,7 +632,7 @@ void BossTw_TurnToPlayer(BossTw* this, PlayState* play) {
         if ((otherTw->actionFunc != BossTw_ShootBeam) && this->work[CAN_SHOOT]) {
             this->work[CAN_SHOOT] = false;
             BossTw_SetupShootBeam(this, play);
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
         } else {
             BossTw_SetupFlyTo(this, play);
         }
@@ -697,7 +697,7 @@ void BossTw_FlyTo(BossTw* this, PlayState* play) {
     Math_ApproachS(&this->actor.shape.rot.y, yawTarget, 0xA, this->rotateSpeed);
     Math_ApproachS(&this->actor.shape.rot.x, pitchTarget, 0xA, this->rotateSpeed);
     Math_ApproachF(&this->rotateSpeed, 4096.0f, 1.0f, 100.0f);
-    Math_ApproachF(&this->actor.speedXZ, 10.0f, 1.0f, 1.0f);
+    Math_ApproachF(&this->actor.speed, 10.0f, 1.0f, 1.0f);
     func_8002D908(&this->actor);
     func_8002D7EC(&this->actor);
 
@@ -972,8 +972,8 @@ void BossTw_ShootBeam(BossTw* this, PlayState* play) {
     BossTw* otherTw = (BossTw*)this->actor.parent;
     Input* input = &play->state.input[0];
 
-    Math_ApproachF(&this->actor.world.pos.y, 400.0f, 0.05f, this->actor.speedXZ);
-    Math_ApproachF(&this->actor.speedXZ, 5.0f, 1.0f, 0.25f);
+    Math_ApproachF(&this->actor.world.pos.y, 400.0f, 0.05f, this->actor.speed);
+    Math_ApproachF(&this->actor.speed, 5.0f, 1.0f, 0.25f);
     SkelAnime_Update(&this->skelAnime);
     this->beamRoll += -0.3f;
 
@@ -1342,7 +1342,7 @@ void BossTw_SetupHitByBeam(BossTw* this, PlayState* play) {
     this->actionFunc = BossTw_HitByBeam;
     Animation_MorphToPlayOnce(&this->skelAnime, &gTwinrovaKotakeKoumeDamageStartAnim, 0.0f);
     this->timers[0] = 53;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if (this->actor.params == TW_KOTAKE) {
         this->work[FOG_TIMER] = 20;
@@ -1382,15 +1382,15 @@ void BossTw_HitByBeam(BossTw* this, PlayState* play) {
     }
 
     Math_ApproachF(&this->actor.world.pos.y, ((Math_SinS(this->work[CS_TIMER_1] * 1500) * 20.0f) + 350.0f) + 50.0f,
-                   0.1f, this->actor.speedXZ);
-    Math_ApproachF(&this->actor.speedXZ, 5.0f, 1.0f, 1.0f);
+                   0.1f, this->actor.speed);
+    Math_ApproachF(&this->actor.speed, 5.0f, 1.0f, 1.0f);
 
     this->actor.world.pos.y -= 50.0f;
     Actor_UpdateBgCheckInfo(play, &this->actor, 50.0f, 50.0f, 100.0f, UPDBGCHECKINFO_FLAG_2);
     this->actor.world.pos.y += 50.0f;
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->timers[0] == 1) {
@@ -1407,7 +1407,7 @@ void BossTw_SetupLaugh(BossTw* this, PlayState* play) {
     this->actionFunc = BossTw_Laugh;
     Animation_MorphToPlayOnce(&this->skelAnime, &gTwinrovaKotakeKoumeLaughAnim, 0.0f);
     this->workf[ANIM_SW_TGT] = Animation_GetLastFrame(&gTwinrovaKotakeKoumeLaughAnim);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void BossTw_Laugh(BossTw* this, PlayState* play) {
@@ -1430,7 +1430,7 @@ void BossTw_SetupSpin(BossTw* this, PlayState* play) {
     this->actionFunc = BossTw_Spin;
     Animation_MorphToPlayOnce(&this->skelAnime, &gTwinrovaKotakeKoumeSpinAnim, -3.0f);
     this->workf[ANIM_SW_TGT] = Animation_GetLastFrame(&gTwinrovaKotakeKoumeSpinAnim);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     SkelAnime_Update(&this->skelAnime);
     this->timers[0] = 20;
 }
@@ -1456,7 +1456,7 @@ void BossTw_Spin(BossTw* this, PlayState* play) {
 void BossTw_SetupMergeCS(BossTw* this, PlayState* play) {
     this->actionFunc = BossTw_MergeCS;
     this->rotateSpeed = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_MorphToLoop(&this->skelAnime, &gTwinrovaKotakeKoumeFlyAnim, -10.0f);
 }
 
@@ -1914,7 +1914,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
 
             if (this->work[CS_TIMER_1] > 80) {
                 this->csState2 = 4;
-                this->actor.speedXZ = 0;
+                this->actor.speed = 0;
 
                 this->subCamEyeNext.x = -80.0f;
                 this->subCamEyeNext.y = 260.0f;
@@ -1942,8 +1942,8 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
             updateCam = true;
             SkelAnime_Update(&sKoumePtr->skelAnime);
             this->subCamAtNext.y = 20.0f + sKoumePtr->actor.world.pos.y;
-            Math_ApproachF(&sKoumePtr->actor.world.pos.y, 350, 0.1f, this->actor.speedXZ);
-            Math_ApproachF(&this->actor.speedXZ, 9.0f, 1.0f, 0.9f);
+            Math_ApproachF(&sKoumePtr->actor.world.pos.y, 350, 0.1f, this->actor.speed);
+            Math_ApproachF(&this->actor.speed, 9.0f, 1.0f, 0.9f);
             Math_ApproachF(&this->subCamUpdateRate, 1.0f, 1.0f, 0.02f);
 
             if (this->work[CS_TIMER_1] >= 30) {
@@ -2077,7 +2077,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
 
             if (this->work[CS_TIMER_1] > 80) {
                 this->csState2 = 12;
-                this->actor.speedXZ = 0;
+                this->actor.speed = 0;
 
                 this->subCamEyeNext.y = 260.0f;
                 this->subCamEyeNext.x = -80.0f;
@@ -2105,8 +2105,8 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
             updateCam = true;
             SkelAnime_Update(&sKotakePtr->skelAnime);
             this->subCamAtNext.y = sKotakePtr->actor.world.pos.y + 20.0f;
-            Math_ApproachF(&sKotakePtr->actor.world.pos.y, 350, 0.1f, this->actor.speedXZ);
-            Math_ApproachF(&this->actor.speedXZ, 9.0f, 1.0f, 0.9f);
+            Math_ApproachF(&sKotakePtr->actor.world.pos.y, 350, 0.1f, this->actor.speed);
+            Math_ApproachF(&this->actor.speed, 9.0f, 1.0f, 0.9f);
             Math_ApproachF(&this->subCamUpdateRate, 1.0f, 1.0f, 0.02f);
 
             if (this->work[CS_TIMER_1] >= 30) {
@@ -2326,7 +2326,7 @@ void BossTw_DeathBall(BossTw* this, PlayState* play) {
 
         this->timers[1] = 10;
         this->rotateSpeed = 8192.0f;
-        this->actor.speedXZ = 5.0f;
+        this->actor.speed = 5.0f;
     } else {
         if (this->timers[1] == 9) {
             this->targetPos.y = 413.0f;
@@ -2348,7 +2348,7 @@ void BossTw_DeathBall(BossTw* this, PlayState* play) {
         Math_ApproachF(&this->targetPos.y, 263.0f, 1.0f, 2.0f);
 
         if (this->targetPos.y == 263.0f) {
-            Math_ApproachF(&this->actor.speedXZ, 0.0f, 1.0f, 0.2f);
+            Math_ApproachF(&this->actor.speed, 0.0f, 1.0f, 0.2f);
             if (sTwinrovaPtr->csState2 == 3) {
                 Actor_Kill(&this->actor);
             }
@@ -2583,9 +2583,9 @@ void BossTw_DeathCSMsgSfx(BossTw* this, PlayState* play) {
                        0.01f);
 
         if (this->work[CS_TIMER_2] >= 880) {
-            Math_ApproachF(&sKotakePtr->actor.world.pos.y, 2000.0f, 1.0f, this->actor.speedXZ);
-            Math_ApproachF(&sKoumePtr->actor.world.pos.y, 2000.0f, 1.0f, this->actor.speedXZ);
-            Math_ApproachF(&this->actor.speedXZ, 10.0f, 1.0f, 0.25f);
+            Math_ApproachF(&sKotakePtr->actor.world.pos.y, 2000.0f, 1.0f, this->actor.speed);
+            Math_ApproachF(&sKoumePtr->actor.world.pos.y, 2000.0f, 1.0f, this->actor.speed);
+            Math_ApproachF(&this->actor.speed, 10.0f, 1.0f, 0.25f);
 
             if (this->work[CS_TIMER_2] >= 930) {
                 Math_ApproachF(&this->workf[UNK_F19], 5.0f, 1.0f, 0.05f);
@@ -2595,10 +2595,10 @@ void BossTw_DeathCSMsgSfx(BossTw* this, PlayState* play) {
             Actor_PlaySfx(&this->actor, NA_SE_EV_GOTO_HEAVEN - SFX_FLAG);
         } else {
             f32 yTarget = Math_CosS(this->work[CS_TIMER_2] * 1700) * 4.0f;
-            Math_ApproachF(&sKotakePtr->actor.world.pos.y, 20.0f + (263.0f + yTarget), 0.1f, this->actor.speedXZ);
+            Math_ApproachF(&sKotakePtr->actor.world.pos.y, 20.0f + (263.0f + yTarget), 0.1f, this->actor.speed);
             yTarget = Math_SinS(this->work[CS_TIMER_2] * 1500) * 4.0f;
-            Math_ApproachF(&sKoumePtr->actor.world.pos.y, 20.0f + (263.0f + yTarget), 0.1f, this->actor.speedXZ);
-            Math_ApproachF(&this->actor.speedXZ, 1.0f, 1.0f, 0.05f);
+            Math_ApproachF(&sKoumePtr->actor.world.pos.y, 20.0f + (263.0f + yTarget), 0.1f, this->actor.speed);
+            Math_ApproachF(&this->actor.speed, 1.0f, 1.0f, 0.05f);
         }
     }
 }
@@ -2639,13 +2639,13 @@ void BossTw_TwinrovaDeathCS(BossTw* this, PlayState* play) {
                 play->envCtx.lightSetting = 0;
                 Math_ApproachF(&play->envCtx.lightBlend, 1.0f, 1.0f, 0.015f);
                 Math_ApproachF(&this->actor.scale.x, 0.00024999998f, 0.1f, 0.00005f);
-                this->actor.shape.rot.y += (s16)this->actor.speedXZ;
-                this->workf[UNK_F13] += this->actor.speedXZ;
+                this->actor.shape.rot.y += (s16)this->actor.speed;
+                this->workf[UNK_F13] += this->actor.speed;
                 if (this->workf[UNK_F13] > 65536.0f) {
                     this->workf[UNK_F13] -= 65536.0f;
                     Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_ROLL);
                 }
-                Math_ApproachF(&this->actor.speedXZ, 12288.0f, 1.0f, 256.0f);
+                Math_ApproachF(&this->actor.speed, 12288.0f, 1.0f, 256.0f);
                 if (this->work[CS_TIMER_1] == 135) {
                     Vec3f spBC;
                     Vec3f spB0;
@@ -2766,7 +2766,7 @@ void BossTw_TwinrovaDeathCS(BossTw* this, PlayState* play) {
                 SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_KOTAKE_KOUME);
                 this->csState2 = 3;
                 this->work[CS_TIMER_2] = 0;
-                this->subCamYaw = this->subCamYawStep = this->actor.speedXZ = this->subCamDistStep = 0.0f;
+                this->subCamYaw = this->subCamYawStep = this->actor.speed = this->subCamDistStep = 0.0f;
             }
             break;
         case 3:
@@ -3925,7 +3925,7 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
                     // pitch
                     distXZ = sqrtf(SQ(xDiff) + SQ(zDiff));
                     this->actor.world.rot.x = RAD_TO_BINANG(Math_FAtan2F(yDiff, distXZ));
-                    this->actor.speedXZ = 20.0f;
+                    this->actor.speed = 20.0f;
 
                     for (i = 0; i < 50; i++) {
                         this->blastTailPos[i] = this->actor.world.pos;
@@ -4113,7 +4113,7 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
                     this->actor.world.rot.y = RAD_TO_BINANG(Math_FAtan2F(xDiff, zDiff));
                     xzDist = sqrtf(SQ(xDiff) + SQ(zDiff));
                     this->actor.world.rot.x = RAD_TO_BINANG(Math_FAtan2F(yDiff, xzDist));
-                    this->actor.speedXZ = 20.0f;
+                    this->actor.speed = 20.0f;
                     for (i = 0; i < 50; i++) {
                         this->blastTailPos[i] = this->actor.world.pos;
                     }
@@ -5377,7 +5377,7 @@ void BossTw_TwinrovaSetupFly(BossTw* this, PlayState* play) {
     zDiff = this->targetPos.z - this->actor.world.pos.z;
     this->actionFunc = BossTw_TwinrovaFly;
     this->rotateSpeed = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = RAD_TO_BINANG(Math_FAtan2F(xDiff, zDiff));
     xzDist = sqrtf(SQ(xDiff) + SQ(zDiff));
     this->actor.world.rot.x = RAD_TO_BINANG(Math_FAtan2F(yDiff, xzDist));
@@ -5403,7 +5403,7 @@ void BossTw_TwinrovaFly(BossTw* this, PlayState* play) {
     Math_ApproachS(&this->actor.world.rot.y, yaw, 0xA, this->rotateSpeed);
     Math_ApproachS(&this->actor.shape.rot.y, yaw, 0xA, this->rotateSpeed);
     Math_ApproachF(&this->rotateSpeed, 2000.0f, 1.0f, 100.0f);
-    Math_ApproachF(&this->actor.speedXZ, 30.0f, 1.0f, 2.0f);
+    Math_ApproachF(&this->actor.speed, 30.0f, 1.0f, 2.0f);
     func_8002D908(&this->actor);
     Math_ApproachF(&this->actor.world.pos.x, this->targetPos.x, 0.1f, fabsf(this->actor.velocity.x) * 1.5f);
     Math_ApproachF(&this->actor.world.pos.y, this->targetPos.y, 0.1f, fabsf(this->actor.velocity.y) * 1.5f);
@@ -5419,7 +5419,7 @@ void BossTw_TwinrovaSetupSpin(BossTw* this, PlayState* play) {
     this->actionFunc = BossTw_TwinrovaSpin;
     Animation_MorphToLoop(&this->skelAnime, &gTwinrovaHoverAnim, 0.0f);
     this->timers[0] = 20;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void BossTw_TwinrovaSpin(BossTw* this, PlayState* play) {
@@ -5440,7 +5440,7 @@ void BossTw_TwinrovaSetupLaugh(BossTw* this, PlayState* play) {
     this->actionFunc = BossTw_TwinrovaLaugh;
     Animation_MorphToPlayOnce(&this->skelAnime, &gTwinrovaLaughAnim, 0.0f);
     this->workf[ANIM_SW_TGT] = Animation_GetLastFrame(&gTwinrovaLaughAnim);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void BossTw_TwinrovaLaugh(BossTw* this, PlayState* play) {

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -1165,7 +1165,7 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
         }
     }
 
-    if ((sPhase2Timer > 10) && !(sPhase2Timer & 7) && (this->actor.speedXZ == 1.0f)) {
+    if ((sPhase2Timer > 10) && !(sPhase2Timer & 7) && (this->actor.speed == 1.0f)) {
         sp48 = this->actor.world.pos;
         sp48.y += 310.0f + (this->actor.shape.yOffset * this->actor.scale.y);
         sp48.x += -10.0f;
@@ -1182,10 +1182,10 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
     Math_SmoothStepToF(&this->actor.shape.yOffset, -1000.0f, 1.0f, 20.0f, 0.0f);
     if (!(sPhase2Timer & 0x100)) {
         this->actor.flags |= ACTOR_FLAG_0;
-        this->actor.speedXZ = 1.0f;
+        this->actor.speed = 1.0f;
     } else {
         this->actor.flags &= ~ACTOR_FLAG_0;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (SkelAnime_Update(&this->skelAnime) && (sFightPhase >= PHASE_3)) {
@@ -1218,7 +1218,7 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
 
 void BossVa_SetupBodyPhase3(BossVa* this) {
     this->colliderBody.info.bumper.dmgFlags = DMG_BOOMERANG;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     sPhase3StopMoving = false;
     BossVa_SetupAction(this, BossVa_BodyPhase3);
 }
@@ -1252,10 +1252,10 @@ void BossVa_BodyPhase3(BossVa* this, PlayState* play) {
         sBodyState = 0;
         if (this->timer == 0) {
             if (Math_SmoothStepToS(&this->vaBodySpinRate, 0xFA0, 1, 0x12C, 0) == 0) {
-                if (this->actor.speedXZ == 0.0f) {
+                if (this->actor.speed == 0.0f) {
                     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
                 }
-                Math_SmoothStepToF(&this->actor.speedXZ, 3.0f, 1.0f, 0.15f, 0.0f);
+                Math_SmoothStepToF(&this->actor.speed, 3.0f, 1.0f, 0.15f, 0.0f);
             }
             this->actor.flags |= ACTOR_FLAG_0;
         } else {
@@ -1264,7 +1264,7 @@ void BossVa_BodyPhase3(BossVa* this, PlayState* play) {
                 sBodyState = 0x80;
             }
             Math_SmoothStepToS(&this->vaBodySpinRate, 0, 1, 0x12C, 0);
-            Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.2f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.2f, 0.0f);
             Math_SmoothStepToF(&this->actor.shape.yOffset, -1420.0f, 1.0f, 30.0f, 0.0f);
         }
     }
@@ -1280,7 +1280,7 @@ void BossVa_BodyPhase3(BossVa* this, PlayState* play) {
     }
 
     if (sPhase3StopMoving) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     Actor_MoveForward(&this->actor);
@@ -1385,13 +1385,13 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
                             Enemy_StartFinishingBlow(play, &this->actor);
                             return;
                         }
-                        this->actor.speedXZ = -10.0f;
+                        this->actor.speed = -10.0f;
                         this->timer = -170 - (s16)(Rand_ZeroOne() * 150.0f);
                     }
                 } else {
                     this->timer = (s16)Rand_CenteredFloat(40.0f) + 160;
                     this->vaBodySpinRate = 0;
-                    this->actor.speedXZ = 0.0f;
+                    this->actor.speed = 0.0f;
                     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 125, COLORFILTER_BUFFLAG_OPA, 255);
                     Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_FAINT);
                 }
@@ -1414,12 +1414,12 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
         Math_SmoothStepToF(&this->actor.shape.yOffset, 0.0f, 1.0f, ((sFightPhase - PHASE_4 + 1) * 5.0f) + 10.0f, 0.0f);
         if (Math_SmoothStepToS(&this->vaBodySpinRate, (s16)((sFightPhase - PHASE_4 + 1) * 500.0f) + 0xFA0, 1, 0x12C,
                                0) == 0) {
-            if (this->actor.speedXZ == 0.0f) {
+            if (this->actor.speed == 0.0f) {
                 this->actor.colorFilterTimer = 0;
                 this->actor.world.rot.y = this->actor.yawTowardsPlayer;
                 this->timer2 = (s16)(Rand_ZeroOne() * 150.0f) + 300;
             }
-            Math_SmoothStepToF(&this->actor.speedXZ, ((sFightPhase - PHASE_4 + 1) * 1.5f) + 4.0f, 1.0f, 0.25f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, ((sFightPhase - PHASE_4 + 1) * 1.5f) + 4.0f, 1.0f, 0.25f, 0.0f);
         }
         this->colliderBody.info.bumper.dmgFlags = DMG_BOOMERANG;
     } else {
@@ -1439,18 +1439,18 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
                 BossVa_Spark(play, this, 2, 0x64, 220.0f, 5.0f, SPARK_BODY, 12.0f, true);
             }
             if (this->timer < -30) {
-                if (this->actor.speedXZ > 0.0f) {
-                    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+                if (this->actor.speed > 0.0f) {
+                    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
                 }
                 Math_SmoothStepToF(&this->actor.shape.yOffset, -1400.0f, 1.0f, 60.0f, 0.0f);
             } else {
-                if (this->actor.speedXZ == 0.0f) {
+                if (this->actor.speed == 0.0f) {
                     this->actor.world.rot.y = this->actor.yawTowardsPlayer + 0x8000;
                     this->timer2 = (s16)(Rand_ZeroOne() * 150.0f) + 330;
                 }
                 Math_SmoothStepToS(&this->vaBodySpinRate, 0xFA0, 1, 0x1F4, 0);
                 tmpf1 = sFightPhase - PHASE_4 + 1;
-                Math_SmoothStepToF(&this->actor.speedXZ, (tmpf1 + tmpf1) + 4.0f, 1.0f, 0.25f, 0.0f);
+                Math_SmoothStepToF(&this->actor.speed, (tmpf1 + tmpf1) + 4.0f, 1.0f, 0.25f, 0.0f);
                 Math_SmoothStepToF(&this->actor.shape.yOffset, 0.0f, 1.0f, 20.0f, 0.0f);
             }
             this->timer++;
@@ -1458,8 +1458,8 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
     }
 
     this->actor.shape.rot.y += this->vaBodySpinRate;
-    if (this->actor.speedXZ < 0.0f) {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    if (this->actor.speed < 0.0f) {
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     }
 
     this->unk_1AC += 0xC31;
@@ -1515,7 +1515,7 @@ void BossVa_SetupBodyDeath(BossVa* this, PlayState* play) {
     SEQCMD_STOP_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 1);
     this->vaCamRotMod = 0xC31;
     sCsState = DEATH_START;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_1A8 = 0.0f;
     Flags_SetClear(play, play->roomCtx.curRoom.num);
     BossVa_SetupAction(this, BossVa_BodyDeath);
@@ -1675,7 +1675,7 @@ void BossVa_BodyDeath(BossVa* this, PlayState* play) {
         play->envCtx.screenFillColor[3] -= 50;
     }
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     this->actor.shape.rot.y += this->vaBodySpinRate;
     this->unk_1AC += this->vaCamRotMod;
 
@@ -1992,7 +1992,7 @@ void BossVa_ZapperAttack(BossVa* this, PlayState* play) {
         return;
     }
 
-    if ((sFightPhase < PHASE_4) && (GET_BODY(this)->actor.speedXZ != 0.0f)) {
+    if ((sFightPhase < PHASE_4) && (GET_BODY(this)->actor.speed != 0.0f)) {
         BossVa_SetupZapperHold(this, play);
         return;
     }
@@ -2381,7 +2381,7 @@ void BossVa_ZapperHold(BossVa* this, PlayState* play) {
     Math_SmoothStepToS(&this->unk_1EA, 0, 1, 0x1770, 0);
     Math_SmoothStepToS(&this->unk_1F2, this->actor.shape.rot.y - 0x4000, 1, 0x2710, 0);
     Math_SmoothStepToS(&this->unk_1F0, this->skelAnime.jointTable[7].z - 0x1388, 1, 0x1770, 0);
-    if (GET_BODY(this)->actor.speedXZ == 0.0f) {
+    if (GET_BODY(this)->actor.speed == 0.0f) {
         BossVa_SetupZapperAttack(this, play);
     }
 }

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -939,7 +939,7 @@ void DemoEffect_UpdateCreationFireball(DemoEffect* this, PlayState* play) {
     DemoEffect* effect;
 
     Actor_MoveForward(&this->actor);
-    this->actor.speedXZ = this->actor.speedXZ + (this->actor.gravity * 0.5f);
+    this->actor.speed = this->actor.speed + (this->actor.gravity * 0.5f);
 
     if (this->fireBall.timer != 0) {
         this->fireBall.timer--;
@@ -980,7 +980,7 @@ void DemoEffect_InitCreationFireball(DemoEffect* this, PlayState* play) {
 
     this->actor.world.rot.y = parent->shape.rot.y;
     this->fireBall.timer = 50;
-    this->actor.speedXZ = 1.5f;
+    this->actor.speed = 1.5f;
     this->actor.minVelocityY = -1.5f;
     this->actor.gravity = -0.03f;
     this->updateFunc = DemoEffect_UpdateCreationFireball;

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -939,7 +939,7 @@ void DemoEffect_UpdateCreationFireball(DemoEffect* this, PlayState* play) {
     DemoEffect* effect;
 
     Actor_MoveForward(&this->actor);
-    this->actor.speed = this->actor.speed + (this->actor.gravity * 0.5f);
+    this->actor.speed += this->actor.gravity * 0.5f;
 
     if (this->fireBall.timer != 0) {
         this->fireBall.timer--;

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
@@ -311,7 +311,7 @@ void DemoGj_DrawRotated(DemoGj* this, PlayState* play, Gfx* displayList) {
 void DemoGj_SetupRotation(DemoGj* this, PlayState* play) {
     f32 yPosition = this->dyna.actor.world.pos.y;
     f32* yVelocity = &this->dyna.actor.velocity.y;
-    f32* speedXZ = &this->dyna.actor.speedXZ;
+    f32* speedXZ = &this->dyna.actor.speed;
     Vec3s* unk_172 = &this->unk_172;
     f32 verticalTranslation;
     Vec3f vec;
@@ -467,7 +467,7 @@ void DemoGj_SetupMovement(DemoGj* this, PlayState* play) {
 
         switch (DemoGj_GetType(this)) {
             case DEMOGJ_TYPE_RUBBLE_PILE_1:
-                actor->speedXZ = kREG(16) + 10.0f;
+                actor->speed = kREG(16) + 10.0f;
                 actor->velocity.y = kREG(17) + 40.0f;
                 unk_172->x = kREG(18);
                 unk_172->y = kREG(19) + 0x3E8;
@@ -477,7 +477,7 @@ void DemoGj_SetupMovement(DemoGj* this, PlayState* play) {
                 break;
 
             case DEMOGJ_TYPE_RUBBLE_PILE_2:
-                actor->speedXZ = kREG(29) + 10.0f;
+                actor->speed = kREG(29) + 10.0f;
                 actor->velocity.y = kREG(30) + 40.0f;
                 unk_172->x = kREG(31);
                 unk_172->y = kREG(32) + 0x3E8;
@@ -487,7 +487,7 @@ void DemoGj_SetupMovement(DemoGj* this, PlayState* play) {
                 break;
 
             case DEMOGJ_TYPE_RUBBLE_PILE_3:
-                actor->speedXZ = kREG(42) + 10.0f;
+                actor->speed = kREG(42) + 10.0f;
                 actor->velocity.y = kREG(43) + 40.0f;
                 unk_172->x = kREG(44);
                 unk_172->y = kREG(45) + 0x3E8;
@@ -497,7 +497,7 @@ void DemoGj_SetupMovement(DemoGj* this, PlayState* play) {
                 break;
 
             case DEMOGJ_TYPE_RUBBLE_PILE_4:
-                actor->speedXZ = kREG(55) + 10.0f;
+                actor->speed = kREG(55) + 10.0f;
                 actor->velocity.y = kREG(56) + 40.0f;
                 unk_172->x = kREG(57);
                 unk_172->y = kREG(58) + 0x3E8;
@@ -507,7 +507,7 @@ void DemoGj_SetupMovement(DemoGj* this, PlayState* play) {
                 break;
 
             case DEMOGJ_TYPE_RUBBLE_PILE_5:
-                actor->speedXZ = kREG(68) + 10.0f;
+                actor->speed = kREG(68) + 10.0f;
                 actor->velocity.y = kREG(69) + 40.0f;
                 unk_172->x = kREG(70);
                 unk_172->y = kREG(71) + 0x3E8;
@@ -517,7 +517,7 @@ void DemoGj_SetupMovement(DemoGj* this, PlayState* play) {
                 break;
 
             case DEMOGJ_TYPE_RUBBLE_PILE_6:
-                actor->speedXZ = kREG(81) + 10.0f;
+                actor->speed = kREG(81) + 10.0f;
                 actor->velocity.y = kREG(82) + 40.0f;
                 unk_172->x = kREG(83);
                 unk_172->y = kREG(84) + 0x3E8;
@@ -527,7 +527,7 @@ void DemoGj_SetupMovement(DemoGj* this, PlayState* play) {
                 break;
 
             case DEMOGJ_TYPE_RUBBLE_PILE_7:
-                actor->speedXZ = kREG(94) + 10.0f;
+                actor->speed = kREG(94) + 10.0f;
                 actor->velocity.y = kREG(95) + 70.0f;
                 unk_172->x = kREG(15);
                 unk_172->y = kREG(14) + 0x3E8;

--- a/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
+++ b/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
@@ -154,9 +154,9 @@ void func_8097CC08(DemoGo* this) {
     f32 something = this->unk_19C;
 
     if (something < 8.0f) {
-        this->actor.speedXZ = (((kREG(15) * 0.01f) + 1.2f) / 8.0f) * something;
+        this->actor.speed = (((kREG(15) * 0.01f) + 1.2f) / 8.0f) * something;
     } else {
-        this->actor.speedXZ = (kREG(15) * 0.01f) + 1.2f;
+        this->actor.speed = (kREG(15) * 0.01f) + 1.2f;
     }
     Actor_MoveForward(&this->actor);
 }

--- a/src/overlays/actors/ovl_En_Am/z_en_am.c
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.c
@@ -275,7 +275,7 @@ void EnAm_SetupSleep(EnAm* this) {
 
     Animation_Change(&this->skelAnime, &gArmosRicochetAnim, 0.0f, lastFrame, lastFrame, ANIMMODE_LOOP, 0.0f);
     this->behavior = AM_BEHAVIOR_DO_NOTHING;
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     this->unk_258 = (this->textureBlend == 255) ? 0 : 1;
     EnAm_SetupAction(this, EnAm_Sleep);
 }
@@ -286,7 +286,7 @@ void EnAm_SetupStatue(EnAm* this) {
     Animation_Change(&this->skelAnime, &gArmosRicochetAnim, 0.0f, lastFrame, lastFrame, ANIMMODE_LOOP, 0.0f);
     this->dyna.actor.flags &= ~ACTOR_FLAG_0;
     this->behavior = AM_BEHAVIOR_DO_NOTHING;
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     EnAm_SetupAction(this, EnAm_Statue);
 }
 
@@ -294,7 +294,7 @@ void EnAm_SetupLunge(EnAm* this) {
     Animation_PlayLoopSetSpeed(&this->skelAnime, &gArmosHopAnim, 4.0f);
     this->unk_258 = 3;
     this->behavior = AM_BEHAVIOR_AGGRO;
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     this->dyna.actor.world.rot.y = this->dyna.actor.shape.rot.y;
     EnAm_SetupAction(this, EnAm_Lunge);
 }
@@ -304,7 +304,7 @@ void EnAm_SetupCooldown(EnAm* this) {
     this->unk_258 = 3;
     this->cooldownTimer = 40;
     this->behavior = AM_BEHAVIOR_AGGRO;
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     this->dyna.actor.world.rot.y = this->dyna.actor.shape.rot.y;
     EnAm_SetupAction(this, EnAm_Cooldown);
 }
@@ -313,7 +313,7 @@ void EnAm_SetupMoveToHome(EnAm* this) {
     Animation_PlayLoopSetSpeed(&this->skelAnime, &gArmosHopAnim, 4.0f);
     this->behavior = AM_BEHAVIOR_GO_HOME;
     this->unk_258 = 1;
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     EnAm_SetupAction(this, EnAm_MoveToHome);
 }
 
@@ -321,14 +321,14 @@ void EnAm_SetupRotateToInit(EnAm* this) {
     Animation_PlayLoopSetSpeed(&this->skelAnime, &gArmosHopAnim, 4.0f);
     this->behavior = AM_BEHAVIOR_GO_HOME;
     this->unk_258 = 1;
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     EnAm_SetupAction(this, EnAm_RotateToInit);
 }
 
 void EnAm_SetupRotateToHome(EnAm* this) {
     Animation_PlayLoopSetSpeed(&this->skelAnime, &gArmosHopAnim, 4.0f);
     this->behavior = AM_BEHAVIOR_GO_HOME;
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     this->dyna.actor.world.rot.y = this->dyna.actor.shape.rot.y;
     EnAm_SetupAction(this, EnAm_RotateToHome);
 }
@@ -341,7 +341,7 @@ void EnAm_SetupRecoilFromDamage(EnAm* this, PlayState* play) {
     Actor_PlaySfx(&this->dyna.actor, NA_SE_EN_AMOS_DAMAGE);
 
     if (EnAm_CanMove(this, play, -6.0f, this->dyna.actor.world.rot.y)) {
-        this->dyna.actor.speedXZ = -6.0f;
+        this->dyna.actor.speed = -6.0f;
     }
 
     this->dyna.actor.colorFilterTimer = 0;
@@ -354,7 +354,7 @@ void EnAm_SetupRicochet(EnAm* this, PlayState* play) {
     this->dyna.actor.world.rot.y = this->dyna.actor.yawTowardsPlayer;
 
     if (EnAm_CanMove(this, play, -6.0f, this->dyna.actor.world.rot.y)) {
-        this->dyna.actor.speedXZ = -6.0f;
+        this->dyna.actor.speed = -6.0f;
     }
 
     this->unk_264 = 0;
@@ -412,13 +412,13 @@ void EnAm_Sleep(EnAm* this, PlayState* play) {
                 this->unk_264 = 0;
             }
 
-            this->dyna.actor.speedXZ += this->dyna.unk_150;
+            this->dyna.actor.speed += this->dyna.unk_150;
             this->shakeOrigin = this->dyna.actor.world.pos;
             this->dyna.actor.world.rot.y = this->dyna.unk_158;
-            this->dyna.actor.speedXZ = CLAMP(this->dyna.actor.speedXZ, -2.5f, 2.5f);
-            Math_SmoothStepToF(&this->dyna.actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
+            this->dyna.actor.speed = CLAMP(this->dyna.actor.speed, -2.5f, 2.5f);
+            Math_SmoothStepToF(&this->dyna.actor.speed, 0.0f, 1.0f, 1.0f, 0.0f);
 
-            if (this->dyna.actor.speedXZ != 0.0f) {
+            if (this->dyna.actor.speed != 0.0f) {
                 Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
             }
 
@@ -507,7 +507,7 @@ void EnAm_MoveToHome(EnAm* this, PlayState* play) {
 
     if (this->skelAnime.curFrame == 8.0f) {
         this->dyna.actor.velocity.y = 12.0f;
-        this->dyna.actor.speedXZ = 6.0f;
+        this->dyna.actor.speed = 6.0f;
     } else if (this->skelAnime.curFrame > 11.0f) {
         if (!(this->dyna.actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
             this->skelAnime.curFrame = 11;
@@ -519,7 +519,7 @@ void EnAm_MoveToHome(EnAm* this, PlayState* play) {
             }
 
             this->dyna.actor.velocity.y = 0.0f;
-            this->dyna.actor.speedXZ = 0.0f;
+            this->dyna.actor.speed = 0.0f;
             this->dyna.actor.world.pos.y = this->dyna.actor.floorHeight;
             EnAm_SpawnEffects(this, play);
 
@@ -530,7 +530,7 @@ void EnAm_MoveToHome(EnAm* this, PlayState* play) {
     }
 
     // turn away from a wall if touching one
-    if ((this->dyna.actor.speedXZ != 0.0f) && (this->dyna.actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
+    if ((this->dyna.actor.speed != 0.0f) && (this->dyna.actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
         this->dyna.actor.world.rot.y = this->dyna.actor.wallYaw;
         Actor_MoveForward(&this->dyna.actor);
     }
@@ -541,12 +541,12 @@ void EnAm_MoveToHome(EnAm* this, PlayState* play) {
 }
 
 void EnAm_RecoilFromDamage(EnAm* this, PlayState* play) {
-    if (this->dyna.actor.speedXZ < 0.0f) {
-        this->dyna.actor.speedXZ += 0.5f;
+    if (this->dyna.actor.speed < 0.0f) {
+        this->dyna.actor.speed += 0.5f;
     }
 
     if ((this->dyna.actor.velocity.y <= 0.0f) && !EnAm_CanMove(this, play, -8.0f, this->dyna.actor.world.rot.y)) {
-        this->dyna.actor.speedXZ = 0.0f;
+        this->dyna.actor.speed = 0.0f;
     }
 
     if (SkelAnime_Update(&this->skelAnime)) {
@@ -605,9 +605,9 @@ void EnAm_Lunge(EnAm* this, PlayState* play) {
             this->dyna.actor.velocity.y = 12.0f;
 
             if (EnAm_CanMove(this, play, 80.0f, this->dyna.actor.world.rot.y)) {
-                this->dyna.actor.speedXZ = 6.0f;
+                this->dyna.actor.speed = 6.0f;
             } else {
-                this->dyna.actor.speedXZ = 0.0f;
+                this->dyna.actor.speed = 0.0f;
             }
 
             this->unk_264 = 1;
@@ -623,7 +623,7 @@ void EnAm_Lunge(EnAm* this, PlayState* play) {
                 }
 
                 this->dyna.actor.velocity.y = 0.0f;
-                this->dyna.actor.speedXZ = 0.0f;
+                this->dyna.actor.speed = 0.0f;
                 this->unk_264 = 0;
                 this->dyna.actor.world.pos.y = this->dyna.actor.floorHeight;
                 EnAm_SpawnEffects(this, play);
@@ -637,7 +637,7 @@ void EnAm_Lunge(EnAm* this, PlayState* play) {
         }
 
         // turn and move away from a wall if contact is made with one
-        if ((this->dyna.actor.speedXZ != 0.0f) && (this->dyna.actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
+        if ((this->dyna.actor.speed != 0.0f) && (this->dyna.actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
             this->dyna.actor.world.rot.y =
                 (this->dyna.actor.wallYaw - this->dyna.actor.world.rot.y) + this->dyna.actor.wallYaw;
             Actor_MoveForward(&this->dyna.actor);
@@ -690,12 +690,12 @@ void EnAm_Statue(EnAm* this, PlayState* play) {
 
             this->unk_258 = 0;
             player->stateFlags2 &= ~(PLAYER_STATE2_0 | PLAYER_STATE2_4 | PLAYER_STATE2_6 | PLAYER_STATE2_8);
-            player->actor.speedXZ = 0.0f;
+            player->actor.speed = 0.0f;
             this->dyna.unk_150 = this->dyna.unk_154 = 0.0f;
         }
 
         this->dyna.actor.world.rot.y = this->dyna.unk_158;
-        this->dyna.actor.speedXZ = Math_SinS(this->unk_258) * (this->dyna.unk_150 * 0.5f);
+        this->dyna.actor.speed = Math_SinS(this->unk_258) * (this->dyna.unk_150 * 0.5f);
     }
 
     if (this->dyna.actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
@@ -714,7 +714,7 @@ void EnAm_SetupStunned(EnAm* this, PlayState* play) {
     this->dyna.actor.world.rot.y = this->dyna.actor.yawTowardsPlayer;
 
     if (EnAm_CanMove(this, play, -6.0f, this->dyna.actor.world.rot.y)) {
-        this->dyna.actor.speedXZ = -6.0f;
+        this->dyna.actor.speed = -6.0f;
     }
 
     Actor_SetColorFilter(&this->dyna.actor, COLORFILTER_COLORFLAG_BLUE, 120, COLORFILTER_BUFFLAG_OPA, 100);
@@ -731,12 +731,12 @@ void EnAm_SetupStunned(EnAm* this, PlayState* play) {
 void EnAm_Stunned(EnAm* this, PlayState* play) {
     Math_SmoothStepToS(&this->dyna.actor.shape.rot.y, this->dyna.actor.world.rot.y, 1, 0xFA0, 0);
 
-    if (this->dyna.actor.speedXZ < 0.0f) {
-        this->dyna.actor.speedXZ += 0.5f;
+    if (this->dyna.actor.speed < 0.0f) {
+        this->dyna.actor.speed += 0.5f;
     }
 
     if ((this->dyna.actor.velocity.y <= 0.0f) && !EnAm_CanMove(this, play, -9.0f, this->dyna.actor.world.rot.y)) {
-        this->dyna.actor.speedXZ = 0.0f;
+        this->dyna.actor.speed = 0.0f;
     }
 
     if (this->dyna.actor.colorFilterTimer == 0) {
@@ -749,17 +749,17 @@ void EnAm_Stunned(EnAm* this, PlayState* play) {
 }
 
 void EnAm_Ricochet(EnAm* this, PlayState* play) {
-    if (this->dyna.actor.speedXZ < 0.0f) {
-        this->dyna.actor.speedXZ += 0.5f;
+    if (this->dyna.actor.speed < 0.0f) {
+        this->dyna.actor.speed += 0.5f;
     }
 
     if ((this->dyna.actor.velocity.y <= 0.0f) &&
-        !EnAm_CanMove(this, play, this->dyna.actor.speedXZ * 1.5f, this->dyna.actor.world.rot.y)) {
-        this->dyna.actor.speedXZ = 0.0f;
+        !EnAm_CanMove(this, play, this->dyna.actor.speed * 1.5f, this->dyna.actor.world.rot.y)) {
+        this->dyna.actor.speed = 0.0f;
     }
 
     if (SkelAnime_Update(&this->skelAnime)) {
-        this->dyna.actor.speedXZ = 0.0f;
+        this->dyna.actor.speed = 0.0f;
         EnAm_SetupLunge(this);
     }
 }

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -197,8 +197,8 @@ void func_809B3CEC(PlayState* play, EnArrow* this) {
     EnArrow_SetupAction(this, func_809B4640);
     Animation_PlayOnce(&this->skelAnime, &gArrow1Anim);
     this->actor.world.rot.y += (s32)(24576.0f * (Rand_ZeroOne() - 0.5f)) + 0x8000;
-    this->actor.velocity.y += (this->actor.speedXZ * (0.4f + (0.4f * Rand_ZeroOne())));
-    this->actor.speedXZ *= (0.04f + 0.3f * Rand_ZeroOne());
+    this->actor.velocity.y += (this->actor.speed * (0.4f + (0.4f * Rand_ZeroOne())));
+    this->actor.speed *= (0.04f + 0.3f * Rand_ZeroOne());
     this->timer = 50;
     this->actor.gravity = -1.5f;
 }
@@ -294,7 +294,7 @@ void EnArrow_Fly(EnArrow* this, PlayState* play) {
                     Math_Vec3f_Diff(&hitActor->world.pos, &this->actor.world.pos, &this->unk_250);
                     hitActor->flags |= ACTOR_FLAG_15;
                     this->collider.base.atFlags &= ~AT_HIT;
-                    this->actor.speedXZ /= 2.0f;
+                    this->actor.speed /= 2.0f;
                     this->actor.velocity.y /= 2.0f;
                 } else {
                     this->hitFlags |= 1;
@@ -336,7 +336,7 @@ void EnArrow_Fly(EnArrow* this, PlayState* play) {
         }
 
         if (this->actor.params <= ARROW_0E) {
-            this->actor.shape.rot.x = Math_Atan2S(this->actor.speedXZ, -this->actor.velocity.y);
+            this->actor.shape.rot.x = Math_Atan2S(this->actor.speed, -this->actor.velocity.y);
         }
     }
 
@@ -458,7 +458,7 @@ void EnArrow_Draw(Actor* thisx, PlayState* play) {
         Gfx_SetupDL_25Opa(play->state.gfxCtx);
         SkelAnime_DrawLod(play, this->skelAnime.skeleton, this->skelAnime.jointTable, NULL, NULL, this,
                           (this->actor.projectedPos.z < MREG(95)) ? 0 : 1);
-    } else if (this->actor.speedXZ != 0.0f) {
+    } else if (this->actor.speed != 0.0f) {
         alpha = (Math_CosS(this->timer * 5000) * 127.5f) + 127.5f;
 
         OPEN_DISPS(play->state.gfxCtx, "../z_en_arrow.c", 1346);
@@ -478,7 +478,7 @@ void EnArrow_Draw(Actor* thisx, PlayState* play) {
         Matrix_Push();
         Matrix_Mult(&play->billboardMtxF, MTXMODE_APPLY);
         // redundant check because this is contained in an if block for non-zero speed
-        Matrix_RotateZ((this->actor.speedXZ == 0.0f) ? 0.0f : BINANG_TO_RAD((play->gameplayFrames & 0xFF) * 4000),
+        Matrix_RotateZ((this->actor.speed == 0.0f) ? 0.0f : BINANG_TO_RAD((play->gameplayFrames & 0xFF) * 4000),
                        MTXMODE_APPLY);
         Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
         gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx, "../z_en_arrow.c", 1374),

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -185,7 +185,7 @@ void func_809B5670(EnAttackNiw* this, PlayState* play) {
     f32 tmpf3;
     Vec3f sp34;
 
-    this->actor.speedXZ = 10.0f;
+    this->actor.speed = 10.0f;
 
     tmpf1 = (this->unk_298.x + play->view.at.x) - play->view.eye.x;
     tmpf2 = (this->unk_298.y + play->view.at.y) - play->view.eye.y;
@@ -266,7 +266,7 @@ void func_809B59B0(EnAttackNiw* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.world.rot.y, this->unk_2D4, 2, this->unk_2DC, 0);
     Math_SmoothStepToS(&this->actor.world.rot.x, this->unk_2D0, 2, this->unk_2DC, 0);
     Math_ApproachF(&this->unk_2DC, 10000.0f, 1.0f, 1000.0f);
-    Math_ApproachF(&this->actor.speedXZ, this->unk_2E0, 0.9f, 1.0f);
+    Math_ApproachF(&this->actor.speed, this->unk_2E0, 0.9f, 1.0f);
     if ((this->actor.gravity == -2.0f) && (this->unk_262 == 0) &&
         ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || (this->unk_25C == 0))) {
         this->unk_2E0 = 0.0f;

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.c
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.c
@@ -133,7 +133,7 @@ void EnBa_Destroy(Actor* thisx, PlayState* play) {
 void EnBa_SetupIdle(EnBa* this) {
     this->unk_14C = 2;
     this->unk_31C = 1500;
-    this->actor.speedXZ = 10.0f;
+    this->actor.speed = 10.0f;
     EnBa_SetupAction(this, EnBa_Idle);
 }
 
@@ -159,7 +159,7 @@ void EnBa_Idle(EnBa* this, PlayState* play) {
     this->unk_2FC.y -= 448.0f;
     this->unk_2FC.x += this->unk_308.x;
     this->unk_2FC.z += this->unk_308.y;
-    func_80033AEC(&this->unk_2FC, &this->unk_158[13], 1.0f, this->actor.speedXZ, 0.0f, 0.0f);
+    func_80033AEC(&this->unk_2FC, &this->unk_158[13], 1.0f, this->actor.speed, 0.0f, 0.0f);
     for (i = 12; i >= 0; i--) {
         func_80035844(&this->unk_158[i + 1], &this->unk_158[i], &sp5C, 0);
         Matrix_Translate(this->unk_158[i + 1].x, this->unk_158[i + 1].y, this->unk_158[i + 1].z, MTXMODE_NEW);
@@ -192,7 +192,7 @@ void EnBa_Idle(EnBa* this, PlayState* play) {
 
 void EnBa_SetupFallAsBlob(EnBa* this) {
     this->unk_14C = 0;
-    this->actor.speedXZ = Rand_CenteredFloat(8.0f);
+    this->actor.speed = Rand_CenteredFloat(8.0f);
     this->actor.world.rot.y = Rand_CenteredFloat(65535.0f);
     this->unk_318 = 20;
     this->actor.gravity = -2.0f;
@@ -223,7 +223,7 @@ void EnBa_SetupSwingAtPlayer(EnBa* this) {
     this->unk_31A = 0;
     this->unk_31C = 1500;
     this->actor.colChkInfo.mass = MASS_IMMOVABLE;
-    this->actor.speedXZ = 20.0f;
+    this->actor.speed = 20.0f;
     EnBa_SetupAction(this, EnBa_SwingAtPlayer);
 }
 
@@ -271,7 +271,7 @@ void EnBa_SwingAtPlayer(EnBa* this, PlayState* play) {
             }
             if (this->unk_31A != 0) {
                 this->unk_31C = 8000;
-                this->actor.speedXZ = 30.0f;
+                this->actor.speed = 30.0f;
                 phi_fp = Math_Vec3f_Yaw(&this->actor.world.pos, &this->unk_2FC);
                 temp = Math_Vec3f_Pitch(&this->actor.world.pos, &this->unk_158[0]) + 0x8000;
                 Math_SmoothStepToS(&this->actor.shape.rot.y, phi_fp, 1, this->unk_31C, 0);
@@ -323,7 +323,7 @@ void func_809B7174(EnBa* this) {
     this->unk_31C = 1500;
     this->unk_318 = 20;
     this->actor.colChkInfo.mass = MASS_IMMOVABLE;
-    this->actor.speedXZ = 10.0f;
+    this->actor.speed = 10.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_HAND_DAMAGE);
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 12);
     EnBa_SetupAction(this, EnBa_RecoilFromDamage);
@@ -344,7 +344,7 @@ void EnBa_RecoilFromDamage(EnBa* this, PlayState* play) {
     this->unk_2FC.y -= 448.0f;
     this->unk_2FC.x += this->unk_308.x;
     this->unk_2FC.z += this->unk_308.y;
-    func_80033AEC(&this->unk_2FC, &this->unk_158[13], 1.0f, this->actor.speedXZ, 0.0f, 0.0f);
+    func_80033AEC(&this->unk_2FC, &this->unk_158[13], 1.0f, this->actor.speed, 0.0f, 0.0f);
     for (i = 12; i >= 0; i--) {
         func_80035844(&this->unk_158[i + 1], &this->unk_158[i], &sp6C, 0);
         Matrix_Translate(this->unk_158[i + 1].x, this->unk_158[i + 1].y, this->unk_158[i + 1].z, MTXMODE_NEW);
@@ -413,7 +413,7 @@ void EnBa_Die(EnBa* this, PlayState* play) {
     s32 i;
 
     if (this->unk_31A != 0) {
-        this->actor.speedXZ = 30.0f;
+        this->actor.speed = 30.0f;
         this->unk_31C = 8000;
         this->actor.world.pos.y += 8.0f;
         temp = Math_Vec3f_Pitch(&this->actor.world.pos, &this->unk_158[0]) + 0x8000;

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -411,7 +411,7 @@ void EnBb_SetupFlameTrail(EnBb* this) {
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnBb_SetupAction(this, EnBb_FlameTrail);
 }
 
@@ -455,7 +455,7 @@ void EnBb_FlameTrail(EnBb* this, PlayState* play) {
 void EnBb_SetupDeath(EnBb* this, PlayState* play) {
     if (this->actor.params <= ENBB_BLUE) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-        this->actor.speedXZ = -7.0f;
+        this->actor.speed = -7.0f;
         this->timer = 5;
         this->actor.shape.rot.x += 0x4E20;
         EffectSsDeadSound_SpawnStationary(play, &this->actor.projectedPos, NA_SE_EN_BUBLE_DEAD, 1, 1, 0x28);
@@ -509,7 +509,7 @@ void EnBb_SetupDamage(EnBb* this) {
     if (this->actor.params > ENBB_GREEN) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
         if (!(this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
-            this->actor.speedXZ = -7.0f;
+            this->actor.speed = -7.0f;
         }
         this->actor.shape.yOffset = 1500.0f;
     }
@@ -522,8 +522,8 @@ void EnBb_SetupDamage(EnBb* this) {
 }
 
 void EnBb_Damage(EnBb* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
-    if (this->actor.speedXZ == 0.0f) {
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
+    if (this->actor.speed == 0.0f) {
         this->actor.shape.yOffset = 200.0f;
         EnBb_SetupDown(this);
     }
@@ -531,7 +531,7 @@ void EnBb_Damage(EnBb* this, PlayState* play) {
 
 void EnBb_SetupBlue(EnBb* this) {
     Animation_PlayLoop(&this->skelAnime, &object_Bb_Anim_000444);
-    this->actor.speedXZ = (Rand_ZeroOne() * 0.5f) + 0.5f;
+    this->actor.speed = (Rand_ZeroOne() * 0.5f) + 0.5f;
     this->timer = (Rand_ZeroOne() * 20.0f) + 40.0f;
     this->unk_264 = (Rand_ZeroOne() * 30.0f) + 180.0f;
     this->targetActor = NULL;
@@ -561,7 +561,7 @@ void EnBb_Blue(EnBb* this, PlayState* play) {
     }
     this->actor.world.pos.y += Math_CosF(this->bobPhase) * (1.0f + this->bobSpeedMod);
     this->bobPhase += 0.2f;
-    Math_SmoothStepToF(&this->actor.speedXZ, this->maxSpeed, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, this->maxSpeed, 1.0f, 0.5f, 0.0f);
 
     if (Math_Vec3f_DistXZ(&this->actor.world.pos, &this->actor.home.pos) > 300.0f) {
         this->vMoveAngleY = Math_Vec3f_Yaw(&this->actor.world.pos, &this->actor.home.pos);
@@ -571,7 +571,7 @@ void EnBb_Blue(EnBb* this, PlayState* play) {
         if (this->timer <= 0) {
             this->charge ^= true;
             this->flyHeightMod = (s16)(Math_CosF(this->bobPhase) * 10.0f);
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             if (this->charge && (this->targetActor == NULL)) {
                 this->vMoveAngleY = this->actor.world.rot.y;
                 if (this->actor.xzDistToPlayer < 200.0f) {
@@ -611,7 +611,7 @@ void EnBb_Blue(EnBb* this, PlayState* play) {
             if ((this->vBombHopPhase == 0) && (explosive != this->targetActor)) {
                 this->vBombHopPhase = -0x8000;
                 this->targetActor = explosive;
-                this->actor.speedXZ *= 0.5f;
+                this->actor.speed *= 0.5f;
             }
             Math_SmoothStepToS(&this->actor.world.rot.y, this->vMoveAngleY, 1, 0x1388, 0);
             Math_SmoothStepToF(&this->actor.world.pos.x, explosive->world.pos.x, 1.0f, 1.5f, 0.0f);
@@ -673,7 +673,7 @@ void EnBb_SetupDown(EnBb* this) {
     this->timer = 200;
     this->actor.colorFilterTimer = 0;
     this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND;
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
     this->flameScaleX = 0.0f;
     this->flameScaleY = 0.0f;
     this->actor.gravity = -2.0f;
@@ -748,7 +748,7 @@ void EnBb_Down(EnBb* this, PlayState* play) {
 void EnBb_SetupRed(PlayState* play, EnBb* this) {
     Animation_PlayLoop(&this->skelAnime, &object_Bb_Anim_000184);
     if (this->action == BB_DOWN) {
-        this->actor.speedXZ = 5.0f;
+        this->actor.speed = 5.0f;
         this->actor.gravity = -1.0f;
         this->actor.velocity.y = 16.0f;
         this->actionState = BBRED_ATTACK;
@@ -762,7 +762,7 @@ void EnBb_SetupRed(PlayState* play, EnBb* this) {
         this->moveMode = BBMOVE_HIDDEN;
         this->actor.world.pos.y -= 80.0f;
         this->actor.home.pos = this->actor.world.pos;
-        this->actor.velocity.y = this->actor.gravity = this->actor.speedXZ = 0.0f;
+        this->actor.velocity.y = this->actor.gravity = this->actor.speed = 0.0f;
         this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND;
         this->actor.flags &= ~ACTOR_FLAG_0;
     }
@@ -785,7 +785,7 @@ void EnBb_Red(EnBb* this, PlayState* play) {
         case BBRED_WAIT:
             if ((Actor_WorldDistXYZToActor(&this->actor, &player->actor) <= 250.0f) && (ABS(yawDiff) <= 0x4000) &&
                 (this->timer == 0)) {
-                this->actor.speedXZ = 5.0f;
+                this->actor.speed = 5.0f;
                 this->actor.gravity = -1.0f;
                 this->actor.velocity.y = 18.0f;
                 this->moveMode = BBMOVE_NOCLIP;
@@ -834,7 +834,7 @@ void EnBb_Red(EnBb* this, PlayState* play) {
             break;
         case BBRED_HIDE:
             if (this->timer == 0) {
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 this->actor.gravity = 0.0f;
                 this->actor.velocity.y = 0.0f;
                 this->actionState = BBRED_WAIT;
@@ -874,7 +874,7 @@ void EnBb_SetWaypoint(EnBb* this, PlayState* play) {
 
 void EnBb_SetupWhite(PlayState* play, EnBb* this) {
     Animation_PlayLoop(&this->skelAnime, &object_Bb_Anim_000444);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.pos.y += 60.0f;
     this->flameScaleX = 100.0f;
     this->action = BB_WHITE;
@@ -885,7 +885,7 @@ void EnBb_SetupWhite(PlayState* play, EnBb* this) {
 }
 
 void EnBb_White(EnBb* this, PlayState* play) {
-    if (this->actor.speedXZ == 0.0f) {
+    if (this->actor.speed == 0.0f) {
         f32 distL1;
         f32 vx;
         f32 vz;
@@ -923,7 +923,7 @@ void EnBb_White(EnBb* this, PlayState* play) {
             this->collider.base.atFlags &= ~AT_HIT;
         }
         this->actor.shape.rot.y = this->actor.world.rot.y;
-    } else if (Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f) == 0.0f) {
+    } else if (Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f) == 0.0f) {
         EnBb_FaceWaypoint(this);
     }
     SkelAnime_Update(&this->skelAnime);
@@ -958,7 +958,7 @@ void EnBb_InitGreen(EnBb* this, PlayState* play) {
     Matrix_MultVec3f(&bobOffset, &this->actor.world.pos);
     this->targetActor = NULL;
     this->action = BB_GREEN;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->vFlameTimer = (Rand_ZeroOne() * 30.0f) + 180.0f;
     EnBb_SetupAction(this, EnBb_Green);
 }
@@ -969,7 +969,7 @@ void EnBb_SetupGreen(EnBb* this) {
     this->actionState = BBGREEN_FLAME_ON;
     this->targetActor = NULL;
     this->action = BB_GREEN;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->vFlameTimer = (Rand_ZeroOne() * 30.0f) + 180.0f;
     this->actor.shape.rot.z = 0;
     this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
@@ -983,7 +983,7 @@ void EnBb_Green(EnBb* this, PlayState* play) {
 
     nextPos.y += 30.0f;
     if (this->actor.params == ENBB_GREEN_BIG) {
-        if (this->actor.speedXZ == 0.0f) {
+        if (this->actor.speed == 0.0f) {
             s16 pitch = Math_Vec3f_Pitch(&this->actor.home.pos, &this->waypointPos);
             s16 yaw = Math_Vec3f_Yaw(&this->actor.home.pos, &this->waypointPos);
             f32 vy = Math_SinS(pitch) * this->maxSpeed;
@@ -1017,7 +1017,7 @@ void EnBb_Green(EnBb* this, PlayState* play) {
                 }
             }
             this->actor.shape.rot.y = this->actor.world.rot.y;
-        } else if (Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f) == 0.0f) {
+        } else if (Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f) == 0.0f) {
             EnBb_FaceWaypoint(this);
         }
     } else {
@@ -1074,7 +1074,7 @@ void EnBb_SetupStunned(EnBb* this) {
                 this->actor.gravity = -2.0f;
                 this->actor.shape.yOffset = 1500.0f;
             }
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->flameScaleX = 0.0f;
             this->flameScaleY = 0.0f;
         } else {
@@ -1206,7 +1206,7 @@ void EnBb_CollisionCheck(EnBb* this, PlayState* play) {
                 } else if ((this->actor.params == ENBB_WHITE) &&
                            ((this->action == BB_WHITE) || (this->action == BB_STUNNED))) {
                     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 12);
-                    this->actor.speedXZ = -8.0f;
+                    this->actor.speed = -8.0f;
                     this->maxSpeed = 0.0f;
                     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
                     Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_DAMAGE);
@@ -1235,7 +1235,7 @@ void EnBb_Update(Actor* thisx, PlayState* play2) {
     }
     if (this->actor.colChkInfo.damageEffect != 0xD) {
         this->actionFunc(this, play);
-        if ((this->actor.params <= ENBB_BLUE) && (this->actor.speedXZ >= -6.0f) &&
+        if ((this->actor.params <= ENBB_BLUE) && (this->actor.speed >= -6.0f) &&
             ((this->actor.flags & ACTOR_FLAG_15) == 0)) {
             Actor_MoveForward(&this->actor);
         }
@@ -1252,7 +1252,7 @@ void EnBb_Update(Actor* thisx, PlayState* play2) {
             this->actor.world.pos.y + (this->actor.shape.yOffset * this->actor.scale.y);
         this->collider.elements->dim.worldSphere.center.z = this->actor.world.pos.z;
 
-        if ((this->action > BB_KILL) && ((this->actor.speedXZ != 0.0f) || (this->action == BB_GREEN))) {
+        if ((this->action > BB_KILL) && ((this->actor.speed != 0.0f) || (this->action == BB_GREEN))) {
             CollisionCheck_SetAT(play, &play->colChkCtx, &this->collider.base);
         }
         if ((this->action > BB_FLAME_TRAIL) &&

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -561,7 +561,7 @@ void EnBb_Blue(EnBb* this, PlayState* play) {
     }
     this->actor.world.pos.y += Math_CosF(this->bobPhase) * (1.0f + this->bobSpeedMod);
     this->bobPhase += 0.2f;
-    Math_SmoothStepToF(&this->actor.speed, this->maxSpeed, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, this->maxSpeedXZ, 1.0f, 0.5f, 0.0f);
 
     if (Math_Vec3f_DistXZ(&this->actor.world.pos, &this->actor.home.pos) > 300.0f) {
         this->vMoveAngleY = Math_Vec3f_Yaw(&this->actor.world.pos, &this->actor.home.pos);
@@ -578,12 +578,12 @@ void EnBb_Blue(EnBb* this, PlayState* play) {
                     Animation_PlayLoop(&this->skelAnime, &object_Bb_Anim_000184);
                     this->vMoveAngleY = this->actor.yawTowardsPlayer;
                 }
-                this->maxSpeed = (Rand_ZeroOne() * 1.5f) + 6.0f;
+                this->maxSpeedXZ = (Rand_ZeroOne() * 1.5f) + 6.0f;
                 this->timer = (Rand_ZeroOne() * 5.0f) + 20.0f;
                 this->actionState = BBBLUE_NORMAL;
             } else {
                 Animation_PlayLoop(&this->skelAnime, &object_Bb_Anim_000444);
-                this->maxSpeed = (Rand_ZeroOne() * 1.5f) + 1.0f;
+                this->maxSpeedXZ = (Rand_ZeroOne() * 1.5f) + 1.0f;
                 this->timer = (Rand_ZeroOne() * 20.0f) + 40.0f;
                 this->vMoveAngleY = Math_SinF(this->bobPhase) * 65535.0f;
             }
@@ -591,7 +591,7 @@ void EnBb_Blue(EnBb* this, PlayState* play) {
         if ((this->actor.xzDistToPlayer < 150.0f) && (this->actionState != BBBLUE_NORMAL)) {
             if (!this->charge) {
                 Animation_PlayLoop(&this->skelAnime, &object_Bb_Anim_000184);
-                this->maxSpeed = (Rand_ZeroOne() * 1.5f) + 6.0f;
+                this->maxSpeedXZ = (Rand_ZeroOne() * 1.5f) + 6.0f;
                 this->timer = (Rand_ZeroOne() * 5.0f) + 20.0f;
                 this->vMoveAngleY = this->actor.yawTowardsPlayer;
                 this->actionState = this->charge = true; // Sets actionState to BBBLUE_AGGRO
@@ -650,7 +650,7 @@ void EnBb_Blue(EnBb* this, PlayState* play) {
         this->collider.base.atFlags &= ~AT_HIT;
     }
 
-    if (this->maxSpeed >= 6.0f) {
+    if (this->maxSpeedXZ >= 6.0f) {
         if ((s32)this->skelAnime.curFrame == 0 || (s32)this->skelAnime.curFrame == 5) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_MOUTH);
         } else if ((s32)this->skelAnime.curFrame == 2 || (s32)this->skelAnime.curFrame == 7) {
@@ -880,7 +880,7 @@ void EnBb_SetupWhite(PlayState* play, EnBb* this) {
     this->action = BB_WHITE;
     this->waypoint = 0;
     this->timer = (Rand_ZeroOne() * 30.0f) + 40.0f;
-    this->maxSpeed = 7.0f;
+    this->maxSpeedXZ = 7.0f;
     EnBb_SetupAction(this, EnBb_White);
 }
 
@@ -890,8 +890,8 @@ void EnBb_White(EnBb* this, PlayState* play) {
         f32 vx;
         f32 vz;
         s16 pitch = Math_Vec3f_Pitch(&this->actor.world.pos, &this->waypointPos);
-        f32 vy = Math_SinS(pitch) * this->maxSpeed;
-        f32 vxz = Math_CosS(pitch) * this->maxSpeed;
+        f32 vy = Math_SinS(pitch) * this->maxSpeedXZ;
+        f32 vxz = Math_CosS(pitch) * this->maxSpeedXZ;
 
         vx = Math_SinS(this->actor.shape.rot.y) * vxz;
         vz = Math_CosS(this->actor.shape.rot.y) * vxz;
@@ -913,10 +913,10 @@ void EnBb_White(EnBb* this, PlayState* play) {
                 this->actor.world.rot.y += 0x1F40;
             }
             this->moveMode = BBMOVE_NORMAL;
-            this->maxSpeed = 0.0f;
+            this->maxSpeedXZ = 0.0f;
         } else {
             this->moveMode = BBMOVE_NOCLIP;
-            this->maxSpeed = 10.0f;
+            this->maxSpeedXZ = 10.0f;
         }
         if (this->collider.base.atFlags & AT_HIT) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_BITE);
@@ -931,7 +931,7 @@ void EnBb_White(EnBb* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_LAUGH);
     }
 
-    if ((this->maxSpeed != 0.0f) && (((s32)this->skelAnime.curFrame == 0) || ((s32)this->skelAnime.curFrame == 5))) {
+    if ((this->maxSpeedXZ != 0.0f) && (((s32)this->skelAnime.curFrame == 0) || ((s32)this->skelAnime.curFrame == 5))) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_MOUTH);
     } else if (((s32)this->skelAnime.curFrame == 2) || ((s32)this->skelAnime.curFrame == 7)) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_WING);
@@ -986,8 +986,8 @@ void EnBb_Green(EnBb* this, PlayState* play) {
         if (this->actor.speed == 0.0f) {
             s16 pitch = Math_Vec3f_Pitch(&this->actor.home.pos, &this->waypointPos);
             s16 yaw = Math_Vec3f_Yaw(&this->actor.home.pos, &this->waypointPos);
-            f32 vy = Math_SinS(pitch) * this->maxSpeed;
-            f32 vxz = Math_CosS(pitch) * this->maxSpeed;
+            f32 vy = Math_SinS(pitch) * this->maxSpeedXZ;
+            f32 vxz = Math_CosS(pitch) * this->maxSpeedXZ;
             f32 vz;
             f32 vx;
             f32 distL1;
@@ -1003,7 +1003,7 @@ void EnBb_Green(EnBb* this, PlayState* play) {
                 EnBb_SetWaypoint(this, play);
             }
             this->moveMode = BBMOVE_NOCLIP;
-            this->maxSpeed = 10.0f;
+            this->maxSpeedXZ = 10.0f;
             if (this->collider.base.atFlags & AT_HIT) {
                 Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_BITE);
                 this->collider.base.atFlags &= ~AT_HIT;
@@ -1207,7 +1207,7 @@ void EnBb_CollisionCheck(EnBb* this, PlayState* play) {
                            ((this->action == BB_WHITE) || (this->action == BB_STUNNED))) {
                     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 12);
                     this->actor.speed = -8.0f;
-                    this->maxSpeed = 0.0f;
+                    this->maxSpeedXZ = 0.0f;
                     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
                     Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLE_DAMAGE);
                 } else if (((this->action == BB_DOWN) && (this->timer < 190)) ||
@@ -1286,8 +1286,8 @@ void EnBb_Draw(Actor* thisx, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_bb.c", 2044);
 
-    blureBase1.z = this->maxSpeed * 80.0f;
-    blureBase2.z = this->maxSpeed * 80.0f;
+    blureBase1.z = this->maxSpeedXZ * 80.0f;
+    blureBase2.z = this->maxSpeedXZ * 80.0f;
     if (this->moveMode != BBMOVE_HIDDEN) {
         if (this->actor.params <= ENBB_BLUE) {
             Gfx_SetupDL_25Opa(play->state.gfxCtx);
@@ -1344,7 +1344,7 @@ void EnBb_Draw(Actor* thisx, PlayState* play) {
         } else {
             Matrix_MultVec3f(&blureBase1, &blureVtx1);
             Matrix_MultVec3f(&blureBase2, &blureVtx2);
-            if ((this->maxSpeed != 0.0f) && (this->action == BB_WHITE) && !(play->gameplayFrames & 1) &&
+            if ((this->maxSpeedXZ != 0.0f) && (this->action == BB_WHITE) && !(play->gameplayFrames & 1) &&
                 (this->actor.colChkInfo.health != 0)) {
                 EffectBlure_AddVertex(Effect_GetByIndex(this->blureIdx), &blureVtx1, &blureVtx2);
             } else if (this->action != BB_WHITE) {

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.h
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.h
@@ -26,7 +26,7 @@ typedef struct EnBb {
     /* 0x0270 */ s16 flameScrollMod;
     /* 0x0274 */ f32 bobPhase;
     /* 0x0278 */ f32 bobSize;
-    /* 0x027C */ f32 maxSpeed;
+    /* 0x027C */ f32 maxSpeedXZ;
     /* 0x0280 */ f32 flyHeightMod;
     /* 0x027C */ f32 bobSpeedMod; // y speed for blue, phase speed for green
     /* 0x0288 */ f32 flameScaleY;

--- a/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
+++ b/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
@@ -54,7 +54,7 @@ void EnBdfire_Init(Actor* thisx, PlayState* play) {
     } else {
         EnBdfire_SetupAction(this, func_809BC598);
         ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 0.0f);
-        this->actor.speedXZ = 30.0f;
+        this->actor.speed = 30.0f;
         this->unk_154 = (25 - (s32)(this->actor.params * 0.8f));
         if (this->unk_154 < 0) {
             this->unk_154 = 0;

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -582,7 +582,7 @@ void func_809BE058(EnBigokuta* this, PlayState* play) {
 
     if ((this->collider.base.ocFlags1 & OC1_HIT) || (this->cylinder[0].base.ocFlags1 & OC1_HIT) ||
         (this->cylinder[1].base.ocFlags1 & OC1_HIT)) {
-        speedXZ = CLAMP_MIN(player->actor.speedXZ, 1.0f);
+        speedXZ = CLAMP_MIN(player->actor.speed, 1.0f);
         if (!(this->collider.base.ocFlags1 & OC1_HIT)) {
             this->cylinder[0].base.ocFlags1 &= ~OC1_HIT;
             this->cylinder[1].base.ocFlags1 &= ~OC1_HIT;

--- a/src/overlays/actors/ovl_En_Bili/z_en_bili.c
+++ b/src/overlays/actors/ovl_En_Bili/z_en_bili.c
@@ -140,7 +140,7 @@ void EnBili_Destroy(Actor* thisx, PlayState* play) {
 // Setup Action Functions
 
 void EnBili_SetupFloatIdle(EnBili* this) {
-    this->actor.speedXZ = 0.7f;
+    this->actor.speed = 0.7f;
     this->collider.info.bumper.effect = 1; // Shock?
     this->timer = 32;
     this->collider.base.atFlags |= AT_ON;
@@ -161,7 +161,7 @@ void EnBili_SetupSpawnedFlyApart(EnBili* this) {
     this->actor.gravity = -0.3f;
     this->collider.base.atFlags &= ~AT_ON;
     this->actionFunc = EnBili_SpawnedFlyApart;
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
 }
 
 /**
@@ -171,7 +171,7 @@ void EnBili_SetupDischargeLightning(EnBili* this) {
     Animation_PlayLoop(&this->skelAnime, &gBiriDischargeLightningAnim);
     this->timer = 10;
     this->actionFunc = EnBili_DischargeLightning;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = -1.0f;
 }
 
@@ -179,19 +179,19 @@ void EnBili_SetupClimb(EnBili* this) {
     Animation_PlayOnce(&this->skelAnime, &gBiriClimbAnim);
     this->collider.base.atFlags &= ~AT_ON;
     this->actionFunc = EnBili_Climb;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
 }
 
 void EnBili_SetupApproachPlayer(EnBili* this) {
-    this->actor.speedXZ = 1.2f;
+    this->actor.speed = 1.2f;
     this->actionFunc = EnBili_ApproachPlayer;
 }
 
 void EnBili_SetupSetNewHomeHeight(EnBili* this) {
     Animation_PlayLoop(&this->skelAnime, &gBiriDefaultAnim);
     this->timer = 96;
-    this->actor.speedXZ = 0.9f;
+    this->actor.speed = 0.9f;
     this->collider.base.atFlags |= AT_ON;
     this->actionFunc = EnBili_SetNewHomeHeight;
     this->actor.home.pos.y = this->actor.world.pos.y;
@@ -205,7 +205,7 @@ void EnBili_SetupRecoil(EnBili* this) {
     this->actor.world.rot.y = Actor_WorldYawTowardPoint(&this->actor, &this->collider.base.ac->prevPos) + 0x8000;
     this->actor.world.rot.x = Actor_WorldPitchTowardPoint(&this->actor, &this->collider.base.ac->prevPos);
     this->actionFunc = EnBili_Recoil;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
 }
 
 /**
@@ -220,7 +220,7 @@ void EnBili_SetupBurnt(EnBili* this) {
     this->collider.base.atFlags &= ~AT_ON;
     this->collider.base.acFlags &= ~AC_ON;
     this->actor.flags |= ACTOR_FLAG_4;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 200, COLORFILTER_BUFFLAG_XLU, 20);
     this->actionFunc = EnBili_Burnt;
 }
@@ -229,7 +229,7 @@ void EnBili_SetupDie(EnBili* this) {
     this->timer = 18;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actionFunc = EnBili_Die;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 /**
@@ -239,7 +239,7 @@ void EnBili_SetupStunned(EnBili* this) {
     this->timer = 80;
     this->collider.info.bumper.effect = 0;
     this->actor.gravity = -1.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 150, COLORFILTER_BUFFLAG_XLU, 80);
     Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->collider.base.atFlags &= ~AT_ON;
@@ -267,7 +267,7 @@ void EnBili_SetupFrozen(EnBili* this, PlayState* play) {
                                        (Rand_ZeroOne() * 0.2f) + 0.7f);
     }
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 150, COLORFILTER_BUFFLAG_XLU, 10);
     this->collider.base.atFlags &= ~AT_ON;
     this->collider.base.acFlags &= ~AC_ON;
@@ -446,7 +446,7 @@ void EnBili_SetNewHomeHeight(EnBili* this, PlayState* play) {
 void EnBili_Recoil(EnBili* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
-    if (Math_StepToF(&this->actor.speedXZ, 0.0f, 0.3f)) {
+    if (Math_StepToF(&this->actor.speed, 0.0f, 0.3f)) {
         this->actor.world.rot.y += 0x8000;
         EnBili_SetupFloatIdle(this);
     }

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.c
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.c
@@ -50,8 +50,8 @@ void EnBird_Init(Actor* thisx, PlayState* play) {
     this->timer = 0;
     this->rotYStep = 2500;
     this->actor.colChkInfo.mass = 0;
-    this->speedXZTarget = 1.5f;
-    this->speedXZStep = 0.5f;
+    this->speedTarget = 1.5f;
+    this->speedStep = 0.5f;
     this->posYMag = 0.0f;
     this->rotYMag = 0.0f;
     this->posYPhaseStep = 0.0f;
@@ -74,10 +74,10 @@ void EnBird_SetupIdle(EnBird* this, s16 params) {
 
 void EnBird_Idle(EnBird* this, PlayState* play) {
     this->actor.shape.yOffset += sinf(this->posYPhase) * this->posYMag;
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.1f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.1f, 0.5f, 0.0f);
 
     if (this->scaleAnimSpeed) {
-        this->skelAnime.playSpeed = this->actor.speedXZ * 2.0f;
+        this->skelAnime.playSpeed = this->actor.speed * 2.0f;
     }
 
     SkelAnime_Update(&this->skelAnime);
@@ -95,7 +95,7 @@ void EnBird_SetupMove(EnBird* this, s16 params) {
 
 void EnBird_Move(EnBird* this, PlayState* play) {
     this->actor.shape.yOffset += sinf(this->posYPhase) * this->posYMag;
-    Math_SmoothStepToF(&this->actor.speedXZ, this->speedXZTarget, 0.1f, this->speedXZStep, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, this->speedTarget, 0.1f, this->speedStep, 0.0f);
 
     if (this->flightDistance < Math_Vec3f_DistXZ(&this->actor.world.pos, &this->actor.home.pos) || this->timer < 4) {
         Math_StepToAngleS(&this->actor.world.rot.y, Math_Vec3f_Yaw(&this->actor.world.pos, &this->actor.home.pos),

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.h
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.h
@@ -17,8 +17,8 @@ typedef struct EnBird {
     /* 0x019C */ s16 scaleAnimSpeed; // when true, anim speed scales with XZ speed while slowing down. otherwise anim plays full speed
     /* 0x01A0 */ f32 posYMag; 
     /* 0x01A4 */ f32 rotYMag; 
-    /* 0x01A8 */ f32 speedXZTarget;
-    /* 0x01AC */ f32 speedXZStep;
+    /* 0x01A8 */ f32 speedTarget;
+    /* 0x01AC */ f32 speedStep;
     /* 0x01B0 */ f32 flightDistance; // radius of "home" area
     /* 0x01B4 */ f32 posYPhase;
     /* 0x01B8 */ f32 posYPhaseStep;

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -131,20 +131,20 @@ void EnBom_Move(EnBom* this, PlayState* play) {
     }
 
     // rebound bomb off the wall it hits
-    if ((this->actor.speedXZ != 0.0f) && (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
+    if ((this->actor.speed != 0.0f) && (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
         if (ABS((s16)(this->actor.wallYaw - this->actor.world.rot.y)) > 0x4000) {
             this->actor.world.rot.y = ((this->actor.wallYaw - this->actor.world.rot.y) + this->actor.wallYaw) - 0x8000;
         }
         Actor_PlaySfx(&this->actor, NA_SE_EV_BOMB_BOUND);
         Actor_MoveForward(&this->actor);
-        this->actor.speedXZ *= 0.7f;
+        this->actor.speed *= 0.7f;
         this->actor.bgCheckFlags &= ~BGCHECKFLAG_WALL;
     }
 
     if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
-        Math_StepToF(&this->actor.speedXZ, 0.0f, 0.08f);
+        Math_StepToF(&this->actor.speed, 0.0f, 0.08f);
     } else {
-        Math_StepToF(&this->actor.speedXZ, 0.0f, 1.0f);
+        Math_StepToF(&this->actor.speed, 0.0f, 1.0f);
         if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) && (this->actor.velocity.y < -3.0f)) {
             func_8002F850(play, &this->actor);
             this->actor.velocity.y *= -0.3f;

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
@@ -112,7 +112,7 @@ void EnBomChu_Explode(EnBomChu* this, PlayState* play) {
     }
 
     this->timer = 1;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if (this->actor.yDistToWater > 0.0f) {
         for (i = 0; i < 40; i++) {
@@ -230,7 +230,7 @@ void EnBomChu_WaitForRelease(EnBomChu* this, PlayState* play) {
         this->axisLeft.y = 0;
         this->axisLeft.z = Math_CosS(this->actor.shape.rot.y + 0x4000);
 
-        this->actor.speedXZ = 8.0f;
+        this->actor.speed = 8.0f;
         //! @bug there is no NULL check on the floor poly.  If the player is out of bounds the floor poly will be NULL
         //! and will cause a crash inside this function.
         EnBomChu_UpdateFloorPoly(this, this->actor.floorPoly, play);
@@ -252,8 +252,8 @@ void EnBomChu_Move(EnBomChu* this, PlayState* play) {
     Vec3f posSide;
     Vec3f posUpDown;
 
-    this->actor.speedXZ = 8.0f;
-    lineLength = this->actor.speedXZ * 2.0f;
+    this->actor.speed = 8.0f;
+    lineLength = this->actor.speed * 2.0f;
 
     if (this->timer != 0) {
         this->timer--;
@@ -289,7 +289,7 @@ void EnBomChu_Move(EnBomChu* this, PlayState* play) {
             EnBomChu_UpdateFloorPoly(this, polySide, play);
             this->actor.world.pos = posSide;
             this->actor.floorBgId = bgIdSide;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
         } else {
             if (this->actor.floorPoly != polyUpDown) {
                 EnBomChu_UpdateFloorPoly(this, polyUpDown, play);
@@ -299,7 +299,7 @@ void EnBomChu_Move(EnBomChu* this, PlayState* play) {
             this->actor.floorBgId = bgIdUpDown;
         }
     } else {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         lineLength *= 3.0f;
         posA = posB;
 

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -234,9 +234,9 @@ void EnBombf_Move(EnBombf* this, PlayState* play) {
     this->flowerBombScale = 1.0f;
 
     if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.025f, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.025f, 0.0f);
     } else {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 1.5f, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 1.5f, 0.0f);
         if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) && (this->actor.velocity.y < -6.0f)) {
             func_8002F850(play, &this->actor);
             this->actor.velocity.y *= -0.5f;
@@ -350,7 +350,7 @@ void EnBombf_Update(Actor* thisx, PlayState* play) {
         }
 
         // rebound bomb off the wall it hits
-        if ((thisx->speedXZ != 0.0f) && (thisx->bgCheckFlags & BGCHECKFLAG_WALL)) {
+        if ((thisx->speed != 0.0f) && (thisx->bgCheckFlags & BGCHECKFLAG_WALL)) {
 
             if (ABS((s16)(thisx->wallYaw - thisx->world.rot.y)) > 0x4000) {
                 if (1) {}
@@ -363,7 +363,7 @@ void EnBombf_Update(Actor* thisx, PlayState* play) {
                                     UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_1 | UPDBGCHECKINFO_FLAG_2 |
                                         UPDBGCHECKINFO_FLAG_3 | UPDBGCHECKINFO_FLAG_4);
             DREG(6) = 0;
-            thisx->speedXZ *= 0.7f;
+            thisx->speed *= 0.7f;
             thisx->bgCheckFlags &= ~BGCHECKFLAG_WALL;
         }
 

--- a/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -224,7 +224,7 @@ void EnButte_FlyAround(EnButte* this, PlayState* play) {
     distSqFromHome = Math3D_Dist2DSq(this->actor.world.pos.x, this->actor.world.pos.z, this->actor.home.pos.x,
                                      this->actor.home.pos.z);
     func_809CD56C(this);
-    Math_SmoothStepToF(&this->actor.speedXZ, flightParams->speedXZTarget, flightParams->speedXZScale,
+    Math_SmoothStepToF(&this->actor.speed, flightParams->speedXZTarget, flightParams->speedXZScale,
                        flightParams->speedXZStep, 0.0f);
 
     if (this->unk_257 == 1) {
@@ -259,7 +259,7 @@ void EnButte_FlyAround(EnButte* this, PlayState* play) {
 
     EnButte_Turn(this);
 
-    animSpeed = this->actor.speedXZ / 2.0f + Rand_ZeroOne() * 0.2f + (1.0f - Math_SinS(this->unk_260)) * 0.15f +
+    animSpeed = this->actor.speed / 2.0f + Rand_ZeroOne() * 0.2f + (1.0f - Math_SinS(this->unk_260)) * 0.15f +
                 (1.0f - Math_SinS(this->unk_25E)) * 0.3f + minAnimSpeed;
     this->skelAnime.playSpeed = CLAMP(animSpeed, 0.2f, 1.5f);
     SkelAnime_Update(&this->skelAnime);
@@ -299,7 +299,7 @@ void EnButte_FollowLink(EnButte* this, PlayState* play) {
     s16 yaw;
 
     func_809CD634(this);
-    Math_SmoothStepToF(&this->actor.speedXZ, flightParams->speedXZTarget, flightParams->speedXZScale,
+    Math_SmoothStepToF(&this->actor.speed, flightParams->speedXZTarget, flightParams->speedXZScale,
                        flightParams->speedXZStep, 0.0f);
     minAnimSpeed = 0.0f;
 
@@ -322,7 +322,7 @@ void EnButte_FollowLink(EnButte* this, PlayState* play) {
 
     EnButte_Turn(this);
 
-    animSpeed = this->actor.speedXZ / 2.0f + Rand_ZeroOne() * 0.2f + (1.0f - Math_SinS(this->unk_260)) * 0.15f +
+    animSpeed = this->actor.speed / 2.0f + Rand_ZeroOne() * 0.2f + (1.0f - Math_SinS(this->unk_260)) * 0.15f +
                 (1.0f - Math_SinS(this->unk_25E)) * 0.3f + minAnimSpeed;
     this->skelAnime.playSpeed = CLAMP(animSpeed, 0.2f, 1.5f);
     SkelAnime_Update(&this->skelAnime);
@@ -334,7 +334,7 @@ void EnButte_FollowLink(EnButte* this, PlayState* play) {
 
     distSqFromHome = Math3D_Dist2DSq(this->actor.world.pos.x, this->actor.world.pos.z, this->actor.home.pos.x,
                                      this->actor.home.pos.z);
-    if (!((player->heldItemAction == PLAYER_IA_DEKU_STICK) && (fabsf(player->actor.speedXZ) < 1.8f) &&
+    if (!((player->heldItemAction == PLAYER_IA_DEKU_STICK) && (fabsf(player->actor.speed) < 1.8f) &&
           (this->swordDownTimer <= 0) && (distSqFromHome < SQ(320.0f)))) {
         EnButte_SetupFlyAround(this);
     } else if (distSqFromHome > SQ(240.0f)) {

--- a/src/overlays/actors/ovl_En_Bw/z_en_bw.c
+++ b/src/overlays/actors/ovl_En_Bw/z_en_bw.c
@@ -162,7 +162,7 @@ void EnBw_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_809CE884(EnBw* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     this->unk_222 -= 250;
     this->actor.scale.x = 0.013f + Math_SinF(this->unk_222 * 0.001f) * 0.0069999998f;
     this->actor.scale.y = 0.013f - Math_SinF(this->unk_222 * 0.001f) * 0.0069999998f;
@@ -178,7 +178,7 @@ void func_809CE9A8(EnBw* this) {
     this->unk_220 = 2;
     this->unk_222 = Rand_ZeroOne() * 200.0f + 200.0f;
     this->unk_232 = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnBw_SetupAction(this, func_809CEA24);
 }
 
@@ -215,13 +215,13 @@ void func_809CEA24(EnBw* this, PlayState* play) {
         }
     }
     sp5C *= this->unk_24C * (10.0f * this->unk_244);
-    this->actor.speedXZ = ABS(sp5C);
+    this->actor.speed = ABS(sp5C);
     if (this->unk_221 != 1) {
         sp58 = Math_SinF(this->unk_240);
         sp60 = ABS(sp58) * 85.0f;
         this->color1.g = sp60;
     }
-    if ((((play->gameplayFrames % 4) == (u32)this->actor.params) && (this->actor.speedXZ != 0.0f) &&
+    if ((((play->gameplayFrames % 4) == (u32)this->actor.params) && (this->actor.speed != 0.0f) &&
          (sp64 =
               BgCheck_AnyLineTest2(&play->colCtx, &this->actor.world.pos, &this->unk_264, &sp68, &sp74, 1, 0, 0, 1))) ||
         (this->unk_222 == 0)) {
@@ -281,7 +281,7 @@ void func_809CEA24(EnBw* this, PlayState* play) {
             }
             this->unk_222 = (Rand_ZeroOne() * 200.0f) + 200.0f;
         }
-    } else if ((this->actor.speedXZ != 0.0f) && (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
+    } else if ((this->actor.speed != 0.0f) && (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
         if (this->unk_236 != this->actor.wallYaw) {
             sp64 = 1;
             this->unk_236 = this->actor.wallYaw;
@@ -339,14 +339,14 @@ void func_809CEA24(EnBw* this, PlayState* play) {
                 func_809CF72C(this);
             } else {
                 Math_SmoothStepToS(&this->actor.world.rot.y, this->unk_236 + this->unk_238, 1,
-                                   this->actor.speedXZ * 1000.0f, 0);
+                                   this->actor.speed * 1000.0f, 0);
             }
             break;
         case 0:
             Math_SmoothStepToF(&this->unk_248, 0.6f, 1.0f, 0.05f, 0.0f);
             if (sp64 == 0) {
                 Math_SmoothStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 1,
-                                   this->actor.speedXZ * 1000.0f, 0);
+                                   this->actor.speed * 1000.0f, 0);
                 if ((this->actor.xzDistToPlayer < 90.0f) && (this->actor.yDistToPlayer < 50.0f) &&
                     Actor_IsFacingPlayer(&this->actor, 0x1554) &&
                     Actor_TestFloorInDirection(&this->actor, play, 71.24802f, this->actor.yawTowardsPlayer)) {
@@ -354,7 +354,7 @@ void func_809CEA24(EnBw* this, PlayState* play) {
                 }
             } else {
                 Math_SmoothStepToS(&this->actor.world.rot.y, this->unk_236 + this->unk_238, 1,
-                                   this->actor.speedXZ * 1000.0f, 0);
+                                   this->actor.speed * 1000.0f, 0);
             }
             if ((this->unk_224 == 0) || (ABS(this->actor.yDistToPlayer) > 60.0f) ||
                 (player2->stateFlags1 & (PLAYER_STATE1_13 | PLAYER_STATE1_14))) {
@@ -370,10 +370,10 @@ void func_809CEA24(EnBw* this, PlayState* play) {
                     this->unk_238 = -this->unk_238;
                 }
                 Math_SmoothStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer - 0x8000, 1,
-                                   this->actor.speedXZ * 1000.0f, 0);
+                                   this->actor.speed * 1000.0f, 0);
             } else {
                 Math_SmoothStepToS(&this->actor.world.rot.y, this->unk_236 + this->unk_238, 1,
-                                   this->actor.speedXZ * 1000.0f, 0);
+                                   this->actor.speed * 1000.0f, 0);
             }
             if (this->unk_224 <= 200) {
                 sp60 = Math_SinS(this->unk_224 * (0x960 - this->unk_224)) * 55.0f;
@@ -399,7 +399,7 @@ void func_809CF72C(EnBw* this) {
     this->unk_250 = 0.6f;
     this->unk_222 = 20;
     this->unk_224 = 0xBB8;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEWALK_AIM);
     EnBw_SetupAction(this, func_809CF7AC);
 }
@@ -426,7 +426,7 @@ void func_809CF7AC(EnBw* this, PlayState* play) {
 
 void func_809CF8F0(EnBw* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gTorchSlugEyestalkFlailAnim, -1.0f);
-    this->actor.speedXZ = 7.0f;
+    this->actor.speed = 7.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
     this->unk_220 = 4;
     this->unk_222 = 1000;
@@ -440,14 +440,14 @@ void func_809CF984(EnBw* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 floorPolyType;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     this->unk_222 += 250;
     this->actor.scale.x = 0.013f - Math_SinF(this->unk_222 * 0.001f) * 0.0034999999f;
     this->actor.scale.y = 0.013f + Math_SinF(this->unk_222 * 0.001f) * 0.0245f;
     this->actor.scale.z = 0.013f - Math_SinF(this->unk_222 * 0.001f) * 0.0034999999f;
     if (this->collider1.base.atFlags & AT_HIT) {
         this->collider1.base.atFlags &= ~AT_HIT;
-        this->actor.speedXZ = -6.0f;
+        this->actor.speed = -6.0f;
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
         if ((&player->actor == this->collider1.base.at) && !(this->collider1.base.atFlags & AT_BOUNCED)) {
             Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
@@ -463,7 +463,7 @@ void func_809CF984(EnBw* this, PlayState* play) {
         Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 30.0f, 11, 4.0f, 0, 0, false);
         this->unk_222 = 3000;
         this->actor.flags &= ~ACTOR_FLAG_24;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         EnBw_SetupAction(this, func_809CE884);
     }
@@ -474,7 +474,7 @@ void func_809CFBA8(EnBw* this) {
     this->unk_220 = 5;
     this->unk_222 = 1000;
     this->unk_260 = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 11.0f;
     this->unk_25C = Rand_ZeroOne() * 0.25f + 1.0f;
     this->unk_224 = 0xBB8;
@@ -532,7 +532,7 @@ void func_809CFF10(EnBw* this) {
     this->unk_220 = 6;
     this->unk_222 = 1000;
     this->unk_221 = 3;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 11.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEWALK_REVERSE);
     this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND;
@@ -574,7 +574,7 @@ void func_809D00F4(EnBw* this) {
     this->unk_220 = 0;
     this->unk_222 = 40;
     this->actor.flags &= ~ACTOR_FLAG_0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_BUBLEWALK_DEAD);
     EnBw_SetupAction(this, func_809D014C);
 }
@@ -594,7 +594,7 @@ void func_809D014C(EnBw* this, PlayState* play) {
 
 void func_809D01CC(EnBw* this) {
     this->unk_220 = 1;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_25C = (Rand_ZeroOne() * 0.25f) + 1.0f;
     this->unk_260 = 0.0f;
     if (this->damageEffect == 0xE) {
@@ -637,7 +637,7 @@ void func_809D0268(EnBw* this, PlayState* play) {
 }
 
 void func_809D03CC(EnBw* this) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (this->damageEffect == 0xE) {
         this->iceTimer = 32;
     }

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -235,7 +235,7 @@ void EnClearTag_Init(Actor* thisx, PlayState* play) {
     if (this->actor.params == CLEAR_TAG_LASER) {
         this->state = CLEAR_TAG_STATE_LASER;
         this->timers[CLEAR_TAG_TIMER_LASER_DEATH] = 70;
-        this->actor.speedXZ = 35.0f;
+        this->actor.speed = 35.0f;
         func_8002D908(&this->actor);
         for (j = 0; j <= 0; j++) {
             func_8002D7EC(&this->actor);
@@ -243,7 +243,7 @@ void EnClearTag_Init(Actor* thisx, PlayState* play) {
         this->actor.scale.x = 0.4f;
         this->actor.scale.y = 0.4f;
         this->actor.scale.z = 2.0f;
-        this->actor.speedXZ = 70.0f;
+        this->actor.speed = 70.0f;
         this->actor.shape.rot.x = -this->actor.shape.rot.x;
 
         func_8002D908(&this->actor);
@@ -362,7 +362,7 @@ void EnClearTag_Update(Actor* thisx, PlayState* play2) {
                     }
                 }
                 Actor_SetScale(&this->actor, 0.2f);
-                this->actor.speedXZ = 7.0f;
+                this->actor.speed = 7.0f;
 
                 if (this->timers[CLEAR_TAG_TIMER_ARWING_UPDATE_STATE] == 0) {
                     if (this->timers[CLEAR_TAG_TIMER_ARWING_ENTER_LOCKED_ON] == 0) {

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -136,7 +136,7 @@ void EnCrow_SetupFlyIdle(EnCrow* this) {
 
 void EnCrow_SetupDiveAttack(EnCrow* this) {
     this->timer = 300;
-    this->actor.speedXZ = 4.0f;
+    this->actor.speed = 4.0f;
     this->skelAnime.playSpeed = 2.0f;
     this->actionFunc = EnCrow_DiveAttack;
 }
@@ -146,7 +146,7 @@ void EnCrow_SetupDamaged(EnCrow* this, PlayState* play) {
     f32 scale;
     Vec3f iceParticlePos;
 
-    this->actor.speedXZ *= Math_CosS(this->actor.world.rot.x);
+    this->actor.speed *= Math_CosS(this->actor.world.rot.x);
     this->actor.velocity.y = 0.0f;
     Animation_Change(&this->skelAnime, &gGuayFlyAnim, 0.4f, 0.0f, 0.0f, ANIMMODE_LOOP_INTERP, -3.0f);
     scale = this->actor.scale.x * 100.0f;
@@ -176,7 +176,7 @@ void EnCrow_SetupDamaged(EnCrow* this, PlayState* play) {
     }
 
     if (this->actor.flags & ACTOR_FLAG_15) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     this->collider.base.acFlags &= ~AC_ON;
@@ -192,7 +192,7 @@ void EnCrow_SetupDie(EnCrow* this) {
 
 void EnCrow_SetupTurnAway(EnCrow* this) {
     this->timer = 100;
-    this->actor.speedXZ = 3.5f;
+    this->actor.speed = 3.5f;
     this->aimRotX = -0x1000;
     this->aimRotY = this->actor.yawTowardsPlayer + 0x8000;
     this->skelAnime.playSpeed = 2.0f;
@@ -232,7 +232,7 @@ void EnCrow_FlyIdle(EnCrow* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
     skelanimeUpdated = Animation_OnFrame(&this->skelAnime, 0.0f);
-    this->actor.speedXZ = (Rand_ZeroOne() * 1.5f) + 3.0f;
+    this->actor.speed = (Rand_ZeroOne() * 1.5f) + 3.0f;
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
         this->aimRotY = this->actor.wallYaw;
@@ -325,7 +325,7 @@ void EnCrow_DiveAttack(EnCrow* this, PlayState* play) {
 }
 
 void EnCrow_Damaged(EnCrow* this, PlayState* play) {
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.5f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.5f);
     this->actor.colorFilterTimer = 40;
 
     if (!(this->actor.flags & ACTOR_FLAG_15)) {

--- a/src/overlays/actors/ovl_En_Cs/z_en_cs.c
+++ b/src/overlays/actors/ovl_En_Cs/z_en_cs.c
@@ -312,7 +312,7 @@ s32 EnCs_HandleWalking(EnCs* this, PlayState* play) {
 
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->walkAngle, 1, 2500, 0);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    this->actor.speedXZ = this->walkSpeed;
+    this->actor.speed = this->walkSpeed;
     Actor_MoveForward(&this->actor);
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
 

--- a/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
+++ b/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
@@ -541,7 +541,7 @@ void EnDaiku_EscapeRun(EnDaiku* this, PlayState* play) {
 
     Math_SmoothStepToS(&this->actor.shape.rot.y, ry, 1, 0xFA0, 0);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    Math_SmoothStepToF(&this->actor.speedXZ, this->runSpeed, 0.6f, dxz, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, this->runSpeed, 0.6f, dxz, 0.0f);
     Actor_MoveForward(&this->actor);
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
 

--- a/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
+++ b/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
@@ -420,12 +420,12 @@ void EnDaikuKakariko_Run(EnDaikuKakariko* this, PlayState* play) {
         if (angleStepDiff == 0) {
             this->run = true;
         } else {
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
         }
     }
 
     if (this->run == true) {
-        Math_SmoothStepToF(&this->actor.speedXZ, this->runSpeed, 0.8f, runDist, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, this->runSpeed, 0.8f, runDist, 0.0f);
     }
 
     Actor_MoveForward(&this->actor);

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
@@ -401,7 +401,7 @@ void EnDekubaba_SetupPrunedSomersault(EnDekubaba* this) {
     this->actor.velocity.y = 4.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x8000;
     this->collider.base.acFlags &= ~AC_ON;
-    this->actor.speedXZ = this->size * 3.0f;
+    this->actor.speed = this->size * 3.0f;
     this->actor.flags |= ACTOR_FLAG_4 | ACTOR_FLAG_5;
     this->actionFunc = EnDekubaba_PrunedSomersault;
 }
@@ -941,7 +941,7 @@ void EnDekubaba_PrunedSomersault(EnDekubaba* this, PlayState* play) {
     f32 deltaZ;
     f32 deltaY;
 
-    Math_StepToF(&this->actor.speedXZ, 0.0f, this->size * 0.1f);
+    Math_StepToF(&this->actor.speed, 0.0f, this->size * 0.1f);
 
     if (this->timer == 0) {
         Math_ScaledStepToS(&this->actor.shape.rot.x, 0x4800, 0x71C);
@@ -954,7 +954,7 @@ void EnDekubaba_PrunedSomersault(EnDekubaba* this, PlayState* play) {
         if ((this->actor.scale.x > 0.005f) &&
             ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) || (this->actor.bgCheckFlags & BGCHECKFLAG_WALL))) {
             this->actor.scale.x = this->actor.scale.y = this->actor.scale.z = 0.0f;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->actor.flags &= ~(ACTOR_FLAG_0 | ACTOR_FLAG_2);
             EffectSsHahen_SpawnBurst(play, &this->actor.world.pos, this->size * 3.0f, 0, this->size * 12.0f,
                                      this->size * 5.0f, 15, HAHEN_OBJECT_DEFAULT, 10, NULL);

--- a/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
+++ b/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
@@ -195,7 +195,7 @@ void EnDekunuts_SetupRun(EnDekunuts* this) {
 void EnDekunuts_SetupGasp(EnDekunuts* this) {
     Animation_PlayLoop(&this->skelAnime, &gDekuNutsGaspAnim);
     this->animFlagAndTimer = 3;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (this->runAwayCount != 0) {
         this->runAwayCount--;
     }
@@ -211,7 +211,7 @@ void EnDekunuts_SetupBeDamaged(EnDekunuts* this) {
     }
     this->collider.base.acFlags &= ~AC_ON;
     this->actionFunc = EnDekunuts_BeDamaged;
-    this->actor.speedXZ = 10.0f;
+    this->actor.speed = 10.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DAMAGE);
     Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_CUTBODY);
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA,
@@ -222,7 +222,7 @@ void EnDekunuts_SetupBeStunned(EnDekunuts* this) {
     Animation_MorphToLoop(&this->skelAnime, &gDekuNutsDamageAnim, -3.0f);
     this->animFlagAndTimer = 5;
     this->actionFunc = EnDekunuts_BeStunned;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA,
                          Animation_GetLastFrame(&gDekuNutsDamageAnim) * this->animFlagAndTimer);
@@ -231,7 +231,7 @@ void EnDekunuts_SetupBeStunned(EnDekunuts* this) {
 void EnDekunuts_SetupDie(EnDekunuts* this) {
     Animation_PlayOnce(&this->skelAnime, &gDekuNutsDieAnim);
     this->actionFunc = EnDekunuts_Die;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_DEAD);
 }
 
@@ -358,7 +358,7 @@ void EnDekunuts_Run(EnDekunuts* this, PlayState* play) {
         this->playWalkSfx = true;
     }
 
-    Math_StepToF(&this->actor.speedXZ, 7.5f, 1.0f);
+    Math_StepToF(&this->actor.speed, 7.5f, 1.0f);
     if (Math_SmoothStepToS(&this->actor.world.rot.y, this->runDirection, 1, 0xE38, 0xB6) == 0) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER) {
             this->runDirection = Actor_WorldYawTowardPoint(&this->actor, &this->actor.home.pos);
@@ -382,7 +382,7 @@ void EnDekunuts_Run(EnDekunuts* this, PlayState* play) {
     if ((this->runAwayCount == 0) && Actor_WorldDistXZToPoint(&this->actor, &this->actor.home.pos) < 20.0f &&
         fabsf(this->actor.world.pos.y - this->actor.home.pos.y) < 2.0f) {
         this->actor.colChkInfo.mass = MASS_IMMOVABLE;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         EnDekunuts_SetupBurrow(this);
     } else if (this->animFlagAndTimer == 0) {
         EnDekunuts_SetupGasp(this);
@@ -400,7 +400,7 @@ void EnDekunuts_Gasp(EnDekunuts* this, PlayState* play) {
 }
 
 void EnDekunuts_BeDamaged(EnDekunuts* this, PlayState* play) {
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 1.0f);
+    Math_StepToF(&this->actor.speed, 0.0f, 1.0f);
     if (SkelAnime_Update(&this->skelAnime)) {
         EnDekunuts_SetupDie(this);
     }

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.c
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.c
@@ -189,7 +189,7 @@ void EnDh_SetupWait(EnDh* this) {
     this->actor.world.pos.x = Rand_CenteredFloat(600.0f) + this->actor.home.pos.x;
     this->actor.world.pos.z = Rand_CenteredFloat(600.0f) + this->actor.home.pos.z;
     this->actor.shape.yOffset = -15000.0f;
-    this->dirtWaveSpread = this->actor.speedXZ = 0.0f;
+    this->dirtWaveSpread = this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->actor.flags |= ACTOR_FLAG_7;
     this->dirtWavePhase = this->actionState = this->actor.params = ENDH_WAIT_UNDERGROUND;
@@ -243,7 +243,7 @@ void EnDh_SetupWalk(EnDh* this) {
                      Animation_GetLastFrame(&object_dh_Anim_003A8C) - 3.0f, ANIMMODE_LOOP, -6.0f);
     this->curAction = DH_WALK;
     this->timer = 300;
-    this->actor.speedXZ = 1.0f;
+    this->actor.speed = 1.0f;
     EnDh_SetupAction(this, EnDh_Walk);
 }
 
@@ -258,7 +258,7 @@ void EnDh_Walk(EnDh* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_LAUGH);
     }
     if (this->actor.xzDistToPlayer <= 100.0f) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         if (Actor_IsFacingPlayer(&this->actor, 60 * 0x10000 / 360)) {
             EnDh_SetupAttack(this);
         }
@@ -271,7 +271,7 @@ void EnDh_SetupRetreat(EnDh* this, PlayState* play) {
     Animation_MorphToLoop(&this->skelAnime, &object_dh_Anim_005880, -4.0f);
     this->curAction = DH_RETREAT;
     this->timer = 70;
-    this->actor.speedXZ = 1.0f;
+    this->actor.speed = 1.0f;
     EnDh_SetupAction(this, EnDh_Retreat);
 }
 
@@ -291,7 +291,7 @@ void EnDh_SetupAttack(EnDh* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &object_dh_Anim_004658, -6.0f);
     this->timer = this->actionState = 0;
     this->curAction = DH_ATTACK;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnDh_SetupAction(this, EnDh_Attack);
 }
 
@@ -360,7 +360,7 @@ void EnDh_Attack(EnDh* this, PlayState* play) {
 void EnDh_SetupBurrow(EnDh* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &object_dh_Anim_002148, -6.0f);
     this->curAction = DH_BURROW;
-    this->dirtWaveSpread = this->actor.speedXZ = 0.0f;
+    this->dirtWaveSpread = this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->dirtWavePhase = 0;
     this->actionState = 0;
@@ -403,7 +403,7 @@ void EnDh_Burrow(EnDh* this, PlayState* play) {
 void EnDh_SetupDamage(EnDh* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &object_dh_Anim_003D6C, -6.0f);
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        this->actor.speedXZ = -1.0f;
+        this->actor.speed = -1.0f;
     }
     Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_DAMAGE);
     this->curAction = DH_DAMAGE;
@@ -411,8 +411,8 @@ void EnDh_SetupDamage(EnDh* this) {
 }
 
 void EnDh_Damage(EnDh* this, PlayState* play) {
-    if (this->actor.speedXZ < 0.0f) {
-        this->actor.speedXZ += 0.15f;
+    if (this->actor.speed < 0.0f) {
+        this->actor.speed += 0.15f;
     }
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     if (SkelAnime_Update(&this->skelAnime)) {
@@ -436,7 +436,7 @@ void EnDh_SetupDeath(EnDh* this) {
     this->curAction = DH_DEATH;
     this->timer = 300;
     this->actor.flags &= ~ACTOR_FLAG_0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     func_800F5B58();
     this->actor.params = ENDH_DEATH;
     Actor_PlaySfx(&this->actor, NA_SE_EN_DEADHAND_DEAD);

--- a/src/overlays/actors/ovl_En_Dha/z_en_dha.c
+++ b/src/overlays/actors/ovl_En_Dha/z_en_dha.c
@@ -182,7 +182,7 @@ void EnDha_SetupWait(EnDha* this) {
     Animation_PlayLoop(&this->skelAnime, &object_dh_Anim_0015B0);
     this->unk_1C0 = 0;
     this->actionTimer = ((Rand_ZeroOne() * 10.0f) + 5.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->actor.home.rot.z = 1;
     EnDha_SetupAction(this, EnDha_Wait);

--- a/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
+++ b/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
@@ -119,7 +119,7 @@ void EnDivingGame_SpawnRuppy(EnDivingGame* this, PlayState* play) {
                                            rupeePos.y, rupeePos.z, 0, (s16)Rand_CenteredFloat(3500.0f) - 1000,
                                            this->rupeesLeftToThrow, 0);
     if (rupee != NULL) {
-        rupee->actor.speedXZ = 12.0f;
+        rupee->actor.speed = 12.0f;
         rupee->actor.velocity.y = 6.0f;
     }
 }

--- a/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -160,7 +160,7 @@ void EnDns_Init(Actor* thisx, PlayState* play) {
     this->maintainCollider = 1;
     this->standOnGround = 1;
     this->dropCollectible = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = -1.0f;
     this->dnsItemEntry = sItemEntries[this->actor.params];

--- a/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
+++ b/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
@@ -164,7 +164,7 @@ void EnDntJiji_Unburrow(EnDntJiji* this, PlayState* play) {
 void EnDntJiji_SetupWalk(EnDntJiji* this, PlayState* play) {
     this->endFrame = (f32)Animation_GetLastFrame(&gDntJijiWalkAnim);
     Animation_Change(&this->skelAnime, &gDntJijiWalkAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_LOOP, -10.0f);
-    this->actor.speedXZ = 1.0f;
+    this->actor.speed = 1.0f;
     this->isSolid = true;
     this->unburrow = true;
     this->actionFunc = EnDntJiji_Walk;
@@ -174,14 +174,14 @@ void EnDntJiji_Walk(EnDntJiji* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 5, 0x3E8, 0);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    Math_ApproachF(&this->actor.speedXZ, 1.0f, 0.2f, 0.4f);
+    Math_ApproachF(&this->actor.speed, 1.0f, 0.2f, 0.4f);
     if (this->sfxTimer == 0) {
         this->sfxTimer = 5;
         Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         this->actor.velocity.y = 9.0f;
-        this->actor.speedXZ = 3.0f;
+        this->actor.speed = 3.0f;
     }
     if (this->actor.xzDistToPlayer < 100.0f) {
         if (CUR_UPG_VALUE(UPG_DEKU_STICKS) == 1) {
@@ -191,7 +191,7 @@ void EnDntJiji_Walk(EnDntJiji* this, PlayState* play) {
         }
         this->actor.textId = 0x104D;
         Message_StartTextbox(play, this->actor.textId, NULL);
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->unused = 5;
         this->actionFunc = EnDntJiji_Talk;
     }
@@ -329,7 +329,7 @@ void EnDntJiji_Hide(EnDntJiji* this, PlayState* play) {
 void EnDntJiji_SetupReturn(EnDntJiji* this, PlayState* play) {
     this->endFrame = (f32)Animation_GetLastFrame(&gDntJijiWalkAnim);
     Animation_Change(&this->skelAnime, &gDntJijiWalkAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_LOOP, -10.0f);
-    this->actor.speedXZ = 2.0f;
+    this->actor.speed = 2.0f;
     this->isSolid = this->unburrow = true;
     this->actionFunc = EnDntJiji_Return;
 }
@@ -345,7 +345,7 @@ void EnDntJiji_Return(EnDntJiji* this, PlayState* play) {
     this->actor.world.rot.y = this->actor.shape.rot.y;
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         this->actor.velocity.y = 9.0f;
-        this->actor.speedXZ = 3.0f;
+        this->actor.speed = 3.0f;
     }
     if (this->sfxTimer == 0) {
         this->sfxTimer = 3;
@@ -361,7 +361,7 @@ void EnDntJiji_Return(EnDntJiji* this, PlayState* play) {
                 SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 8, NA_BGM_ENEMY);
             }
         }
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->isSolid = 0;
         this->actionFunc = EnDntJiji_SetupBurrow;
     }

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -291,7 +291,7 @@ void EnDntNomal_TargetUnburrow(EnDntNomal* this, PlayState* play) {
 void EnDntNomal_SetupTargetWalk(EnDntNomal* this, PlayState* play) {
     this->endFrame = (f32)Animation_GetLastFrame(&gHintNutsRunAnim);
     Animation_Change(&this->skelAnime, &gHintNutsRunAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_LOOP, -10.0f);
-    this->actor.speedXZ = 1.0f;
+    this->actor.speed = 1.0f;
     this->actor.colChkInfo.mass = 0;
     this->actionFunc = EnDntNomal_TargetWalk;
 }
@@ -309,7 +309,7 @@ void EnDntNomal_TargetWalk(EnDntNomal* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
     if (this->actor.world.pos.z > -30.0f) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actionFunc = EnDntNomal_TargetFacePlayer;
     }
 }
@@ -384,7 +384,7 @@ void EnDntNomal_TargetReturn(EnDntNomal* this, PlayState* play) {
 
     Math_SmoothStepToS(&this->actor.shape.rot.y, RAD_TO_BINANG(Math_FAtan2F(dx, dz)), 3, 0x1388, 0);
     if (fabsf(this->actor.shape.rot.y - RAD_TO_BINANG(Math_FAtan2F(dx, dz))) < 20.0f) {
-        this->actor.speedXZ = 1.0f;
+        this->actor.speed = 1.0f;
     }
     if (Animation_OnFrame(&this->skelAnime, 0.0f) || Animation_OnFrame(&this->skelAnime, 6.0f)) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
@@ -394,7 +394,7 @@ void EnDntNomal_TargetReturn(EnDntNomal* this, PlayState* play) {
         this->endFrame = (f32)Animation_GetLastFrame(&gHintNutsBurrowAnim);
         Animation_Change(&this->skelAnime, &gHintNutsBurrowAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_ONCE, -10.0f);
         this->actor.world.pos.z = -173.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actionFunc = EnDntNomal_TargetBurrow;
     }
 }
@@ -508,7 +508,7 @@ void EnDntNomal_StageUnburrow(EnDntNomal* this, PlayState* play) {
 void EnDntNomal_SetupStageCelebrate(EnDntNomal* this, PlayState* play) {
     this->endFrame = (f32)Animation_GetLastFrame(&gDntStageWalkAnim);
     Animation_Change(&this->skelAnime, &gDntStageWalkAnim, 1.0f, 0.0f, this->endFrame, ANIMMODE_LOOP, -10.0f);
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
     this->isSolid = true;
     this->actionFunc = EnDntNomal_StageCelebrate;
 }
@@ -522,7 +522,7 @@ void EnDntNomal_StageCelebrate(EnDntNomal* this, PlayState* play) {
         if ((fabsf(dx) < 10.0f) && (fabsf(dz) < 10.0f) && (Message_GetState(&play->msgCtx) != TEXT_STATE_NONE)) {
             this->action = DNT_ACTION_PRIZE;
             this->actionFunc = EnDntNomal_SetupStageDance;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             return;
         }
         Math_SmoothStepToS(&this->actor.shape.rot.y, RAD_TO_BINANG(Math_FAtan2F(dx, dz)), 1, 0xBB8, 0);
@@ -708,7 +708,7 @@ void EnDntNomal_StageAttack(EnDntNomal* this, PlayState* play) {
 void EnDntNomal_StageSetupReturn(EnDntNomal* this, PlayState* play) {
     this->endFrame = (f32)Animation_GetLastFrame(&gDntStageWalkAnim);
     Animation_Change(&this->skelAnime, &gDntStageWalkAnim, 1.5f, 0.0f, this->endFrame, ANIMMODE_LOOP, -10.0f);
-    this->actor.speedXZ = 4.0f;
+    this->actor.speed = 4.0f;
     this->isSolid = false;
     this->actionFunc = EnDntNomal_StageReturn;
 }
@@ -729,7 +729,7 @@ void EnDntNomal_StageReturn(EnDntNomal* this, PlayState* play) {
     if ((fabsf(sp2C) < 7.0f) && (fabsf(sp28) < 7.0f)) {
         this->actor.world.pos.x = this->flowerPos.x;
         this->actor.world.pos.z = this->flowerPos.z;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actionFunc = EnDntNomal_SetupStageHide;
     }
 }

--- a/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
+++ b/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
@@ -165,7 +165,7 @@ void EnDodojr_SetupCrawlTowardsTarget(EnDodojr* this) {
 
     Animation_Change(&this->skelAnime, &object_dodojr_Anim_000860, 1.8f, 0.0f, lastFrame, ANIMMODE_LOOP_INTERP, -10.0f);
     this->actor.velocity.y = 0.0f;
-    this->actor.speedXZ = 2.6f;
+    this->actor.speed = 2.6f;
     this->actor.gravity = -0.8f;
 }
 
@@ -173,7 +173,7 @@ void EnDodojr_SetupFlipBounce(EnDodojr* this) {
     f32 lastFrame = Animation_GetLastFrame(&object_dodojr_Anim_0004A0);
 
     Animation_Change(&this->skelAnime, &object_dodojr_Anim_0004A0, 1.0f, 0.0f, lastFrame, ANIMMODE_ONCE, -10.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.x = 0.0f;
     this->actor.velocity.z = 0.0f;
     this->actor.gravity = -0.8f;
@@ -205,7 +205,7 @@ void EnDodojr_SetupDespawn(EnDodojr* this) {
     this->actor.shape.shadowDraw = NULL;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actor.home.pos = this->actor.world.pos;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.gravity = -0.8f;
     this->timer = 30;
     this->dustPos = this->actor.world.pos;
@@ -214,7 +214,7 @@ void EnDodojr_SetupDespawn(EnDodojr* this) {
 void EnDodojr_SetupEatBomb(EnDodojr* this) {
     Animation_Change(&this->skelAnime, &object_dodojr_Anim_000724, 1.0f, 8.0f, 12.0f, ANIMMODE_ONCE, 0.0f);
     Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_EAT);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.x = 0.0f;
     this->actor.velocity.z = 0.0f;
     this->actor.gravity = -0.8f;
@@ -423,7 +423,7 @@ void EnDodojr_EmergeFromGround(EnDodojr* this, PlayState* play) {
     if (sp2C == 0.0f) {
         this->actor.shape.shadowDraw = ActorShadow_DrawCircle;
         this->actor.world.rot.x = this->actor.shape.rot.x;
-        this->actor.speedXZ = 2.6f;
+        this->actor.speed = 2.6f;
         this->actionFunc = EnDodojr_CrawlTowardsTarget;
     }
 }

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -357,7 +357,7 @@ void EnDodongo_Destroy(Actor* thisx, PlayState* play) {
 
 void EnDodongo_SetupIdle(EnDodongo* this) {
     Animation_MorphToLoop(&this->skelAnime, &gDodongoWaitAnim, -4.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->timer = Rand_S16Offset(30, 50);
     this->actionState = DODONGO_IDLE;
     EnDodongo_SetupAction(this, EnDodongo_Idle);
@@ -367,7 +367,7 @@ void EnDodongo_SetupWalk(EnDodongo* this) {
     f32 frames = Animation_GetLastFrame(&gDodongoWalkAnim);
 
     Animation_Change(&this->skelAnime, &gDodongoWalkAnim, 0.0f, 0.0f, frames, ANIMMODE_LOOP, -4.0f);
-    this->actor.speedXZ = 1.5f;
+    this->actor.speed = 1.5f;
     this->timer = Rand_S16Offset(50, 70);
     this->rightFootStep = true;
     this->actionState = DODONGO_WALK;
@@ -377,14 +377,14 @@ void EnDodongo_SetupWalk(EnDodongo* this) {
 void EnDodongo_SetupBreatheFire(EnDodongo* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gDodongoBreatheFireAnim, -4.0f);
     this->actionState = DODONGO_BREATHE_FIRE;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnDodongo_SetupAction(this, EnDodongo_BreatheFire);
 }
 
 void EnDodongo_SetupEndBreatheFire(EnDodongo* this) {
     Animation_PlayOnce(&this->skelAnime, &gDodongoAfterBreatheFireAnim);
     this->actionState = DODONGO_END_BREATHE_FIRE;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnDodongo_SetupAction(this, EnDodongo_EndBreatheFire);
 }
 
@@ -392,14 +392,14 @@ void EnDodongo_SetupSwallowBomb(EnDodongo* this) {
     Animation_Change(&this->skelAnime, &gDodongoBreatheFireAnim, -1.0f, 35.0f, 0.0f, ANIMMODE_ONCE, -4.0f);
     this->actionState = DODONGO_SWALLOW_BOMB;
     this->timer = 25;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnDodongo_SetupAction(this, EnDodongo_SwallowBomb);
 }
 
 void EnDodongo_SetupStunned(EnDodongo* this) {
     Animation_Change(&this->skelAnime, &gDodongoBreatheFireAnim, 0.0f, 25.0f, 0.0f, ANIMMODE_ONCE, -4.0f);
     this->actionState = DODONGO_STUNNED;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (this->damageEffect == 0xF) {
         this->iceTimer = 36;
     }
@@ -532,10 +532,10 @@ void EnDodongo_Walk(EnDodongo* this, PlayState* play) {
 
     yawDiff = ABS(yawDiff);
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 1.5f, 0.1f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 1.5f, 0.1f, 1.0f, 0.0f);
 
-    playbackSpeed = this->actor.speedXZ * 0.75f;
-    if (this->actor.speedXZ >= 0.0f) {
+    playbackSpeed = this->actor.speed * 0.75f;
+    if (this->actor.speed >= 0.0f) {
         if (playbackSpeed > 3.0f / 2) {
             playbackSpeed = 3.0f / 2;
         }
@@ -596,7 +596,7 @@ void EnDodongo_SetupSweepTail(EnDodongo* this) {
     Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_DAMAGE);
     this->actionState = DODONGO_SWEEP_TAIL;
     this->timer = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnDodongo_SetupAction(this, EnDodongo_SweepTail);
 }
 
@@ -664,7 +664,7 @@ void EnDodongo_SetupDeath(EnDodongo* this, PlayState* play) {
     Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_DEAD);
     this->actionState = DODONGO_DEATH;
     this->actor.flags &= ~ACTOR_FLAG_0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnDodongo_SetupAction(this, EnDodongo_Death);
 }
 

--- a/src/overlays/actors/ovl_En_Dog/z_en_dog.c
+++ b/src/overlays/actors/ovl_En_Dog/z_en_dog.c
@@ -277,7 +277,7 @@ void EnDog_Init(Actor* thisx, PlayState* play) {
                 if (!gSaveContext.dogIsLost) {
                     this->nextBehavior = DOG_SIT;
                     this->actionFunc = EnDog_Wait;
-                    this->actor.speedXZ = 0.0f;
+                    this->actor.speed = 0.0f;
                     return;
                 } else {
                     Actor_Kill(&this->actor);
@@ -317,7 +317,7 @@ void EnDog_FollowPath(EnDog* this, PlayState* play) {
         } else {
             speed = 4.0f;
         }
-        Math_SmoothStepToF(&this->actor.speedXZ, speed, 0.4f, 1.0f, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, speed, 0.4f, 1.0f, 0.0f);
         EnDog_Orient(this, play);
         this->actor.shape.rot = this->actor.world.rot;
 
@@ -357,7 +357,7 @@ void EnDog_ChooseMovement(EnDog* this, PlayState* play) {
         }
         this->actionFunc = EnDog_FollowPath;
     }
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.4f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.4f, 1.0f, 0.0f);
 }
 
 void EnDog_FollowPlayer(EnDog* this, PlayState* play) {
@@ -366,7 +366,7 @@ void EnDog_FollowPlayer(EnDog* this, PlayState* play) {
     if (gSaveContext.dogParams == 0) {
         this->nextBehavior = DOG_SIT;
         this->actionFunc = EnDog_Wait;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         return;
     }
 
@@ -389,7 +389,7 @@ void EnDog_FollowPlayer(EnDog* this, PlayState* play) {
         speed = 1.0f;
     }
 
-    Math_ApproachF(&this->actor.speedXZ, speed, 0.6f, 1.0f);
+    Math_ApproachF(&this->actor.speed, speed, 0.6f, 1.0f);
 
     if (!(this->actor.xzDistToPlayer > 400.0f)) {
         Math_SmoothStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 10, 1000, 1);
@@ -399,7 +399,7 @@ void EnDog_FollowPlayer(EnDog* this, PlayState* play) {
 
 void EnDog_RunAway(EnDog* this, PlayState* play) {
     if (this->actor.xzDistToPlayer < 200.0f) {
-        Math_ApproachF(&this->actor.speedXZ, 4.0f, 0.6f, 1.0f);
+        Math_ApproachF(&this->actor.speed, 4.0f, 0.6f, 1.0f);
         Math_SmoothStepToS(&this->actor.world.rot.y, (this->actor.yawTowardsPlayer ^ 0x8000), 10, 1000, 1);
     } else {
         this->actionFunc = EnDog_FaceLink;
@@ -416,7 +416,7 @@ void EnDog_FaceLink(EnDog* this, PlayState* play) {
     if (200.0f <= this->actor.xzDistToPlayer) {
         this->nextBehavior = DOG_WALK;
 
-        Math_ApproachF(&this->actor.speedXZ, 1.0f, 0.6f, 1.0f);
+        Math_ApproachF(&this->actor.speed, 1.0f, 0.6f, 1.0f);
 
         rotTowardLink = this->actor.yawTowardsPlayer;
         prevRotY = this->actor.world.rot.y;
@@ -428,7 +428,7 @@ void EnDog_FaceLink(EnDog* this, PlayState* play) {
         if (absAngleDiff < 200.0f) {
             this->nextBehavior = DOG_SIT;
             this->actionFunc = EnDog_Wait;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
         }
     } else {
         this->nextBehavior = DOG_RUN;

--- a/src/overlays/actors/ovl_En_Dog/z_en_dog.c
+++ b/src/overlays/actors/ovl_En_Dog/z_en_dog.c
@@ -304,7 +304,7 @@ void EnDog_Destroy(Actor* thisx, PlayState* play) {
 void EnDog_FollowPath(EnDog* this, PlayState* play) {
     s32 behaviors[] = { DOG_SIT, DOG_BOW, DOG_BARK };
     s32 unused[] = { 40, 80, 20 };
-    f32 speed;
+    f32 speedXZ;
     s32 frame;
 
     if (EnDog_CanFollow(this, play) == 1) {
@@ -313,11 +313,11 @@ void EnDog_FollowPath(EnDog* this, PlayState* play) {
 
     if (DECR(this->behaviorTimer) != 0) {
         if (this->nextBehavior == DOG_WALK) {
-            speed = 1.0f;
+            speedXZ = 1.0f;
         } else {
-            speed = 4.0f;
+            speedXZ = 4.0f;
         }
-        Math_SmoothStepToF(&this->actor.speed, speed, 0.4f, 1.0f, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, speedXZ, 0.4f, 1.0f, 0.0f);
         EnDog_Orient(this, play);
         this->actor.shape.rot = this->actor.world.rot;
 
@@ -361,7 +361,7 @@ void EnDog_ChooseMovement(EnDog* this, PlayState* play) {
 }
 
 void EnDog_FollowPlayer(EnDog* this, PlayState* play) {
-    f32 speed;
+    f32 speedXZ;
 
     if (gSaveContext.dogParams == 0) {
         this->nextBehavior = DOG_SIT;
@@ -375,21 +375,21 @@ void EnDog_FollowPlayer(EnDog* this, PlayState* play) {
             this->nextBehavior = DOG_BOW;
         }
         gSaveContext.dogParams = 0;
-        speed = 0.0f;
+        speedXZ = 0.0f;
     } else if (this->actor.xzDistToPlayer > 100.0f) {
         this->nextBehavior = DOG_RUN;
-        speed = 4.0f;
+        speedXZ = 4.0f;
     } else if (this->actor.xzDistToPlayer < 40.0f) {
         if (this->nextBehavior != DOG_BOW && this->nextBehavior != DOG_BOW_2) {
             this->nextBehavior = DOG_BOW;
         }
-        speed = 0.0f;
+        speedXZ = 0.0f;
     } else {
         this->nextBehavior = DOG_WALK;
-        speed = 1.0f;
+        speedXZ = 1.0f;
     }
 
-    Math_ApproachF(&this->actor.speed, speed, 0.6f, 1.0f);
+    Math_ApproachF(&this->actor.speed, speedXZ, 0.6f, 1.0f);
 
     if (!(this->actor.xzDistToPlayer > 400.0f)) {
         Math_SmoothStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 10, 1000, 1);

--- a/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
+++ b/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
@@ -185,7 +185,7 @@ void EnEiyer_SetupAppearFromGround(EnEiyer* this) {
     this->actor.world.pos.y = this->actor.home.pos.y - 40.0f;
     this->actor.world.pos.z = this->actor.home.pos.z;
     this->actor.velocity.y = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if (this->actor.params != 0xA) {
         if (this->actor.params == 0) {
@@ -208,7 +208,7 @@ void EnEiyer_SetupAppearFromGround(EnEiyer* this) {
 
 void EnEiyer_SetupUnderground(EnEiyer* this) {
     if (this->actor.params == 0xA) {
-        this->actor.speedXZ = -0.5f;
+        this->actor.speed = -0.5f;
         this->actionFunc = EnEiyer_WanderUnderground;
     } else {
         this->actionFunc = EnEiyer_CircleUnderground;
@@ -226,7 +226,7 @@ void EnEiyer_SetupInactive(EnEiyer* this) {
 }
 
 void EnEiyer_SetupAmbush(EnEiyer* this, PlayState* play) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_PlayOnce(&this->skelanime, &gStingerBackflipAnim);
     this->collider.info.bumper.dmgFlags = DMG_DEFAULT;
     this->basePos = this->actor.world.pos;
@@ -280,7 +280,7 @@ void EnEiyer_SetupHurt(EnEiyer* this) {
     this->timer = 40;
     this->actor.gravity = 0.0f;
     this->actor.velocity.y = 0.0f;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 200, COLORFILTER_BUFFLAG_OPA, 40);
     this->collider.base.acFlags &= ~AC_ON;
     this->actionFunc = EnEiyer_Hurt;
@@ -291,10 +291,10 @@ void EnEiyer_SetupDie(EnEiyer* this) {
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 200, COLORFILTER_BUFFLAG_OPA, 40);
 
     if (this->collider.info.bumper.dmgFlags != (DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT)) {
-        this->actor.speedXZ = 6.0f;
+        this->actor.speed = 6.0f;
         Animation_MorphToLoop(&this->skelanime, &gStingerHitAnim, -3.0f);
     } else {
-        this->actor.speedXZ -= 6.0f;
+        this->actor.speed -= 6.0f;
     }
 
     this->collider.info.bumper.dmgFlags = DMG_DEFAULT;
@@ -305,7 +305,7 @@ void EnEiyer_SetupDie(EnEiyer* this) {
 
 void EnEiyer_SetupDead(EnEiyer* this) {
     this->actor.colorFilterParams |= 0x2000;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actionFunc = EnEiyer_Dead;
 }
@@ -313,7 +313,7 @@ void EnEiyer_SetupDead(EnEiyer* this) {
 void EnEiyer_SetupStunned(EnEiyer* this) {
     Animation_Change(&this->skelanime, &gStingerPopOutAnim, 2.0f, 0.0f, 0.0f, 0, -8.0f);
     this->timer = 80;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = -1.0f;
     this->collider.dim.height = sColCylInit.dim.height + 8;
@@ -395,7 +395,7 @@ void EnEiyer_Ambush(EnEiyer* this, PlayState* play) {
         this->actor.world.pos.z = (Math_CosS(this->actor.shape.rot.y) * xzOffset) + this->basePos.z;
     } else {
         Math_StepToF(&this->actor.world.pos.y, this->actor.home.pos.y + 80.0f, 0.5f);
-        this->actor.speedXZ = 0.8f;
+        this->actor.speed = 0.8f;
     }
 
     if (animFinished) {
@@ -419,13 +419,13 @@ void EnEiyer_Glide(EnEiyer* this, PlayState* play) {
     }
 
     curFrame = this->skelanime.curFrame;
-    Math_ApproachF(&this->basePos.y, this->actor.floorHeight + 80.0f + 5.0f, 0.3f, this->actor.speedXZ);
+    Math_ApproachF(&this->basePos.y, this->actor.floorHeight + 80.0f + 5.0f, 0.3f, this->actor.speed);
     this->actor.world.pos.y = this->basePos.y - cosf((curFrame - 5.0f) * (M_PI / 40)) * 5.0f;
 
     if (curFrame <= 45.0f) {
-        Math_StepToF(&this->actor.speedXZ, 1.0f, 0.03f);
+        Math_StepToF(&this->actor.speed, 1.0f, 0.03f);
     } else {
-        Math_StepToF(&this->actor.speedXZ, 1.5f, 0.03f);
+        Math_StepToF(&this->actor.speed, 1.5f, 0.03f);
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
@@ -467,14 +467,14 @@ void EnEiyer_StartAttack(EnEiyer* this, PlayState* play) {
     }
 
     this->actor.world.rot.x = -this->actor.shape.rot.x;
-    Math_StepToF(&this->actor.speedXZ, 5.0f, 0.3f);
+    Math_StepToF(&this->actor.speed, 5.0f, 0.3f);
     Math_ApproachS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 2, 0x71C);
     func_8002F974(&this->actor, NA_SE_EN_EIER_FLY - SFX_FLAG);
 }
 
 void EnEiyer_DiveAttack(EnEiyer* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
-    this->actor.speedXZ *= 1.1f;
+    this->actor.speed *= 1.1f;
 
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         EnEiyer_SetupLand(this);
@@ -490,7 +490,7 @@ void EnEiyer_DiveAttack(EnEiyer* this, PlayState* play) {
 void EnEiyer_Land(EnEiyer* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
     Math_ScaledStepToS(&this->actor.world.rot.x, -0x4000, 0x450);
-    Math_StepToF(&this->actor.speedXZ, 7.0f, 1.0f);
+    Math_StepToF(&this->actor.speed, 7.0f, 1.0f);
 
     if (this->timer == -1) {
         if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
@@ -521,7 +521,7 @@ void EnEiyer_Hurt(EnEiyer* this, PlayState* play) {
         this->timer--;
     }
 
-    Math_ApproachF(&this->basePos.y, this->actor.floorHeight + 80.0f + 5.0f, 0.5f, this->actor.speedXZ);
+    Math_ApproachF(&this->basePos.y, this->actor.floorHeight + 80.0f + 5.0f, 0.5f, this->actor.speed);
     this->actor.world.pos.y = this->basePos.y - 5.0f;
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
@@ -546,7 +546,7 @@ void EnEiyer_Hurt(EnEiyer* this, PlayState* play) {
 void EnEiyer_Die(EnEiyer* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
 
-    if (this->actor.speedXZ > 0.0f) {
+    if (this->actor.speed > 0.0f) {
         Math_ScaledStepToS(&this->actor.shape.rot.x, -0x4000, 0x400);
     } else {
         Math_ScaledStepToS(&this->actor.shape.rot.x, 0x4000, 0x400);

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -257,7 +257,7 @@ void func_80A0214C(EnElf* this, PlayState* play) {
                 this->unk_2AC = 0x400;
                 this->unk_2B8 = 2.0f;
                 this->func_2C8 = func_80A020A4;
-                this->actor.speedXZ = 1.5f;
+                this->actor.speed = 1.5f;
                 this->unk_2C0 = (s16)Rand_ZeroFloat(8.0f) + 4;
             } else {
                 this->unk_2C0 = 10;
@@ -542,7 +542,7 @@ void func_80A03018(EnElf* this, PlayState* play) {
     s16 targetYaw;
     Vec3f* unk_28C = &this->unk_28C;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, this->unk_2B8, 0.2f, 0.5f, 0.01f);
+    Math_SmoothStepToF(&this->actor.speed, this->unk_2B8, 0.2f, 0.5f, 0.01f);
 
     switch (this->unk_2A8) {
         case 0:
@@ -584,7 +584,7 @@ void func_80A03148(EnElf* this, Vec3f* arg1, f32 arg2, f32 arg3, f32 arg4) {
 
     xzVelocity = sqrtf(SQ(xVelTarget) + SQ(zVelTarget));
 
-    this->actor.speedXZ = clampedXZ = CLAMP(xzVelocity, arg2, arg3);
+    this->actor.speed = clampedXZ = CLAMP(xzVelocity, arg2, arg3);
 
     if ((xzVelocity != clampedXZ) && (xzVelocity != 0.0f)) {
         xzVelocity = clampedXZ / xzVelocity;
@@ -941,7 +941,7 @@ void func_80A03CF8(EnElf* this, PlayState* play) {
                 if (arrowPointedActor != NULL) {
                     func_80A03148(this, &nextPos, 0.0f, 20.0f, 0.2f);
 
-                    if (this->actor.speedXZ >= 5.0f) {
+                    if (this->actor.speed >= 5.0f) {
                         EnElf_SpawnSparkles(this, play, 16);
                     }
                 } else {
@@ -1240,7 +1240,7 @@ void func_80A04DE4(EnElf* this, PlayState* play) {
 
     func_80A03148(this, &headCopy, 0, 20.0f, 0.2f);
 
-    if (this->actor.speedXZ >= 5.0f) {
+    if (this->actor.speed >= 5.0f) {
         EnElf_SpawnSparkles(this, play, 16);
     }
 

--- a/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
+++ b/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
@@ -215,7 +215,7 @@ void EnExRuppy_DropIntoWater(EnExRuppy* this, PlayState* play) {
     if ((divingGame != NULL) && (divingGame->actor.update != NULL) &&
         ((divingGame->unk_296 == 0) || (this->actor.bgCheckFlags & BGCHECKFLAG_WATER) || (this->timer == 0))) {
         this->invisible = true;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actor.velocity.x = this->actor.velocity.y = this->actor.velocity.z = 0.0f;
         this->actor.gravity = 0.0f;
         func_80078914(&this->actor.projectedPos, NA_SE_EV_BOMB_DROP_WATER);

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -306,7 +306,7 @@ s32 EnFd_ColliderCheck(EnFd* this, PlayState* play) {
         }
         this->attackTimer = 30;
         Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
-        func_8002F71C(play, &this->actor, this->actor.speedXZ + 2.0f, this->actor.yawTowardsPlayer, 6.0f);
+        func_8002F71C(play, &this->actor, this->actor.speed + 2.0f, this->actor.yawTowardsPlayer, 6.0f);
     }
     return false;
 }
@@ -442,7 +442,7 @@ void EnFd_Fade(EnFd* this, PlayState* play) {
             this->invincibilityTimer = 0;
             this->spinTimer = 0;
             this->actionFunc = EnFd_WaitForCore;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
         }
     }
 }
@@ -489,7 +489,7 @@ void EnFd_SpinAndGrow(EnFd* this, PlayState* play) {
         this->actor.scale.y = 0.01f;
         this->actor.world.rot.y ^= 0x8000;
         this->actor.flags |= ACTOR_FLAG_0;
-        this->actor.speedXZ = 8.0f;
+        this->actor.speed = 8.0f;
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENFD_ANIM_1);
         this->actionFunc = EnFd_JumpToGround;
     } else {
@@ -502,7 +502,7 @@ void EnFd_SpinAndGrow(EnFd* this, PlayState* play) {
 void EnFd_JumpToGround(EnFd* this, PlayState* play) {
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && !(this->actor.velocity.y > 0.0f)) {
         this->actor.velocity.y = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actor.world.rot.y = this->actor.shape.rot.y;
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENFD_ANIM_2);
         this->actionFunc = EnFd_Land;
@@ -587,7 +587,7 @@ void EnFd_Run(EnFd* this, PlayState* play) {
         if (this->invincibilityTimer == 0) {
             this->actor.world.rot.y ^= 0x8000;
             this->actor.velocity.y = 6.0f;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENFD_ANIM_1);
             this->actionFunc = EnFd_JumpToGround;
             return;
@@ -624,7 +624,7 @@ void EnFd_Run(EnFd* this, PlayState* play) {
     if (this->skelAnime.curFrame == 6.0f || this->skelAnime.curFrame == 13.0f || this->skelAnime.curFrame == 28.0f) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_KICK);
     }
-    Math_SmoothStepToF(&this->actor.speedXZ, 8.0f, 0.1f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 8.0f, 0.1f, 1.0f, 0.0f);
 }
 
 /**

--- a/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.c
+++ b/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.c
@@ -88,9 +88,9 @@ void EnFdFire_UpdatePos(EnFdFire* this, Vec3f* targetPos) {
     f32 zDiff = targetPos->z - this->actor.world.pos.z;
 
     dist = sqrtf(SQ(xDiff) + SQ(yDiff) + SQ(zDiff));
-    if (fabsf(dist) > fabsf(this->actor.speedXZ)) {
-        this->actor.velocity.x = (xDiff / dist) * this->actor.speedXZ;
-        this->actor.velocity.z = (zDiff / dist) * this->actor.speedXZ;
+    if (fabsf(dist) > fabsf(this->actor.speed)) {
+        this->actor.velocity.x = (xDiff / dist) * this->actor.speed;
+        this->actor.velocity.z = (zDiff / dist) * this->actor.speed;
     } else {
         this->actor.velocity.x = 0.0f;
         this->actor.velocity.z = 0.0f;
@@ -130,7 +130,7 @@ void EnFdFire_Init(Actor* thisx, PlayState* play) {
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, &sDamageTable, &sColChkInit);
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actor.gravity = -0.6f;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     this->actor.velocity.y = 12.0f;
     this->spawnRadius = Math_Vec3f_DistXYZ(&this->actor.world.pos, &player->actor.world.pos);
     this->scale = 3.0f;
@@ -153,7 +153,7 @@ void func_80A0E70C(EnFdFire* this, PlayState* play) {
     EnFdFire_UpdatePos(this, &targetPos);
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (!(this->actor.velocity.y > 0.0f))) {
         this->actor.velocity = velocity;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND;
         if (this->actor.params & 0x8000) {
             this->deathTimer = 200;
@@ -188,16 +188,16 @@ void EnFdFire_DanceTowardsPlayer(EnFdFire* this, PlayState* play) {
         this->actionFunc = EnFdFire_Disappear;
     } else {
         Math_SmoothStepToS(&this->actor.world.rot.y, Math_Vec3f_Yaw(&this->actor.world.pos, &pos), 8, 0xFA0, 1);
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.4f, 1.0f, 0.0f);
-        if (this->actor.speedXZ < 0.1f) {
-            this->actor.speedXZ = 5.0f;
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.4f, 1.0f, 0.0f);
+        if (this->actor.speed < 0.1f) {
+            this->actor.speed = 5.0f;
         }
         func_8002D868(&this->actor);
     }
 }
 
 void EnFdFire_Disappear(EnFdFire* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.6f, 9.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.6f, 9.0f, 0.0f);
     func_8002D868(&this->actor);
     Math_SmoothStepToF(&this->scale, 0.0f, 0.3f, 0.1f, 0.0f);
     this->actor.shape.shadowScale = 20.0f;

--- a/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
+++ b/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
@@ -104,7 +104,7 @@ void EnFhgFire_Init(Actor* thisx, PlayState* play) {
     if (this->actor.params == FHGFIRE_LIGHTNING_SHOCK) {
         this->actor.draw = NULL;
         EnFhgFire_SetUpdate(this, EnFhgFire_LightningShock);
-        this->actor.speedXZ = 30.0f;
+        this->actor.speed = 30.0f;
         Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_SPARK);
     } else if (this->actor.params == FHGFIRE_LIGHTNING_BURST) {
         EnFhgFire_SetUpdate(this, EnFhgFire_LightningBurst);
@@ -141,7 +141,7 @@ void EnFhgFire_Init(Actor* thisx, PlayState* play) {
         f32 dzL;
         f32 dxzL;
 
-        this->actor.speedXZ = (this->actor.world.rot.x == 0) ? 8.0f : 3.0f;
+        this->actor.speed = (this->actor.world.rot.x == 0) ? 8.0f : 3.0f;
         EnFhgFire_SetUpdate(this, EnFhgFire_EnergyBall);
 
         this->work[FHGFIRE_TIMER] = 70;
@@ -501,7 +501,7 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
                         if (bossGnd->flyMode == GND_FLY_NEUTRAL) {
                             angleModX = Rand_CenteredFloat(0x2000);
                             angleModY = Rand_CenteredFloat(0x2000);
-                            this->actor.speedXZ = 15.0f;
+                            this->actor.speed = 15.0f;
                         } else {
                             angleModX = 0;
                             angleModY = 0;
@@ -511,10 +511,10 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
                             }
 
                             if (!canBottleReflect2 && (player->meleeWeaponAnimation >= PLAYER_MWA_SPIN_ATTACK_1H)) {
-                                this->actor.speedXZ = 20.0f;
+                                this->actor.speed = 20.0f;
                                 this->work[FHGFIRE_RETURN_COUNT] = 4;
                             } else {
-                                this->actor.speedXZ += 1.0f;
+                                this->actor.speed += 1.0f;
                             }
                         }
                         this->actor.world.rot.y = RAD_TO_BINANG(Math_FAtan2F(dxPG, dzPG)) + angleModY;
@@ -539,7 +539,7 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
             case FHGFIRE_LIGHT_BLUE:
                 if ((bossGnd->flyMode == GND_FLY_RETURN) && (this->work[FHGFIRE_RETURN_COUNT] < 100)) {
                     this->actor.world.rot.y = RAD_TO_BINANG(Math_FAtan2F(dxPG, dzPG));
-                    if ((sqrtf(SQ(dxPG) + SQ(dzPG)) < (150.0f + (this->actor.speedXZ * 8.0f)))) {
+                    if ((sqrtf(SQ(dxPG) + SQ(dzPG)) < (150.0f + (this->actor.speed * 8.0f)))) {
                         this->work[FHGFIRE_FIRE_MODE] = FHGFIRE_LIGHT_REFLECT;
                         bossGnd->returnSuccess = true;
                         this->work[FHGFIRE_TIMER] = 8;
@@ -582,7 +582,7 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
                     this->actor.world.rot.x = RAD_TO_BINANG(Math_FAtan2F(dyL, dxzL));
                     this->work[FHGFIRE_FIRE_MODE] = FHGFIRE_LIGHT_GREEN;
                     Actor_PlaySfx(&this->actor, NA_SE_IT_SWORD_REFLECT_MG);
-                    this->actor.speedXZ += 2.0f;
+                    this->actor.speed += 2.0f;
                 }
                 break;
         }
@@ -631,8 +631,8 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play) {
         }
         Lights_PointNoGlowSetInfo(&this->lightInfo, (s16)this->actor.world.pos.x, (s16)this->actor.world.pos.y,
                                   (s16)this->actor.world.pos.z, 255, 255, 255, 200);
-        if (this->actor.speedXZ > 20.0f) {
-            this->actor.speedXZ = 20.0f;
+        if (this->actor.speed > 20.0f) {
+            this->actor.speed = 20.0f;
         }
         Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_FIRE - SFX_FLAG);
         // "Why ah ah ah ah"

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -118,7 +118,7 @@ void EnFireRock_Init(Actor* thisx, PlayState* play) {
             break;
         case FIRE_ROCK_BROKEN_PIECE1:
             this->actor.velocity.y = Rand_ZeroFloat(3.0f) + 4.0f;
-            this->actor.speedXZ = Rand_ZeroFloat(3.0f) + 3.0f;
+            this->actor.speed = Rand_ZeroFloat(3.0f) + 3.0f;
             this->scale = (Rand_ZeroFloat(1.0f) / 100.0f) + 0.02f;
             Actor_SetScale(&this->actor, this->scale);
             this->actor.gravity = -1.5f;
@@ -130,7 +130,7 @@ void EnFireRock_Init(Actor* thisx, PlayState* play) {
             break;
         case FIRE_ROCK_BROKEN_PIECE2:
             this->actor.velocity.y = Rand_ZeroFloat(3.0f) + 4.0f;
-            this->actor.speedXZ = Rand_ZeroFloat(3.0f) + 2.0f;
+            this->actor.speed = Rand_ZeroFloat(3.0f) + 2.0f;
             this->scale = (Rand_ZeroFloat(1.0f) / 500.0f) + 0.01f;
             Actor_SetScale(&this->actor, this->scale);
             this->actor.gravity = -1.2f;
@@ -352,7 +352,7 @@ void EnFireRock_Update(Actor* thisx, PlayState* play) {
                     this->collider.base.atFlags &= ~AT_BOUNCED;
                     Actor_PlaySfx(thisx, NA_SE_EV_BRIDGE_OPEN_STOP);
                     thisx->velocity.y = 0.0f;
-                    thisx->speedXZ = 0.0f;
+                    thisx->speed = 0.0f;
                     this->actionFunc = EnFireRock_SpawnMoreBrokenPieces;
                     // "☆☆☆☆☆ Shield Defense Lv1 ☆☆☆☆☆"
                     osSyncPrintf(VT_FGCOL(YELLOW) "☆☆☆☆☆ シールド防御 Lv１ ☆☆☆☆☆ \n" VT_RST);

--- a/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
+++ b/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
@@ -201,7 +201,7 @@ void EnFirefly_Destroy(Actor* thisx, PlayState* play) {
 
 void EnFirefly_SetupFlyIdle(EnFirefly* this) {
     this->timer = Rand_S16Offset(70, 100);
-    this->actor.speedXZ = (Rand_ZeroOne() * 1.5f) + 1.5f;
+    this->actor.speed = (Rand_ZeroOne() * 1.5f) + 1.5f;
     Math_ScaledStepToS(&this->actor.shape.rot.y, Actor_WorldYawTowardPoint(&this->actor, &this->actor.home.pos), 0x300);
     this->targetPitch = ((this->maxAltitude < this->actor.world.pos.y) ? 0xC00 : -0xC00) + 0x1554;
     this->skelAnime.playSpeed = 1.0f;
@@ -220,7 +220,7 @@ void EnFirefly_SetupFall(EnFirefly* this) {
 
 void EnFirefly_SetupDie(EnFirefly* this) {
     this->timer = 15;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actionFunc = EnFirefly_Die;
 }
 
@@ -228,7 +228,7 @@ void EnFirefly_SetupRebound(EnFirefly* this) {
     this->actor.world.rot.x = 0x7000;
     this->timer = 18;
     this->skelAnime.playSpeed = 1.0f;
-    this->actor.speedXZ = 2.5f;
+    this->actor.speed = 2.5f;
     this->actionFunc = EnFirefly_Rebound;
 }
 
@@ -262,7 +262,7 @@ void EnFirefly_SetupFrozenFall(EnFirefly* this, PlayState* play) {
 
     this->actor.flags |= ACTOR_FLAG_4;
     this->auraType = KEESE_AURA_NONE;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 255);
     Actor_PlaySfx(&this->actor, NA_SE_EN_FFLY_DEAD);
 
@@ -279,7 +279,7 @@ void EnFirefly_SetupFrozenFall(EnFirefly* this, PlayState* play) {
 
 void EnFirefly_SetupPerch(EnFirefly* this) {
     this->timer = 1;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actionFunc = EnFirefly_Perch;
 }
 
@@ -287,7 +287,7 @@ void EnFirefly_SetupDisturbDiveAttack(EnFirefly* this) {
     this->skelAnime.playSpeed = 3.0f;
     this->actor.shape.rot.x = 0x1554;
     this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
     this->timer = 50;
     this->actionFunc = EnFirefly_DisturbDiveAttack;
 }
@@ -311,7 +311,7 @@ s32 EnFirefly_ReturnToPerch(EnFirefly* this, PlayState* play) {
         distFromHome *= 0.05f;
 
         if (distFromHome < 1.0f) {
-            this->actor.speedXZ *= distFromHome;
+            this->actor.speed *= distFromHome;
         }
 
         Math_ScaledStepToS(&this->actor.shape.rot.y, Actor_WorldYawTowardPoint(&this->actor, &this->actor.home.pos),
@@ -373,7 +373,7 @@ void EnFirefly_FlyIdle(EnFirefly* this, PlayState* play) {
         this->timer--;
     }
     skelanimeUpdated = Animation_OnFrame(&this->skelAnime, 0.0f);
-    this->actor.speedXZ = (Rand_ZeroOne() * 1.5f) + 1.5f;
+    this->actor.speed = (Rand_ZeroOne() * 1.5f) + 1.5f;
     if (this->onFire || (this->actor.params == KEESE_ICE_FLY) ||
         ((EnFirefly_ReturnToPerch(this, play) == 0) && (EnFirefly_SeekTorch(this, play) == 0))) {
         if (skelanimeUpdated) {
@@ -421,7 +421,7 @@ void EnFirefly_Fall(EnFirefly* this, PlayState* play) {
     }
     this->actor.colorFilterTimer = 40;
     SkelAnime_Update(&this->skelAnime);
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.5f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.5f);
     if (this->actor.flags & ACTOR_FLAG_15) {
         this->actor.colorFilterTimer = 40;
     } else {
@@ -457,7 +457,7 @@ void EnFirefly_DiveAttack(EnFirefly* this, PlayState* play) {
     if (this->timer != 0) {
         this->timer--;
     }
-    Math_StepToF(&this->actor.speedXZ, 4.0f, 0.5f);
+    Math_StepToF(&this->actor.speed, 4.0f, 0.5f);
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.wallYaw, 2, 0xC00, 0x300);
         Math_ScaledStepToS(&this->actor.shape.rot.x, this->targetPitch, 0x100);
@@ -497,7 +497,7 @@ void EnFirefly_Rebound(EnFirefly* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     Math_ScaledStepToS(&this->actor.shape.rot.x, 0, 0x100);
     Math_StepToF(&this->actor.velocity.y, 0.0f, 0.4f);
-    if (Math_StepToF(&this->actor.speedXZ, 0.0f, 0.15f)) {
+    if (Math_StepToF(&this->actor.speed, 0.0f, 0.15f)) {
         if (this->timer != 0) {
             this->timer--;
         }
@@ -518,7 +518,7 @@ void EnFirefly_FlyAway(EnFirefly* this, PlayState* play) {
         EnFirefly_SetupFlyIdle(this);
         return;
     }
-    Math_StepToF(&this->actor.speedXZ, 3.0f, 0.3f);
+    Math_StepToF(&this->actor.speed, 3.0f, 0.3f);
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
         this->targetPitch = 0x954;
     } else if ((this->actor.bgCheckFlags & BGCHECKFLAG_CEILING) || (this->maxAltitude < this->actor.world.pos.y)) {
@@ -537,7 +537,7 @@ void EnFirefly_FlyAway(EnFirefly* this, PlayState* play) {
 
 void EnFirefly_Stunned(EnFirefly* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.5f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.5f);
     Math_ScaledStepToS(&this->actor.shape.rot.x, 0x1554, 0x100);
     if (this->timer != 0) {
         this->timer--;

--- a/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -200,8 +200,8 @@ void EnFish_Respawning_SetupSlowDown(EnFish* this) {
 
 void EnFish_Respawning_SlowDown(EnFish* this, PlayState* play) {
     EnFish_SetYOffset(this);
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.05f, 0.3f, 0.0f);
-    this->skelAnime.playSpeed = CLAMP_MAX(this->actor.speedXZ * 1.4f + 0.8f, 2.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.05f, 0.3f, 0.0f);
+    this->skelAnime.playSpeed = CLAMP_MAX(this->actor.speed * 1.4f + 0.8f, 2.0f);
     SkelAnime_Update(&this->skelAnime);
     this->actor.shape.rot.y = this->actor.world.rot.y;
 
@@ -229,7 +229,7 @@ void EnFish_Respawning_FollowChild(EnFish* this, PlayState* play) {
     s32 pad;
 
     EnFish_SetYOffset(this);
-    Math_SmoothStepToF(&this->actor.speedXZ, 1.8f, 0.08f, 0.4f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 1.8f, 0.08f, 0.4f, 0.0f);
 
     if ((EnFish_XZDistanceSquared(&this->actor.world.pos, &this->actor.home.pos) > SQ(80.0f)) || (this->timer < 4)) {
         Math_StepToAngleS(&this->actor.world.rot.y, Math_Vec3f_Yaw(&this->actor.world.pos, &this->actor.home.pos),
@@ -240,7 +240,7 @@ void EnFish_Respawning_FollowChild(EnFish* this, PlayState* play) {
     }
 
     this->actor.shape.rot.y = this->actor.world.rot.y;
-    this->skelAnime.playSpeed = CLAMP_MAX(this->actor.speedXZ * 1.5f + 0.8f, 4.0f);
+    this->skelAnime.playSpeed = CLAMP_MAX(this->actor.speed * 1.5f + 0.8f, 4.0f);
     SkelAnime_Update(&this->skelAnime);
 
     if (this->timer <= 0) {
@@ -270,7 +270,7 @@ void EnFish_Respawning_FleePlayer(EnFish* this, PlayState* play) {
 
     EnFish_SetYOffset(this);
     playerClose = EnFish_CheckXZDistanceToPlayer(this, play);
-    Math_SmoothStepToF(&this->actor.speedXZ, 4.2f, 0.08f, 1.4f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 4.2f, 0.08f, 1.4f, 0.0f);
 
     if (EnFish_XZDistanceSquared(&this->actor.world.pos, &this->actor.home.pos) > SQ(160.0f)) {
         yaw = Math_Vec3f_Yaw(&this->actor.world.pos, &this->actor.home.pos);
@@ -296,7 +296,7 @@ void EnFish_Respawning_FleePlayer(EnFish* this, PlayState* play) {
     }
 
     this->actor.shape.rot.y = this->actor.world.rot.y;
-    this->skelAnime.playSpeed = CLAMP_MAX(this->actor.speedXZ * 1.5f + 0.8f, 4.0f);
+    this->skelAnime.playSpeed = CLAMP_MAX(this->actor.speed * 1.5f + 0.8f, 4.0f);
 
     SkelAnime_Update(&this->skelAnime);
 
@@ -325,7 +325,7 @@ void EnFish_Respawning_ApproachPlayer(EnFish* this, PlayState* play) {
     s16 temp_a0_2;
 
     EnFish_SetYOffset(this);
-    Math_SmoothStepToF(&this->actor.speedXZ, 1.8f, 0.1f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 1.8f, 0.1f, 0.5f, 0.0f);
 
     if (EnFish_XZDistanceSquared(&this->actor.world.pos, &this->actor.home.pos) > SQ(80.0f)) {
         yaw = Math_Vec3f_Yaw(&this->actor.world.pos, &this->actor.home.pos);
@@ -346,7 +346,7 @@ void EnFish_Respawning_ApproachPlayer(EnFish* this, PlayState* play) {
     }
 
     this->actor.shape.rot.y = this->actor.world.rot.y;
-    this->skelAnime.playSpeed = CLAMP_MAX((this->actor.speedXZ * 1.5f) + 0.8f, 4.0f);
+    this->skelAnime.playSpeed = CLAMP_MAX((this->actor.speed * 1.5f) + 0.8f, 4.0f);
 
     SkelAnime_Update(&this->skelAnime);
 
@@ -368,7 +368,7 @@ void EnFish_Dropped_SetupFall(EnFish* this) {
 }
 
 void EnFish_Dropped_Fall(EnFish* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.1f, 0.1f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.1f, 0.1f, 0.0f);
     Math_StepToAngleS(&this->actor.world.rot.x, 0x4000, 100);
     Math_StepToAngleS(&this->actor.world.rot.z, -0x4000, 100);
     this->actor.shape.rot.x = this->actor.world.rot.x;
@@ -435,7 +435,7 @@ void EnFish_Dropped_FlopOnGround(EnFish* this, PlayState* play) {
     s16 frames = play->state.frames;
     s16 targetXRot;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, Rand_ZeroOne() * 0.2f, 0.1f, 0.1f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, Rand_ZeroOne() * 0.2f, 0.1f, 0.1f, 0.0f);
 
     targetXRot = (s16)((((frames >> 5) & 2) | ((frames >> 2) & 1)) << 0xB) * 0.3f;
 
@@ -485,12 +485,12 @@ void EnFish_Dropped_SetupSwimAway(EnFish* this) {
 void EnFish_Dropped_SwimAway(EnFish* this, PlayState* play) {
     s32 pad;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 2.8f, 0.1f, 0.4f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 2.8f, 0.1f, 0.4f, 0.0f);
 
     // If touching wall or not in water, turn back and slow down for one frame.
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || !(this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
         this->actor.home.rot.y = Math_Vec3f_Yaw(&this->actor.world.pos, &this->actor.home.pos);
-        this->actor.speedXZ *= 0.5f;
+        this->actor.speed *= 0.5f;
     }
 
     Math_StepToAngleS(&this->actor.world.rot.x, 0, 1500);
@@ -511,7 +511,7 @@ void EnFish_Dropped_SwimAway(EnFish* this, PlayState* play) {
         Actor_SetScale(&this->actor, this->actor.scale.x * 0.982f);
     }
 
-    this->skelAnime.playSpeed = CLAMP_MAX((this->actor.speedXZ * 1.5f) + 1.0f, 4.0f);
+    this->skelAnime.playSpeed = CLAMP_MAX((this->actor.speed * 1.5f) + 1.0f, 4.0f);
     SkelAnime_Update(&this->skelAnime);
 
     if (this->timer <= 0) {
@@ -555,7 +555,7 @@ void EnFish_Unique_SwimIdle(EnFish* this, PlayState* play) {
     }
 
     EnFish_SetYOffset(this);
-    Math_SmoothStepToF(&this->actor.speedXZ, speed[0], speed[1], speed[2], 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, speed[0], speed[1], speed[2], 0.0f);
 
     extraPlaySpeed = 0.0f;
 
@@ -569,7 +569,7 @@ void EnFish_Unique_SwimIdle(EnFish* this, PlayState* play) {
     }
 
     this->actor.shape.rot.y = this->actor.world.rot.y;
-    playSpeed = (this->actor.speedXZ * 1.2f) + 0.2f + extraPlaySpeed;
+    playSpeed = (this->actor.speed * 1.2f) + 0.2f + extraPlaySpeed;
     this->skelAnime.playSpeed = CLAMP(playSpeed, 1.5f, 0.5);
     SkelAnime_Update(&this->skelAnime);
 

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -195,7 +195,7 @@ void EnFloormas_MakeVulnerable(EnFloormas* this) {
 void EnFloormas_SetupBigDecideAction(EnFloormas* this) {
     Animation_PlayOnce(&this->skelAnime, &gWallmasterWaitAnim);
     this->actionFunc = EnFloormas_BigDecideAction;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnFloormas_SetupStand(EnFloormas* this) {
@@ -212,26 +212,26 @@ void EnFloormas_SetupBigWalk(EnFloormas* this) {
 
     this->actionTimer = Rand_S16Offset(2, 4);
     this->actionFunc = EnFloormas_BigWalk;
-    this->actor.speedXZ = 1.5f;
+    this->actor.speed = 1.5f;
 }
 
 void EnFloormas_SetupBigStopWalk(EnFloormas* this) {
     Animation_PlayOnce(&this->skelAnime, &gWallmasterStopWalkAnim);
     this->actionFunc = EnFloormas_BigStopWalk;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnFloormas_SetupRun(EnFloormas* this) {
     this->actionTimer = 0;
     this->actionFunc = EnFloormas_Run;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     this->skelAnime.playSpeed = 3.0f;
 }
 
 void EnFloormas_SetupTurn(EnFloormas* this) {
     s16 rotDelta = this->actionTarget - this->actor.shape.rot.y;
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (rotDelta > 0) {
         Animation_MorphToPlayOnce(&this->skelAnime, &gFloormasterTurnAnim, -3.0f);
     } else {
@@ -251,7 +251,7 @@ void EnFloormas_SetupTurn(EnFloormas* this) {
 void EnFloormas_SetupHover(EnFloormas* this, PlayState* play) {
     Animation_Change(&this->skelAnime, &gWallmasterHoverAnim, 3.0f, 0, Animation_GetLastFrame(&gWallmasterHoverAnim),
                      ANIMMODE_ONCE, -3.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.gravity = 0.0f;
     EnFloormas_MakeInvulnerable(this);
     Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 15.0f, 6, 20.0f, 300, 100, true);
@@ -263,12 +263,12 @@ void EnFloormas_SetupCharge(EnFloormas* this) {
     this->actionTimer = 25;
     this->actor.gravity = -0.15f;
     this->actionFunc = EnFloormas_Charge;
-    this->actor.speedXZ = 0.5f;
+    this->actor.speed = 0.5f;
 }
 
 void EnFloormas_SetupLand(EnFloormas* this) {
     Animation_Change(&this->skelAnime, &gWallmasterJumpAnim, 1.0f, 41.0f, 42.0f, ANIMMODE_ONCE, 5.0f);
-    if ((this->actor.speedXZ < 0.0f) || (this->actionFunc != EnFloormas_Charge)) {
+    if ((this->actor.speed < 0.0f) || (this->actionFunc != EnFloormas_Charge)) {
         this->actionTimer = 30;
     } else {
         this->actionTimer = 45;
@@ -294,7 +294,7 @@ void EnFloormas_SetupSplit(EnFloormas* this) {
     this->collider.dim.radius = sCylinderInit.dim.radius * 0.6f;
     this->collider.dim.height = sCylinderInit.dim.height * 0.6f;
     this->collider.info.bumperFlags &= ~BUMP_HOOKABLE;
-    this->actor.speedXZ = 4.0f;
+    this->actor.speed = 4.0f;
     this->actor.velocity.y = 7.0f;
     // using div creates a signed check.
     this->actor.colChkInfo.health = sColChkInfoInit.health >> 1;
@@ -304,7 +304,7 @@ void EnFloormas_SetupSplit(EnFloormas* this) {
 void EnFloormas_SetupSmWalk(EnFloormas* this) {
     Animation_PlayLoopSetSpeed(&this->skelAnime, &gWallmasterWalkAnim, 4.5f);
     this->actionFunc = EnFloormas_SmWalk;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
 }
 
 void EnFloormas_SetupSmDecideAction(EnFloormas* this) {
@@ -312,7 +312,7 @@ void EnFloormas_SetupSmDecideAction(EnFloormas* this) {
         Animation_PlayLoopSetSpeed(&this->skelAnime, &gWallmasterWalkAnim, 4.5f);
     }
     this->actionFunc = EnFloormas_SmDecideAction;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
 }
 
 void EnFloormas_SetupSmShrink(EnFloormas* this, PlayState* play) {
@@ -320,7 +320,7 @@ void EnFloormas_SetupSmShrink(EnFloormas* this, PlayState* play) {
     static Vec3f accel = { 0.0f, 0.0f, 0.0f };
     Vec3f pos;
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     pos.x = this->actor.world.pos.x;
     pos.y = this->actor.world.pos.y + 15.0f;
@@ -332,13 +332,13 @@ void EnFloormas_SetupSmShrink(EnFloormas* this, PlayState* play) {
 void EnFloormas_SetupSlaveJumpAtMaster(EnFloormas* this) {
     Animation_Change(&this->skelAnime, &gWallmasterJumpAnim, 2.0f, 0.0f, 41.0f, ANIMMODE_ONCE, 0.0f);
     this->actionFunc = EnFloormas_SmSlaveJumpAtMaster;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnFloormas_SetupJumpAtLink(EnFloormas* this) {
     Animation_Change(&this->skelAnime, &gWallmasterJumpAnim, 2.0f, 0.0f, 41.0f, ANIMMODE_ONCE, 0.0f);
     this->actionFunc = EnFloormas_JumpAtLink;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnFloormas_SetupGrabLink(EnFloormas* this, Player* player) {
@@ -347,7 +347,7 @@ void EnFloormas_SetupGrabLink(EnFloormas* this, Player* player) {
 
     Animation_Change(&this->skelAnime, &gWallmasterJumpAnim, 1.0f, 36.0f, 45.0f, ANIMMODE_ONCE, -3.0f);
     this->actor.flags &= ~ACTOR_FLAG_0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     EnFloormas_MakeInvulnerable(this);
     if (!LINK_IS_ADULT) {
@@ -397,20 +397,20 @@ void EnFloormas_SetupTakeDamage(EnFloormas* this) {
     }
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 20);
     this->actionFunc = EnFloormas_TakeDamage;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     this->actor.velocity.y = 5.5f;
 }
 
 void EnFloormas_SetupRecover(EnFloormas* this) {
     Animation_PlayOnce(&this->skelAnime, &gWallmasterRecoverFromDamageAnim);
-    this->actor.velocity.y = this->actor.speedXZ = 0.0f;
+    this->actor.velocity.y = this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->actionFunc = EnFloormas_Recover;
 }
 
 void EnFloormas_SetupFreeze(EnFloormas* this) {
     Animation_Change(&this->skelAnime, &gWallmasterJumpAnim, 1.5f, 0, 20.0f, ANIMMODE_ONCE, -3.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (this->actor.colChkInfo.damageEffect == 4) {
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_GRAY, 255, COLORFILTER_BUFFLAG_OPA, 80);
     } else {
@@ -591,7 +591,7 @@ void EnFloormas_Charge(EnFloormas* this, PlayState* play) {
         this->actionTimer--;
     }
 
-    Math_StepToF(&this->actor.speedXZ, 15.0f, SQ(this->actor.speedXZ) * (1.0f / 3.0f));
+    Math_StepToF(&this->actor.speed, 15.0f, SQ(this->actor.speed) * (1.0f / 3.0f));
     Math_ScaledStepToS(&this->actor.shape.rot.x, -0x1680, 0x140);
 
     distFromGround = this->actor.world.pos.y - this->actor.floorHeight;
@@ -628,14 +628,14 @@ void EnFloormas_Land(EnFloormas* this, PlayState* play) {
         }
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (isOnGround) {
-        Math_StepToF(&this->actor.speedXZ, 0.0f, 2.0f);
+        Math_StepToF(&this->actor.speed, 0.0f, 2.0f);
     }
 
-    if ((this->actor.speedXZ > 0.0f) && ((this->actor.world.pos.y - this->actor.floorHeight) < 12.0f)) {
+    if ((this->actor.speed > 0.0f) && ((this->actor.world.pos.y - this->actor.floorHeight) < 12.0f)) {
         EnFloormas_Slide(this, play);
     }
 
@@ -667,7 +667,7 @@ void EnFloormas_Split(EnFloormas* this, PlayState* play) {
             this->smActionTimer = 50;
             EnFloormas_SetupStand(this);
         }
-        Math_StepToF(&this->actor.speedXZ, 0.0f, 1.0f);
+        Math_StepToF(&this->actor.speed, 0.0f, 1.0f);
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
@@ -745,11 +745,11 @@ void EnFloormas_JumpAtLink(EnFloormas* this, PlayState* play) {
     if (this->skelAnime.curFrame < 20.0f) {
         Math_ApproachS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 2, 0xE38);
     } else if (Animation_OnFrame(&this->skelAnime, 20.0f)) {
-        this->actor.speedXZ = 5.0f;
+        this->actor.speed = 5.0f;
         this->actor.velocity.y = 7.0f;
     } else if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
         this->actionTimer = 0x32;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
         EnFloormas_SetupLand(this);
     } else if ((this->actor.yDistToPlayer < -10.0f) && (this->collider.base.ocFlags1 & OC1_HIT) &&
@@ -806,7 +806,7 @@ void EnFloormas_GrabLink(EnFloormas* this, PlayState* play) {
         this->actor.shape.rot.x = 0;
         this->actor.velocity.y = 6.0f;
         this->actor.flags |= ACTOR_FLAG_0;
-        this->actor.speedXZ = -3.0f;
+        this->actor.speed = -3.0f;
         EnFloormas_SetupLand(this);
     } else {
         // Damage link every 20 frames
@@ -839,7 +839,7 @@ void EnFloormas_SmSlaveJumpAtMaster(EnFloormas* this, PlayState* play) {
         return;
     }
     if (Animation_OnFrame(&this->skelAnime, 20.0f)) {
-        this->actor.speedXZ = 5.0f;
+        this->actor.speed = 5.0f;
         this->actor.velocity.y = 7.0f;
     } else if (this->skelAnime.curFrame < 20.0f) {
         Math_ApproachS(&this->actor.shape.rot.y, Actor_WorldYawTowardActor(&this->actor, primFloormas), 2, 0xE38);
@@ -849,14 +849,14 @@ void EnFloormas_SmSlaveJumpAtMaster(EnFloormas* this, PlayState* play) {
         EnFloormas_SetupSmWait(this);
         this->collider.base.ocFlags1 |= OC1_ON;
     } else if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         Actor_PlaySfx(&this->actor, NA_SE_EN_FLOORMASTER_SM_LAND);
         EnFloormas_SetupLand(this);
     }
 
     if (fabsf(this->actor.world.pos.x - primFloormas->world.pos.x) < 5.0f &&
         fabsf(this->actor.world.pos.z - primFloormas->world.pos.z) < 5.0f) {
-        Math_StepToF(&this->actor.speedXZ, 0, 2.0f);
+        Math_StepToF(&this->actor.speed, 0, 2.0f);
     }
 }
 
@@ -950,7 +950,7 @@ void EnFloormas_TakeDamage(EnFloormas* this, PlayState* play) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
     }
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.2f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.2f);
 }
 
 void EnFloormas_Recover(EnFloormas* this, PlayState* play) {
@@ -1025,12 +1025,12 @@ void EnFloormas_Update(Actor* thisx, PlayState* play) {
     if (this->actionFunc != EnFloormas_SmWait) {
         if (this->collider.base.atFlags & AT_HIT) {
             this->collider.base.atFlags &= ~AT_HIT;
-            this->actor.speedXZ *= -0.5f;
+            this->actor.speed *= -0.5f;
 
-            if (-5.0f < this->actor.speedXZ) {
-                this->actor.speedXZ = -5.0f;
+            if (-5.0f < this->actor.speed) {
+                this->actor.speed = -5.0f;
             } else {
-                this->actor.speedXZ = this->actor.speedXZ;
+                this->actor.speed = this->actor.speed;
             }
 
             this->actor.velocity.y = 5.0f;

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -224,7 +224,7 @@ void EnFr_OrientUnderwater(EnFr* this) {
     this->actor.world.pos.y = sLogSpotToFromWater[this->actor.params].yDist + this->posLogSpot.y;
     this->actor.world.rot.y = this->actor.shape.rot.y =
         RAD_TO_BINANG(sLogSpotToFromWater[this->actor.params].yaw) + 0x8000;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = 0.0f;
 }
@@ -418,7 +418,7 @@ void EnFr_JumpingOutOfWater(EnFr* this, PlayState* play) {
         this->skelAnime.playSpeed = 0.0f;
     } else if (this->skelAnime.curFrame == 3.0f) {
         this->actor.gravity = -10.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actor.velocity.y = 47.0f;
     }
 
@@ -501,7 +501,7 @@ void EnFr_JumpingBackIntoWater(EnFr* this, PlayState* play) {
     if (this->skelAnime.curFrame == 6.0f) {
         this->skelAnime.playSpeed = 0.0f;
     } else if (this->skelAnime.curFrame == 3.0f) {
-        this->actor.speedXZ = 6.0f;
+        this->actor.speed = 6.0f;
         this->actor.gravity = -10.0f;
         this->actor.velocity.y = 25.0f;
     }

--- a/src/overlays/actors/ovl_En_Fw/z_en_fw.c
+++ b/src/overlays/actors/ovl_En_Fw/z_en_fw.c
@@ -239,7 +239,7 @@ void EnFw_Run(EnFw* this, PlayState* play) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_MAN_DAMAGE);
             this->explosionTimer = 6;
         }
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->explosionTimer != 0) {
@@ -273,7 +273,7 @@ void EnFw_Run(EnFw* this, PlayState* play) {
         DECR(this->damageTimer);
         if ((200.0f - this->runRadius) < 0.9f) {
             if (DECR(this->returnToParentTimer) == 0) {
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 this->actionFunc = EnFw_TurnToParentInitPos;
                 return;
             }
@@ -283,7 +283,7 @@ void EnFw_Run(EnFw* this, PlayState* play) {
         Math_SmoothStepToF(&this->runRadius, 200.0f, 0.3f, 100.0f, 0.0f);
 
         if (this->turnAround) {
-            Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.1f, 1.0f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.1f, 1.0f, 0.0f);
             tmpAngle = (s16)(this->actor.world.rot.y ^ 0x8000);
             facingDir = this->actor.shape.rot.y;
             tmpAngle = Math_SmoothStepToF(&facingDir, tmpAngle, 0.1f, 10000.0f, 0.0f);
@@ -312,7 +312,7 @@ void EnFw_Run(EnFw* this, PlayState* play) {
                 Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_MAN_SLIDE);
                 this->slideSfxTimer = 4;
             }
-            Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.1f, 1.0f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.1f, 1.0f, 0.0f);
             this->skelAnime.playSpeed = 0.0f;
             EnFw_SpawnDust(this, 8, 0.16f, 0.2f, 3, 8.0f, 20.0f, ((Rand_ZeroOne() - 0.5f) * 0.2f) + 0.3f);
             this->slideTimer--;
@@ -321,7 +321,7 @@ void EnFw_Run(EnFw* this, PlayState* play) {
                 this->runDirection = -this->runDirection;
             }
         } else {
-            Math_SmoothStepToF(&this->actor.speedXZ, 6.0f, 0.1f, 1.0f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 6.0f, 0.1f, 1.0f, 0.0f);
             curFrame = this->skelAnime.curFrame;
             if (curFrame == 1 || curFrame == 4) {
                 Actor_PlaySfx(&this->actor, NA_SE_EN_FLAME_MAN_RUN);

--- a/src/overlays/actors/ovl_En_Fz/z_en_fz.c
+++ b/src/overlays/actors/ovl_En_Fz/z_en_fz.c
@@ -181,7 +181,7 @@ void EnFz_Init(Actor* thisx, PlayState* play) {
     this->isFreezing = false;
     this->isActive = true;
     this->isDespawning = false;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.gravity = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->posOrigin.y = this->actor.world.pos.y;
@@ -326,14 +326,14 @@ void EnFz_ApplyDamage(EnFz* this, PlayState* play) {
         this->actor.bgCheckFlags &= ~BGCHECKFLAG_WALL;
         this->isMoving = false;
         this->speedXZ = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->isFreezing) {
         if ((this->actor.params < 0) && (this->collider1.base.atFlags & AT_HIT)) {
             this->isMoving = false;
             this->collider1.base.acFlags &= ~AC_HIT;
-            this->actor.speedXZ = this->speedXZ = 0.0f;
+            this->actor.speed = this->speedXZ = 0.0f;
             this->timer = 10;
             EnFz_SetupDisappear(this);
         } else if (this->collider2.base.acFlags & AC_BOUNCED) {
@@ -479,7 +479,7 @@ void EnFz_SetupAimForFreeze(EnFz* this) {
     this->timer = 40;
     this->actionFunc = EnFz_AimForFreeze;
     this->speedXZ = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnFz_AimForFreeze(EnFz* this, PlayState* play) {
@@ -556,7 +556,7 @@ void EnFz_SetupDespawn(EnFz* this, PlayState* play) {
     this->speedXZ = 0.0f;
     this->actor.gravity = 0.0f;
     this->actor.velocity.y = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_ChangeCategory(play, &play->actorCtx, &this->actor, ACTORCAT_PROP);
     Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos, 0x60);
     this->actionFunc = EnFz_Despawn;
@@ -574,7 +574,7 @@ void EnFz_SetupMelt(EnFz* this) {
     this->isDespawning = true;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actionFunc = EnFz_Melt;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->speedXZ = 0.0f;
 }
 
@@ -697,7 +697,7 @@ void EnFz_Update(Actor* thisx, PlayState* play) {
         }
     }
 
-    Math_StepToF(&this->actor.speedXZ, this->speedXZ, 0.2f);
+    Math_StepToF(&this->actor.speed, this->speedXZ, 0.2f);
     Actor_MoveForward(&this->actor);
 
     if (this->updateBgInfo) {

--- a/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -177,7 +177,7 @@ void EnGb_Init(Actor* thisx, PlayState* play) {
     ActorShape_Init(&this->dyna.actor.shape, 0.0f, ActorShadow_DrawCircle, 35.0f);
     Actor_SetScale(&this->dyna.actor, 0.01f);
     this->dyna.actor.colChkInfo.mass = 0xFF;
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     this->dyna.actor.velocity.y = 0.0f;
     this->dyna.actor.gravity = -1.0f;
     this->actionTimer = (s16)Rand_ZeroFloat(100.0f) + 100;

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -257,7 +257,7 @@ void EnGe2_CaptureCharge(EnGe2* this, PlayState* play) {
     this->actor.shape.rot.y = this->actor.world.rot.y;
     if (this->actor.xzDistToPlayer < 50.0f) {
         EnGe2_ChangeAction(this, GE2_ACTION_CAPTURECLOSE);
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->timer > 0) {
@@ -285,7 +285,7 @@ void EnGe2_CaptureTurn(EnGe2* this, PlayState* play) {
     if (this->actor.world.rot.y == this->actor.yawTowardsPlayer) {
         EnGe2_ChangeAction(this, GE2_ACTION_CAPTURECHARGE);
         this->timer = 50;
-        this->actor.speedXZ = 4.0f;
+        this->actor.speed = 4.0f;
     }
 }
 
@@ -311,7 +311,7 @@ void EnGe2_KnockedOut(EnGe2* this, PlayState* play) {
 void EnGe2_TurnPlayerSpotted(EnGe2* this, PlayState* play) {
     s32 playerSpotted;
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if (this->stateFlags & GE2_STATE_TALKED) {
         this->stateFlags &= ~GE2_STATE_TALKED;
@@ -347,7 +347,7 @@ void EnGe2_TurnPlayerSpotted(EnGe2* this, PlayState* play) {
 void EnGe2_AboutTurn(EnGe2* this, PlayState* play) {
     s32 playerSpotted;
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     playerSpotted = Ge2_DetectPlayerInAction(play, this);
 
     if (playerSpotted != 0) {
@@ -370,7 +370,7 @@ void EnGe2_Walk(EnGe2* this, PlayState* play) {
 
     playerSpotted = Ge2_DetectPlayerInAction(play, this);
     if (playerSpotted != 0) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         EnGe2_ChangeAction(this, GE2_ACTION_TURNPLAYERSPOTTED);
         this->timer = 100;
         this->playerSpottedParam = playerSpotted;
@@ -379,10 +379,10 @@ void EnGe2_Walk(EnGe2* this, PlayState* play) {
         this->walkTimer = 0;
         this->walkDirection += 0x8000;
         EnGe2_ChangeAction(this, GE2_ACTION_ABOUTTURN);
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     } else {
         this->walkTimer++;
-        this->actor.speedXZ = 2.0f;
+        this->actor.speed = 2.0f;
     }
 }
 
@@ -478,7 +478,7 @@ void EnGe2_ForceTalk(EnGe2* this, PlayState* play) {
 
 void EnGe2_SetupCapturePlayer(EnGe2* this, PlayState* play) {
     this->stateFlags |= GE2_STATE_CAPTURING;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnGe2_ChangeAction(this, GE2_ACTION_CAPTURETURN);
     func_8002DF54(play, &this->actor, PLAYER_CSMODE_95);
     func_80078884(NA_SE_SY_FOUND);
@@ -521,7 +521,7 @@ void EnGe2_UpdateFriendly(Actor* thisx, PlayState* play) {
 
     if (Actor_ProcessTalkRequest(&this->actor, play)) {
         if ((this->actor.params & 0xFF) == GE2_TYPE_PATROLLING) {
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             EnGe2_ChangeAction(this, GE2_ACTION_WAITLOOKATPLAYER);
         }
         this->actionFunc = EnGe2_SetActionAfterTalk;
@@ -566,7 +566,7 @@ void EnGe2_Update(Actor* thisx, PlayState* play) {
         EnGe2_ChangeAction(this, GE2_ACTION_KNOCKEDOUT);
         this->timer = 100;
         this->stateFlags |= GE2_STATE_KO;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         Actor_PlaySfx(&this->actor, NA_SE_VO_SK_CRASH);
     } else {
         this->actionFunc(this, play);
@@ -612,7 +612,7 @@ void EnGe2_UpdateStunned(Actor* thisx, PlayState* play2) {
         EnGe2_ChangeAction(this, GE2_ACTION_KNOCKEDOUT);
         this->timer = 100;
         this->stateFlags |= GE2_STATE_KO;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         Actor_PlaySfx(&this->actor, NA_SE_VO_SK_CRASH);
     }
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -411,7 +411,7 @@ void EnGeldB_SetupReady(EnGeldB* this) {
     Animation_MorphToLoop(&this->skelAnime, &gGerudoRedNeutralAnim, -4.0f);
     this->action = GELDB_READY;
     this->timer = Rand_ZeroOne() * 10.0f + 5.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnGeldB_SetupAction(this, EnGeldB_Ready);
 }
@@ -490,13 +490,13 @@ void EnGeldB_Advance(EnGeldB* this, PlayState* play) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 0x2EE, 0);
         this->actor.world.rot.y = this->actor.shape.rot.y;
         if (this->actor.xzDistToPlayer <= 40.0f) {
-            Math_SmoothStepToF(&this->actor.speedXZ, -8.0f, 1.0f, 1.5f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, -8.0f, 1.0f, 1.5f, 0.0f);
         } else if (this->actor.xzDistToPlayer > 55.0f) {
-            Math_SmoothStepToF(&this->actor.speedXZ, 8.0f, 1.0f, 1.5f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 8.0f, 1.0f, 1.5f, 0.0f);
         } else {
-            Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 6.65f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 6.65f, 0.0f);
         }
-        this->skelAnime.playSpeed = this->actor.speedXZ / 8.0f;
+        this->skelAnime.playSpeed = this->actor.speed / 8.0f;
         facingAngletoLink = player->actor.shape.rot.y - this->actor.shape.rot.y;
         facingAngletoLink = ABS(facingAngletoLink);
         if ((this->actor.xzDistToPlayer < 150.0f) && (player->meleeWeaponState != 0) && (facingAngletoLink >= 0x1F40)) {
@@ -564,7 +564,7 @@ void EnGeldB_SetupRollForward(EnGeldB* this) {
     this->invisible = true;
     this->action = GELDB_ROLL_FORWARD;
     this->actor.world.rot.y = this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
-    this->actor.speedXZ = 10.0f;
+    this->actor.speed = 10.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     EnGeldB_SetupAction(this, EnGeldB_RollForward);
 }
@@ -575,7 +575,7 @@ void EnGeldB_RollForward(EnGeldB* this, PlayState* play) {
 
     if (SkelAnime_Update(&this->skelAnime)) {
         this->invisible = false;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         if (!Actor_IsFacingPlayer(&this->actor, 0x1554)) {
             EnGeldB_SetupReady(this);
             this->timer = (Rand_ZeroOne() * 5.0f) + 5.0f;
@@ -635,9 +635,9 @@ void EnGeldB_SetupCircle(EnGeldB* this) {
     f32 lastFrame = Animation_GetLastFrame(&gGerudoRedSidestepAnim);
 
     Animation_Change(&this->skelAnime, &gGerudoRedSidestepAnim, 1.0f, 0.0f, lastFrame, ANIMMODE_LOOP_INTERP, 0.0f);
-    this->actor.speedXZ = Rand_CenteredFloat(12.0f);
+    this->actor.speed = Rand_CenteredFloat(12.0f);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    this->skelAnime.playSpeed = -this->actor.speedXZ * 0.5f;
+    this->skelAnime.playSpeed = -this->actor.speed * 0.5f;
     this->timer = Rand_ZeroOne() * 30.0f + 30.0f;
     this->action = GELDB_CIRCLE;
     this->approachRate = 0.0f;
@@ -658,35 +658,35 @@ void EnGeldB_Circle(EnGeldB* this, PlayState* play) {
         this->actor.world.rot.y = this->actor.shape.rot.y + 0x3A98;
         angleBehindLink = player->actor.shape.rot.y + 0x8000;
         if (Math_SinS(angleBehindLink - this->actor.shape.rot.y) >= 0.0f) {
-            this->actor.speedXZ -= 0.25f;
-            if (this->actor.speedXZ < -8.0f) {
-                this->actor.speedXZ = -8.0f;
+            this->actor.speed -= 0.25f;
+            if (this->actor.speed < -8.0f) {
+                this->actor.speed = -8.0f;
             }
         } else if (Math_SinS(angleBehindLink - this->actor.shape.rot.y) < 0.0f) {
-            this->actor.speedXZ += 0.25f;
-            if (this->actor.speedXZ > 8.0f) {
-                this->actor.speedXZ = 8.0f;
+            this->actor.speed += 0.25f;
+            if (this->actor.speed > 8.0f) {
+                this->actor.speed = 8.0f;
             }
         }
         if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
-            !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ, this->actor.shape.rot.y + 0x3E80)) {
+            !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed, this->actor.shape.rot.y + 0x3E80)) {
             if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-                if (this->actor.speedXZ >= 0.0f) {
+                if (this->actor.speed >= 0.0f) {
                     phi_v1 = this->actor.shape.rot.y + 0x3E80;
                 } else {
                     phi_v1 = this->actor.shape.rot.y - 0x3E80;
                 }
                 phi_v1 = this->actor.wallYaw - phi_v1;
             } else {
-                this->actor.speedXZ *= -0.8f;
+                this->actor.speed *= -0.8f;
                 phi_v1 = 0;
             }
             if (ABS(phi_v1) > 0x4000) {
-                this->actor.speedXZ *= -0.8f;
-                if (this->actor.speedXZ < 0.0f) {
-                    this->actor.speedXZ -= 0.5f;
+                this->actor.speed *= -0.8f;
+                if (this->actor.speed < 0.0f) {
+                    this->actor.speed -= 0.5f;
                 } else {
-                    this->actor.speedXZ += 0.5f;
+                    this->actor.speed += 0.5f;
                 }
             }
         }
@@ -701,8 +701,8 @@ void EnGeldB_Circle(EnGeldB* this, PlayState* play) {
             this->actor.world.pos.x += Math_SinS(this->actor.shape.rot.y) * this->approachRate;
             this->actor.world.pos.z += Math_CosS(this->actor.shape.rot.y) * this->approachRate;
         }
-        if (ABS(this->approachRate) < ABS(this->actor.speedXZ)) {
-            this->skelAnime.playSpeed = -this->actor.speedXZ * 0.5f;
+        if (ABS(this->approachRate) < ABS(this->actor.speed)) {
+            this->skelAnime.playSpeed = -this->actor.speed * 0.5f;
         } else {
             this->skelAnime.playSpeed = -this->approachRate * 0.5f;
         }
@@ -742,15 +742,15 @@ void EnGeldB_SetupSpinDodge(EnGeldB* this, PlayState* play) {
     Animation_Change(&this->skelAnime, &gGerudoRedSidestepAnim, 1.0f, 0.0f, lastFrame, ANIMMODE_LOOP_INTERP, 0.0f);
     sp3E = player->actor.shape.rot.y;
     if (Math_SinS(sp3E - this->actor.shape.rot.y) > 0.0f) {
-        this->actor.speedXZ = -10.0f;
+        this->actor.speed = -10.0f;
     } else if (Math_SinS(sp3E - this->actor.shape.rot.y) < 0.0f) {
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
     } else if (Rand_ZeroOne() > 0.5f) {
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
     } else {
-        this->actor.speedXZ = -10.0f;
+        this->actor.speed = -10.0f;
     }
-    this->skelAnime.playSpeed = -this->actor.speedXZ * 0.5f;
+    this->skelAnime.playSpeed = -this->actor.speed * 0.5f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->timer = 6;
     this->approachRate = 0.0f;
@@ -769,16 +769,16 @@ void EnGeldB_SpinDodge(EnGeldB* this, PlayState* play) {
 
     this->actor.world.rot.y = this->actor.yawTowardsPlayer + 0x3A98;
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
-        !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ, this->actor.shape.rot.y + 0x3E80)) {
+        !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed, this->actor.shape.rot.y + 0x3E80)) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-            if (this->actor.speedXZ >= 0.0f) {
+            if (this->actor.speed >= 0.0f) {
                 phi_v1 = this->actor.shape.rot.y + 0x3E80;
             } else {
                 phi_v1 = this->actor.shape.rot.y - 0x3E80;
             }
             phi_v1 = this->actor.wallYaw - phi_v1;
         } else {
-            this->actor.speedXZ *= -0.8f;
+            this->actor.speed *= -0.8f;
             phi_v1 = 0;
         }
         if (ABS(phi_v1) > 0x4000) {
@@ -797,8 +797,8 @@ void EnGeldB_SpinDodge(EnGeldB* this, PlayState* play) {
         this->actor.world.pos.x += Math_SinS(this->actor.yawTowardsPlayer) * this->approachRate;
         this->actor.world.pos.z += Math_CosS(this->actor.yawTowardsPlayer) * this->approachRate;
     }
-    if (ABS(this->approachRate) < ABS(this->actor.speedXZ)) {
-        this->skelAnime.playSpeed = -this->actor.speedXZ * 0.5f;
+    if (ABS(this->approachRate) < ABS(this->actor.speed)) {
+        this->skelAnime.playSpeed = -this->actor.speed * 0.5f;
     } else {
         this->skelAnime.playSpeed = -this->approachRate * 0.5f;
     }
@@ -828,7 +828,7 @@ void EnGeldB_SpinDodge(EnGeldB* this, PlayState* play) {
             }
         }
     } else {
-        if (this->actor.speedXZ >= 0.0f) {
+        if (this->actor.speed >= 0.0f) {
             this->actor.shape.rot.y += 0x4000;
         } else {
             this->actor.shape.rot.y -= 0x4000;
@@ -841,7 +841,7 @@ void EnGeldB_SetupSlash(EnGeldB* this) {
     this->swordCollider.base.atFlags &= ~AT_BOUNCED;
     this->action = GELDB_SLASH;
     this->spinAttackState = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Audio_StopSfxByPosAndId(&this->actor.projectedPos, NA_SE_EN_GERUDOFT_BREATH);
     EnGeldB_SetupAction(this, EnGeldB_Slash);
 }
@@ -854,7 +854,7 @@ void EnGeldB_Slash(EnGeldB* this, PlayState* play) {
     angleFacingLink = ABS(angleFacingLink);
     angleToLink = ABS(angleToLink);
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if ((s32)this->skelAnime.curFrame == 1) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_ATTACK);
         this->swordState = 1;
@@ -900,7 +900,7 @@ void EnGeldB_SetupSpinAttack(EnGeldB* this) {
     this->swordCollider.base.atFlags &= ~(AT_HIT | AT_BOUNCED);
     this->action = GELDB_SPIN_ATTACK;
     this->spinAttackState = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnGeldB_SetupAction(this, EnGeldB_SpinAttack);
 }
 
@@ -922,7 +922,7 @@ void EnGeldB_SpinAttack(EnGeldB* this, PlayState* play) {
                 func_8002DF54(play, &this->actor, PLAYER_CSMODE_24);
                 Message_StartTextbox(play, 0x6003, &this->actor);
                 this->timer = 30;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 Actor_PlaySfx(&this->actor, NA_SE_EN_TWINROBA_YOUNG_LAUGH);
                 return;
             }
@@ -934,10 +934,10 @@ void EnGeldB_SpinAttack(EnGeldB* this, PlayState* play) {
         Actor_SpawnFloorDustRing(play, &this->actor, &this->leftFootPos, 3.0f, 2, 2.0f, 0, 0, false);
         Actor_SpawnFloorDustRing(play, &this->actor, &this->rightFootPos, 3.0f, 2, 2.0f, 0, 0, false);
         this->swordState = 1;
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
         Actor_PlaySfx(&this->actor, NA_SE_EN_GERUDOFT_ATTACK);
     } else if ((s32)this->skelAnime.curFrame == 21) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     } else if ((s32)this->skelAnime.curFrame == 24) {
         this->swordState = -1;
     }
@@ -980,7 +980,7 @@ void EnGeldB_SetupRollBack(EnGeldB* this) {
     this->timer = 0;
     this->invisible = true;
     this->action = GELDB_ROLL_BACK;
-    this->actor.speedXZ = -8.0f;
+    this->actor.speed = -8.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.shape.rot.y = this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     EnGeldB_SetupAction(this, EnGeldB_RollBack);
@@ -1004,7 +1004,7 @@ void EnGeldB_RollBack(EnGeldB* this, PlayState* play) {
 
 void EnGeldB_SetupStunned(EnGeldB* this) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
     if ((this->damageEffect != GELDB_DMG_FREEZE) || (this->action == GELDB_SPIN_ATTACK)) {
         Animation_PlayOnceSetSpeed(&this->skelAnime, &gGerudoRedDamageAnim, 0.0f);
@@ -1019,11 +1019,11 @@ void EnGeldB_SetupStunned(EnGeldB* this) {
 
 void EnGeldB_Stunned(EnGeldB* this, PlayState* play) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ += 0.05f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed += 0.05f;
         }
         this->invisible = false;
     }
@@ -1040,7 +1040,7 @@ void EnGeldB_SetupDamaged(EnGeldB* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gGerudoRedDamageAnim, -4.0f);
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
         this->invisible = false;
-        this->actor.speedXZ = -4.0f;
+        this->actor.speed = -4.0f;
     } else {
         this->invisible = true;
     }
@@ -1055,11 +1055,11 @@ void EnGeldB_Damaged(EnGeldB* this, PlayState* play) {
     s16 angleToWall;
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ += 0.05f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed += 0.05f;
         }
         this->invisible = false;
     }
@@ -1088,7 +1088,7 @@ void EnGeldB_SetupJump(EnGeldB* this) {
     this->timer = 0;
     this->invisible = false;
     this->action = GELDB_JUMP;
-    this->actor.speedXZ = 6.5f;
+    this->actor.speed = 6.5f;
     this->actor.velocity.y = 15.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
@@ -1105,7 +1105,7 @@ void EnGeldB_Jump(EnGeldB* this, PlayState* play) {
         (this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH))) {
         this->actor.world.rot.y = this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
         this->actor.shape.rot.x = 0;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actor.velocity.y = 0.0f;
         this->actor.world.pos.y = this->actor.floorHeight;
         if (!Actor_OtherIsTargeted(play, &this->actor)) {
@@ -1122,7 +1122,7 @@ void EnGeldB_SetupBlock(EnGeldB* this) {
     if (this->swordState != 0) {
         this->swordState = -1;
     }
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->action = GELDB_BLOCK;
     this->timer = (s32)Rand_CenteredFloat(10.0f) + 10;
     Animation_Change(&this->skelAnime, &gGerudoRedBlockAnim, 0.0f, 0.0f, lastFrame, ANIMMODE_ONCE, 0.0f);
@@ -1192,13 +1192,13 @@ void EnGeldB_SetupSidestep(EnGeldB* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 0xFA0, 1);
     playerRotY = player->actor.shape.rot.y;
     if (Math_SinS(playerRotY - this->actor.shape.rot.y) > 0.0f) {
-        this->actor.speedXZ = -6.0f;
+        this->actor.speed = -6.0f;
     } else if (Math_SinS(playerRotY - this->actor.shape.rot.y) < 0.0f) {
-        this->actor.speedXZ = 6.0f;
+        this->actor.speed = 6.0f;
     } else {
-        this->actor.speedXZ = Rand_CenteredFloat(12.0f);
+        this->actor.speed = Rand_CenteredFloat(12.0f);
     }
-    this->skelAnime.playSpeed = -this->actor.speedXZ * 0.5f;
+    this->skelAnime.playSpeed = -this->actor.speed * 0.5f;
     this->approachRate = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x3FFF;
     this->timer = Rand_ZeroOne() * 10.0f + 5.0f;
@@ -1217,34 +1217,34 @@ void EnGeldB_Sidestep(EnGeldB* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 0xBB8, 1);
     behindLinkAngle = player->actor.shape.rot.y + 0x8000;
     if (Math_SinS(behindLinkAngle - this->actor.shape.rot.y) > 0.0f) {
-        this->actor.speedXZ += 0.125f;
+        this->actor.speed += 0.125f;
     } else if (Math_SinS(behindLinkAngle - this->actor.shape.rot.y) <= 0.0f) {
-        this->actor.speedXZ -= 0.125f;
+        this->actor.speed -= 0.125f;
     }
 
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
-        !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ, this->actor.shape.rot.y + 0x3E80)) {
+        !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed, this->actor.shape.rot.y + 0x3E80)) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-            if (this->actor.speedXZ >= 0.0f) {
+            if (this->actor.speed >= 0.0f) {
                 phi_v1 = this->actor.shape.rot.y + 0x3E80;
             } else {
                 phi_v1 = this->actor.shape.rot.y - 0x3E80;
             }
             phi_v1 = this->actor.wallYaw - phi_v1;
         } else {
-            this->actor.speedXZ *= -0.8f;
+            this->actor.speed *= -0.8f;
             phi_v1 = 0;
         }
         if (ABS(phi_v1) > 0x4000) {
-            this->actor.speedXZ *= -0.8f;
-            if (this->actor.speedXZ < 0.0f) {
-                this->actor.speedXZ -= 0.5f;
+            this->actor.speed *= -0.8f;
+            if (this->actor.speed < 0.0f) {
+                this->actor.speed -= 0.5f;
             } else {
-                this->actor.speedXZ += 0.5f;
+                this->actor.speed += 0.5f;
             }
         }
     }
-    if (this->actor.speedXZ >= 0.0f) {
+    if (this->actor.speed >= 0.0f) {
         this->actor.world.rot.y = this->actor.shape.rot.y + 0x3E80;
     } else {
         this->actor.world.rot.y = this->actor.shape.rot.y - 0x3E80;
@@ -1260,8 +1260,8 @@ void EnGeldB_Sidestep(EnGeldB* this, PlayState* play) {
         this->actor.world.pos.x += Math_SinS(this->actor.shape.rot.y) * this->approachRate;
         this->actor.world.pos.z += Math_CosS(this->actor.shape.rot.y) * this->approachRate;
     }
-    if (ABS(this->approachRate) < ABS(this->actor.speedXZ)) {
-        this->skelAnime.playSpeed = -this->actor.speedXZ * 0.5f;
+    if (ABS(this->approachRate) < ABS(this->actor.speed)) {
+        this->skelAnime.playSpeed = -this->actor.speed * 0.5f;
     } else {
         this->skelAnime.playSpeed = -this->approachRate * 0.5f;
     }
@@ -1317,7 +1317,7 @@ void EnGeldB_SetupDefeated(EnGeldB* this) {
     this->actor.world.rot.y = this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
         this->invisible = false;
-        this->actor.speedXZ = -6.0f;
+        this->actor.speed = -6.0f;
     } else {
         this->invisible = true;
     }
@@ -1329,10 +1329,10 @@ void EnGeldB_SetupDefeated(EnGeldB* this) {
 
 void EnGeldB_Defeated(EnGeldB* this, PlayState* play) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
         this->invisible = false;
     }
     if (SkelAnime_Update(&this->skelAnime)) {
@@ -1384,7 +1384,7 @@ void EnGeldB_CollisionCheck(EnGeldB* this, PlayState* play) {
                         key = Item_DropCollectible(play, &this->actor.world.pos, this->keyFlag | ITEM00_SMALL_KEY);
                         if (key != NULL) {
                             key->actor.world.rot.y = Math_Vec3f_Yaw(&key->actor.world.pos, &this->actor.home.pos);
-                            key->actor.speedXZ = 6.0f;
+                            key->actor.speed = 6.0f;
                             Audio_PlaySfxGeneral(NA_SE_SY_TRE_BOX_APPEAR, &gSfxDefaultPos, 4,
                                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
                                                  &gSfxDefaultReverb);
@@ -1640,7 +1640,7 @@ s32 EnGeldB_DodgeRanged(PlayState* play, EnGeldB* this) {
             this->actor.world.rot.y = this->actor.shape.rot.y + 0x3FFF;
             if ((ABS(angleToFacing) < 0x2000) || (ABS(angleToFacing) > 0x5FFF)) {
                 EnGeldB_SetupSidestep(this, play);
-                this->actor.speedXZ *= 3.0f;
+                this->actor.speed *= 3.0f;
             } else if (ABS(angleToFacing) < 0x5FFF) {
                 EnGeldB_SetupRollBack(this);
             }

--- a/src/overlays/actors/ovl_En_Gm/z_en_gm.c
+++ b/src/overlays/actors/ovl_En_Gm/z_en_gm.c
@@ -119,7 +119,7 @@ void func_80A3D838(EnGm* this, PlayState* play) {
         this->actor.textId = 0x3049;
         this->updateFunc = func_80A3DFBC;
         this->actionFunc = func_80A3DB04;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actor.gravity = -1.0f;
         this->actor.velocity.y = 0.0f;
     }

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -654,7 +654,7 @@ void EnGo_Init(Actor* thisx, PlayState* play) {
                 EnGo_SetupAction(this, EnGo_CurledUp);
             } else {
                 this->actor.shape.yOffset = 1400.0f;
-                this->actor.speedXZ = 3.0f;
+                this->actor.speed = 3.0f;
                 EnGo_SetupAction(this, EnGo_GoronLinkRolling);
             }
             break;
@@ -717,7 +717,7 @@ void EnGo_StopRolling(EnGo* this, PlayState* play) {
         }
     }
 
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
     if ((EnGo_FollowPath(this, play) == true) && (this->unk_218 == 0)) {
         bomb = (EnBom*)Actor_Spawn(&play->actorCtx, play, ACTOR_EN_BOM, this->actor.world.pos.x,
                                    this->actor.world.pos.y, this->actor.world.pos.z, 0, 0, 0, 0);
@@ -725,7 +725,7 @@ void EnGo_StopRolling(EnGo* this, PlayState* play) {
             bomb->timer = 0;
         }
 
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         EnGo_SetupAction(this, func_80A4008C);
     }
 
@@ -750,7 +750,7 @@ void func_80A4008C(EnGo* this, PlayState* play) {
 void EnGo_GoronLinkRolling(EnGo* this, PlayState* play) {
     if ((EnGo_FollowPath(this, play) == true) && Flags_GetSwitch(play, this->actor.params >> 8) &&
         (this->unk_218 == 0)) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         EnGo_SetupAction(this, func_80A4008C);
         SET_INFTABLE(INFTABLE_109);
     }
@@ -924,11 +924,11 @@ void func_80A40A54(EnGo* this, PlayState* play) {
     f32 float1 = ((f32)0x8000 / Animation_GetLastFrame(&gGoronAnim_010590));
     f32 float2 = this->skelAnime.curFrame * float1;
 
-    this->actor.speedXZ = Math_SinS((s16)float2);
+    this->actor.speed = Math_SinS((s16)float2);
     if (EnGo_FollowPath(this, play) && this->unk_218 == 0) {
         EnGo_ChangeAnim(this, ENGO_ANIM_1);
         this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronAnim_004930);
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         EnGo_SetupAction(this, EnGo_BiggoronActionFunc);
     }
 }
@@ -1068,7 +1068,7 @@ void EnGo_DrawRolling(EnGo* this, PlayState* play) {
 
     Matrix_Push();
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
-    Matrix_RotateZYX((s16)(play->state.frames * ((s16)this->actor.speedXZ * 1400)), 0, this->actor.shape.rot.z,
+    Matrix_RotateZYX((s16)(play->state.frames * ((s16)this->actor.speed * 1400)), 0, this->actor.shape.rot.z,
                      MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, "../z_en_go.c", 2368),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -906,7 +906,7 @@ s32 func_80A44AB0(EnGo2* this, PlayState* play) {
             if (this->collider.base.ocFlags2 & OC2_HIT_PLAYER) {
                 this->collider.base.ocFlags2 &= ~OC2_HIT_PLAYER;
 
-                arg2 = this->actionFunc == EnGo2_ContinueRolling ? 1.5f : this->actor.speedXZ * 1.5f;
+                arg2 = this->actionFunc == EnGo2_ContinueRolling ? 1.5f : this->actor.speed * 1.5f;
 
                 play->damagePlayer(play, -4);
                 func_8002F71C(play, &this->actor, arg2, this->actor.yawTowardsPlayer, 6.0f);
@@ -1110,17 +1110,17 @@ void func_80A45360(EnGo2* this, f32* alpha) {
 }
 
 void EnGo2_RollForward(EnGo2* this) {
-    f32 speedXZ = this->actor.speedXZ;
+    f32 speedXZ = this->actor.speed;
 
     if (this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->actionFunc != EnGo2_ContinueRolling) {
         Actor_MoveForward(&this->actor);
     }
 
-    this->actor.speedXZ = speedXZ;
+    this->actor.speed = speedXZ;
 }
 
 void func_80A454CC(EnGo2* this) {
@@ -1339,21 +1339,21 @@ void EnGo2_GetItemAnimation(EnGo2* this, PlayState* play) {
     this->unk_211 = true;
     this->actionFunc = func_80A46B40;
     this->skelAnime.playSpeed = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->skelAnime.curFrame = this->skelAnime.endFrame;
 }
 
 void EnGo2_SetupRolling(EnGo2* this, PlayState* play) {
     if ((this->actor.params & 0x1F) == GORON_CITY_ROLLING_BIG || (this->actor.params & 0x1F) == GORON_CITY_LINK) {
         this->collider.info.bumperFlags = BUMP_ON;
-        this->actor.speedXZ = GET_INFTABLE(INFTABLE_11E) ? 6.0f : 3.6000001f;
+        this->actor.speed = GET_INFTABLE(INFTABLE_11E) ? 6.0f : 3.6000001f;
     } else {
-        this->actor.speedXZ = 6.0f;
+        this->actor.speed = 6.0f;
     }
     this->actor.flags |= ACTOR_FLAG_24;
     this->animTimer = 10;
     this->actor.shape.yOffset = 1800.0f;
-    this->actor.speedXZ += this->actor.speedXZ; // Speeding up
+    this->actor.speed += this->actor.speed; // Speeding up
     this->actionFunc = EnGo2_ContinueRolling;
 }
 
@@ -1377,7 +1377,7 @@ void EnGo2_StopRolling(EnGo2* this, PlayState* play) {
     this->unk_590 = 0;
     this->actionFunc = EnGo2_GroundRolling;
     this->actor.shape.yOffset = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 s32 EnGo2_IsFreeingGoronInFire(EnGo2* this, PlayState* play) {
@@ -1434,7 +1434,7 @@ s32 EnGo2_IsGoronLinkReversing(EnGo2* this) {
 }
 
 s32 EnGo2_IsRolling(EnGo2* this) {
-    if (this->interactInfo.talkState == NPC_TALK_STATE_IDLE || this->actor.speedXZ < 1.0f) {
+    if (this->interactInfo.talkState == NPC_TALK_STATE_IDLE || this->actor.speed < 1.0f) {
         return false;
     }
     if (EnGo2_IsRollingOnGround(this, 2, 20.0 / 3.0f, 0)) {
@@ -1698,7 +1698,7 @@ void EnGo2_GoronDmtBombFlowerAnimation(EnGo2* this, PlayState* play) {
     f32 float1 = this->skelAnime.endFrame;
     f32 float2 = this->skelAnime.curFrame * ((f32)0x8000 / float1);
 
-    this->actor.speedXZ = Math_SinS(float2);
+    this->actor.speed = Math_SinS(float2);
     if ((EnGo2_Orient(this, play)) && (this->waypoint == 0)) {
         EnGo2_GetItemAnimation(this, play);
     }
@@ -1718,7 +1718,7 @@ void EnGo2_ContinueRolling(EnGo2* this, PlayState* play) {
     if (((this->actor.params & 0x1F) != GORON_DMT_ROLLING_SMALL || !(this->actor.xyzDistToPlayerSq > SQ(float1))) &&
         DECR(this->animTimer) == 0) {
         this->actionFunc = EnGo2_SlowRolling;
-        this->actor.speedXZ *= 0.5f; // slowdown
+        this->actor.speed *= 0.5f; // slowdown
     }
     EnGo2_GetDustData(this, 2);
 }
@@ -1746,7 +1746,7 @@ void EnGo2_SlowRolling(EnGo2* this, PlayState* play) {
             EnGo2_StopRolling(this, play);
             return;
         }
-        Math_ApproachF(&this->actor.speedXZ, EnGo2_GetTargetXZSpeed(this), 0.4f, 0.6f);
+        Math_ApproachF(&this->actor.speed, EnGo2_GetTargetXZSpeed(this), 0.4f, 0.6f);
         this->actor.shape.rot = this->actor.world.rot;
     }
 }
@@ -1772,11 +1772,11 @@ void EnGo2_GroundRolling(EnGo2* this, PlayState* play) {
 
 void EnGo2_ReverseRolling(EnGo2* this, PlayState* play) {
     if (!EnGo2_IsRolling(this)) {
-        Math_ApproachF(&this->actor.speedXZ, 0.0f, 0.6f, 0.8f);
-        if (this->actor.speedXZ >= 1.0f) {
+        Math_ApproachF(&this->actor.speed, 0.0f, 0.6f, 0.8f);
+        if (this->actor.speed >= 1.0f) {
             EnGo2_GetDustData(this, 3);
         }
-        if ((s32)this->actor.speedXZ == 0) {
+        if ((s32)this->actor.speed == 0) {
             this->actor.world.rot.y ^= 0x8000;
             this->actor.shape.rot.y = this->actor.world.rot.y;
             this->reverse ^= 1;
@@ -1913,7 +1913,7 @@ void EnGo2_GoronFireGenericAction(EnGo2* this, PlayState* play) {
                 this->actor.shape.rot = this->actor.world.rot;
                 this->animTimer = 60;
                 this->actor.gravity = 0.0f;
-                this->actor.speedXZ = 2.0f;
+                this->actor.speed = 2.0f;
                 this->interactInfo.headRot = zeroVec;
                 this->interactInfo.torsoRot = zeroVec;
                 this->goronState++;
@@ -1936,7 +1936,7 @@ void EnGo2_GoronFireGenericAction(EnGo2* this, PlayState* play) {
                 Actor_MoveForward(&this->actor);
             } else {
                 this->animTimer = 0;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 if ((((this->actor.params & 0xFC00) >> 0xA) != 1) && (((this->actor.params & 0xFC00) >> 0xA) != 2) &&
                     (((this->actor.params & 0xFC00) >> 0xA) != 4) && (((this->actor.params & 0xFC00) >> 0xA) != 5) &&
                     (((this->actor.params & 0xFC00) >> 0xA) != 9) && (((this->actor.params & 0xFC00) >> 0xA) != 11)) {
@@ -2011,7 +2011,7 @@ s32 EnGo2_DrawRolling(EnGo2* this, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_go2.c", 2914);
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
-    speedXZ = this->actionFunc == EnGo2_ReverseRolling ? 0.0f : this->actor.speedXZ;
+    speedXZ = this->actionFunc == EnGo2_ReverseRolling ? 0.0f : this->actor.speed;
     Matrix_RotateZYX((play->state.frames * ((s16)speedXZ * 1400)), 0, this->actor.shape.rot.z, MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx, "../z_en_go2.c", 2926),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);

--- a/src/overlays/actors/ovl_En_Goma/z_en_goma.c
+++ b/src/overlays/actors/ovl_En_Goma/z_en_goma.c
@@ -128,7 +128,7 @@ void EnGoma_Init(Actor* thisx, PlayState* play) {
         this->eggScale = 1.0f;
         this->actor.velocity.y = Rand_ZeroOne() * 5.0f + 5.0f;
         this->actionFunc = EnGoma_Debris;
-        this->actor.speedXZ = Rand_ZeroOne() * 2.3f + 1.5f;
+        this->actor.speed = Rand_ZeroOne() * 2.3f + 1.5f;
         this->actionTimer = 30;
         this->actor.scale.x = Rand_ZeroOne() * 0.005f + 0.01f;
         this->actor.scale.y = Rand_ZeroOne() * 0.005f + 0.01f;
@@ -144,7 +144,7 @@ void EnGoma_Init(Actor* thisx, PlayState* play) {
         if (this->actor.params < 3) { // Spawned by boss
             this->actionFunc = EnGoma_EggFallToGround;
             this->invincibilityTimer = 10;
-            this->actor.speedXZ = 1.5f;
+            this->actor.speed = 1.5f;
         } else if (this->actor.params == 8 || this->actor.params == 6) {
             this->actionFunc = EnGoma_Egg;
             this->spawnNum = sSpawnNum++;
@@ -193,7 +193,7 @@ void EnGoma_SetupFlee(EnGoma* this) {
 
 void EnGoma_Flee(EnGoma* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
-    Math_ApproachF(&this->actor.speedXZ, 20.0f / 3.0f, 0.5f, 2.0f);
+    Math_ApproachF(&this->actor.speed, 20.0f / 3.0f, 0.5f, 2.0f);
     Math_ApproachS(&this->actor.world.rot.y, Actor_WorldYawTowardActor(&this->actor, &GET_PLAYER(play)->actor) + 0x8000,
                    3, 2000);
     Math_ApproachS(&this->actor.shape.rot.y, this->actor.world.rot.y, 2, 3000);
@@ -235,7 +235,7 @@ void EnGoma_EggFallToGround(EnGoma* this, PlayState* play) {
                 this->actionTimer = 3;
                 Math_ApproachF(&this->eggScale, 0.75f, 0.5f, 1.0f);
                 this->actor.velocity.y = 5.0f;
-                this->actor.speedXZ = 2.0f;
+                this->actor.speed = 2.0f;
             } else {
                 Math_ApproachF(&this->eggScale, 1.5f, 0.5f, 1.0f);
             }
@@ -259,9 +259,9 @@ void EnGoma_EggFallToGround(EnGoma* this, PlayState* play) {
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Math_ApproachZeroF(&this->actor.speedXZ, 0.2f, 0.05f);
+        Math_ApproachZeroF(&this->actor.speed, 0.2f, 0.05f);
     }
-    this->eggPitch += (this->actor.speedXZ * 0.1f);
+    this->eggPitch += (this->actor.speed * 0.1f);
     this->actor.shape.rot.y = this->actor.world.rot.y;
 }
 
@@ -306,7 +306,7 @@ void EnGoma_SetupHatch(EnGoma* this, PlayState* play) {
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnGoma_SpawnHatchDebris(this, play);
     this->eggScale = 1.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnGoma_Hatch(EnGoma* this, PlayState* play) {
@@ -328,7 +328,7 @@ void EnGoma_SetupHurt(EnGoma* this, PlayState* play) {
         this->actionTimer = 10;
     }
 
-    this->actor.speedXZ = 20.0f;
+    this->actor.speed = 20.0f;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer + 0x8000;
     if (this->actor.params < 6) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_BJR_DAM1);
@@ -341,7 +341,7 @@ void EnGoma_Hurt(EnGoma* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Math_ApproachZeroF(&this->actor.speedXZ, 1.0f, 2.0f);
+        Math_ApproachZeroF(&this->actor.speed, 1.0f, 2.0f);
     }
 
     if (this->actionTimer == 0) {
@@ -373,7 +373,7 @@ void EnGoma_Die(EnGoma* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Math_ApproachZeroF(&this->actor.speedXZ, 1.0f, 2.0f);
+        Math_ApproachZeroF(&this->actor.speed, 1.0f, 2.0f);
     }
 
     if (this->actionTimer == 17) {
@@ -401,7 +401,7 @@ void EnGoma_Dead(EnGoma* this, PlayState* play) {
     Vec3f pos;
 
     SkelAnime_Update(&this->skelanime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 1.0f, 2.0f);
+    Math_ApproachZeroF(&this->actor.speed, 1.0f, 2.0f);
 
     if (this->actionTimer == 2) {
         pos.x = this->actor.world.pos.x;
@@ -454,7 +454,7 @@ void EnGoma_PrepareJump(EnGoma* this, PlayState* play) {
     s16 targetAngle;
 
     SkelAnime_Update(&this->skelanime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
 
     targetAngle = Actor_WorldYawTowardActor(&this->actor, &GET_PLAYER(play)->actor);
     Math_ApproachS(&this->actor.world.rot.y, targetAngle, 2, 4000);
@@ -477,7 +477,7 @@ void EnGoma_Land(EnGoma* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Math_ApproachZeroF(&this->actor.speedXZ, 1.0f, 2.0f);
+        Math_ApproachZeroF(&this->actor.speed, 1.0f, 2.0f);
     }
     if (this->actionTimer == 0) {
         EnGoma_SetupStand(this);
@@ -500,7 +500,7 @@ void EnGoma_SetupJump(EnGoma* this) {
 void EnGoma_Jump(EnGoma* this, PlayState* play) {
     this->actor.flags |= ACTOR_FLAG_24;
     SkelAnime_Update(&this->skelanime);
-    Math_ApproachF(&this->actor.speedXZ, 10.0f, 0.5f, 5.0f);
+    Math_ApproachF(&this->actor.speed, 10.0f, 0.5f, 5.0f);
 
     if (this->actor.velocity.y <= 0.0f && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         EnGoma_SetupLand(this);
@@ -515,7 +515,7 @@ void EnGoma_Jump(EnGoma* this, PlayState* play) {
 
 void EnGoma_Stand(EnGoma* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+    Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
     Math_ApproachS(&this->actor.shape.rot.y, Actor_WorldYawTowardActor(&this->actor, &GET_PLAYER(play)->actor), 2,
                    3000);
 
@@ -535,7 +535,7 @@ void EnGoma_ChasePlayer(EnGoma* this, PlayState* play) {
         }
     }
 
-    Math_ApproachF(&this->actor.speedXZ, 10.0f / 3.0f, 0.5f, 2.0f);
+    Math_ApproachF(&this->actor.speed, 10.0f / 3.0f, 0.5f, 2.0f);
     Math_ApproachS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 3, 2000);
     Math_ApproachS(&this->actor.shape.rot.y, this->actor.world.rot.y, 2, 3000);
 
@@ -570,7 +570,7 @@ void EnGoma_Stunned(EnGoma* this, PlayState* play) {
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
         this->actor.velocity.y = 0.0f;
-        Math_ApproachZeroF(&this->actor.speedXZ, 0.5f, 2.0f);
+        Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
     }
 
     if (this->stunTimer == 0) {
@@ -615,7 +615,7 @@ void EnGoma_UpdateHit(EnGoma* this, PlayState* play) {
 
         if ((this->colCyl1.base.atFlags & AT_HIT) && this->actionFunc == EnGoma_Jump) {
             EnGoma_SetupLand(this);
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->actor.velocity.y = 0.0f;
         }
 
@@ -630,7 +630,7 @@ void EnGoma_UpdateHit(EnGoma* this, PlayState* play) {
                     if (this->actionFunc == EnGoma_Jump) {
                         EnGoma_SetupLand(this);
                         this->actor.velocity.y = 0.0f;
-                        this->actor.speedXZ = -5.0f;
+                        this->actor.speed = -5.0f;
                     } else {
                         Matrix_RotateY(BINANG_TO_RAD_ALT(player->actor.shape.rot.y), MTXMODE_NEW);
                         Matrix_MultVec3f(&sShieldKnockbackVel, &this->shieldKnockbackVel);

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
@@ -299,7 +299,7 @@ s32 EnGoroiwa_MoveAndFall(EnGoroiwa* this, PlayState* play) {
     s32 pad;
     Vec3s* nextPointPos;
 
-    Math_StepToF(&this->actor.speedXZ, R_EN_GOROIWA_SPEED * 0.01f, 0.3f);
+    Math_StepToF(&this->actor.speed, R_EN_GOROIWA_SPEED * 0.01f, 0.3f);
     func_8002D868(&this->actor);
     path = &play->pathList[this->actor.params & 0xFF];
     nextPointPos = (Vec3s*)SEGMENTED_TO_VIRTUAL(path->points) + this->nextWaypoint;
@@ -322,7 +322,7 @@ s32 EnGoroiwa_Move(EnGoroiwa* this, PlayState* play) {
     nextPointPosF.x = nextPointPos->x;
     nextPointPosF.y = nextPointPos->y;
     nextPointPosF.z = nextPointPos->z;
-    Math_StepToF(&this->actor.speedXZ, R_EN_GOROIWA_SPEED * 0.01f, 0.3f);
+    Math_StepToF(&this->actor.speed, R_EN_GOROIWA_SPEED * 0.01f, 0.3f);
     if (Math3D_Vec3fDistSq(&nextPointPosF, &this->actor.world.pos) < SQ(5.0f)) {
         Math_Vec3f_Diff(&nextPointPosF, &this->actor.world.pos, &posDiff);
     } else {
@@ -331,9 +331,9 @@ s32 EnGoroiwa_Move(EnGoroiwa* this, PlayState* play) {
         posDiff.z = nextPointPosF.z - currentPointPos->z;
     }
     EnGoroiwa_Vec3fNormalize(&this->actor.velocity, &posDiff);
-    this->actor.velocity.x *= this->actor.speedXZ;
-    this->actor.velocity.y *= this->actor.speedXZ;
-    this->actor.velocity.z *= this->actor.speedXZ;
+    this->actor.velocity.x *= this->actor.speed;
+    this->actor.velocity.y *= this->actor.speed;
+    this->actor.velocity.z *= this->actor.speed;
     nextPointReached = true;
     nextPointReached &= Math_StepToF(&this->actor.world.pos.x, nextPointPosF.x, fabsf(this->actor.velocity.x));
     nextPointReached &= Math_StepToF(&this->actor.world.pos.y, nextPointPosF.y, fabsf(this->actor.velocity.y));
@@ -637,7 +637,7 @@ void EnGoroiwa_SetupMoveAndFallToGround(EnGoroiwa* this) {
     EnGoroiwa_UpdateFlags(this, ENGOROIWA_ENABLE_OC);
     this->actor.gravity = -0.86f;
     this->actor.minVelocityY = -15.0f;
-    this->actor.speedXZ *= 0.15f;
+    this->actor.speed *= 0.15f;
     this->actor.velocity.y = 5.0f;
     this->rollRotSpeed = 1.0f;
 }
@@ -657,7 +657,7 @@ void EnGoroiwa_SetupWait(EnGoroiwa* this) {
     static s16 waitDurations[] = { 20, 6 };
 
     this->actionFunc = EnGoroiwa_Wait;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnGoroiwa_UpdateFlags(this, ENGOROIWA_ENABLE_OC);
     this->waitTimer = waitDurations[this->actor.home.rot.z & 1];
     this->rollRotSpeed = 0.0f;
@@ -676,7 +676,7 @@ void EnGoroiwa_SetupMoveUp(EnGoroiwa* this) {
     this->actionFunc = EnGoroiwa_MoveUp;
     EnGoroiwa_UpdateFlags(this, ENGOROIWA_ENABLE_AT | ENGOROIWA_ENABLE_OC);
     this->rollRotSpeed = 0.0f;
-    this->actor.velocity.y = fabsf(this->actor.speedXZ) * 0.1f;
+    this->actor.velocity.y = fabsf(this->actor.speed) * 0.1f;
 }
 
 void EnGoroiwa_MoveUp(EnGoroiwa* this, PlayState* play) {
@@ -690,7 +690,7 @@ void EnGoroiwa_MoveUp(EnGoroiwa* this, PlayState* play) {
     } else if (EnGoroiwa_MoveUpToNextWaypoint(this, play)) {
         EnGoroiwa_NextWaypoint(this, play);
         EnGoroiwa_SetupRoll(this);
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 }
 
@@ -699,7 +699,7 @@ void EnGoroiwa_SetupMoveDown(EnGoroiwa* this) {
     EnGoroiwa_UpdateFlags(this, ENGOROIWA_ENABLE_AT | ENGOROIWA_ENABLE_OC);
     this->rollRotSpeed = 0.3f;
     this->bounceCount = 0;
-    this->actor.velocity.y = fabsf(this->actor.speedXZ) * -0.3f;
+    this->actor.velocity.y = fabsf(this->actor.speed) * -0.3f;
     this->stateFlags |= ENGOROIWA_RETAIN_ROT_SPEED;
     this->stateFlags &= ~ENGOROIWA_IN_WATER;
 }
@@ -716,7 +716,7 @@ void EnGoroiwa_MoveDown(EnGoroiwa* this, PlayState* play) {
         EnGoroiwa_NextWaypoint(this, play);
         EnGoroiwa_SetupRoll(this);
         this->stateFlags &= ~ENGOROIWA_RETAIN_ROT_SPEED;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 }
 

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -659,7 +659,7 @@ void func_80A5455C(EnHeishi2* this, PlayState* play) {
         rotY = Rand_CenteredFloat(7000.0f) + this->actor.yawTowardsPlayer;
         bomb = (EnBom*)Actor_Spawn(&play->actorCtx, play, ACTOR_EN_BOM, pos.x, pos.y, pos.z, 0, rotY, 0, 0);
         if (bomb != NULL) {
-            bomb->actor.speedXZ = Rand_CenteredFloat(5.0f) + 10.0f;
+            bomb->actor.speed = Rand_CenteredFloat(5.0f) + 10.0f;
             bomb->actor.velocity.y = Rand_CenteredFloat(5.0f) + 10.0f;
         }
 

--- a/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
+++ b/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
@@ -172,7 +172,7 @@ void EnHeishi3_CatchStart(EnHeishi3* this, PlayState* play) {
     Animation_Change(&this->skelAnime, &gEnHeishiWalkAnim, 1.0f, 0.0f, (s16)frameCount, ANIMMODE_LOOP, -10.0f);
     this->caughtTimer = 20;
     this->actionFunc = func_80A55BD4;
-    this->actor.speedXZ = 2.5f;
+    this->actor.speed = 2.5f;
 }
 
 void func_80A55BD4(EnHeishi3* this, PlayState* play) {
@@ -183,7 +183,7 @@ void func_80A55BD4(EnHeishi3* this, PlayState* play) {
     }
     if (this->caughtTimer == 0) {
         this->actionFunc = EnHeishi3_ResetAnimationToIdle;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     } else {
         Math_SmoothStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 5, 3000, 0);
     }

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
@@ -186,12 +186,12 @@ void EnHintnuts_SetupRun(EnHintnuts* this) {
 void EnHintnuts_SetupTalk(EnHintnuts* this) {
     Animation_MorphToLoop(&this->skelAnime, &gHintNutsTalkAnim, -5.0f);
     this->actionFunc = EnHintnuts_Talk;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnHintnuts_SetupLeave(EnHintnuts* this, PlayState* play) {
     Animation_MorphToLoop(&this->skelAnime, &gHintNutsRunAnim, -5.0f);
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
     this->animFlagAndTimer = 100;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->collider.base.ocFlags1 &= ~OC1_ON;
@@ -350,7 +350,7 @@ void EnHintnuts_Run(EnHintnuts* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
     }
 
-    Math_StepToF(&this->actor.speedXZ, 7.5f, 1.0f);
+    Math_StepToF(&this->actor.speed, 7.5f, 1.0f);
     if (Math_SmoothStepToS(&this->actor.world.rot.y, this->unk_196, 1, 0xE38, 0xB6) == 0) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER) {
             this->unk_196 = Actor_WorldYawTowardPoint(&this->actor, &this->actor.home.pos);
@@ -375,7 +375,7 @@ void EnHintnuts_Run(EnHintnuts* this, PlayState* play) {
         EnHintnuts_SetupTalk(this);
     } else if (this->animFlagAndTimer == 0 && Actor_WorldDistXZToPoint(&this->actor, &this->actor.home.pos) < 20.0f &&
                fabsf(this->actor.world.pos.y - this->actor.home.pos.y) < 2.0f) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         if (this->actor.category == ACTORCAT_BG) {
             this->actor.flags &= ~(ACTOR_FLAG_0 | ACTOR_FLAG_3 | ACTOR_FLAG_16);
             this->actor.flags |= ACTOR_FLAG_0 | ACTOR_FLAG_2;

--- a/src/overlays/actors/ovl_En_Holl/z_en_holl.c
+++ b/src/overlays/actors/ovl_En_Holl/z_en_holl.c
@@ -206,7 +206,7 @@ void func_80A591C0(EnHoll* this, PlayState* play) {
                 func_8009728C(play, &play->roomCtx, this->actor.room) != 0) {
                 EnHoll_SetupAction(this, EnHoll_NextAction);
                 this->unk_14F = 1;
-                player->actor.speedXZ = 0.0f;
+                player->actor.speed = 0.0f;
             }
         }
     } else if (this->unk_14F != 0) {

--- a/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
+++ b/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
@@ -384,11 +384,11 @@ void EnHonotrap_FlameMove(EnHonotrap* this, PlayState* play) {
 
         tempVel = this->actor.velocity;
         Math3D_Vec3fReflect(&tempVel, &shieldNorm, &this->actor.velocity);
-        this->actor.speedXZ = this->speedMod * 0.5f;
+        this->actor.speed = this->speedMod * 0.5f;
         this->actor.world.rot.y = Math_Atan2S(this->actor.velocity.z, this->actor.velocity.x);
         EnHonotrap_SetupFlameVanish(this);
     } else if (this->collider.tris.base.atFlags & AT_HIT) {
-        this->actor.velocity.y = this->actor.speedXZ = 0.0f;
+        this->actor.velocity.y = this->actor.speed = 0.0f;
         EnHonotrap_SetupFlameVanish(this);
     } else if (this->timer <= 0) {
         EnHonotrap_SetupFlameVanish(this);
@@ -403,7 +403,7 @@ void EnHonotrap_FlameMove(EnHonotrap* this, PlayState* play) {
 void EnHonotrap_SetupFlameChase(EnHonotrap* this) {
     this->actionFunc = EnHonotrap_FlameChase;
 
-    this->actor.velocity.x = this->actor.velocity.y = this->actor.velocity.z = this->actor.speedXZ = 0.0f;
+    this->actor.velocity.x = this->actor.velocity.y = this->actor.velocity.z = this->actor.speed = 0.0f;
     this->actor.world.rot.x = this->actor.world.rot.y = this->actor.world.rot.z = 0;
 
     this->timer = 100;
@@ -413,7 +413,7 @@ void EnHonotrap_FlameChase(EnHonotrap* this, PlayState* play) {
     s32 pad;
 
     Math_ScaledStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 0x300);
-    Math_StepToF(&this->actor.speedXZ, 3.0f, 0.1f);
+    Math_StepToF(&this->actor.speed, 3.0f, 0.1f);
     this->actor.gravity = (-this->actor.yDistToPlayer < 10.0f) ? 0.08f : -0.08f;
     func_8002D868(&this->actor);
     if (this->actor.velocity.y > 1.0f) {
@@ -432,7 +432,7 @@ void EnHonotrap_FlameChase(EnHonotrap* this, PlayState* play) {
         this->actor.world.rot.y = ((shieldRot.y * 2) - this->actor.world.rot.y) + 0x8000;
         EnHonotrap_SetupFlameVanish(this);
     } else if (this->collider.cyl.base.atFlags & AT_HIT) {
-        this->actor.speedXZ *= 0.1f;
+        this->actor.speed *= 0.1f;
         this->actor.velocity.y *= 0.1f;
         EnHonotrap_SetupFlameVanish(this);
     } else if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || (this->timer <= 0)) {

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -453,7 +453,7 @@ s32 EnHorse_BgCheckBridgeJumpPoint(EnHorse* this, PlayState* play) {
     if (play->sceneId != SCENE_GERUDO_VALLEY) {
         return false;
     }
-    if (this->actor.speedXZ < 12.8f) {
+    if (this->actor.speed < 12.8f) {
         return false;
     }
     if (GET_EVENTCHKINF_CARPENTERS_FREE_ALL()) {
@@ -488,7 +488,7 @@ s32 EnHorse_CheckBridgeJumps(EnHorse* this, PlayState* play) {
     f32 xMax;
     s32 i;
 
-    if (this->actor.speedXZ < 12.8f) {
+    if (this->actor.speed < 12.8f) {
         return false;
     }
 
@@ -581,19 +581,19 @@ void EnHorse_UpdateIngoRaceInfo(EnHorse* this, PlayState* play, RaceInfo* raceIn
     sp50 = Actor_WorldDistXZToActor(&this->actor, &GET_PLAYER(play)->actor);
     relPlayerYaw = Actor_WorldYawTowardActor(&this->actor, &GET_PLAYER(play)->actor) - this->actor.world.rot.y;
     if (sp50 <= 200.0f || (fabsf(Math_SinS(relPlayerYaw)) < 0.8f && Math_CosS(relPlayerYaw) > 0.0f)) {
-        if (this->actor.speedXZ < this->ingoHorseMaxSpeed) {
-            this->actor.speedXZ += 0.47f;
+        if (this->actor.speed < this->ingoHorseMaxSpeed) {
+            this->actor.speed += 0.47f;
         } else {
-            this->actor.speedXZ -= 0.47f;
+            this->actor.speed -= 0.47f;
         }
         this->ingoRaceFlags |= 1;
         return;
     }
 
-    if (this->actor.speedXZ < raceInfo->waypoints[this->curRaceWaypoint].speed) {
-        this->actor.speedXZ = this->actor.speedXZ + 0.4f;
+    if (this->actor.speed < raceInfo->waypoints[this->curRaceWaypoint].speed) {
+        this->actor.speed = this->actor.speed + 0.4f;
     } else {
-        this->actor.speedXZ = this->actor.speedXZ - 0.4f;
+        this->actor.speed = this->actor.speed - 0.4f;
     }
     this->ingoRaceFlags &= ~0x1;
 }
@@ -812,7 +812,7 @@ void EnHorse_Init(Actor* thisx, PlayState* play2) {
     this->actor.gravity = -3.5f;
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawHorse, 20.0f);
     this->action = ENHORSE_ACT_IDLE;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Collider_InitCylinder(play, &this->cyl1);
     Collider_SetCylinder(play, &this->cyl1, &this->actor, &sCylinderInit1);
     Collider_InitCylinder(play, &this->cyl2);
@@ -933,7 +933,7 @@ void EnHorse_StartMountedIdle(EnHorse* this);
 void EnHorse_StartGalloping(EnHorse* this);
 
 void EnHorse_Frozen(EnHorse* this, PlayState* play) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->noInputTimer--;
     if (this->noInputTimer < 0) {
         this->cyl1.base.ocFlags1 |= OC1_ON;
@@ -948,7 +948,7 @@ void EnHorse_Frozen(EnHorse* this, PlayState* play) {
                 if (play->csCtx.state != 0) {
                     EnHorse_StartMountedIdle(this);
                 } else {
-                    this->actor.speedXZ = 8.0f;
+                    this->actor.speed = 8.0f;
                     EnHorse_StartGalloping(this);
                 }
             } else if (this->prevAction == 2) {
@@ -986,10 +986,10 @@ void EnHorse_UpdateSpeed(EnHorse* this, PlayState* play, f32 brakeDecel, f32 bra
     s16 turn;
 
     if (!EnHorse_PlayerCanMove(this, play)) {
-        if (this->actor.speedXZ > 8) {
-            this->actor.speedXZ -= decel;
-        } else if (this->actor.speedXZ < 0) {
-            this->actor.speedXZ = 0;
+        if (this->actor.speed > 8) {
+            this->actor.speed -= decel;
+        } else if (this->actor.speed < 0) {
+            this->actor.speed = 0;
         }
 
         return;
@@ -1000,17 +1000,17 @@ void EnHorse_UpdateSpeed(EnHorse* this, PlayState* play, f32 brakeDecel, f32 bra
     baseSpeed *= EnHorse_SlopeSpeedMultiplier(this, play);
     EnHorse_StickDirection(&this->curStick, &stickMag, &stickAngle);
     if (Math_CosS(stickAngle) <= brakeAngle) {
-        this->actor.speedXZ -= brakeDecel;
-        this->actor.speedXZ = this->actor.speedXZ < 0.0f ? 0.0f : this->actor.speedXZ;
+        this->actor.speed -= brakeDecel;
+        this->actor.speed = this->actor.speed < 0.0f ? 0.0f : this->actor.speed;
         return;
     }
 
     if (stickMag < minStickMag) {
         this->stateFlags &= ~ENHORSE_BOOST;
         this->stateFlags &= ~ENHORSE_BOOST_DECEL;
-        this->actor.speedXZ -= decel;
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ = 0.0f;
+        this->actor.speed -= decel;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed = 0.0f;
         }
 
         return;
@@ -1018,39 +1018,39 @@ void EnHorse_UpdateSpeed(EnHorse* this, PlayState* play, f32 brakeDecel, f32 bra
 
     if (this->stateFlags & ENHORSE_BOOST) {
         if ((16 - this->boostTimer) > 0) {
-            this->actor.speedXZ = (EnHorse_SlopeSpeedMultiplier(this, play) * this->boostSpeed - this->actor.speedXZ) /
-                                      (16 - this->boostTimer) +
-                                  this->actor.speedXZ;
+            this->actor.speed = (EnHorse_SlopeSpeedMultiplier(this, play) * this->boostSpeed - this->actor.speed) /
+                                    (16 - this->boostTimer) +
+                                this->actor.speed;
         } else {
-            this->actor.speedXZ = EnHorse_SlopeSpeedMultiplier(this, play) * this->boostSpeed;
+            this->actor.speed = EnHorse_SlopeSpeedMultiplier(this, play) * this->boostSpeed;
         }
 
-        if ((EnHorse_SlopeSpeedMultiplier(this, play) * this->boostSpeed) <= this->actor.speedXZ) {
+        if ((EnHorse_SlopeSpeedMultiplier(this, play) * this->boostSpeed) <= this->actor.speed) {
             this->stateFlags &= ~ENHORSE_BOOST;
             this->stateFlags |= ENHORSE_BOOST_DECEL;
         }
 
     } else if (this->stateFlags & ENHORSE_BOOST_DECEL) {
-        if (baseSpeed < this->actor.speedXZ) {
-            temp_f12 = this->actor.speedXZ;
-            this->actor.speedXZ = temp_f12 - 0.06f;
-        } else if (this->actor.speedXZ < baseSpeed) {
-            this->actor.speedXZ = baseSpeed;
+        if (baseSpeed < this->actor.speed) {
+            temp_f12 = this->actor.speed;
+            this->actor.speed = temp_f12 - 0.06f;
+        } else if (this->actor.speed < baseSpeed) {
+            this->actor.speed = baseSpeed;
             this->stateFlags &= ~ENHORSE_BOOST_DECEL;
         }
     } else {
-        this->actor.speedXZ +=
-            (this->actor.speedXZ <= baseSpeed * (1.0f / 54.0f) * stickMag ? 1.0f : -1.0f) * 50.0f * 0.01f;
-        if (baseSpeed < this->actor.speedXZ) {
-            this->actor.speedXZ = this->actor.speedXZ - decel;
-            if (this->actor.speedXZ < baseSpeed) {
-                this->actor.speedXZ = baseSpeed;
+        this->actor.speed +=
+            (this->actor.speed <= baseSpeed * (1.0f / 54.0f) * stickMag ? 1.0f : -1.0f) * 50.0f * 0.01f;
+        if (baseSpeed < this->actor.speed) {
+            this->actor.speed = this->actor.speed - decel;
+            if (this->actor.speed < baseSpeed) {
+                this->actor.speed = baseSpeed;
             }
         }
     }
 
     temp_f12 = *stickAnglePtr * (1 / 32236.f);
-    traction = 2.2f - (this->actor.speedXZ * (1.0f / this->boostSpeed));
+    traction = 2.2f - (this->actor.speed * (1.0f / this->boostSpeed));
     turn = *stickAnglePtr * temp_f12 * temp_f12 * traction;
     turn = CLAMP(turn, -turnSpeed * traction, turnSpeed * traction);
     this->actor.world.rot.y += turn;
@@ -1093,7 +1093,7 @@ void EnHorse_MountedIdle(EnHorse* this, PlayState* play) {
     f32 mag;
     s16 angle = 0;
 
-    this->actor.speedXZ = 0;
+    this->actor.speed = 0;
     EnHorse_StickDirection(&this->curStick, &mag, &angle);
     if (mag > 10.0f && EnHorse_PlayerCanMove(this, play) == true) {
         if (Math_CosS(angle) <= -0.5f) {
@@ -1133,7 +1133,7 @@ void EnHorse_MountedIdleWhinneying(EnHorse* this, PlayState* play) {
     f32 stickMag;
     s16 stickAngle = 0;
 
-    this->actor.speedXZ = 0;
+    this->actor.speed = 0;
     EnHorse_StickDirection(&this->curStick, &stickMag, &stickAngle);
     if (stickMag > 10.0f && EnHorse_PlayerCanMove(this, play) == true) {
         if (Math_CosS(stickAngle) <= -0.5f) {
@@ -1162,7 +1162,7 @@ void EnHorse_MountedTurn(EnHorse* this, PlayState* play) {
     s16 clampedYaw;
     s16 stickAngle;
 
-    this->actor.speedXZ = 0;
+    this->actor.speed = 0;
     EnHorse_PlayWalkingSfx(this);
     EnHorse_StickDirection(&this->curStick, &stickMag, &stickAngle);
     if (stickMag > 10.0f) {
@@ -1234,15 +1234,15 @@ void EnHorse_MountedWalk(EnHorse* this, PlayState* play) {
         (this->noInputTimer > 0.0f && this->noInputTimer < this->noInputTimerMax - 20.0f)) {
         EnHorse_UpdateSpeed(this, play, 0.3f, -0.5f, 10.0f, 0.06f, 3.0f, 400);
     } else {
-        this->actor.speedXZ = 3.0f;
+        this->actor.speed = 3.0f;
     }
 
-    if (this->actor.speedXZ == 0.0f) {
+    if (this->actor.speed == 0.0f) {
         this->stateFlags &= ~ENHORSE_FLAG_9;
         EnHorse_StartMountedIdleResetAnim(this);
         this->noInputTimer = 0;
         this->noInputTimerMax = 0;
-    } else if (this->actor.speedXZ > 3.0f) {
+    } else if (this->actor.speed > 3.0f) {
         this->stateFlags &= ~ENHORSE_FLAG_9;
         EnHorse_StartTrotting(this);
         this->noInputTimer = 0;
@@ -1258,10 +1258,10 @@ void EnHorse_MountedWalk(EnHorse* this, PlayState* play) {
 
     if (this->waitTimer <= 0) {
         this->stateFlags &= ~ENHORSE_FLAG_9;
-        this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.75f;
-        if (SkelAnime_Update(&this->skin.skelAnime) || this->actor.speedXZ == 0.0f) {
+        this->skin.skelAnime.playSpeed = this->actor.speed * 0.75f;
+        if (SkelAnime_Update(&this->skin.skelAnime) || this->actor.speed == 0.0f) {
             if (this->noInputTimer <= 0.0f) {
-                if (this->actor.speedXZ > 3.0f) {
+                if (this->actor.speed > 3.0f) {
                     EnHorse_StartTrotting(this);
                     this->noInputTimer = 0;
                     this->noInputTimerMax = 0;
@@ -1275,7 +1275,7 @@ void EnHorse_MountedWalk(EnHorse* this, PlayState* play) {
             }
         }
     } else {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->waitTimer--;
     }
 }
@@ -1301,17 +1301,17 @@ void EnHorse_MountedTrot(EnHorse* this, PlayState* play) {
 
     EnHorse_UpdateSpeed(this, play, 0.3f, -0.5f, 10.0f, 0.06f, 6.0f, 400);
     EnHorse_StickDirection(&this->curStick, &stickMag, &stickAngle);
-    if (this->actor.speedXZ < 3.0f) {
+    if (this->actor.speed < 3.0f) {
         EnHorse_StartWalkingInterruptable(this);
     }
 
-    this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.375f;
+    this->skin.skelAnime.playSpeed = this->actor.speed * 0.375f;
     if (SkelAnime_Update(&this->skin.skelAnime)) {
         EnHorse_PlayTrottingSfx(this);
         Rumble_Request(0.0f, 60, 8, 255);
-        if (this->actor.speedXZ >= 6.0f) {
+        if (this->actor.speed >= 6.0f) {
             EnHorse_StartGallopingInterruptable(this);
-        } else if (this->actor.speedXZ < 3.0f) {
+        } else if (this->actor.speed < 3.0f) {
             EnHorse_StartWalkingInterruptable(this);
         } else {
             EnHorse_MountedTrotReset(this);
@@ -1367,20 +1367,20 @@ void EnHorse_MountedGallop(EnHorse* this, PlayState* play) {
         EnHorse_UpdateSpeed(this, play, 0.3f, -0.5f, 10.0f, 0.06f, 8.0f, 0x190);
     } else if (this->noInputTimer > 0.0f) {
         this->noInputTimer -= 1;
-        this->actor.speedXZ = 8.0f;
+        this->actor.speed = 8.0f;
     }
-    if (this->actor.speedXZ < 6.0f) {
+    if (this->actor.speed < 6.0f) {
         EnHorse_StartTrotting(this);
     }
 
-    this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.3f;
+    this->skin.skelAnime.playSpeed = this->actor.speed * 0.3f;
     if (SkelAnime_Update(&this->skin.skelAnime)) {
         EnHorse_PlayGallopingSfx(this);
         Rumble_Request(0, 120, 8, 255);
         if (EnHorse_PlayerCanMove(this, play) == true) {
             if (stickMag >= 10.0f && Math_CosS(stickAngle) <= -0.5f) {
                 EnHorse_StartBraking(this, play);
-            } else if (this->actor.speedXZ < 6.0f) {
+            } else if (this->actor.speed < 6.0f) {
                 EnHorse_StartTrotting(this);
             } else {
                 EnHorse_MountedGallopReset(this);
@@ -1409,7 +1409,7 @@ void EnHorse_MountedRearing(EnHorse* this, PlayState* play) {
     f32 stickMag;
     s16 stickAngle;
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (this->curFrame > 25.0f) {
         if (!(this->stateFlags & ENHORSE_LAND2_SOUND)) {
             this->stateFlags |= ENHORSE_LAND2_SOUND;
@@ -1457,15 +1457,15 @@ void EnHorse_StartBraking(EnHorse* this, PlayState* play) {
 }
 
 void EnHorse_Stopping(EnHorse* this, PlayState* play) {
-    if (this->actor.speedXZ > 0.0f) {
-        this->actor.speedXZ = this->actor.speedXZ - 0.6f;
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ = 0.0f;
+    if (this->actor.speed > 0.0f) {
+        this->actor.speed = this->actor.speed - 0.6f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed = 0.0f;
         }
     }
 
     if (this->stateFlags & ENHORSE_STOPPING_NEIGH_SOUND && this->skin.skelAnime.curFrame > 29.0f) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         if (Rand_ZeroOne() > 0.5) {
             this->unk_21C = this->unk_228;
             if (this->stateFlags & ENHORSE_DRAW) {
@@ -1480,9 +1480,9 @@ void EnHorse_Stopping(EnHorse* this, PlayState* play) {
     }
 
     if (this->skin.skelAnime.curFrame > 29.0f) {
-        this->actor.speedXZ = 0.0f;
-    } else if (this->actor.speedXZ > 3.0f && this->stateFlags & ENHORSE_FORCE_REVERSING) {
-        this->actor.speedXZ = 3.0f;
+        this->actor.speed = 0.0f;
+    } else if (this->actor.speed > 3.0f && this->stateFlags & ENHORSE_FORCE_REVERSING) {
+        this->actor.speed = 3.0f;
     }
 
     if (SkelAnime_Update(&this->skin.skelAnime)) {
@@ -1524,7 +1524,7 @@ void EnHorse_Reverse(EnHorse* this, PlayState* play) {
             (this->noInputTimer > 0.0f && this->noInputTimer < this->noInputTimerMax - 20.0f)) {
             if (stickMag < 10.0f && this->noInputTimer <= 0.0f) {
                 EnHorse_StartMountedIdleResetAnim(this);
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 return;
             }
             if (stickMag < 10.0f) {
@@ -1532,7 +1532,7 @@ void EnHorse_Reverse(EnHorse* this, PlayState* play) {
             } else if (Math_CosS(stickAngle) > -0.5f) {
                 this->noInputTimerMax = 0;
                 EnHorse_StartMountedIdleResetAnim(this);
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 return;
             }
         } else if (stickMag < 10.0f) {
@@ -1540,13 +1540,13 @@ void EnHorse_Reverse(EnHorse* this, PlayState* play) {
         }
     } else if (player->actor.flags & ACTOR_FLAG_8) {
         EnHorse_StartMountedIdleResetAnim(this);
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         return;
     } else {
         stickAngle = -0x7FFF;
     }
 
-    this->actor.speedXZ = -2.0f;
+    this->actor.speed = -2.0f;
     turnAmount = 0x7FFF - stickAngle;
     turnAmount = CLAMP(turnAmount, -1200.0f, 1200.0f);
     this->actor.world.rot.y += turnAmount;
@@ -1558,7 +1558,7 @@ void EnHorse_Reverse(EnHorse* this, PlayState* play) {
             this->noInputTimerMax = 0;
         }
     }
-    this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.5f * 1.5f;
+    this->skin.skelAnime.playSpeed = this->actor.speed * 0.5f * 1.5f;
     if (SkelAnime_Update(&this->skin.skelAnime) && (f32)this->noInputTimer <= 0.0f &&
         EnHorse_PlayerCanMove(this, play) == true) {
         if (stickMag > 10.0f && Math_CosS(stickAngle) <= -0.5f) {
@@ -1617,7 +1617,7 @@ void EnHorse_LowJump(EnHorse* this, PlayState* play) {
 
     curFrame = this->skin.skelAnime.curFrame;
     this->stateFlags |= ENHORSE_JUMPING;
-    this->actor.speedXZ = 12.0f;
+    this->actor.speed = 12.0f;
     if (curFrame > 17.0f) {
         this->actor.gravity = -3.5f;
         if (this->actor.velocity.y == 0) {
@@ -1692,7 +1692,7 @@ void EnHorse_HighJump(EnHorse* this, PlayState* play) {
 
     curFrame = this->skin.skelAnime.curFrame;
     this->stateFlags |= ENHORSE_JUMPING;
-    this->actor.speedXZ = 13.0f;
+    this->actor.speed = 13.0f;
     if (curFrame > 23.0f) {
         this->actor.gravity = -3.5f;
         if (this->actor.velocity.y == 0) {
@@ -1764,7 +1764,7 @@ void EnHorse_Inactive(EnHorse* this, PlayState* play2) {
 
 void EnHorse_PlayIdleAnimation(EnHorse* this, s32 anim, f32 morphFrames, f32 startFrame) {
     this->action = ENHORSE_ACT_IDLE;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (anim != ENHORSE_ANIM_IDLE && anim != ENHORSE_ANIM_WHINNEY && anim != ENHORSE_ANIM_REARING) {
         anim = ENHORSE_ANIM_IDLE;
     }
@@ -1810,7 +1810,7 @@ void EnHorse_StartIdleRidable(EnHorse* this) {
 void EnHorse_StartMovingAnimation(EnHorse* this, s32 animId, f32 morphFrames, f32 startFrame);
 
 void EnHorse_Idle(EnHorse* this, PlayState* play) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnHorse_IdleAnimSounds(this, play);
 
     if (DREG(53) && this->type == HORSE_EPONA) {
@@ -1945,17 +1945,17 @@ void EnHorse_FollowPlayer(EnHorse* this, PlayState* play) {
     }
 
     if (this->animationIdx == ENHORSE_ANIM_GALLOP) {
-        this->actor.speedXZ = 8;
-        this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.3f;
+        this->actor.speed = 8;
+        this->skin.skelAnime.playSpeed = this->actor.speed * 0.3f;
     } else if (this->animationIdx == ENHORSE_ANIM_TROT) {
-        this->actor.speedXZ = 6;
-        this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.375f;
+        this->actor.speed = 6;
+        this->skin.skelAnime.playSpeed = this->actor.speed * 0.375f;
     } else if (this->animationIdx == ENHORSE_ANIM_WALK) {
-        this->actor.speedXZ = 3;
+        this->actor.speed = 3;
         EnHorse_PlayWalkingSfx(this);
-        this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.75f;
+        this->skin.skelAnime.playSpeed = this->actor.speed * 0.75f;
     } else {
-        this->actor.speedXZ = 0;
+        this->actor.speed = 0;
         this->skin.skelAnime.playSpeed = 1.0f;
     }
 
@@ -1989,7 +1989,7 @@ void EnHorse_UpdateIngoHorseAnim(EnHorse* this);
 void EnHorse_InitIngoHorse(EnHorse* this) {
     this->curRaceWaypoint = 0;
     this->soundTimer = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnHorse_UpdateIngoHorseAnim(this);
     this->unk_21C = this->unk_228;
     if (this->stateFlags & ENHORSE_DRAW) {
@@ -2021,17 +2021,17 @@ void EnHorse_UpdateIngoHorseAnim(EnHorse* this) {
 
     this->action = ENHORSE_ACT_INGO_RACE;
     this->stateFlags &= ~ENHORSE_SANDDUST_SOUND;
-    if (this->actor.speedXZ == 0.0f) {
+    if (this->actor.speed == 0.0f) {
         if (this->animationIdx != ENHORSE_ANIM_IDLE) {
             animChanged = true;
         }
         this->animationIdx = ENHORSE_ANIM_IDLE;
-    } else if (this->actor.speedXZ <= 3.0f) {
+    } else if (this->actor.speed <= 3.0f) {
         if (this->animationIdx != ENHORSE_ANIM_WALK) {
             animChanged = true;
         }
         this->animationIdx = ENHORSE_ANIM_WALK;
-    } else if (this->actor.speedXZ <= 6.0f) {
+    } else if (this->actor.speed <= 6.0f) {
         if (this->animationIdx != ENHORSE_ANIM_TROT) {
             animChanged = true;
         }
@@ -2044,13 +2044,13 @@ void EnHorse_UpdateIngoHorseAnim(EnHorse* this) {
     }
 
     if (this->animationIdx == ENHORSE_ANIM_WALK) {
-        animSpeed = this->actor.speedXZ * 0.5f;
+        animSpeed = this->actor.speed * 0.5f;
     } else if (this->animationIdx == ENHORSE_ANIM_TROT) {
-        animSpeed = this->actor.speedXZ * 0.25f;
+        animSpeed = this->actor.speed * 0.25f;
         Audio_PlaySfxGeneral(NA_SE_EV_HORSE_RUN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
     } else if (this->animationIdx == ENHORSE_ANIM_GALLOP) {
-        animSpeed = this->actor.speedXZ * 0.2f;
+        animSpeed = this->actor.speed * 0.2f;
         Audio_PlaySfxGeneral(NA_SE_EV_HORSE_RUN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
     } else {
@@ -2079,25 +2079,25 @@ void EnHorse_UpdateIngoRace(EnHorse* this, PlayState* play) {
 
     EnHorse_UpdateIngoRaceInfo(this, play, &sIngoRace);
     if (!this->inRace) {
-        this->actor.speedXZ = 0.0f;
-        this->rider->speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
+        this->rider->speed = 0.0f;
         if (this->animationIdx != ENHORSE_ANIM_IDLE) {
             EnHorse_UpdateIngoHorseAnim(this);
         }
     }
 
     if (this->animationIdx == ENHORSE_ANIM_WALK) {
-        playSpeed = this->actor.speedXZ * 0.5f;
+        playSpeed = this->actor.speed * 0.5f;
     } else if (this->animationIdx == ENHORSE_ANIM_TROT) {
-        playSpeed = this->actor.speedXZ * 0.25f;
+        playSpeed = this->actor.speed * 0.25f;
     } else if (this->animationIdx == ENHORSE_ANIM_GALLOP) {
-        playSpeed = this->actor.speedXZ * 0.2f;
+        playSpeed = this->actor.speed * 0.2f;
     } else {
         playSpeed = 1.0f;
     }
     this->skin.skelAnime.playSpeed = playSpeed;
     if (SkelAnime_Update(&this->skin.skelAnime) ||
-        (this->animationIdx == ENHORSE_ANIM_IDLE && this->actor.speedXZ != 0.0f)) {
+        (this->animationIdx == ENHORSE_ANIM_IDLE && this->actor.speed != 0.0f)) {
         EnHorse_UpdateIngoHorseAnim(this);
     }
 
@@ -2115,7 +2115,7 @@ void EnHorse_CsMoveInit(EnHorse* this, PlayState* play, CsCmdActorAction* action
     this->animationIdx = ENHORSE_ANIM_GALLOP;
     this->cutsceneAction = 1;
     Animation_PlayOnceSetSpeed(&this->skin.skelAnime, sAnimationHeaders[this->type][this->animationIdx],
-                               this->actor.speedXZ * 0.3f);
+                               this->actor.speed * 0.3f);
 }
 
 void EnHorse_CsPlayHighJumpAnim(EnHorse* this, PlayState* play);
@@ -2129,18 +2129,18 @@ void EnHorse_CsMoveToPoint(EnHorse* this, PlayState* play, CsCmdActorAction* act
     endPos.z = action->endPos.z;
     if (Math3D_Vec3f_DistXYZ(&endPos, &this->actor.world.pos) > speed) {
         EnHorse_RotateToPoint(this, play, &endPos, 400);
-        this->actor.speedXZ = speed;
+        this->actor.speed = speed;
         this->skin.skelAnime.playSpeed = speed * 0.3f;
     } else {
         this->actor.world.pos = endPos;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (SkelAnime_Update(&this->skin.skelAnime)) {
         EnHorse_PlayGallopingSfx(this);
         Rumble_Request(0.0f, 120, 8, 255);
         Animation_PlayOnceSetSpeed(&this->skin.skelAnime, sAnimationHeaders[this->type][this->animationIdx],
-                                   this->actor.speedXZ * 0.3f);
+                                   this->actor.speed * 0.3f);
     }
 }
 
@@ -2188,7 +2188,7 @@ void EnHorse_CsJump(EnHorse* this, PlayState* play, CsCmdActorAction* action) {
     }
     temp_f2 = this->skin.skelAnime.curFrame;
     this->stateFlags |= ENHORSE_JUMPING;
-    this->actor.speedXZ = 13.0f;
+    this->actor.speed = 13.0f;
     if (temp_f2 > 19.0f) {
         this->actor.gravity = -3.5f;
         if (this->actor.velocity.y == 0.0f) {
@@ -2246,7 +2246,7 @@ void EnHorse_CsRearingInit(EnHorse* this, PlayState* play, CsCmdActorAction* act
 }
 
 void EnHorse_CsRearing(EnHorse* this, PlayState* play, CsCmdActorAction* action) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (this->curFrame > 25.0f) {
         if (!(this->stateFlags & ENHORSE_LAND2_SOUND)) {
             this->stateFlags |= ENHORSE_LAND2_SOUND;
@@ -2278,7 +2278,7 @@ void EnHorse_WarpMoveInit(EnHorse* this, PlayState* play, CsCmdActorAction* acti
     this->animationIdx = ENHORSE_ANIM_GALLOP;
     this->cutsceneAction = 4;
     Animation_PlayOnceSetSpeed(&this->skin.skelAnime, sAnimationHeaders[this->type][this->animationIdx],
-                               this->actor.speedXZ * 0.3f);
+                               this->actor.speed * 0.3f);
 }
 
 void EnHorse_CsWarpMoveToPoint(EnHorse* this, PlayState* play, CsCmdActorAction* action) {
@@ -2290,18 +2290,18 @@ void EnHorse_CsWarpMoveToPoint(EnHorse* this, PlayState* play, CsCmdActorAction*
     endPos.z = action->endPos.z;
     if (Math3D_Vec3f_DistXYZ(&endPos, &this->actor.world.pos) > speed) {
         EnHorse_RotateToPoint(this, play, &endPos, 400);
-        this->actor.speedXZ = speed;
+        this->actor.speed = speed;
         this->skin.skelAnime.playSpeed = speed * 0.3f;
     } else {
         this->actor.world.pos = endPos;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (SkelAnime_Update(&this->skin.skelAnime)) {
         EnHorse_PlayGallopingSfx(this);
         Rumble_Request(0.0f, 120, 8, 255);
         Animation_PlayOnceSetSpeed(&this->skin.skelAnime, sAnimationHeaders[this->type][this->animationIdx],
-                                   this->actor.speedXZ * 0.3f);
+                                   this->actor.speed * 0.3f);
     }
 }
 
@@ -2326,7 +2326,7 @@ void EnHorse_CsWarpRearingInit(EnHorse* this, PlayState* play, CsCmdActorAction*
 }
 
 void EnHorse_CsWarpRearing(EnHorse* this, PlayState* play, CsCmdActorAction* action) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (this->curFrame > 25.0f) {
         if (!(this->stateFlags & ENHORSE_LAND2_SOUND)) {
             this->stateFlags |= ENHORSE_LAND2_SOUND;
@@ -2352,7 +2352,7 @@ void EnHorse_InitCutscene(EnHorse* this, PlayState* play) {
     this->playerControlled = false;
     this->action = ENHORSE_ACT_CS_UPDATE;
     this->cutsceneAction = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 s32 EnHorse_GetCutsceneFunctionIndex(s32 csAction) {
@@ -2428,12 +2428,12 @@ s32 EnHorse_UpdateHbaRaceInfo(EnHorse* this, PlayState* play, RaceInfo* raceInfo
     }
 
     this->actor.shape.rot.y = this->actor.world.rot.y;
-    if (this->actor.speedXZ < raceInfo->waypoints[this->curRaceWaypoint].speed && !(this->hbaFlags & 1)) {
-        this->actor.speedXZ += 0.4f;
+    if (this->actor.speed < raceInfo->waypoints[this->curRaceWaypoint].speed && !(this->hbaFlags & 1)) {
+        this->actor.speed += 0.4f;
     } else {
-        this->actor.speedXZ -= 0.4f;
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ = 0.0f;
+        this->actor.speed -= 0.4f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed = 0.0f;
         }
     }
     return 0;
@@ -2446,7 +2446,7 @@ void EnHorse_InitHorsebackArchery(EnHorse* this) {
     this->soundTimer = 0;
     this->curRaceWaypoint = 0;
     this->hbaTimer = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnHorse_UpdateHbaAnim(this);
 }
 
@@ -2455,17 +2455,17 @@ void EnHorse_UpdateHbaAnim(EnHorse* this) {
     f32 animSpeed;
 
     this->action = ENHORSE_ACT_HBA;
-    if (this->actor.speedXZ == 0.0f) {
+    if (this->actor.speed == 0.0f) {
         if (this->animationIdx != ENHORSE_ANIM_IDLE) {
             animChanged = true;
         }
         this->animationIdx = ENHORSE_ANIM_IDLE;
-    } else if (this->actor.speedXZ <= 3.0f) {
+    } else if (this->actor.speed <= 3.0f) {
         if (this->animationIdx != ENHORSE_ANIM_WALK) {
             animChanged = true;
         }
         this->animationIdx = ENHORSE_ANIM_WALK;
-    } else if (this->actor.speedXZ <= 6.0f) {
+    } else if (this->actor.speed <= 6.0f) {
         if (this->animationIdx != ENHORSE_ANIM_TROT) {
             animChanged = true;
         }
@@ -2478,14 +2478,14 @@ void EnHorse_UpdateHbaAnim(EnHorse* this) {
     }
 
     if (this->animationIdx == ENHORSE_ANIM_WALK) {
-        animSpeed = this->actor.speedXZ * 0.5f;
+        animSpeed = this->actor.speed * 0.5f;
     } else if (this->animationIdx == ENHORSE_ANIM_TROT) {
-        animSpeed = this->actor.speedXZ * 0.25f;
+        animSpeed = this->actor.speed * 0.25f;
         Audio_PlaySfxGeneral(NA_SE_EV_HORSE_RUN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         Rumble_Request(0.0f, 60, 8, 255);
     } else if (this->animationIdx == ENHORSE_ANIM_GALLOP) {
-        animSpeed = this->actor.speedXZ * 0.2f;
+        animSpeed = this->actor.speed * 0.2f;
         Audio_PlaySfxGeneral(NA_SE_EV_HORSE_RUN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         Rumble_Request(0.0f, 120, 8, 255);
@@ -2549,25 +2549,25 @@ void EnHorse_UpdateHorsebackArchery(EnHorse* this, PlayState* play) {
     }
 
     if (!this->hbaStarted) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         if (this->animationIdx != ENHORSE_ANIM_IDLE) {
             EnHorse_UpdateHbaAnim(this);
         }
     }
 
     if (this->animationIdx == ENHORSE_ANIM_WALK) {
-        playSpeed = this->actor.speedXZ * 0.5f;
+        playSpeed = this->actor.speed * 0.5f;
     } else if (this->animationIdx == ENHORSE_ANIM_TROT) {
-        playSpeed = this->actor.speedXZ * 0.25f;
+        playSpeed = this->actor.speed * 0.25f;
     } else if (this->animationIdx == ENHORSE_ANIM_GALLOP) {
-        playSpeed = this->actor.speedXZ * 0.2f;
+        playSpeed = this->actor.speed * 0.2f;
     } else {
         playSpeed = 1.0f;
     }
 
     this->skin.skelAnime.playSpeed = playSpeed;
     if (SkelAnime_Update(&this->skin.skelAnime) ||
-        (this->animationIdx == ENHORSE_ANIM_IDLE && this->actor.speedXZ != 0.0f)) {
+        (this->animationIdx == ENHORSE_ANIM_IDLE && this->actor.speed != 0.0f)) {
         EnHorse_UpdateHbaAnim(this);
     }
 }
@@ -2575,7 +2575,7 @@ void EnHorse_UpdateHorsebackArchery(EnHorse* this, PlayState* play) {
 void EnHorse_InitFleePlayer(EnHorse* this) {
     this->action = ENHORSE_ACT_FLEE_PLAYER;
     this->stateFlags |= ENHORSE_UNRIDEABLE;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnHorse_FleePlayer(EnHorse* this, PlayState* play) {
@@ -2600,39 +2600,39 @@ void EnHorse_FleePlayer(EnHorse* this, PlayState* play) {
     // Run home
     if (playerDistToHome > 300.0f) {
         if (distToHome > 150.0f) {
-            this->actor.speedXZ += 0.4f;
-            if (this->actor.speedXZ > 8.0f) {
-                this->actor.speedXZ = 8.0f;
+            this->actor.speed += 0.4f;
+            if (this->actor.speed > 8.0f) {
+                this->actor.speed = 8.0f;
             }
         } else {
-            this->actor.speedXZ -= 0.47f;
-            if (this->actor.speedXZ < 0.0f) {
-                this->actor.speedXZ = 0.0f;
+            this->actor.speed -= 0.47f;
+            if (this->actor.speed < 0.0f) {
+                this->actor.speed = 0.0f;
             }
         }
     } else {
         // Run away from Link
         if (distToPlayer < 300.0f) {
-            this->actor.speedXZ += 0.4f;
-            if (this->actor.speedXZ > 8.0f) {
-                this->actor.speedXZ = 8.0f;
+            this->actor.speed += 0.4f;
+            if (this->actor.speed > 8.0f) {
+                this->actor.speed = 8.0f;
             }
         } else {
-            this->actor.speedXZ -= 0.47f;
-            if (this->actor.speedXZ < 0.0f) {
-                this->actor.speedXZ = 0.0f;
+            this->actor.speed -= 0.47f;
+            if (this->actor.speed < 0.0f) {
+                this->actor.speed = 0.0f;
             }
         }
     }
 
-    if (this->actor.speedXZ >= 6.0f) { // hoof it
-        this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.3f;
+    if (this->actor.speed >= 6.0f) { // hoof it
+        this->skin.skelAnime.playSpeed = this->actor.speed * 0.3f;
         nextAnim = ENHORSE_ANIM_GALLOP;
-    } else if (this->actor.speedXZ >= 3.0f) { // trot
-        this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.375f;
+    } else if (this->actor.speed >= 3.0f) { // trot
+        this->skin.skelAnime.playSpeed = this->actor.speed * 0.375f;
         nextAnim = ENHORSE_ANIM_TROT;
-    } else if (this->actor.speedXZ > 0.1f) { // walk
-        this->skin.skelAnime.playSpeed = this->actor.speedXZ * 0.75f;
+    } else if (this->actor.speed > 0.1f) { // walk
+        this->skin.skelAnime.playSpeed = this->actor.speed * 0.75f;
         nextAnim = ENHORSE_ANIM_WALK;
         EnHorse_PlayWalkingSfx(this);
     } else { // idle
@@ -2752,7 +2752,7 @@ void EnHorse_BridgeJumpInit(EnHorse* this, PlayState* play) {
     this->bridgeJumpRelAngle = this->actor.world.rot.y - sBridgeJumps[this->bridgeJumpIdx].angle;
     this->bridgeJumpTimer = 0;
     this->actor.gravity = 0.0f;
-    this->actor.speedXZ = 0;
+    this->actor.speed = 0;
     Animation_Change(&this->skin.skelAnime, sAnimationHeaders[this->type][this->animationIdx], 1.5f, 0.0f,
                      Animation_GetLastFrame(sAnimationHeaders[this->type][this->animationIdx]), ANIMMODE_ONCE, -3.0f);
     this->unk_21C = this->unk_228;
@@ -2802,7 +2802,7 @@ void EnHorse_BridgeJumpMove(EnHorse* this, PlayState* play) {
 }
 
 void EnHorse_CheckBridgeJumpLanding(EnHorse* this, PlayState* play) {
-    this->actor.speedXZ = 8.0f;
+    this->actor.speed = 8.0f;
     this->skin.skelAnime.playSpeed = 1.5f;
     if (SkelAnime_Update(&this->skin.skelAnime)) {
         this->stateFlags &= ~ENHORSE_JUMPING;
@@ -2906,7 +2906,7 @@ void EnHorse_CheckFloors(EnHorse* this, PlayState* play) {
     f32 nx;
     f32 ny;
     f32 nz;
-    s32 galloping = this->actor.speedXZ > 8;
+    s32 galloping = this->actor.speed > 8;
     f32 dist;
     f32 waterHeight;
     WaterBox* waterBox;
@@ -2959,7 +2959,7 @@ void EnHorse_CheckFloors(EnHorse* this, PlayState* play) {
         pos = frontPos;
         pos.y = this->yFront;
         dist = Math3D_DistPlaneToPos(nx, ny, nz, this->actor.floorPoly->dist, &pos);
-        if ((frontFloor != this->actor.floorPoly) && (this->actor.speedXZ >= 0.0f)) {
+        if ((frontFloor != this->actor.floorPoly) && (this->actor.speed >= 0.0f)) {
             if ((!(this->stateFlags & ENHORSE_JUMPING) && dist < -40.0f) ||
                 (this->stateFlags & ENHORSE_JUMPING && dist < -200.0f)) {
                 EnHorse_ObstructMovement(this, play, 4, galloping);
@@ -2970,7 +2970,7 @@ void EnHorse_CheckFloors(EnHorse* this, PlayState* play) {
         pos = backPos;
         pos.y = this->yBack;
         dist = Math3D_DistPlaneToPos(nx, ny, nz, this->actor.floorPoly->dist, &pos);
-        if (((backFloor != this->actor.floorPoly) && (this->actor.speedXZ <= 0.0f) &&
+        if (((backFloor != this->actor.floorPoly) && (this->actor.speed <= 0.0f) &&
              !(this->stateFlags & ENHORSE_JUMPING) && (dist < -40.0f)) ||
             (this->stateFlags & ENHORSE_JUMPING && dist < -200.0f)) {
             EnHorse_ObstructMovement(this, play, 5, galloping);
@@ -2980,7 +2980,7 @@ void EnHorse_CheckFloors(EnHorse* this, PlayState* play) {
         if (ny < 0.81915206f || // cos(35 degrees)
             SurfaceType_IsHorseBlocked(&play->colCtx, this->actor.floorPoly, this->actor.floorBgId) ||
             SurfaceType_GetFloorType(&play->colCtx, this->actor.floorPoly, this->actor.floorBgId) == FLOOR_TYPE_7) {
-            if (this->actor.speedXZ >= 0.0f) {
+            if (this->actor.speed >= 0.0f) {
                 EnHorse_ObstructMovement(this, play, 4, galloping);
             } else {
                 EnHorse_ObstructMovement(this, play, 5, galloping);
@@ -3135,8 +3135,8 @@ void EnHorse_UpdateBgCheckInfo(EnHorse* this, PlayState* play) {
     // void 0 trick required to match, but is surely not real. revisit at a later time
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) &&
         Math_CosS(this->actor.wallYaw - ((void)0, this->actor.world).rot.y) < -0.3f) {
-        if (this->actor.speedXZ > 4.0f) {
-            this->actor.speedXZ -= 1.0f;
+        if (this->actor.speed > 4.0f) {
+            this->actor.speed -= 1.0f;
             Audio_PlaySfxGeneral(NA_SE_EV_HORSE_SANDDUST, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         }
@@ -3146,7 +3146,7 @@ void EnHorse_UpdateBgCheckInfo(EnHorse* this, PlayState* play) {
         return;
     }
 
-    if (this->actor.speedXZ < 0.0f) {
+    if (this->actor.speed < 0.0f) {
         return;
     }
 
@@ -3155,8 +3155,8 @@ void EnHorse_UpdateBgCheckInfo(EnHorse* this, PlayState* play) {
         return;
     }
 
-    if (this->actor.speedXZ > 8.0f) {
-        if (this->actor.speedXZ < 12.8f) {
+    if (this->actor.speed > 8.0f) {
+        if (this->actor.speed < 12.8f) {
             intersectDist = 160.0f;
             movingFast = 0;
         } else {
@@ -3298,9 +3298,8 @@ void EnHorse_UpdateBgCheckInfo(EnHorse* this, PlayState* play) {
     } else if (movingFast == false && obstacleHeight > 19.0f && obstacleHeight <= 40.0f) {
         EnHorse_Stub1(this);
         this->postDrawFunc = EnHorse_LowJumpInit;
-    } else if ((movingFast == true && this->actor.speedXZ < 13.8f && obstacleHeight > 19.0f &&
-                obstacleHeight <= 72.0f) ||
-               (this->actor.speedXZ > 13.8f && obstacleHeight <= 112.0f)) {
+    } else if ((movingFast == true && this->actor.speed < 13.8f && obstacleHeight > 19.0f && obstacleHeight <= 72.0f) ||
+               (this->actor.speed > 13.8f && obstacleHeight <= 112.0f)) {
 
         EnHorse_Stub2(this);
         this->postDrawFunc = EnHorse_HighJumpInit;
@@ -3430,7 +3429,7 @@ void EnHorse_TiltBody(EnHorse* this, PlayState* play) {
     s32 targetRoll;
     s16 turnVel;
 
-    speed = this->actor.speedXZ / this->boostSpeed;
+    speed = this->actor.speed / this->boostSpeed;
     turnVel = this->actor.shape.rot.y - this->lastYaw;
     targetRoll = -((s16)((1820.0f * speed) * (turnVel / 480.00003f)));
     rollDiff = targetRoll - this->actor.world.rot.z;
@@ -3522,8 +3521,8 @@ void EnHorse_Update(Actor* thisx, PlayState* play2) {
             }
         }
         if (this->jntSph.elements[0].info.ocElemFlags & OCELEM_HIT) {
-            if (thisx->speedXZ > 6.0f) {
-                thisx->speedXZ -= 1.0f;
+            if (thisx->speed > 6.0f) {
+                thisx->speed -= 1.0f;
             }
         }
         if (this->jntSph.base.acFlags & AC_HIT) {
@@ -3583,13 +3582,13 @@ void EnHorse_Update(Actor* thisx, PlayState* play2) {
             }
         }
 
-        if (thisx->speedXZ == 0.0f && !(this->stateFlags & ENHORSE_FLAG_19)) {
+        if (thisx->speed == 0.0f && !(this->stateFlags & ENHORSE_FLAG_19)) {
             thisx->colChkInfo.mass = 0xFF;
         } else {
             thisx->colChkInfo.mass = 0xFE;
         }
 
-        if (thisx->speedXZ >= 5.0f) {
+        if (thisx->speed >= 5.0f) {
             this->cyl1.base.atFlags |= AT_ON;
         } else {
             this->cyl1.base.atFlags &= ~AT_ON;

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -352,7 +352,7 @@ typedef struct {
     s16 x;
     s16 y;
     s16 z;
-    s16 speed;
+    s16 speedXZ;
     s16 angle;
 } RaceWaypoint;
 
@@ -590,10 +590,10 @@ void EnHorse_UpdateIngoRaceInfo(EnHorse* this, PlayState* play, RaceInfo* raceIn
         return;
     }
 
-    if (this->actor.speed < raceInfo->waypoints[this->curRaceWaypoint].speed) {
-        this->actor.speed = this->actor.speed + 0.4f;
+    if (this->actor.speed < raceInfo->waypoints[this->curRaceWaypoint].speedXZ) {
+        this->actor.speed += 0.4f;
     } else {
-        this->actor.speed = this->actor.speed - 0.4f;
+        this->actor.speed -= 0.4f;
     }
     this->ingoRaceFlags &= ~0x1;
 }
@@ -1042,7 +1042,7 @@ void EnHorse_UpdateSpeed(EnHorse* this, PlayState* play, f32 brakeDecel, f32 bra
         this->actor.speed +=
             (this->actor.speed <= baseSpeed * (1.0f / 54.0f) * stickMag ? 1.0f : -1.0f) * 50.0f * 0.01f;
         if (baseSpeed < this->actor.speed) {
-            this->actor.speed = this->actor.speed - decel;
+            this->actor.speed -= decel;
             if (this->actor.speed < baseSpeed) {
                 this->actor.speed = baseSpeed;
             }
@@ -1458,7 +1458,7 @@ void EnHorse_StartBraking(EnHorse* this, PlayState* play) {
 
 void EnHorse_Stopping(EnHorse* this, PlayState* play) {
     if (this->actor.speed > 0.0f) {
-        this->actor.speed = this->actor.speed - 0.6f;
+        this->actor.speed -= 0.6f;
         if (this->actor.speed < 0.0f) {
             this->actor.speed = 0.0f;
         }
@@ -2122,15 +2122,16 @@ void EnHorse_CsPlayHighJumpAnim(EnHorse* this, PlayState* play);
 
 void EnHorse_CsMoveToPoint(EnHorse* this, PlayState* play, CsCmdActorAction* action) {
     Vec3f endPos;
-    f32 speed = 8.0f;
+    f32 speedXZ = 8.0f;
 
     endPos.x = action->endPos.x;
     endPos.y = action->endPos.y;
     endPos.z = action->endPos.z;
-    if (Math3D_Vec3f_DistXYZ(&endPos, &this->actor.world.pos) > speed) {
+
+    if (Math3D_Vec3f_DistXYZ(&endPos, &this->actor.world.pos) > speedXZ) {
         EnHorse_RotateToPoint(this, play, &endPos, 400);
-        this->actor.speed = speed;
-        this->skin.skelAnime.playSpeed = speed * 0.3f;
+        this->actor.speed = speedXZ;
+        this->skin.skelAnime.playSpeed = speedXZ * 0.3f;
     } else {
         this->actor.world.pos = endPos;
         this->actor.speed = 0.0f;
@@ -2283,15 +2284,16 @@ void EnHorse_WarpMoveInit(EnHorse* this, PlayState* play, CsCmdActorAction* acti
 
 void EnHorse_CsWarpMoveToPoint(EnHorse* this, PlayState* play, CsCmdActorAction* action) {
     Vec3f endPos;
-    f32 speed = 8.0f;
+    f32 speedXZ = 8.0f;
 
     endPos.x = action->endPos.x;
     endPos.y = action->endPos.y;
     endPos.z = action->endPos.z;
-    if (Math3D_Vec3f_DistXYZ(&endPos, &this->actor.world.pos) > speed) {
+
+    if (Math3D_Vec3f_DistXYZ(&endPos, &this->actor.world.pos) > speedXZ) {
         EnHorse_RotateToPoint(this, play, &endPos, 400);
-        this->actor.speed = speed;
-        this->skin.skelAnime.playSpeed = speed * 0.3f;
+        this->actor.speed = speedXZ;
+        this->skin.skelAnime.playSpeed = speedXZ * 0.3f;
     } else {
         this->actor.world.pos = endPos;
         this->actor.speed = 0.0f;
@@ -2428,7 +2430,7 @@ s32 EnHorse_UpdateHbaRaceInfo(EnHorse* this, PlayState* play, RaceInfo* raceInfo
     }
 
     this->actor.shape.rot.y = this->actor.world.rot.y;
-    if (this->actor.speed < raceInfo->waypoints[this->curRaceWaypoint].speed && !(this->hbaFlags & 1)) {
+    if (this->actor.speed < raceInfo->waypoints[this->curRaceWaypoint].speedXZ && !(this->hbaFlags & 1)) {
         this->actor.speed += 0.4f;
     } else {
         this->actor.speed -= 0.4f;

--- a/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
+++ b/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
@@ -139,15 +139,15 @@ void func_80A686A8(EnHorseGanon* this, PlayState* play) {
     this->actor.shape.rot.y = this->actor.world.rot.y;
 
     if (Actor_WorldDistXZToActor(&this->actor, &GET_PLAYER(play)->actor) <= 300.0f) {
-        if (this->actor.speedXZ < 12.0f) {
-            this->actor.speedXZ += 1.0f;
+        if (this->actor.speed < 12.0f) {
+            this->actor.speed += 1.0f;
         } else {
-            this->actor.speedXZ -= 1.0f;
+            this->actor.speed -= 1.0f;
         }
-    } else if (this->actor.speedXZ < D_80A69248[this->unk_1EC].unk_6) {
-        this->actor.speedXZ += 0.5f;
+    } else if (this->actor.speed < D_80A69248[this->unk_1EC].unk_6) {
+        this->actor.speed += 0.5f;
     } else {
-        this->actor.speedXZ -= 0.5f;
+        this->actor.speed -= 0.5f;
     }
 }
 
@@ -173,7 +173,7 @@ void EnHorseGanon_Init(Actor* thisx, PlayState* play) {
     this->actor.gravity = -3.5f;
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawHorse, 20.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.focus.pos = this->actor.world.pos;
     this->action = 0;
     this->actor.focus.pos.y += 70.0f;
@@ -204,7 +204,7 @@ void func_80A68AC4(EnHorseGanon* this) {
 }
 
 void func_80A68AF0(EnHorseGanon* this, PlayState* play) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     SkelAnime_Update(&this->skin.skelAnime);
 }
 
@@ -214,12 +214,12 @@ void func_80A68B20(EnHorseGanon* this) {
 
     animationChanged = 0;
     this->action = 1;
-    if (this->actor.speedXZ <= 3.0f) {
+    if (this->actor.speed <= 3.0f) {
         if (this->currentAnimation != 2) {
             animationChanged = 1;
         }
         this->currentAnimation = 2;
-    } else if (this->actor.speedXZ <= 6.0f) {
+    } else if (this->actor.speed <= 6.0f) {
         if (this->currentAnimation != 3) {
             animationChanged = 1;
         }
@@ -232,13 +232,13 @@ void func_80A68B20(EnHorseGanon* this) {
     }
 
     if (this->currentAnimation == 2) {
-        sp30 = this->actor.speedXZ / 3.0f;
+        sp30 = this->actor.speed / 3.0f;
     } else if (this->currentAnimation == 3) {
-        sp30 = this->actor.speedXZ / 5.0f;
+        sp30 = this->actor.speed / 5.0f;
         Audio_PlaySfxGeneral(NA_SE_EV_HORSE_RUN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
     } else if (this->currentAnimation == 4) {
-        sp30 = this->actor.speedXZ / 7.0f;
+        sp30 = this->actor.speed / 7.0f;
         Audio_PlaySfxGeneral(NA_SE_EV_HORSE_RUN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
     } else {

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
@@ -123,11 +123,11 @@ f32 func_80A695A4(EnHorseLinkChild* this) {
     f32 result;
 
     if (this->animationIdx == 2) {
-        result = D_80A6AF64[this->animationIdx] * this->actor.speedXZ * (1.0f / 2.0f);
+        result = D_80A6AF64[this->animationIdx] * this->actor.speed * (1.0f / 2.0f);
     } else if (this->animationIdx == 3) {
-        result = D_80A6AF64[this->animationIdx] * this->actor.speedXZ * (1.0f / 3.0f);
+        result = D_80A6AF64[this->animationIdx] * this->actor.speed * (1.0f / 3.0f);
     } else if (this->animationIdx == 4) {
-        result = D_80A6AF64[this->animationIdx] * this->actor.speedXZ * (1.0f / 5.0f);
+        result = D_80A6AF64[this->animationIdx] * this->actor.speed * (1.0f / 5.0f);
     } else {
         result = D_80A6AF64[this->animationIdx];
     }
@@ -147,7 +147,7 @@ void EnHorseLinkChild_Init(Actor* thisx, PlayState* play) {
     Actor_SetScale(&this->actor, 0.005f);
     this->actor.gravity = -3.5f;
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawHorse, 20.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->action = 1;
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.focus.pos.y += 70.0f;
@@ -198,7 +198,7 @@ void func_80A6988C(EnHorseLinkChild* this) {
 }
 
 void func_80A698F4(EnHorseLinkChild* this, PlayState* play) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (SkelAnime_Update(&this->skin.skelAnime)) {
         func_80A6988C(this);
     }
@@ -206,7 +206,7 @@ void func_80A698F4(EnHorseLinkChild* this, PlayState* play) {
 
 void func_80A6993C(EnHorseLinkChild* this, s32 newAnimationIdx) {
     this->action = 2;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if (!((newAnimationIdx == 0) || (newAnimationIdx == 1))) {
         newAnimationIdx = 0;
@@ -245,7 +245,7 @@ void func_80A699FC(EnHorseLinkChild* this, PlayState* play) {
 void func_80A69B7C(EnHorseLinkChild* this) {
     this->action = 1;
     this->animationIdx = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_Change(&this->skin.skelAnime, sAnimations[this->animationIdx], func_80A695A4(this), 0.0f,
                      Animation_GetLastFrame(sAnimations[this->animationIdx]), ANIMMODE_ONCE, -5.0f);
 }
@@ -277,13 +277,13 @@ void func_80A69C18(EnHorseLinkChild* this, PlayState* play) {
             return;
         } else if ((distFromLink < 1000.0f) && (distFromLink >= 300.0f)) {
             newAnimationIdx = 4;
-            this->actor.speedXZ = 6.0f;
+            this->actor.speed = 6.0f;
         } else if ((distFromLink < 300.0f) && (distFromLink >= 150.0f)) {
             newAnimationIdx = 3;
-            this->actor.speedXZ = 4.0f;
+            this->actor.speed = 4.0f;
         } else if ((distFromLink < 150.0f) && (distFromLink >= 70.0f)) {
             newAnimationIdx = 2;
-            this->actor.speedXZ = 2.0f;
+            this->actor.speed = 2.0f;
             this->unk_1F0 = 0;
         } else {
             func_80A6993C(this, 1);
@@ -304,7 +304,7 @@ void func_80A69C18(EnHorseLinkChild* this, PlayState* play) {
 void func_80A69EC0(EnHorseLinkChild* this) {
     this->action = 3;
     this->animationIdx = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_Change(&this->skin.skelAnime, sAnimations[this->animationIdx], func_80A695A4(this), 0.0f,
                      Animation_GetLastFrame(sAnimations[this->animationIdx]), ANIMMODE_ONCE, -5.0f);
 }
@@ -374,16 +374,16 @@ void func_80A6A068(EnHorseLinkChild* this, PlayState* play) {
             if (distLinkFromHome > 250.0f) {
                 if (distFromHome >= 300.0f) {
                     newAnimationIdx = 4;
-                    this->actor.speedXZ = 6.0f;
+                    this->actor.speed = 6.0f;
                 } else if ((distFromHome < 300.0f) && (distFromHome >= 150.0f)) {
                     newAnimationIdx = 3;
-                    this->actor.speedXZ = 4.0f;
+                    this->actor.speed = 4.0f;
                 } else if ((distFromHome < 150.0f) && (distFromHome >= 70.0f)) {
                     newAnimationIdx = 2;
-                    this->actor.speedXZ = 2.0f;
+                    this->actor.speed = 2.0f;
                     this->unk_1F0 = 0;
                 } else {
-                    this->actor.speedXZ = 0.0f;
+                    this->actor.speed = 0.0f;
                     if (this->animationIdx == 0) {
                         newAnimationIdx = animationEnded == true ? 1 : 0;
                     } else {
@@ -393,16 +393,16 @@ void func_80A6A068(EnHorseLinkChild* this, PlayState* play) {
             } else {
                 if (distFromLink < 200.0f) {
                     newAnimationIdx = 4;
-                    this->actor.speedXZ = 6.0f;
+                    this->actor.speed = 6.0f;
                 } else if (distFromLink < 300.0f) {
                     newAnimationIdx = 3;
-                    this->actor.speedXZ = 4.0f;
+                    this->actor.speed = 4.0f;
                 } else if (distFromLink < 400.0f) {
                     newAnimationIdx = 2;
-                    this->actor.speedXZ = 2.0f;
+                    this->actor.speed = 2.0f;
                     this->unk_1F0 = 0;
                 } else {
-                    this->actor.speedXZ = 0.0f;
+                    this->actor.speed = 0.0f;
                     if (this->animationIdx == 0) {
                         newAnimationIdx = animationEnded == true ? 1 : 0;
                     } else {
@@ -411,7 +411,7 @@ void func_80A6A068(EnHorseLinkChild* this, PlayState* play) {
                 }
             }
         } else {
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             if (this->animationIdx == 0) {
                 newAnimationIdx = animationEnded == true ? 1 : 0;
             } else {
@@ -448,7 +448,7 @@ void func_80A6A5A4(EnHorseLinkChild* this, PlayState* play) {
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         func_80A6A724(this);
     } else {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         yawDiff = Actor_WorldYawTowardActor(&this->actor, &GET_PLAYER(play)->actor) - this->actor.world.rot.y;
         // 0.7071 = cos(pi/4)
         if ((Math_CosS(yawDiff) < 0.7071f) && (this->animationIdx == 2)) {
@@ -472,7 +472,7 @@ void func_80A6A724(EnHorseLinkChild* this) {
     this->action = 4;
     this->animationIdx = 2;
     this->unk_1E8 = false;
-    this->actor.speedXZ = 2.0f;
+    this->actor.speed = 2.0f;
     Animation_Change(&this->skin.skelAnime, sAnimations[this->animationIdx], func_80A695A4(this), 0.0f,
                      Animation_GetLastFrame(sAnimations[this->animationIdx]), ANIMMODE_ONCE, -5.0f);
 }
@@ -505,25 +505,25 @@ void func_80A6A7D0(EnHorseLinkChild* this, PlayState* play) {
         if (!this->unk_1E8) {
             if (dist >= 300.0f) {
                 newAnimationIdx = 4;
-                this->actor.speedXZ = 6.0f;
+                this->actor.speed = 6.0f;
             } else if (dist >= 150.0f) {
                 newAnimationIdx = 3;
-                this->actor.speedXZ = 4.0f;
+                this->actor.speed = 4.0f;
             } else {
                 newAnimationIdx = 2;
-                this->actor.speedXZ = 2.0f;
+                this->actor.speed = 2.0f;
                 this->unk_1F0 = 0;
             }
         } else {
             if (dist >= 300.0f) {
                 newAnimationIdx = 4;
-                this->actor.speedXZ = 6.0f;
+                this->actor.speed = 6.0f;
             } else if (dist >= 150.0f) {
                 newAnimationIdx = 3;
-                this->actor.speedXZ = 4.0f;
+                this->actor.speed = 4.0f;
             } else if (dist >= 70.0f) {
                 newAnimationIdx = 2;
-                this->actor.speedXZ = 2.0f;
+                this->actor.speed = 2.0f;
                 this->unk_1F0 = 0;
             } else {
                 func_80A6A4DC(this);

--- a/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
+++ b/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
@@ -164,11 +164,11 @@ f32 func_80A6B30C(EnHorseNormal* this) {
     f32 result;
 
     if (this->animationIdx == 4) {
-        result = D_80A6D4C8[this->animationIdx] * this->actor.speedXZ * (1 / 2.0f);
+        result = D_80A6D4C8[this->animationIdx] * this->actor.speed * (1 / 2.0f);
     } else if (this->animationIdx == 5) {
-        result = D_80A6D4C8[this->animationIdx] * this->actor.speedXZ * (1 / 3.0f);
+        result = D_80A6D4C8[this->animationIdx] * this->actor.speed * (1 / 3.0f);
     } else if (this->animationIdx == 6) {
-        result = D_80A6D4C8[this->animationIdx] * this->actor.speedXZ * (1 / 5.0f);
+        result = D_80A6D4C8[this->animationIdx] * this->actor.speed * (1 / 5.0f);
     } else {
         result = D_80A6D4C8[this->animationIdx];
     }
@@ -189,7 +189,7 @@ void EnHorseNormal_Init(Actor* thisx, PlayState* play) {
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.gravity = -3.5f;
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawHorse, 20.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.focus.pos.y += 70.0f;
     this->action = HORSE_CYCLE_ANIMATIONS;
@@ -280,7 +280,7 @@ void func_80A6B91C(EnHorseNormal* this, PlayState* play) {
     this->action = HORSE_FOLLOW_PATH;
     this->animationIdx = 6;
     this->waypoint = 0;
-    this->actor.speedXZ = 7.0f;
+    this->actor.speed = 7.0f;
     Animation_Change(&this->skin.skelAnime, sAnimations[this->animationIdx], func_80A6B30C(this), 0.0f,
                      Animation_GetLastFrame(sAnimations[this->animationIdx]), ANIMMODE_ONCE, 0.0f);
 }
@@ -323,7 +323,7 @@ void EnHorseNormal_NextAnimation(EnHorseNormal* this) {
 }
 
 void EnHorseNormal_CycleAnimations(EnHorseNormal* this, PlayState* play) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if (SkelAnime_Update(&this->skin.skelAnime)) {
         EnHorseNormal_NextAnimation(this);
@@ -335,7 +335,7 @@ void func_80A6BC48(EnHorseNormal* this) {
     this->animationIdx = 0;
     this->unk_21C = 0;
     this->unk_21E = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_218 = 0.0f;
     Animation_Change(&this->skin.skelAnime, sAnimations[this->animationIdx], func_80A6B30C(this), 0.0f,
                      Animation_GetLastFrame(sAnimations[this->animationIdx]), ANIMMODE_ONCE, 0.0f);
@@ -374,27 +374,27 @@ void EnHorseNormal_Wander(EnHorseNormal* this, PlayState* play) {
     switch (D_80A6D510[this->animationIdx]) {
         case 0:
             func_80A6BD7C(this);
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->unk_218 = 0.0f;
             break;
         case 1:
             if (Rand_ZeroOne() < 0.1f) {
                 this->unk_218 = 2.0f * Rand_ZeroOne() - 1.0f;
             }
-            this->actor.speedXZ += this->unk_218;
-            if (this->actor.speedXZ <= 0.0f) {
-                this->actor.speedXZ = 0.0f;
+            this->actor.speed += this->unk_218;
+            if (this->actor.speed <= 0.0f) {
+                this->actor.speed = 0.0f;
                 this->unk_218 = 0.0f;
                 phi_t0 = 0;
-            } else if (this->actor.speedXZ < 3.0f) {
+            } else if (this->actor.speed < 3.0f) {
                 func_80A6B250(this);
                 phi_t0 = 4;
-            } else if (this->actor.speedXZ < 6.0f) {
+            } else if (this->actor.speed < 6.0f) {
                 phi_t0 = 5;
-            } else if (this->actor.speedXZ < 8.0f) {
+            } else if (this->actor.speed < 8.0f) {
                 phi_t0 = 6;
             } else {
-                this->actor.speedXZ = 8.0f;
+                this->actor.speed = 8.0f;
                 phi_t0 = 6;
             }
             if (Rand_ZeroOne() < 0.1f || (this->unk_21E == 0 && ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
@@ -448,7 +448,7 @@ void EnHorseNormal_Wander(EnHorseNormal* this, PlayState* play) {
                         phi_t0 = 4;
                     } else {
                         phi_t0 = D_80A6D4F4[(s32)(Rand_ZeroOne() * 2)];
-                        this->actor.speedXZ = 0.0f;
+                        this->actor.speed = 0.0f;
                         this->unk_218 = 0.0f;
                     }
                     break;
@@ -486,7 +486,7 @@ void func_80A6C4CC(EnHorseNormal* this) {
     this->animationIdx = 0;
     this->unk_21C = 0;
     this->unk_21E = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_218 = 0.0f;
     Animation_Change(&this->skin.skelAnime, sAnimations[this->animationIdx], func_80A6B30C(this), 0.0f,
                      Animation_GetLastFrame(sAnimations[this->animationIdx]), ANIMMODE_ONCE, 0.0f);
@@ -519,7 +519,7 @@ void func_80A6C6B0(EnHorseNormal* this) {
     this->unk_21C = 0;
     this->unk_21E = 0;
     this->actor.flags |= ACTOR_FLAG_4 | ACTOR_FLAG_5;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_218 = 0.0f;
     Animation_Change(&this->skin.skelAnime, sAnimations[this->animationIdx], func_80A6B30C(this), 0.0f,
                      Animation_GetLastFrame(sAnimations[this->animationIdx]), ANIMMODE_ONCE, 0.0f);
@@ -592,7 +592,7 @@ void EnHorseNormal_Update(Actor* thisx, PlayState* play) {
     this->unk_204.y += 120.0f;
     Collider_UpdateCylinder(&this->actor, &this->bodyCollider);
     CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyCollider.base);
-    if (this->actor.speedXZ == 0.0f) {
+    if (this->actor.speed == 0.0f) {
         this->actor.colChkInfo.mass = MASS_IMMOVABLE;
     } else {
         this->actor.colChkInfo.mass = MASS_HEAVY;

--- a/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
+++ b/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
@@ -84,7 +84,7 @@ static CollisionCheckInfoInit sColChkInfoInit = { 10, 35, 100, MASS_HEAVY };
 
 typedef struct {
     /* 0x0 */ Vec3s pos;
-    /* 0x6 */ u8 speed;
+    /* 0x6 */ u8 speedXZ;
 } HorsePosSpeed; // size = 0x8
 
 // these seem to be valid coords on Hyrule field, along with target speeds
@@ -140,7 +140,7 @@ void EnHorseZelda_Move(EnHorseZelda* this, PlayState* play) {
         } else {
             this->actor.speed -= 1.0f;
         }
-    } else if (this->actor.speed < sHorseFieldPositions[this->fieldPosIndex].speed) {
+    } else if (this->actor.speed < sHorseFieldPositions[this->fieldPosIndex].speedXZ) {
         this->actor.speed += 0.5f;
     } else {
         this->actor.speed -= 0.5f;

--- a/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
+++ b/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
@@ -135,15 +135,15 @@ void EnHorseZelda_Move(EnHorseZelda* this, PlayState* play) {
     this->actor.shape.rot.y = this->actor.world.rot.y;
 
     if (Actor_WorldDistXZToActor(&this->actor, &GET_PLAYER(play)->actor) <= 300.0f) {
-        if (this->actor.speedXZ < 12.0f) {
-            this->actor.speedXZ += 1.0f;
+        if (this->actor.speed < 12.0f) {
+            this->actor.speed += 1.0f;
         } else {
-            this->actor.speedXZ -= 1.0f;
+            this->actor.speed -= 1.0f;
         }
-    } else if (this->actor.speedXZ < sHorseFieldPositions[this->fieldPosIndex].speed) {
-        this->actor.speedXZ += 0.5f;
+    } else if (this->actor.speed < sHorseFieldPositions[this->fieldPosIndex].speed) {
+        this->actor.speed += 0.5f;
     } else {
-        this->actor.speedXZ -= 0.5f;
+        this->actor.speed -= 0.5f;
     }
 }
 
@@ -154,7 +154,7 @@ void EnHorseZelda_Init(Actor* thisx, PlayState* play) {
     Actor_SetScale(&this->actor, 0.0115f);
     this->actor.gravity = -3.5f;
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawHorse, 20.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.focus.pos = this->actor.world.pos;
     this->action = 0;
     this->actor.focus.pos.y += 70.0f;
@@ -188,7 +188,7 @@ void EnHorseZelda_SetupStop(EnHorseZelda* this) {
 }
 
 void EnHorseZelda_Stop(EnHorseZelda* this, PlayState* play) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (SkelAnime_Update(&this->skin.skelAnime)) {
         EnHorseZelda_SetupStop(this);
     }
@@ -199,7 +199,7 @@ void EnHorseZelda_Spur(EnHorseZelda* this) {
 
     this->action = 1;
     this->animationIndex = 0;
-    speedMod = this->actor.speedXZ / 6.0f;
+    speedMod = this->actor.speed / 6.0f;
     Audio_PlaySfxGeneral(NA_SE_EV_HORSE_RUN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                          &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
     Animation_Change(&this->skin.skelAnime, sAnimationHeaders[this->animationIndex],
@@ -233,7 +233,7 @@ void EnHorseZelda_Update(Actor* thisx, PlayState* play) {
     s32 pad;
 
     sActionFuncs[this->action](this, play);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_MoveForward(&this->actor);
     Actor_UpdateBgCheckInfo(play, &this->actor, 20.0f, 55.0f, 100.0f,
                             UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2 | UPDBGCHECKINFO_FLAG_3 |

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -926,7 +926,7 @@ void EnHy_InitImpl(EnHy* this, PlayState* play) {
         switch (this->actor.params & 0x7F) {
             case ENHY_TYPE_BOJ_3:
                 if (this->path != NULL) {
-                    this->actor.speedXZ = 3.0f;
+                    this->actor.speed = 3.0f;
                 }
                 this->actionFunc = func_80A711B4;
                 break;
@@ -1009,7 +1009,7 @@ void EnHy_DoNothing(EnHy* this, PlayState* play) {
 void func_80A712C0(EnHy* this, PlayState* play) {
     if ((this->actor.xzDistToPlayer <= 100.0f) && (this->path != NULL)) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_7);
-        this->actor.speedXZ = 0.4f;
+        this->actor.speed = 0.4f;
         this->actionFunc = func_80A7134C;
     }
 
@@ -1028,7 +1028,7 @@ void func_80A7134C(EnHy* this, PlayState* play) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENHY_ANIM_7);
     }
 
-    this->actor.speedXZ = 0.4f;
+    this->actor.speed = 0.4f;
     distSq = Path_OrientAndGetDistSq(&this->actor, this->path, this->waypoint, &yaw);
     Math_SmoothStepToS(&this->actor.world.rot.y, yaw, 10, 1000, 1);
     this->actor.shape.rot = this->actor.world.rot;

--- a/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
+++ b/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
@@ -307,10 +307,10 @@ void EnIceHono_SetupActionSmallFlame(EnIceHono* this) {
     this->alpha = 255;
     if (this->actor.params == 1) {
         this->smallFlameTargetYScale = (Rand_ZeroOne() * 0.005f) + 0.004f;
-        this->actor.speedXZ = (Rand_ZeroOne() * 1.6f) + 0.5f;
+        this->actor.speed = (Rand_ZeroOne() * 1.6f) + 0.5f;
     } else {
         this->smallFlameTargetYScale = (Rand_ZeroOne() * 0.005f) + 0.003f;
-        this->actor.speedXZ = (Rand_ZeroOne() * 2.0f) + 0.5f;
+        this->actor.speed = (Rand_ZeroOne() * 2.0f) + 0.5f;
     }
 }
 
@@ -323,7 +323,7 @@ void EnIceHono_SmallFlameMove(EnIceHono* this, PlayState* play) {
         Math_StepToF(&this->actor.scale.y, 0.0001f, 0.00015f);
     }
     this->actor.scale.z = this->actor.scale.x;
-    Math_StepToF(&this->actor.speedXZ, 0, 0.06f);
+    Math_StepToF(&this->actor.speed, 0, 0.06f);
     Actor_MoveForward(&this->actor);
     Actor_UpdateBgCheckInfo(play, &this->actor, 10.0f, 10.0f, 0.0f, UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
 

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -292,7 +292,7 @@ void EnIk_SetupStandUp(EnIk* this) {
 
     Animation_Change(&this->skelAnime, &gIronKnuckleStandUpAnim, 0.0f, startFrame, endFrame, ANIMMODE_ONCE, 0.0f);
     this->unk_2F8 = 3;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnIk_SetupAction(this, EnIk_StandUp);
 }
 
@@ -323,7 +323,7 @@ void EnIk_SetupIdle(EnIk* this) {
 
     this->actor.flags |= ACTOR_FLAG_0 | ACTOR_FLAG_2;
     this->unk_2F8 = 4;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_Change(&this->skelAnime, &object_ik_Anim_00DD50, 0.0f, 0.0f, endFrame, ANIMMODE_LOOP, 4.0f);
     EnIk_SetupAction(this, EnIk_Idle);
 }
@@ -355,12 +355,12 @@ void EnIk_SetupWalkOrRun(EnIk* this) {
     if (this->armorStatusFlag == 0) {
         Animation_Change(&this->skelAnime, &gIronKnuckleWalkAnim, 1.0f, 0.0f,
                          Animation_GetLastFrame(&gIronKnuckleWalkAnim), ANIMMODE_LOOP, -4.0f);
-        this->actor.speedXZ = 0.9f;
+        this->actor.speed = 0.9f;
     } else {
         Animation_Change(&this->skelAnime, &gIronKnuckleRunAnim, 1.0f, 0.0f,
                          Animation_GetLastFrame(&gIronKnuckleRunAnim), ANIMMODE_LOOP, -4.0f);
         Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_DASH);
-        this->actor.speedXZ = 2.5f;
+        this->actor.speed = 2.5f;
     }
 
     this->actor.world.rot.y = this->actor.shape.rot.y;
@@ -439,7 +439,7 @@ void EnIk_SetupVerticalAttack(EnIk* this) {
 
     this->unk_2FF = 1;
     this->unk_2F8 = 6;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_Change(&this->skelAnime, &gIronKnuckleVerticalAttackAnim, 1.5f, 0.0f, endFrame, ANIMMODE_ONCE, -4.0f);
     EnIk_SetupAction(this, EnIk_VerticalAttack);
 }
@@ -509,7 +509,7 @@ void EnIk_SetupDoubleHorizontalAttack(EnIk* this) {
     this->unk_2FF = 2;
     this->unk_300 = 0;
     this->unk_2F8 = 6;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_Change(&this->skelAnime, &gIronKnuckleHorizontalAttackAnim, 0.0f, 0.0f, endFrame, ANIMMODE_ONCE_INTERP,
                      -6.0f);
     this->isBreakingProp = false;
@@ -571,7 +571,7 @@ void EnIk_SetupSingleHorizontalAttack(EnIk* this) {
 
     this->unk_2F8 = 1;
     this->unk_2FF = 3;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_Change(&this->skelAnime, &gIronKnuckleHorizontalAttackAnim, 0.5f, 13.0f, endFrame, ANIMMODE_ONCE_INTERP,
                      -4.0f);
     EnIk_SetupAction(this, EnIk_SingleHorizontalAttack);
@@ -601,7 +601,7 @@ void EnIk_SetupStopAndBlock(EnIk* this) {
 
     this->unk_2FE = 0;
     this->unk_2F8 = 9;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_Change(&this->skelAnime, &gIronKnuckleBlockAnim, 1.0f, 0.0f, endFrame, ANIMMODE_ONCE_INTERP, -4.0f);
     EnIk_SetupAction(this, EnIk_StopAndBlock);
 }
@@ -634,11 +634,11 @@ void EnIk_SetupReactToAttack(EnIk* this) {
     if (ABS(yawDiff) <= 0x4000) {
         Animation_Change(&this->skelAnime, &gIronKnuckleFrontHitAnim, 1.0f, 0.0f,
                          Animation_GetLastFrame(&gIronKnuckleFrontHitAnim), ANIMMODE_ONCE, -4.0f);
-        this->actor.speedXZ = -6.0f;
+        this->actor.speed = -6.0f;
     } else {
         Animation_Change(&this->skelAnime, &gIronKnuckleBackHitAnim, 1.0f, 0.0f,
                          Animation_GetLastFrame(&gIronKnuckleBackHitAnim), ANIMMODE_ONCE, -4.0f);
-        this->actor.speedXZ = 6.0f;
+        this->actor.speed = 6.0f;
     }
 
     this->unk_2FE = 0;
@@ -646,7 +646,7 @@ void EnIk_SetupReactToAttack(EnIk* this) {
 }
 
 void EnIk_ReactToAttack(EnIk* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 1.0f, 0.0f);
 
     if (BodyBreak_SpawnParts(&this->actor, &this->bodyBreak, play, this->actor.params + 4)) {
         this->bodyBreak.val = BODYBREAK_STATUS_FINISHED;
@@ -667,7 +667,7 @@ void EnIk_SetupDie(EnIk* this) {
 
     this->unk_2FE = 0;
     this->unk_2F8 = 2;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Animation_Change(&this->skelAnime, &gIronKnuckleDeathAnim, 1.0f, 0.0f, endFrame, ANIMMODE_ONCE, -4.0f);
     this->animationTimer = 24;
     Actor_PlaySfx(&this->actor, NA_SE_EN_IRONNACK_DEAD);

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -263,9 +263,9 @@ void EnInsect_SlowDown(EnInsect* this, PlayState* play) {
 
     type = this->actor.params & 3;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.1f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.1f, 0.5f, 0.0f);
 
-    playSpeed = (Rand_ZeroOne() * 0.8f) + (this->actor.speedXZ * 1.2f);
+    playSpeed = (Rand_ZeroOne() * 0.8f) + (this->actor.speed * 1.2f);
     this->skelAnime.playSpeed = CLAMP(playSpeed, 0.0f, 1.9f);
 
     SkelAnime_Update(&this->skelAnime);
@@ -299,7 +299,7 @@ void EnInsect_Crawl(EnInsect* this, PlayState* play) {
     s16 yaw;
     s16 type = this->actor.params & 3;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 1.5f, 0.1f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 1.5f, 0.1f, 0.5f, 0.0f);
 
     if (EnInsect_XZDistanceSquared(&this->actor.world.pos, &this->actor.home.pos) > 1600.0f ||
         (this->actionTimer < 4)) {
@@ -311,7 +311,7 @@ void EnInsect_Crawl(EnInsect* this, PlayState* play) {
     }
 
     this->actor.shape.rot.y = this->actor.world.rot.y;
-    this->skelAnime.playSpeed = CLAMP(this->actor.speedXZ * 1.4f, 0.7f, 1.9f);
+    this->skelAnime.playSpeed = CLAMP(this->actor.speed * 1.4f, 0.7f, 1.9f);
 
     SkelAnime_Update(&this->skelAnime);
 
@@ -346,7 +346,7 @@ void EnInsect_RunFromPlayer(EnInsect* this, PlayState* play) {
     s16 yaw;
     s16 playerIsClose = this->actor.xzDistToPlayer < 40.0f;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 1.8f, 0.1f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 1.8f, 0.1f, 0.5f, 0.0f);
 
     if (EnInsect_XZDistanceSquared(&this->actor.world.pos, &this->actor.home.pos) > 25600.0f || this->actionTimer < 4) {
         yaw = Math_Vec3f_Yaw(&this->actor.world.pos, &this->actor.home.pos);
@@ -368,7 +368,7 @@ void EnInsect_RunFromPlayer(EnInsect* this, PlayState* play) {
         Math_ScaledStepToS(&this->actor.world.rot.y, yaw, 2000);
     }
     this->actor.shape.rot.y = this->actor.world.rot.y;
-    this->skelAnime.playSpeed = CLAMP(this->actor.speedXZ * 1.6f, 0.8f, 1.9f);
+    this->skelAnime.playSpeed = CLAMP(this->actor.speed * 1.6f, 0.8f, 1.9f);
     SkelAnime_Update(&this->skelAnime);
 
     if (this->actionTimer <= 0 || !playerIsClose) {
@@ -384,7 +384,7 @@ void EnInsect_SetupCaught(EnInsect* this) {
     Actor_SetScale(&this->actor, 0.001f);
 
     this->actor.draw = NULL;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     EnInsect_SetCrawlAnim(this);
 
@@ -426,7 +426,7 @@ void EnInsect_Dig(EnInsect* this, PlayState* play) {
     s32 pad[2];
     Vec3f velocity;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.1f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.1f, 0.5f, 0.0f);
     Math_StepToS(&this->actor.shape.rot.x, 10922, 352);
 
     Actor_SetScale(&this->actor, CLAMP_MIN(this->actor.scale.x - 0.0002f, 0.001f));
@@ -472,9 +472,9 @@ void EnInsect_WalkOnWater(EnInsect* this, PlayState* play) {
     type = this->actor.params & 3;
 
     if (this->actionTimer > 80) {
-        Math_StepToF(&this->actor.speedXZ, 0.6f, 0.08f);
+        Math_StepToF(&this->actor.speed, 0.6f, 0.08f);
     } else {
-        Math_StepToF(&this->actor.speedXZ, 0.0f, 0.02f);
+        Math_StepToF(&this->actor.speed, 0.0f, 0.02f);
     }
     this->actor.velocity.y = 0.0f;
     this->actor.world.pos.y += this->actor.yDistToWater;
@@ -523,7 +523,7 @@ void EnInsect_SetupDrown(EnInsect* this) {
     this->actionTimer = 100;
     EnInsect_SetCrawlAnim(this);
     this->actor.velocity.y = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.minVelocityY = -0.8f;
     this->actor.gravity = -0.04f;
     this->insectFlags &= ~(INSECT_FLAG_0 | INSECT_FLAG_1);
@@ -635,21 +635,21 @@ void EnInsect_Dropped(EnInsect* this, PlayState* play) {
     Actor_SetScale(&this->actor, CLAMP_MAX(thisTemp->actor.scale.x + 0.0008f, 0.01f));
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Math_SmoothStepToF(&this->actor.speedXZ, this->unk_324, 0.1f, 0.5f, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, this->unk_324, 0.1f, 0.5f, 0.0f);
         Math_ScaledStepToS(&this->actor.world.rot.y, this->unk_328, 2000);
         sp50 = Math_ScaledStepToS(&this->actor.world.rot.x, 0, 2000);
         this->actor.shape.rot.y = this->actor.world.rot.y;
         this->actor.shape.rot.x = this->actor.world.rot.x;
     } else {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.1f, 0.5f, 0.0f);
-        this->actor.speedXZ += (Rand_ZeroOne() - 0.5f) * 0.14f;
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.1f, 0.5f, 0.0f);
+        this->actor.speed += (Rand_ZeroOne() - 0.5f) * 0.14f;
         this->actor.velocity.y += Rand_ZeroOne() * 0.12f;
         this->actor.world.rot.y += this->unk_316;
         this->actor.shape.rot.y = this->actor.world.rot.y;
         this->actor.shape.rot.x -= 2000;
     }
 
-    phi_f2 = Rand_ZeroOne() * 0.5f + this->actor.speedXZ * 1.3f;
+    phi_f2 = Rand_ZeroOne() * 0.5f + this->actor.speed * 1.3f;
     if (phi_f2 < 0.0f) {
         this->skelAnime.playSpeed = 0.0f;
     } else {

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
@@ -403,8 +403,8 @@ void EnIshi_LiftedUp(EnIshi* this, PlayState* play) {
 }
 
 void EnIshi_SetupFly(EnIshi* this) {
-    this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speedXZ;
-    this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speedXZ;
+    this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speed;
+    this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speed;
     if ((this->actor.params & 1) == ROCK_SMALL) {
         sRotSpeedX = (Rand_ZeroOne() - 0.5f) * 16000.0f;
         sRotSpeedY = (Rand_ZeroOne() - 0.5f) * 2400.0f;

--- a/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
+++ b/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
@@ -385,7 +385,7 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                     piece->actionState = ENKANBAN_AIR;
                     piece->actor.world.rot.y = (s16)Rand_CenteredFloat(0x3000) + this->actor.yawTowardsPlayer + 0x8000;
                     piece->actor.velocity.y = Rand_ZeroFloat(2.0f) + 3.0f;
-                    piece->actor.speedXZ = Rand_ZeroFloat(2.0f) + 3.0f;
+                    piece->actor.speed = Rand_ZeroFloat(2.0f) + 3.0f;
                     if (piece->partCount >= 4) {
                         piece->bounceX = (s16)Rand_ZeroFloat(10.0f) + 6;
                         piece->bounceZ = (s16)Rand_ZeroFloat(10.0f) + 6;
@@ -498,7 +498,7 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                 this->spinVel.z = -0xC00;
             }
             if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-                this->actor.speedXZ *= -0.5f;
+                this->actor.speed *= -0.5f;
                 Actor_PlaySfx(&this->actor, NA_SE_EV_WOODPLATE_BOUND);
             }
             if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER_TOUCH) {
@@ -525,7 +525,7 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                 } else {
                     this->actor.velocity.y = 0.0f;
                 }
-                this->actor.speedXZ *= 0.7f;
+                this->actor.speed *= 0.7f;
                 if ((this->spinRot.x == 0) && (this->bounceX != 0)) {
                     this->spinVel.x = this->bounceX * 0x200;
                     if (this->bounceX != 0) {
@@ -597,35 +597,35 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                 s32 rippleDelay;
                 s32 rippleScale;
 
-                if ((player->actor.speedXZ > 0.0f) && (player->actor.world.pos.y < this->actor.world.pos.y) &&
+                if ((player->actor.speed > 0.0f) && (player->actor.world.pos.y < this->actor.world.pos.y) &&
                     (this->actor.xyzDistToPlayerSq < SQ(50.0f))) {
-                    Math_ApproachF(&this->actor.speedXZ, player->actor.speedXZ, 1.0f, 0.2f);
-                    if (this->actor.speedXZ > 1.0f) {
-                        this->actor.speedXZ = 1.0f;
+                    Math_ApproachF(&this->actor.speed, player->actor.speed, 1.0f, 0.2f);
+                    if (this->actor.speed > 1.0f) {
+                        this->actor.speed = 1.0f;
                     }
                     if (Math_SmoothStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer + 0x8000, 1, 0x1000,
                                            0) > 0) {
-                        this->spinVel.y = this->actor.speedXZ * 1000.0f;
+                        this->spinVel.y = this->actor.speed * 1000.0f;
                     } else {
-                        this->spinVel.y = this->actor.speedXZ * -1000.0f;
+                        this->spinVel.y = this->actor.speed * -1000.0f;
                     }
                 }
                 if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-                    this->actor.speedXZ = 0.0f;
+                    this->actor.speed = 0.0f;
                 }
                 Actor_MoveForward(&this->actor);
-                if (this->actor.speedXZ != 0.0f) {
+                if (this->actor.speed != 0.0f) {
                     Actor_UpdateBgCheckInfo(play, &this->actor, 10.0f, 10.0f, 50.0f,
                                             UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
                     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-                        this->actor.speedXZ *= -0.5f;
+                        this->actor.speed *= -0.5f;
                         if (this->spinVel.y > 0) {
                             this->spinVel.y = -0x7D0;
                         } else {
                             this->spinVel.y = 0x7D0;
                         }
                     }
-                    Math_ApproachZeroF(&this->actor.speedXZ, 1.0f, 0.15f);
+                    Math_ApproachZeroF(&this->actor.speed, 1.0f, 0.15f);
                 }
                 this->actor.shape.rot.y += this->spinVel.y;
                 Math_ApproachS(&this->spinVel.y, 0, 1, 0x3A);
@@ -634,9 +634,9 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                 Math_ApproachS(&this->spinRot.z, Math_CosS(3000 * this->frameCount) * 500.0f, 2, 0x1000);
                 Math_ApproachZeroF(&this->floorRot.x, 0.5f, 0.2f);
                 Math_ApproachZeroF(&this->floorRot.z, 0.5f, 0.2f);
-                if (fabsf(this->actor.speedXZ) > 1.0f) {
+                if (fabsf(this->actor.speed) > 1.0f) {
                     rippleDelay = 0;
-                } else if (fabsf(this->actor.speedXZ) > 0.5f) {
+                } else if (fabsf(this->actor.speed) > 0.5f) {
                     rippleDelay = 3;
                 } else {
                     rippleDelay = 7;
@@ -661,12 +661,12 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                     this->bounceX = (s16)Rand_ZeroFloat(10.0f) + 6;
                     this->bounceZ = (s16)Rand_ZeroFloat(10.0f) + 6;
                     this->actor.velocity.y = 2.0f + hammerStrength;
-                    this->actor.speedXZ = Rand_ZeroFloat(1.0f);
+                    this->actor.speed = Rand_ZeroFloat(1.0f);
                 } else {
                     this->bounceX = (s16)Rand_ZeroFloat(7.0f) + 3;
                     this->bounceZ = (s16)Rand_ZeroFloat(7.0f) + 3;
                     this->actor.velocity.y = 3.0f + hammerStrength;
-                    this->actor.speedXZ = Rand_ZeroFloat(1.5f);
+                    this->actor.speed = Rand_ZeroFloat(1.5f);
                 }
                 this->spinVel.y = Rand_CenteredFloat(0x1800);
                 if (Rand_ZeroOne() < 0.5f) {
@@ -700,12 +700,12 @@ void EnKanban_Update(Actor* thisx, PlayState* play2) {
                             this->bounceX = (s16)Rand_ZeroFloat(10.0f) + 6;
                             this->bounceZ = (s16)Rand_ZeroFloat(10.0f) + 6;
                             this->actor.velocity.y = 2.5f + bombStrength;
-                            this->actor.speedXZ = 3.0f + bombStrength;
+                            this->actor.speed = 3.0f + bombStrength;
                         } else {
                             this->bounceX = (s16)Rand_ZeroFloat(7.0f) + 3;
                             this->bounceZ = (s16)Rand_ZeroFloat(7.0f) + 3;
                             this->actor.velocity.y = 5.0f + bombStrength;
-                            this->actor.speedXZ = 4.0f + bombStrength;
+                            this->actor.speed = 4.0f + bombStrength;
                         }
                         this->spinVel.y = Rand_CenteredFloat(0x1800);
                         if (Rand_ZeroOne() < 0.5f) {

--- a/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
+++ b/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
@@ -176,7 +176,7 @@ void EnKarebaba_SetupDying(EnKarebaba* this) {
     this->actor.gravity = -0.8f;
     this->actor.velocity.y = 4.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x8000;
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_DEKU_JR_DEAD);
     this->actor.flags |= ACTOR_FLAG_4 | ACTOR_FLAG_5;
     this->actionFunc = EnKarebaba_Dying;
@@ -318,7 +318,7 @@ void EnKarebaba_Dying(EnKarebaba* this, PlayState* play) {
     Vec3f position;
     Vec3f rotation;
 
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.1f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.1f);
 
     if (this->actor.params == 0) {
         Math_ScaledStepToS(&this->actor.shape.rot.x, 0x4800, 0x71C);
@@ -327,7 +327,7 @@ void EnKarebaba_Dying(EnKarebaba* this, PlayState* play) {
         if (this->actor.scale.x > 0.005f &&
             ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) || (this->actor.bgCheckFlags & BGCHECKFLAG_WALL))) {
             this->actor.scale.x = this->actor.scale.y = this->actor.scale.z = 0.0f;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->actor.flags &= ~(ACTOR_FLAG_0 | ACTOR_FLAG_2);
             EffectSsHahen_SpawnBurst(play, &this->actor.world.pos, 3.0f, 0, 12, 5, 15, HAHEN_OBJECT_DEFAULT, 10, NULL);
         }

--- a/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
+++ b/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
@@ -347,8 +347,8 @@ void EnKusa_LiftedUp(EnKusa* this, PlayState* play) {
     if (Actor_HasNoParent(&this->actor, play)) {
         this->actor.room = play->roomCtx.curRoom.num;
         EnKusa_SetupFall(this);
-        this->actor.velocity.x = this->actor.speedXZ * Math_SinS(this->actor.world.rot.y);
-        this->actor.velocity.z = this->actor.speedXZ * Math_CosS(this->actor.world.rot.y);
+        this->actor.velocity.x = this->actor.speed * Math_SinS(this->actor.world.rot.y);
+        this->actor.velocity.z = this->actor.speed * Math_CosS(this->actor.world.rot.y);
         this->actor.colChkInfo.mass = 240;
         this->actor.gravity = -0.1f;
         EnKusa_UpdateVelY(this);

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -383,7 +383,7 @@ void EnKz_SetupMweep(EnKz* this, PlayState* play) {
     subCamEye.z += 260.0f;
     Play_SetCameraAtEye(play, this->subCamId, &subCamAt, &subCamEye);
     func_8002DF54(play, &this->actor, PLAYER_CSMODE_8);
-    this->actor.speedXZ = 0.1f;
+    this->actor.speed = 0.1f;
     this->actionFunc = EnKz_Mweep;
 }
 
@@ -403,7 +403,7 @@ void EnKz_Mweep(EnKz* this, PlayState* play) {
         Inventory_ReplaceItem(play, ITEM_BOTTLE_RUTOS_LETTER, ITEM_BOTTLE_EMPTY);
         EnKz_SetMovedPos(this, play);
         SET_EVENTCHKINF(EVENTCHKINF_33);
-        this->actor.speedXZ = 0.0;
+        this->actor.speed = 0.0;
         this->actionFunc = EnKz_StopMweep;
     }
     if (this->skelanime.curFrame == 13.0f) {

--- a/src/overlays/actors/ovl_En_Lightbox/z_en_lightbox.c
+++ b/src/overlays/actors/ovl_En_Lightbox/z_en_lightbox.c
@@ -76,20 +76,20 @@ void EnLightbox_Update(Actor* thisx, PlayState* play) {
         if (Actor_HasParent(thisx, play)) {
             this->dyna.unk_162++;
         } else {
-            if (thisx->speedXZ) {
+            if (thisx->speed) {
                 if (thisx->bgCheckFlags & BGCHECKFLAG_WALL) {
                     thisx->world.rot.y = (thisx->world.rot.y + thisx->wallYaw) - thisx->world.rot.y;
                     Audio_PlaySfxGeneral(NA_SE_EV_BOMB_BOUND, &thisx->projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                                          &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
-                    thisx->speedXZ *= 0.7f;
+                    thisx->speed *= 0.7f;
                     thisx->bgCheckFlags &= ~BGCHECKFLAG_WALL;
                 }
             }
 
             if (!(thisx->bgCheckFlags & BGCHECKFLAG_GROUND)) {
-                Math_StepToF(&thisx->speedXZ, 0, IREG(57) / 100.0f);
+                Math_StepToF(&thisx->speed, 0, IREG(57) / 100.0f);
             } else {
-                Math_StepToF(&thisx->speedXZ, 0, IREG(58) / 100.0f);
+                Math_StepToF(&thisx->speed, 0, IREG(58) / 100.0f);
                 if ((thisx->bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) && (thisx->velocity.y < IREG(59) / 100.0f)) {
                     Audio_PlaySfxGeneral(NA_SE_EV_BOMB_BOUND, &thisx->projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                                          &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -433,7 +433,7 @@ void EnMb_FindWaypointTowardsPlayer(EnMb* this, PlayState* play) {
 
 void EnMb_SetupSpearGuardLookAround(EnMb* this) {
     Animation_MorphToLoop(&this->skelAnime, &gEnMbSpearLookLeftAndRightAnim, -4.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->timer1 = Rand_S16Offset(30, 50);
     this->state = ENMB_STATE_IDLE;
     EnMb_SetupAction(this, EnMb_SpearGuardLookAround);
@@ -441,7 +441,7 @@ void EnMb_SetupSpearGuardLookAround(EnMb* this) {
 
 void EnMb_SetupClubWaitPlayerNear(EnMb* this) {
     Animation_PlayLoop(&this->skelAnime, &gEnMbClubStandStillClubDownAnim);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->timer1 = Rand_S16Offset(30, 50);
     this->state = ENMB_STATE_IDLE;
     EnMb_SetupAction(this, EnMb_ClubWaitPlayerNear);
@@ -449,7 +449,7 @@ void EnMb_SetupClubWaitPlayerNear(EnMb* this) {
 
 void EnMb_SetupSpearPatrolTurnTowardsWaypoint(EnMb* this, PlayState* play) {
     Animation_MorphToLoop(&this->skelAnime, &gEnMbSpearLookLeftAndRightAnim, -4.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->timer1 = Rand_S16Offset(40, 80);
     this->state = ENMB_STATE_IDLE;
     EnMb_NextWaypoint(this, play);
@@ -459,7 +459,7 @@ void EnMb_SetupSpearPatrolTurnTowardsWaypoint(EnMb* this, PlayState* play) {
 void EnMb_SetupSpearGuardWalk(EnMb* this) {
     Animation_Change(&this->skelAnime, &gEnMbSpearWalkAnim, 0.0f, 0.0f, Animation_GetLastFrame(&gEnMbSpearWalkAnim),
                      ANIMMODE_LOOP, -4.0f);
-    this->actor.speedXZ = 0.59999996f;
+    this->actor.speed = 0.59999996f;
     this->timer1 = Rand_S16Offset(50, 70);
     this->unk_332 = 1;
     this->state = ENMB_STATE_WALK;
@@ -469,7 +469,7 @@ void EnMb_SetupSpearGuardWalk(EnMb* this) {
 void EnMb_SetupSpearPatrolWalkTowardsWaypoint(EnMb* this) {
     f32 frameCount = Animation_GetLastFrame(&gEnMbSpearWalkAnim);
 
-    this->actor.speedXZ = 0.59999996f;
+    this->actor.speed = 0.59999996f;
     this->timer1 = Rand_S16Offset(50, 70);
     this->unk_332 = 1;
     this->state = ENMB_STATE_WALK;
@@ -482,7 +482,7 @@ void EnMb_SetupSpearPrepareAndCharge(EnMb* this) {
 
     Animation_MorphToPlayOnce(&this->skelAnime, &gEnMbSpearPrepareChargeAnim, -4.0f);
     this->state = ENMB_STATE_ATTACK;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->timer3 = (s16)frameCount + 6;
     Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_SPEAR_AT);
     if (this->actor.params == ENMB_TYPE_SPEAR_GUARD) {
@@ -498,7 +498,7 @@ void EnMb_SetupSpearPatrolImmediateCharge(EnMb* this) {
     this->attack = ENMB_ATTACK_SPEAR;
     this->state = ENMB_STATE_ATTACK;
     this->timer3 = 3;
-    this->actor.speedXZ = 10.0f;
+    this->actor.speed = 10.0f;
     EnMb_SetupAction(this, EnMb_SpearPatrolImmediateCharge);
 }
 
@@ -537,7 +537,7 @@ void EnMb_SetupSpearPatrolEndCharge(EnMb* this) {
     this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND;
     this->timer1 = 0;
     this->timer3 = 50;
-    this->actor.speedXZ = -8.0f;
+    this->actor.speed = -8.0f;
     this->actor.velocity.y = 6.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_SLIDE);
     EnMb_SetupAction(this, EnMb_SpearPatrolEndCharge);
@@ -578,14 +578,14 @@ void EnMb_SetupClubDead(EnMb* this) {
     this->hitbox.dim.height = 80;
     this->hitbox.dim.radius = 95;
     this->timer1 = 30;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_DEAD);
     EnMb_SetupAction(this, EnMb_ClubDead);
 }
 
 void EnMb_SetupStunned(EnMb* this) {
     this->state = ENMB_STATE_STUNNED;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 120, COLORFILTER_BUFFLAG_OPA, 80);
     if (this->damageEffect == ENMB_DMGEFF_STUN_ICE) {
         this->iceEffectTimer = 40;
@@ -676,8 +676,8 @@ void EnMb_SpearPatrolTurnTowardsWaypoint(EnMb* this, PlayState* play) {
 void EnMb_SpearEndChargeQuick(EnMb* this, PlayState* play) {
     s32 pad;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.5f, 1.0f, 0.0f);
-    if (this->actor.speedXZ > 1.0f) {
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.5f, 1.0f, 0.0f);
+    if (this->actor.speed > 1.0f) {
         Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 5.0f, 3, 4.0f, 100, 15, false);
     }
     if (SkelAnime_Update(&this->skelAnime)) {
@@ -688,7 +688,7 @@ void EnMb_SpearEndChargeQuick(EnMb* this, PlayState* play) {
                 Animation_Change(&this->skelAnime, &gEnMbSpearPrepareChargeAnim, -1.0f,
                                  Animation_GetLastFrame(&gEnMbSpearPrepareChargeAnim), 0.0f, ANIMMODE_ONCE, 0.0f);
                 this->timer1 = 1;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_SPEAR_NORM);
             }
         } else {
@@ -726,9 +726,9 @@ void EnMb_SpearPatrolEndCharge(EnMb* this, PlayState* play) {
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 1.5f, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 1.5f, 0.0f);
 
-        if (this->actor.speedXZ > 1.0f) {
+        if (this->actor.speed > 1.0f) {
             Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 5.0f, 3, 4.0f, 100, 15, false);
         }
 
@@ -745,14 +745,14 @@ void EnMb_SpearPatrolEndCharge(EnMb* this, PlayState* play) {
                     /* Play the charge animation in reverse: let go of the spear and stand normally */
                     Animation_Change(&this->skelAnime, &gEnMbSpearPrepareChargeAnim, -1.0f, lastFrame, 0.0f,
                                      ANIMMODE_ONCE, 0.0f);
-                    this->actor.speedXZ = 0.0f;
+                    this->actor.speed = 0.0f;
                     Actor_PlaySfx(&this->actor, NA_SE_EN_MORIBLIN_SPEAR_NORM);
                 }
             } else {
                 if (this->actor.xzDistToPlayer <= 160.0f) {
-                    this->actor.speedXZ = -5.0f;
+                    this->actor.speed = -5.0f;
                 } else {
-                    this->actor.speedXZ = 0.0f;
+                    this->actor.speed = 0.0f;
                 }
             }
         }
@@ -799,7 +799,7 @@ void EnMb_SpearGuardPrepareAndCharge(EnMb* this, PlayState* play) {
         this->timer3--;
         Math_SmoothStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 1, 0xBB8, 0);
     } else {
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
         this->attack = ENMB_ATTACK_SPEAR;
         Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 5.0f, 3, 4.0f, 100, 15, false);
         if (prevFrame != (s32)this->skelAnime.curFrame &&
@@ -897,7 +897,7 @@ void EnMb_SpearPatrolPrepareAndCharge(EnMb* this, PlayState* play) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.world.rot.y, 1, 0x1F40, 0);
         endCharge = false;
     } else {
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
         this->attack = ENMB_ATTACK_SPEAR;
         Actor_SpawnFloorDustRing(play, &this->actor, &this->actor.world.pos, 5.0f, 3, 4.0f, 100, 15, false);
         if (prevFrame != (s32)this->skelAnime.curFrame &&
@@ -937,7 +937,7 @@ void EnMb_SpearPatrolPrepareAndCharge(EnMb* this, PlayState* play) {
         player->actor.world.pos.z = this->actor.world.pos.z + Math_SinS(this->actor.shape.rot.y) * 10.0f +
                                     Math_CosS(this->actor.shape.rot.y) * 89.0f;
         player->unk_850 = 0;
-        player->actor.speedXZ = 0.0f;
+        player->actor.speed = 0.0f;
         player->actor.velocity.y = 0.0f;
     }
 
@@ -952,7 +952,7 @@ void EnMb_SpearPatrolPrepareAndCharge(EnMb* this, PlayState* play) {
             }
         }
         this->attack = ENMB_ATTACK_NONE;
-        this->actor.speedXZ = -10.0f;
+        this->actor.speed = -10.0f;
         EnMb_SetupSpearPatrolEndCharge(this);
     }
 }
@@ -1006,7 +1006,7 @@ void EnMb_SpearPatrolImmediateCharge(EnMb* this, PlayState* play) {
         player->actor.world.pos.z = this->actor.world.pos.z + Math_SinS(this->actor.shape.rot.y) * 10.0f +
                                     Math_CosS(this->actor.shape.rot.y) * 89.0f;
         player->unk_850 = 0;
-        player->actor.speedXZ = 0.0f;
+        player->actor.speed = 0.0f;
         player->actor.velocity.y = 0.0f;
     }
 
@@ -1020,7 +1020,7 @@ void EnMb_SpearPatrolImmediateCharge(EnMb* this, PlayState* play) {
                 func_8002F71C(play, &this->actor, 4.0f, this->actor.world.rot.y, 4.0f);
             }
             this->attack = ENMB_ATTACK_NONE;
-            this->actor.speedXZ = -10.0f;
+            this->actor.speed = -10.0f;
             EnMb_SetupSpearPatrolEndCharge(this);
             this->timer3 = 1;
         } else {
@@ -1081,7 +1081,7 @@ void EnMb_ClubDead(EnMb* this, PlayState* play) {
     effPos = this->actor.world.pos;
     effPos.x += Math_SinS(this->actor.shape.rot.y) * -70.0f;
     effPos.z += Math_CosS(this->actor.shape.rot.y) * -70.0f;
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     effPosBase = effPos;
 
     if (SkelAnime_Update(&this->skelAnime)) {
@@ -1123,8 +1123,8 @@ void EnMb_SpearGuardWalk(EnMb* this, PlayState* play) {
     f32 playSpeedAbs;
 
     relYawTowardsPlayer = ABS(relYawTowardsPlayer);
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.59999996f, 0.1f, 1.0f, 0.0f);
-    this->skelAnime.playSpeed = this->actor.speedXZ;
+    Math_SmoothStepToF(&this->actor.speed, 0.59999996f, 0.1f, 1.0f, 0.0f);
+    this->skelAnime.playSpeed = this->actor.speed;
     prevFrame = this->skelAnime.curFrame;
     SkelAnime_Update(&this->skelAnime);
 
@@ -1185,8 +1185,8 @@ void EnMb_SpearPatrolWalkTowardsWaypoint(EnMb* this, PlayState* play) {
         (Rand_ZeroOne() < 0.1f && Math_Vec3f_DistXZ(&this->actor.home.pos, &this->actor.world.pos) <= 4.0f)) {
         EnMb_SetupSpearPatrolTurnTowardsWaypoint(this, play);
     } else {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.59999996f, 0.1f, 1.0f, 0.0f);
-        this->skelAnime.playSpeed = 2.0f * this->actor.speedXZ;
+        Math_SmoothStepToF(&this->actor.speed, 0.59999996f, 0.1f, 1.0f, 0.0f);
+        this->skelAnime.playSpeed = 2.0f * this->actor.speed;
     }
 
     this->yawToWaypoint = Math_Vec3f_Yaw(&this->actor.world.pos, &this->waypointPos);
@@ -1246,10 +1246,10 @@ void EnMb_SetupSpearDamaged(EnMb* this) {
 
     if (ABS(relYawTowardsPlayer) <= 0x4000) {
         Animation_MorphToPlayOnce(&this->skelAnime, &gEnMbSpearDamagedFromFrontAnim, -4.0f);
-        this->actor.speedXZ = -8.0f;
+        this->actor.speed = -8.0f;
     } else {
         Animation_MorphToPlayOnce(&this->skelAnime, &gEnMbSpearDamagedFromBehindAnim, -4.0f);
-        this->actor.speedXZ = 8.0f;
+        this->actor.speed = 8.0f;
     }
 
     this->timer1 = 30;
@@ -1260,7 +1260,7 @@ void EnMb_SetupSpearDamaged(EnMb* this) {
 }
 
 void EnMb_SpearDamaged(EnMb* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     if (SkelAnime_Update(&this->skelAnime)) {
         if (this->actor.params <= ENMB_TYPE_SPEAR_GUARD) {
             EnMb_SetupSpearGuardLookAround(this);
@@ -1275,11 +1275,11 @@ void EnMb_SetupSpearDead(EnMb* this) {
 
     if (ABS(relYawTowardsPlayer) <= 0x4000) {
         Animation_MorphToPlayOnce(&this->skelAnime, &gEnMbSpearFallOnItsBackAnim, -4.0f);
-        this->actor.speedXZ = -8.0f;
+        this->actor.speed = -8.0f;
     } else {
         /* The gEnMbSpearFallFaceDownAnim animation was probably meant to be used here */
         Animation_MorphToPlayOnce(&this->skelAnime, &gEnMbSpearFallOnItsBackAnim, -4.0f);
-        this->actor.speedXZ = 8.0f;
+        this->actor.speed = 8.0f;
     }
 
     this->actor.world.rot.y = this->actor.shape.rot.y;
@@ -1293,7 +1293,7 @@ void EnMb_SetupSpearDead(EnMb* this) {
 void EnMb_SpearDead(EnMb* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
 
     if ((player->stateFlags2 & PLAYER_STATE2_7) && player->actor.parent == &this->actor) {
         player->stateFlags2 &= ~PLAYER_STATE2_7;

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -752,7 +752,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
         this->waypoint = 1;
         this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
         this->actionFunc = func_80AABD0C;
-        this->actor.speedXZ = 1.5f;
+        this->actor.speed = 1.5f;
         return;
     }
 
@@ -814,7 +814,7 @@ void func_80AABD0C(EnMd* this, PlayState* play) {
     func_80AAA92C(this, 11);
 
     this->skelAnime.playSpeed = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.home.pos = this->actor.world.pos;
     this->actionFunc = func_80AAB8F8;
 }

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -387,7 +387,7 @@ s32 func_80AADEF0(EnMm* this, PlayState* play) {
 
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->yawToWaypoint, 1, 2500, 0);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    Math_SmoothStepToF(&this->actor.speedXZ, this->speedXZ, 0.6f, this->distToWaypoint, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, this->speedXZ, 0.6f, this->distToWaypoint, 0.0f);
     Actor_MoveForward(&this->actor);
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
 
@@ -401,7 +401,7 @@ void func_80AAE224(EnMm* this, PlayState* play) {
         this->mouthTexIndex = RM_MOUTH_CLOSED;
         this->unk_254 |= 1;
         this->unk_1E0 = 0;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         EnMm_ChangeAnim(this, RM_ANIM_SIT_WAIT, &this->curAnimIndex);
     }
 }

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
@@ -182,7 +182,7 @@ void func_80AAF2BC(EnMm2* this, PlayState* play) {
     }
     SkelAnime_Update(&this->skelAnime);
     this->unk_1F6++;
-    Math_SmoothStepToF(&this->actor.speedXZ, 10.0f, 0.6f, 2.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 10.0f, 0.6f, 2.0f, 0.0f);
 }
 
 void func_80AAF330(EnMm2* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -85,7 +85,7 @@ void EnMs_Init(Actor* thisx, PlayState* play) {
     Actor_SetScale(&this->actor, 0.015f);
 
     this->actor.colChkInfo.mass = MASS_IMMOVABLE;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = -1.0f;
 

--- a/src/overlays/actors/ovl_En_Niw/z_en_niw.c
+++ b/src/overlays/actors/ovl_En_Niw/z_en_niw.c
@@ -425,7 +425,7 @@ void EnNiw_ResetAction(EnNiw* this, PlayState* play) {
 void func_80AB6324(EnNiw* this, PlayState* play) {
     if (this->unk_308 != 0) {
         this->actor.velocity.y = Rand_ZeroFloat(2.0f) + 4.0f;
-        this->actor.speedXZ = Rand_ZeroFloat(2.0f) + 3.0f;
+        this->actor.speed = Rand_ZeroFloat(2.0f) + 3.0f;
         this->actionFunc = func_80AB63A8;
     }
     func_80AB5BF8(this, play, 1);
@@ -438,8 +438,8 @@ void func_80AB63A8(EnNiw* this, PlayState* play) {
         this->unk_2AC.z = this->unk_2B8.z = this->actor.world.pos.z;
         this->timer5 = this->timer4 = this->unk_29E = 0;
 
-        this->unk_26C[7] = this->unk_26C[5] = this->unk_26C[6] = this->unk_26C[8] = this->actor.speedXZ =
-            this->unk_2FC = this->unk_300 = 0.0f;
+        this->unk_26C[7] = this->unk_26C[5] = this->unk_26C[6] = this->unk_26C[8] = this->actor.speed = this->unk_2FC =
+            this->unk_300 = 0.0f;
 
         this->actionFunc = func_80AB6570;
     } else {
@@ -461,7 +461,7 @@ void func_80AB6450(EnNiw* this, PlayState* play) {
         this->path = 0;
         this->timer4 = 30;
         this->actor.flags &= ~ACTOR_FLAG_0;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actionFunc = func_80AB6BF8;
     } else {
         // GI_NONE in this case allows the player to lift the actor
@@ -483,7 +483,7 @@ void func_80AB6570(EnNiw* this, PlayState* play) {
             this->path = 0;
             this->timer4 = 30;
             this->actor.flags &= ~ACTOR_FLAG_0;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->actionFunc = func_80AB6BF8;
             return;
         }
@@ -496,7 +496,7 @@ void func_80AB6570(EnNiw* this, PlayState* play) {
                 this->sfxTimer3 = 100;
             }
             this->unk_2A0 = Rand_ZeroFloat(1.99f);
-            this->actor.speedXZ = 4.0f;
+            this->actor.speed = 4.0f;
             this->unk_300 = 0.0f;
             this->unk_2FC = 0.0f;
             this->actionFunc = func_80AB6A38;
@@ -554,7 +554,7 @@ void func_80AB6570(EnNiw* this, PlayState* play) {
         } else {
             this->timer4 = 4;
             if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 this->actor.velocity.y = 3.5f;
             }
         }
@@ -599,8 +599,8 @@ void func_80AB6A38(EnNiw* this, PlayState* play) {
         this->unk_2AC.y = this->unk_2B8.y = this->actor.world.pos.y;
         this->unk_2AC.z = this->unk_2B8.z = this->actor.world.pos.z;
         this->timer5 = this->timer4 = this->unk_29E = 0;
-        this->unk_26C[7] = this->unk_26C[5] = this->unk_26C[6] = this->unk_26C[8] = this->actor.speedXZ =
-            this->unk_2FC = this->unk_300 = 0.0f;
+        this->unk_26C[7] = this->unk_26C[5] = this->unk_26C[6] = this->unk_26C[8] = this->actor.speed = this->unk_2FC =
+            this->unk_300 = 0.0f;
         this->actionFunc = EnNiw_ResetAction;
     } else {
         path = &play->pathList[pathIndex];
@@ -660,7 +660,7 @@ void func_80AB6D08(EnNiw* this, PlayState* play) {
             this->unk_2AC.z = this->unk_2B8.z = this->actor.world.pos.z;
             this->timer5 = this->timer4 = this->unk_29E = 0;
 
-            this->unk_26C[7] = this->unk_26C[5] = this->unk_26C[6] = this->unk_26C[8] = this->actor.speedXZ =
+            this->unk_26C[7] = this->unk_26C[5] = this->unk_26C[6] = this->unk_26C[8] = this->actor.speed =
                 this->unk_2FC = this->unk_300 = 0.0f;
 
             this->actionFunc = EnNiw_ResetAction;
@@ -669,7 +669,7 @@ void func_80AB6D08(EnNiw* this, PlayState* play) {
 
         this->path = 1;
         this->timer5 = 80;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actor.velocity.y = 4.0f;
     } else {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
@@ -692,7 +692,7 @@ void func_80AB6D08(EnNiw* this, PlayState* play) {
         this->path = 0;
         this->timer4 = 30;
         this->actor.flags &= ~ACTOR_FLAG_0;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actionFunc = func_80AB6BF8;
     } else {
         if (this->timer5 >= 6) {
@@ -717,7 +717,7 @@ void func_80AB6F04(EnNiw* this, PlayState* play) {
         EnNiw_SpawnAttackCucco(this, play);
     }
 
-    this->actor.speedXZ = 2.0f;
+    this->actor.speed = 2.0f;
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER) {
         this->actor.gravity = 0.0f;
@@ -733,17 +733,17 @@ void func_80AB6F04(EnNiw* this, PlayState* play) {
         }
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
             this->actor.velocity.y = 10.0f;
-            this->actor.speedXZ = 1.0f;
+            this->actor.speed = 1.0f;
         }
     } else {
         this->actor.gravity = -2.0f;
 
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
             this->actor.velocity.y = 10.0f;
-            this->actor.speedXZ = 1.0f;
+            this->actor.speed = 1.0f;
             this->actor.gravity = 0.0f;
         } else {
-            this->actor.speedXZ = 4.0f;
+            this->actor.speed = 4.0f;
         }
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
             this->actor.gravity = -2.0f;
@@ -810,7 +810,7 @@ void func_80AB7204(EnNiw* this, PlayState* play) {
 
     if (this->timer7 < 2) {
         if (this->timer7 == 1) {
-            this->actor.speedXZ = 3.0f;
+            this->actor.speed = 3.0f;
             this->unk_2A0 = Rand_ZeroFloat(1.99f);
             this->timer1 = this->timer2 = this->timer3 = this->timer4 = 0;
         } else {
@@ -823,7 +823,7 @@ void func_80AB7290(EnNiw* this, PlayState* play) {
     Animation_Change(&this->skelAnime, &gCuccoAnim, 1.0f, 0.0f, Animation_GetLastFrame(&gCuccoAnim), ANIMMODE_LOOP,
                      -10.0f);
     this->unk_2A0 = Rand_ZeroFloat(1.99f);
-    this->actor.speedXZ = 4.0f;
+    this->actor.speed = 4.0f;
     this->actionFunc = func_80AB7328;
 }
 
@@ -835,8 +835,8 @@ void func_80AB7328(EnNiw* this, PlayState* play) {
         this->unk_2AC.y = this->unk_2B8.y = this->actor.world.pos.y;
         this->unk_2AC.z = this->unk_2B8.z = this->actor.world.pos.z;
         this->timer5 = this->timer4 = this->unk_29E = 0;
-        this->unk_26C[7] = this->unk_26C[5] = this->unk_26C[6] = this->unk_26C[8] = this->actor.speedXZ =
-            this->unk_2FC = this->unk_300 = 0.0f;
+        this->unk_26C[7] = this->unk_26C[5] = this->unk_26C[6] = this->unk_26C[8] = this->actor.speed = this->unk_2FC =
+            this->unk_300 = 0.0f;
         if (this->actor.params == 4) {
             this->actor.params = 0;
         }
@@ -1008,7 +1008,7 @@ void EnNiw_Update(Actor* thisx, PlayState* play) {
         osSyncPrintf(VT_FGCOL(YELLOW) "☆☆☆☆☆ 修整後Ｙ！ ☆☆☆☆☆ %f\n" VT_RST, thisx->world.pos.y);
         osSyncPrintf(VT_FGCOL(YELLOW) "☆☆☆☆☆ 修整後Ｚ！ ☆☆☆☆☆ %f\n" VT_RST, thisx->world.pos.z);
         osSyncPrintf("\n\n");
-        thisx->speedXZ = 0.0f;
+        thisx->speed = 0.0f;
         thisx->gravity = -2.0f;
         Math_Vec3f_Copy(&this->unk_2AC, &thisx->home.pos);
         Math_Vec3f_Copy(&this->unk_2B8, &thisx->home.pos);
@@ -1059,7 +1059,7 @@ void EnNiw_Update(Actor* thisx, PlayState* play) {
         if (thisx->xzDistToPlayer > 10.0f) {
             D_80AB85E0 = 1;
             this->timer5 = this->timer4 = this->unk_29E = 0;
-            thisx->speedXZ = 0.0f;
+            thisx->speed = 0.0f;
             this->unk_2FC = 0.0f;
             this->unk_300 = 0.0f;
             this->unk_26C[7] = 0.0f;

--- a/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.c
+++ b/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.c
@@ -106,7 +106,7 @@ void func_80AB9210(EnNiwGirl* this, PlayState* play) {
     f32 zDistBetween;
 
     SkelAnime_Update(&this->skelAnime);
-    Math_ApproachF(&this->actor.speedXZ, 3.0f, 0.2f, 0.4f);
+    Math_ApproachF(&this->actor.speed, 3.0f, 0.2f, 0.4f);
 
     // Find the X and Z distance between the girl and the cuckoo she is chasing
     xDistBetween = this->chasedEnNiw->actor.world.pos.x - this->actor.world.pos.x;
@@ -169,7 +169,7 @@ void func_80AB94D0(EnNiwGirl* this, PlayState* play) {
     if (Message_GetState(&play->msgCtx) != TEXT_STATE_NONE) {
         this->chasedEnNiw->path = 0;
     }
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.8f, 0.2f);
+    Math_ApproachZeroF(&this->actor.speed, 0.8f, 0.2f);
     if (Actor_ProcessTalkRequest(&this->actor, play)) {
         if (this->actor.textId == 0x70EA) {
             this->unk_27A = 1;

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
@@ -91,7 +91,7 @@ void func_80ABBB34(EnNutsball* this, PlayState* play) {
         this->actor.shape.rot.y = 0;
         this->timer = 30;
         this->actionFunc = func_80ABBBA8;
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
     }
 }
 

--- a/src/overlays/actors/ovl_En_Ny/z_en_ny.c
+++ b/src/overlays/actors/ovl_En_Ny/z_en_ny.c
@@ -115,7 +115,7 @@ void EnNy_Init(Actor* thisx, PlayState* play) {
     this->unk_1CA = 0;
     this->unk_1D0 = 0;
     Actor_SetScale(&this->actor, 0.01f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.shape.rot.y = 0;
     this->actor.gravity = -0.4f;
     this->hitPlayer = 0;
@@ -237,7 +237,7 @@ void EnNy_Move(EnNy* this, PlayState* play) {
         Math_ApproachF(&this->unk_1F4, 2000.0f, 1.0f, 100.0f);
         this->actor.world.rot.y = this->actor.shape.rot.y;
         yawDiff = Math_FAtan2F(this->actor.yDistToPlayer, this->actor.xzDistToPlayer);
-        this->actor.speedXZ = fabsf(cosf(yawDiff) * this->unk_1E8);
+        this->actor.speed = fabsf(cosf(yawDiff) * this->unk_1E8);
         if (this->unk_1F0 < this->actor.yDistToWater) {
             this->unk_1EC = sinf(yawDiff) * this->unk_1E8;
         }
@@ -256,7 +256,7 @@ void EnNy_TurnToStone(EnNy* this, PlayState* play) {
                 Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
             }
             this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND_TOUCH;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->actor.world.rot.y = this->actor.shape.rot.y;
             func_80ABCE38(this);
         }
@@ -295,7 +295,7 @@ s32 EnNy_CollisionCheck(EnNy* this, PlayState* play) {
         this->collider.base.atFlags &= ~AT_BOUNCED;
         this->hitPlayer = 1;
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-        this->actor.speedXZ = -4.0f;
+        this->actor.speed = -4.0f;
         return 0;
     }
     if (this->collider.base.atFlags & AT_HIT) {

--- a/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
+++ b/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
@@ -153,7 +153,7 @@ void EnOkuta_Init(Actor* thisx, PlayState* play) {
         this->timer = 30;
         thisx->shape.rot.y = 0;
         this->actionFunc = EnOkuta_ProjectileFly;
-        thisx->speedXZ = 10.0f;
+        thisx->speed = 10.0f;
     }
 }
 
@@ -478,8 +478,8 @@ void EnOkuta_ProjectileFly(EnOkuta* this, PlayState* play) {
     this->actor.home.rot.z += 0x1554;
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER) {
         this->actor.gravity = -1.0f;
-        this->actor.speedXZ -= 0.1f;
-        this->actor.speedXZ = CLAMP_MIN(this->actor.speedXZ, 1.0f);
+        this->actor.speed -= 0.1f;
+        this->actor.speed = CLAMP_MIN(this->actor.speed, 1.0f);
     }
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) ||
         (this->collider.base.atFlags & AT_HIT) || this->collider.base.acFlags & AC_HIT ||

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -842,8 +842,8 @@ void func_80ACBC0C(EnOwl* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.world.rot.y, this->unk_400, 2, 0x80, 0x40);
     this->actor.shape.rot.y = this->actor.world.rot.y;
 
-    if (this->actor.speedXZ < 16.0f) {
-        this->actor.speedXZ += 0.5f;
+    if (this->actor.speed < 16.0f) {
+        this->actor.speed += 0.5f;
     }
 
     if ((this->unk_3F8 + 1000.0f) < this->actor.world.pos.y) {
@@ -866,11 +866,11 @@ void func_80ACBD4C(EnOwl* this, PlayState* play) {
     if (this->skelAnime.curFrame > 45.0f) {
         this->actor.velocity.y = 2.0f;
         this->actor.gravity = 0.0f;
-        this->actor.speedXZ = 8.0f;
+        this->actor.speed = 8.0f;
     } else if (this->skelAnime.curFrame > 17.0f) {
         this->actor.velocity.y = 6.0f;
         this->actor.gravity = 0.0f;
-        this->actor.speedXZ = 4.0f;
+        this->actor.speed = 4.0f;
     }
 
     if (this->actionFlags & 1) {
@@ -911,7 +911,7 @@ void func_80ACBF50(EnOwl* this, PlayState* play) {
         this->unk_3FE = 6;
         this->actor.velocity.y = 2.0f;
         this->actor.gravity = 0.0f;
-        this->actor.speedXZ = 4.0f;
+        this->actor.speed = 4.0f;
     }
     this->actionFlags |= 8;
 }
@@ -972,9 +972,9 @@ void func_80ACC00C(EnOwl* this, PlayState* play) {
 
 void func_80ACC23C(EnOwl* this, PlayState* play) {
     if (this->skelAnime.curFrame < 20.0f) {
-        this->actor.speedXZ = 1.5f;
+        this->actor.speed = 1.5f;
     } else {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         Math_SmoothStepToS(&this->actor.world.rot.y, this->unk_400, 2, 0x384, 0x258);
         this->actor.shape.rot.y = this->actor.world.rot.y;
     }
@@ -985,7 +985,7 @@ void func_80ACC23C(EnOwl* this, PlayState* play) {
         this->unk_3FE = 5;
         this->actor.velocity.y = 0.0f;
         this->actor.gravity = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     this->actionFlags |= 8;
@@ -1359,7 +1359,7 @@ void func_80ACD220(EnOwl* this, Vec3f* arg1, f32 arg2) {
     rpy.z = (arg1->z - this->actor.world.pos.z) * arg2;
 
     Math_StepToF(&this->actor.velocity.y, rpy.y, 1.0f);
-    this->actor.speedXZ = sqrtf(SQ(rpy.x) + SQ(rpy.z));
+    this->actor.speed = sqrtf(SQ(rpy.x) + SQ(rpy.z));
     this->actor.world.rot.y = Math_Vec3f_Yaw(&this->actor.world.pos, arg1);
     this->actor.shape.rot.y = this->actor.world.rot.y;
 }
@@ -1391,7 +1391,7 @@ void func_80ACD2CC(EnOwl* this, PlayState* play) {
         this->actor.world.pos = pos;
         this->actor.draw = EnOwl_Draw;
         this->actionFlags &= ~4;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     } else {
         pos.x -= Math_SinS(angle) * this->unk_3F8;
         pos.z += Math_CosS(angle) * this->unk_3F8;

--- a/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -45,13 +45,13 @@ void func_80ACDDE8(EnPart* this, PlayState* play) {
             this->actor.gravity = -0.3f - Rand_ZeroOne() * 0.5f;
             this->rotZSpeed = 0.3f;
             this->timer = 25;
-            this->actor.speedXZ = (Rand_ZeroOne() - 0.5f) * 2.0f;
+            this->actor.speed = (Rand_ZeroOne() - 0.5f) * 2.0f;
             break;
         case 13:
             this->timer = 400;
             FALLTHROUGH;
         case 12:
-            this->actor.speedXZ = Rand_CenteredFloat(6.0f);
+            this->actor.speed = Rand_CenteredFloat(6.0f);
             this->actor.home.pos = this->actor.world.pos;
             this->timer += 60;
             this->actor.velocity.y = Rand_ZeroOne() * 5.0f + 4.0f;
@@ -76,7 +76,7 @@ void func_80ACDDE8(EnPart* this, PlayState* play) {
             EffectSsEnFire_SpawnVec3f(play, &this->actor, &this->actor.world.pos, 40, 0x8001, 0, -1);
             FALLTHROUGH;
         case 3:
-            this->actor.speedXZ = (Rand_ZeroOne() - 0.5f) * 3.0f;
+            this->actor.speed = (Rand_ZeroOne() - 0.5f) * 3.0f;
             this->timer = (s16)(Rand_ZeroOne() * 17.0f) + 10;
             this->actor.velocity.y = Rand_ZeroOne() * 3.0f + 8.0f;
             this->actor.gravity = -0.6f - Rand_ZeroOne() * 0.3f;
@@ -91,7 +91,7 @@ void func_80ACDDE8(EnPart* this, PlayState* play) {
                 sign = -1.0f;
             }
             this->actor.velocity.y = 0.0f;
-            this->actor.speedXZ = 6.0f * sign;
+            this->actor.speed = 6.0f * sign;
             this->actor.gravity = -1.2f;
             this->rotZSpeed = 0.15f * sign;
             ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 30.0f);
@@ -114,7 +114,7 @@ void func_80ACE13C(EnPart* this, PlayState* play) {
 
         if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) || (this->actor.world.pos.y <= this->actor.floorHeight)) {
             this->action = 4;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->actor.gravity = 0.0f;
             this->actor.velocity.y = 0.0f;
         }
@@ -252,7 +252,7 @@ void EnPart_Update(Actor* thisx, PlayState* play) {
     if ((this->actor.params > 4 && this->actor.params < 9) || this->actor.params < 0) {
         Actor_UpdateBgCheckInfo(play, &this->actor, 5.0f, 15.0f, 0.0f, UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
         if (this->actor.params >= 0) {
-            Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
             if (thisx->bgCheckFlags & BGCHECKFLAG_GROUND) {
                 thisx->bgCheckFlags &= ~BGCHECKFLAG_GROUND;
                 thisx->velocity.y = 6.0f;

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -496,7 +496,7 @@ void EnPeehat_Ground_SetStateSeekPlayer(EnPeehat* this) {
 void EnPeehat_Ground_StateSeekPlayer(EnPeehat* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 3.0f, 1.0f, 0.25f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 3.0f, 1.0f, 0.25f, 0.0f);
     Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.floorHeight + 80.0f, 1.0f, 3.0f, 0.0f);
     if (this->seekPlayerTimer <= 0) {
         EnPeehat_Ground_SetStateLanding(this);
@@ -537,7 +537,7 @@ void EnPeehat_Larva_StateSeekPlayer(EnPeehat* this, PlayState* play) {
     if (this->actor.parent != NULL && this->actor.parent->update == NULL) {
         this->actor.parent = NULL;
     }
-    this->actor.speedXZ = speedXZ;
+    this->actor.speed = speedXZ;
     if (this->actor.world.pos.y - this->actor.floorHeight >= 70.0f) {
         Math_SmoothStepToF(&this->actor.velocity.y, -1.3f, 1.0f, 0.5f, 0.0f);
     } else {
@@ -598,7 +598,7 @@ void EnPeehat_Ground_SetStateLanding(EnPeehat* this) {
 
 void EnPeehat_Ground_StateLanding(EnPeehat* this, PlayState* play) {
     Math_SmoothStepToF(&this->actor.shape.yOffset, -1000.0f, 1.0f, 50.0f, 0.0f);
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 1.0f, 0.0f);
     Math_SmoothStepToS(&this->actor.shape.rot.x, 0, 1, 50, 0);
     if (SkelAnime_Update(&this->skelAnime)) {
         EnPeehat_Ground_SetStateGround(this);
@@ -625,7 +625,7 @@ void EnPeehat_Flying_SetStateLanding(EnPeehat* this) {
 
 void EnPeehat_Flying_StateLanding(EnPeehat* this, PlayState* play) {
     Math_SmoothStepToF(&this->actor.shape.yOffset, -1000.0f, 1.0f, 50.0f, 0.0f);
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 1.0f, 0.0f);
     Math_SmoothStepToS(&this->actor.shape.rot.x, 0, 1, 50, 0);
     if (SkelAnime_Update(&this->skelAnime)) {
         EnPeehat_Flying_SetStateGround(this);
@@ -646,7 +646,7 @@ void EnPeehat_Flying_StateLanding(EnPeehat* this, PlayState* play) {
 
 void EnPeehat_Ground_SetStateHover(EnPeehat* this) {
     Animation_PlayLoop(&this->skelAnime, &gPeehatFlyingAnim);
-    this->actor.speedXZ = Rand_ZeroOne() * 0.5f + 2.5f;
+    this->actor.speed = Rand_ZeroOne() * 0.5f + 2.5f;
     this->unk_2D4 = Rand_ZeroOne() * 10 + 10;
     this->state = PEAHAT_STATE_15;
     EnPeehat_SetupAction(this, EnPeehat_Ground_StateHover);
@@ -665,7 +665,7 @@ void EnPeehat_Ground_StateHover(EnPeehat* this, PlayState* play) {
     this->unk_2E0 += ((0.0f <= cos) ? cos : -cos) + 0.07f;
     this->unk_2D4--;
     if (this->unk_2D4 <= 0) {
-        this->actor.speedXZ = Rand_ZeroOne() * 0.5f + 2.5f;
+        this->actor.speed = Rand_ZeroOne() * 0.5f + 2.5f;
         this->unk_2D4 = Rand_ZeroOne() * 10.0f + 10.0f;
         this->unk_2F4 = (Rand_ZeroOne() - 0.5f) * 1000.0f;
     }
@@ -694,7 +694,7 @@ void EnPeehat_Ground_StateHover(EnPeehat* this, PlayState* play) {
 
 void EnPeehat_Ground_SetStateReturnHome(EnPeehat* this) {
     this->state = PEAHAT_STATE_RETURN_HOME;
-    this->actor.speedXZ = 2.5f;
+    this->actor.speed = 2.5f;
     EnPeehat_SetupAction(this, EnPeehat_Ground_StateReturnHome);
 }
 
@@ -732,7 +732,7 @@ void EnPeehat_Ground_StateReturnHome(EnPeehat* this, PlayState* play) {
 void EnPeehat_SetStateAttackRecoil(EnPeehat* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gPeehatRecoilAnim, -4.0f);
     this->state = PEAHAT_STATE_ATTACK_RECOIL;
-    this->actor.speedXZ = -9.0f;
+    this->actor.speed = -9.0f;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     EnPeehat_SetupAction(this, EnPeehat_StateAttackRecoil);
 }
@@ -740,8 +740,8 @@ void EnPeehat_SetStateAttackRecoil(EnPeehat* this) {
 void EnPeehat_StateAttackRecoil(EnPeehat* this, PlayState* play) {
     this->bladeRot += this->bladeRotVel;
     SkelAnime_Update(&this->skelAnime);
-    this->actor.speedXZ += 0.5f;
-    if (this->actor.speedXZ == 0.0f) {
+    this->actor.speed += 0.5f;
+    if (this->actor.speed == 0.0f) {
         // Is PEAHAT_TYPE_LARVA
         if (this->actor.params > 0) {
             Vec3f zeroVec = { 0, 0, 0 };
@@ -768,7 +768,7 @@ void EnPeehat_StateAttackRecoil(EnPeehat* this, PlayState* play) {
 void EnPeehat_SetStateBoomerangStunned(EnPeehat* this) {
     this->state = PEAHAT_STATE_STUNNED;
     if (this->actor.floorHeight < this->actor.world.pos.y) {
-        this->actor.speedXZ = -9.0f;
+        this->actor.speed = -9.0f;
     }
     this->bladeRotVel = 0;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
@@ -778,7 +778,7 @@ void EnPeehat_SetStateBoomerangStunned(EnPeehat* this) {
 }
 
 void EnPeehat_StateBoomerangStunned(EnPeehat* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 1.0f, 0.0f);
     Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.floorHeight, 1.0f, 8.0f, 0.0f);
     if (this->actor.colorFilterTimer == 0) {
         EnPeehat_Ground_SetStateRise(this);
@@ -788,7 +788,7 @@ void EnPeehat_StateBoomerangStunned(EnPeehat* this, PlayState* play) {
 void EnPeehat_Adult_SetStateDie(EnPeehat* this) {
     this->bladeRotVel = 0;
     this->isStateDieFirstUpdate = 1;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
     this->state = PEAHAT_STATE_DYING;
     this->scaleShift = 0.0f;
@@ -803,7 +803,7 @@ void EnPeehat_Adult_StateDie(EnPeehat* this, PlayState* play) {
             Animation_MorphToPlayOnce(&this->skelAnime, &gPeehatRecoilAnim, -4.0f);
             this->bladeRotVel = 4000;
             this->unk_2D4 = 14;
-            this->actor.speedXZ = 0;
+            this->actor.speed = 0;
             this->actor.velocity.y = 6;
             this->isStateDieFirstUpdate = 0;
             this->actor.shape.rot.z = this->actor.shape.rot.x = 0;
@@ -827,8 +827,8 @@ void EnPeehat_Adult_StateDie(EnPeehat* this, PlayState* play) {
             func_80033480(play, &pos, 80.0f, 1, 150, 100, 1);
             EnPeehat_SpawnDust(play, this, &pos, 75.0f, 2, 1.05f, 2.0f);
         }
-        if (this->actor.speedXZ < 0) {
-            this->actor.speedXZ += 0.25f;
+        if (this->actor.speed < 0) {
+            this->actor.speed += 0.25f;
         }
         this->unk_2D4--;
         if (this->unk_2D4 <= 0) {
@@ -925,7 +925,7 @@ void EnPeehat_Update(Actor* thisx, PlayState* play) {
         EnPeehat_Adult_CollisionCheck(this, play);
     }
     if (thisx->colChkInfo.damageEffect != PEAHAT_DMG_EFF_LIGHT_ICE_ARROW) {
-        if (thisx->speedXZ != 0.0f || thisx->velocity.y != 0.0f) {
+        if (thisx->speed != 0.0f || thisx->velocity.y != 0.0f) {
             Actor_MoveForward(thisx);
             Actor_UpdateBgCheckInfo(play, thisx, 25.0f, 30.0f, 30.0f, UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
         }
@@ -1067,7 +1067,7 @@ void EnPeehat_Draw(Actor* thisx, PlayState* play) {
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     SkelAnime_DrawOpa(play, this->skelAnime.skeleton, this->skelAnime.jointTable, EnPeehat_OverrideLimbDraw,
                       EnPeehat_PostLimbDraw, this);
-    if (this->actor.speedXZ != 0.0f || this->actor.velocity.y != 0.0f) {
+    if (this->actor.speed != 0.0f || this->actor.velocity.y != 0.0f) {
         Matrix_MultVec3f(&D_80AD285C[0], &this->colQuad.dim.quad[1]);
         Matrix_MultVec3f(&D_80AD285C[1], &this->colQuad.dim.quad[0]);
         Matrix_MultVec3f(&D_80AD285C[2], &this->colQuad.dim.quad[3]);

--- a/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
+++ b/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
@@ -99,7 +99,7 @@ void EnPoDesert_SetNextPathPoint(EnPoDesert* this, PlayState* play) {
     this->initDistToNextPoint = CLAMP_MIN(this->initDistToNextPoint, 1.0f);
     this->currentPathPoint++;
     this->yDiff = this->actor.home.pos.y - this->actor.world.pos.y;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (path->count == this->currentPathPoint) {
         this->currentPathPoint = 0;
     }
@@ -114,7 +114,7 @@ void EnPoDesert_SetupMoveToNextPoint(EnPoDesert* this) {
 void EnPoDesert_SetupDisappear(EnPoDesert* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gPoeFieldDisappearAnim, -6.0f);
     this->actionTimer = 16;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DISAPPEAR);
     this->actionFunc = EnPoDesert_Disappear;
 }
@@ -160,7 +160,7 @@ void EnPoDesert_MoveToNextPoint(EnPoDesert* this, PlayState* play) {
     temp_f20 = Actor_WorldDistXZToPoint(&this->actor, &this->actor.home.pos);
     this->actor.world.rot.y = Actor_WorldYawTowardPoint(&this->actor, &this->actor.home.pos);
     Math_ApproachS(&this->actor.shape.rot.y, this->actor.world.rot.y + 0x8000, 5, 0x400);
-    this->actor.speedXZ = sinf(this->speedModifier * (M_PI / 32.0f)) * 2.5f + 5.5f;
+    this->actor.speed = sinf(this->speedModifier * (M_PI / 32.0f)) * 2.5f + 5.5f;
     func_8002F974(&this->actor, NA_SE_EN_PO_FLY - SFX_FLAG);
     this->targetY = this->actor.home.pos.y - ((temp_f20 * this->yDiff) / this->initDistToNextPoint);
     if (temp_f20 < 40.0f) {

--- a/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
+++ b/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
@@ -213,7 +213,7 @@ void EnPoField_SetupAppear(EnPoField* this) {
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
     this->actor.home.pos.y = this->actor.world.pos.y;
     if (this->actor.params == EN_PO_FIELD_BIG) {
-        this->actor.speedXZ = 12.0f;
+        this->actor.speed = 12.0f;
         this->collider.dim.radius = 35;
         this->collider.dim.height = 100;
         this->collider.dim.yShift = 10;
@@ -221,7 +221,7 @@ void EnPoField_SetupAppear(EnPoField* this) {
         this->scaleModifier = 0.014f;
         this->actor.naviEnemyId = NAVI_ENEMY_BIG_POE;
     } else {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->collider.dim.radius = D_80AD7080.dim.radius;
         this->collider.dim.height = D_80AD7080.dim.height;
         this->collider.dim.yShift = D_80AD7080.dim.yShift;
@@ -252,7 +252,7 @@ void EnPoField_SetupFlee(EnPoField* this) {
     Animation_MorphToLoop(&this->skelAnime, &gPoeFieldFleeAnim, -5.0f);
     this->collider.base.acFlags |= AC_ON;
     this->actionFunc = EnPoField_Flee;
-    this->actor.speedXZ = 12.0f;
+    this->actor.speed = 12.0f;
     if (this->actionFunc != EnPoField_Damage) {
         this->actor.flags |= ACTOR_FLAG_0;
         this->actor.world.rot.y = this->actor.shape.rot.y + 0x8000;
@@ -269,7 +269,7 @@ void EnPoField_SetupDamage(EnPoField* this) {
         this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->collider.base.ac) + 0x8000;
     }
     this->collider.base.acFlags &= ~(AC_HIT | AC_ON);
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 16);
     this->actionFunc = EnPoField_Damage;
 }
@@ -277,7 +277,7 @@ void EnPoField_SetupDamage(EnPoField* this) {
 void EnPoField_SetupDeath(EnPoField* this) {
     this->actionTimer = 0;
     this->actor.flags &= ~ACTOR_FLAG_0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->actor.naviEnemyId = NAVI_ENEMY_NONE;
     if (this->flameTimer >= 20) {
@@ -290,7 +290,7 @@ void EnPoField_SetupDisappear(EnPoField* this) {
     Animation_MorphToLoop(&this->skelAnime, &gPoeFieldDisappearAnim, -6.0f);
     this->actionTimer = 16;
     this->collider.base.acFlags &= ~(AC_HIT | AC_ON);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DISAPPEAR);
     this->actionFunc = EnPoField_Disappear;
@@ -379,18 +379,18 @@ void EnPoField_CorrectYPos(EnPoField* this, PlayState* play) {
 void EnPoField_SetFleeSpeed(EnPoField* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     f32 speed =
-        ((player->stateFlags1 & PLAYER_STATE1_23) && player->rideActor != NULL) ? player->rideActor->speedXZ : 12.0f;
+        ((player->stateFlags1 & PLAYER_STATE1_23) && player->rideActor != NULL) ? player->rideActor->speed : 12.0f;
 
     if (this->actor.xzDistToPlayer < 300.0f) {
-        this->actor.speedXZ = speed * 1.5f + 2.0f;
+        this->actor.speed = speed * 1.5f + 2.0f;
     } else if (this->actor.xzDistToPlayer < 400.0f) {
-        this->actor.speedXZ = speed * 1.25f + 2.0f;
+        this->actor.speed = speed * 1.25f + 2.0f;
     } else if (this->actor.xzDistToPlayer < 500.0f) {
-        this->actor.speedXZ = speed + 2.0f;
+        this->actor.speed = speed + 2.0f;
     } else {
-        this->actor.speedXZ = 12.0f;
+        this->actor.speed = 12.0f;
     }
-    this->actor.speedXZ = CLAMP_MIN(this->actor.speedXZ, 12.0f);
+    this->actor.speed = CLAMP_MIN(this->actor.speed, 12.0f);
 }
 
 void EnPoField_WaitForSpawn(EnPoField* this, PlayState* play) {
@@ -526,7 +526,7 @@ void EnPoField_Flee(EnPoField* this, PlayState* play) {
 }
 
 void EnPoField_Damage(EnPoField* this, PlayState* play) {
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.5f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.5f);
     if (SkelAnime_Update(&this->skelAnime)) {
         if (this->actor.colChkInfo.health == 0) {
             EnPoField_SetupDeath(this);

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -183,7 +183,7 @@ void EnPoRelay_Talk(EnPoRelay* this, PlayState* play) {
 void EnPoRelay_Race(EnPoRelay* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     Vec3f vec;
-    f32 speed;
+    f32 speedXZ;
     f32 multiplier;
 
     if (this->actionTimer != 0) {
@@ -192,18 +192,18 @@ void EnPoRelay_Race(EnPoRelay* this, PlayState* play) {
     if (this->actionTimer == 0 && Rand_ZeroOne() < 0.03f) {
         this->actionTimer = 32;
         if (this->pathIndex < 23) {
-            speed = Rand_ZeroOne() * 3.0f;
-            if (speed < 1.0f) {
+            speedXZ = Rand_ZeroOne() * 3.0f;
+            if (speedXZ < 1.0f) {
                 multiplier = 1.0f;
-            } else if (speed < 2.0f) {
+            } else if (speedXZ < 2.0f) {
                 multiplier = -1.0f;
             } else {
                 multiplier = 0.0f;
             }
-            speed = 30.0f * multiplier;
+            speedXZ = 30.0f * multiplier;
             Actor_Spawn(&play->actorCtx, play, ACTOR_EN_HONOTRAP,
-                        Math_CosS(this->unk_19A) * speed + this->actor.world.pos.x, this->actor.world.pos.y,
-                        Math_SinS(this->unk_19A) * speed + this->actor.world.pos.z, 0,
+                        Math_CosS(this->unk_19A) * speedXZ + this->actor.world.pos.x, this->actor.world.pos.y,
+                        Math_SinS(this->unk_19A) * speedXZ + this->actor.world.pos.z, 0,
                         (this->unk_19A + 0x8000) - (0x2000 * multiplier), 0, HONOTRAP_FLAME_DROP);
         }
     }
@@ -217,20 +217,20 @@ void EnPoRelay_Race(EnPoRelay* this, PlayState* play) {
                                     player->actor.world.pos.z) != 0) ||
             (Math3D_PointInSquare2D(1580.0f, 2090.0f, -3030.0f, -2500.0f, player->actor.world.pos.x,
                                     player->actor.world.pos.z) != 0)) {
-            speed = (this->hookshotSlotFull) ? player->actor.speed * 1.4f : player->actor.speed * 1.2f;
+            speedXZ = (this->hookshotSlotFull) ? player->actor.speed * 1.4f : player->actor.speed * 1.2f;
         } else if (this->actor.xzDistToPlayer < 150.0f) {
-            speed = (this->hookshotSlotFull) ? player->actor.speed * 1.2f : player->actor.speed;
+            speedXZ = (this->hookshotSlotFull) ? player->actor.speed * 1.2f : player->actor.speed;
         } else if (this->actor.xzDistToPlayer < 300.0f) {
-            speed = (this->hookshotSlotFull) ? player->actor.speed : player->actor.speed * 0.8f;
+            speedXZ = (this->hookshotSlotFull) ? player->actor.speed : player->actor.speed * 0.8f;
         } else if (this->hookshotSlotFull) {
-            speed = 4.5f;
+            speedXZ = 4.5f;
         } else {
-            speed = 3.5f;
+            speedXZ = 3.5f;
         }
         multiplier = 250.0f - this->actor.xzDistToPlayer;
         multiplier = CLAMP_MIN(multiplier, 0.0f);
-        speed += multiplier * 0.02f + 1.0f;
-        Math_ApproachF(&this->actor.speed, speed, 0.5f, 1.5f);
+        speedXZ += multiplier * 0.02f + 1.0f;
+        Math_ApproachF(&this->actor.speed, speedXZ, 0.5f, 1.5f);
     } else {
         Math_ApproachF(&this->actor.speed, 3.5f, 0.5f, 1.5f);
     }

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -148,7 +148,7 @@ void EnPoRelay_SetupRace(EnPoRelay* this) {
 void EnPoRelay_SetupEndRace(EnPoRelay* this) {
     this->actor.world.rot.y = this->actor.home.rot.y + 0xC000;
     this->actor.flags &= ~ACTOR_FLAG_27;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actionFunc = EnPoRelay_EndRace;
 }
 
@@ -217,11 +217,11 @@ void EnPoRelay_Race(EnPoRelay* this, PlayState* play) {
                                     player->actor.world.pos.z) != 0) ||
             (Math3D_PointInSquare2D(1580.0f, 2090.0f, -3030.0f, -2500.0f, player->actor.world.pos.x,
                                     player->actor.world.pos.z) != 0)) {
-            speed = (this->hookshotSlotFull) ? player->actor.speedXZ * 1.4f : player->actor.speedXZ * 1.2f;
+            speed = (this->hookshotSlotFull) ? player->actor.speed * 1.4f : player->actor.speed * 1.2f;
         } else if (this->actor.xzDistToPlayer < 150.0f) {
-            speed = (this->hookshotSlotFull) ? player->actor.speedXZ * 1.2f : player->actor.speedXZ;
+            speed = (this->hookshotSlotFull) ? player->actor.speed * 1.2f : player->actor.speed;
         } else if (this->actor.xzDistToPlayer < 300.0f) {
-            speed = (this->hookshotSlotFull) ? player->actor.speedXZ : player->actor.speedXZ * 0.8f;
+            speed = (this->hookshotSlotFull) ? player->actor.speed : player->actor.speed * 0.8f;
         } else if (this->hookshotSlotFull) {
             speed = 4.5f;
         } else {
@@ -230,9 +230,9 @@ void EnPoRelay_Race(EnPoRelay* this, PlayState* play) {
         multiplier = 250.0f - this->actor.xzDistToPlayer;
         multiplier = CLAMP_MIN(multiplier, 0.0f);
         speed += multiplier * 0.02f + 1.0f;
-        Math_ApproachF(&this->actor.speedXZ, speed, 0.5f, 1.5f);
+        Math_ApproachF(&this->actor.speed, speed, 0.5f, 1.5f);
     } else {
-        Math_ApproachF(&this->actor.speedXZ, 3.5f, 0.5f, 1.5f);
+        Math_ApproachF(&this->actor.speed, 3.5f, 0.5f, 1.5f);
     }
     EnPoRelay_Vec3sToVec3f(&vec, &D_80AD8C30[this->pathIndex]);
     if (Actor_WorldDistXZToPoint(&this->actor, &vec) < 40.0f) {

--- a/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
+++ b/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
@@ -247,7 +247,7 @@ void func_80AD9368(EnPoSisters* this) {
     Animation_MorphToLoop(&this->skelAnime, &gPoeSistersSwayAnim, -3.0f);
     this->unk_19A = Rand_S16Offset(2, 3);
     this->actionFunc = func_80ADA4A8;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void func_80AD93C4(EnPoSisters* this) {
@@ -269,14 +269,14 @@ void func_80AD944C(EnPoSisters* this) {
         this->collider.base.acFlags |= AC_HARD;
     }
     Animation_MorphToLoop(&this->skelAnime, &gPoeSistersAttackAnim, -5.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_19A = Animation_GetLastFrame(&gPoeSistersAttackAnim) * 3 + 3;
     this->unk_199 &= ~2;
     this->actionFunc = func_80ADA7F0;
 }
 
 void func_80AD94E0(EnPoSisters* this) {
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     if (this->unk_194 == 0) {
         this->collider.base.colType = COLTYPE_METAL;
         this->collider.base.acFlags |= AC_HARD;
@@ -306,7 +306,7 @@ void func_80AD95D8(EnPoSisters* this) {
                                       : Actor_WorldYawTowardActor(&this->actor, this->collider.base.ac) + 0x8000;
     }
     if (this->unk_194 != 0) {
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
     }
     this->unk_199 &= ~0xB;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 16);
@@ -318,14 +318,14 @@ void func_80AD96A4(EnPoSisters* this) {
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x8000;
     this->unk_19A = 5;
     this->unk_199 |= 0xB;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     this->actionFunc = func_80ADAC70;
 }
 
 void func_80AD9718(EnPoSisters* this) {
     Animation_Change(&this->skelAnime, &gPoeSistersAppearDisappearAnim, 1.5f, 0.0f,
                      Animation_GetLastFrame(&gPoeSistersAppearDisappearAnim), ANIMMODE_ONCE, -3.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_19C = 100;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->unk_199 &= ~5;
@@ -365,7 +365,7 @@ void func_80AD98F4(EnPoSisters* this, PlayState* play) {
         this->actor.world.rot.y = this->actor.shape.rot.y;
     }
     this->unk_19A = 15;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
     this->unk_199 &= ~1;
     this->actionFunc = func_80ADAE6C;
@@ -373,7 +373,7 @@ void func_80AD98F4(EnPoSisters* this, PlayState* play) {
 
 void func_80AD99D4(EnPoSisters* this, PlayState* play) {
     this->unk_19A = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.pos.y += 42.0f;
     this->actor.shape.yOffset = -6000.0f;
     this->actor.flags &= ~ACTOR_FLAG_0;
@@ -500,7 +500,7 @@ void func_80AD9F90(EnPoSisters* this) {
     Animation_PlayLoop(&this->skelAnime, &gPoeSistersFloatAnim);
     this->unk_199 |= 0xA;
     this->actionFunc = func_80ADBB6C;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
 }
 
 void func_80ADA028(EnPoSisters* this) {
@@ -509,7 +509,7 @@ void func_80ADA028(EnPoSisters* this) {
     this->unk_199 |= 0x15;
     this->actor.flags |= ACTOR_FLAG_0;
     this->actionFunc = func_80ADBBF4;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void func_80ADA094(EnPoSisters* this, PlayState* play) {
@@ -608,13 +608,13 @@ void func_80ADA4A8(EnPoSisters* this, PlayState* play) {
 
 void func_80ADA530(EnPoSisters* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    Math_StepToF(&this->actor.speedXZ, 1.0f, 0.2f);
+    Math_StepToF(&this->actor.speed, 1.0f, 0.2f);
     if (Animation_OnFrame(&this->skelAnime, 0.0f) && this->unk_19A != 0) {
         this->unk_19A--;
     }
     if (this->actor.xzDistToPlayer < 200.0f && fabsf(this->actor.yDistToPlayer + 5.0f) < 30.0f) {
         func_80AD943C(this);
-    } else if (this->unk_19A == 0 && Math_StepToF(&this->actor.speedXZ, 0.0f, 0.2f) != 0) {
+    } else if (this->unk_19A == 0 && Math_StepToF(&this->actor.speed, 0.0f, 0.2f) != 0) {
         func_80AD9368(this);
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
@@ -632,7 +632,7 @@ void func_80ADA6A0(EnPoSisters* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
     temp_v0 = this->actor.yawTowardsPlayer - player->actor.shape.rot.y;
-    Math_StepToF(&this->actor.speedXZ, 2.0f, 0.2f);
+    Math_StepToF(&this->actor.speed, 2.0f, 0.2f);
     if (temp_v0 > 0x3000) {
         Math_ScaledStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer + 0x3000, 0x71C);
     } else if (temp_v0 < -0x3000) {
@@ -686,8 +686,8 @@ void func_80ADA8C0(EnPoSisters* this, PlayState* play) {
 
 void func_80ADA9E8(EnPoSisters* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    this->actor.shape.rot.y -= (this->actor.speedXZ * 10.0f) * 128.0f;
-    if (Math_StepToF(&this->actor.speedXZ, 0.0f, 0.1f) != 0) {
+    this->actor.shape.rot.y -= (this->actor.speed * 10.0f) * 128.0f;
+    if (Math_StepToF(&this->actor.speed, 0.0f, 0.1f) != 0) {
         this->actor.world.rot.y = this->actor.shape.rot.y;
         if (this->unk_194 != 0) {
             func_80AD93C4(this);
@@ -719,7 +719,7 @@ void func_80ADAAA4(EnPoSisters* this, PlayState* play) {
         this->actor.world.pos.y = this->actor.parent->world.pos.y;
         func_80AD97C8(this, play);
     } else if (this->unk_194 != 0) {
-        Math_StepToF(&this->actor.speedXZ, 0.0f, 0.5f);
+        Math_StepToF(&this->actor.speed, 0.0f, 0.5f);
     }
 }
 
@@ -1097,7 +1097,7 @@ void func_80ADBF58(EnPoSisters* this, PlayState* play) {
         play->envCtx.lightSettingOverride = 4;
     }
     if (this->unk_19A < 0) {
-        Math_StepToF(&this->actor.speedXZ, 5.0f, 0.2f);
+        Math_StepToF(&this->actor.speed, 5.0f, 0.2f);
     }
     if (this->unk_19A == -70 && this->unk_194 == 1) {
         SfxSource_PlaySfxAtFixedWorldPos(play, &D_80ADD7BC, 40, NA_SE_EN_PO_LAUGH);

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -213,7 +213,7 @@ void EnPoh_Init(Actor* thisx, PlayState* play) {
         } else {
             collectible = Item_DropCollectible(play, &this->actor.world.pos, 0x4000 | ITEM00_RUPEE_BLUE);
             if (collectible != NULL) {
-                collectible->actor.speedXZ = 0.0f;
+                collectible->actor.speed = 0.0f;
             }
         }
     } else if (this->actor.params == EN_POH_FLAT) {
@@ -259,7 +259,7 @@ void func_80ADE114(EnPoh* this) {
     Animation_PlayLoop(&this->skelAnime, this->info->idleAnim);
     this->unk_198 = Rand_S16Offset(2, 3);
     this->actionFunc = func_80ADEAC4;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnPoh_SetupIdle(EnPoh* this) {
@@ -272,7 +272,7 @@ void func_80ADE1BC(EnPoh* this) {
     Animation_PlayLoop(&this->skelAnime, this->info->idleAnim2);
     this->actionFunc = func_80ADEC9C;
     this->unk_198 = 0;
-    this->actor.speedXZ = 2.0f;
+    this->actor.speed = 2.0f;
 }
 
 void EnPoh_SetupAttack(EnPoh* this) {
@@ -282,7 +282,7 @@ void EnPoh_SetupAttack(EnPoh* this) {
         Animation_PlayLoop(&this->skelAnime, &gPoeComposerAttackAnim);
     }
     this->unk_198 = 12;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
     this->actionFunc = EnPoh_Attack;
 }
@@ -299,14 +299,14 @@ void func_80ADE28C(EnPoh* this) {
         this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->colliderCyl.base.ac) + 0x8000;
     }
     this->colliderCyl.base.acFlags &= ~AC_ON;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 16);
     this->actionFunc = func_80ADEECC;
 }
 
 void func_80ADE368(EnPoh* this) {
     Animation_MorphToLoop(&this->skelAnime, this->info->fleeAnim, -5.0f);
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x8000;
     this->colliderCyl.base.acFlags |= AC_ON;
     this->unk_198 = 200;
@@ -329,7 +329,7 @@ void EnPoh_SetupInitialAction(EnPoh* this) {
 }
 
 void func_80ADE48C(EnPoh* this) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->unk_198 = 0;
     this->actor.naviEnemyId = NAVI_ENEMY_NONE;
@@ -340,19 +340,19 @@ void func_80ADE48C(EnPoh* this) {
 void func_80ADE4C8(EnPoh* this) {
     Animation_PlayOnce(&this->skelAnime, this->info->idleAnim2);
     this->actionFunc = func_80ADF574;
-    this->actor.speedXZ = -5.0f;
+    this->actor.speed = -5.0f;
 }
 
 void func_80ADE514(EnPoh* this) {
     Animation_PlayLoop(&this->skelAnime, this->info->idleAnim);
     this->unk_19C = this->actor.world.rot.y + 0x8000;
     this->actionFunc = func_80ADF5E0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnPoh_SetupDisappear(EnPoh* this) {
     this->unk_194 = 32;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_DISAPPEAR);
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
@@ -361,7 +361,7 @@ void EnPoh_SetupDisappear(EnPoh* this) {
 
 void EnPoh_SetupAppear(EnPoh* this) {
     this->unk_194 = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_APPEAR);
     Actor_PlaySfx(&this->actor, NA_SE_EN_PO_LAUGH);
     this->actionFunc = EnPoh_Appear;
@@ -494,7 +494,7 @@ void func_80ADEAC4(EnPoh* this, PlayState* play) {
 
 void EnPoh_Idle(EnPoh* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    Math_StepToF(&this->actor.speedXZ, 1.0f, 0.2f);
+    Math_StepToF(&this->actor.speed, 1.0f, 0.2f);
     if (Animation_OnFrame(&this->skelAnime, 0.0f) && this->unk_198 != 0) {
         this->unk_198--;
     }
@@ -555,7 +555,7 @@ void EnPoh_Attack(EnPoh* this, PlayState* play) {
     if (this->unk_198 >= 10) {
         Math_ScaledStepToS(&this->actor.world.rot.y, this->actor.yawTowardsPlayer, 0xE38);
     } else if (this->unk_198 == 9) {
-        this->actor.speedXZ = 5.0f;
+        this->actor.speed = 5.0f;
         this->skelAnime.playSpeed = 2.0f;
     } else if (this->unk_198 == 0) {
         EnPoh_SetupIdle(this);
@@ -564,7 +564,7 @@ void EnPoh_Attack(EnPoh* this, PlayState* play) {
 }
 
 void func_80ADEECC(EnPoh* this, PlayState* play) {
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.5f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.5f);
     if (SkelAnime_Update(&this->skelAnime)) {
         if (this->actor.colChkInfo.health != 0) {
             func_80ADE368(this);
@@ -654,7 +654,7 @@ void func_80ADF574(EnPoh* this, PlayState* play) {
         EnPoh_SetupIdle(this);
         this->unk_198 = 23;
     } else {
-        Math_StepToF(&this->actor.speedXZ, 0.0f, 0.5f);
+        Math_StepToF(&this->actor.speed, 0.0f, 0.5f);
         this->actor.shape.rot.y += 0x1000;
     }
 }

--- a/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.c
+++ b/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.c
@@ -68,11 +68,11 @@ void EnPubox_Destroy(Actor* thisx, PlayState* play) {
 void EnPubox_Update(Actor* thisx, PlayState* play) {
     EnPubox* this = (EnPubox*)thisx;
 
-    thisx->speedXZ += this->dyna.unk_150;
+    thisx->speed += this->dyna.unk_150;
     thisx->world.rot.y = this->dyna.unk_158;
-    thisx->speedXZ = (thisx->speedXZ < -2.5f) ? -2.5f : ((thisx->speedXZ > 2.5f) ? 2.5f : thisx->speedXZ);
-    Math_SmoothStepToF(&thisx->speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
-    if (thisx->speedXZ != 0.0f) {
+    thisx->speed = (thisx->speed < -2.5f) ? -2.5f : ((thisx->speed > 2.5f) ? 2.5f : thisx->speed);
+    Math_SmoothStepToF(&thisx->speed, 0.0f, 1.0f, 1.0f, 0.0f);
+    if (thisx->speed != 0.0f) {
         Audio_PlaySfxGeneral(NA_SE_EV_ROCK_SLIDE - SFX_FLAG, &thisx->projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
     }

--- a/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.c
+++ b/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.c
@@ -70,7 +70,7 @@ void EnPubox_Update(Actor* thisx, PlayState* play) {
 
     thisx->speed += this->dyna.unk_150;
     thisx->world.rot.y = this->dyna.unk_158;
-    thisx->speed = (thisx->speed < -2.5f) ? -2.5f : ((thisx->speed > 2.5f) ? 2.5f : thisx->speed);
+    thisx->speed = CLAMP(thisx->speed, -2.5f, 2.5f);
     Math_SmoothStepToF(&thisx->speed, 0.0f, 1.0f, 1.0f, 0.0f);
     if (thisx->speed != 0.0f) {
         Audio_PlaySfxGeneral(NA_SE_EV_ROCK_SLIDE - SFX_FLAG, &thisx->projectedPos, 4, &gSfxDefaultFreqAndVolScale,

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -234,7 +234,7 @@ void EnRd_SetupIdle(EnRd* this) {
 
     this->action = REDEAD_ACTION_IDLE;
     this->timer = (Rand_ZeroOne() * 10.0f) + 5.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnRd_SetupAction(this, EnRd_Idle);
 }
@@ -300,7 +300,7 @@ void EnRd_SetupRiseFromCoffin(EnRd* this) {
     this->actor.shape.rot.x = -0x4000;
     this->actor.gravity = 0.0f;
     this->actor.shape.yOffset = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnRd_SetupAction(this, EnRd_RiseFromCoffin);
 }
 
@@ -319,8 +319,8 @@ void EnRd_RiseFromCoffin(EnRd* this, PlayState* play) {
         if (Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.home.pos.y + 50.0f, 0.3f, 2.0f, 0.3f) == 0.0f) {
             if (this->timer != 0) {
                 this->timer--;
-                Math_SmoothStepToF(&this->actor.speedXZ, 6.0f, 0.3f, 1.0f, 0.3f);
-            } else if (Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.3f, 1.0f, 0.3f) == 0.0f) {
+                Math_SmoothStepToF(&this->actor.speed, 6.0f, 0.3f, 1.0f, 0.3f);
+            } else if (Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.3f, 1.0f, 0.3f) == 0.0f) {
                 Math_SmoothStepToS(&this->actor.shape.rot.x, 0, 1, 0x7D0, 0);
             }
         }
@@ -330,7 +330,7 @@ void EnRd_RiseFromCoffin(EnRd* this, PlayState* play) {
 void EnRd_SetupWalkToPlayer(EnRd* this, PlayState* play) {
     Animation_Change(&this->skelAnime, &gGibdoRedeadWalkAnim, 1.0f, 4.0f, Animation_GetLastFrame(&gGibdoRedeadWalkAnim),
                      ANIMMODE_LOOP_INTERP, -4.0f);
-    this->actor.speedXZ = 0.4f;
+    this->actor.speed = 0.4f;
     this->action = REDEAD_ACTION_WALK_TO_PLAYER_OR_RELEASE_GRAB;
     EnRd_SetupAction(this, EnRd_WalkToPlayer);
 }
@@ -343,7 +343,7 @@ void EnRd_WalkToPlayer(EnRd* this, PlayState* play) {
     s32 pad;
     s16 yaw = this->actor.yawTowardsPlayer - this->actor.shape.rot.y - this->headYRotation - this->upperBodyYRotation;
 
-    this->skelAnime.playSpeed = this->actor.speedXZ;
+    this->skelAnime.playSpeed = this->actor.speed;
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 0xFA, 0);
     Math_SmoothStepToS(&this->headYRotation, 0, 1, 0x64, 0);
     Math_SmoothStepToS(&this->upperBodyYRotation, 0, 1, 0x64, 0);
@@ -415,7 +415,7 @@ void EnRd_WalkToHome(EnRd* this, PlayState* play) {
     if (Actor_WorldDistXYZToPoint(&this->actor, &this->actor.home.pos) >= 5.0f) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, targetY, 1, 0x1C2, 0);
     } else {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         if (Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, 1, 0x1C2, 0) == 0) {
             if (this->actor.params != REDEAD_TYPE_CRYING) {
                 EnRd_SetupIdle(this);
@@ -476,9 +476,9 @@ void EnRd_WalkToParent(EnRd* this, PlayState* play) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, targetY, 1, 0xFA, 0);
 
         if (Actor_WorldDistXYZToPoint(&this->actor, &parentPos) >= 45.0f) {
-            this->actor.speedXZ = 0.4f;
+            this->actor.speed = 0.4f;
         } else {
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
 
             if (this->actor.params != REDEAD_TYPE_CRYING) {
                 EnRd_SetupIdle(this);
@@ -508,7 +508,7 @@ void EnRd_SetupGrab(EnRd* this) {
     this->timer = this->grabState = 0;
     this->grabDamageTimer = 200;
     this->action = REDEAD_ACTION_GRAB;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnRd_SetupAction(this, EnRd_Grab);
 }
 
@@ -645,7 +645,7 @@ void EnRd_SetupDamaged(EnRd* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gGibdoRedeadDamageAnim, -6.0f);
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        this->actor.speedXZ = -2.0f;
+        this->actor.speed = -2.0f;
     }
 
     this->actor.flags |= ACTOR_FLAG_0;
@@ -657,8 +657,8 @@ void EnRd_SetupDamaged(EnRd* this) {
 void EnRd_Damaged(EnRd* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (this->actor.speedXZ < 0.0f) {
-        this->actor.speedXZ += 0.15f;
+    if (this->actor.speed < 0.0f) {
+        this->actor.speed += 0.15f;
     }
 
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
@@ -684,7 +684,7 @@ void EnRd_SetupDead(EnRd* this) {
     this->action = REDEAD_ACTION_DEAD;
     this->timer = 300;
     this->actor.flags &= ~ACTOR_FLAG_0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_DEAD);
     EnRd_SetupAction(this, EnRd_Dead);
 }
@@ -723,7 +723,7 @@ void EnRd_Dead(EnRd* this, PlayState* play) {
 
 void EnRd_SetupStunned(EnRd* this) {
     this->action = REDEAD_ACTION_STUNNED;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     if (gSaveContext.sunsSongState != SUNSSONG_INACTIVE) {
         this->stunnedBySunsSong = true;
@@ -857,11 +857,11 @@ void EnRd_Update(Actor* thisx, PlayState* play) {
         }
 
         this->actionFunc(this, play);
-        if (this->action != REDEAD_ACTION_GRAB && this->actor.speedXZ != 0.0f) {
+        if (this->action != REDEAD_ACTION_GRAB && this->actor.speed != 0.0f) {
             Actor_MoveForward(&this->actor);
         }
 
-        if ((this->actor.shape.rot.x == 0) && (this->action != REDEAD_ACTION_GRAB) && (this->actor.speedXZ != 0.0f)) {
+        if ((this->actor.shape.rot.x == 0) && (this->action != REDEAD_ACTION_GRAB) && (this->actor.speed != 0.0f)) {
             Actor_UpdateBgCheckInfo(play, &this->actor, 30.0f, 20.0f, 35.0f,
                                     UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2 | UPDBGCHECKINFO_FLAG_3 |
                                         UPDBGCHECKINFO_FLAG_4);

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -282,7 +282,7 @@ void EnReeba_SetupMoveBig(EnReeba* this, PlayState* play) {
 }
 
 void EnReeba_MoveBig(EnReeba* this, PlayState* play) {
-    f32 speed;
+    f32 accel;
     s16 yawDiff;
     s16 yaw;
     s32 surfaceType;
@@ -303,8 +303,9 @@ void EnReeba_MoveBig(EnReeba* this, PlayState* play) {
             this->bigLeeverTimer = 30;
         }
 
-        speed = (this->actor.xzDistToPlayer - 20.0f) / ((Rand_ZeroOne() * 50.0f) + 150.0f);
-        this->actor.speed += speed * 1.8f;
+        accel = (this->actor.xzDistToPlayer - 20.0f) / ((Rand_ZeroOne() * 50.0f) + 150.0f);
+        this->actor.speed += accel * 1.8f;
+        
         if (this->actor.speed >= 3.0f) {
             this->actor.speed = 3.0f;
         }

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -305,7 +305,7 @@ void EnReeba_MoveBig(EnReeba* this, PlayState* play) {
 
         accel = (this->actor.xzDistToPlayer - 20.0f) / ((Rand_ZeroOne() * 50.0f) + 150.0f);
         this->actor.speed += accel * 1.8f;
-        
+
         if (this->actor.speed >= 3.0f) {
             this->actor.speed = 3.0f;
         }

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -194,7 +194,6 @@ void EnReeba_SetupSurface(EnReeba* this, PlayState* play) {
     this->actor.flags &= ~ACTOR_FLAG_27;
     this->actor.world.pos.y = this->actor.floorHeight;
 
-
     if (this->type != LEEVER_TYPE_SMALL) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_RIVA_BIG_APPEAR);
     } else {
@@ -247,7 +246,7 @@ void EnReeba_Surface(EnReeba* this, PlayState* play) {
                 this->actionfunc = EnReeba_SetupMoveBig;
             } else {
                 this->moveTimer = 130;
-                this->actor.speedXZ = Rand_ZeroFloat(4.0f) + 6.0f;
+                this->actor.speed = Rand_ZeroFloat(4.0f) + 6.0f;
                 this->actionfunc = EnReeba_Move;
             }
         }
@@ -266,7 +265,7 @@ void EnReeba_Move(EnReeba* this, PlayState* play) {
     surfaceType = SurfaceType_GetFloorType(&play->colCtx, this->actor.floorPoly, this->actor.floorBgId);
 
     if ((surfaceType != FLOOR_TYPE_4) && (surfaceType != FLOOR_TYPE_7)) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actionfunc = EnReeba_SetupSink;
     } else if ((this->moveTimer == 0) || (this->actor.xzDistToPlayer < 30.0f) ||
                (this->actor.xzDistToPlayer > 400.0f) || (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
@@ -305,12 +304,12 @@ void EnReeba_MoveBig(EnReeba* this, PlayState* play) {
         }
 
         speed = (this->actor.xzDistToPlayer - 20.0f) / ((Rand_ZeroOne() * 50.0f) + 150.0f);
-        this->actor.speedXZ += speed * 1.8f;
-        if (this->actor.speedXZ >= 3.0f) {
-            this->actor.speedXZ = 3.0f;
+        this->actor.speed += speed * 1.8f;
+        if (this->actor.speed >= 3.0f) {
+            this->actor.speed = 3.0f;
         }
-        if (this->actor.speedXZ < -3.0f) {
-            this->actor.speedXZ = -3.0f;
+        if (this->actor.speed < -3.0f) {
+            this->actor.speed = -3.0f;
         }
 
         yawDiff = (this->bigLeeverTimer == 0) ? this->actor.yawTowardsPlayer : -this->actor.yawTowardsPlayer;
@@ -326,7 +325,7 @@ void EnReeba_MoveBig(EnReeba* this, PlayState* play) {
 }
 
 void EnReeba_Bumped(EnReeba* this, PlayState* play) {
-    Math_ApproachZeroF(&this->actor.speedXZ, 1.0f, 0.3f);
+    Math_ApproachZeroF(&this->actor.speed, 1.0f, 0.3f);
 
     if (this->moveTimer == 0) {
         if (this->type != LEEVER_TYPE_SMALL) {
@@ -347,7 +346,7 @@ void EnReeba_SetupSink(EnReeba* this, PlayState* play) {
 
 void EnReeba_Sink(EnReeba* this, PlayState* play) {
     Math_ApproachZeroF(&this->actor.shape.shadowScale, 1.0f, 0.3f);
-    Math_ApproachZeroF(&this->actor.speedXZ, 0.1f, 0.3f);
+    Math_ApproachZeroF(&this->actor.speed, 0.1f, 0.3f);
     SkelAnime_Update(&this->skelanime);
 
     if ((this->yOffsetTarget + 10.0f) <= this->actor.shape.yOffset) {
@@ -365,7 +364,7 @@ void EnReeba_Sink(EnReeba* this, PlayState* play) {
 
 void EnReeba_SetupDamaged(EnReeba* this, PlayState* play) {
     this->damagedTimer = 14;
-    this->actor.speedXZ = -8.0f;
+    this->actor.speed = -8.0f;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
     this->actionfunc = EnReeba_Damaged;
@@ -374,8 +373,8 @@ void EnReeba_SetupDamaged(EnReeba* this, PlayState* play) {
 void EnReeba_Damaged(EnReeba* this, PlayState* play) {
     SkelAnime_Update(&this->skelanime);
 
-    if (this->actor.speedXZ < 0.0f) {
-        this->actor.speedXZ += 1.0f;
+    if (this->actor.speed < 0.0f) {
+        this->actor.speed += 1.0f;
     }
 
     if (this->damagedTimer == 0) {
@@ -391,7 +390,7 @@ void EnReeba_Damaged(EnReeba* this, PlayState* play) {
 void EnReeba_SetupStunned(EnReeba* this, PlayState* play) {
     this->waitTimer = 14;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-    this->actor.speedXZ = -8.0f;
+    this->actor.speed = -8.0f;
     this->actor.flags |= ACTOR_FLAG_27;
     this->actor.flags &= ~(ACTOR_FLAG_0 | ACTOR_FLAG_2);
     this->actionfunc = EnReeba_Stunned;
@@ -402,11 +401,11 @@ void EnReeba_Stunned(EnReeba* this, PlayState* play) {
     f32 scale;
 
     if (this->waitTimer != 0) {
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ += 1.0f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed += 1.0f;
         }
     } else {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
 
         if ((this->stunType == LEEVER_STUN_OTHER) || (this->actor.colChkInfo.health != 0)) {
             if (this->stunType == LEEVER_STUN_ICE) {
@@ -456,7 +455,7 @@ void EnReeba_StunDie(EnReeba* this, PlayState* play) {
 }
 
 void EnReeba_SetupDie(EnReeba* this, PlayState* play) {
-    this->actor.speedXZ = -8.0f;
+    this->actor.speed = -8.0f;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
     this->waitTimer = 14;
@@ -470,11 +469,11 @@ void EnReeba_Die(EnReeba* this, PlayState* play) {
     Vec3f velocity = { 0.0f, 0.0f, 0.0f };
 
     if (this->waitTimer != 0) {
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ += 1.0f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed += 1.0f;
         }
     } else {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         Math_ApproachZeroF(&this->scale, 0.1f, 0.01f);
 
         if (this->scale < 0.01f) {
@@ -635,7 +634,7 @@ void EnReeba_Update(Actor* thisx, PlayState* play2) {
         this->collider.base.atFlags &= ~AT_BOUNCED;
 
         if ((this->actionfunc == EnReeba_Move) || (this->actionfunc == EnReeba_MoveBig)) {
-            this->actor.speedXZ = 8.0f;
+            this->actor.speed = 8.0f;
             this->actor.world.rot.y *= -1.0f;
             this->moveTimer = 14;
             this->actionfunc = EnReeba_Bumped;

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -205,8 +205,8 @@ void EnRr_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyCylinder(play, &this->collider2);
 }
 
-void EnRr_SetSpeed(EnRr* this, f32 speed) {
-    this->actor.speed = speed;
+void EnRr_Move(EnRr* this, f32 speedXZ) {
+    this->actor.speed = speedXZ;
     Actor_PlaySfx(&this->actor, NA_SE_EN_LIKE_WALK);
 }
 
@@ -579,7 +579,7 @@ void EnRr_Approach(EnRr* this, PlayState* play) {
     if ((this->actionTimer == 0) && (this->actor.xzDistToPlayer < 160.0f)) {
         EnRr_SetupReach(this);
     } else if ((this->actor.xzDistToPlayer < 400.0f) && (this->actor.speed == 0.0f)) {
-        EnRr_SetSpeed(this, 2.0f);
+        EnRr_Move(this, 2.0f);
     }
 }
 
@@ -742,7 +742,7 @@ void EnRr_Retreat(EnRr* this, PlayState* play) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer + 0x8000, 0xA, 0x3E8, 0);
         this->actor.world.rot.y = this->actor.shape.rot.y;
         if (this->actor.speed == 0.0f) {
-            EnRr_SetSpeed(this, 2.0f);
+            EnRr_Move(this, 2.0f);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -176,7 +176,7 @@ void EnRr_Init(Actor* thisx, PlayState* play2) {
     this->actor.scale.y = 0.013f;
     this->actor.scale.x = this->actor.scale.z = 0.014f;
     this->actor.colChkInfo.mass = MASS_IMMOVABLE;
-    this->actor.velocity.y = this->actor.speedXZ = 0.0f;
+    this->actor.velocity.y = this->actor.speed = 0.0f;
     this->actor.gravity = -0.4f;
     this->actionTimer = 0;
     this->eatenShield = 0;
@@ -206,7 +206,7 @@ void EnRr_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnRr_SetSpeed(EnRr* this, f32 speed) {
-    this->actor.speedXZ = speed;
+    this->actor.speed = speed;
     Actor_PlaySfx(&this->actor, NA_SE_EN_LIKE_WALK);
 }
 
@@ -256,7 +256,7 @@ void EnRr_SetupGrabPlayer(EnRr* this, Player* player) {
     this->ocTimer = 8;
     this->hasPlayer = true;
     this->reachState = 0;
-    this->segMoveRate = this->swallowOffset = this->actor.speedXZ = 0.0f;
+    this->segMoveRate = this->swallowOffset = this->actor.speed = 0.0f;
     this->pulseSizeTarget = 0.15f;
     this->segPhaseVelTarget = 5000.0f;
     this->wobbleSizeTarget = 512.0f;
@@ -578,7 +578,7 @@ void EnRr_Approach(EnRr* this, PlayState* play) {
     this->actor.world.rot.y = this->actor.shape.rot.y;
     if ((this->actionTimer == 0) && (this->actor.xzDistToPlayer < 160.0f)) {
         EnRr_SetupReach(this);
-    } else if ((this->actor.xzDistToPlayer < 400.0f) && (this->actor.speedXZ == 0.0f)) {
+    } else if ((this->actor.xzDistToPlayer < 400.0f) && (this->actor.speed == 0.0f)) {
         EnRr_SetSpeed(this, 2.0f);
     }
 }
@@ -741,7 +741,7 @@ void EnRr_Retreat(EnRr* this, PlayState* play) {
     } else {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer + 0x8000, 0xA, 0x3E8, 0);
         this->actor.world.rot.y = this->actor.shape.rot.y;
-        if (this->actor.speedXZ == 0.0f) {
+        if (this->actor.speed == 0.0f) {
             EnRr_SetSpeed(this, 2.0f);
         }
     }
@@ -796,7 +796,7 @@ void EnRr_Update(Actor* thisx, PlayState* play) {
         ASSERT(0, "0", "../z_en_rr.c", 1355);
     }
 
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.1f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.1f);
     Actor_MoveForward(&this->actor);
     Collider_UpdateCylinder(&this->actor, &this->collider1);
     this->collider2.dim.pos.x = this->mouthPos.x;

--- a/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
+++ b/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
@@ -346,7 +346,7 @@ void func_80AEB1D8(EnRu1* this) {
     this->actor.velocity.x = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.velocity.z = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.gravity = 0.0f;
     this->actor.minVelocityY = 0.0f;
     func_80AEB0EC(this, 0);
@@ -789,9 +789,9 @@ void func_80AEC40C(EnRu1* this) {
     f32 unk_26C = this->unk_26C;
 
     if (unk_26C < 8.0f) {
-        this->actor.speedXZ = (((kREG(3) * 0.01f) + 2.7f) / 8.0f) * unk_26C;
+        this->actor.speed = (((kREG(3) * 0.01f) + 2.7f) / 8.0f) * unk_26C;
     } else {
-        this->actor.speedXZ = (kREG(3) * 0.01f) + 2.7f;
+        this->actor.speed = (kREG(3) * 0.01f) + 2.7f;
     }
     this->actor.velocity.y = -1.0f;
     Actor_MoveForward(&this->actor);
@@ -803,7 +803,7 @@ void func_80AEC4CC(EnRu1* this) {
 }
 
 void func_80AEC4F4(EnRu1* this) {
-    f32* speedXZ = &this->actor.speedXZ;
+    f32* speedXZ = &this->actor.speed;
     f32* unk_26C = &this->unk_26C;
 
     if (this->unk_26C < 8.0f) {
@@ -1050,7 +1050,7 @@ s32 func_80AECF6C(EnRu1* this, PlayState* play) {
     s32 pad2[5];
 
     this->unk_26C += 1.0f;
-    if ((player->actor.speedXZ == 0.0f) && (this->unk_26C >= 3.0f)) {
+    if ((player->actor.speed == 0.0f) && (this->unk_26C >= 3.0f)) {
         otherPlayer = GET_PLAYER(play);
         player->actor.world.pos.x = otherPlayer->unk_450.x;
         player->actor.world.pos.y = otherPlayer->unk_450.y;
@@ -1203,7 +1203,7 @@ void func_80AED520(EnRu1* this, PlayState* play) {
 }
 
 void func_80AED57C(EnRu1* this) {
-    if (this->actor.speedXZ != 0.0f) {
+    if (this->actor.speed != 0.0f) {
         func_80078914(&this->actor.projectedPos, NA_SE_VO_RT_THROW);
     }
 }
@@ -1337,7 +1337,7 @@ void func_80AEDB30(EnRu1* this, PlayState* play) {
         velocityY = &this->actor.velocity.y;
         dynaPolyActor = DynaPoly_GetActor(&play->colCtx, this->actor.floorBgId);
         if (*velocityY <= 0.0f) {
-            speedXZ = &this->actor.speedXZ;
+            speedXZ = &this->actor.speed;
             if (dynaPolyActor != NULL) {
                 if (dynaPolyActor->actor.id != ACTOR_EN_BOX) {
                     *speedXZ = 0.0f;
@@ -1370,7 +1370,7 @@ void func_80AEDB30(EnRu1* this, PlayState* play) {
         }
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_CEILING) {
-        speedXZ = &this->actor.speedXZ;
+        speedXZ = &this->actor.speed;
         velocityY = &this->actor.velocity.y;
         if (*speedXZ >= (kREG(27) * 0.01f) + 3.0f) {
             *speedXZ *= (kREG(19) * 0.01f) + 0.8f;
@@ -1383,7 +1383,7 @@ void func_80AEDB30(EnRu1* this, PlayState* play) {
         }
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-        speedXZ = &this->actor.speedXZ;
+        speedXZ = &this->actor.speed;
         if (*speedXZ != 0.0f) {
             rotY = this->actor.world.rot.y;
             wallYaw = this->actor.wallYaw;
@@ -1409,7 +1409,7 @@ void func_80AEDB30(EnRu1* this, PlayState* play) {
 }
 
 void func_80AEDEF4(EnRu1* this, PlayState* play) {
-    f32* speedXZ = &this->actor.speedXZ;
+    f32* speedXZ = &this->actor.speed;
     DynaPolyActor* dynaPolyActor = DynaPoly_GetActor(&play->colCtx, this->actor.floorBgId);
 
     if (dynaPolyActor != NULL && dynaPolyActor->actor.id == ACTOR_EN_BOX) {
@@ -1436,7 +1436,7 @@ void func_80AEE02C(EnRu1* this) {
     this->actor.velocity.x = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.velocity.z = 0.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.gravity = 0.0f;
     this->actor.minVelocityY = 0.0f;
 }
@@ -1449,7 +1449,7 @@ void func_80AEE050(EnRu1* this) {
     EnRu1* thisx = this; // necessary to match
 
     if (this->unk_350 == 0) {
-        if ((this->actor.minVelocityY == 0.0f) && (this->actor.speedXZ == 0.0f)) {
+        if ((this->actor.minVelocityY == 0.0f) && (this->actor.speed == 0.0f)) {
             this->unk_350 = 1;
             func_80AEE02C(this);
             this->unk_35C = 0;
@@ -1463,12 +1463,12 @@ void func_80AEE050(EnRu1* this) {
                 this->actor.minVelocityY = 0.0f;
                 this->actor.velocity.y = 0.0f;
             }
-            this->actor.speedXZ *= 0.5f;
-            if (this->actor.speedXZ <= 0.1f) {
-                this->actor.speedXZ = 0.0f;
+            this->actor.speed *= 0.5f;
+            if (this->actor.speed <= 0.1f) {
+                this->actor.speed = 0.0f;
             }
-            this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speedXZ;
-            this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speedXZ;
+            this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speed;
+            this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speed;
             func_8002D7EC(&this->actor);
         }
     } else {
@@ -1571,7 +1571,7 @@ void func_80AEE488(EnRu1* this, PlayState* play) {
 
 void func_80AEE568(EnRu1* this, PlayState* play) {
     if (!func_80AEE394(this, play)) {
-        if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (this->actor.speedXZ == 0.0f) &&
+        if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (this->actor.speed == 0.0f) &&
             (this->actor.minVelocityY == 0.0f)) {
             func_80AEE02C(this);
             Actor_OfferCarry(&this->actor, play);
@@ -1628,7 +1628,7 @@ void func_80AEE7C4(EnRu1* this, PlayState* play) {
         frameCount = Animation_GetLastFrame(&gRutoChildSittingAnim);
         Animation_Change(&this->skelAnime, &gRutoChildSittingAnim, 1.0f, 0, frameCount, ANIMMODE_LOOP, -8.0f);
         func_80AED6DC(this, play);
-        this->actor.speedXZ *= (kREG(25) * 0.01f) + 1.0f;
+        this->actor.speed *= (kREG(25) * 0.01f) + 1.0f;
         this->actor.velocity.y *= (kREG(26) * 0.01f) + 1.0f;
         this->actor.minVelocityY = -((kREG(24) * 0.01f) + 6.8f);
         this->actor.gravity = -((kREG(23) * 0.01f) + 1.3f);

--- a/src/overlays/actors/ovl_En_Sb/z_en_sb.c
+++ b/src/overlays/actors/ovl_En_Sb/z_en_sb.c
@@ -118,7 +118,7 @@ void EnSb_Init(Actor* thisx, PlayState* play) {
     this->actor.colChkInfo.mass = 0;
     Actor_SetScale(&this->actor, 0.006f);
     this->actor.shape.rot.y = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.gravity = -0.35f;
     this->fire = 0;
     this->hitByWindArrow = false;
@@ -190,12 +190,12 @@ void EnSb_SetupCooldown(EnSb* this, s32 changeSpeed) {
     this->behavior = SHELLBLADE_WAIT_CLOSED;
     if (changeSpeed) {
         if (this->actor.yDistToWater > 0.0f) {
-            this->actor.speedXZ = -5.0f;
+            this->actor.speed = -5.0f;
             if (this->actor.velocity.y < 0.0f) {
                 this->actor.velocity.y = 2.1f;
             }
         } else {
-            this->actor.speedXZ = -6.0f;
+            this->actor.speed = -6.0f;
             if (this->actor.velocity.y < 0.0f) {
                 this->actor.velocity.y = 1.4f;
             }
@@ -256,11 +256,11 @@ void EnSb_TurnAround(EnSb* this, PlayState* play) {
         this->actor.world.rot.y = this->attackYaw;
         if (this->actor.yDistToWater > 0.0f) {
             this->actor.velocity.y = 3.0f;
-            this->actor.speedXZ = 5.0f;
+            this->actor.speed = 5.0f;
             this->actor.gravity = -0.35f;
         } else {
             this->actor.velocity.y = 2.0f;
-            this->actor.speedXZ = 6.0f;
+            this->actor.speed = 6.0f;
             this->actor.gravity = -2.0f;
         }
         EnSb_SpawnBubbles(play, this);
@@ -272,7 +272,7 @@ void EnSb_TurnAround(EnSb* this, PlayState* play) {
 }
 
 void EnSb_Lunge(EnSb* this, PlayState* play) {
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.2f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.2f);
     if ((this->actor.velocity.y <= -0.1f) || (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH)) {
         if (!(this->actor.yDistToWater > 0.0f)) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
@@ -289,7 +289,7 @@ void EnSb_Bounce(EnSb* this, PlayState* play) {
 
     currentFrame = this->skelAnime.curFrame;
     frameCount = Animation_GetLastFrame(&object_sb_Anim_0000B4);
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.2f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.2f);
 
     if (currentFrame == frameCount) {
         if (this->bouncesLeft != 0) {
@@ -297,18 +297,18 @@ void EnSb_Bounce(EnSb* this, PlayState* play) {
             this->timer = 1;
             if (this->actor.yDistToWater > 0.0f) {
                 this->actor.velocity.y = 3.0f;
-                this->actor.speedXZ = 5.0f;
+                this->actor.speed = 5.0f;
                 this->actor.gravity = -0.35f;
             } else {
                 this->actor.velocity.y = 2.0f;
-                this->actor.speedXZ = 6.0f;
+                this->actor.speed = 6.0f;
                 this->actor.gravity = -2.0f;
             }
             EnSb_SpawnBubbles(play, this);
             EnSb_SetupLunge(this);
         } else if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
             this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND_TOUCH;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->timer = 1;
             EnSb_SetupWaitClosed(this);
             osSyncPrintf(VT_FGCOL(RED) "攻撃終了！！" VT_RST "\n"); // "Attack Complete!"
@@ -321,13 +321,13 @@ void EnSb_Cooldown(EnSb* this, PlayState* play) {
         this->timer--;
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
             this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
         }
     } else {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
             this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND;
             this->actionFunc = EnSb_WaitClosed;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.c
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.c
@@ -238,7 +238,7 @@ void EnSkb_SetupDespawn(EnSkb* this) {
     this->actionState = SKB_BEHAVIOR_BURIED;
     this->setColliderAT = false;
     this->actor.flags &= ~ACTOR_FLAG_0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_AKINDONUTS_HIDE);
     EnSkb_SetupAction(this, EnSkb_Despawn);
 }
@@ -259,7 +259,7 @@ void EnSkb_SetupWalkForward(EnSkb* this) {
                      Animation_GetLastFrame(&gStalchildWalkingAnim), ANIMMODE_LOOP, -4.0f);
     this->actionState = SKB_BEHAVIOR_WALKING;
     this->headlessYawOffset = 0;
-    this->actor.speedXZ = this->actor.scale.y * 160.0f;
+    this->actor.speed = this->actor.scale.y * 160.0f;
     EnSkb_SetupAction(this, EnSkb_WalkForward);
 }
 
@@ -307,7 +307,7 @@ void EnSkb_SetupAttack(EnSkb* this) {
                      Animation_GetLastFrame(&gStalchildAttackingAnim), ANIMMODE_ONCE_INTERP, 4.0f);
     this->collider.base.atFlags &= ~AT_BOUNCED;
     this->actionState = SKB_BEHAVIOR_ATTACKING;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnSkb_SetupAction(this, EnSkb_Attack);
 }
 
@@ -346,7 +346,7 @@ void EnSkb_Recoil(EnSkb* this, PlayState* play) {
 
 void EnSkb_SetupStunned(EnSkb* this) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
     Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
     this->setColliderAT = false;
@@ -356,11 +356,11 @@ void EnSkb_SetupStunned(EnSkb* this) {
 
 void EnSkb_Stunned(EnSkb* this, PlayState* play) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ += 0.05f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed += 0.05f;
         }
     }
     if ((this->actor.colorFilterTimer == 0) && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
@@ -375,7 +375,7 @@ void EnSkb_Stunned(EnSkb* this, PlayState* play) {
 void EnSkb_SetupTakeDamage(EnSkb* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gStalchildDamagedAnim, -4.0f);
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        this->actor.speedXZ = -4.0f;
+        this->actor.speed = -4.0f;
     }
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     Actor_PlaySfx(&this->actor, NA_SE_EN_STALKID_DAMAGE);
@@ -393,11 +393,11 @@ void EnSkb_TakeDamage(EnSkb* this, PlayState* play) {
             this->breakFlags = (*new_var) | 2;
         }
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-            this->actor.speedXZ = 0;
+            this->actor.speed = 0;
         }
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-            if (this->actor.speedXZ < 0.0f) {
-                this->actor.speedXZ += 0.05f;
+            if (this->actor.speed < 0.0f) {
+                this->actor.speed += 0.05f;
             }
         }
 
@@ -413,7 +413,7 @@ void EnSkb_SetupDeath(EnSkb* this, PlayState* play) {
     this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        this->actor.speedXZ = -6.0f;
+        this->actor.speed = -6.0f;
     }
     this->actionState = SKB_BEHAVIOR_DYING;
     this->actor.flags &= ~ACTOR_FLAG_0;

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -440,7 +440,7 @@ void EnSkj_Init(Actor* thisx, PlayState* play2) {
             this->backflipFlag = 0;
             this->needlesToShoot = 3;
             this->hitsUntilDodge = 3;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->actor.velocity.y = 0.0f;
             this->actor.gravity = -1.0f;
             EnSkj_CalculateCenter(this);
@@ -508,7 +508,7 @@ s32 EnSkj_ShootNeedle(EnSkj* this, PlayState* play) {
                                        this->actor.shape.rot.x, this->actor.shape.rot.y, this->actor.shape.rot.z, 0);
     if (needle != NULL) {
         needle->killTimer = 100;
-        needle->actor.speedXZ = 24.0f;
+        needle->actor.speed = 24.0f;
         return 1;
     }
     return 0;
@@ -646,7 +646,7 @@ s32 func_80AFEDF8(EnSkj* this, PlayState* play) {
 
 void EnSkj_Backflip(EnSkj* this) {
     this->actor.velocity.y = 8.0f;
-    this->actor.speedXZ = -8.0f;
+    this->actor.speed = -8.0f;
 
     EnSkj_ChangeAnim(this, SKJ_ANIM_BACKFLIP);
     EnSkj_SetupAction(this, SKJ_ACTION_FADE);
@@ -764,7 +764,7 @@ void EnSkj_PickNextFightAction(EnSkj* this, PlayState* play) {
 
 void func_80AFF2A0(EnSkj* this) {
     EnSkj_CalculateCenter(this);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnSkj_ChangeAnim(this, SKJ_ANIM_LAND);
     EnSkj_SetupAction(this, SKJ_ACTION_WAIT_FOR_LAND_ANIM);
 }
@@ -1082,7 +1082,7 @@ void EnSkj_StartMaskTrade(EnSkj* this, PlayState* play) {
 
 void EnSkj_JumpFromStump(EnSkj* this) {
     this->actor.velocity.y = 8.0f;
-    this->actor.speedXZ = 2.0f;
+    this->actor.speed = 2.0f;
     EnSkj_ChangeAnim(this, SKJ_ANIM_BACKFLIP);
     Animation_Reverse(&this->skelAnime);
     this->skelAnime.curFrame = this->skelAnime.startFrame;
@@ -1093,7 +1093,7 @@ void EnSkj_WaitForLanding(EnSkj* this, PlayState* play) {
     if (this->actor.velocity.y <= 0.0f) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
             this->actor.bgCheckFlags &= ~BGCHECKFLAG_GROUND_TOUCH;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             EnSkj_SetupWaitForLandAnimFinish(this);
         }
     }
@@ -1114,7 +1114,7 @@ void EnSkj_WaitForLandAnimFinish(EnSkj* this, PlayState* play) {
 
 void EnSkj_SetupWalkToPlayer(EnSkj* this) {
     this->unk_2F0 = 0.0f;
-    this->actor.speedXZ = 2.0f;
+    this->actor.speed = 2.0f;
     EnSkj_ChangeAnim(this, SKJ_ANIM_WALK_TO_PLAYER);
     EnSkj_SetupAction(this, SKJ_ACTION_SARIA_SONG_WALK_TO_PLAYER);
 }
@@ -1124,7 +1124,7 @@ void EnSkj_WalkToPlayer(EnSkj* this, PlayState* play) {
     Math_ApproachF(&this->unk_2F0, 2000.0f, 1.0f, 100.0f);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     if (this->actor.xzDistToPlayer < 120.0f) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         EnSkj_SetupAskForMask(this, play);
     }
 }
@@ -1268,7 +1268,7 @@ void EnSkj_PlayOcarinaGame(EnSkj* this, PlayState* play) {
 
 void EnSkj_SetupLeaveOcarinaGame(EnSkj* this) {
     this->actor.velocity.y = 8.0f;
-    this->actor.speedXZ = -8.0f;
+    this->actor.speed = -8.0f;
     EnSkj_ChangeAnim(this, SKJ_ANIM_BACKFLIP);
     EnSkj_SetupAction(this, SKJ_ACTION_OCARINA_GAME_LEAVE);
 }

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -947,7 +947,7 @@ void EnSt_BounceAround(EnSt* this, PlayState* play) {
     this->actor.shape.rot = this->actor.world.rot;
     if (EnSt_IsDoneBouncing(this, play)) {
         this->actor.shape.yOffset = 400.0f;
-        this->actor.speedXZ = 1.0f;
+        this->actor.speed = 1.0f;
         this->actor.gravity = -2.0f;
         EnSt_SetupAction(this, EnSt_FinishBouncing);
     } else {

--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -275,7 +275,7 @@ void EnSw_Init(Actor* thisx, PlayState* play) {
         case 4:
             this->unk_360 = 1;
             this->actor.velocity.y = 8.0f;
-            this->actor.speedXZ = 4.0f;
+            this->actor.speed = 4.0f;
             this->actor.gravity = -1.0f;
             FALLTHROUGH;
         case 2:
@@ -510,9 +510,9 @@ void func_80B0D3AC(EnSw* this, PlayState* play) {
     this->actor.world.pos.x += this->unk_364.x * this->actor.velocity.y;
     this->actor.world.pos.y += this->unk_364.y * this->actor.velocity.y;
     this->actor.world.pos.z += this->unk_364.z * this->actor.velocity.y;
-    this->actor.world.pos.x += this->unk_37C.x * this->actor.speedXZ;
-    this->actor.world.pos.y += this->unk_37C.y * this->actor.speedXZ;
-    this->actor.world.pos.z += this->unk_37C.z * this->actor.speedXZ;
+    this->actor.world.pos.x += this->unk_37C.x * this->actor.speed;
+    this->actor.world.pos.y += this->unk_37C.y * this->actor.speed;
+    this->actor.world.pos.z += this->unk_37C.z * this->actor.speed;
     this->actor.velocity.y += this->actor.gravity;
     this->actor.velocity.y = CLAMP_MIN(this->actor.velocity.y, this->actor.minVelocityY);
 
@@ -527,7 +527,7 @@ void func_80B0D3AC(EnSw* this, PlayState* play) {
         Actor_SetScale(&this->actor, 0.02f);
         this->actionFunc = func_80B0D590;
         this->actor.velocity.y = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->actor.gravity = 0.0f;
     }
 }
@@ -762,7 +762,7 @@ void func_80B0E314(EnSw* this, Vec3f arg1, f32 arg4) {
     f32 yDiff;
     f32 zDiff;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, arg4, 0.3f, 100.0f, 0.1f);
+    Math_SmoothStepToF(&this->actor.speed, arg4, 0.3f, 100.0f, 0.1f);
     xDiff = arg1.x - this->actor.world.pos.x;
     yDiff = arg1.y - this->actor.world.pos.y;
     zDiff = arg1.z - this->actor.world.pos.z;
@@ -774,9 +774,9 @@ void func_80B0E314(EnSw* this, Vec3f arg1, f32 arg4) {
         yDist = yDiff / dist;
         zDist = zDiff / dist;
     }
-    xDist *= this->actor.speedXZ;
-    yDist *= this->actor.speedXZ;
-    zDist *= this->actor.speedXZ;
+    xDist *= this->actor.speed;
+    yDist *= this->actor.speed;
+    zDist *= this->actor.speed;
     this->actor.world.pos.x += xDist;
     this->actor.world.pos.y += yDist;
     this->actor.world.pos.z += zDist;
@@ -871,7 +871,7 @@ void func_80B0E90C(EnSw* this, PlayState* play) {
     s32 pad;
 
     func_80B0E314(this, this->unk_448, 0.0f);
-    if (this->actor.speedXZ == 0.0f) {
+    if (this->actor.speed == 0.0f) {
         this->unk_444 = func_80B0DE34(this, &this->actor.home.pos);
         this->unk_448 = this->actor.home.pos;
         this->actionFunc = func_80B0E9BC;

--- a/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
+++ b/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
@@ -375,7 +375,7 @@ void func_80B12460(EnSyatekiNiw* this, PlayState* play) {
             break;
 
         case 1:
-            this->actor.speedXZ = 2.0f;
+            this->actor.speed = 2.0f;
             if (this->unk_25C == 0) {
                 this->unk_25C = 3;
                 this->actor.velocity.y = 3.5f;
@@ -389,7 +389,7 @@ void func_80B12460(EnSyatekiNiw* this, PlayState* play) {
 
             phi_f16 = (this->unk_298 == 0) ? 5000.0f : -5000.0f;
             if (this->actor.world.pos.z > 100.0f) {
-                this->actor.speedXZ = 2.0f;
+                this->actor.speed = 2.0f;
                 this->actor.gravity = -0.3f;
                 this->actor.velocity.y = 5.0f;
                 this->unk_29A = 2;
@@ -398,7 +398,7 @@ void func_80B12460(EnSyatekiNiw* this, PlayState* play) {
 
         case 2:
             if ((player->actor.world.pos.z - 40.0f) < this->actor.world.pos.z) {
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
             }
 
             if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (this->actor.world.pos.z > 110.0f)) {
@@ -409,7 +409,7 @@ void func_80B12460(EnSyatekiNiw* this, PlayState* play) {
                 this->unk_278 = 0.0f;
                 this->unk_280 = 0.0f;
                 this->unk_288 = 0.0f;
-                this->actor.speedXZ = 0.5f;
+                this->actor.speed = 0.5f;
                 this->unk_254 = this->unk_256 = 0;
                 this->unk_28E = this->unk_290 = 0;
                 this->unk_296 = 1;
@@ -419,7 +419,7 @@ void func_80B12460(EnSyatekiNiw* this, PlayState* play) {
 
         case 3:
             if ((player->actor.world.pos.z - 50.0f) < this->actor.world.pos.z) {
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 this->unk_262 = 0x3C;
                 this->unk_25A = 0x14;
                 this->unk_264 = 10000.0f;
@@ -449,7 +449,7 @@ void func_80B12460(EnSyatekiNiw* this, PlayState* play) {
                 this->unk_296 = 5;
                 this->unk_256 = this->unk_258;
                 this->unk_254 = this->unk_258;
-                this->actor.speedXZ = 1.0f;
+                this->actor.speed = 1.0f;
             }
 
             if ((this->unk_25A == 0) && ((player->actor.world.pos.z - 30.0f) < this->actor.world.pos.z)) {
@@ -457,7 +457,7 @@ void func_80B12460(EnSyatekiNiw* this, PlayState* play) {
                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                 this->unk_25E = 0x14;
                 this->unk_29A = 6;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
             }
             break;
 
@@ -501,7 +501,7 @@ void func_80B128F8(EnSyatekiNiw* this, PlayState* play) {
     Actor_GetScreenPos(play, &this->actor, &sp26, &sp24);
     if ((this->actor.projectedPos.z > 200.0f) && (this->actor.projectedPos.z < 800.0f) && (sp26 > 0) &&
         (sp26 < SCREEN_WIDTH) && (sp24 > 0) && (sp24 < SCREEN_HEIGHT)) {
-        this->actor.speedXZ = 5.0f;
+        this->actor.speed = 5.0f;
         this->unk_298 = Rand_ZeroFloat(1.99f);
         this->unk_2D8 = Rand_CenteredFloat(8000.0f) + -10000.0f;
         this->unk_262 = 0x1E;

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -433,8 +433,8 @@ void EnTa_RunWithAccelerationAndSfx(EnTa* this, PlayState* play) {
     if (framesMod12 == 0 || framesMod12 == 6) {
         Actor_PlaySfx(&this->actor, NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_DIRT);
     }
-    if (this->actor.speedXZ < 6.0f) {
-        this->actor.speedXZ += 0.4f;
+    if (this->actor.speed < 6.0f) {
+        this->actor.speed += 0.4f;
     }
     Actor_MoveForward(&this->actor);
 }
@@ -651,7 +651,7 @@ void EnTa_TalkFoundSuperCucco(EnTa* this, PlayState* play) {
         // Make the found cucco fly directly upwards and then forget about it
         this->superCuccos[lastFoundSuperCuccoIdx]->actor.gravity = 0.1f;
         this->superCuccos[lastFoundSuperCuccoIdx]->actor.velocity.y = 0.0f;
-        this->superCuccos[lastFoundSuperCuccoIdx]->actor.speedXZ = 0.0f;
+        this->superCuccos[lastFoundSuperCuccoIdx]->actor.speed = 0.0f;
         this->superCuccos[lastFoundSuperCuccoIdx]->actor.parent = NULL;
 
         if (player->interactRangeActor == &this->superCuccos[lastFoundSuperCuccoIdx]->actor) {

--- a/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -479,7 +479,7 @@ void EnTest_SetupIdle(EnTest* this) {
     Animation_PlayLoop(&this->skelAnime, &gStalfosMiddleGuardAnim);
     this->unk_7C8 = 0xA;
     this->timer = (Rand_ZeroOne() * 10.0f) + 5.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnTest_SetupAction(this, EnTest_Idle);
 }
@@ -584,33 +584,33 @@ void EnTest_WalkAndBlock(EnTest* this, PlayState* play) {
         }
 
         if (this->actor.xzDistToPlayer <= (80.0f + checkDist)) {
-            Math_SmoothStepToF(&this->actor.speedXZ, -5.0f, 1.0f, 0.8f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, -5.0f, 1.0f, 0.8f, 0.0f);
         } else if (this->actor.xzDistToPlayer > (110.0f + checkDist)) {
-            Math_SmoothStepToF(&this->actor.speedXZ, 5.0f, 1.0f, 0.8f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 5.0f, 1.0f, 0.8f, 0.0f);
         }
 
-        if (this->actor.speedXZ >= 5.0f) {
-            this->actor.speedXZ = 5.0f;
-        } else if (this->actor.speedXZ < -5.0f) {
-            this->actor.speedXZ = -5.0f;
+        if (this->actor.speed >= 5.0f) {
+            this->actor.speed = 5.0f;
+        } else if (this->actor.speed < -5.0f) {
+            this->actor.speed = -5.0f;
         }
 
         if ((this->actor.params == STALFOS_TYPE_CEILING) &&
-            !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ, this->actor.world.rot.y)) {
-            this->actor.speedXZ *= -1.0f;
+            !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed, this->actor.world.rot.y)) {
+            this->actor.speed *= -1.0f;
         }
 
-        if (ABS(this->actor.speedXZ) < 3.0f) {
+        if (ABS(this->actor.speed) < 3.0f) {
             Animation_Change(&this->skelAnime, &gStalfosSlowAdvanceAnim, 0.0f, this->skelAnime.curFrame,
                              Animation_GetLastFrame(&gStalfosSlowAdvanceAnim), 0, -6.0f);
-            playSpeed = this->actor.speedXZ * 10.0f;
+            playSpeed = this->actor.speed * 10.0f;
         } else {
             Animation_Change(&this->skelAnime, &gStalfosFastAdvanceAnim, 0.0f, this->skelAnime.curFrame,
                              Animation_GetLastFrame(&gStalfosFastAdvanceAnim), 0, -4.0f);
-            playSpeed = this->actor.speedXZ * 10.0f * 0.02f;
+            playSpeed = this->actor.speed * 10.0f * 0.02f;
         }
 
-        if (this->actor.speedXZ >= 0.0f) {
+        if (this->actor.speed >= 0.0f) {
             if (this->unk_7DE == 0) {
                 this->unk_7DE++;
             }
@@ -702,7 +702,7 @@ void EnTest_WalkAndBlock(EnTest* this, PlayState* play) {
                 EnTest_SetupStopAndBlock(this);
             }
         } else if (Rand_ZeroOne() < 0.1f) {
-            this->actor.speedXZ = 5.0f;
+            this->actor.speed = 5.0f;
         }
     }
 }
@@ -779,7 +779,7 @@ void func_80860C24(EnTest* this, PlayState* play) {
 void func_80860EC0(EnTest* this) {
     Animation_PlayLoop(&this->skelAnime, &gStalfosSidestepAnim);
     this->unk_7C8 = 0xF;
-    this->actor.speedXZ = (Rand_ZeroOne() > 0.5f) ? -0.5f : 0.5f;
+    this->actor.speed = (Rand_ZeroOne() > 0.5f) ? -0.5f : 0.5f;
     this->timer = (s16)((Rand_ZeroOne() * 15.0f) + 25.0f);
     this->unk_7EC = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
@@ -803,25 +803,25 @@ void func_80860F84(EnTest* this, PlayState* play) {
         this->actor.world.rot.y = this->actor.shape.rot.y + 0x3E80;
         playerYaw180 = player->actor.shape.rot.y + 0x8000;
 
-        if (this->actor.speedXZ >= 0.0f) {
-            if (this->actor.speedXZ < 6.0f) {
-                this->actor.speedXZ += 0.5f;
+        if (this->actor.speed >= 0.0f) {
+            if (this->actor.speed < 6.0f) {
+                this->actor.speed += 0.5f;
             } else {
-                this->actor.speedXZ = 6.0f;
+                this->actor.speed = 6.0f;
             }
         } else {
-            if (this->actor.speedXZ > -6.0f) {
-                this->actor.speedXZ -= 0.5f;
+            if (this->actor.speed > -6.0f) {
+                this->actor.speed -= 0.5f;
             } else {
-                this->actor.speedXZ = -6.0f;
+                this->actor.speed = -6.0f;
             }
         }
 
         if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
             ((this->actor.params == STALFOS_TYPE_CEILING) &&
-             !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ, this->actor.world.rot.y))) {
+             !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed, this->actor.world.rot.y))) {
             if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-                if (this->actor.speedXZ >= 0.0f) {
+                if (this->actor.speed >= 0.0f) {
                     newYaw = this->actor.shape.rot.y + 0x3FFF;
                 } else {
                     newYaw = this->actor.shape.rot.y - 0x3FFF;
@@ -829,17 +829,17 @@ void func_80860F84(EnTest* this, PlayState* play) {
 
                 newYaw = this->actor.wallYaw - newYaw;
             } else {
-                this->actor.speedXZ *= -0.8f;
+                this->actor.speed *= -0.8f;
                 newYaw = 0;
             }
 
             if (ABS(newYaw) > 0x4000) {
-                this->actor.speedXZ *= -0.8f;
+                this->actor.speed *= -0.8f;
 
-                if (this->actor.speedXZ < 0.0f) {
-                    this->actor.speedXZ -= 0.5f;
+                if (this->actor.speed < 0.0f) {
+                    this->actor.speed -= 0.5f;
                 } else {
-                    this->actor.speedXZ += 0.5f;
+                    this->actor.speed += 0.5f;
                 }
             }
         }
@@ -861,7 +861,7 @@ void func_80860F84(EnTest* this, PlayState* play) {
             this->actor.world.pos.z += Math_CosS(this->actor.shape.rot.y) * this->unk_7EC;
         }
 
-        this->skelAnime.playSpeed = this->actor.speedXZ * 0.5f;
+        this->skelAnime.playSpeed = this->actor.speed * 0.5f;
 
         prevFrame = (s32)this->skelAnime.curFrame;
         SkelAnime_Update(&this->skelAnime);
@@ -896,7 +896,7 @@ void EnTest_SetupSlashDown(EnTest* this) {
     Audio_StopSfxByPosAndId(&this->actor.projectedPos, NA_SE_EN_STAL_WARAU);
     this->swordCollider.base.atFlags &= ~AT_BOUNCED;
     this->unk_7C8 = 0x10;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnTest_SetupAction(this, EnTest_SlashDown);
     this->swordCollider.info.toucher.damage = 16;
 
@@ -906,7 +906,7 @@ void EnTest_SetupSlashDown(EnTest* this) {
 }
 
 void EnTest_SlashDown(EnTest* this, PlayState* play) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if ((s32)this->skelAnime.curFrame < 4) {
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 0xBB8, 0);
@@ -934,7 +934,7 @@ void EnTest_SlashDown(EnTest* this, PlayState* play) {
 void EnTest_SetupSlashDownEnd(EnTest* this) {
     Animation_PlayOnce(&this->skelAnime, &gStalfosRecoverFromDownSlashAnim);
     this->unk_7C8 = 0x12;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnTest_SetupAction(this, EnTest_SlashDownEnd);
 }
 
@@ -996,7 +996,7 @@ void EnTest_SetupSlashUp(EnTest* this) {
     this->swordCollider.base.atFlags &= ~AT_BOUNCED;
     this->unk_7C8 = 0x11;
     this->swordCollider.info.toucher.damage = 16;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnTest_SetupAction(this, EnTest_SlashUp);
 
     if (this->unk_7DE != 0) {
@@ -1005,7 +1005,7 @@ void EnTest_SetupSlashUp(EnTest* this) {
 }
 
 void EnTest_SlashUp(EnTest* this, PlayState* play) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if ((s32)this->skelAnime.curFrame == 2) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_SAKEBI);
@@ -1034,9 +1034,9 @@ void EnTest_SetupJumpBack(EnTest* this) {
     }
 
     if (this->actor.params != STALFOS_TYPE_CEILING) {
-        this->actor.speedXZ = -11.0f;
+        this->actor.speed = -11.0f;
     } else {
-        this->actor.speedXZ = -7.0f;
+        this->actor.speed = -7.0f;
     }
 }
 
@@ -1079,7 +1079,7 @@ void EnTest_SetupJumpslash(EnTest* this) {
     this->timer = 0;
     this->unk_7C8 = 0x17;
     this->actor.velocity.y = 10.0f;
-    this->actor.speedXZ = 8.0f;
+    this->actor.speed = 8.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->swordCollider.base.atFlags &= ~AT_BOUNCED;
@@ -1100,7 +1100,7 @@ void EnTest_Jumpslash(EnTest* this, PlayState* play) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_SAKEBI);
             Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
         } else {
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             EnTest_SetupIdle(this);
         }
     }
@@ -1110,13 +1110,13 @@ void EnTest_Jumpslash(EnTest* this, PlayState* play) {
     }
 
     if (this->actor.world.pos.y <= this->actor.floorHeight) {
-        if (this->actor.speedXZ != 0.0f) {
+        if (this->actor.speed != 0.0f) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
 
         this->actor.world.pos.y = this->actor.floorHeight;
         this->actor.velocity.y = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 }
 
@@ -1125,7 +1125,7 @@ void EnTest_SetupJumpUp(EnTest* this) {
     this->timer = 0;
     this->unk_7C8 = 4;
     this->actor.velocity.y = 14.0f;
-    this->actor.speedXZ = 6.0f;
+    this->actor.speed = 6.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnTest_SetupAction(this, EnTest_JumpUp);
@@ -1146,7 +1146,7 @@ void EnTest_JumpUp(EnTest* this, PlayState* play) {
         }
 
         this->actor.velocity.y = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->unk_7C8 = 0xC;
         this->timer = 4;
         Animation_Change(&this->skelAnime, &gStalfosLandFromLeapAnim, 0.0f, 0.0f, 0.0f, 2, 0.0f);
@@ -1158,7 +1158,7 @@ void EnTest_SetupStopAndBlock(EnTest* this) {
     Animation_Change(&this->skelAnime, &gStalfosBlockWithShieldAnim, 2.0f, 0.0f,
                      Animation_GetLastFrame(&gStalfosBlockWithShieldAnim), 2, 2.0f);
     this->unk_7C8 = 0x15;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->timer = (Rand_ZeroOne() * 10.0f) + 11.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->unk_7DE = 5;
@@ -1166,7 +1166,7 @@ void EnTest_SetupStopAndBlock(EnTest* this) {
 }
 
 void EnTest_StopAndBlock(EnTest* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     SkelAnime_Update(&this->skelAnime);
 
     if ((ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y)) > 0x3E80) &&
@@ -1189,11 +1189,11 @@ void EnTest_SetupIdleFromBlock(EnTest* this) {
 }
 
 void EnTest_IdleFromBlock(EnTest* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 1.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 1.5f, 0.0f);
     SkelAnime_Update(&this->skelAnime);
 
     if (this->skelAnime.morphWeight == 0.0f) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->unk_7DE = 0;
 
         if (!EnTest_ReactToProjectile(play, this)) {
@@ -1210,7 +1210,7 @@ void func_80862154(EnTest* this) {
     Animation_PlayOnce(&this->skelAnime, &gStalfosFlinchFromHitFrontAnim);
     Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_DAMAGE);
     this->unk_7C8 = 8;
-    this->actor.speedXZ = -2.0f;
+    this->actor.speed = -2.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
     EnTest_SetupAction(this, func_808621D4);
 }
@@ -1218,10 +1218,10 @@ void func_80862154(EnTest* this) {
 void func_808621D4(EnTest* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.1f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.1f, 0.0f);
 
     if (SkelAnime_Update(&this->skelAnime)) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
 
         if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) &&
             ((ABS((s16)(this->actor.wallYaw - this->actor.shape.rot.y)) < 0x38A4) &&
@@ -1254,7 +1254,7 @@ void func_80862398(EnTest* this) {
     Animation_PlayOnce(&this->skelAnime, &gStalfosFlinchFromHitBehindAnim);
     Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_DAMAGE);
     this->unk_7C8 = 9;
-    this->actor.speedXZ = -2.0f;
+    this->actor.speed = -2.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 8);
     EnTest_SetupAction(this, func_80862418);
 }
@@ -1262,10 +1262,10 @@ void func_80862398(EnTest* this) {
 void func_80862418(EnTest* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.1f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.1f, 0.0f);
 
     if (SkelAnime_Update(&this->skelAnime)) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
 
         if (!EnTest_ReactToProjectile(play, this)) {
             EnTest_ChooseAction(this, play);
@@ -1295,7 +1295,7 @@ void EnTest_SetupStunned(EnTest* this) {
     this->unk_7DE = 0;
     this->swordState = 0;
     this->skelAnime.playSpeed = 0.0f;
-    this->actor.speedXZ = -4.0f;
+    this->actor.speed = -4.0f;
 
     if (this->lastDamageEffect == STALFOS_DMGEFF_LIGHT) {
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_GRAY, 120, COLORFILTER_BUFFLAG_OPA, 80);
@@ -1316,7 +1316,7 @@ void EnTest_SetupStunned(EnTest* this) {
 void EnTest_Stunned(EnTest* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 1.0f, 0.0f);
 
     if (this->actor.colorFilterTimer == 0) {
         if (this->actor.colChkInfo.health == 0) {
@@ -1334,7 +1334,7 @@ void EnTest_Stunned(EnTest* this, PlayState* play) {
 
             this->unk_7C8 = 8;
         } else {
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             if (!EnTest_ReactToProjectile(play, this)) {
                 EnTest_ChooseAction(this, play);
             }
@@ -1351,7 +1351,7 @@ void func_808627C4(EnTest* this, PlayState* play) {
 
     Animation_MorphToLoop(&this->skelAnime, &gStalfosSidestepAnim, -2.0f);
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 0xFA0, 1);
-    this->actor.speedXZ = ((play->gameplayFrames % 2) != 0) ? -4.0f : 4.0f;
+    this->actor.speed = ((play->gameplayFrames % 2) != 0) ? -4.0f : 4.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x3FFF;
     this->timer = (Rand_ZeroOne() * 20.0f) + 20.0f;
     this->unk_7C8 = 0x18;
@@ -1377,25 +1377,25 @@ void func_808628C8(EnTest* this, PlayState* play) {
         this->unk_7DE++;
     }
 
-    if (this->actor.speedXZ >= 0.0f) {
-        if (this->actor.speedXZ < 6.0f) {
-            this->actor.speedXZ += 0.125f;
+    if (this->actor.speed >= 0.0f) {
+        if (this->actor.speed < 6.0f) {
+            this->actor.speed += 0.125f;
         } else {
-            this->actor.speedXZ = 6.0f;
+            this->actor.speed = 6.0f;
         }
     } else {
-        if (this->actor.speedXZ > -6.0f) {
-            this->actor.speedXZ -= 0.125f;
+        if (this->actor.speed > -6.0f) {
+            this->actor.speed -= 0.125f;
         } else {
-            this->actor.speedXZ = -6.0f;
+            this->actor.speed = -6.0f;
         }
     }
 
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
         ((this->actor.params == STALFOS_TYPE_CEILING) &&
-         !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ, this->actor.shape.rot.y + 0x3FFF))) {
+         !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed, this->actor.shape.rot.y + 0x3FFF))) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-            if (this->actor.speedXZ >= 0.0f) {
+            if (this->actor.speed >= 0.0f) {
                 newYaw = (this->actor.shape.rot.y + 0x3FFF);
             } else {
                 newYaw = (this->actor.shape.rot.y - 0x3FFF);
@@ -1403,17 +1403,17 @@ void func_808628C8(EnTest* this, PlayState* play) {
 
             newYaw = this->actor.wallYaw - newYaw;
         } else {
-            this->actor.speedXZ *= -0.8f;
+            this->actor.speed *= -0.8f;
             newYaw = 0;
         }
 
         if (ABS(newYaw) > 0x4000) {
-            this->actor.speedXZ *= -0.8f;
+            this->actor.speed *= -0.8f;
 
-            if (this->actor.speedXZ < 0.0f) {
-                this->actor.speedXZ -= 0.5f;
+            if (this->actor.speed < 0.0f) {
+                this->actor.speed -= 0.5f;
             } else {
-                this->actor.speedXZ += 0.5f;
+                this->actor.speed += 0.5f;
             }
         }
     }
@@ -1437,7 +1437,7 @@ void func_808628C8(EnTest* this, PlayState* play) {
         this->actor.world.pos.z += (Math_CosS(this->actor.shape.rot.y) * this->unk_7EC);
     }
 
-    this->skelAnime.playSpeed = this->actor.speedXZ * 0.5f;
+    this->skelAnime.playSpeed = this->actor.speed * 0.5f;
 
     prevFrame = (s32)this->skelAnime.curFrame;
     SkelAnime_Update(&this->skelAnime);
@@ -1538,7 +1538,7 @@ void func_80862FA8(EnTest* this, PlayState* play) {
     this->unk_7DE = 0;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->actor.colorFilterTimer = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if (this->actor.params <= STALFOS_TYPE_CEILING) {
         this->unk_7C8 = 5;
@@ -1567,7 +1567,7 @@ void func_808630F0(EnTest* this, PlayState* play) {
     this->unk_7C8 = 6;
     this->actor.colorFilterTimer = 0;
     this->unk_7DE = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if (this->actor.params <= STALFOS_TYPE_CEILING) {
         this->actor.flags &= ~ACTOR_FLAG_0;
@@ -1657,7 +1657,7 @@ void EnTest_UpdateDamage(EnTest* this, PlayState* play) {
         this->bodyCollider.base.acFlags &= ~AC_HIT;
 
         if (this->unk_7C8 >= 0xA) {
-            this->actor.speedXZ = -4.0f;
+            this->actor.speed = -4.0f;
         }
     } else if (this->bodyCollider.base.acFlags & AC_HIT) {
         this->bodyCollider.base.acFlags &= ~AC_HIT;
@@ -1898,7 +1898,7 @@ void EnTest_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot
 
         if ((limbIndex == STALFOS_LIMB_FOOT_L) || (limbIndex == STALFOS_LIMB_ANKLE_R)) {
             if ((this->unk_7C8 == 0x15) || (this->unk_7C8 == 0x16)) {
-                if (this->actor.speedXZ != 0.0f) {
+                if (this->actor.speed != 0.0f) {
                     Matrix_MultVec3f(&D_80864658, &sp64);
                     Actor_SpawnFloorDustRing(play, &this->actor, &sp64, 10.0f, 1, 8.0f, 100, 15, false);
                 }
@@ -1974,7 +1974,7 @@ void EnTest_Draw(Actor* thisx, PlayState* play) {
 // a variation of sidestep
 void func_80864158(EnTest* this, f32 xzSpeed) {
     Animation_MorphToLoop(&this->skelAnime, &gStalfosSidestepAnim, -2.0f);
-    this->actor.speedXZ = xzSpeed;
+    this->actor.speed = xzSpeed;
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x3FFF;
     this->timer = (Rand_ZeroOne() * 20.0f) + 15.0f;
     this->unk_7C8 = 0x18;

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -222,13 +222,13 @@ void EnTite_SetupIdle(EnTite* this) {
     Animation_MorphToLoop(&this->skelAnime, &object_tite_Anim_0012E4, 4.0f);
     this->action = TEKTITE_IDLE;
     this->vIdleTimer = Rand_S16Offset(15, 30);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnTite_SetupAction(this, EnTite_Idle);
 }
 
 void EnTite_Idle(EnTite* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     if (this->actor.params == TEKTITE_BLUE) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER) {
             // Float on water surface
@@ -256,7 +256,7 @@ void EnTite_SetupAttack(EnTite* this) {
     this->action = TEKTITE_ATTACK;
     this->vAttackState = TEKTITE_BEGIN_LUNGE;
     this->vQueuedJumps = Rand_S16Offset(1, 3);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnTite_SetupAction(this, EnTite_Attack);
@@ -284,7 +284,7 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
                 }
                 this->actor.velocity.y = 8.0f;
                 this->actor.gravity = -1.0f;
-                this->actor.speedXZ = 4.0f;
+                this->actor.speed = 4.0f;
                 break;
             case TEKTITE_MID_LUNGE:
                 // Continue trajectory until tektite has negative velocity and has landed on ground/water surface
@@ -299,7 +299,7 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
                                 this->actor.world.pos.y = this->actor.floorHeight;
                             }
                             this->actor.velocity.y = 0.0f;
-                            this->actor.speedXZ = 0.0f;
+                            this->actor.speed = 0.0f;
                         } else {
                             this->actor.gravity = 0.0f;
                             if (this->actor.velocity.y < -8.0f) {
@@ -311,7 +311,7 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
                                 EffectSsGRipple_Spawn(play, &ripplePos, 0, 500, 0);
                             } else {
                                 this->actor.velocity.y = 0.0f;
-                                this->actor.speedXZ = 0.0f;
+                                this->actor.speed = 0.0f;
                             }
                         }
                         this->actor.world.rot.y = this->actor.shape.rot.y;
@@ -370,7 +370,7 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
                 Player* player = GET_PLAYER(play);
                 this->collider.base.atFlags &= ~AT_HIT;
                 Animation_MorphToLoop(&this->skelAnime, &object_tite_Anim_0012E4, 4.0f);
-                this->actor.speedXZ = -6.0f;
+                this->actor.speed = -6.0f;
                 this->actor.world.rot.y = this->actor.yawTowardsPlayer;
                 if (&player->actor == this->collider.base.at) {
                     if (!(this->collider.base.atFlags & AT_BOUNCED)) {
@@ -387,7 +387,7 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
         case TEKTITE_SUBMERGED:
             // Float up to water surface
             Math_SmoothStepToF(&this->actor.velocity.y, 0.0f, 1.0f, 2.0f, 0.0f);
-            Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
             Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.world.pos.y + this->actor.yDistToWater, 1.0f, 2.0f,
                                0.0f);
             break;
@@ -404,7 +404,7 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
     // if landed, kill XZ speed and play appropriate sound effect
     if (this->actor.params == TEKTITE_BLUE) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER_TOUCH) {
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             if (this->vAttackState == TEKTITE_SUBMERGED) {
                 Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_LAND_WATER);
             } else {
@@ -415,7 +415,7 @@ void EnTite_Attack(EnTite* this, PlayState* play) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
         }
     } else if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
     }
 }
@@ -428,7 +428,7 @@ void EnTite_SetupTurnTowardPlayer(EnTite* this) {
         if (this->actor.velocity.y <= 0.0f) {
             this->actor.gravity = 0.0f;
             this->actor.velocity.y = 0.0f;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
         }
     }
     EnTite_SetupAction(this, EnTite_TurnTowardPlayer);
@@ -443,7 +443,7 @@ void EnTite_TurnTowardPlayer(EnTite* this, PlayState* play) {
         (this->actor.velocity.y <= 0.0f)) {
         this->actor.gravity = 0.0f;
         this->actor.velocity.y = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
     // Calculate turn velocity and animation speed based on angle to player
     if ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
@@ -493,7 +493,7 @@ void EnTite_SetupMoveTowardPlayer(EnTite* this) {
     this->action = TEKTITE_MOVE_TOWARD_PLAYER;
     this->actor.velocity.y = 10.0f;
     this->actor.gravity = -1.0f;
-    this->actor.speedXZ = 4.0f;
+    this->actor.speed = 4.0f;
     this->vQueuedJumps = Rand_S16Offset(1, 3);
     if ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_JUMP_WATER);
@@ -507,7 +507,7 @@ void EnTite_SetupMoveTowardPlayer(EnTite* this) {
  *  Jumping toward player as a method of travel (different from attacking, has no hitbox)
  */
 void EnTite_MoveTowardPlayer(EnTite* this, PlayState* play) {
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 0.1f, 1.0f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 0.1f, 1.0f, 0.0f);
     SkelAnime_Update(&this->skelAnime);
 
     if (this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND_TOUCH | BGCHECKFLAG_WATER_TOUCH)) {
@@ -536,7 +536,7 @@ void EnTite_MoveTowardPlayer(EnTite* this, PlayState* play) {
           (this->actor.bgCheckFlags & (BGCHECKFLAG_WATER | BGCHECKFLAG_WATER_TOUCH)))) &&
         (this->actor.velocity.y <= 0.0f)) {
         // slightly turn toward player upon landing and snap to ground or water.
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 4000, 0);
         this->actor.world.rot.y = this->actor.shape.rot.y;
         if ((this->actor.params != TEKTITE_BLUE) || !(this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
@@ -570,7 +570,7 @@ void EnTite_MoveTowardPlayer(EnTite* this, PlayState* play) {
                 EnTite_SetupTurnTowardPlayer(this);
             } else {
                 this->actor.velocity.y = 10.0f;
-                this->actor.speedXZ = 4.0f;
+                this->actor.speed = 4.0f;
                 this->actor.flags |= ACTOR_FLAG_24;
                 this->actor.gravity = -1.0f;
                 if ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
@@ -581,7 +581,7 @@ void EnTite_MoveTowardPlayer(EnTite* this, PlayState* play) {
             }
         } else {
             this->actor.velocity.y = 10.0f;
-            this->actor.speedXZ = 4.0f;
+            this->actor.speed = 4.0f;
             this->actor.flags |= ACTOR_FLAG_24;
             this->actor.gravity = -1.0f;
             if ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)) {
@@ -609,7 +609,7 @@ void EnTite_MoveTowardPlayer(EnTite* this, PlayState* play) {
 void EnTite_SetupRecoil(EnTite* this) {
     this->action = TEKTITE_RECOIL;
     Animation_MorphToLoop(&this->skelAnime, &object_tite_Anim_0012E4, 4.0f);
-    this->actor.speedXZ = -6.0f;
+    this->actor.speed = -6.0f;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     this->actor.gravity = -1.0f;
     EnTite_SetupAction(this, EnTite_Recoil);
@@ -622,7 +622,7 @@ void EnTite_Recoil(EnTite* this, PlayState* play) {
     s16 angleToPlayer;
 
     // Snap to ground or water surface upon landing
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     if (((this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH)) ||
          (this->actor.params == TEKTITE_BLUE && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER))) &&
         (this->actor.velocity.y <= 0.0f)) {
@@ -653,7 +653,7 @@ void EnTite_Recoil(EnTite* this, PlayState* play) {
 
     // If player is far away, idle. Otherwise attack or move
     angleToPlayer = (this->actor.yawTowardsPlayer - this->actor.shape.rot.y);
-    if ((this->actor.speedXZ == 0.0f) &&
+    if ((this->actor.speed == 0.0f) &&
         ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) ||
          ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)))) {
         this->actor.world.rot.y = this->actor.shape.rot.y;
@@ -677,7 +677,7 @@ void EnTite_SetupStunned(EnTite* this) {
     Animation_Change(&this->skelAnime, &object_tite_Anim_0012E4, 0.0f, 0.0f,
                      (f32)Animation_GetLastFrame(&object_tite_Anim_0012E4), ANIMMODE_LOOP, 4.0f);
     this->action = TEKTITE_STUNNED;
-    this->actor.speedXZ = -6.0f;
+    this->actor.speed = -6.0f;
     this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     if (this->damageEffect == 0xF) {
         this->spawnIceTimer = 48;
@@ -692,7 +692,7 @@ void EnTite_SetupStunned(EnTite* this) {
 void EnTite_Stunned(EnTite* this, PlayState* play) {
     s16 angleToPlayer;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     // Snap to ground or water
     if (((this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH)) ||
          ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER))) &&
@@ -722,7 +722,7 @@ void EnTite_Stunned(EnTite* this, PlayState* play) {
     }
     // Decide on next action based on health, flip state and player distance
     angleToPlayer = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
-    if (((this->actor.colorFilterTimer == 0) && (this->actor.speedXZ == 0.0f)) &&
+    if (((this->actor.colorFilterTimer == 0) && (this->actor.speed == 0.0f)) &&
         ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) ||
          ((this->actor.params == TEKTITE_BLUE) && (this->actor.bgCheckFlags & BGCHECKFLAG_WATER)))) {
         this->actor.world.rot.y = this->actor.shape.rot.y;
@@ -748,7 +748,7 @@ void EnTite_Stunned(EnTite* this, PlayState* play) {
 void EnTite_SetupDeathCry(EnTite* this) {
     this->action = TEKTITE_DEATH_CRY;
     this->actor.colorFilterTimer = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnTite_SetupAction(this, EnTite_DeathCry);
 }
 
@@ -783,7 +783,7 @@ void EnTite_SetupFlipOnBack(EnTite* this) {
     Actor_PlaySfx(&this->actor, NA_SE_EN_TEKU_REVERSE);
     this->flipState = TEKTITE_FLIPPED;
     this->vOnBackTimer = 500;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.gravity = -1.0f;
     this->vLegTwitchTimer = (Rand_ZeroOne() * 50.0f);
     this->actor.velocity.y = 11.0f;

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -167,7 +167,7 @@ void EnTk_RestAnim(EnTk* this, PlayState* play) {
                      -10.0f);
 
     this->actionCountdown = Rand_S16Offset(60, 60);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 
 void EnTk_WalkAnim(EnTk* this, PlayState* play) {
@@ -564,7 +564,7 @@ void EnTk_Walk(EnTk* this, PlayState* play) {
         this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
         this->actionFunc = EnTk_Dig;
     } else {
-        this->actor.speedXZ = EnTk_Step(this, play);
+        this->actor.speed = EnTk_Step(this, play);
         EnTk_Orient(this, play);
         Math_SmoothStepToS(&this->headRot, 0, 6, 1000, 1);
         EnTk_CheckCurrentSpot(this);

--- a/src/overlays/actors/ovl_En_Tp/z_en_tp.c
+++ b/src/overlays/actors/ovl_En_Tp/z_en_tp.c
@@ -215,7 +215,7 @@ void EnTp_Tail_FollowHead(EnTp* this, PlayState* play) {
         }
 
         if (this->head->unk_150 != 0) {
-            this->actor.speedXZ = this->red = this->actor.velocity.y = this->heightPhase = 0.0f;
+            this->actor.speed = this->red = this->actor.velocity.y = this->heightPhase = 0.0f;
             if (this->actor.world.pos.y < this->head->actor.home.pos.y) {
                 this->actor.flags &= ~ACTOR_FLAG_0;
             }
@@ -263,7 +263,7 @@ void EnTp_Head_ApproachPlayer(EnTp* this, PlayState* play) {
 
     this->actor.world.pos.y += Math_CosF(this->heightPhase) * (2.0f + this->extraHeightVariation);
     this->heightPhase += 0.2f;
-    Math_SmoothStepToF(&this->actor.speedXZ, 2.5f, 0.1f, 0.2f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 2.5f, 0.1f, 0.2f, 0.0f);
     this->timer--;
 
     if (this->timer != 0) {
@@ -377,9 +377,9 @@ void EnTp_Head_TakeOff(EnTp* this, PlayState* play) {
     s32 pad;
     Player* player = GET_PLAYER(play);
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 2.5f, 0.1f, 0.2f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 2.5f, 0.1f, 0.2f, 0.0f);
     Math_SmoothStepToF(&this->actor.world.pos.y, player->actor.world.pos.y + 85.0f + this->horizontalVariation, 1.0f,
-                       this->actor.speedXZ * 0.25f, 0.0f);
+                       this->actor.speed * 0.25f, 0.0f);
     Audio_PlaySfxGeneral(NA_SE_EN_TAIL_FLY - SFX_FLAG, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                          &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
 
@@ -399,7 +399,7 @@ void EnTp_Head_TakeOff(EnTp* this, PlayState* play) {
     }
 
     this->actor.world.pos.y +=
-        Math_CosF(this->heightPhase) * ((this->actor.speedXZ * 0.25f) + this->extraHeightVariation);
+        Math_CosF(this->heightPhase) * ((this->actor.speed * 0.25f) + this->extraHeightVariation);
     this->actor.world.rot.y += this->unk_164;
     this->heightPhase += 0.2f;
 
@@ -423,7 +423,7 @@ void EnTp_Head_SetupWait(EnTp* this) {
     this->actor.shape.rot.x = -0x4000;
     this->timer = 60;
     this->unk_15C = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnTp_SetupAction(this, EnTp_Head_Wait);
 }
 
@@ -517,13 +517,13 @@ void EnTp_Head_BurrowReturnHome(EnTp* this, PlayState* play) {
             if (this->actor.shape.rot.x != -0x4000) {
                 this->timer = 80;
                 this->actor.velocity.y = 0.0f;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 this->actor.world.pos = this->actor.home.pos;
                 this->actor.shape.rot.x = -0x4000;
 
                 for (now = (EnTp*)this->actor.child; now != NULL; now = (EnTp*)now->actor.child) {
                     now->actor.velocity.y = 0.0f;
-                    now->actor.speedXZ = 0.0f;
+                    now->actor.speed = 0.0f;
                     now->actor.world.pos = this->actor.home.pos;
                     now->actor.world.pos.y = this->actor.home.pos.y - 80.0f;
                 }
@@ -540,7 +540,7 @@ void EnTp_Head_BurrowReturnHome(EnTp* this, PlayState* play) {
             this->red -= 15;
         }
 
-        this->actor.speedXZ = 2.0f * Math_CosS(this->actor.shape.rot.x);
+        this->actor.speed = 2.0f * Math_CosS(this->actor.shape.rot.x);
         this->actor.velocity.y = Math_SinS(this->actor.shape.rot.x) * -2.0f;
 
         if ((this->actor.world.pos.y - this->actor.floorHeight) < 20.0f) {
@@ -681,7 +681,7 @@ void EnTp_Update(Actor* thisx, PlayState* play) {
         }
 
         // Turn away from wall
-        if ((this->actor.speedXZ != 0.0f) && (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
+        if ((this->actor.speed != 0.0f) && (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)) {
             yawToWall = this->actor.wallYaw - this->actor.world.rot.y;
 
             if (ABS(yawToWall) > 0x4000) {

--- a/src/overlays/actors/ovl_En_Trap/z_en_trap.c
+++ b/src/overlays/actors/ovl_En_Trap/z_en_trap.c
@@ -72,7 +72,7 @@ void EnTrap_Init(Actor* thisx, PlayState* play) {
     Actor_SetScale(thisx, 0.1f);
     thisx->gravity = -2.0f;
     if (thisx->params & SPIKETRAP_MODE_LINEAR) {
-        thisx->speedXZ = this->moveSpeedForwardBack.z = this->upperParams & 0xF;
+        thisx->speed = this->moveSpeedForwardBack.z = this->upperParams & 0xF;
         Actor_PlaySfx(thisx, NA_SE_EV_SPINE_TRAP_MOVE);
     } else if (thisx->params & SPIKETRAP_MODE_CIRCULAR) {
         this->vRadius = (this->upperParams & 0xF) * 40.0f;

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
@@ -248,7 +248,7 @@ void EnTuboTrap_Levitate(EnTuboTrap* this, PlayState* play) {
     Math_ApproachF(&this->actor.world.pos.y, this->targetY, 0.8f, 3.0f);
 
     if (fabsf(this->actor.world.pos.y - this->targetY) < 10.0f) {
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
         this->actionFunc = EnTuboTrap_Fly;
     }

--- a/src/overlays/actors/ovl_En_Vm/z_en_vm.c
+++ b/src/overlays/actors/ovl_En_Vm/z_en_vm.c
@@ -362,7 +362,7 @@ void EnVm_SetupDie(EnVm* this) {
     this->actor.world.pos.y += 5000.0f * this->actor.scale.y;
     this->actor.velocity.y = 8.0f;
     this->actor.gravity = -0.5f;
-    this->actor.speedXZ = Rand_ZeroOne() + 1.0f;
+    this->actor.speed = Rand_ZeroOne() + 1.0f;
     this->actor.world.rot.y = Rand_CenteredFloat(65535.0f);
     EnVm_SetupAction(this, EnVm_Die);
 }

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -196,20 +196,20 @@ void EnWallmas_SetupStand(EnWallmas* this) {
 void EnWallmas_SetupWalk(EnWallmas* this) {
     Animation_PlayOnceSetSpeed(&this->skelAnime, &gWallmasterWalkAnim, 3.0f);
     this->actionFunc = EnWallmas_Walk;
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
 }
 
 void EnWallmas_SetupJumpToCeiling(EnWallmas* this) {
     Animation_PlayOnce(&this->skelAnime, &gWallmasterStopWalkAnim);
     this->actionFunc = EnWallmas_JumpToCeiling;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 }
 void EnWallmas_SetupReturnToCeiling(EnWallmas* this) {
     AnimationHeader* objSegFrameCount = &gWallmasterJumpAnim;
     AnimationHeader* objSegChangee = &gWallmasterJumpAnim;
 
     this->timer = 0;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     Animation_Change(&this->skelAnime, objSegChangee, 3.0f, 0.0f, Animation_GetLastFrame(objSegFrameCount),
                      ANIMMODE_ONCE, -3.0f);
@@ -227,13 +227,13 @@ void EnWallmas_SetupTakeDamage(EnWallmas* this) {
 
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 20);
     this->actionFunc = EnWallmas_TakeDamage;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     this->actor.velocity.y = 10.0f;
 }
 
 void EnWallmas_SetupCooldown(EnWallmas* this) {
     Animation_PlayOnce(&this->skelAnime, &gWallmasterRecoverFromDamageAnim);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->actionFunc = EnWallmas_Cooldown;
@@ -241,7 +241,7 @@ void EnWallmas_SetupCooldown(EnWallmas* this) {
 
 void EnWallmas_SetupDie(EnWallmas* this, PlayState* play) {
     static Vec3f zeroVec = { 0.0f, 0.0f, 0.0f };
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
 
     EffectSsDeadDb_Spawn(play, &this->actor.world.pos, &zeroVec, &zeroVec, 250, -10, 255, 255, 255, 255, 0, 0, 255, 1,
@@ -255,7 +255,7 @@ void EnWallmas_SetupTakePlayer(EnWallmas* this, PlayState* play) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gWallmasterHoverAnim, -5.0f);
     this->timer = -0x1E;
     this->actionFunc = EnWallmas_TakePlayer;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
 
     this->yTarget = this->actor.yDistToPlayer;
@@ -277,7 +277,7 @@ void EnWallmas_ProximityOrSwitchInit(EnWallmas* this) {
 void EnWallmas_SetupStun(EnWallmas* this) {
     Animation_Change(&this->skelAnime, &gWallmasterJumpAnim, 1.5f, 0, 20.0f, ANIMMODE_ONCE, -3.0f);
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     if (this->actor.colChkInfo.damageEffect == 4) {
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_GRAY, 255, COLORFILTER_BUFFLAG_OPA, 80);
     } else {
@@ -399,7 +399,7 @@ void EnWallmas_TakeDamage(EnWallmas* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_M_GND);
     }
 
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 0.2f);
+    Math_StepToF(&this->actor.speed, 0.0f, 0.2f);
 }
 
 void EnWallmas_Cooldown(EnWallmas* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
+++ b/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
@@ -124,7 +124,7 @@ void func_80B32384(EnWeiyer* this) {
     this->unk_27C = (cosf(-M_PI / 8) * 3.0f) + this->actor.world.pos.y;
     Animation_MorphToLoop(&this->skelAnime, &gStingerHitAnim, -5.0f);
     this->unk_194 = 30;
-    this->actor.speedXZ = CLAMP_MAX(this->actor.speedXZ, 2.5f);
+    this->actor.speed = CLAMP_MAX(this->actor.speed, 2.5f);
     this->collider.base.atFlags &= ~AT_ON;
     this->unk_280 = this->actor.floorHeight;
     this->actionFunc = func_80B328E8;
@@ -134,7 +134,7 @@ void func_80B32434(EnWeiyer* this) {
     Animation_MorphToLoop(&this->skelAnime, &gStingerHitAnim, -5.0f);
     this->collider.base.atFlags |= AT_ON;
     this->unk_194 = 0;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     this->actionFunc = func_80B32C2C;
 }
 
@@ -156,7 +156,7 @@ void func_80B32538(EnWeiyer* this) {
     this->unk_194 = 200;
     this->unk_196 = this->actor.yawTowardsPlayer + 0x8000;
     this->unk_27C = this->actor.world.pos.y;
-    this->actor.speedXZ = CLAMP_MAX(this->actor.speedXZ, 4.0f);
+    this->actor.speed = CLAMP_MAX(this->actor.speed, 4.0f);
     this->collider.base.atFlags &= ~AT_ON;
     this->skelAnime.playSpeed = 1.0f;
     this->actionFunc = func_80B33018;
@@ -169,7 +169,7 @@ void func_80B325A0(EnWeiyer* this) {
     this->collider.base.acFlags &= ~AC_ON;
     this->actor.gravity = 0.0f;
     this->actor.velocity.y = 0.0f;
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 200, COLORFILTER_BUFFLAG_OPA, 40);
     this->collider.dim.height = sCylinderInit.dim.height;
     this->actionFunc = func_80B331CC;
@@ -178,7 +178,7 @@ void func_80B325A0(EnWeiyer* this) {
 void func_80B32660(EnWeiyer* this) {
     Animation_Change(&this->skelAnime, &gStingerPopOutAnim, 2.0f, 0.0f, 0.0f, ANIMMODE_LOOP, -8.0f);
     this->unk_194 = 80;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actor.gravity = -1.0f;
     this->collider.dim.height = sCylinderInit.dim.height + 15;
@@ -194,13 +194,13 @@ void func_80B32724(EnWeiyer* this) {
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 200, COLORFILTER_BUFFLAG_OPA, 40);
     this->collider.base.atFlags &= ~AT_ON;
     this->collider.base.acFlags &= ~AC_ON;
-    this->actor.speedXZ = 3.0f;
+    this->actor.speed = 3.0f;
     this->actionFunc = func_80B332B4;
 }
 
 void func_80B327B0(EnWeiyer* this) {
     this->actor.colorFilterParams |= 0x2000;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.velocity.y = 0.0f;
     this->actionFunc = func_80B33338;
 }
@@ -208,7 +208,7 @@ void func_80B327B0(EnWeiyer* this) {
 void func_80B327D8(EnWeiyer* this) {
     this->actor.shape.rot.x = -0x2000;
     this->unk_194 = -1;
-    this->actor.speedXZ = 5.0f;
+    this->actor.speed = 5.0f;
     this->actionFunc = func_80B3349C;
 }
 
@@ -243,9 +243,9 @@ void func_80B328E8(EnWeiyer* this, PlayState* play) {
     this->actor.world.pos.y = this->unk_27C - cosf((curFrame - 5.0f) * (M_PI / 40)) * 3.0f;
 
     if (curFrame <= 45.0f) {
-        Math_StepToF(&this->actor.speedXZ, 1.0f, 0.03f);
+        Math_StepToF(&this->actor.speed, 1.0f, 0.03f);
     } else {
-        Math_StepToF(&this->actor.speedXZ, 1.3f, 0.03f);
+        Math_StepToF(&this->actor.speed, 1.3f, 0.03f);
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
@@ -330,7 +330,7 @@ void func_80B32D30(EnWeiyer* this, PlayState* play) {
     }
 
     Math_ScaledStepToS(&this->actor.shape.rot.x, 0, 0x800);
-    Math_StepToF(&this->actor.speedXZ, 0.0f, 1.0f);
+    Math_StepToF(&this->actor.speed, 0.0f, 1.0f);
 
     if (this->unk_194 != 0) {
         this->unk_194--;
@@ -368,9 +368,9 @@ void func_80B32E34(EnWeiyer* this, PlayState* play) {
         func_80B32538(this);
     } else {
         if (Actor_IsFacingPlayer(&this->actor, 0x2800)) {
-            Math_StepToF(&this->actor.speedXZ, 4.0f, 0.2f);
+            Math_StepToF(&this->actor.speed, 4.0f, 0.2f);
         } else {
-            Math_StepToF(&this->actor.speedXZ, 1.3f, 0.2f);
+            Math_StepToF(&this->actor.speed, 1.3f, 0.2f);
         }
 
         if (this->actor.home.pos.y < this->actor.world.pos.y) {
@@ -406,9 +406,9 @@ void func_80B33018(EnWeiyer* this, PlayState* play) {
     this->actor.world.pos.y = this->unk_27C - cosf((curFrame - 5.0f) * (M_PI / 40)) * 3.0f;
 
     if (curFrame <= 45.0f) {
-        Math_StepToF(&this->actor.speedXZ, 1.0f, 0.03f);
+        Math_StepToF(&this->actor.speed, 1.0f, 0.03f);
     } else {
-        Math_StepToF(&this->actor.speedXZ, 1.3f, 0.03f);
+        Math_StepToF(&this->actor.speed, 1.3f, 0.03f);
     }
 
     if (this->unk_194 != 0) {

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -412,7 +412,7 @@ void EnWf_SetupWait(EnWf* this) {
     Animation_MorphToLoop(&this->skelAnime, &gWolfosWaitingAnim, -4.0f);
     this->action = WOLFOS_ACTION_WAIT;
     this->actionTimer = (Rand_ZeroOne() * 10.0f) + 2.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnWf_SetupAction(this, EnWf_Wait);
 }
@@ -507,14 +507,14 @@ void EnWf_RunAtPlayer(EnWf* this, PlayState* play) {
         }
 
         if (this->actor.xzDistToPlayer <= (50.0f + baseRange)) {
-            Math_SmoothStepToF(&this->actor.speedXZ, -8.0f, 1.0f, 1.5f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, -8.0f, 1.0f, 1.5f, 0.0f);
         } else if ((65.0f + baseRange) < this->actor.xzDistToPlayer) {
-            Math_SmoothStepToF(&this->actor.speedXZ, 8.0f, 1.0f, 1.5f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 8.0f, 1.0f, 1.5f, 0.0f);
         } else {
-            Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 6.65f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 6.65f, 0.0f);
         }
 
-        this->skelAnime.playSpeed = this->actor.speedXZ * 0.175f;
+        this->skelAnime.playSpeed = this->actor.speed * 0.175f;
         playerFacingAngleDiff = player->actor.shape.rot.y - this->actor.shape.rot.y;
         playerFacingAngleDiff = ABS(playerFacingAngleDiff);
 
@@ -618,7 +618,7 @@ void EnWf_SetupRunAroundPlayer(EnWf* this) {
         this->runAngle = -16000;
     }
 
-    this->skelAnime.playSpeed = this->actor.speedXZ = 6.0f;
+    this->skelAnime.playSpeed = this->actor.speed = 6.0f;
     this->skelAnime.playSpeed *= 0.175f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->actionTimer = (Rand_ZeroOne() * 30.0f) + 30.0f;
@@ -646,7 +646,7 @@ void EnWf_RunAroundPlayer(EnWf* this, PlayState* play) {
 
         // Actor_TestFloorInDirection is useless here (see comment below)
         if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
-            !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ, this->actor.shape.rot.y)) {
+            !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed, this->actor.shape.rot.y)) {
             angle2 = (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)
                          ? (this->actor.wallYaw - this->actor.yawTowardsPlayer) - this->runAngle
                          : 0;
@@ -675,8 +675,8 @@ void EnWf_RunAroundPlayer(EnWf* this, PlayState* play) {
             this->actor.world.pos.z += Math_CosS(this->actor.shape.rot.y) * this->runSpeed;
         }
 
-        if (ABS(this->runSpeed) < ABS(this->actor.speedXZ)) {
-            this->skelAnime.playSpeed = this->actor.speedXZ * 0.175f;
+        if (ABS(this->runSpeed) < ABS(this->actor.speed)) {
+            this->skelAnime.playSpeed = this->actor.speed * 0.175f;
         } else {
             this->skelAnime.playSpeed = this->runSpeed * 0.175f;
         }
@@ -722,7 +722,7 @@ void EnWf_SetupSlash(EnWf* this) {
     this->unk_2FA = 0; // Set and not used
     this->actionTimer = 7;
     this->skelAnime.endFrame = 20.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     EnWf_SetupAction(this, EnWf_Slash);
 }
@@ -735,7 +735,7 @@ void EnWf_Slash(EnWf* this, PlayState* play) {
 
     shapeAngleDiff = ABS(shapeAngleDiff);
     yawAngleDiff = ABS(yawAngleDiff);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if (((curFrame >= 9) && (curFrame <= 12)) || ((curFrame >= 17) && (curFrame <= 19))) {
         if (this->slashStatus == 0) {
@@ -839,7 +839,7 @@ void EnWf_RecoilFromBlockedSlash(EnWf* this, PlayState* play) {
 
 void EnWf_SetupBackflipAway(EnWf* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gWolfosBackflippingAnim, -3.0f);
-    this->actor.speedXZ = -6.0f;
+    this->actor.speed = -6.0f;
     this->actor.shape.rot.y = this->actor.world.rot.y = this->actor.yawTowardsPlayer;
     this->actionTimer = 0;
     this->unk_300 = true;
@@ -866,7 +866,7 @@ void EnWf_BackflipAway(EnWf* this, PlayState* play) {
 
 void EnWf_SetupStunned(EnWf* this) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     Actor_PlaySfx(&this->actor, NA_SE_EN_GOMA_JR_FREEZE);
@@ -877,12 +877,12 @@ void EnWf_SetupStunned(EnWf* this) {
 
 void EnWf_Stunned(EnWf* this, PlayState* play) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ += 0.05f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed += 0.05f;
         }
 
         this->unk_300 = false;
@@ -902,7 +902,7 @@ void EnWf_SetupDamaged(EnWf* this) {
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
         this->unk_300 = false;
-        this->actor.speedXZ = -4.0f;
+        this->actor.speed = -4.0f;
     } else {
         this->unk_300 = true;
     }
@@ -918,12 +918,12 @@ void EnWf_Damaged(EnWf* this, PlayState* play) {
     s16 angleToWall;
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ += 0.05f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed += 0.05f;
         }
 
         this->unk_300 = false;
@@ -962,7 +962,7 @@ void EnWf_SetupSomersaultAndAttack(EnWf* this) {
     this->actionTimer = 0;
     this->unk_300 = false;
     this->action = WOLFOS_ACTION_TURN_TOWARDS_PLAYER;
-    this->actor.speedXZ = 6.5f;
+    this->actor.speed = 6.5f;
     this->actor.velocity.y = 15.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_STAL_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
@@ -982,7 +982,7 @@ void EnWf_SomersaultAndAttack(EnWf* this, PlayState* play) {
         (this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH))) {
         this->actor.world.rot.y = this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
         this->actor.shape.rot.x = 0;
-        this->actor.speedXZ = this->actor.velocity.y = 0.0f;
+        this->actor.speed = this->actor.velocity.y = 0.0f;
         this->actor.world.pos.y = this->actor.floorHeight;
 
         if (!Actor_OtherIsTargeted(play, &this->actor)) {
@@ -1000,7 +1000,7 @@ void EnWf_SetupBlocking(EnWf* this) {
         this->slashStatus = -1;
     }
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->action = WOLFOS_ACTION_BLOCKING;
     this->actionTimer = 10;
 
@@ -1078,7 +1078,7 @@ void EnWf_SetupSidestep(EnWf* this, PlayState* play) {
         this->runAngle = -16000;
     }
 
-    this->skelAnime.playSpeed = this->actor.speedXZ = 6.0f;
+    this->skelAnime.playSpeed = this->actor.speed = 6.0f;
     this->skelAnime.playSpeed *= 0.175f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->runSpeed = 0.0f;
@@ -1100,7 +1100,7 @@ void EnWf_Sidestep(EnWf* this, PlayState* play) {
 
     // Actor_TestFloorInDirection is useless here (see comment below)
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
-        !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ, this->actor.shape.rot.y)) {
+        !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed, this->actor.shape.rot.y)) {
         s16 angle = (this->actor.bgCheckFlags & BGCHECKFLAG_WALL)
                         ? (this->actor.wallYaw - this->actor.yawTowardsPlayer) - this->runAngle
                         : 0;
@@ -1131,8 +1131,8 @@ void EnWf_Sidestep(EnWf* this, PlayState* play) {
         this->actor.world.pos.z += Math_CosS(this->actor.shape.rot.y) * this->runSpeed;
     }
 
-    if (ABS(this->runSpeed) < ABS(this->actor.speedXZ)) {
-        this->skelAnime.playSpeed = this->actor.speedXZ * 0.175f;
+    if (ABS(this->runSpeed) < ABS(this->actor.speed)) {
+        this->skelAnime.playSpeed = this->actor.speed * 0.175f;
     } else {
         this->skelAnime.playSpeed = this->runSpeed * 0.175f;
     }
@@ -1185,7 +1185,7 @@ void EnWf_SetupDie(EnWf* this) {
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
         this->unk_300 = false;
-        this->actor.speedXZ = -6.0f;
+        this->actor.speed = -6.0f;
     } else {
         this->unk_300 = true;
     }
@@ -1199,11 +1199,11 @@ void EnWf_SetupDie(EnWf* this) {
 
 void EnWf_Die(EnWf* this, PlayState* play) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
         this->unk_300 = false;
     }
 
@@ -1485,7 +1485,7 @@ s32 EnWf_DodgeRanged(PlayState* play, EnWf* this) {
             this->actor.world.rot.y = this->actor.shape.rot.y + 0x3FFF;
             if ((ABS(angleToFacing) < 0x2000) || (ABS(angleToFacing) > 0x5FFF)) {
                 EnWf_SetupSidestep(this, play);
-                this->actor.speedXZ *= 2.0f;
+                this->actor.speed *= 2.0f;
             } else if (ABS(angleToFacing) < 0x5FFF) {
                 EnWf_SetupBackflipAway(this);
             }

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -384,7 +384,7 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
             if (((player->rideActor == NULL) && (sqrt(this->actor.xyzDistToPlayerSq) < 20.0) &&
                  (player->linearVelocity != 0.0f)) ||
                 ((player->rideActor != NULL) && (sqrt(this->actor.xyzDistToPlayerSq) < 60.0) &&
-                 (player->rideActor->speedXZ != 0.0f))) {
+                 (player->rideActor->speed != 0.0f))) {
                 if ((this->unk_14C >= 0) && (this->unk_14C < 0x64)) {
                     Item_DropCollectibleRandom(play, &this->actor, &this->actor.world.pos,
                                                ((this->unk_14C << 4) | 0x8000));

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -583,7 +583,7 @@ AnimationHeader* EnXc_GetCurrentHarpAnim(PlayState* play, s32 index) {
 
 void EnXc_CalcXZAccel(EnXc* this) {
     f32 timer = this->timer;
-    f32* speedXZ = &this->actor.speedXZ;
+    f32* speedXZ = &this->actor.speed;
 
     if (timer < 9.0f) {
         *speedXZ = 0.0f;
@@ -602,7 +602,7 @@ void func_80B3D644(EnXc* this) {
 
 void EnXc_CalcXZSpeed(EnXc* this) {
     f32 timer = this->timer;
-    f32* speedXZ = &this->actor.speedXZ;
+    f32* speedXZ = &this->actor.speed;
 
     if (timer < 3.0f) {
         *speedXZ = (((kREG(2) * 0.01f) + 1.2f) / 3.0f) * (3.0f - timer);
@@ -681,7 +681,7 @@ void EnXc_SetupWalkAction(EnXc* this) {
 
     *timer += 1.0f;
     if (*timer >= 12.0f) {
-        this->actor.speedXZ = (kREG(2) * 0.01f) + 1.2f;
+        this->actor.speed = (kREG(2) * 0.01f) + 1.2f;
         this->action = SHEIK_ACTION_WALK;
     }
 }
@@ -705,7 +705,7 @@ void EnXc_SetupStoppedAction(EnXc* this) {
     *timer += 1.0f;
     if (*timer >= 12.0f) {
         this->action = SHEIK_ACTION_STOPPED;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 }
 
@@ -821,7 +821,7 @@ void EnXc_SetupReverseAccel(EnXc* this, PlayState* play) {
 void EnXc_SetupReverseWalkAction(EnXc* this) {
     this->timer++;
     if (this->timer >= 12.0f) {
-        this->actor.speedXZ = (kREG(2) * 0.01f) + 1.2f;
+        this->actor.speed = (kREG(2) * 0.01f) + 1.2f;
         this->action = SHEIK_ACTION_REVERSE_WALK;
     }
 }
@@ -844,7 +844,7 @@ void EnXc_SetupNutThrow(EnXc* this) {
                          Animation_GetLastFrame(&gSheikThrowingNutAnim), ANIMMODE_ONCE, 0.0f);
         this->action = SHEIK_ACTION_THROW_NUT;
         this->timer = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 }
 
@@ -1157,7 +1157,7 @@ void func_80B3EC90(EnXc* this, PlayState* play) {
 void func_80B3ECD8(EnXc* this) {
     this->timer++;
     if (this->timer >= 12.0f) {
-        this->actor.speedXZ = kREG(2) * 0.01f + 1.2f;
+        this->actor.speed = kREG(2) * 0.01f + 1.2f;
         this->action = SHEIK_ACTION_24;
     }
 }

--- a/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.c
+++ b/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.c
@@ -90,7 +90,7 @@ void func_80B43AD4(EnYukabyun* this, PlayState* play) {
     this->actor.shape.rot.y += this->unk_150;
     if (this->unk_150 >= 0x2000) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
         this->actionfunc = func_80B43B6C;
     }
     Math_StepToF(&this->actor.world.pos.y, this->actor.home.pos.y + 30.0f, 1.0f);

--- a/src/overlays/actors/ovl_En_Zf/z_en_zf.c
+++ b/src/overlays/actors/ovl_En_Zf/z_en_zf.c
@@ -220,7 +220,7 @@ s32 EnZf_PrimaryFloorCheck(EnZf* this, PlayState* play, f32 dist) {
     Vec3f curPos;
 
     if (dist == 0.0f) {
-        dist = ((this->actor.speedXZ >= 0.0f) ? 1.0f : -1.0f);
+        dist = ((this->actor.speed >= 0.0f) ? 1.0f : -1.0f);
         dist = ((this->actor.params >= ENZF_TYPE_LIZALFOS_MINIBOSS_A) ? dist * 45.0f : dist * 30.0f);
     }
 
@@ -252,7 +252,7 @@ s16 EnZf_SecondaryFloorCheck(EnZf* this, PlayState* play, f32 dist) {
     f32 cos;
     Vec3f curPos;
 
-    if ((this->actor.speedXZ != 0.0f) && EnZf_PrimaryFloorCheck(this, play, this->actor.speedXZ)) {
+    if ((this->actor.speed != 0.0f) && EnZf_PrimaryFloorCheck(this, play, this->actor.speed)) {
         return true;
     }
 
@@ -698,7 +698,7 @@ void func_80B45384(EnZf* this) {
                      ANIMMODE_LOOP_INTERP, -4.0f);
     this->action = ENZF_ACTION_3;
     this->unk_3F0 = Rand_ZeroOne() * 10.0f + 5.0f;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnZf_SetupAction(this, func_80B4543C);
 }
@@ -768,7 +768,7 @@ void EnZf_SetupApproachPlayer(EnZf* this, PlayState* play) {
             EnZf_FindNextPlatformTowardsPlayer(&this->actor.world.pos, this->curPlatform, this->homePlatform, play);
         this->hopAnimIndex = 0;
     }
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnZf_SetupAction(this, EnZf_ApproachPlayer);
 }
 
@@ -807,7 +807,7 @@ void EnZf_ApproachPlayer(EnZf* this, PlayState* play) {
                 temp_v1 = this->actor.wallYaw - this->actor.shape.rot.y;
                 temp_v1 = ABS(temp_v1);
 
-                if ((this->unk_3F8 && (this->actor.speedXZ > 0.0f)) ||
+                if ((this->unk_3F8 && (this->actor.speed > 0.0f)) ||
                     ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) && (temp_v1 >= 0x5C19))) {
                     if ((Actor_WorldDistXZToPoint(&this->actor, &sPlatformPositions[this->nextPlatform]) < sp44) &&
                         !EnZf_PrimaryFloorCheck(this, play, 191.9956f)) {
@@ -824,7 +824,7 @@ void EnZf_ApproachPlayer(EnZf* this, PlayState* play) {
                     }
                 } else {
                     this->actor.shape.rot.y = this->actor.world.rot.y = this->actor.yawTowardsPlayer;
-                    Math_SmoothStepToF(&this->actor.speedXZ, 8.0f, 1.0f, 1.5f, 0.0f);
+                    Math_SmoothStepToF(&this->actor.speed, 8.0f, 1.0f, 1.5f, 0.0f);
                 }
             }
         }
@@ -834,12 +834,12 @@ void EnZf_ApproachPlayer(EnZf* this, PlayState* play) {
         }
 
         if (this->actor.xzDistToPlayer <= (70.0f + sp40)) {
-            Math_SmoothStepToF(&this->actor.speedXZ, -8.0f, 1.0f, 0.5f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, -8.0f, 1.0f, 0.5f, 0.0f);
         } else {
-            Math_SmoothStepToF(&this->actor.speedXZ, 8.0f, 1.0f, 0.5f, 0.0f);
+            Math_SmoothStepToF(&this->actor.speed, 8.0f, 1.0f, 0.5f, 0.0f);
         }
 
-        this->skelAnime.playSpeed = this->actor.speedXZ * 1.2f;
+        this->skelAnime.playSpeed = this->actor.speed * 1.2f;
 
         temp_v1 = player->actor.shape.rot.y - this->actor.shape.rot.y;
         temp_v1 = ABS(temp_v1);
@@ -924,9 +924,9 @@ void EnZf_SetupJumpForward(EnZf* this) {
     this->actor.velocity.y = 15.0f;
 
     if (this->actor.params >= ENZF_TYPE_LIZALFOS_MINIBOSS_A) { // miniboss
-        this->actor.speedXZ = 16.0f;
+        this->actor.speed = 16.0f;
     } else {
-        this->actor.speedXZ = 10.0f;
+        this->actor.speed = 10.0f;
     }
 
     this->action = ENZF_ACTION_JUMP_FORWARD;
@@ -939,7 +939,7 @@ void EnZf_JumpForward(EnZf* this, PlayState* play) {
         this->actor.world.pos.y = this->actor.floorHeight;
         this->hopAnimIndex = 0;
         this->actor.velocity.y = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (SkelAnime_Update(&this->skelAnime)) {
@@ -948,7 +948,7 @@ void EnZf_JumpForward(EnZf* this, PlayState* play) {
             this->unk_3F0 = 10;
             Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_JUMP);
         } else {
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->hopAnimIndex = 0;
             EnZf_SetupApproachPlayer(this, play);
         }
@@ -1036,7 +1036,7 @@ void func_80B462E4(EnZf* this, PlayState* play) {
         Actor_TestFloorInDirection(&this->actor, play, 40.0f, (s16)(this->actor.shape.rot.y + 0x3FFF)) ||
         Actor_TestFloorInDirection(&this->actor, play, -40.0f, (s16)(this->actor.shape.rot.y + 0x3FFF))) {
         Animation_PlayLoop(&this->skelAnime, &gZfSidesteppingAnim);
-        this->actor.speedXZ = Rand_CenteredFloat(12.0f);
+        this->actor.speed = Rand_CenteredFloat(12.0f);
         this->actor.world.rot.y = this->actor.shape.rot.y;
         this->unk_3F0 = Rand_ZeroOne() * 10.0f + 20.0f;
         this->hopAnimIndex = 0;
@@ -1066,42 +1066,42 @@ void func_80B463E4(EnZf* this, PlayState* play) {
         angleBehindPlayer = player->actor.shape.rot.y + 0x8000;
 
         if (Math_SinS(angleBehindPlayer - this->actor.shape.rot.y) >= 0.0f) {
-            this->actor.speedXZ -= 0.25f;
-            if (this->actor.speedXZ < -8.0f) {
-                this->actor.speedXZ = -8.0f;
+            this->actor.speed -= 0.25f;
+            if (this->actor.speed < -8.0f) {
+                this->actor.speed = -8.0f;
             }
         } else if (Math_SinS(angleBehindPlayer - this->actor.shape.rot.y) < 0.0f) { // Superfluous check
-            this->actor.speedXZ += 0.25f;
-            if (this->actor.speedXZ > 8.0f) {
-                this->actor.speedXZ = 8.0f;
+            this->actor.speed += 0.25f;
+            if (this->actor.speed > 8.0f) {
+                this->actor.speed = 8.0f;
             }
         }
 
         if (this->actor.params >= ENZF_TYPE_LIZALFOS_MINIBOSS_A) { // miniboss
             if (this->unk_3F8) {
-                this->actor.speedXZ = -this->actor.speedXZ;
+                this->actor.speed = -this->actor.speed;
             }
         } else if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
-                   !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ,
+                   !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed,
                                                this->actor.shape.rot.y + 0x3FFF)) {
             if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-                if (this->actor.speedXZ >= 0.0f) {
+                if (this->actor.speed >= 0.0f) {
                     phi_v0_3 = this->actor.shape.rot.y + 0x3FFF;
                 } else {
                     phi_v0_3 = this->actor.shape.rot.y - 0x3FFF;
                 }
                 phi_v0_3 = this->actor.wallYaw - phi_v0_3;
             } else {
-                this->actor.speedXZ *= -0.8f;
+                this->actor.speed *= -0.8f;
                 phi_v0_3 = 0;
             }
 
             if (ABS(phi_v0_3) > 0x4000) {
-                this->actor.speedXZ *= -0.8f;
-                if (this->actor.speedXZ < 0.0f) {
-                    this->actor.speedXZ -= 0.5f;
+                this->actor.speed *= -0.8f;
+                if (this->actor.speed < 0.0f) {
+                    this->actor.speed -= 0.5f;
                 } else {
-                    this->actor.speedXZ += 0.5f;
+                    this->actor.speed += 0.5f;
                 }
             }
         }
@@ -1123,8 +1123,8 @@ void func_80B463E4(EnZf* this, PlayState* play) {
             this->actor.world.pos.z += Math_CosS(this->actor.shape.rot.y) * this->unk_408;
         }
 
-        if (ABS(this->actor.speedXZ) >= ABS(this->unk_408)) {
-            this->skelAnime.playSpeed = this->actor.speedXZ * 0.75f;
+        if (ABS(this->actor.speed) >= ABS(this->unk_408)) {
+            this->skelAnime.playSpeed = this->actor.speed * 0.75f;
         } else if (this->skelAnime.playSpeed < 0.0f) {
             this->skelAnime.playSpeed = this->unk_408 * -0.75f;
         } else {
@@ -1175,7 +1175,7 @@ void EnZf_SetupSlash(EnZf* this) {
     this->swordCollider.base.atFlags &= ~AT_BOUNCED;
     this->action = ENZF_ACTION_SLASH;
     Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_CRY);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     EnZf_SetupAction(this, EnZf_Slash);
 }
 
@@ -1184,7 +1184,7 @@ void EnZf_Slash(EnZf* this, PlayState* play) {
     s16 rotDiff;
     s16 yawDiff;
 
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
 
     if ((s32)this->skelAnime.curFrame == 10) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_ATTACK);
@@ -1259,7 +1259,7 @@ void EnZf_SetupJumpBack(EnZf* this) {
     this->hopAnimIndex = 1;
     this->action = ENZF_ACTION_JUMP_BACK;
     this->actor.velocity.y = 15.0f;
-    this->actor.speedXZ = -15.0f;
+    this->actor.speed = -15.0f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_JUMP);
     EnZf_SetupAction(this, EnZf_JumpBack);
 }
@@ -1269,7 +1269,7 @@ void EnZf_JumpBack(EnZf* this, PlayState* play) {
         this->actor.world.pos.y = this->actor.floorHeight;
         this->hopAnimIndex = 0;
         this->actor.velocity.y = 0.0f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (SkelAnime_Update(&this->skelAnime)) {
@@ -1292,7 +1292,7 @@ void EnZf_JumpBack(EnZf* this, PlayState* play) {
 void EnZf_SetupStunned(EnZf* this) {
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) &&
         ((this->actor.velocity.y == 0.0f) || (this->actor.velocity.y == -4.0f))) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->hopAnimIndex = 0;
     } else {
         this->hopAnimIndex = 1;
@@ -1313,12 +1313,12 @@ void EnZf_Stunned(EnZf* this, PlayState* play) {
     s16 angleToWall;
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ += 0.05f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed += 0.05f;
         }
         this->hopAnimIndex = 0;
     }
@@ -1362,7 +1362,7 @@ void EnZf_SetupSheatheSword(EnZf* this, PlayState* play) {
 
     Animation_Change(&this->skelAnime, &gZfSheathingSwordAnim, 2.0f, 0.0f, lastFrame, ANIMMODE_ONCE, morphFrames);
     this->action = ENZF_ACTION_SHEATHE_SWORD;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->curPlatform = EnZf_FindPlatform(&this->actor.world.pos, this->curPlatform);
     this->nextPlatform =
         EnZf_FindNextPlatformAwayFromPlayer(&this->actor.world.pos, this->curPlatform, this->homePlatform, play);
@@ -1387,7 +1387,7 @@ void EnZf_SetupHopAndTaunt(EnZf* this) {
     this->hopAnimIndex = 0;
     Animation_MorphToPlayOnce(&this->skelAnime, sHoppingAnims[0], -4.0f);
     this->action = ENZF_ACTION_HOP_AND_TAUNT;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->unk_40C = 0.0f;
     this->unk_408 = 0.0f;
     EnZf_SetupAction(this, EnZf_HopAndTaunt);
@@ -1397,7 +1397,7 @@ void EnZf_HopAndTaunt(EnZf* this, PlayState* play) {
     f32 lastFrame;
     f32 maxDist = 400.0f;
 
-    Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.5f, 0.0f);
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer + 0x8000, 1, 4000, 0);
 
     // Upstairs
@@ -1436,7 +1436,7 @@ void EnZf_HopAndTaunt(EnZf* this, PlayState* play) {
 
                 case 1:
                     this->actor.velocity.y = this->unk_40C + 10.0f;
-                    this->actor.speedXZ = this->unk_408;
+                    this->actor.speed = this->unk_408;
                     this->unk_408 = 0.0f;
                     this->unk_40C = 0.0f;
                     break;
@@ -1515,12 +1515,12 @@ void EnZf_HopAway(EnZf* this, PlayState* play) {
                         this->actor.velocity.y += 8.0f;
                     }
 
-                    this->actor.speedXZ = 8.0f;
+                    this->actor.speed = 8.0f;
                     break;
 
                 case 2:
                     this->actor.velocity.y = 15.0f;
-                    this->actor.speedXZ = 20.0f;
+                    this->actor.speed = 20.0f;
                     break;
 
                 default: // 0
@@ -1532,12 +1532,12 @@ void EnZf_HopAway(EnZf* this, PlayState* play) {
                     for (phi_v1 = 20; phi_v1 >= 0; phi_v1--, phi_f20_2 += 10.0f, phi_f0 += 1.2f) {
 
                         if (!EnZf_PrimaryFloorCheck(this, play, phi_f20_2)) {
-                            this->actor.speedXZ = phi_f0;
+                            this->actor.speed = phi_f0;
                             this->actor.velocity.y = 12.0f;
                             break;
                         }
                     }
-                    if (this->actor.speedXZ == 0.0f) {
+                    if (this->actor.speed == 0.0f) {
                         EnZf_SetupHopAndTaunt(this);
                     }
             }
@@ -1549,7 +1549,7 @@ void EnZf_HopAway(EnZf* this, PlayState* play) {
                 Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_ONGND);
                 this->actor.velocity.y = 0.0f;
                 this->actor.world.pos.y = this->actor.floorHeight;
-                this->actor.speedXZ = 0.0f;
+                this->actor.speed = 0.0f;
                 Actor_SpawnFloorDustRing(play, &this->actor, &this->leftFootPos, 3.0f, 2, 2.0f, 0, 0, false);
                 Actor_SpawnFloorDustRing(play, &this->actor, &this->rightFootPos, 3.0f, 2, 2.0f, 0, 0, false);
 
@@ -1588,7 +1588,7 @@ void EnZf_SetupDrawSword(EnZf* this, PlayState* play) {
     Animation_PlayOnce(&this->skelAnime, &gZfDrawingSwordAnim);
     this->actor.world.rot.y += 0x8000;
     this->action = ENZF_ACTION_DRAW_SWORD;
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->curPlatform = EnZf_FindPlatform(&this->actor.world.pos, this->curPlatform);
     this->nextPlatform =
         EnZf_FindNextPlatformAwayFromPlayer(&this->actor.world.pos, this->curPlatform, this->homePlatform, play);
@@ -1620,7 +1620,7 @@ void EnZf_SetupDamaged(EnZf* this) {
 
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) &&
         ((this->actor.velocity.y == 0.0f) || (this->actor.velocity.y == -4.0f))) {
-        this->actor.speedXZ = -4.0f;
+        this->actor.speed = -4.0f;
         this->hopAnimIndex = 0;
     } else {
         this->hopAnimIndex = 1;
@@ -1643,12 +1643,12 @@ void EnZf_Damaged(EnZf* this, PlayState* play) {
     s16 wallYawDiff;
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        if (this->actor.speedXZ < 0.0f) {
-            this->actor.speedXZ += 0.05f;
+        if (this->actor.speed < 0.0f) {
+            this->actor.speed += 0.05f;
         }
         this->hopAnimIndex = 0;
     }
@@ -1708,7 +1708,7 @@ void EnZf_SetupJumpUp(EnZf* this) {
     this->hopAnimIndex = 1;
     this->action = ENZF_ACTION_JUMP_UP;
     this->actor.velocity.y = 22.0f;
-    this->actor.speedXZ = 7.5f;
+    this->actor.speed = 7.5f;
     Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_JUMP);
     this->actor.world.rot.y = this->actor.shape.rot.y;
     EnZf_SetupAction(this, EnZf_JumpUp);
@@ -1728,7 +1728,7 @@ void EnZf_JumpUp(EnZf* this, PlayState* play) {
         } else if (this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH)) {
             this->actor.velocity.y = 0.0f;
             this->actor.world.rot.y = this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
-            this->actor.speedXZ = 0.0f;
+            this->actor.speed = 0.0f;
             this->actor.world.pos.y = this->actor.floorHeight;
             EnZf_SetupSlash(this);
             Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_ATTACK);
@@ -1751,9 +1751,9 @@ void func_80B483E4(EnZf* this, PlayState* play) {
         playerRotY = player->actor.shape.rot.y;
 
         if (Math_SinS(playerRotY - this->actor.shape.rot.y) >= 0.0f) {
-            this->actor.speedXZ = -6.0f;
+            this->actor.speed = -6.0f;
         } else if (Math_SinS(playerRotY - this->actor.shape.rot.y) < 0.0f) { // Superfluous check
-            this->actor.speedXZ = 6.0f;
+            this->actor.speed = 6.0f;
         }
 
         this->unk_408 = 0.0f;
@@ -1781,12 +1781,12 @@ void EnZf_CircleAroundPlayer(EnZf* this, PlayState* play) {
 
     if (this->actor.params >= ENZF_TYPE_LIZALFOS_MINIBOSS_A) { // miniboss
         if (this->unk_3F8) {
-            this->actor.speedXZ = -this->actor.speedXZ;
+            this->actor.speed = -this->actor.speed;
         }
     } else if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) ||
-               !Actor_TestFloorInDirection(&this->actor, play, this->actor.speedXZ, this->actor.shape.rot.y + 0x3FFF)) {
+               !Actor_TestFloorInDirection(&this->actor, play, this->actor.speed, this->actor.shape.rot.y + 0x3FFF)) {
         if (this->actor.bgCheckFlags & BGCHECKFLAG_WALL) {
-            if (this->actor.speedXZ >= 0.0f) {
+            if (this->actor.speed >= 0.0f) {
                 phi_v0_4 = this->actor.shape.rot.y + 0x3FFF;
             } else {
                 phi_v0_4 = this->actor.shape.rot.y - 0x3FFF;
@@ -1794,24 +1794,24 @@ void EnZf_CircleAroundPlayer(EnZf* this, PlayState* play) {
 
             phi_v0_4 = this->actor.wallYaw - phi_v0_4;
         } else {
-            this->actor.speedXZ *= -0.8f;
+            this->actor.speed *= -0.8f;
             phi_v0_4 = 0;
         }
 
         if (ABS(phi_v0_4) > 0x4000) {
-            this->actor.speedXZ *= -0.8f;
-            if (this->actor.speedXZ < 0.0f) {
-                this->actor.speedXZ -= 0.5f;
+            this->actor.speed *= -0.8f;
+            if (this->actor.speed < 0.0f) {
+                this->actor.speed -= 0.5f;
             } else {
-                this->actor.speedXZ += 0.5f;
+                this->actor.speed += 0.5f;
             }
         }
     }
 
     if (Math_SinS(playerRot - this->actor.shape.rot.y) >= 0.0f) {
-        this->actor.speedXZ += 0.125f;
+        this->actor.speed += 0.125f;
     } else {
-        this->actor.speedXZ -= 0.125f;
+        this->actor.speed -= 0.125f;
     }
 
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x4000;
@@ -1833,8 +1833,8 @@ void EnZf_CircleAroundPlayer(EnZf* this, PlayState* play) {
         this->actor.world.pos.z += Math_CosS(this->actor.shape.rot.y) * this->unk_408;
     }
 
-    if (ABS(this->actor.speedXZ) >= ABS(this->unk_408)) {
-        this->skelAnime.playSpeed = -this->actor.speedXZ * 0.75f;
+    if (ABS(this->actor.speed) >= ABS(this->unk_408)) {
+        this->skelAnime.playSpeed = -this->actor.speed * 0.75f;
     } else if (this->skelAnime.playSpeed < 0.0f) {
         this->skelAnime.playSpeed = this->unk_408 * -0.75f;
     } else {
@@ -1849,7 +1849,7 @@ void EnZf_CircleAroundPlayer(EnZf* this, PlayState* play) {
     this->curPlatform = EnZf_FindPlatform(&this->actor.world.pos, this->curPlatform);
 
     if (EnZf_FindPlatform(&player->actor.world.pos, -1) != this->curPlatform) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
 
         if ((this->actor.params >= ENZF_TYPE_LIZALFOS_MINIBOSS_A) /* miniboss */ &&
             (D_80B4A1B4 == this->actor.params)) {
@@ -1908,7 +1908,7 @@ void EnZf_SetupDie(EnZf* this) {
 
     if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) &&
         ((this->actor.velocity.y == 0.0f) || (this->actor.velocity.y == -4.0f))) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->hopAnimIndex = 0;
     } else {
         this->hopAnimIndex = 1;
@@ -1941,11 +1941,11 @@ void EnZf_SetupDie(EnZf* this) {
 void EnZf_Die(EnZf* this, PlayState* play) {
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND_TOUCH) {
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
     }
 
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
-        Math_SmoothStepToF(&this->actor.speedXZ, 0.0f, 1.0f, 0.15f, 0.0f);
+        Math_SmoothStepToF(&this->actor.speed, 0.0f, 1.0f, 0.15f, 0.0f);
         this->hopAnimIndex = 0;
     }
 
@@ -2045,8 +2045,8 @@ void EnZf_Update(Actor* thisx, PlayState* play) {
     if (this->actor.colChkInfo.damageEffect != ENZF_DMGEFF_IMMUNE) {
         this->unk_3F8 = false;
         if ((this->hopAnimIndex != 1) && (this->action != ENZF_ACTION_HOP_AWAY)) {
-            if (this->actor.speedXZ != 0.0f) {
-                this->unk_3F8 = EnZf_PrimaryFloorCheck(this, play, this->actor.speedXZ * 1.5f);
+            if (this->actor.speed != 0.0f) {
+                this->unk_3F8 = EnZf_PrimaryFloorCheck(this, play, this->actor.speed * 1.5f);
             }
             if (!this->unk_3F8) {
                 this->unk_3F8 = EnZf_PrimaryFloorCheck(this, play, 0.0f);
@@ -2294,10 +2294,10 @@ void EnZf_SetupCircleAroundPlayer(EnZf* this, f32 speed) {
     this->unk_3F0 = Rand_ZeroOne() * 10.0f + 8.0f;
 
     if (this->actor.params == ENZF_TYPE_DINOLFOS) {
-        this->actor.speedXZ = 2.0f * speed;
+        this->actor.speed = 2.0f * speed;
         this->unk_3F0 /= 2;
     } else {
-        this->actor.speedXZ = speed;
+        this->actor.speed = speed;
     }
 
     this->hopAnimIndex = 0;
@@ -2387,7 +2387,7 @@ s32 EnZf_DodgeRangedWaiting(PlayState* play, EnZf* this) {
             phi_t0 |= 2;
         }
 
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
 
         if ((ABS(yawToProjectile) < 0x2000) || (ABS(yawToProjectile) >= 0x6000)) {
             if (phi_t0 == 0) {

--- a/src/overlays/actors/ovl_En_Zf/z_en_zf.c
+++ b/src/overlays/actors/ovl_En_Zf/z_en_zf.c
@@ -2289,15 +2289,15 @@ void EnZf_Draw(Actor* thisx, PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_zf.c", 3601);
 }
 
-void EnZf_SetupCircleAroundPlayer(EnZf* this, f32 speed) {
+void EnZf_SetupCircleAroundPlayer(EnZf* this, f32 speedXZ) {
     Animation_MorphToLoop(&this->skelAnime, &gZfSidesteppingAnim, -1.0f);
     this->unk_3F0 = Rand_ZeroOne() * 10.0f + 8.0f;
 
     if (this->actor.params == ENZF_TYPE_DINOLFOS) {
-        this->actor.speed = 2.0f * speed;
+        this->actor.speed = 2.0f * speedXZ;
         this->unk_3F0 /= 2;
     } else {
-        this->actor.speed = speed;
+        this->actor.speed = speedXZ;
     }
 
     this->hopAnimIndex = 0;

--- a/src/overlays/actors/ovl_En_Zf/z_en_zf.c
+++ b/src/overlays/actors/ovl_En_Zf/z_en_zf.c
@@ -46,7 +46,7 @@ void func_80B483E4(EnZf* this, PlayState* play);
 void EnZf_CircleAroundPlayer(EnZf* this, PlayState* play);
 void EnZf_SetupDie(EnZf* this);
 void EnZf_Die(EnZf* this, PlayState* play);
-void EnZf_SetupCircleAroundPlayer(EnZf* this, f32 speed);
+void EnZf_SetupCircleAroundPlayer(EnZf* this, f32 speedXZ);
 s32 EnZf_DodgeRangedEngaging(PlayState* play, EnZf* this);
 s32 EnZf_DodgeRangedWaiting(PlayState* play, EnZf* this);
 

--- a/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
+++ b/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
@@ -183,7 +183,7 @@ void func_80B4B010(EnZl1* this, PlayState* play) {
         Letterbox_SetSizeTarget(32);
         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_NOTHING_ALT);
         player->actor.world.pos = playerPos;
-        player->actor.speedXZ = 0.0f;
+        player->actor.speed = 0.0f;
         this->unk_1E2 = 0;
         this->actionFunc = func_80B4B240;
         Audio_PlayFanfare(NA_BGM_APPEAR);

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -326,7 +326,7 @@ s32 EnZl4_SetupFromLegendCs(EnZl4* this, PlayState* play) {
     playerx->world.pos.x += 56.0f * Math_SinS(rotY);
     playerx->world.pos.z += 56.0f * Math_CosS(rotY);
 
-    player->linearVelocity = playerx->speedXZ = 0.0f;
+    player->linearVelocity = playerx->speed = 0.0f;
 
     EnZl4_SetActiveCamMove(play, 5);
     Letterbox_SetSizeTarget(32);
@@ -437,7 +437,7 @@ s32 EnZl4_CsWaitForPlayer(EnZl4* this, PlayState* play) {
     rotY = this->actor.shape.rot.y;
     playerx->world.pos.x += 56.0f * Math_SinS(rotY);
     playerx->world.pos.z += 56.0f * Math_CosS(rotY);
-    playerx->speedXZ = 0.0f;
+    playerx->speed = 0.0f;
     player->linearVelocity = 0.0f;
     return true;
 }

--- a/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
+++ b/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
@@ -77,7 +77,7 @@ void EnfHG_Init(Actor* thisx, PlayState* play2) {
     Actor_SetScale(&this->actor, 0.011499999f);
     this->actor.gravity = -3.5f;
     ActorShape_Init(&this->actor.shape, -2600.0f, NULL, 20.0f);
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.focus.pos.y += 70.0f;
     Skin_Init(play, &this->skin, &gPhantomHorseSkel, &gPhantomHorseRunningAnim);
@@ -167,7 +167,7 @@ void EnfHG_Intro(EnfHG* this, PlayState* play) {
             player->actor.world.pos.y = GND_BOSSROOM_CENTER_Y + 7.0f;
             player->actor.world.pos.z = GND_BOSSROOM_CENTER_Z + 155.0f;
             player->actor.world.rot.y = player->actor.shape.rot.y = 0;
-            player->actor.speedXZ = 0.0f;
+            player->actor.speed = 0.0f;
             this->subCamEye.x = GND_BOSSROOM_CENTER_X + 0.0f;
             this->subCamEye.y = GND_BOSSROOM_CENTER_Y + 37.0f;
             this->subCamEye.z = GND_BOSSROOM_CENTER_Z + 170.0f;

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -1604,7 +1604,7 @@ void Fishing_DrawLureHook(PlayState* play, Vec3f* pos, Vec3f* refPos, u8 hookInd
 
     Matrix_Translate(pos->x, pos->y, pos->z, MTXMODE_NEW);
 
-    if ((player->actor.speedXZ == 0.0f) && (D_80B7E138 == 0.0f)) {
+    if ((player->actor.speed == 0.0f) && (D_80B7E138 == 0.0f)) {
         Math_ApproachF(&sLureHookRotY[hookIndex], ry, 0.1f, 0.3f);
     } else {
         sLureHookRotY[hookIndex] = ry;
@@ -1815,7 +1815,7 @@ void Fishing_DrawLureAndLine(PlayState* play, Vec3f* linePos, Vec3f* lineRot) {
         sLurePos = sReelLinePos[LINE_SEG_COUNT - 1];
         sLureRot.x = sReelLineRot[LINE_SEG_COUNT - 2].x + M_PI;
 
-        if ((player->actor.speedXZ == 0.0f) && (D_80B7E0B0 == 0)) {
+        if ((player->actor.speed == 0.0f) && (D_80B7E0B0 == 0)) {
             Math_ApproachF(&sLureRot.y, sReelLineRot[LINE_SEG_COUNT - 2].y, 0.1f, 0.2f);
         } else {
             sLureRot.y = sReelLineRot[LINE_SEG_COUNT - 2].y;
@@ -2908,9 +2908,9 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
     this->actor.uncullZoneScale = 50.0f;
 
     if (this->unk_150 == 0) {
-        sp118 = (player->actor.speedXZ * 0.15f) + 0.25f;
+        sp118 = (player->actor.speed * 0.15f) + 0.25f;
     } else {
-        sp118 = (player->actor.speedXZ * 0.3f) + 0.25f;
+        sp118 = (player->actor.speed * 0.3f) + 0.25f;
     }
 
     if ((D_80B7E0B0 != 0) || (sSubCamId != SUB_CAM_ID_DONE) ||
@@ -3056,7 +3056,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
         case 10:
             this->unk_1B4 = this->actor.home.pos;
 
-            Math_ApproachF(&this->actor.speedXZ, 2.0f, 1.0f, 0.5f);
+            Math_ApproachF(&this->actor.speed, 2.0f, 1.0f, 0.5f);
             Math_ApproachF(&this->unk_1B0, 4096.0f, 1.0f, 256.0f);
 
             if (sp124 < 40.0f) {
@@ -3078,7 +3078,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
         case 11:
             this->unk_1B4 = this->actor.home.pos;
 
-            Math_ApproachF(&this->actor.speedXZ, 0.0f, 1.0f, 0.05f);
+            Math_ApproachF(&this->actor.speed, 0.0f, 1.0f, 0.05f);
             Math_ApproachF(&this->unk_1B0, 0.0f, 1.0f, 256.0f);
 
             if (sp124 >= 40.0f) {
@@ -3115,7 +3115,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             break;
 
         case 0:
-            Math_ApproachF(&this->actor.speedXZ, 1.0f, 1.0f, 0.05f);
+            Math_ApproachF(&this->actor.speed, 1.0f, 1.0f, 0.05f);
             Math_ApproachF(&this->unk_1B0, 0.0f, 1.0f, 256.0f);
 
             if (this->unk_17A[0] == 0) {
@@ -3152,14 +3152,14 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
 
                 if ((this->actor.xzDistToPlayer < (250.0f * sp118)) || (this->unk_17A[1] != 0)) {
                     Math_ApproachF(&this->unk_1B0, 8192.0f, 1.0f, 768.0f);
-                    Math_ApproachF(&this->actor.speedXZ, 4.2f, 1.0f, 0.75);
+                    Math_ApproachF(&this->actor.speed, 4.2f, 1.0f, 0.75);
                     this->unk_190 = 1.2f;
                     this->unk_194 = 4000.0f;
                     this->unk_17A[0] = 20;
                 } else {
                     this->unk_190 = 1.0f;
                     this->unk_194 = 2000.0f;
-                    Math_ApproachF(&this->actor.speedXZ, 1.5f, 1.0f, 0.1f);
+                    Math_ApproachF(&this->actor.speed, 1.5f, 1.0f, 0.1f);
                 }
 
                 if ((this->unk_17A[0] == 0) || (sp124 < 50.0f)) {
@@ -3181,7 +3181,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             Math_ApproachS(&this->unk_166, 0, 0x14, 0x20);
 
             if ((this->actor.xzDistToPlayer < (250.0f * sp118)) || (this->unk_17A[1] != 0)) {
-                Math_ApproachF(&this->actor.speedXZ, 3.0f, 1.0f, 0.75);
+                Math_ApproachF(&this->actor.speed, 3.0f, 1.0f, 0.75);
                 this->unk_190 = 1.0f;
                 this->unk_17A[0] = 20;
                 this->unk_194 = 4000.0f;
@@ -3195,12 +3195,12 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             } else if (sp124 > 50.0f) {
                 this->unk_190 = 0.8f;
                 this->unk_194 = 1500.0f;
-                Math_ApproachF(&this->actor.speedXZ, 1.0f, 1.0f, 0.1f);
+                Math_ApproachF(&this->actor.speed, 1.0f, 1.0f, 0.1f);
                 Math_ApproachF(&this->unk_1B0, 2048.0f, 1.0f, 128.0f);
             } else {
                 this->unk_190 = 0.4f;
                 this->unk_194 = 500.0f;
-                Math_ApproachZeroF(&this->actor.speedXZ, 1.0f, 0.02f);
+                Math_ApproachZeroF(&this->actor.speed, 1.0f, 0.02f);
                 Math_ApproachF(&this->unk_1B0, 0.0f, 1.0f, 256.0f);
             }
 
@@ -3230,11 +3230,11 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                 Math_ApproachS(&this->unk_166, -0x1000, 0x14, 0x100);
 
                 if (this->actor.world.pos.y < (WATER_SURFACE_Y(play) - 20.0f)) {
-                    Math_ApproachF(&this->actor.speedXZ, 0.5f, 1.0f, 0.1f);
+                    Math_ApproachF(&this->actor.speed, 0.5f, 1.0f, 0.1f);
                 } else {
-                    Math_ApproachZeroF(&this->actor.speedXZ, 1.0f, 0.01f);
+                    Math_ApproachZeroF(&this->actor.speed, 1.0f, 0.01f);
 
-                    if ((this->actor.speedXZ == 0.0f) || (this->actor.world.pos.y > (WATER_SURFACE_Y(play) - 5.0f))) {
+                    if ((this->actor.speed == 0.0f) || (this->actor.world.pos.y > (WATER_SURFACE_Y(play) - 5.0f))) {
                         this->unk_1B4.x = Rand_ZeroFloat(300.0f);
                         this->unk_1B4.z = Rand_ZeroFloat(300.0f);
                         this->unk_1B4.y = this->actor.floorHeight + 10.0f;
@@ -3268,7 +3268,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                 if (sp124 > 40.0f) {
                     this->unk_190 = 0.7f;
                     this->unk_194 = 1200.0f;
-                    Math_ApproachF(&this->actor.speedXZ, 0.5f, 1.0f, 0.01f);
+                    Math_ApproachF(&this->actor.speed, 0.5f, 1.0f, 0.01f);
                     Math_ApproachF(&this->unk_1B0, 2048.0f, 1.0f, 128.0f);
                 } else {
                     this->unk_158 = -1;
@@ -3331,7 +3331,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                     this->unk_194 = 500.0f;
                     this->unk_17A[0] = (s16)Rand_ZeroFloat(10.0f) + 2;
                 }
-                Math_ApproachF(&this->actor.speedXZ, -0.2f, 1.0f, 0.1f);
+                Math_ApproachF(&this->actor.speed, -0.2f, 1.0f, 0.1f);
                 this->unk_15E = 1;
             } else {
                 if (this->unk_15E != 0) {
@@ -3339,7 +3339,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                     this->unk_1B0 = 0.0f;
                     this->unk_194 = 3000.0f;
                 }
-                Math_ApproachF(&this->actor.speedXZ, 3.0f, 1.0f, 0.15f);
+                Math_ApproachF(&this->actor.speed, 3.0f, 1.0f, 0.15f);
                 this->unk_15E = 0;
             }
 
@@ -3423,7 +3423,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             this->unk_1B4.z = sLurePos.z + sp100.z;
             this->unk_1B4.y = sLurePos.y - 10.0f;
             this->unk_1B0 = 4096.0f;
-            Math_ApproachF(&this->actor.speedXZ, this->unk_188 * 0.8f, 1.0f, 1.0f);
+            Math_ApproachF(&this->actor.speed, this->unk_188 * 0.8f, 1.0f, 1.0f);
 
             if ((D_80B7A694 != 3) || (sLurePos.y > (WATER_SURFACE_Y(play) + 5.0f)) ||
                 (sqrtf(SQ(sLurePos.x) + SQ(sLurePos.z)) > 800.0f)) {
@@ -3448,7 +3448,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             this->unk_151 = 50;
             sp134 = 2;
             this->unk_1B4 = sLurePos;
-            Math_ApproachF(&this->actor.speedXZ, this->unk_188, 1.0f, 1.0f);
+            Math_ApproachF(&this->actor.speed, this->unk_188, 1.0f, 1.0f);
 
             if ((D_80B7A694 != 3) || (this->unk_17A[0] == 0) || (sLurePos.y > (WATER_SURFACE_Y(play) + 5.0f)) ||
                 (sqrtf(SQ(sLurePos.x) + SQ(sLurePos.z)) > 800.0f)) {
@@ -3511,7 +3511,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
         case -3:
             this->unk_151 = 50;
             this->unk_1B4 = sLurePos;
-            Math_ApproachF(&this->actor.speedXZ, 2.0f, 1.0f, 1.0f);
+            Math_ApproachF(&this->actor.speed, 2.0f, 1.0f, 1.0f);
 
             if ((D_80B7A694 != 3) || (this->unk_17A[0] == 0) || (sLurePos.y > (WATER_SURFACE_Y(play) + 5.0f)) ||
                 (sqrtf(SQ(sLurePos.x) + SQ(sLurePos.z)) > 800.0f)) {
@@ -3678,17 +3678,17 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                         D_80B7E11C = 0.0f;
                         this->unk_190 = 1.6f;
                         this->unk_194 = 6000.0f;
-                        Math_ApproachF(&this->actor.speedXZ, 7.5f, 1.0f, 1.0f);
+                        Math_ApproachF(&this->actor.speed, 7.5f, 1.0f, 1.0f);
                         Math_ApproachS(&this->unk_170, 0x4E20, 2, 0xFA0);
                     } else {
                         if ((D_80B7E124 == 0) && (D_80B7E0B6 == 2)) {
                             this->unk_190 = 1.0f;
                             this->unk_194 = 2000.0f;
-                            Math_ApproachF(&this->actor.speedXZ, 3.0f, 1.0f, 0.2f);
+                            Math_ApproachF(&this->actor.speed, 3.0f, 1.0f, 0.2f);
                         } else {
                             this->unk_190 = 1.4f;
                             this->unk_194 = 5000.0f;
-                            Math_ApproachF(&this->actor.speedXZ, 5.0f, 1.0f, 0.5f);
+                            Math_ApproachF(&this->actor.speed, 5.0f, 1.0f, 0.5f);
                         }
 
                         if (this->unk_150 == 0) {
@@ -3713,7 +3713,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                         D_80B7E11C = 1.3f - (this->unk_1AC * 0.00899f * 1.4f);
                     }
 
-                    Math_ApproachF(&this->actor.speedXZ, 2.0f, 1.0f, 0.5f);
+                    Math_ApproachF(&this->actor.speed, 2.0f, 1.0f, 0.5f);
 
                     if (this->unk_17A[1] == 0) {
                         this->unk_152 = 0;
@@ -3734,7 +3734,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             }
 
             if (D_80B7E124 || (D_80B7E0B6 != 2)) {
-                if (this->actor.speedXZ < 3.0f) {
+                if (this->actor.speed < 3.0f) {
                     if ((D_80B7E0AE & 8) != 0) {
                         sp100.x = -0.8f;
                     } else {
@@ -3759,11 +3759,11 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
 
             if ((SQ(sp10C.x) + SQ(sp10C.y) + SQ(sp10C.z)) > SQ(20.0f)) {
                 Math_ApproachF(&this->actor.world.pos.x, sReelLinePos[LINE_SEG_COUNT - 2].x, 0.2f,
-                               2.0f * (this->actor.speedXZ * 1.5f));
+                               2.0f * (this->actor.speed * 1.5f));
                 Math_ApproachF(&this->actor.world.pos.y, sReelLinePos[LINE_SEG_COUNT - 2].y, 0.2f,
-                               2.0f * (this->actor.speedXZ * 1.5f) * 5.0f * 0.1f);
+                               2.0f * (this->actor.speed * 1.5f) * 5.0f * 0.1f);
                 Math_ApproachF(&this->actor.world.pos.z, sReelLinePos[LINE_SEG_COUNT - 2].z, 0.2f,
-                               2.0f * (this->actor.speedXZ * 1.5f));
+                               2.0f * (this->actor.speed * 1.5f));
             }
 
             if (CHECK_BTN_ALL(input->cur.button, BTN_A) || (input->rel.stick_y < -30)) {
@@ -3995,7 +3995,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                 D_80B7A898 = 3;
             }
 
-            Math_ApproachF(&this->actor.speedXZ, 5.0f, 1.0f, 1.0f);
+            Math_ApproachF(&this->actor.speed, 5.0f, 1.0f, 1.0f);
 
             if (sp124 < 20.0f) {
                 Math_ApproachS(&this->unk_170, 0x4E20, 2, 0xFA0);
@@ -4054,7 +4054,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                 spF6 = -0x1F40;
             }
 
-            if (this->actor.speedXZ >= 3.2f) {
+            if (this->actor.speed >= 3.2f) {
                 Math_ApproachS(&this->unk_16E, spF6, 2, 0x4E20);
             } else {
                 Math_ApproachS(&this->unk_16E, spF6, 3, 0xBB8);
@@ -4088,7 +4088,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
         Math_ApproachS(&this->unk_162, this->unk_168, spF0, spEE);
         Math_ApproachS(&this->unk_164, this->unk_16A, spFA, 0x2000);
 
-        if (this->actor.speedXZ <= 0.5f) {
+        if (this->actor.speed <= 0.5f) {
             Math_ApproachS(&this->actor.shape.rot.x, 0, 10, this->unk_178);
             Math_ApproachS(&this->unk_178, 0x500, 1, 0x20);
         } else {
@@ -4119,13 +4119,13 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
 
         if ((this->actor.world.pos.y < WATER_SURFACE_Y(play)) &&
             (this->actor.world.pos.y > (WATER_SURFACE_Y(play) - 10.0f)) && ((this->unk_15C & 1) == 0) &&
-            (this->actor.speedXZ > 0.0f)) {
+            (this->actor.speed > 0.0f)) {
             Vec3f pos = this->actor.world.pos;
             pos.y = WATER_SURFACE_Y(play);
             Fishing_SpawnRipple(&this->actor.projectedPos, play->specialEffects, &pos, 80.0f, 500.0f, 150, 90);
         }
 
-        if ((this->actor.speedXZ > 0.0f) || (this->unk_158 == 5)) {
+        if ((this->actor.speed > 0.0f) || (this->unk_158 == 5)) {
             f32 velocityY = this->actor.velocity.y;
 
             spD8 = this->unk_1AC * 0.1f;
@@ -5189,7 +5189,7 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
     if ((D_80B7E0AC != 0) && (D_80B7A6CC == 0) && (player->actor.world.pos.z > 1360.0f) &&
         (fabsf(player->actor.world.pos.x) < 25.0f)) {
         player->actor.world.pos.z = 1360.0f;
-        player->actor.speedXZ = 0.0f;
+        player->actor.speed = 0.0f;
 
         if (D_80B7A6D0 == 0) {
             D_80B7A6CC = 10;
@@ -5377,7 +5377,7 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
 
         case 11:
             player->actor.world.pos.z = 1360.0f;
-            player->actor.speedXZ = 0.0f;
+            player->actor.speed = 0.0f;
 
             if (Message_GetState(&play->msgCtx) == TEXT_STATE_NONE) {
                 Camera* mainCam = Play_GetCamera(play, CAM_ID_MAIN);
@@ -5527,7 +5527,7 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
     }
 
     if ((player->actor.floorHeight < (WATER_SURFACE_Y(play) - 3.0f)) &&
-        (player->actor.world.pos.y < (player->actor.floorHeight + 3.0f)) && (player->actor.speedXZ > 1.0f) &&
+        (player->actor.world.pos.y < (player->actor.floorHeight + 3.0f)) && (player->actor.speed > 1.0f) &&
         ((play->gameplayFrames % 2) == 0)) {
         Vec3f pos;
 
@@ -5538,7 +5538,7 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
     }
 
     if ((player->actor.floorHeight < WATER_SURFACE_Y(play)) &&
-        (player->actor.floorHeight > (WATER_SURFACE_Y(play) - 10.0f)) && (player->actor.speedXZ >= 4.0f) &&
+        (player->actor.floorHeight > (WATER_SURFACE_Y(play) - 10.0f)) && (player->actor.speed >= 4.0f) &&
         ((play->gameplayFrames % 4) == 0)) {
         s16 i;
 

--- a/src/overlays/actors/ovl_Item_Shield/z_item_shield.c
+++ b/src/overlays/actors/ovl_Item_Shield/z_item_shield.c
@@ -130,7 +130,7 @@ void func_80B86BC8(ItemShield* this, PlayState* play) {
         this->actor.velocity.y = 4.0f;
         this->actor.minVelocityY = -4.0f;
         this->actor.gravity = -0.8f;
-        this->actor.speedXZ = 0.0f;
+        this->actor.speed = 0.0f;
         this->timer = 160;
     } else {
         Collider_UpdateCylinder(&this->actor, &this->collider);
@@ -205,7 +205,7 @@ void func_80B86F68(ItemShield* this, PlayState* play) {
     this->actor.gravity = -0.8;
     this->unk_198 = 0;
     this->timer = 70;
-    this->actor.speedXZ = 0;
+    this->actor.speed = 0;
 }
 
 void ItemShield_Update(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -249,7 +249,7 @@ void ObjBean_FollowPath(ObjBean* this, PlayState* play) {
     f32 sp30;
     f32 mag;
 
-    Math_StepToF(&this->dyna.actor.speedXZ, sBeanSpeeds[this->unk_1F6].velocity, sBeanSpeeds[this->unk_1F6].accel);
+    Math_StepToF(&this->dyna.actor.speed, sBeanSpeeds[this->unk_1F6].velocity, sBeanSpeeds[this->unk_1F6].accel);
     path = &play->pathList[(this->dyna.actor.params >> 8) & 0x1F];
     nextPathPoint = &((Vec3s*)SEGMENTED_TO_VIRTUAL(path->points))[this->nextPointIndex];
 
@@ -257,7 +257,7 @@ void ObjBean_FollowPath(ObjBean* this, PlayState* play) {
 
     Math_Vec3f_Diff(&pathPointsFloat, &this->pathPoints, &acell);
     mag = Math3D_Vec3fMagnitude(&acell);
-    speed = CLAMP_MIN(this->dyna.actor.speedXZ, 0.5f);
+    speed = CLAMP_MIN(this->dyna.actor.speed, 0.5f);
     if (speed > mag) {
         currentPoint = &((Vec3s*)SEGMENTED_TO_VIRTUAL(path->points))[this->currentPointIndex];
 
@@ -273,12 +273,12 @@ void ObjBean_FollowPath(ObjBean* this, PlayState* play) {
         Math_Vec3s_DiffToVec3f(&sp40, nextPathPoint, currentPoint);
         Math_Vec3s_DiffToVec3f(&sp34, sp4C, nextPathPoint);
         if (Math3D_CosOut(&sp40, &sp34, &sp30)) {
-            this->dyna.actor.speedXZ = 0.0f;
+            this->dyna.actor.speed = 0.0f;
         } else {
-            this->dyna.actor.speedXZ *= (sp30 + 1.0f) * 0.5f;
+            this->dyna.actor.speed *= (sp30 + 1.0f) * 0.5f;
         }
     } else {
-        Math_Vec3f_Scale(&acell, this->dyna.actor.speedXZ / mag);
+        Math_Vec3f_Scale(&acell, this->dyna.actor.speed / mag);
         this->pathPoints.x += acell.x;
         this->pathPoints.y += acell.y;
         this->pathPoints.z += acell.z;
@@ -764,7 +764,7 @@ void ObjBean_WaitForPlayer(ObjBean* this, PlayState* play) {
 void ObjBean_SetupFly(ObjBean* this) {
     this->actionFunc = ObjBean_Fly;
     ObjBean_SetDrawMode(this, BEAN_STATE_DRAW_PLANT);
-    this->dyna.actor.speedXZ = 0.0f;
+    this->dyna.actor.speed = 0.0f;
     this->dyna.actor.flags |= ACTOR_FLAG_4; // Never stop updating
 }
 

--- a/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
+++ b/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
@@ -226,7 +226,7 @@ void ObjKibako_SetupHeld(ObjKibako* this) {
 void ObjKibako_Held(ObjKibako* this, PlayState* play) {
     if (Actor_HasNoParent(&this->actor, play)) {
         this->actor.room = play->roomCtx.curRoom.num;
-        if (fabsf(this->actor.speedXZ) < 0.1f) {
+        if (fabsf(this->actor.speed) < 0.1f) {
             Actor_PlaySfx(&this->actor, NA_SE_EV_PUT_DOWN_WOODBOX);
             ObjKibako_SetupIdle(this);
             this->collider.base.ocFlags1 &= ~OC1_TYPE_PLAYER;
@@ -240,8 +240,8 @@ void ObjKibako_Held(ObjKibako* this, PlayState* play) {
 }
 
 void ObjKibako_SetupThrown(ObjKibako* this) {
-    this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speedXZ;
-    this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speedXZ;
+    this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speed;
+    this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speed;
     this->actor.colChkInfo.mass = 240;
     this->actionFunc = ObjKibako_Thrown;
 }

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
@@ -292,8 +292,8 @@ void ObjTsubo_LiftedUp(ObjTsubo* this, PlayState* play) {
 }
 
 void ObjTsubo_SetupThrown(ObjTsubo* this) {
-    this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speedXZ;
-    this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speedXZ;
+    this->actor.velocity.x = Math_SinS(this->actor.world.rot.y) * this->actor.speed;
+    this->actor.velocity.z = Math_CosS(this->actor.world.rot.y) * this->actor.speed;
     this->actor.colChkInfo.mass = 240;
     D_80BA1B50 = (Rand_ZeroOne() - 0.7f) * 2800.0f;
     D_80BA1B58 = (Rand_ZeroOne() - 0.5f) * 2000.0f;

--- a/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
+++ b/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
@@ -181,7 +181,7 @@ void ShotSun_UpdateHyliaSun(ShotSun* this, PlayState* play) {
             collectible = Item_DropCollectible(play, &spawnPos, ITEM00_MAGIC_LARGE);
             if (collectible != NULL) {
                 collectible->despawnTimer = 6000;
-                collectible->actor.speedXZ = 0.0f;
+                collectible->actor.speed = 0.0f;
             }
         }
         Actor_Kill(&this->actor);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -8525,12 +8525,12 @@ s32 func_80843E64(PlayState* play, Player* this) {
     return 0;
 }
 
-void func_8084409C(PlayState* play, Player* this, f32 speed, f32 velocityY) {
+void func_8084409C(PlayState* play, Player* this, f32 speedXZ, f32 velocityY) {
     Actor* heldActor = this->heldActor;
 
     if (!func_80835644(play, this, heldActor)) {
         heldActor->world.rot.y = this->actor.shape.rot.y;
-        heldActor->speed = speed;
+        heldActor->speed = speedXZ;
         heldActor->velocity.y = velocityY;
         func_80834644(play, this);
         Player_PlaySfx(this, NA_SE_PL_THROW);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1574,7 +1574,7 @@ static LinkAnimationHeader* D_808543D4[] = {
 
 // return type can't be void due to regalloc in func_8084FCAC
 BAD_RETURN(s32) func_80832210(Player* this) {
-    this->actor.speedXZ = 0.0f;
+    this->actor.speed = 0.0f;
     this->linearVelocity = 0.0f;
 }
 
@@ -3916,14 +3916,14 @@ void func_80837C0C(PlayState* play, Player* this, s32 arg2, f32 arg3, f32 arg4, 
             if (arg2 == 2) {
                 this->unk_850 = 4;
 
-                this->actor.speedXZ = 3.0f;
+                this->actor.speed = 3.0f;
                 this->linearVelocity = 3.0f;
                 this->actor.velocity.y = 6.0f;
 
                 func_80832C2C(play, this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_damage_run, this->modelAnimType));
                 func_80832698(this, NA_SE_VO_LI_DAMAGE_S);
             } else {
-                this->actor.speedXZ = arg3;
+                this->actor.speed = arg3;
                 this->linearVelocity = arg3;
                 this->actor.velocity.y = arg4;
 
@@ -8525,12 +8525,12 @@ s32 func_80843E64(PlayState* play, Player* this) {
     return 0;
 }
 
-void func_8084409C(PlayState* play, Player* this, f32 speedXZ, f32 velocityY) {
+void func_8084409C(PlayState* play, Player* this, f32 speed, f32 velocityY) {
     Actor* heldActor = this->heldActor;
 
     if (!func_80835644(play, this, heldActor)) {
         heldActor->world.rot.y = this->actor.shape.rot.y;
-        heldActor->speedXZ = speedXZ;
+        heldActor->speed = speed;
         heldActor->velocity.y = velocityY;
         func_80834644(play, this);
         Player_PlaySfx(this, NA_SE_PL_THROW);
@@ -9307,7 +9307,7 @@ void func_80846120(Player* this, PlayState* play) {
     if (LinkAnimation_OnFrame(&this->skelAnime, 229.0f)) {
         Actor* heldActor = this->heldActor;
 
-        heldActor->speedXZ = Math_SinS(heldActor->shape.rot.x) * 40.0f;
+        heldActor->speed = Math_SinS(heldActor->shape.rot.x) * 40.0f;
         heldActor->velocity.y = Math_CosS(heldActor->shape.rot.x) * 40.0f;
         heldActor->gravity = -2.0f;
         heldActor->minVelocityY = -30.0f;
@@ -9358,7 +9358,7 @@ void func_80846358(Player* this, PlayState* play) {
         Actor* heldActor = this->heldActor;
 
         heldActor->world.rot.y = this->actor.shape.rot.y;
-        heldActor->speedXZ = 10.0f;
+        heldActor->speed = 10.0f;
         heldActor->velocity.y = 20.0f;
         func_80834644(play, this);
         Player_PlaySfx(this, NA_SE_PL_THROW);
@@ -9396,7 +9396,7 @@ void func_808464B0(Player* this, PlayState* play) {
 
         if (!func_80835644(play, this, heldActor)) {
             heldActor->velocity.y = 0.0f;
-            heldActor->speedXZ = 0.0f;
+            heldActor->speed = 0.0f;
             func_80834644(play, this);
             if (heldActor->id == ACTOR_EN_BOM_CHU) {
                 func_8083B8F4(this, play);
@@ -10282,7 +10282,7 @@ void Player_UpdateCamAndSeqModes(PlayState* play, Player* this) {
             } else {
                 camMode = CAM_MODE_NORMAL;
                 if ((this->linearVelocity == 0.0f) &&
-                    (!(this->stateFlags1 & PLAYER_STATE1_23) || (this->rideActor->speedXZ == 0.0f))) {
+                    (!(this->stateFlags1 & PLAYER_STATE1_23) || (this->rideActor->speed == 0.0f))) {
                     // not moving
                     seqMode = SEQ_MODE_STILL;
                 }
@@ -10606,29 +10606,29 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
                 s16 yawDiff = this->actor.world.rot.y - sp6E;
                 s32 pad;
 
-                if ((ABS(yawDiff) > 0x6000) && (this->actor.speedXZ != 0.0f)) {
+                if ((ABS(yawDiff) > 0x6000) && (this->actor.speed != 0.0f)) {
                     sp70 = 0.0f;
                     sp6E += 0x8000;
                 }
 
-                if (Math_StepToF(&this->actor.speedXZ, sp70, 0.35f) && (sp70 == 0.0f)) {
+                if (Math_StepToF(&this->actor.speed, sp70, 0.35f) && (sp70 == 0.0f)) {
                     this->actor.world.rot.y = this->currentYaw;
                 }
 
                 if (this->linearVelocity != 0.0f) {
                     s32 phi_v0;
 
-                    phi_v0 = (fabsf(this->linearVelocity) * 700.0f) - (fabsf(this->actor.speedXZ) * 100.0f);
+                    phi_v0 = (fabsf(this->linearVelocity) * 700.0f) - (fabsf(this->actor.speed) * 100.0f);
                     phi_v0 = CLAMP(phi_v0, 0, 1350);
 
                     Math_ScaledStepToS(&this->actor.world.rot.y, sp6E, phi_v0);
                 }
 
-                if ((this->linearVelocity == 0.0f) && (this->actor.speedXZ != 0.0f)) {
-                    func_800F4138(&this->actor.projectedPos, 0xD0, this->actor.speedXZ);
+                if ((this->linearVelocity == 0.0f) && (this->actor.speed != 0.0f)) {
+                    func_800F4138(&this->actor.projectedPos, 0xD0, this->actor.speed);
                 }
             } else {
-                this->actor.speedXZ = this->linearVelocity;
+                this->actor.speed = this->linearVelocity;
                 this->actor.world.rot.y = this->currentYaw;
             }
 
@@ -12058,7 +12058,7 @@ void func_8084CC98(Player* this, PlayState* play) {
     this->currentYaw = this->actor.shape.rot.y = rideActor->actor.shape.rot.y;
 
     if ((this->csMode != PLAYER_CSMODE_NONE) ||
-        (!func_8083224C(play) && ((rideActor->actor.speedXZ != 0.0f) || !func_8083B644(this, play)) &&
+        (!func_8083224C(play) && ((rideActor->actor.speed != 0.0f) || !func_8083B644(this, play)) &&
          !func_8083C1DC(this, play))) {
         if (D_808535E0 == 0) {
             if (this->unk_84F != 0) {
@@ -12971,7 +12971,7 @@ void func_8084F390(Player* this, PlayState* play) {
     this->stateFlags2 |= PLAYER_STATE2_5 | PLAYER_STATE2_6;
     LinkAnimation_Update(play, &this->skelAnime);
     func_8084269C(play, this);
-    func_800F4138(&this->actor.projectedPos, NA_SE_PL_SLIP_LEVEL - SFX_FLAG, this->actor.speedXZ);
+    func_800F4138(&this->actor.projectedPos, NA_SE_PL_SLIP_LEVEL - SFX_FLAG, this->actor.speed);
 
     if (func_8083B040(this, play) == 0) {
         floorPoly = this->actor.floorPoly;
@@ -13268,8 +13268,8 @@ void func_8085002C(Player* this) {
 
     sp26 = this->actor.world.rot.y - this->actor.shape.rot.y;
 
-    sp28 = (s32)(this->actor.speedXZ * -200.0f * Math_CosS(sp26) * (Rand_CenteredFloat(2.0f) + 10.0f)) & 0xFFFF;
-    sp2A = (s32)(this->actor.speedXZ * 100.0f * Math_SinS(sp26) * (Rand_CenteredFloat(2.0f) + 10.0f)) & 0xFFFF;
+    sp28 = (s32)(this->actor.speed * -200.0f * Math_CosS(sp26) * (Rand_CenteredFloat(2.0f) + 10.0f)) & 0xFFFF;
+    sp2A = (s32)(this->actor.speed * 100.0f * Math_SinS(sp26) * (Rand_CenteredFloat(2.0f) + 10.0f)) & 0xFFFF;
 
     D_80858AC8.unk_06 += sp28 >> 2;
     D_80858AC8.unk_08 += sp2A >> 2;

--- a/src/overlays/effects/ovl_Effect_Ss_G_Spk/z_eff_ss_g_spk.c
+++ b/src/overlays/effects/ovl_Effect_Ss_G_Spk/z_eff_ss_g_spk.c
@@ -132,8 +132,8 @@ void EffectSsGSpk_Update(PlayState* play, u32 index, EffectSs* this) {
 void EffectSsGSpk_UpdateNoAccel(PlayState* play, u32 index, EffectSs* this) {
     if (this->actor != NULL) {
         if ((this->actor->category == ACTORCAT_EXPLOSIVE) && (this->actor->update != NULL)) {
-            this->pos.x += (Math_SinS(this->actor->world.rot.y) * this->actor->speedXZ);
-            this->pos.z += (Math_CosS(this->actor->world.rot.y) * this->actor->speedXZ);
+            this->pos.x += (Math_SinS(this->actor->world.rot.y) * this->actor->speed);
+            this->pos.z += (Math_CosS(this->actor->world.rot.y) * this->actor->speed);
         }
     }
 


### PR DESCRIPTION
Changes the actor instance variable `speedXZ` to `speed`.
Reasoning is because the axes this speed value is used for depends entirely on which move function in z_actor.c is used. A proposed change in https://github.com/zeldaret/oot/pull/1476 will rename these functions to indicate which axes they will operate in. Some more context/conversations are in #1476 

This is mostly a find and replace PR (though the diff is massive because it gets used everywhere)
There are some instances of `speedXZ` left in the repo for temps or actor instance variables. I left them if they are actually used in the xz axes.