### PR TITLE
Fix comment in `PreRender_FetchFbufCoverage`

### DIFF
--- a/src/code/PreRender.c
+++ b/src/code/PreRender.c
@@ -369,12 +369,12 @@ void PreRender_FetchFbufCoverage(PreRender* this, Gfx** gfxp) {
     //
     // G_RM_VISCVG is the following special render mode:
     //  IM_RD    : Allow read-modify-write operations on the framebuffer
-    //  FORCE_BL : Apply the blender to all pixels rather than just edges
-    //  (G_BL_CLR_IN * G_BL_0 + G_BL_CLR_BL * G_BL_A_MEM) / (G_BL_0 + G_BL_CLR_BL) = G_BL_A_MEM
+    //  FORCE_BL : Apply the blender to all pixels rather than just edges, skip the division step of the blend formula
+    //  (G_BL_CLR_IN * G_BL_0 + G_BL_CLR_BL * G_BL_A_MEM) = G_BL_CLR_BL * G_BL_A_MEM
     //
-    // G_BL_A_MEM ("memory alpha") is coverage, therefore this blender configuration emits only the coverage
-    // and discards any pixel colors. For an RGBA16 framebuffer, each of the three color channels r,g,b will
-    // receive the coverage value individually.
+    // G_BL_A_MEM ("memory alpha") is coverage, therefore this blender configuration emits only the coverage (up to a
+    // constant factor determined by blend color) and discards any pixel colors. For an RGBA16 framebuffer, each of the
+    // three color channels r,g,b will receive the coverage value individually.
     //
     // Also disables other modes such as alpha compare and texture perspective correction
     gDPSetOtherMode(gfx++,


### PR DESCRIPTION
Better accuracy regarding how the RDP blender works