### PR TITLE
Prefer clang-format-14

### DIFF
--- a/format.py
+++ b/format.py
@@ -14,8 +14,8 @@ from typing import List
 
 
 # clang-format, clang-tidy and clang-apply-replacements default version
-# Version 11 is used when available for more consistency between contributors
-CLANG_VER = 11
+# This specific version is used when available, for more consistency between contributors
+CLANG_VER = 14
 
 # Clang-Format options (see .clang-format for rules applied)
 FORMAT_OPTS = "-i -style=file"

--- a/format.py
+++ b/format.py
@@ -144,6 +144,12 @@ def format_files(src_files: List[str], extra_files: List[str], nb_jobs: int):
 
 def main():
     parser = argparse.ArgumentParser(description="Format files in the codebase to enforce most style rules")
+    parser.add_argument(
+        "--show-paths",
+        dest="show_paths",
+        action="store_true",
+        help="Print the paths to the clang-* binaries used",
+    )
     parser.add_argument("files", metavar="file", nargs="*")
     parser.add_argument(
         "-j",
@@ -154,6 +160,13 @@ def main():
         help="number of jobs to run (default: 1 without -j, number of cpus with -j)",
     )
     args = parser.parse_args()
+
+    if args.show_paths:
+        import shutil
+
+        print("CLANG_FORMAT             ->", shutil.which(CLANG_FORMAT))
+        print("CLANG_TIDY               ->", shutil.which(CLANG_TIDY))
+        print("CLANG_APPLY_REPLACEMENTS ->", shutil.which(CLANG_APPLY_REPLACEMENTS))
 
     nb_jobs = args.jobs or multiprocessing.cpu_count()
     if nb_jobs > 1:

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2815,11 +2815,11 @@ Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 pos
             overlayEntry->numLoaded = 0;
         }
 
-        actorInit = (void*)(uintptr_t)(
-            (overlayEntry->initInfo != NULL)
-                ? (void*)((uintptr_t)overlayEntry->initInfo -
-                          (intptr_t)((uintptr_t)overlayEntry->vramStart - (uintptr_t)overlayEntry->loadedRamAddr))
-                : NULL);
+        actorInit = (void*)(uintptr_t)((overlayEntry->initInfo != NULL)
+                                           ? (void*)((uintptr_t)overlayEntry->initInfo -
+                                                     (intptr_t)((uintptr_t)overlayEntry->vramStart -
+                                                                (uintptr_t)overlayEntry->loadedRamAddr))
+                                           : NULL);
     }
 
     objBankIndex = Object_GetIndex(&play->objectCtx, actorInit->objectId);

--- a/src/code/z_effect_soft_sprite.c
+++ b/src/code/z_effect_soft_sprite.c
@@ -213,11 +213,11 @@ void EffectSs_Spawn(PlayState* play, s32 type, s32 priority, void* initParams) {
             osSyncPrintf(VT_RST);
         }
 
-        initInfo = (void*)(uintptr_t)(
-            (overlayEntry->initInfo != NULL)
-                ? (void*)((uintptr_t)overlayEntry->initInfo -
-                          (intptr_t)((uintptr_t)overlayEntry->vramStart - (uintptr_t)overlayEntry->loadedRamAddr))
-                : NULL);
+        initInfo = (void*)(uintptr_t)((overlayEntry->initInfo != NULL)
+                                          ? (void*)((uintptr_t)overlayEntry->initInfo -
+                                                    (intptr_t)((uintptr_t)overlayEntry->vramStart -
+                                                               (uintptr_t)overlayEntry->loadedRamAddr))
+                                          : NULL);
     }
 
     if (initInfo->init == NULL) {

--- a/src/code/z_map_mark.c
+++ b/src/code/z_map_mark.c
@@ -63,10 +63,10 @@ void MapMark_Init(PlayState* play) {
     Overlay_Load(overlay->vromStart, overlay->vromEnd, overlay->vramStart, overlay->vramEnd, overlay->loadedRamAddr);
 
     sLoadedMarkDataTable = gMapMarkDataTable;
-    sLoadedMarkDataTable = (void*)(u32)(
-        (overlay->vramTable != NULL)
-            ? (void*)((u32)overlay->vramTable - (s32)((u32)overlay->vramStart - (u32)overlay->loadedRamAddr))
-            : NULL);
+    sLoadedMarkDataTable = (void*)(u32)((overlay->vramTable != NULL)
+                                            ? (void*)((u32)overlay->vramTable -
+                                                      (s32)((u32)overlay->vramStart - (u32)overlay->loadedRamAddr))
+                                            : NULL);
 }
 
 void MapMark_ClearPointers(PlayState* play) {


### PR DESCRIPTION
We were staying with clang-format-11 because there were formatting behavior changes from some version and it was annoying to deal with everyone having different versions
The same situation still applies but clang-format-11 is pretty old at this point
 
Availability of `clang-format-*` in the Ubuntu packages:
![image](https://github.com/zeldaret/oot/assets/5306619/69804200-eea8-4fde-ad2f-8dbb5a300850)
"x" is "in  ubuntu's apt package lists"
https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=clang-format-14&searchon=names
-> clang-format-14 sounds reasonable

I haven't checked if clang-format-14 can be installed on ubuntu 20.04 using https://apt.llvm.org/ , I'd guess yes (also this exists https://apt.llvm.org/focal/dists/llvm-toolchain-focal-14/ so it makes me think yes but idk). Any testing would be nice


------

MM, Fado and ZAPD are also aligned on clang-format-11 so it would be nice to coordinate

Guess I'm opening this to spearhead the transition