### PR TITLE
Import fault bss under NON_MATCHING

### DIFF
--- a/data/fault.bss.s
+++ b/data/fault.bss.s
@@ -7,6 +7,8 @@
 
 .section .bss
 
+// Note: This file is only included in the MATCHING build, the data is imported for non-matching
+
 .balign 16
 
 glabel sFaultInstance

--- a/data/fault.bss.s
+++ b/data/fault.bss.s
@@ -7,7 +7,7 @@
 
 .section .bss
 
-// Note: This file is only included in the MATCHING build, the data is imported for non-matching
+# Note: This file is only included in the MATCHING build, the data is imported for non-matching
 
 .balign 16
 

--- a/data/fault_drawer.bss.s
+++ b/data/fault_drawer.bss.s
@@ -7,10 +7,12 @@
 
 .section .bss
 
+// Note: This file is only included in the MATCHING build, the data is imported for non-matching
+
 .balign 16
 
 glabel sFaultDrawer
     .space 0x3C
 
-glabel D_8016B6C0
-    .space 0x20
+glabel D_8016B6CC
+    .space 0x24

--- a/data/fault_drawer.bss.s
+++ b/data/fault_drawer.bss.s
@@ -14,5 +14,5 @@
 glabel sFaultDrawer
     .space 0x3C
 
-glabel D_8016B6CC
+glabel D_8016B6BC
     .space 0x24

--- a/data/fault_drawer.bss.s
+++ b/data/fault_drawer.bss.s
@@ -7,7 +7,7 @@
 
 .section .bss
 
-// Note: This file is only included in the MATCHING build, the data is imported for non-matching
+# Note: This file is only included in the MATCHING build, the data is imported for non-matching
 
 .balign 16
 

--- a/spec
+++ b/spec
@@ -409,9 +409,11 @@ beginseg
     include "build/src/code/irqmgr.o"
     include "build/src/code/debug_malloc.o"
     include "build/src/code/fault.o"
-    include "build/data/fault.bss.o"
     include "build/src/code/fault_drawer.o"
+#ifndef NON_MATCHING
+    include "build/data/fault.bss.o"
     include "build/data/fault_drawer.bss.o"
+#endif
     include "build/src/code/kanread.o"
     include "build/src/code/ucode_disas.o"
     pad_text // audio library aligned to 32 bytes?

--- a/src/code/fault.c
+++ b/src/code/fault.c
@@ -76,12 +76,21 @@ const char* sFpExceptionNames[] = {
     "Unimplemented operation", "Invalid operation", "Division by zero", "Overflow", "Underflow", "Inexact operation",
 };
 
-// TODO: import .bss (has reordering issues)
+#ifndef NON_MATCHING
+// TODO: match .bss (has reordering issues)
 extern FaultMgr* sFaultInstance;
 extern u8 sFaultAwaitingInput;
 extern STACK(sFaultStack, 0x600);
 extern StackEntry sFaultThreadInfo;
 extern FaultMgr gFaultMgr;
+#else
+// Non-matching version for struct shiftability
+FaultMgr* sFaultInstance;
+u8 sFaultAwaitingInput;
+STACK(sFaultStack, 0x600);
+StackEntry sFaultThreadInfo;
+FaultMgr gFaultMgr;
+#endif
 
 typedef struct {
     /* 0x00 */ s32 (*callback)(void*, void*);

--- a/src/code/fault_drawer.c
+++ b/src/code/fault_drawer.c
@@ -99,7 +99,15 @@ FaultDrawer sFaultDrawerDefault = {
     NULL,
 };
 
+#ifndef NON_MATCHING
+// TODO: match .bss (has reordering issues)
 extern FaultDrawer sFaultDrawer;
+extern char D_8016B6CC[0x24];
+#else
+// Non-matching version for struct shiftability
+FaultDrawer sFaultDrawer;
+char D_8016B6CC[0x24];
+#endif
 
 void FaultDrawer_SetOsSyncPrintfEnabled(u32 enabled) {
     sFaultDrawer.osSyncPrintfEnabled = enabled;

--- a/src/code/fault_drawer.c
+++ b/src/code/fault_drawer.c
@@ -102,11 +102,11 @@ FaultDrawer sFaultDrawerDefault = {
 #ifndef NON_MATCHING
 // TODO: match .bss (has reordering issues)
 extern FaultDrawer sFaultDrawer;
-extern char D_8016B6CC[0x24];
+extern char D_8016B6BC[0x24];
 #else
 // Non-matching version for struct shiftability
 FaultDrawer sFaultDrawer;
-char D_8016B6CC[0x24];
+char D_8016B6BC[0x24];
 #endif
 
 void FaultDrawer_SetOsSyncPrintfEnabled(u32 enabled) {


### PR DESCRIPTION
Importing for NON_MATCHING allows shifting the structs without having to manually change sizes in the asm files. The `FaultMgr` struct contains various substructs such as `OSThread` and `Input`, those structs are not shiftable prior to this change and it's not immediately obvious that it's due to unimported fault bss.
This is intended as a temporary solution until fault bss reordering is worked out for matching.
