### PR TITLE
Fix deprecated warnings becoming errors for clang 15

### DIFF
--- a/tools/fado/lib/vc_vector/vc_vector.c
+++ b/tools/fado/lib/vc_vector/vc_vector.c
@@ -112,15 +112,15 @@ bool vc_vector_is_equals(vc_vector* vector1, vc_vector* vector2) {
   return memcmp(vector1->data, vector2->data, size_vector1) == 0;
 }
 
-float vc_vector_get_growth_factor() {
+float vc_vector_get_growth_factor(void) {
   return GROWTH_FACTOR;
 }
 
-size_t vc_vector_get_default_count_of_elements() {
+size_t vc_vector_get_default_count_of_elements(void) {
   return DEFAULT_COUNT_OF_ELEMENTS;
 }
 
-size_t vc_vector_struct_size() {
+size_t vc_vector_struct_size(void) {
   return sizeof(vc_vector);
 }
 

--- a/tools/fado/lib/vc_vector/vc_vector.h
+++ b/tools/fado/lib/vc_vector/vc_vector.h
@@ -24,13 +24,13 @@ void vc_vector_release(vc_vector* vector);
 bool vc_vector_is_equals(vc_vector* vector1, vc_vector* vector2);
 
 // Returns constant value of the vector growth factor.
-float vc_vector_get_growth_factor();
+float vc_vector_get_growth_factor(void);
 
 // Returns constant value of the vector default count of elements.
-size_t vc_vector_get_default_count_of_elements();
+size_t vc_vector_get_default_count_of_elements(void);
 
 // Returns constant value of the vector struct size.
-size_t vc_vector_struct_size();
+size_t vc_vector_struct_size(void);
 
 // ----------------------------------------------------------------------------
 // Element access

--- a/tools/fado/src/main.c
+++ b/tools/fado/src/main.c
@@ -15,7 +15,7 @@
 
 #include "version.inc"
 
-void PrintVersion() {
+void PrintVersion(void) {
     printf("Fado (Fairy-Assisted relocations for Decompiled Overlays), version %s\n", versionNumber);
     printf("Copyright (C) 2021 Elliptic Ellipsis\n");
     printf("%s\n", credits);
@@ -88,7 +88,7 @@ static size_t posArgCount = ARRAY_COUNT(posArgInfo);
 static size_t optCount = ARRAY_COUNT(optInfo);
 static struct option longOptions[ARRAY_COUNT(optInfo)];
 
-void ConstructLongOpts() {
+void ConstructLongOpts(void) {
     size_t i;
 
     for (i = 0; i < optCount; i++) {


### PR DESCRIPTION
https://www9.open-std.org/jtc1/sc22/wg14/www/docs/n2841.htm

Fixes all the following errors:
```
error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
```