### PR TITLE
another round of trailing whitespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 # Detect compiler and set variables appropriately.
 ifeq ($(COMPILER),gcc)
   CC       := $(MIPS_BINUTILS_PREFIX)gcc
-else 
+else
 ifeq ($(COMPILER),ido)
   CC       := tools/ido_recomp/$(DETECTED_OS)/7.1/cc
   CC_OLD   := tools/ido_recomp/$(DETECTED_OS)/5.3/cc
@@ -121,7 +121,7 @@ ASFLAGS := -march=vr4300 -32 -no-pad-sections -Iinclude
 ifeq ($(COMPILER),gcc)
   CFLAGS += -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -mdivide-breaks -fno-zero-initialized-in-bss -fno-toplevel-reorder -ffreestanding -fno-common -fno-merge-constants -mno-explicit-relocs -mno-split-addresses $(CHECK_WARNINGS) -funsigned-char
   MIPS_VERSION := -mips3
-else 
+else
   # we support Microsoft extensions such as anonymous structs, which the compiler does support but warns for their usage. Surpress the warnings with -woff.
   CFLAGS += -G 0 -non_shared -fullwarn -verbose -Xcpluscomm $(INC) -Wab,-r4300_mul -woff 516,649,838,712
   MIPS_VERSION := -mips2
@@ -281,7 +281,7 @@ $(ROM): $(ELF)
 $(ELF): $(TEXTURE_FILES_OUT) $(ASSET_FILES_OUT) $(O_FILES) $(OVL_RELOC_FILES) build/ldscript.txt build/undefined_syms.txt
 	$(LD) -T build/undefined_syms.txt -T build/ldscript.txt --no-check-sections --accept-unknown-input-arch --emit-relocs -Map build/z64.map -o $@
 
-## Order-only prerequisites 
+## Order-only prerequisites
 # These ensure e.g. the O_FILES are built before the OVL_RELOC_FILES.
 # The intermediate phony targets avoid quadratically-many dependencies between the targets and prerequisites.
 

--- a/assets/xml/objects/object_mori_tex.xml
+++ b/assets/xml/objects/object_mori_tex.xml
@@ -14,7 +14,7 @@
         <Texture Name="gMoriHashiraPlatformsTex" OutName="hashira_platform" Format="rgba16" Height="32" Width="32" Offset="0x4A00"/>
 
         <!-- This is just a guess since its unused -->
-        <Texture Name="gMoriWaterTex" OutName="water" Format="rgba16" Height="8" Width="32" Offset="0x5200"/> 
+        <Texture Name="gMoriWaterTex" OutName="water" Format="rgba16" Height="8" Width="32" Offset="0x5200"/>
 
         <Texture Name="gMoriHashigoLadderTex" OutName="ladder" Format="rgba16" Height="32" Width="32" Offset="0x5400"/>
 

--- a/assets/xml/objects/object_rs.xml
+++ b/assets/xml/objects/object_rs.xml
@@ -21,7 +21,7 @@
         <Texture Name="gBombchuShopkeeperFingersTex" OutName="fingers" Format="ci8" Width="16" Height="16" Offset="0x4568" TlutOffset="0x2EE8"/>
         <Texture Name="gBombchuShopkeeperVestTex" OutName="vest" Format="i8" Width="8" Height="16" Offset="0x4668"/>
         <Texture Name="gBombchuShopkeeperTorsoTex" OutName="torso" Format="ci8" Width="8" Height="32" Offset="0x46E8" TlutOffset="0x2EE8"/>
-        
+
         <Limb Name="gBombchuShopkeeperTorsoLimb" LimbType="Standard" Offset="0x47E8"/>
         <Limb Name="gBombchuShopkeeperLeftUpperArmLimb" LimbType="Standard" Offset="0x47F4"/>
         <Limb Name="gBombchuShopkeeperLeftForearmLimb" LimbType="Standard" Offset="0x4800"/>

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -1,6 +1,6 @@
 # VSCode
 
-A lot of people on this project use VSCode as their coding environment. 
+A lot of people on this project use VSCode as their coding environment.
 
 ## Extensions
 
@@ -23,7 +23,7 @@ There are a number of useful extensions available to make work more efficient:
 - Ctrl + P offers a box to use to search for and open files.
 - Ctrl + Shift + P offers a box for commands like editing settings or reloading the window.
 
