### PR TITLE
Ensure all boss title cards are extracted as IA8

### DIFF
--- a/assets/xml/objects/object_bv.xml
+++ b/assets/xml/objects/object_bv.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="object_bv" Segment="6">
         <!-- Boss title card -->
-        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="i8" Width="128" Height="120" Offset="0x1230"/>
+        <Texture Name="gBarinadeTitleCardTex" OutName="barinade_title_card" Format="ia8" Width="128" Height="120" Offset="0x1230"/>
 
         <Skeleton Name="gBarinadeBodySkel" Type="Normal" LimbType="Standard" Offset="0x15B18"/>
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x17498"/>

--- a/assets/xml/objects/object_fd.xml
+++ b/assets/xml/objects/object_fd.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="object_fd" Segment="6">
         <!-- Boss title card -->
-        <Texture Name="gVolvagiaBossTitleCardTex" OutName="volvagia_boss_title_card" Format="i8" Width="128" Height="120" Offset="0xD700"/>
+        <Texture Name="gVolvagiaBossTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0xD700"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x114E0"/>

--- a/assets/xml/objects/object_fd.xml
+++ b/assets/xml/objects/object_fd.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="object_fd" Segment="6">
         <!-- Boss title card -->
-        <Texture Name="gVolvagiaBossTitleCardTex" OutName="volvagia_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0xD700"/>
+        <Texture Name="gVolvagiaTitleCardTex" OutName="volvagia_title_card" Format="ia8" Width="128" Height="120" Offset="0xD700"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gVolvagiaLeftArmSkel" Type="Normal" LimbType="Standard" Offset="0x114E0"/>

--- a/assets/xml/objects/object_fhg.xml
+++ b/assets/xml/objects/object_fhg.xml
@@ -18,7 +18,7 @@
         <Animation Name="gPhantomHorseFenceJumpAnim" Offset="0xC180"/>
 
         <!-- Boss title card -->
-        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="i8" Width="128" Height="120" Offset="0x59A0"/>
+        <Texture Name="gPhantomGanonTitleCardTex" OutName="phantom_ganon_title_card" Format="ia8" Width="128" Height="120" Offset="0x59A0"/>
 
         <!-- Energy attack DLists -->
         <DList Name="gPhantomWarpDL" Offset="0xFAA0"/>

--- a/assets/xml/objects/object_ganon.xml
+++ b/assets/xml/objects/object_ganon.xml
@@ -68,7 +68,7 @@
         <DList Name="gGanondorfRightHandOpenDL" Offset="0xC9E8"/>
 
         <!-- Ganondorf Title Card Texture -->
-        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="i8" Width="128" Height="40" Offset="0xCF00"/>
+        <Texture Name="gGanondorfTitleCardTex" OutName="ganondorf_title_card" Format="ia8" Width="128" Height="40" Offset="0xCF00"/>
 
         <!-- Ganondorf Animation -->
         <Animation Name="gGanondorfEndingFloatAnim" Offset="0x11348"/> <!-- Original name is "ONOLEE" (lit. "Curse you!" from his in-game dialogue) -->

--- a/assets/xml/objects/object_goma.xml
+++ b/assets/xml/objects/object_goma.xml
@@ -159,7 +159,7 @@
         <Texture Name="gGohmaIrisTex" OutName="gohma_iris" Format="rgba16" Width="32" Height="32" Offset="0x193A8"/>
 
         <!-- Boss title card -->
-        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="i8" Width="128" Height="120" Offset="0x19BA8"/>
+        <Texture Name="gGohmaTitleCardTex" OutName="gohma_title_card" Format="ia8" Width="128" Height="120" Offset="0x19BA8"/>
 
         <!-- Door -->
         <DList Name="gGohmaDoorDL" Offset="0x1EC20"/>

--- a/assets/xml/objects/object_kingdodongo.xml
+++ b/assets/xml/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Blob Name="object_kingdodongo_Blob_017410" Size="0x3C00" Offset="0x17410"/> <!-- title card texture -->
+        <Texture Name="gKingDodongoBossTitleCardTex" OutName="king_dodongo_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x1B010"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x1B01C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x1B028"/>

