### PR TITLE
Give ObjectContext unk_09 field name numKeepObjects

### DIFF
--- a/include/z64object.h
+++ b/include/z64object.h
@@ -18,7 +18,7 @@ typedef struct {
     /* 0x0000 */ void*  spaceStart;
     /* 0x0004 */ void*  spaceEnd; // original name: "endSegment"
     /* 0x0008 */ u8     num; // number of objects in bank
-    /* 0x0009 */ u8     unk_09;
+    /* 0x0009 */ u8     numKeepObjects; // number of "keep" objects in bank including link
     /* 0x000A */ u8     mainKeepIndex; // "gameplay_keep" index in bank
     /* 0x000B */ u8     subKeepIndex; // "gameplay_field_keep" or "gameplay_dangeon_keep" index in bank
     /* 0x000C */ ObjectStatus status[OBJECT_EXCHANGE_BANK_MAX];

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -28,7 +28,7 @@ s32 Object_Spawn(ObjectContext* objectCtx, s16 objectId) {
     }
 
     objectCtx->num++;
-    objectCtx->unk_09 = objectCtx->num;
+    objectCtx->numKeepObjects = objectCtx->num;
 
     return objectCtx->num - 1;
 }
@@ -56,7 +56,7 @@ void Object_InitBank(PlayState* play, ObjectContext* objectCtx) {
         spaceSize = 1024000;
     }
 
-    objectCtx->num = objectCtx->unk_09 = 0;
+    objectCtx->num = objectCtx->numKeepObjects = 0;
     objectCtx->mainKeepIndex = objectCtx->subKeepIndex = 0;
 
     for (i = 0; i < OBJECT_EXCHANGE_BANK_MAX; i++) {
@@ -257,7 +257,7 @@ void Scene_CommandObjectList(PlayState* play, SceneCmd* cmd) {
     void* nextPtr;
 
     k = 0;
-    i = play->objectCtx.unk_09;
+    i = play->objectCtx.numKeepObjects;
     firstStatus = &play->objectCtx.status[0];
     status = &play->objectCtx.status[i];
 


### PR DESCRIPTION
Rename unk_09 in ObjectContext to numKeepObjects. The numKeepObjects field of ObjectContext is incremented by Object_Spawn, which is only used to spawn link and objects in gameplay_keep, gameplay_field_keep, and gameplay_dangeon_keep. Thus, numKeepObjects counts the number of "keep" objects (including link) pushed to the ObjectContext status array.

On room transition, Scene_CommandObjectList iterates through objects in the ObjectContext status array from index numKeepObjects to index num - 1, keeping objects that are in the same order between the ObjectContext status array and the next room's object list and removing the rest of the objects from the ObjectContext status array (before adding new objects to the ObjectContext status array). Thus, Scene_CommandObjectList ignores "keep" objects (including link).