-- Make use of VSCode's search/search-and-replace features. 
+- Make use of VSCode's search/search-and-replace features.
     - Ctrl + Click goes to a definition.
     - Ctrl + F for search in current file
     - Ctrl + H for replace in current file

--- a/include/z64camera.h
+++ b/include/z64camera.h
@@ -42,7 +42,7 @@
 #define CAM_LETTERBOX_MEDIUM CAM_LETTERBOX(2)
 #define CAM_LETTERBOX_LARGE  CAM_LETTERBOX(3)
 
-#define CAM_LETTERBOX_INSTANT CAM_LETTERBOX(8) // Bit to determine whether to set the current value directly (on), or to set the size target (off) 
+#define CAM_LETTERBOX_INSTANT CAM_LETTERBOX(8) // Bit to determine whether to set the current value directly (on), or to set the size target (off)
 #define CAM_LETTERBOX_IGNORE  CAM_LETTERBOX(0xF) // No change in letterbox size, keep the previous size
 
 // Camera-unique hud visibility mode macros
@@ -121,7 +121,7 @@
 #define CAM_VIEW_FOV (1 << 5) // camera->fov
 #define CAM_VIEW_ROLL (1 << 6) // camera->roll
 
-// All scenes using `SCENE_CAM_TYPE_FIXED_SHOP_VIEWPOINT` or `SCENE_CAM_TYPE_FIXED_TOGGLE_VIEWPOINT` are expected 
+// All scenes using `SCENE_CAM_TYPE_FIXED_SHOP_VIEWPOINT` or `SCENE_CAM_TYPE_FIXED_TOGGLE_VIEWPOINT` are expected
 // to have their first two bgCamInfo entries be the following:
 #define BGCAM_INDEX_TOGGLE_LOCKED 0
 #define BGCAM_INDEX_TOGGLE_PIVOT 1

--- a/include/z64cutscene.h
+++ b/include/z64cutscene.h
@@ -212,7 +212,7 @@ typedef enum {
 } CutsceneTextType;
 
 typedef enum {
-    /* 0x03 */ CS_FADE_OUT_FANFARE = 3, 
+    /* 0x03 */ CS_FADE_OUT_FANFARE = 3,
     /* 0x04 */ CS_FADE_OUT_BGM_MAIN
 } CutsceneFadeOutSeqPlayer;
 

--- a/include/z64cutscene_commands.h
+++ b/include/z64cutscene_commands.h
@@ -137,7 +137,7 @@
     CMD_W(cmdType), CMD_W(entries)
 
 /**
- * Defines a cue that an actor can listen for. 
+ * Defines a cue that an actor can listen for.
  * The actor can choose whether or not to use the position and rotation data supplied to it.
  * The cue `id` is a number that has an actor-specific meaning.
  */
@@ -154,7 +154,7 @@
     CS_CMD_PLAYER_CUE, CMD_W(entries)
 
 /**
- * A player cue is the same as `CS_ACTOR_CUE` but is specifically for player. 
+ * A player cue is the same as `CS_ACTOR_CUE` but is specifically for player.
  */
 #define CS_PLAYER_CUE(id, startFrame, endFrame, rotX, rotY, rotZ, startX, startY, startZ, endX, endY, endZ, unused0, unused1, unused2) \
     CS_ACTOR_CUE(id, startFrame, endFrame, rotX, rotY, rotZ, startX, startY, startZ, endX, endY, endZ, unused0, unused1, unused2)
@@ -166,7 +166,7 @@
     CS_CMD_TEXT, CMD_W(entries)
 
 /**
- * Starts a textbox at the specified time. 
+ * Starts a textbox at the specified time.
  * For `CS_TEXT_OCARINA_ACTION`, `textId` is used as an ocarina action.
  * For a choice textbox, `altTextId1` is the top text id to branch to and `altTextId2` is the bottom.
  */
@@ -246,11 +246,11 @@
     CMD_HH(unused0, startFrame), CMD_HBB(endFrame, hour, min), CMD_W(0)
 
 /**
- * Sends the player to a new destination. 
+ * Sends the player to a new destination.
  * `destination` maps to a custom block of code that must implement the scene transition on its own.
  * This custom code can also do other tasks like changing age, setting flags, or any other setup that is needed
  * before going to the next destination.
- * 
+ *
  * @see `CutsceneDestination`
  * @note `endFrame` is not used in the implementation of the command, so its value does not matter
  */

