### PR TITLE
Fix issues with texture sizes in `object_mori_tex`

### DIFF
--- a/assets/xml/objects/object_mori_tex.xml
+++ b/assets/xml/objects/object_mori_tex.xml
@@ -11,10 +11,8 @@
         <Texture Name="gMoriStalfosPlatformSideTex" OutName="stalfos_platform_side" Format="rgba16" Height="32" Width="64" Offset="0x3200"/>
         <Texture Name="gMoriStalfosPlatformTopTex" OutName="stalfos_platform_top" Format="rgba16" Height="32" Width="32" Offset="0x4200"/>
 
-        <Texture Name="gMoriHashiraPlatformsTex" OutName="hashira_platform" Format="rgba16" Height="32" Width="32" Offset="0x4A00"/>
-
-        <!-- This is just a guess since its unused -->
-        <Texture Name="gMoriWaterTex" OutName="water" Format="rgba16" Height="8" Width="32" Offset="0x5200"/>
+        <Texture Name="gMoriHashiraPlatformsTex" OutName="hashira_platform" Format="rgba16" Height="16" Width="16" Offset="0x4A00"/>
+        <Texture Name="gMoriWaterTex" OutName="water" Format="rgba16" Height="32" Width="32" Offset="0x4C00"/>
 
         <Texture Name="gMoriHashigoLadderTex" OutName="ladder" Format="rgba16" Height="32" Width="32" Offset="0x5400"/>
 


### PR DESCRIPTION
Relevant conversation in discord: https://discord.com/channels/688807550715560050/915273929369731173/1084701786411106355

I didn't find this or even fix it; I just noticed that nobody was PRing it, so I did it myself. The short summary is that `gMoriHashiraPlatformsTex` is actually 16x16, not 32x32, as evidenced by its DList. And `gMoriWaterTex` *is* used; it just didn't look like it because `gMoriHashiraPlatformsTex` was too big.