--- a/assets/xml/objects/object_kingdodongo.xml
+++ b/assets/xml/objects/object_kingdodongo.xml
@@ -48,7 +48,7 @@
         <Texture Name="object_kingdodongo_Tex_016D90" OutName="tex_00016D90" Format="rgba16" Width="8" Height="8" Offset="0x16D90"/>
         <Texture Name="object_kingdodongo_Tex_016E10" OutName="tex_00016E10" Format="rgba16" Width="32" Height="16" Offset="0x16E10"/>
         <Texture Name="object_kingdodongo_Tex_017210" OutName="tex_00017210" Format="rgba16" Width="8" Height="32" Offset="0x17210"/>
-        <Texture Name="gKingDodongoBossTitleCardTex" OutName="king_dodongo_boss_title_card" Format="ia8" Width="128" Height="120" Offset="0x17410"/>
+        <Texture Name="gKingDodongoTitleCardTex" OutName="king_dodongo_title_card" Format="ia8" Width="128" Height="120" Offset="0x17410"/>
         <Limb Name="object_kingdodongo_Limb_01B010" LimbType="Standard" Offset="0x1B010"/>
         <Limb Name="object_kingdodongo_Limb_01B01C" LimbType="Standard" Offset="0x1B01C"/>
         <Limb Name="object_kingdodongo_Limb_01B028" LimbType="Standard" Offset="0x1B028"/>

--- a/assets/xml/objects/object_mo.xml
+++ b/assets/xml/objects/object_mo.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="object_mo" Segment="6">
         <!-- Morpha's Title Card -->
-        <Texture Name="gMorphaTitleCardTex" Format="i8" Width="128" Height="120" Offset="0x1010"/>
+        <Texture Name="gMorphaTitleCardTex" Format="ia8" Width="128" Height="120" Offset="0x1010"/>
 
         <!-- DLists for Morpha's Core -->
         <DList Name="gMorphaCoreMembraneDL" Offset="0x6700"/>

--- a/assets/xml/objects/object_sst.xml
+++ b/assets/xml/objects/object_sst.xml
@@ -2,7 +2,7 @@
     <ExternalFile XmlPath="objects/gameplay_keep.xml" OutPath="assets/objects/gameplay_keep/"/>
     <File Name="object_sst" Segment="6">
         <!-- Boss Title Card -->
-        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="i8" Width="128" Height="120" Offset="0x13D80"/>
+        <Texture Name="gBongoTitleCardTex" OutName="bongo_title_card" Format="ia8" Width="128" Height="120" Offset="0x13D80"/>
 
         <!-- Skeletons -->
         <Skeleton Name="gBongoLeftHandSkel" Type="Flex" LimbType="Standard" Offset="0x04DE0"/>

--- a/assets/xml/objects/object_tw.xml
+++ b/assets/xml/objects/object_tw.xml
@@ -350,7 +350,7 @@
         <DList Name="gTwinrovaBroomFireTrailDL" Offset="0x2E098"/>
 
         <!-- Twinrova Title Card -->