--- a/include/z64environment.h
+++ b/include/z64environment.h
@@ -148,8 +148,8 @@ typedef struct {
 
 // `EnvLightSettings` is very similar to `CurrentEnvLightSettings` with one key difference.
 // The light settings data in the scene packs blend rate information with the fog near value.
-// The blendRate determines how fast the current light settings fade to the next one 
-// (under LIGHT_MODE_SETTINGS, otherwise unused). 
+// The blendRate determines how fast the current light settings fade to the next one
+// (under LIGHT_MODE_SETTINGS, otherwise unused).
 
 // Get blend rate from `EnvLightSettings.blendRateAndFogNear` in 0-255 range
 #define ENV_LIGHT_SETTINGS_BLEND_RATE_U8(blendRateAndFogNear) (((blendRateAndFogNear) >> 10) * 4)
@@ -162,7 +162,7 @@ typedef struct {
     /* 0x09 */ s8 light2Dir[3];
     /* 0x0C */ u8 light2Color[3];
     /* 0x0F */ u8 fogColor[3];
-    /* 0x12 */ s16 blendRateAndFogNear; 
+    /* 0x12 */ s16 blendRateAndFogNear;
     /* 0x14 */ s16 zFar;
 } EnvLightSettings; // size = 0x16
 

--- a/include/z64item.h
+++ b/include/z64item.h
@@ -2,7 +2,7 @@
 #define Z64ITEM_H
 
 // Note that z_kaleido_scope_PAL.c assumes that the dimensions and texture format here also matches the dimensions and
-// texture format for MAP_NAME_TEX1_* 
+// texture format for MAP_NAME_TEX1_*
 #define ITEM_NAME_TEX_WIDTH 128
 #define ITEM_NAME_TEX_HEIGHT 16
 #define ITEM_NAME_TEX_SIZE ((ITEM_NAME_TEX_WIDTH * ITEM_NAME_TEX_HEIGHT) / 2) // 128x16 IA4 texture

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -43,7 +43,7 @@ typedef struct {
 } Spawn;
 
 // TODO: ZAPD Compatibility
-typedef Spawn EntranceEntry; 
+typedef Spawn EntranceEntry;
 
 typedef struct {
     /* 0x00 */ u8 count; // number of points in the path

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.h
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.h
@@ -15,8 +15,8 @@ typedef struct EnBird {
     /* 0x0194 */ u32 unk_194; // set to 0 but otherwise unused
     /* 0x0198 */ s32 timer;
     /* 0x019C */ s16 scaleAnimSpeed; // when true, anim speed scales with XZ speed while slowing down. otherwise anim plays full speed
-    /* 0x01A0 */ f32 posYMag; 
-    /* 0x01A4 */ f32 rotYMag; 
+    /* 0x01A0 */ f32 posYMag;
+    /* 0x01A4 */ f32 rotYMag;
     /* 0x01A8 */ f32 speedTarget;
     /* 0x01AC */ f32 speedStep;
     /* 0x01B0 */ f32 flightDistance; // radius of "home" area

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.h
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.h
@@ -43,7 +43,7 @@ typedef struct EnTa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ Vec3s jointTable[ENTA_LIMB_MAX];
-    /* 0x01F6 */ Vec3s morphTable[ENTA_LIMB_MAX]; 
+    /* 0x01F6 */ Vec3s morphTable[ENTA_LIMB_MAX];
     /* 0x025C */ EnTaActionFunc actionFunc;
     /* 0x0260 */ EnTaAnimFunc animFunc;
     /* 0x0264 */ ColliderCylinder collider;

--- a/tools/asmsplitter/asmsplitter.py
+++ b/tools/asmsplitter/asmsplitter.py
@@ -31,7 +31,7 @@ for directory in dirs:
         continue
 
     print("Processing asm//" + directory)
-    
+
     folderName = os.path.splitext(directory)[0]
     lines = ReadAllLines("asm//" + directory)
     functions = list()
@@ -65,5 +65,5 @@ for directory in dirs:
         cLines.insert(len(cLines), "#pragma GLOBAL_ASM(\"asm/non_matchings/code/" + folderName + "/" + func.funcName + ".s\")\n")
 
     WriteAllLines("c//" + folderName + ".c", cLines)
-    
+
 print("Done!")

--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -9,13 +9,13 @@
 #include "spec.h"
 #include "util.h"
 
-// Note: *SECTION ALIGNMENT* Object files built with a compiler such as GCC can, by default, use narrower 
+// Note: *SECTION ALIGNMENT* Object files built with a compiler such as GCC can, by default, use narrower
 // alignment for sections size, compared to IDO padding sections to a 0x10-aligned size.
-// To properly generate relocations relative to section starts, sections currently need to be aligned 
-// explicitly (to 0x10 currently, a narrower alignment might work), otherwise the linker does implicit alignment 
-// and inserts padding between the address indicated by section start symbols (such as *SegmentRoDataStart) and 
+// To properly generate relocations relative to section starts, sections currently need to be aligned
+// explicitly (to 0x10 currently, a narrower alignment might work), otherwise the linker does implicit alignment
+// and inserts padding between the address indicated by section start symbols (such as *SegmentRoDataStart) and
 // the actual aligned start of the section.
-// With IDO, the padding of sections to an aligned size makes the section start at aligned addresses out of the box, 
+// With IDO, the padding of sections to an aligned size makes the section start at aligned addresses out of the box,
 // so the explicit alignment has no further effect.
 
 struct Segment *g_segments;

--- a/tools/msgdis.py
+++ b/tools/msgdis.py
@@ -309,7 +309,7 @@ def cvt(m):
 
 doubles = re.compile(r"(?<!\\)(\"\")")
 def fixup_message(message):
-    return re.sub(doubles, cvt, ("\"" + message.replace("\n","\\n\"\n\"") + "\"")).replace("\n ","\n").replace("BOX_BREAK\"","\nBOX_BREAK\n\"").replace("BOX_BREAK ","\nBOX_BREAK\n").strip()
+    return re.sub(doubles, cvt, ("\"" + message.replace("\n","\\n\"\n\"") + "\"")).replace("\n ","\n").replace("BOX_BREAK\"","\nBOX_BREAK\n\"").replace("BOX_BREAK ","\nBOX_BREAK\n").replace(" \n", "\n").strip()
 ###
 
 def dump_all_text():

--- a/tools/spec.c
+++ b/tools/spec.c
@@ -153,7 +153,7 @@ STMTId get_stmt_id_by_stmt_name(const char *stmtName, int lineNum) {
 
 bool parse_segment_statement(struct Segment *currSeg, STMTId stmt, char* args, int lineNum) {
     // ensure no duplicates (except for 'include' or 'pad_text')
-    if (stmt != STMT_include && stmt != STMT_include_data_with_rodata && stmt != STMT_pad_text && 
+    if (stmt != STMT_include && stmt != STMT_include_data_with_rodata && stmt != STMT_pad_text &&
         (currSeg->fields & (1 << stmt)))
         util_fatal_error("line %i: duplicate '%s' statement", lineNum, stmtNames[stmt]);
 
@@ -292,7 +292,7 @@ void parse_rom_spec(char *spec, struct Segment **segments, int *segment_count)
 /**
  * @brief Parses the spec, looking only for the segment with the name `segmentName`.
  * Returns true if the segment was found, false otherwise
- * 
+ *
  * @param[out] dstSegment The Segment to be filled. Will only contain the data of the searched segment, or garbage if the segment was not found. dstSegment must be previously allocated, a stack variable is recommended
  * @param[in,out] spec A null-terminated string containing the whole spec file. This string will be modified by this function
  * @param[in] segmentName The name of the segment being searched
@@ -344,8 +344,8 @@ bool get_single_segment_by_name(struct Segment* dstSegment, char *spec, const ch
 
 /**
  * @brief Frees the elements of the passed Segment. Will not free the pointer itself
- * 
- * @param segment 
+ *
+ * @param segment
  */
 void free_single_segment_elements(struct Segment *segment) {
     if (segment->includes != NULL) {


### PR DESCRIPTION
Minor stuff. The small change is `tools/msgdis.py` is nice though, as it removes trailing whitespaces from the message_data.h file(s), making the files easier to edit manually for some.