-        <Texture Name="gTwinrovaTitleCardTex" OutName="twinrova_title_card" Format="i8" Width="128" Height="120" Offset="0x2E170"/>
+        <Texture Name="gTwinrovaTitleCardTex" OutName="twinrova_title_card" Format="ia8" Width="128" Height="120" Offset="0x2E170"/>
 
         <!-- Twinrova Limbs -->
         <Limb Name="gTwinrovaPelvisLimb" LimbType="Standard" Offset="0x31D70"/>

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -404,8 +404,7 @@ void BossDodongo_IntroCutscene(BossDodongo* this, PlayState* play) {
             if (this->unk_198 == 0x5A) {
                 if (!GET_EVENTCHKINF(EVENTCHKINF_71)) {
                     TitleCard_InitBossName(play, &play->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(&object_kingdodongo_Blob_017410), 0xA0, 0xB4, 0x80,
-                                           0x28);
+                                           SEGMENTED_TO_VIRTUAL(gKingDodongoBossTitleCardTex), 160, 180, 128, 40);
                 }
                 SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_FIRE_BOSS);
             }

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -404,7 +404,7 @@ void BossDodongo_IntroCutscene(BossDodongo* this, PlayState* play) {
             if (this->unk_198 == 0x5A) {
                 if (!GET_EVENTCHKINF(EVENTCHKINF_71)) {
                     TitleCard_InitBossName(play, &play->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gKingDodongoBossTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gKingDodongoTitleCardTex), 160, 180, 128, 40);
                 }
                 SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_FIRE_BOSS);
             }

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -490,7 +490,7 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
                 }
                 if ((this->timers[3] == 130) && !GET_EVENTCHKINF(EVENTCHKINF_73)) {
                     TitleCard_InitBossName(play, &play->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 160, 180, 128, 40);
                 }
                 if (this->timers[3] <= 100) {
                     this->subCamEyeVel.x = this->subCamEyeVel.y = this->subCamEyeVel.z = 2.0f;

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -490,7 +490,7 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
                 }
                 if ((this->timers[3] == 130) && !GET_EVENTCHKINF(EVENTCHKINF_73)) {
                     TitleCard_InitBossName(play, &play->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gVolvagiaTitleCardTex), 160, 180, 128, 40);
                 }
                 if (this->timers[3] <= 100) {
                     this->subCamEyeVel.x = this->subCamEyeVel.y = this->subCamEyeVel.z = 2.0f;

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -489,8 +489,8 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
                     SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_FIRE_BOSS);
                 }
                 if ((this->timers[3] == 130) && !GET_EVENTCHKINF(EVENTCHKINF_73)) {
-                    TitleCard_InitBossName(play, &play->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gVolvagiaTitleCardTex), 160, 180, 128, 40);
+                    TitleCard_InitBossName(play, &play->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gVolvagiaTitleCardTex),
+                                           160, 180, 128, 40);
                 }
                 if (this->timers[3] <= 100) {
                     this->subCamEyeVel.x = this->subCamEyeVel.y = this->subCamEyeVel.z = 2.0f;

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -921,7 +921,7 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
 
                 if (!GET_EVENTCHKINF(EVENTCHKINF_70)) {
                     TitleCard_InitBossName(play, &play->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex),
-                                           0xA0, 0xB4, 0x80, 0x28);
+                                           160, 180, 128, 40);
                 }
 
                 SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_BOSS);

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -1420,8 +1420,8 @@ void BossMo_IntroCs(BossMo* this, PlayState* play) {
                 SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_BOSS);
             }
             if (this->timers[2] == 130) {
-                TitleCard_InitBossName(play, &play->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 0xA0,
-                                       0xB4, 0x80, 0x28);
+                TitleCard_InitBossName(play, &play->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 160,
+                                       180, 128, 40);
                 SET_EVENTCHKINF(EVENTCHKINF_74);
             }
             break;

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -2214,8 +2214,8 @@ void BossTw_TwinrovaIntroCS(BossTw* this, PlayState* play) {
                 play->envCtx.prevLightSetting = 1;
                 play->envCtx.lightSetting = 1;
                 play->envCtx.lightBlend = 0.0f;
-                TitleCard_InitBossName(play, &play->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gTwinrovaTitleCardTex),
-                                       0xA0, 0xB4, 0x80, 0x28);
+                TitleCard_InitBossName(play, &play->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gTwinrovaTitleCardTex), 160,
+                                       180, 128, 40);
                 SET_EVENTCHKINF(EVENTCHKINF_75);
                 SEQCMD_PLAY_SEQUENCE(SEQ_PLAYER_BGM_MAIN, 0, 0, NA_BGM_BOSS);
             }

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -974,7 +974,7 @@ void BossVa_BodyIntro(BossVa* this, PlayState* play) {
 
                 if (!GET_EVENTCHKINF(EVENTCHKINF_76)) {
                     TitleCard_InitBossName(play, &play->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gBarinadeTitleCardTex),
-                                           0xA0, 0xB4, 0x80, 0x28);
+                                           160, 180, 128, 40);
                 }
 
                 if (Rand_ZeroOne() < 0.1f) {


### PR DESCRIPTION
Tharo noticed on discord that some of the boss title cards were being extracted as I8 when they *should* be IA8, as per this displaylist:
```c
gDPLoadTextureBlock(OVERLAY_DISP++, (s32*)titleCtx->texture, G_IM_FMT_IA, G_IM_SIZ_8b, width, height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
```

I made sure all boss title cards were being extracted as IA8 here; if you don't see the title card in this PR, then it was *already* an IA8. As a bonus, I extracted KD's boss title card (it was the only one that wasn't currently being extracted) and made it so calls to `TitleCard_InitBossName` standardized on using decimal instead of hex.