### PR TITLE
Name player's generic `actionVar`s

### DIFF
--- a/include/z64player.h
+++ b/include/z64player.h
@@ -707,8 +707,8 @@ typedef struct Player {
     /* 0x0846 */ u8 unk_846;
     /* 0x0847 */ s8 unk_847[4];
     /* 0x084B */ s8 unk_84B[4];
-    /* 0x084F */ s8 unk_84F;
-    /* 0x0850 */ s16 unk_850; // multipurpose timer
+    /* 0x084F */ s8 actionVar1; // context dependent variable that has different meanings depending on what action is currently running
+    /* 0x0850 */ s16 actionVar2; // context dependent variable that has different meanings depending on what action is currently running
     /* 0x0854 */ f32 unk_854;
     /* 0x0858 */ f32 unk_858;
     /* 0x085C */ f32 unk_85C; // stick length among other things

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -756,7 +756,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 }
             }
             if (this->work[MO_TENT_ACTION_STATE] == MO_TENT_GRAB) {
-                player->unk_850 = 0xA;
+                player->actionVar2 = 0xA;
                 player->actor.speed = player->actor.velocity.y = 0;
                 Math_ApproachF(&player->actor.world.pos.x, this->grabPosRot.pos.x, 0.5f, 20.0f);
                 Math_ApproachF(&player->actor.world.pos.y, this->grabPosRot.pos.y, 0.5f, 20.0f);
@@ -814,7 +814,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                     Math_ApproachS(&this->tentRot[indS1].z, tempf2, 1.0f / this->tentMaxAngle, this->tentSpeed);
                 }
             }
-            player->unk_850 = 0xA;
+            player->actionVar2 = 0xA;
             player->actor.world.pos.x = this->grabPosRot.pos.x;
             player->actor.world.pos.y = this->grabPosRot.pos.y;
             player->actor.world.pos.z = this->grabPosRot.pos.z;
@@ -833,7 +833,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                     this->work[MO_TENT_ACTION_STATE] = MO_TENT_RETREAT;
                     this->work[MO_TENT_INVINC_TIMER] = 50;
                     if (&this->actor == player->actor.parent) {
-                        player->unk_850 = 0x65;
+                        player->actionVar2 = 0x65;
                         player->actor.parent = NULL;
                         player->csMode = PLAYER_CSMODE_NONE;
                         if (this->timers[0] == 0) {
@@ -863,7 +863,7 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
         case MO_TENT_CUT:
             Sfx_PlaySfxAtPos(&this->tentTipPos, NA_SE_EV_WATER_WALL - SFX_FLAG);
             if (&this->actor == player->actor.parent) {
-                player->unk_850 = 0x65;
+                player->actionVar2 = 0x65;
                 player->actor.parent = NULL;
                 player->csMode = PLAYER_CSMODE_NONE;
             }
@@ -1784,7 +1784,7 @@ void BossMo_CoreCollisionCheck(BossMo* this, PlayState* play) {
                             sMorphaTent2->tent2KillTimer = 1;
                         }
                         if (player->actor.parent != NULL) {
-                            player->unk_850 = 0x65;
+                            player->actionVar2 = 0x65;
                             player->actor.parent = NULL;
                             player->csMode = PLAYER_CSMODE_NONE;
                         }
@@ -1803,7 +1803,7 @@ void BossMo_CoreCollisionCheck(BossMo* this, PlayState* play) {
                     sMorphaTent1->timers[0] = 40;
                     sMorphaTent1->actor.flags &= ~ACTOR_FLAG_0;
                     if (player->actor.parent == &sMorphaTent1->actor) {
-                        player->unk_850 = 0x65;
+                        player->actionVar2 = 0x65;
                         player->actor.parent = NULL;
                         player->csMode = PLAYER_CSMODE_NONE;
                     }

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -1749,7 +1749,7 @@ void BossSst_HandClap(BossSst* this, PlayState* play) {
     }
 
     if (player->actor.parent == &this->actor) {
-        player->unk_850 = 0;
+        player->actionVar2 = 0;
         player->actor.world.pos = this->actor.world.pos;
     }
 }
@@ -1844,7 +1844,7 @@ void BossSst_HandGrab(BossSst* this, PlayState* play) {
     this->actor.world.pos.x += this->actor.speed * Math_SinS(this->actor.world.rot.y);
     this->actor.world.pos.z += this->actor.speed * Math_CosS(this->actor.world.rot.y);
     if (player->stateFlags2 & PLAYER_STATE2_7) {
-        player->unk_850 = 0;
+        player->actionVar2 = 0;
         player->actor.world.pos = this->actor.world.pos;
         player->actor.shape.rot.y = this->actor.shape.rot.y;
     }
@@ -1938,7 +1938,7 @@ void BossSst_HandSwing(BossSst* this, PlayState* play) {
     }
 
     if (player->stateFlags2 & PLAYER_STATE2_7) {
-        player->unk_850 = 0;
+        player->actionVar2 = 0;
         Math_Vec3f_Copy(&player->actor.world.pos, &this->actor.world.pos);
         player->actor.shape.rot.x = this->actor.shape.rot.x;
         player->actor.shape.rot.z = (this->vParity * -0x4000) + this->actor.shape.rot.z;
@@ -2422,7 +2422,7 @@ void BossSst_HandReleasePlayer(BossSst* this, PlayState* play, s32 dropPlayer) {
 
     if (player->actor.parent == &this->actor) {
         player->actor.parent = NULL;
-        player->unk_850 = 100;
+        player->actionVar2 = 100;
         this->colliderJntSph.base.ocFlags1 |= OC1_ON;
         OTHER_HAND(this)->colliderJntSph.base.ocFlags1 |= OC1_ON;
         if (dropPlayer) {

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -129,7 +129,7 @@ void DoorAna_WaitOpen(DoorAna* this, PlayState* play) {
     player = GET_PLAYER(play);
     if (Math_StepToF(&this->actor.scale.x, 0.01f, 0.001f)) {
         if ((this->actor.targetMode != 0) && (play->transitionTrigger == TRANS_TRIGGER_OFF) &&
-            (player->stateFlags1 & PLAYER_STATE1_31) && (player->unk_84F == 0)) {
+            (player->stateFlags1 & PLAYER_STATE1_31) && (player->actionVar1 == 0)) {
             destinationIdx = ((this->actor.params >> 0xC) & 7) - 1;
             Play_SetupRespawnPoint(play, RESPAWN_MODE_RETURN, 0x4FF);
             gSaveContext.respawn[RESPAWN_MODE_RETURN].pos.y = this->actor.world.pos.y;

--- a/src/overlays/actors/ovl_En_Dha/z_en_dha.c
+++ b/src/overlays/actors/ovl_En_Dha/z_en_dha.c
@@ -245,7 +245,7 @@ void EnDha_Wait(EnDha* this, PlayState* play) {
             if ((player->stateFlags2 & PLAYER_STATE2_7) && (&this->actor == player->actor.parent)) {
                 player->stateFlags2 &= ~PLAYER_STATE2_7;
                 player->actor.parent = NULL;
-                player->unk_850 = 200;
+                player->actionVar2 = 200;
             }
 
             if (this->actor.home.rot.z != 0) {
@@ -285,7 +285,7 @@ void EnDha_Wait(EnDha* this, PlayState* play) {
         if ((player->stateFlags2 & PLAYER_STATE2_7) && (&this->actor == player->actor.parent)) {
             player->stateFlags2 &= ~PLAYER_STATE2_7;
             player->actor.parent = NULL;
-            player->unk_850 = 200;
+            player->actionVar2 = 200;
         }
 
         this->actor.home.rot.z = 1;
@@ -306,7 +306,7 @@ void EnDha_TakeDamage(EnDha* this, PlayState* play) {
     if ((player->stateFlags2 & PLAYER_STATE2_7) && (&this->actor == player->actor.parent)) {
         player->stateFlags2 &= ~PLAYER_STATE2_7;
         player->actor.parent = NULL;
-        player->unk_850 = 200;
+        player->actionVar2 = 200;
     }
 
     Math_SmoothStepToS(&this->limbAngleX[1], 0, 1, 2000, 0);
@@ -344,7 +344,7 @@ void EnDha_Die(EnDha* this, PlayState* play) {
     if ((player->stateFlags2 & PLAYER_STATE2_7) && (&this->actor == player->actor.parent)) {
         player->stateFlags2 &= ~PLAYER_STATE2_7;
         player->actor.parent = NULL;
-        player->unk_850 = 200;
+        player->actionVar2 = 200;
     }
 
     Math_SmoothStepToS(&this->limbAngleX[1], 0, 1, 0x7D0, 0);

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -604,7 +604,7 @@ void EnMb_Stunned(EnMb* this, PlayState* play) {
     if ((player->stateFlags2 & PLAYER_STATE2_7) && player->actor.parent == &this->actor) {
         player->stateFlags2 &= ~PLAYER_STATE2_7;
         player->actor.parent = NULL;
-        player->unk_850 = 200;
+        player->actionVar2 = 200;
         func_8002F71C(play, &this->actor, 4.0f, this->actor.world.rot.y, 4.0f);
         this->attack = ENMB_ATTACK_NONE;
     }
@@ -721,7 +721,7 @@ void EnMb_SpearPatrolEndCharge(EnMb* this, PlayState* play) {
     if ((player->stateFlags2 & PLAYER_STATE2_7) && player->actor.parent == &this->actor) {
         player->stateFlags2 &= ~PLAYER_STATE2_7;
         player->actor.parent = NULL;
-        player->unk_850 = 200;
+        player->actionVar2 = 200;
         func_8002F71C(play, &this->actor, 4.0f, this->actor.world.rot.y, 4.0f);
     }
 
@@ -936,7 +936,7 @@ void EnMb_SpearPatrolPrepareAndCharge(EnMb* this, PlayState* play) {
         hasHitPlayer = true;
         player->actor.world.pos.z = this->actor.world.pos.z + Math_SinS(this->actor.shape.rot.y) * 10.0f +
                                     Math_CosS(this->actor.shape.rot.y) * 89.0f;
-        player->unk_850 = 0;
+        player->actionVar2 = 0;
         player->actor.speed = 0.0f;
         player->actor.velocity.y = 0.0f;
     }
@@ -947,7 +947,7 @@ void EnMb_SpearPatrolPrepareAndCharge(EnMb* this, PlayState* play) {
             if (player->stateFlags2 & PLAYER_STATE2_7) {
                 player->stateFlags2 &= ~PLAYER_STATE2_7;
                 player->actor.parent = NULL;
-                player->unk_850 = 200;
+                player->actionVar2 = 200;
                 func_8002F71C(play, &this->actor, 4.0f, this->actor.world.rot.y, 4.0f);
             }
         }
@@ -1005,7 +1005,7 @@ void EnMb_SpearPatrolImmediateCharge(EnMb* this, PlayState* play) {
         hasHitPlayer = true;
         player->actor.world.pos.z = this->actor.world.pos.z + Math_SinS(this->actor.shape.rot.y) * 10.0f +
                                     Math_CosS(this->actor.shape.rot.y) * 89.0f;
-        player->unk_850 = 0;
+        player->actionVar2 = 0;
         player->actor.speed = 0.0f;
         player->actor.velocity.y = 0.0f;
     }
@@ -1016,7 +1016,7 @@ void EnMb_SpearPatrolImmediateCharge(EnMb* this, PlayState* play) {
             if (player->stateFlags2 & PLAYER_STATE2_7) {
                 player->stateFlags2 &= ~PLAYER_STATE2_7;
                 player->actor.parent = NULL;
-                player->unk_850 = 200;
+                player->actionVar2 = 200;
                 func_8002F71C(play, &this->actor, 4.0f, this->actor.world.rot.y, 4.0f);
             }
             this->attack = ENMB_ATTACK_NONE;
@@ -1298,7 +1298,7 @@ void EnMb_SpearDead(EnMb* this, PlayState* play) {
     if ((player->stateFlags2 & PLAYER_STATE2_7) && player->actor.parent == &this->actor) {
         player->stateFlags2 &= ~PLAYER_STATE2_7;
         player->actor.parent = NULL;
-        player->unk_850 = 200;
+        player->actionVar2 = 200;
         func_8002F71C(play, &this->actor, 4.0f, this->actor.world.rot.y, 4.0f);
         this->attack = ENMB_ATTACK_NONE;
     }
@@ -1381,7 +1381,7 @@ void EnMb_CheckColliding(EnMb* this, PlayState* play) {
             if ((player->stateFlags2 & PLAYER_STATE2_7) && player->actor.parent == &this->actor) {
                 player->stateFlags2 &= ~PLAYER_STATE2_7;
                 player->actor.parent = NULL;
-                player->unk_850 = 200;
+                player->actionVar2 = 200;
                 func_8002F71C(play, &this->actor, 6.0f, this->actor.world.rot.y, 6.0f);
             }
             this->damageEffect = this->actor.colChkInfo.damageEffect;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1689,13 +1689,13 @@ void func_80832564(PlayState* play, Player* this) {
 s32 func_80832594(Player* this, s32 arg1, s32 arg2) {
     s16 temp = this->unk_A80 - D_808535D8;
 
-    this->unk_850 += arg1 + (s16)(ABS(temp) * fabsf(D_808535D4) * 2.5415802156203426e-06f);
+    this->actionVar2 += arg1 + (s16)(ABS(temp) * fabsf(D_808535D4) * 2.5415802156203426e-06f);
 
     if (CHECK_BTN_ANY(sControlInput->press.button, BTN_A | BTN_B)) {
-        this->unk_850 += 5;
+        this->actionVar2 += 5;
     }
 
-    return this->unk_850 > arg2;
+    return this->actionVar2 > arg2;
 }
 
 void func_80832630(PlayState* play) {
@@ -3078,13 +3078,17 @@ s32 Player_SetupAction(PlayState* play, Player* this, PlayerActionFunc actionFun
     }
 
     func_80832DBC(this);
+
     this->stateFlags1 &= ~(PLAYER_STATE1_2 | PLAYER_STATE1_6 | PLAYER_STATE1_26 | PLAYER_STATE1_28 | PLAYER_STATE1_29 |
                            PLAYER_STATE1_31);
     this->stateFlags2 &= ~(PLAYER_STATE2_19 | PLAYER_STATE2_27 | PLAYER_STATE2_28);
     this->stateFlags3 &= ~(PLAYER_STATE3_1 | PLAYER_STATE3_3 | PLAYER_STATE3_7);
-    this->unk_84F = 0;
-    this->unk_850 = 0;
+
+    this->actionVar1 = 0;
+    this->actionVar2 = 0;
+
     this->unk_6AC = 0;
+
     func_808326F0(this);
 
     return 1;
@@ -3249,7 +3253,7 @@ void func_80836448(PlayState* play, Player* this, LinkAnimationHeader* anim) {
 
         if (Inventory_ConsumeFairy(play)) {
             play->gameOverCtx.state = GAMEOVER_REVIVE_START;
-            this->unk_84F = 1;
+            this->actionVar1 = 1;
         } else {
             play->gameOverCtx.state = GAMEOVER_DEATH_START;
             Audio_StopBgmAndFanfare(0);
@@ -3847,7 +3851,7 @@ void func_80837B60(Player* this) {
 void func_80837B9C(Player* this, PlayState* play) {
     Player_SetupAction(play, this, Player_Action_8084411C, 0);
     Player_AnimPlayLoop(play, this, &gPlayerAnim_link_normal_landing_wait);
-    this->unk_850 = 1;
+    this->actionVar2 = 1;
     if (this->unk_6AD != 3) {
         this->unk_6AD = 0;
     }
@@ -3899,7 +3903,7 @@ void func_80837C0C(PlayState* play, Player* this, s32 arg2, f32 arg3, f32 arg4, 
         Player_AnimPlayLoopAdjusted(play, this, &gPlayerAnim_link_normal_electric_shock);
         func_80832224(this);
 
-        this->unk_850 = 20;
+        this->actionVar2 = 20;
     } else {
         arg5 -= this->actor.shape.rot.y;
         if (this->stateFlags1 & PLAYER_STATE1_27) {
@@ -3922,7 +3926,7 @@ void func_80837C0C(PlayState* play, Player* this, s32 arg2, f32 arg3, f32 arg4, 
             func_80832224(this);
 
             if (arg2 == 2) {
-                this->unk_850 = 4;
+                this->actionVar2 = 4;
 
                 this->actor.speed = 3.0f;
                 this->speedXZ = 3.0f;
@@ -4125,7 +4129,7 @@ s32 func_808382DC(Player* this, PlayState* play) {
                             Player_SetupAction(play, this, Player_Action_808435C4, 0);
                         }
 
-                        if (!(this->unk_84F = sp54)) {
+                        if (!(this->actionVar1 = sp54)) {
                             func_80833638(this, func_80834BD4);
 
                             if (this->unk_870 < 0.5f) {
@@ -4327,8 +4331,8 @@ void func_80838E70(PlayState* play, Player* this, f32 arg2, s16 arg3) {
     Player_SetupAction(play, this, Player_Action_80845CA4, 0);
     func_80832440(play, this);
 
-    this->unk_84F = 1;
-    this->unk_850 = 1;
+    this->actionVar1 = 1;
+    this->actionVar2 = 1;
 
     this->unk_450.x = (Math_SinS(arg3) * arg2) + this->actor.world.pos.x;
     this->unk_450.z = (Math_CosS(arg3) * arg2) + this->actor.world.pos.z;
@@ -4528,11 +4532,11 @@ s32 Player_HandleExitsAndVoids(PlayState* play, Player* this, CollisionPoly* pol
                         Sfx_PlaySfxCentered(NA_SE_OC_ABYSS);
                     } else {
                         func_80838F5C(play, this);
-                        this->unk_850 = 9999;
+                        this->actionVar2 = 9999;
                         if (this->floorProperty == FLOOR_PROPERTY_5) {
-                            this->unk_84F = -1;
+                            this->actionVar1 = -1;
                         } else {
-                            this->unk_84F = 1;
+                            this->actionVar1 = 1;
                         }
                     }
                 }
@@ -4647,7 +4651,7 @@ s32 func_80839800(Player* this, PlayState* play) {
 
                 func_80838E70(play, this, 50.0f, this->actor.shape.rot.y);
 
-                this->unk_84F = 0;
+                this->actionVar1 = 0;
                 this->unk_447 = this->doorType;
                 this->stateFlags1 |= PLAYER_STATE1_29;
 
@@ -4660,7 +4664,7 @@ s32 func_80839800(Player* this, PlayState* play) {
                 func_80832224(this);
 
                 if (this->doorTimer != 0) {
-                    this->unk_850 = 0;
+                    this->actionVar2 = 0;
                     Player_AnimChangeOnceMorph(play, this, func_80833338(this));
                     this->skelAnime.endFrame = 0.0f;
                 } else {
@@ -4829,7 +4833,7 @@ void func_80839FFC(Player* this, PlayState* play) {
 void func_8083A060(Player* this, PlayState* play) {
     func_80839FFC(this, play);
     if (func_8008E9C4(this)) {
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
     }
 }
 
@@ -4903,14 +4907,14 @@ void func_8083A388(PlayState* play, Player* this) {
 }
 
 void func_8083A3B0(PlayState* play, Player* this) {
-    s32 sp1C = this->unk_850;
-    s32 sp18 = this->unk_84F;
+    s32 sp1C = this->actionVar2;
+    s32 sp18 = this->actionVar1;
 
     func_80835DAC(play, this, Player_Action_8084BF1C, 0);
     this->actor.velocity.y = 0.0f;
 
-    this->unk_850 = sp1C;
-    this->unk_84F = sp18;
+    this->actionVar2 = sp1C;
+    this->actionVar1 = sp18;
 }
 
 void func_8083A40C(PlayState* play, Player* this) {
@@ -4923,9 +4927,9 @@ void func_8083A434(PlayState* play, Player* this) {
     this->stateFlags1 |= PLAYER_STATE1_10 | PLAYER_STATE1_29;
 
     if (this->getItemId == GI_HEART_CONTAINER_2) {
-        this->unk_850 = 20;
+        this->actionVar2 = 20;
     } else if (this->getItemId >= 0) {
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
     } else {
         this->getItemId = -this->getItemId;
     }
@@ -4951,7 +4955,7 @@ s32 func_8083A4A8(Player* this, PlayState* play) {
     }
 
     func_80838940(this, anim, temp, play, NA_SE_VO_LI_AUTO_JUMP);
-    this->unk_850 = 1;
+    this->actionVar2 = 1;
 
     return 1;
 }
@@ -5027,8 +5031,8 @@ s32 func_8083A6AC(Player* this, PlayState* play) {
                                              ANIM_FLAG_0 | ANIM_FLAG_UPDATE_Y | ANIM_FLAG_PLAYER_2 |
                                                  ANIM_FLAG_PLAYER_SETMOVE | ANIM_FLAG_NO_MOVE | ANIM_FLAG_PLAYER_7);
 
-                this->unk_850 = -1;
-                this->unk_84F = sp50;
+                this->actionVar2 = -1;
+                this->actionVar1 = sp50;
             } else {
                 this->stateFlags1 |= PLAYER_STATE1_13;
                 this->stateFlags1 &= ~PLAYER_STATE1_17;
@@ -5179,7 +5183,7 @@ void func_8083AE40(Player* this, s16 objectId) {
 void func_8083AF44(PlayState* play, Player* this, s32 magicSpell) {
     func_80835DE4(play, this, Player_Action_808507F4, 0);
 
-    this->unk_84F = magicSpell - 3;
+    this->actionVar1 = magicSpell - 3;
     Magic_RequestChange(play, sMagicSpellCosts[magicSpell], MAGIC_CONSUME_WAIT_PREVIEW);
 
     LinkAnimation_PlayOnceSetSpeed(play, &this->skelAnime, &gPlayerAnim_link_magic_tame, 0.83f);
@@ -5301,17 +5305,17 @@ s32 func_8083B040(Player* this, PlayState* play) {
                                 Inventory_ChangeAmmo(ITEM_MAGIC_BEAN, -1);
                                 func_80835DE4(play, this, Player_Action_8084279C, 0);
                                 this->stateFlags1 |= PLAYER_STATE1_29;
-                                this->unk_850 = 0x50;
-                                this->unk_84F = -1;
+                                this->actionVar2 = 0x50;
+                                this->actionVar1 = -1;
                             }
                             targetActor->flags |= ACTOR_FLAG_8;
                             this->unk_664 = this->targetActor;
                         } else if (sp2C == EXCH_ITEM_BOTTLE_RUTOS_LETTER) {
-                            this->unk_84F = 1;
+                            this->actionVar1 = 1;
                             this->actor.textId = 0x4005;
                             func_80835EA4(play, 1);
                         } else {
-                            this->unk_84F = 2;
+                            this->actionVar1 = 2;
                             this->actor.textId = 0xCF;
                             func_80835EA4(play, 4);
                         }
@@ -5319,11 +5323,11 @@ s32 func_8083B040(Player* this, PlayState* play) {
                         this->actor.flags |= ACTOR_FLAG_8;
                         this->exchangeItemId = sp2C;
 
-                        if (this->unk_84F < 0) {
+                        if (this->actionVar1 < 0) {
                             Player_AnimChangeOnceMorph(play, this,
                                                        GET_PLAYER_ANIM(PLAYER_ANIMGROUP_check, this->modelAnimType));
                         } else {
-                            Player_AnimPlayOnce(play, this, D_80854548[this->unk_84F]);
+                            Player_AnimPlayOnce(play, this, D_80854548[this->actionVar1]);
                         }
 
                         func_80832224(this);
@@ -5359,7 +5363,7 @@ s32 func_8083B040(Player* this, PlayState* play) {
             } else if (func_8083AD4C(play, this)) {
                 if (!(this->stateFlags1 & PLAYER_STATE1_23)) {
                     Player_SetupAction(play, this, Player_Action_8084B1D8, 1);
-                    this->unk_850 = 13;
+                    this->actionVar2 = 13;
                     func_8083B010(this);
                 }
                 this->stateFlags1 |= PLAYER_STATE1_20;
@@ -5543,8 +5547,8 @@ void func_8083BCD0(Player* this, PlayState* play, s32 arg2) {
 
     if (arg2) {}
 
-    this->unk_850 = 1;
-    this->unk_84F = arg2;
+    this->actionVar2 = 1;
+    this->actionVar1 = arg2;
 
     this->yaw = this->actor.shape.rot.y + (arg2 << 0xE);
     this->speedXZ = !(arg2 & 1) ? 6.0f : 8.5f;
@@ -5771,10 +5775,10 @@ s32 func_8083C6B8(PlayState* play, Player* this) {
             Player_SetupAction(play, this, Player_Action_8084ECA4, 0);
 
             if (this->actor.yDistToWater > 12.0f) {
-                this->unk_850 = 1;
+                this->actionVar2 = 1;
             }
 
-            Player_AnimPlayOnceAdjusted(play, this, D_80854554[this->unk_850].unk_00);
+            Player_AnimPlayOnceAdjusted(play, this, D_80854554[this->actionVar2].unk_00);
 
             Player_PlaySfx(this, NA_SE_IT_SWORD_SWING);
             func_80832698(this, NA_SE_VO_LI_AUTO_JUMP);
@@ -5837,7 +5841,7 @@ s32 func_8083C910(PlayState* play, Player* this, f32 arg2) {
             Player_SetupAction(play, this, Player_Action_8084D7C4, 0);
             Player_AnimChangeLoopSlowMorph(play, this, &gPlayerAnim_link_swimer_swim);
             this->stateFlags1 |= PLAYER_STATE1_27 | PLAYER_STATE1_29;
-            this->unk_850 = 20;
+            this->actionVar2 = 20;
             this->speedXZ = 2.0f;
             Player_SetBootData(play, this);
             return 0;
@@ -5851,7 +5855,7 @@ s32 func_8083C910(PlayState* play, Player* this, f32 arg2) {
 
 void func_8083CA20(PlayState* play, Player* this) {
     if (func_8083C910(play, this, 180.0f)) {
-        this->unk_850 = -20;
+        this->actionVar2 = -20;
     }
 }
 
@@ -5859,7 +5863,7 @@ void func_8083CA54(PlayState* play, Player* this) {
     this->speedXZ = 2.0f;
     gSaveContext.entranceSpeed = 2.0f;
     if (func_8083C910(play, this, 120.0f)) {
-        this->unk_850 = -15;
+        this->actionVar2 = -15;
     }
 }
 
@@ -5871,9 +5875,9 @@ void func_8083CA9C(PlayState* play, Player* this) {
     this->speedXZ = gSaveContext.entranceSpeed;
 
     if (func_8083C910(play, this, 800.0f)) {
-        this->unk_850 = -80 / this->speedXZ;
-        if (this->unk_850 < -20) {
-            this->unk_850 = -20;
+        this->actionVar2 = -80 / this->speedXZ;
+        if (this->actionVar2 < -20) {
+            this->actionVar2 = -20;
         }
     }
 }
@@ -5936,7 +5940,7 @@ void func_8083CE0C(Player* this, PlayState* play) {
 void func_8083CEAC(Player* this, PlayState* play) {
     Player_SetupAction(play, this, Player_Action_80840450, 1);
     Player_AnimChangeOnceMorph(play, this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_wait2waitR, this->modelAnimType));
-    this->unk_850 = 1;
+    this->actionVar2 = 1;
 }
 
 void func_8083CF10(Player* this, PlayState* play) {
@@ -6025,7 +6029,7 @@ s32 func_8083D12C(PlayState* play, Player* this, Input* arg2) {
                         this->stateFlags1 |= PLAYER_STATE1_10 | PLAYER_STATE1_11 | PLAYER_STATE1_29;
                     }
 
-                    this->unk_850 = 2;
+                    this->actionVar2 = 2;
                 }
 
                 func_80832340(play, this);
@@ -6049,7 +6053,7 @@ s32 func_8083D12C(PlayState* play, Player* this, Input* arg2) {
 void func_8083D330(PlayState* play, Player* this) {
     Player_AnimPlayLoop(play, this, &gPlayerAnim_link_swimer_swim);
     this->unk_6C2 = 16000;
-    this->unk_850 = 1;
+    this->actionVar2 = 1;
 }
 
 void func_8083D36C(PlayState* play, Player* this) {
@@ -6059,7 +6063,7 @@ void func_8083D36C(PlayState* play, Player* this) {
         if ((this->currentBoots != PLAYER_BOOTS_IRON) && (this->stateFlags2 & PLAYER_STATE2_10)) {
             this->stateFlags2 &= ~PLAYER_STATE2_10;
             func_8083D12C(play, this, NULL);
-            this->unk_84F = 1;
+            this->actionVar1 = 1;
         } else if (Player_Action_80844A44 == this->actionFunc) {
             Player_SetupAction(play, this, Player_Action_8084DC48, 0);
             func_8083D330(play, this);
@@ -6407,9 +6411,9 @@ s32 Player_HandleSlopes(PlayState* play, Player* this, CollisionPoly* floorPoly)
             func_80832564(play, this);
 
             if (sFloorShapePitch >= 0) {
-                this->unk_84F = 1;
+                this->actionVar1 = 1;
             }
-            Player_AnimChangeLoopMorph(play, this, sSlopeSlipAnims[this->unk_84F]);
+            Player_AnimChangeLoopMorph(play, this, sSlopeSlipAnims[this->actionVar1]);
             this->speedXZ = sqrtf(SQ(this->actor.velocity.x) + SQ(this->actor.velocity.z));
             this->yaw = playerVelYaw;
             return true;
@@ -6660,7 +6664,7 @@ s32 func_8083EC18(Player* this, PlayState* play, u32 wallFlags) {
                     this->stateFlags1 &= ~PLAYER_STATE1_27;
 
                     if ((sp8C != 0) || (wallFlags & WALL_FLAG_1)) {
-                        if ((this->unk_84F = sp8C) != 0) {
+                        if ((this->actionVar1 = sp8C) != 0) {
                             if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
                                 anim = &gPlayerAnim_link_normal_Fclimb_startA;
                             } else {
@@ -6671,12 +6675,12 @@ s32 func_8083EC18(Player* this, PlayState* play, u32 wallFlags) {
                             anim = this->ageProperties->unk_A4;
                             sp34 = sp34 - 1.0f;
                         }
-                        this->unk_850 = -2;
+                        this->actionVar2 = -2;
                         this->actor.world.pos.y += phi_f20;
                         this->actor.shape.rot.y = this->yaw = this->actor.wallYaw + 0x8000;
                     } else {
                         anim = this->ageProperties->unk_A8;
-                        this->unk_850 = -4;
+                        this->actionVar2 = -4;
                         this->actor.shape.rot.y = this->yaw = this->actor.wallYaw;
                     }
 
@@ -7171,11 +7175,11 @@ void Player_Action_80840450(Player* this, PlayState* play) {
         }
     }
 
-    if (this->unk_850 != 0) {
+    if (this->actionVar2 != 0) {
         if (LinkAnimation_Update(play, &this->skelAnime)) {
             func_80832DBC(this);
             Player_AnimPlayLoop(play, this, func_808334E4(this));
-            this->unk_850 = 0;
+            this->actionVar2 = 0;
             this->stateFlags3 &= ~PLAYER_STATE3_3;
         }
         func_80833C3C(this);
@@ -7364,11 +7368,11 @@ void Player_Action_80840BC8(Player* this, PlayState* play) {
     }
 
     if (sp40 != 0) {
-        if (this->unk_850 != 0) {
-            if (DECR(this->unk_850) == 0) {
+        if (this->actionVar2 != 0) {
+            if (DECR(this->actionVar2) == 0) {
                 this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
             }
-            this->skelAnime.jointTable[0].y = (this->skelAnime.jointTable[0].y + ((this->unk_850 & 1) * 0x50)) - 0x28;
+            this->skelAnime.jointTable[0].y = (this->skelAnime.jointTable[0].y + ((this->actionVar2 & 1) * 0x50)) - 0x28;
         } else {
             func_80832DBC(this);
             func_808409CC(play, this);
@@ -7377,7 +7381,7 @@ void Player_Action_80840BC8(Player* this, PlayState* play) {
 
     func_8083721C(this);
 
-    if (this->unk_850 == 0) {
+    if (this->actionVar2 == 0) {
         if (!func_80837348(play, this, D_80854418, 1)) {
             if (func_80833B54(this)) {
                 func_8083CEAC(this, play);
@@ -7989,7 +7993,7 @@ s32 func_8084269C(PlayState* play, Player* this) {
 void Player_Action_8084279C(Player* this, PlayState* play) {
     func_80832CB0(play, this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_check_wait, this->modelAnimType));
 
-    if (DECR(this->unk_850) == 0) {
+    if (DECR(this->actionVar2) == 0) {
         if (!func_8083B040(this, play)) {
             func_8083A098(this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_check_end, this->modelAnimType), play);
         }
@@ -8012,7 +8016,7 @@ s32 func_8084285C(Player* this, f32 arg1, f32 arg2, f32 arg3) {
 s32 func_808428D8(Player* this, PlayState* play) {
     if (!Player_IsChildWithHylianShield(this) && (Player_GetMeleeWeaponHeld(this) != 0) && D_80853614) {
         Player_AnimPlayOnce(play, this, &gPlayerAnim_link_normal_defense_kiru);
-        this->unk_84F = 1;
+        this->actionVar1 = 1;
         this->meleeWeaponAnimation = PLAYER_MWA_STAB_1H;
         this->yaw = this->actor.shape.rot.y + this->unk_6BE;
         return 1;
@@ -8217,8 +8221,8 @@ void Player_Action_80843188(Player* this, PlayState* play) {
         if (!Player_IsChildWithHylianShield(this)) {
             Player_AnimPlayLoop(play, this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_defense_wait, this->modelAnimType));
         }
-        this->unk_850 = 1;
-        this->unk_84F = 0;
+        this->actionVar2 = 1;
+        this->actionVar1 = 0;
     }
 
     if (!Player_IsChildWithHylianShield(this)) {
@@ -8229,7 +8233,7 @@ void Player_Action_80843188(Player* this, PlayState* play) {
 
     func_8083721C(this);
 
-    if (this->unk_850 != 0) {
+    if (this->actionVar2 != 0) {
         sp54 = sControlInput->rel.stick_y * 100;
         sp50 = sControlInput->rel.stick_x * -120;
         sp4E = this->actor.shape.rot.y - Camera_GetInputDirYaw(GET_ACTIVE_CAM(play));
@@ -8257,14 +8261,14 @@ void Player_Action_80843188(Player* this, PlayState* play) {
         this->unk_6BC = this->actor.focus.rot.x;
         Math_ScaledStepToS(&this->unk_6BE, sp4A, sp46);
 
-        if (this->unk_84F != 0) {
+        if (this->actionVar1 != 0) {
             if (!func_80842DF4(play, this)) {
                 if (this->skelAnime.curFrame < 2.0f) {
                     func_80833A20(this, 1);
                 }
             } else {
-                this->unk_850 = 1;
-                this->unk_84F = 0;
+                this->actionVar2 = 1;
+                this->actionVar1 = 0;
             }
         } else if (!func_80842964(this, play)) {
             if (func_8083C2B0(this, play)) {
@@ -8307,7 +8311,7 @@ void Player_Action_808435C4(Player* this, PlayState* play) {
 
     func_8083721C(this);
 
-    if (this->unk_84F == 0) {
+    if (this->actionVar1 == 0) {
         D_808535E0 = func_80836670(this, play);
         if ((func_80834B5C == this->func_82C) || (func_808374A0(play, this, &this->skelAnime2, 4.0f) > 0)) {
             Player_SetupAction(play, this, Player_Action_80840450, 1);
@@ -8341,7 +8345,7 @@ void Player_Action_8084377C(Player* this, PlayState* play) {
 
     func_808382BC(this);
 
-    if (!(this->stateFlags1 & PLAYER_STATE1_29) && (this->unk_850 == 0) && (this->unk_8A1 != 0)) {
+    if (!(this->stateFlags1 & PLAYER_STATE1_29) && (this->actionVar2 == 0) && (this->unk_8A1 != 0)) {
         s16 temp = this->actor.shape.rot.y - this->unk_8A2;
 
         this->yaw = this->actor.shape.rot.y = this->unk_8A2;
@@ -8358,15 +8362,15 @@ void Player_Action_8084377C(Player* this, PlayState* play) {
     }
 
     if (LinkAnimation_Update(play, &this->skelAnime) && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
-        if (this->unk_850 != 0) {
-            this->unk_850--;
-            if (this->unk_850 == 0) {
+        if (this->actionVar2 != 0) {
+            this->actionVar2--;
+            if (this->actionVar2 == 0) {
                 func_80853080(this, play);
             }
         } else if ((this->stateFlags1 & PLAYER_STATE1_29) ||
                    (!(this->cylinder.base.acFlags & AC_HIT) && (this->unk_8A1 == 0))) {
             if (this->stateFlags1 & PLAYER_STATE1_29) {
-                this->unk_850++;
+                this->actionVar2++;
             } else {
                 Player_SetupAction(play, this, Player_Action_80843954, 0);
                 this->stateFlags1 |= PLAYER_STATE1_26;
@@ -8392,7 +8396,7 @@ void Player_Action_80843954(Player* this, PlayState* play) {
 
     if (LinkAnimation_Update(play, &this->skelAnime) && (this->speedXZ == 0.0f)) {
         if (this->stateFlags1 & PLAYER_STATE1_29) {
-            this->unk_850++;
+            this->actionVar2++;
         } else {
             Player_SetupAction(play, this, Player_Action_80843A38, 0);
             this->stateFlags1 |= PLAYER_STATE1_26;
@@ -8431,10 +8435,10 @@ void Player_Action_80843A38(Player* this, PlayState* play) {
 static Vec3f D_808545E4 = { 0.0f, 0.0f, 5.0f };
 
 void func_80843AE8(PlayState* play, Player* this) {
-    if (this->unk_850 != 0) {
-        if (this->unk_850 > 0) {
-            this->unk_850--;
-            if (this->unk_850 == 0) {
+    if (this->actionVar2 != 0) {
+        if (this->actionVar2 > 0) {
+            this->actionVar2--;
+            if (this->actionVar2 == 0) {
                 if (this->stateFlags1 & PLAYER_STATE1_27) {
                     LinkAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_swimer_swim_wait, 1.0f, 0.0f,
                                          Animation_GetLastFrame(&gPlayerAnim_link_swimer_swim_wait), ANIMMODE_ONCE,
@@ -8444,7 +8448,7 @@ void func_80843AE8(PlayState* play, Player* this) {
                                          Animation_GetLastFrame(&gPlayerAnim_link_derth_rebirth), ANIMMODE_ONCE, 0.0f);
                 }
                 gSaveContext.healthAccumulator = 0x140;
-                this->unk_850 = -1;
+                this->actionVar2 = -1;
             }
         } else if (gSaveContext.healthAccumulator == 0) {
             this->stateFlags1 &= ~PLAYER_STATE1_7;
@@ -8457,8 +8461,8 @@ void func_80843AE8(PlayState* play, Player* this) {
             func_80837AFC(this, -20);
             Audio_SetBgmVolumeOnDuringFanfare();
         }
-    } else if (this->unk_84F != 0) {
-        this->unk_850 = 60;
+    } else if (this->actionVar1 != 0) {
+        this->actionVar2 = 60;
         Player_SpawnFairy(play, this, &this->actor.world.pos, &D_808545E4, FAIRY_REVIVE_DEATH);
         Player_PlaySfx(this, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
         OnePointCutscene_Init(play, 9908, 125, &this->actor, CAM_ID_MAIN);
@@ -8615,10 +8619,10 @@ void Player_Action_8084411C(Player* this, PlayState* play) {
 
         func_80836670(this, play);
 
-        if (((this->stateFlags2 & PLAYER_STATE2_19) && (this->unk_84F == 2)) || !func_8083BBA0(this, play)) {
+        if (((this->stateFlags2 & PLAYER_STATE2_19) && (this->actionVar1 == 2)) || !func_8083BBA0(this, play)) {
             if (this->actor.velocity.y < 0.0f) {
-                if (this->unk_850 >= 0) {
-                    if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || (this->unk_850 == 0) ||
+                if (this->actionVar2 >= 0) {
+                    if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || (this->actionVar2 == 0) ||
                         (this->fallDistance > 0)) {
                         if ((sYDistToFloor > 800.0f) || (this->stateFlags1 & PLAYER_STATE1_2)) {
                             func_80843E14(this, NA_SE_VO_LI_FALL_S);
@@ -8627,11 +8631,11 @@ void Player_Action_8084411C(Player* this, PlayState* play) {
 
                         LinkAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_normal_landing, 1.0f, 0.0f, 0.0f,
                                              ANIMMODE_ONCE, 8.0f);
-                        this->unk_850 = -1;
+                        this->actionVar2 = -1;
                     }
                 } else {
-                    if ((this->unk_850 == -1) && (this->fallDistance > 120.0f) && (sYDistToFloor > 280.0f)) {
-                        this->unk_850 = -2;
+                    if ((this->actionVar2 == -1) && (this->fallDistance > 120.0f) && (sYDistToFloor > 280.0f)) {
+                        this->actionVar2 = -2;
                         func_80843E14(this, NA_SE_VO_LI_FALL_L);
                     }
 
@@ -8665,9 +8669,9 @@ void Player_Action_8084411C(Player* this, PlayState* play) {
 
         if (this->stateFlags2 & PLAYER_STATE2_19) {
             if (func_8008E9C4(this)) {
-                anim = D_80853D4C[this->unk_84F][2];
+                anim = D_80853D4C[this->actionVar1][2];
             } else {
-                anim = D_80853D4C[this->unk_84F][1];
+                anim = D_80853D4C[this->actionVar1][1];
             }
         } else if (this->skelAnime.animation == &gPlayerAnim_link_normal_run_jump) {
             anim = &gPlayerAnim_link_normal_run_jump_end;
@@ -8688,9 +8692,9 @@ void Player_Action_8084411C(Player* this, PlayState* play) {
             func_8083A098(this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_landing, this->modelAnimType), play);
             this->skelAnime.endFrame = 8.0f;
             if (sp3C == 1) {
-                this->unk_850 = 10;
+                this->actionVar2 = 10;
             } else {
-                this->unk_850 = 20;
+                this->actionVar2 = 20;
             }
         } else if (sp3C == 0) {
             func_8083A098(this, anim, play);
@@ -8724,7 +8728,7 @@ void Player_Action_80844708(Player* this, PlayState* play) {
     }
 
     if (func_80842964(this, play) == 0) {
-        if (this->unk_850 != 0) {
+        if (this->actionVar2 != 0) {
             Math_StepToF(&this->speedXZ, 0.0f, 2.0f);
 
             temp = func_808374A0(play, this, &this->skelAnime, 5.0f);
@@ -8755,7 +8759,7 @@ void Player_Action_80844708(Player* this, PlayState* play) {
                     Player_RequestRumble(this, 255, 20, 150, 0);
                     Player_PlaySfx(this, NA_SE_PL_BODY_HIT);
                     func_80832698(this, NA_SE_VO_LI_CLIMB_END);
-                    this->unk_850 = 1;
+                    this->actionVar2 = 1;
                     return;
                 }
             }
@@ -8874,7 +8878,7 @@ void func_80844DC8(Player* this, PlayState* play) {
     Player_SetupAction(play, this, Player_Action_80844E68, 1);
     this->unk_868 = 0.0f;
     Player_AnimPlayLoop(play, this, D_80854360[Player_HoldsTwoHandedWeapon(this)]);
-    this->unk_850 = 1;
+    this->actionVar2 = 1;
 }
 
 void func_80844E3C(Player* this) {
@@ -8893,18 +8897,18 @@ void Player_Action_80844E68(Player* this, PlayState* play) {
         func_808355DC(this);
         this->stateFlags1 &= ~PLAYER_STATE1_17;
         Player_AnimPlayLoop(play, this, D_80854360[Player_HoldsTwoHandedWeapon(this)]);
-        this->unk_850 = -1;
+        this->actionVar2 = -1;
     }
 
     func_8083721C(this);
 
-    if (!func_80842964(this, play) && (this->unk_850 != 0)) {
+    if (!func_80842964(this, play) && (this->actionVar2 != 0)) {
         func_80844E3C(this);
 
-        if (this->unk_850 < 0) {
+        if (this->actionVar2 < 0) {
             if (this->unk_858 >= 0.1f) {
                 this->unk_845 = 0;
-                this->unk_850 = 1;
+                this->actionVar2 = 1;
             } else if (!CHECK_BTN_ALL(sControlInput->cur.button, BTN_B)) {
                 func_80844D68(this, play);
             }
@@ -9087,7 +9091,7 @@ void Player_Action_80845668(Player* this, PlayState* play) {
             }
 
             func_80838940(this, NULL, temp1, play, NA_SE_VO_LI_AUTO_JUMP);
-            this->unk_850 = -1;
+            this->actionVar2 = -1;
             return;
         }
     } else {
@@ -9123,9 +9127,9 @@ void Player_Action_80845668(Player* this, PlayState* play) {
         }
 
         if ((this->skelAnime.animation == &gPlayerAnim_link_normal_100step_up) || (this->skelAnime.curFrame > 5.0f)) {
-            if (this->unk_850 == 0) {
+            if (this->actionVar2 == 0) {
                 func_80832854(this);
-                this->unk_850 = 1;
+                this->actionVar2 = 1;
             }
             Math_StepToF(&this->actor.shape.yOffset, 0.0f, 150.0f);
         }
@@ -9217,18 +9221,18 @@ void Player_Action_80845CA4(Player* this, PlayState* play) {
     s32 pad;
 
     if (!func_8083B040(this, play)) {
-        if (this->unk_850 == 0) {
+        if (this->actionVar2 == 0) {
             LinkAnimation_Update(play, &this->skelAnime);
 
             if (DECR(this->doorTimer) == 0) {
                 this->speedXZ = 0.1f;
-                this->unk_850 = 1;
+                this->actionVar2 = 1;
             }
-        } else if (this->unk_84F == 0) {
+        } else if (this->actionVar1 == 0) {
             sp3C = 5.0f * D_808535E8;
 
             if (func_80845BA0(play, this, &sp3C, -1) < 30) {
-                this->unk_84F = 1;
+                this->actionVar1 = 1;
                 this->stateFlags1 |= PLAYER_STATE1_29;
 
                 this->unk_450.x = this->unk_45C.x;
@@ -9245,8 +9249,8 @@ void Player_Action_80845CA4(Player* this, PlayState* play) {
                     this->unk_450.x = (Math_SinS(sConveyorYaw) * 400.0f) + this->actor.world.pos.x;
                     this->unk_450.z = (Math_CosS(sConveyorYaw) * 400.0f) + this->actor.world.pos.z;
                 }
-            } else if (this->unk_850 < 0) {
-                this->unk_850++;
+            } else if (this->actionVar2 < 0) {
+                this->actionVar2++;
 
                 sp34 = gSaveContext.entranceSpeed;
                 sp30 = -1;
@@ -9254,7 +9258,7 @@ void Player_Action_80845CA4(Player* this, PlayState* play) {
 
             temp = func_80845BA0(play, this, &sp34, sp30);
 
-            if ((this->unk_850 == 0) || ((temp == 0) && (this->speedXZ == 0.0f) &&
+            if ((this->actionVar2 == 0) || ((temp == 0) && (this->speedXZ == 0.0f) &&
                                          (Play_GetCamera(play, CAM_ID_MAIN)->stateFlags & CAM_STATE_4))) {
 
                 func_8005B1A4(Play_GetCamera(play, CAM_ID_MAIN));
@@ -9281,9 +9285,9 @@ void Player_Action_80845EF8(Player* this, PlayState* play) {
     func_80836670(this, play);
 
     if (sp2C) {
-        if (this->unk_850 == 0) {
+        if (this->actionVar2 == 0) {
             if (DECR(this->doorTimer) == 0) {
-                this->unk_850 = 1;
+                this->actionVar2 = 1;
                 this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
             }
         } else {
@@ -9335,7 +9339,7 @@ static struct_80832924 D_8085461C[] = {
 };
 
 void Player_Action_80846120(Player* this, PlayState* play) {
-    if (LinkAnimation_Update(play, &this->skelAnime) && (this->unk_850++ > 20)) {
+    if (LinkAnimation_Update(play, &this->skelAnime) && (this->actionVar2++ > 20)) {
         if (!func_8083B040(this, play)) {
             func_8083A098(this, &gPlayerAnim_link_normal_heavy_carry_end, play);
         }
@@ -9371,11 +9375,11 @@ void Player_Action_80846260(Player* this, PlayState* play) {
 
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_AnimPlayLoop(play, this, &gPlayerAnim_link_silver_wait);
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
         return;
     }
 
-    if (this->unk_850 == 0) {
+    if (this->actionVar2 == 0) {
         if (LinkAnimation_OnFrame(&this->skelAnime, 27.0f)) {
             Actor* interactRangeActor = this->interactRangeActor;
 
@@ -9417,13 +9421,13 @@ void Player_Action_80846358(Player* this, PlayState* play) {
 void Player_Action_80846408(Player* this, PlayState* play) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_AnimPlayLoop(play, this, &gPlayerAnim_link_normal_nocarry_free_wait);
-        this->unk_850 = 15;
+        this->actionVar2 = 15;
         return;
     }
 
-    if (this->unk_850 != 0) {
-        this->unk_850--;
-        if (this->unk_850 == 0) {
+    if (this->actionVar2 != 0) {
+        this->actionVar2--;
+        if (this->actionVar2 == 0) {
             func_8083A098(this, &gPlayerAnim_link_normal_nocarry_free_end, play);
             this->stateFlags1 &= ~PLAYER_STATE1_11;
             func_80832698(this, NA_SE_VO_LI_DAMAGE_S);
@@ -9541,7 +9545,7 @@ void func_80846648(PlayState* play, Player* this) {
 void func_80846660(PlayState* play, Player* this) {
     Player_SetupAction(play, this, Player_Action_8084F710, 0);
     if ((play->sceneId == SCENE_LAKE_HYLIA) && IS_CUTSCENE_LAYER) {
-        this->unk_84F = 1;
+        this->actionVar1 = 1;
     }
     this->stateFlags1 |= PLAYER_STATE1_29;
     LinkAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_okarina_warp_goal, 2.0f / 3.0f, 0.0f, 24.0f,
@@ -9584,7 +9588,7 @@ void func_808467D4(PlayState* play, Player* this) {
     if (LINK_IS_ADULT) {
         func_80846720(play, this, 0);
     }
-    this->unk_850 = 20;
+    this->actionVar2 = 20;
 }
 
 void func_808468A8(PlayState* play, Player* this) {
@@ -10677,7 +10681,7 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
             Player_AnimReplaceApplyFlags(play, this,
                                          ANIM_FLAG_0 | ANIM_FLAG_UPDATE_Y | ANIM_FLAG_PLAYER_SETMOVE |
                                              ANIM_FLAG_NO_MOVE | ANIM_FLAG_PLAYER_7);
-            this->unk_850 = 99;
+            this->actionVar2 = 99;
         }
 
         if (this->unk_844 == 0) {
@@ -11204,7 +11208,7 @@ void Player_Draw(Actor* thisx, PlayState* play2) {
         }
 
         if (this->stateFlags2 & PLAYER_STATE2_14) {
-            f32 scale = (this->unk_84F >> 1) * 22.0f;
+            f32 scale = (this->actionVar1 >> 1) * 22.0f;
 
             gSPSegment(POLY_XLU_DISP++, 0x08,
                        Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, 0, (0 - play->gameplayFrames) % 128, 32,
@@ -11382,7 +11386,7 @@ void Player_Action_8084B1D8(Player* this, PlayState* play) {
                         BTN_A | BTN_B | BTN_R | BTN_CUP | BTN_CLEFT | BTN_CRIGHT | BTN_CDOWN)))) {
         func_8083C148(this, play);
         Sfx_PlaySfxCentered(NA_SE_SY_CAMERA_ZOOM_UP);
-    } else if ((DECR(this->unk_850) == 0) || (this->unk_6AD != 2)) {
+    } else if ((DECR(this->actionVar2) == 0) || (this->unk_6AD != 2)) {
         if (func_8008F128(this)) {
             this->unk_6AE |= 0x43;
         } else {
@@ -11445,9 +11449,9 @@ void Player_Action_8084B530(Player* this, PlayState* play) {
         if (!func_8084B4D4(play, this) && !func_8084B3CC(play, this) && !func_8083ADD4(play, this)) {
             if ((this->targetActor != this->interactRangeActor) || !func_8083E5A8(this, play)) {
                 if (this->stateFlags1 & PLAYER_STATE1_23) {
-                    s32 sp24 = this->unk_850;
+                    s32 sp24 = this->actionVar2;
                     func_8083A360(play, this);
-                    this->unk_850 = sp24;
+                    this->actionVar2 = sp24;
                 } else if (func_808332B8(this)) {
                     func_80838F18(play, this);
                 } else {
@@ -11526,8 +11530,8 @@ void Player_Action_8084B898(Player* this, PlayState* play) {
     this->stateFlags2 |= PLAYER_STATE2_0 | PLAYER_STATE2_6 | PLAYER_STATE2_8;
 
     if (func_80832CB0(play, this, &gPlayerAnim_link_normal_pushing)) {
-        this->unk_850 = 1;
-    } else if (this->unk_850 == 0) {
+        this->actionVar2 = 1;
+    } else if (this->actionVar2 == 0) {
         if (LinkAnimation_OnFrame(&this->skelAnime, 11.0f)) {
             func_80832698(this, NA_SE_VO_LI_PUSH);
         }
@@ -11577,9 +11581,9 @@ void Player_Action_8084B9E4(Player* this, PlayState* play) {
     this->stateFlags2 |= PLAYER_STATE2_0 | PLAYER_STATE2_6 | PLAYER_STATE2_8;
 
     if (func_80832CB0(play, this, anim)) {
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
     } else {
-        if (this->unk_850 == 0) {
+        if (this->actionVar2 == 0) {
             if (LinkAnimation_OnFrame(&this->skelAnime, 11.0f)) {
                 func_80832698(this, NA_SE_VO_LI_PUSH);
             }
@@ -11627,9 +11631,9 @@ void Player_Action_8084BBE4(Player* this, PlayState* play) {
 
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         // clang-format off
-        anim = (this->unk_84F > 0) ? &gPlayerAnim_link_normal_fall_wait : GET_PLAYER_ANIM(PLAYER_ANIMGROUP_jump_climb_wait, this->modelAnimType); Player_AnimPlayLoop(play, this, anim);
+        anim = (this->actionVar1 > 0) ? &gPlayerAnim_link_normal_fall_wait : GET_PLAYER_ANIM(PLAYER_ANIMGROUP_jump_climb_wait, this->modelAnimType); Player_AnimPlayLoop(play, this, anim);
         // clang-format on
-    } else if (this->unk_84F == 0) {
+    } else if (this->actionVar1 == 0) {
         if (this->skelAnime.animation == &gPlayerAnim_link_normal_fall) {
             temp = 11.0f;
         } else {
@@ -11639,19 +11643,19 @@ void Player_Action_8084BBE4(Player* this, PlayState* play) {
         if (LinkAnimation_OnFrame(&this->skelAnime, temp)) {
             func_80832770(this, NA_SE_PL_WALK_GROUND);
             if (this->skelAnime.animation == &gPlayerAnim_link_normal_fall) {
-                this->unk_84F = 1;
+                this->actionVar1 = 1;
             } else {
-                this->unk_84F = -1;
+                this->actionVar1 = -1;
             }
         }
     }
 
     Math_ScaledStepToS(&this->actor.shape.rot.y, this->yaw, 0x800);
 
-    if (this->unk_84F != 0) {
+    if (this->actionVar1 != 0) {
         func_80837268(this, &sp3C, &sp3A, 0.0f, play);
         if (this->unk_847[this->unk_846] >= 0) {
-            if (this->unk_84F > 0) {
+            if (this->actionVar1 > 0) {
                 anim = GET_PLAYER_ANIM(PLAYER_ANIMGROUP_fall_up, this->modelAnimType);
             } else {
                 anim = GET_PLAYER_ANIM(PLAYER_ANIMGROUP_jump_climb_up, this->modelAnimType);
@@ -11662,7 +11666,7 @@ void Player_Action_8084BBE4(Player* this, PlayState* play) {
 
         if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_A) || (this->actor.shape.feetFloorFlag != 0)) {
             func_80837B60(this);
-            if (this->unk_84F < 0) {
+            if (this->actionVar1 < 0) {
                 this->speedXZ = -0.8f;
             } else {
                 this->speedXZ = 0.8f;
@@ -11692,7 +11696,7 @@ void Player_Action_8084BDFC(Player* this, PlayState* play) {
 }
 
 void func_8084BEE4(Player* this) {
-    Player_PlaySfx(this, (this->unk_84F != 0) ? NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_VINE
+    Player_PlaySfx(this, (this->actionVar1 != 0) ? NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_VINE
                                               : NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD);
 }
 
@@ -11715,7 +11719,7 @@ void Player_Action_8084BF1C(Player* this, PlayState* play) {
     this->fallStartHeight = this->actor.world.pos.y;
     this->stateFlags2 |= PLAYER_STATE2_6;
 
-    if ((this->unk_84F != 0) && (ABS(sp84) < ABS(sp80))) {
+    if ((this->actionVar1 != 0) && (ABS(sp84) < ABS(sp80))) {
         phi_f0 = ABS(sp80) * 0.0325f;
         sp84 = 0;
     } else {
@@ -11737,7 +11741,7 @@ void Player_Action_8084BF1C(Player* this, PlayState* play) {
 
     this->skelAnime.playSpeed = phi_f2 * phi_f0;
 
-    if (this->unk_850 >= 0) {
+    if (this->actionVar2 >= 0) {
         if ((this->actor.wallPoly != NULL) && (this->actor.wallBgId != BGCHECK_SCENE)) {
             DynaPolyActor* wallPolyActor = DynaPoly_GetActor(&play->colCtx, this->actor.wallBgId);
             if (wallPolyActor != NULL) {
@@ -11751,22 +11755,22 @@ void Player_Action_8084BF1C(Player* this, PlayState* play) {
         func_8083F360(play, this, 26.0f, this->ageProperties->unk_3C, 50.0f, -20.0f);
     }
 
-    if ((this->unk_850 < 0) || !func_8083FBC0(this, play)) {
+    if ((this->actionVar2 < 0) || !func_8083FBC0(this, play)) {
         if (LinkAnimation_Update(play, &this->skelAnime) != 0) {
-            if (this->unk_850 < 0) {
-                this->unk_850 = ABS(this->unk_850) & 1;
+            if (this->actionVar2 < 0) {
+                this->actionVar2 = ABS(this->actionVar2) & 1;
                 return;
             }
 
             if (sp84 != 0) {
-                sp68 = this->unk_84F + this->unk_850;
+                sp68 = this->actionVar1 + this->actionVar2;
 
                 if (sp84 > 0) {
                     D_8085488C.y = this->ageProperties->unk_40;
                     temp_f0 = func_8083973C(play, this, &D_8085488C, &sp5C);
 
                     if (this->actor.world.pos.y < temp_f0) {
-                        if (this->unk_84F != 0) {
+                        if (this->actionVar1 != 0) {
                             this->actor.world.pos.y = temp_f0;
                             this->stateFlags1 &= ~PLAYER_STATE1_21;
                             func_8083A5C4(play, this, this->actor.wallPoly, this->ageProperties->unk_3C,
@@ -11776,7 +11780,7 @@ void Player_Action_8084BF1C(Player* this, PlayState* play) {
                             func_8083A9B8(this, &gPlayerAnim_link_normal_jump_climb_up_free, play);
                             this->stateFlags1 |= PLAYER_STATE1_14;
                         } else {
-                            func_8083F070(this, this->ageProperties->unk_CC[this->unk_850], play);
+                            func_8083F070(this, this->ageProperties->unk_CC[this->actionVar2], play);
                         }
                     } else {
                         this->skelAnime.prevTransl = this->ageProperties->unk_4A[sp68];
@@ -11784,14 +11788,14 @@ void Player_Action_8084BF1C(Player* this, PlayState* play) {
                     }
                 } else {
                     if ((this->actor.world.pos.y - this->actor.floorHeight) < 15.0f) {
-                        if (this->unk_84F != 0) {
+                        if (this->actionVar1 != 0) {
                             func_8083FB7C(this, play);
                         } else {
-                            if (this->unk_850 != 0) {
+                            if (this->actionVar2 != 0) {
                                 this->skelAnime.prevTransl = this->ageProperties->unk_44;
                             }
-                            func_8083F070(this, this->ageProperties->unk_C4[this->unk_850], play);
-                            this->unk_850 = 1;
+                            func_8083F070(this, this->ageProperties->unk_C4[this->actionVar2], play);
+                            this->actionVar2 = 1;
                         }
                     } else {
                         sp68 ^= 1;
@@ -11801,16 +11805,16 @@ void Player_Action_8084BF1C(Player* this, PlayState* play) {
                                              ANIMMODE_ONCE, 0.0f);
                     }
                 }
-                this->unk_850 ^= 1;
+                this->actionVar2 ^= 1;
             } else {
-                if ((this->unk_84F != 0) && (sp80 != 0)) {
-                    anim2 = this->ageProperties->unk_BC[this->unk_850];
+                if ((this->actionVar1 != 0) && (sp80 != 0)) {
+                    anim2 = this->ageProperties->unk_BC[this->actionVar2];
 
                     if (sp80 > 0) {
-                        this->skelAnime.prevTransl = this->ageProperties->unk_7A[this->unk_850];
+                        this->skelAnime.prevTransl = this->ageProperties->unk_7A[this->actionVar2];
                         Player_AnimPlayOnce(play, this, anim2);
                     } else {
-                        this->skelAnime.prevTransl = this->ageProperties->unk_86[this->unk_850];
+                        this->skelAnime.prevTransl = this->ageProperties->unk_86[this->actionVar2];
                         LinkAnimation_Change(play, &this->skelAnime, anim2, -1.0f, Animation_GetLastFrame(anim2), 0.0f,
                                              ANIMMODE_ONCE, 0.0f);
                     }
@@ -11823,10 +11827,10 @@ void Player_Action_8084BF1C(Player* this, PlayState* play) {
         }
     }
 
-    if (this->unk_850 < 0) {
-        if (((this->unk_850 == -2) &&
+    if (this->actionVar2 < 0) {
+        if (((this->actionVar2 == -2) &&
              (LinkAnimation_OnFrame(&this->skelAnime, 14.0f) || LinkAnimation_OnFrame(&this->skelAnime, 29.0f))) ||
-            ((this->unk_850 == -4) &&
+            ((this->actionVar2 == -4) &&
              (LinkAnimation_OnFrame(&this->skelAnime, 22.0f) || LinkAnimation_OnFrame(&this->skelAnime, 35.0f) ||
               LinkAnimation_OnFrame(&this->skelAnime, 49.0f) || LinkAnimation_OnFrame(&this->skelAnime, 55.0f)))) {
             func_8084BEE4(this);
@@ -11872,7 +11876,7 @@ void Player_Action_8084C5F8(Player* this, PlayState* play) {
 
     sp38 = D_80854898;
 
-    if (this->unk_850 != 0) {
+    if (this->actionVar2 != 0) {
         func_80832924(this, D_808548A8);
         sp38 = D_808548A0;
     }
@@ -11984,8 +11988,8 @@ s32 func_8084C9BC(Player* this, PlayState* play) {
     s32 sp38;
     f32 sp34;
 
-    if (this->unk_850 < 0) {
-        this->unk_850 = 99;
+    if (this->actionVar2 < 0) {
+        this->actionVar2 = 99;
     } else {
         sp38 = (this->mountSide < 0) ? 0 : 1;
         if (!func_8084C89C(play, this, sp38, &sp34)) {
@@ -12088,10 +12092,10 @@ void Player_Action_8084CC98(Player* this, PlayState* play) {
 
     func_8084CBF4(this, 1.0f, 10.0f);
 
-    if (this->unk_850 == 0) {
+    if (this->actionVar2 == 0) {
         if (LinkAnimation_Update(play, &this->skelAnime)) {
             this->skelAnime.animation = &gPlayerAnim_link_uma_wait_1;
-            this->unk_850 = 99;
+            this->actionVar2 = 99;
             return;
         }
 
@@ -12114,12 +12118,12 @@ void Player_Action_8084CC98(Player* this, PlayState* play) {
     func_8002DE74(play, this);
     this->skelAnime.prevTransl = D_8085499C;
 
-    if ((rideActor->animationIdx != this->unk_850) && ((rideActor->animationIdx >= 2) || (this->unk_850 >= 2))) {
-        if ((this->unk_850 = rideActor->animationIdx) < 2) {
+    if ((rideActor->animationIdx != this->actionVar2) && ((rideActor->animationIdx >= 2) || (this->actionVar2 >= 2))) {
+        if ((this->actionVar2 = rideActor->animationIdx) < 2) {
             f32 rand = Rand_ZeroOne();
             s32 temp = 0;
 
-            this->unk_850 = 1;
+            this->actionVar2 = 1;
 
             if (rand < 0.1f) {
                 temp = 2;
@@ -12128,20 +12132,20 @@ void Player_Action_8084CC98(Player* this, PlayState* play) {
             }
             Player_AnimPlayOnce(play, this, D_8085498C[temp]);
         } else {
-            this->skelAnime.animation = D_80854944[this->unk_850 - 2];
+            this->skelAnime.animation = D_80854944[this->actionVar2 - 2];
             Animation_SetMorph(play, &this->skelAnime, 8.0f);
-            if (this->unk_850 < 4) {
+            if (this->actionVar2 < 4) {
                 func_80834644(play, this);
-                this->unk_84F = 0;
+                this->actionVar1 = 0;
             }
         }
     }
 
-    if (this->unk_850 == 1) {
+    if (this->actionVar2 == 1) {
         if ((D_808535E0 != 0) || func_8083224C(play)) {
             Player_AnimPlayOnce(play, this, &gPlayerAnim_link_uma_wait_3);
         } else if (LinkAnimation_Update(play, &this->skelAnime)) {
-            this->unk_850 = 99;
+            this->actionVar2 = 99;
         } else if (this->skelAnime.animation == &gPlayerAnim_link_uma_wait_1) {
             func_80832924(this, D_808549A4);
         }
@@ -12158,11 +12162,11 @@ void Player_Action_8084CC98(Player* this, PlayState* play) {
             this->csMode = PLAYER_CSMODE_NONE;
         }
         this->unk_6AD = 0;
-        this->unk_84F = 0;
-    } else if ((this->unk_850 < 2) || (this->unk_850 >= 4)) {
+        this->actionVar1 = 0;
+    } else if ((this->actionVar2 < 2) || (this->actionVar2 >= 4)) {
         D_808535E0 = func_80836670(this, play);
         if (D_808535E0 != 0) {
-            this->unk_84F = 0;
+            this->actionVar1 = 0;
         }
     }
 
@@ -12176,10 +12180,10 @@ void Player_Action_8084CC98(Player* this, PlayState* play) {
         (!func_8083224C(play) && ((rideActor->actor.speed != 0.0f) || !func_8083B644(this, play)) &&
          !func_8083C1DC(this, play))) {
         if (D_808535E0 == 0) {
-            if (this->unk_84F != 0) {
+            if (this->actionVar1 != 0) {
                 if (LinkAnimation_Update(play, &this->skelAnime2)) {
                     rideActor->stateFlags &= ~ENHORSE_FLAG_8;
-                    this->unk_84F = 0;
+                    this->actionVar1 = 0;
                 }
 
                 if (this->skelAnime2.animation == &gPlayerAnim_link_uma_stop_muti) {
@@ -12205,14 +12209,14 @@ void Player_Action_8084CC98(Player* this, PlayState* play) {
                 if (EN_HORSE_CHECK_3(rideActor)) {
                     anim = &gPlayerAnim_link_uma_stop_muti;
                 } else if (EN_HORSE_CHECK_2(rideActor)) {
-                    if ((this->unk_850 >= 2) && (this->unk_850 != 99)) {
-                        anim = D_80854968[this->unk_850 - 2];
+                    if ((this->actionVar2 >= 2) && (this->actionVar2 != 99)) {
+                        anim = D_80854968[this->actionVar2 - 2];
                     }
                 }
 
                 if (anim != NULL) {
                     LinkAnimation_PlayOnce(play, &this->skelAnime2, anim);
-                    this->unk_84F = 1;
+                    this->actionVar1 = 1;
                 }
             }
         }
@@ -12358,7 +12362,7 @@ void Player_Action_8084D7C4(Player* this, PlayState* play) {
         func_8084B158(play, this, NULL, this->speedXZ);
         func_8084B000(this);
 
-        if (DECR(this->unk_850) == 0) {
+        if (DECR(this->actionVar2) == 0) {
             func_80838F18(play, this);
         }
     }
@@ -12470,8 +12474,8 @@ void Player_Action_8084DC48(Player* this, PlayState* play) {
             return;
         }
 
-        if (this->unk_84F == 0) {
-            if (this->unk_850 == 0) {
+        if (this->actionVar1 == 0) {
+            if (this->actionVar2 == 0) {
                 if (LinkAnimation_Update(play, &this->skelAnime) ||
                     ((this->skelAnime.curFrame >= 22.0f) && !CHECK_BTN_ALL(sControlInput->cur.button, BTN_A))) {
                     func_8083D330(play, this);
@@ -12491,20 +12495,20 @@ void Player_Action_8084DC48(Player* this, PlayState* play) {
                 (this->actor.yDistToWater < D_80854784[CUR_UPG_VALUE(UPG_SCALE)])) {
                 func_8084DBC4(play, this, -2.0f);
             } else {
-                this->unk_84F++;
+                this->actionVar1++;
                 Player_AnimChangeLoopSlowMorph(play, this, &gPlayerAnim_link_swimer_swim_wait);
             }
-        } else if (this->unk_84F == 1) {
+        } else if (this->actionVar1 == 1) {
             LinkAnimation_Update(play, &this->skelAnime);
             func_8084B000(this);
 
             if (this->unk_6C2 < 10000) {
-                this->unk_84F++;
-                this->unk_850 = this->actor.yDistToWater;
+                this->actionVar1++;
+                this->actionVar2 = this->actor.yDistToWater;
                 Player_AnimChangeLoopSlowMorph(play, this, &gPlayerAnim_link_swimer_swim);
             }
         } else if (!func_8083D12C(play, this, sControlInput)) {
-            sp2C = (this->unk_850 * 0.018f) + 4.0f;
+            sp2C = (this->actionVar2 * 0.018f) + 4.0f;
 
             if (this->stateFlags1 & PLAYER_STATE1_11) {
                 sControlInput = NULL;
@@ -12545,9 +12549,9 @@ s32 func_8084DFF4(PlayState* play, Player* this) {
         return 1;
     }
 
-    if (this->unk_84F == 0) {
+    if (this->actionVar1 == 0) {
         giEntry = &sGetItemTable[this->getItemId - 1];
-        this->unk_84F = 1;
+        this->actionVar1 = 1;
 
         Message_StartTextbox(play, giEntry->textId, &this->actor);
         Item_Give(play, giEntry->itemId);
@@ -12640,7 +12644,7 @@ static s16 sWarpSongEntrances[] = {
 void Player_Action_8084E3C4(Player* this, PlayState* play) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_AnimPlayLoopAdjusted(play, this, &gPlayerAnim_link_normal_okarina_swing);
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
         if (this->stateFlags2 & (PLAYER_STATE2_23 | PLAYER_STATE2_25)) {
             this->stateFlags2 |= PLAYER_STATE2_24;
         } else {
@@ -12649,7 +12653,7 @@ void Player_Action_8084E3C4(Player* this, PlayState* play) {
         return;
     }
 
-    if (this->unk_850 == 0) {
+    if (this->actionVar2 == 0) {
         return;
     }
 
@@ -12717,12 +12721,12 @@ void Player_Action_8084E6D4(Player* this, PlayState* play) {
     s32 cond;
 
     if (LinkAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_850 != 0) {
-            if (this->unk_850 >= 2) {
-                this->unk_850--;
+        if (this->actionVar2 != 0) {
+            if (this->actionVar2 >= 2) {
+                this->actionVar2--;
             }
 
-            if (func_8084DFF4(play, this) && (this->unk_850 == 1)) {
+            if (func_8084DFF4(play, this) && (this->actionVar2 == 1)) {
                 cond = ((this->targetActor != NULL) && (this->exchangeItemId < 0)) ||
                        (this->stateFlags3 & PLAYER_STATE3_5);
 
@@ -12762,11 +12766,11 @@ void Player_Action_8084E6D4(Player* this, PlayState* play) {
                 Player_AnimPlayOnceAdjusted(play, this, &gPlayerAnim_link_demo_get_itemA);
             }
 
-            this->unk_850 = 2;
+            this->actionVar2 = 2;
             func_80835EA4(play, 9);
         }
     } else {
-        if (this->unk_850 == 0) {
+        if (this->actionVar2 == 0) {
             if (!LINK_IS_ADULT) {
                 func_80832924(this, D_808549E0);
             }
@@ -12798,9 +12802,9 @@ static struct_80832924 D_808549F4[] = {
 
 void Player_Action_8084E9AC(Player* this, PlayState* play) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_84F == 0) {
-            if (DECR(this->unk_850) == 0) {
-                this->unk_84F = 1;
+        if (this->actionVar1 == 0) {
+            if (DECR(this->actionVar2) == 0) {
+                this->actionVar1 = 1;
                 this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
             }
         } else {
@@ -12826,7 +12830,7 @@ static u8 D_808549FC[] = {
 
 void Player_Action_8084EAC0(Player* this, PlayState* play) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_850 == 0) {
+        if (this->actionVar2 == 0) {
             if (this->itemAction == PLAYER_IA_BOTTLE_POE) {
                 s32 rand = Rand_S16Offset(-1, 3);
 
@@ -12860,20 +12864,20 @@ void Player_Action_8084EAC0(Player* this, PlayState* play) {
             }
 
             Player_AnimPlayLoopAdjusted(play, this, &gPlayerAnim_link_bottle_drink_demo_wait);
-            this->unk_850 = 1;
+            this->actionVar2 = 1;
             return;
         }
 
         func_8083C0E8(this, play);
         func_8005B1A4(Play_GetCamera(play, CAM_ID_MAIN));
-    } else if (this->unk_850 == 1) {
+    } else if (this->actionVar2 == 1) {
         if ((gSaveContext.healthAccumulator == 0) && (gSaveContext.magicState != MAGIC_STATE_FILL)) {
             Player_AnimChangeOnceMorphAdjusted(play, this, &gPlayerAnim_link_bottle_drink_demo_end);
-            this->unk_850 = 2;
+            this->actionVar2 = 2;
             Player_UpdateBottleHeld(play, this, ITEM_BOTTLE_EMPTY, PLAYER_IA_BOTTLE);
         }
         func_80832698(this, NA_SE_VO_LI_DRINK - SFX_FLAG);
-    } else if ((this->unk_850 == 2) && LinkAnimation_OnFrame(&this->skelAnime, 29.0f)) {
+    } else if ((this->actionVar2 == 2) && LinkAnimation_OnFrame(&this->skelAnime, 29.0f)) {
         func_80832698(this, NA_SE_VO_LI_BREATH_DRINK);
     }
 }
@@ -12891,29 +12895,29 @@ void Player_Action_8084ECA4(Player* this, PlayState* play) {
     s32 temp;
     s32 i;
 
-    sp24 = &D_80854554[this->unk_850];
+    sp24 = &D_80854554[this->actionVar2];
     func_8083721C(this);
 
     if (LinkAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_84F != 0) {
-            if (this->unk_850 == 0) {
-                Message_StartTextbox(play, sBottleCatchInfos[this->unk_84F - 1].textId, &this->actor);
+        if (this->actionVar1 != 0) {
+            if (this->actionVar2 == 0) {
+                Message_StartTextbox(play, sBottleCatchInfos[this->actionVar1 - 1].textId, &this->actor);
                 Audio_PlayFanfare(NA_BGM_ITEM_GET | 0x900);
-                this->unk_850 = 1;
+                this->actionVar2 = 1;
             } else if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-                this->unk_84F = 0;
+                this->actionVar1 = 0;
                 func_8005B1A4(Play_GetCamera(play, CAM_ID_MAIN));
             }
         } else {
             func_8083C0E8(this, play);
         }
     } else {
-        if (this->unk_84F == 0) {
+        if (this->actionVar1 == 0) {
             temp = this->skelAnime.curFrame - sp24->unk_08;
 
             if (temp >= 0) {
                 if (sp24->unk_09 >= temp) {
-                    if (this->unk_850 != 0) {
+                    if (this->actionVar2 != 0) {
                         if (temp == 0) {
                             Player_PlaySfx(this, NA_SE_IT_SCOOP_UP_WATER);
                         }
@@ -12928,8 +12932,8 @@ void Player_Action_8084ECA4(Player* this, PlayState* play) {
                         }
 
                         if (i < ARRAY_COUNT(sBottleCatchInfos)) {
-                            this->unk_84F = i + 1;
-                            this->unk_850 = 0;
+                            this->actionVar1 = i + 1;
+                            this->actionVar2 = 0;
                             this->stateFlags1 |= PLAYER_STATE1_28 | PLAYER_STATE1_29;
                             this->interactRangeActor->parent = &this->actor;
                             Player_UpdateBottleHeld(play, this, catchInfo->itemId, ABS(catchInfo->itemAction));
@@ -13012,7 +13016,7 @@ void Player_Action_8084F104(Player* this, PlayState* play) {
     this->stateFlags2 |= PLAYER_STATE2_5;
 
     if (LinkAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_850 < 0) {
+        if (this->actionVar2 < 0) {
             func_8083C0E8(this, play);
         } else if (this->exchangeItemId == EXCH_ITEM_NONE) {
             Actor* targetActor = this->targetActor;
@@ -13030,21 +13034,21 @@ void Player_Action_8084F104(Player* this, PlayState* play) {
                 this->unk_862 = ABS(giEntry->gi);
             }
 
-            if (this->unk_850 == 0) {
+            if (this->actionVar2 == 0) {
                 Message_StartTextbox(play, this->actor.textId, &this->actor);
 
                 if ((this->itemAction == PLAYER_IA_CHICKEN) || (this->itemAction == PLAYER_IA_POCKET_CUCCO)) {
                     Player_PlaySfx(this, NA_SE_EV_CHICKEN_CRY_M);
                 }
 
-                this->unk_850 = 1;
+                this->actionVar2 = 1;
             } else if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
                 this->actor.flags &= ~ACTOR_FLAG_8;
                 this->unk_862 = 0;
 
-                if (this->unk_84F == 1) {
+                if (this->actionVar1 == 1) {
                     Player_AnimPlayOnce(play, this, &gPlayerAnim_link_bottle_read_end);
-                    this->unk_850 = -1;
+                    this->actionVar2 = -1;
                 } else {
                     func_8083C0E8(this, play);
                 }
@@ -13052,11 +13056,11 @@ void Player_Action_8084F104(Player* this, PlayState* play) {
                 func_8005B1A4(Play_GetCamera(play, CAM_ID_MAIN));
             }
         }
-    } else if (this->unk_850 >= 0) {
+    } else if (this->actionVar2 >= 0) {
         func_80832924(this, D_80854A3C);
     }
 
-    if ((this->unk_84F == 0) && (this->unk_664 != NULL)) {
+    if ((this->actionVar1 == 0) && (this->unk_664 != NULL)) {
         this->yaw = this->actor.shape.rot.y = func_8083DB98(this, 0);
     }
 }
@@ -13099,7 +13103,7 @@ void Player_Action_8084F390(Player* this, PlayState* play) {
         Player_GetSlopeDirection(floorPoly, &slopeNormal, &downwardSlopeYaw);
 
         sp44 = downwardSlopeYaw;
-        if (this->unk_84F != 0) {
+        if (this->actionVar1 != 0) {
             sp44 = downwardSlopeYaw + 0x8000;
         }
 
@@ -13124,7 +13128,7 @@ void Player_Action_8084F390(Player* this, PlayState* play) {
         if (Math_AsymStepToF(&this->speedXZ, sp50, sp4C, sp48) && (sp50 == 0)) {
             LinkAnimationHeader* anim;
 
-            if (this->unk_84F == 0) {
+            if (this->actionVar1 == 0) {
                 anim = GET_PLAYER_ANIM(PLAYER_ANIMGROUP_down_slope_slip_end, this->modelAnimType);
             } else {
                 anim = GET_PLAYER_ANIM(PLAYER_ANIMGROUP_up_slope_slip_end, this->modelAnimType);
@@ -13138,7 +13142,7 @@ void Player_Action_8084F390(Player* this, PlayState* play) {
 }
 
 void Player_Action_8084F608(Player* this, PlayState* play) {
-    if ((DECR(this->unk_850) == 0) && func_8083ADD4(play, this)) {
+    if ((DECR(this->actionVar2) == 0) && func_8083ADD4(play, this)) {
         func_80852280(play, this, NULL);
         Player_SetupAction(play, this, Player_Action_80852E14, 0);
         Player_Action_80852E14(this, play);
@@ -13147,23 +13151,23 @@ void Player_Action_8084F608(Player* this, PlayState* play) {
 
 void Player_Action_8084F698(Player* this, PlayState* play) {
     Player_SetupAction(play, this, Player_Action_8084F608, 0);
-    this->unk_850 = 40;
+    this->actionVar2 = 40;
     Actor_Spawn(&play->actorCtx, play, ACTOR_DEMO_KANKYO, 0.0f, 0.0f, 0.0f, 0, 0, 0, DEMOKANKYO_WARP_IN);
 }
 
 void Player_Action_8084F710(Player* this, PlayState* play) {
     s32 pad;
 
-    if ((this->unk_84F != 0) && (play->csCtx.curFrame < 305)) {
+    if ((this->actionVar1 != 0) && (play->csCtx.curFrame < 305)) {
         this->actor.gravity = 0.0f;
         this->actor.velocity.y = 0.0f;
     } else if (sYDistToFloor < 150.0f) {
         if (LinkAnimation_Update(play, &this->skelAnime)) {
-            if (this->unk_850 == 0) {
+            if (this->actionVar2 == 0) {
                 if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
                     this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
                     func_808328A0(this);
-                    this->unk_850 = 1;
+                    this->actionVar2 = 1;
                 }
             } else {
                 if ((play->sceneId == SCENE_KOKIRI_FOREST) && func_8083ADD4(play, this)) {
@@ -13189,13 +13193,13 @@ void Player_Action_8084F710(Player* this, PlayState* play) {
 void Player_Action_8084F88C(Player* this, PlayState* play) {
     LinkAnimation_Update(play, &this->skelAnime);
 
-    if ((this->unk_850++ > 8) && (play->transitionTrigger == TRANS_TRIGGER_OFF)) {
+    if ((this->actionVar2++ > 8) && (play->transitionTrigger == TRANS_TRIGGER_OFF)) {
 
-        if (this->unk_84F != 0) {
+        if (this->actionVar1 != 0) {
             if (play->sceneId == SCENE_ICE_CAVERN) {
                 Play_TriggerRespawn(play);
                 play->nextEntranceIndex = ENTR_ICE_CAVERN_0;
-            } else if (this->unk_84F < 0) {
+            } else if (this->actionVar1 < 0) {
                 Play_TriggerRespawn(play);
             } else {
                 Play_TriggerVoidOut(play);
@@ -13249,13 +13253,13 @@ void Player_Action_8084FA54(Player* this, PlayState* play) {
 }
 
 void Player_Action_8084FB10(Player* this, PlayState* play) {
-    if (this->unk_84F >= 0) {
-        if (this->unk_84F < 6) {
-            this->unk_84F++;
+    if (this->actionVar1 >= 0) {
+        if (this->actionVar1 < 6) {
+            this->actionVar1++;
         }
 
         if (func_80832594(this, 1, 100)) {
-            this->unk_84F = -1;
+            this->actionVar1 = -1;
             EffectSsIcePiece_SpawnBurst(play, &this->actor.world.pos, this->actor.scale.x);
             Player_PlaySfx(this, NA_SE_PL_ICE_BROKEN);
         } else {
@@ -13277,8 +13281,8 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
     LinkAnimation_Update(play, &this->skelAnime);
     func_808382BC(this);
 
-    if (((this->unk_850 % 25) != 0) || func_80837B18(play, this, -1)) {
-        if (DECR(this->unk_850) == 0) {
+    if (((this->actionVar2 % 25) != 0) || func_80837B18(play, this, -1)) {
+        if (DECR(this->actionVar2) == 0) {
             func_80839F90(this, play);
         }
     }
@@ -13525,9 +13529,9 @@ void Player_Action_8085063C(Player* this, PlayState* play) {
     LinkAnimation_Update(play, &this->skelAnime);
     func_80836670(this, play);
 
-    if (this->unk_850 == 0) {
+    if (this->actionVar2 == 0) {
         Message_StartTextbox(play, 0x3B, &this->actor);
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
         return;
     }
 
@@ -13557,14 +13561,14 @@ void Player_Action_8085063C(Player* this, PlayState* play) {
 void Player_Action_8085076C(Player* this, PlayState* play) {
     s32 respawnData = gSaveContext.respawn[RESPAWN_MODE_TOP].data;
 
-    if (this->unk_850 > 20) {
+    if (this->actionVar2 > 20) {
         this->actor.draw = Player_Draw;
         this->actor.world.pos.y += 60.0f;
         func_80837B9C(this, play);
         return;
     }
 
-    if (this->unk_850++ == 20) {
+    if (this->actionVar2++ == 20) {
         gSaveContext.respawn[RESPAWN_MODE_TOP].data = respawnData + 1;
         Sfx_PlaySfxAtPos(&gSaveContext.respawn[RESPAWN_MODE_TOP].pos, NA_SE_PL_MAGIC_WIND_WARP);
     }
@@ -13613,38 +13617,38 @@ static struct_80832924 D_80854A8C[][2] = {
 
 void Player_Action_808507F4(Player* this, PlayState* play) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_84F < 0) {
+        if (this->actionVar1 < 0) {
             if ((this->itemAction == PLAYER_IA_NAYRUS_LOVE) || (gSaveContext.magicState == MAGIC_STATE_IDLE)) {
                 func_80839FFC(this, play);
                 func_8005B1A4(Play_GetCamera(play, CAM_ID_MAIN));
             }
         } else {
-            if (this->unk_850 == 0) {
-                LinkAnimation_PlayOnceSetSpeed(play, &this->skelAnime, D_80854A58[this->unk_84F], 0.83f);
+            if (this->actionVar2 == 0) {
+                LinkAnimation_PlayOnceSetSpeed(play, &this->skelAnime, D_80854A58[this->actionVar1], 0.83f);
 
-                if (func_80846A00(play, this, this->unk_84F) != NULL) {
+                if (func_80846A00(play, this, this->actionVar1) != NULL) {
                     this->stateFlags1 |= PLAYER_STATE1_28 | PLAYER_STATE1_29;
-                    if ((this->unk_84F != 0) || (gSaveContext.respawn[RESPAWN_MODE_TOP].data <= 0)) {
+                    if ((this->actionVar1 != 0) || (gSaveContext.respawn[RESPAWN_MODE_TOP].data <= 0)) {
                         gSaveContext.magicState = MAGIC_STATE_CONSUME_SETUP;
                     }
                 } else {
                     Magic_Reset(play);
                 }
             } else {
-                LinkAnimation_PlayLoopSetSpeed(play, &this->skelAnime, D_80854A64[this->unk_84F], 0.83f);
+                LinkAnimation_PlayLoopSetSpeed(play, &this->skelAnime, D_80854A64[this->actionVar1], 0.83f);
 
-                if (this->unk_84F == 0) {
-                    this->unk_850 = -10;
+                if (this->actionVar1 == 0) {
+                    this->actionVar2 = -10;
                 }
             }
 
-            this->unk_850++;
+            this->actionVar2++;
         }
     } else {
-        if (this->unk_850 < 0) {
-            this->unk_850++;
+        if (this->actionVar2 < 0) {
+            this->actionVar2++;
 
-            if (this->unk_850 == 0) {
+            if (this->actionVar2 == 0) {
                 gSaveContext.respawn[RESPAWN_MODE_TOP].data = 1;
                 Play_SetupRespawnPoint(play, RESPAWN_MODE_TOP, 0x6FF);
                 gSaveContext.save.info.fw.set = 1;
@@ -13657,20 +13661,20 @@ void Player_Action_808507F4(Player* this, PlayState* play) {
                 gSaveContext.save.info.fw.roomIndex = gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex;
                 gSaveContext.save.info.fw.tempSwchFlags = gSaveContext.respawn[RESPAWN_MODE_DOWN].tempSwchFlags;
                 gSaveContext.save.info.fw.tempCollectFlags = gSaveContext.respawn[RESPAWN_MODE_DOWN].tempCollectFlags;
-                this->unk_850 = 2;
+                this->actionVar2 = 2;
             }
-        } else if (this->unk_84F >= 0) {
-            if (this->unk_850 == 0) {
+        } else if (this->actionVar1 >= 0) {
+            if (this->actionVar2 == 0) {
                 func_80832924(this, D_80854A80);
-            } else if (this->unk_850 == 1) {
-                func_80832924(this, D_80854A8C[this->unk_84F]);
-                if ((this->unk_84F == 2) && LinkAnimation_OnFrame(&this->skelAnime, 30.0f)) {
+            } else if (this->actionVar2 == 1) {
+                func_80832924(this, D_80854A8C[this->actionVar1]);
+                if ((this->actionVar1 == 2) && LinkAnimation_OnFrame(&this->skelAnime, 30.0f)) {
                     this->stateFlags1 &= ~(PLAYER_STATE1_28 | PLAYER_STATE1_29);
                 }
-            } else if (D_80854A7C[this->unk_84F] < this->unk_850++) {
-                LinkAnimation_PlayOnceSetSpeed(play, &this->skelAnime, D_80854A70[this->unk_84F], 0.83f);
+            } else if (D_80854A7C[this->actionVar1] < this->actionVar2++) {
+                LinkAnimation_PlayOnceSetSpeed(play, &this->skelAnime, D_80854A70[this->actionVar1], 0.83f);
                 this->yaw = this->actor.shape.rot.y;
-                this->unk_84F = -1;
+                this->actionVar1 = -1;
             }
         }
     }
@@ -13717,7 +13721,7 @@ void Player_Action_80850AEC(Player* this, PlayState* play) {
 }
 
 void Player_Action_80850C68(Player* this, PlayState* play) {
-    if ((this->unk_850 != 0) && ((this->unk_858 != 0.0f) || (this->unk_85C != 0.0f))) {
+    if ((this->actionVar2 != 0) && ((this->unk_858 != 0.0f) || (this->unk_85C != 0.0f))) {
         f32 updateScale = R_UPDATE_RATE * 0.5f;
 
         this->skelAnime.curFrame += this->skelAnime.playSpeed * updateScale;
@@ -13737,7 +13741,7 @@ void Player_Action_80850C68(Player* this, PlayState* play) {
     } else if (LinkAnimation_Update(play, &this->skelAnime)) {
         this->unk_860 = 2;
         Player_AnimPlayLoop(play, this, &gPlayerAnim_link_fishing_wait);
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
     }
 
     func_8083721C(this);
@@ -14071,7 +14075,7 @@ void func_808511D4(PlayState* play, Player* this, void* anim) {
 void func_808511FC(PlayState* play, Player* this, void* anim) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_AnimChangeLoopMorphAdjustedZeroRootYawSpeed(play, this, anim);
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
     }
 }
 
@@ -14085,7 +14089,7 @@ void func_80851248(PlayState* play, Player* this, void* anim) {
 void func_80851294(PlayState* play, Player* this, void* anim) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_AnimReplaceNormalPlayLoopAdjusted(play, this, anim);
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
     }
 }
 
@@ -14117,9 +14121,9 @@ void func_80851368(PlayState* play, Player* this, CsCmdActorCue* cue) {
 void func_808513BC(PlayState* play, Player* this, CsCmdActorCue* cue) {
     this->actor.gravity = 0.0f;
 
-    if (this->unk_84F == 0) {
+    if (this->actionVar1 == 0) {
         if (func_8083D12C(play, this, NULL)) {
-            this->unk_84F = 1;
+            this->actionVar1 = 1;
         } else {
             func_8084B158(play, this, NULL, fabsf(this->actor.velocity.y));
             Math_ScaledStepToS(&this->unk_6C2, -10000, 800);
@@ -14129,7 +14133,7 @@ void func_808513BC(PlayState* play, Player* this, CsCmdActorCue* cue) {
     }
 
     if (LinkAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_84F == 1) {
+        if (this->actionVar1 == 1) {
             Player_AnimChangeLoopSlowMorph(play, this, &gPlayerAnim_link_swimer_swim_wait);
         } else {
             Player_AnimPlayLoop(play, this, &gPlayerAnim_link_swimer_swim_wait);
@@ -14234,7 +14238,7 @@ void func_80851828(PlayState* play, Player* this, CsCmdActorCue* cue) {
     func_80845BA0(play, this, &sp1C, 10);
 
     if (play->sceneId == SCENE_JABU_JABU_BOSS) {
-        if (this->unk_850 == 0) {
+        if (this->actionVar2 == 0) {
             if (Message_GetState(&play->msgCtx) == TEXT_STATE_NONE) {
                 return;
             }
@@ -14245,8 +14249,8 @@ void func_80851828(PlayState* play, Player* this, CsCmdActorCue* cue) {
         }
     }
 
-    this->unk_850++;
-    if (this->unk_850 > 20) {
+    this->actionVar2++;
+    if (this->actionVar2 > 20) {
         this->csMode = PLAYER_CSMODE_11;
     }
 }
@@ -14258,10 +14262,10 @@ void func_808518DC(PlayState* play, Player* this, CsCmdActorCue* cue) {
 void func_8085190C(PlayState* play, Player* this, CsCmdActorCue* cue) {
     func_80851314(this);
 
-    if (this->unk_850 != 0) {
+    if (this->actionVar2 != 0) {
         if (LinkAnimation_Update(play, &this->skelAnime)) {
             Player_AnimPlayLoop(play, this, func_808334E4(this));
-            this->unk_850 = 0;
+            this->actionVar2 = 0;
         }
 
         func_80833C3C(this);
@@ -14348,10 +14352,10 @@ static struct_80832924 D_808551B4[] = {
 void func_80851BE8(PlayState* play, Player* this, CsCmdActorCue* cue) {
     LinkAnimation_Update(play, &this->skelAnime);
 
-    this->unk_850++;
+    this->actionVar2++;
 
-    if (this->unk_850 >= 180) {
-        if (this->unk_850 == 180) {
+    if (this->actionVar2 >= 180) {
+        if (this->actionVar2 == 180) {
             LinkAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_okarina_warp_goal, (2.0f / 3.0f), 10.0f,
                                  Animation_GetLastFrame(&gPlayerAnim_link_okarina_warp_goal), ANIMMODE_ONCE, -8.0f);
         }
@@ -14360,13 +14364,13 @@ void func_80851BE8(PlayState* play, Player* this, CsCmdActorCue* cue) {
 }
 
 void func_80851CA4(PlayState* play, Player* this, CsCmdActorCue* cue) {
-    if (LinkAnimation_Update(play, &this->skelAnime) && (this->unk_850 == 0) &&
+    if (LinkAnimation_Update(play, &this->skelAnime) && (this->actionVar2 == 0) &&
         (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         Player_AnimPlayOnce(play, this, &gPlayerAnim_link_normal_back_downB);
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
     }
 
-    if (this->unk_850 != 0) {
+    if (this->actionVar2 != 0) {
         func_8083721C(this);
     }
 }
@@ -14423,8 +14427,8 @@ void func_80851ECC(PlayState* play, Player* this, CsCmdActorCue* cue) {
 void func_80851F14(PlayState* play, Player* this, LinkAnimationHeader* anim, struct_80832924* arg3) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_AnimPlayLoopAdjusted(play, this, anim);
-        this->unk_850 = 1;
-    } else if (this->unk_850 == 0) {
+        this->actionVar2 = 1;
+    } else if (this->actionVar2 == 0) {
         func_80832924(this, arg3);
     }
 }
@@ -14445,8 +14449,8 @@ void func_80851FB0(PlayState* play, Player* this, CsCmdActorCue* cue) {
         Player_AnimReplacePlayLoop(play, this, &gPlayerAnim_clink_op3_wait3,
                                    ANIM_FLAG_PLAYER_2 | ANIM_FLAG_PLAYER_SETMOVE | ANIM_FLAG_NO_MOVE |
                                        ANIM_FLAG_PLAYER_7);
-        this->unk_850 = 1;
-    } else if (this->unk_850 == 0) {
+        this->actionVar2 = 1;
+    } else if (this->actionVar2 == 0) {
         func_80832924(this, D_808551BC);
         if (LinkAnimation_OnFrame(&this->skelAnime, 240.0f)) {
             this->actor.shape.shadowDraw = ActorShadow_DrawFeet;
@@ -14527,8 +14531,8 @@ void func_80852280(PlayState* play, Player* this, CsCmdActorCue* cue) {
 void func_80852298(PlayState* play, Player* this, CsCmdActorCue* cue) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_AnimReplaceNormalPlayLoopAdjusted(play, this, &gPlayerAnim_clink_demo_koutai_wait);
-        this->unk_850 = 1;
-    } else if (this->unk_850 == 0) {
+        this->actionVar2 = 1;
+    } else if (this->actionVar2 == 0) {
         if (LinkAnimation_OnFrame(&this->skelAnime, 10.0f)) {
             func_80846720(play, this, 1);
         }
@@ -14556,10 +14560,10 @@ void func_80852358(PlayState* play, Player* this, CsCmdActorCue* cue) {
 void func_80852388(PlayState* play, Player* this, CsCmdActorCue* cue) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_AnimPlayLoopAdjusted(play, this, &gPlayerAnim_demo_link_twait);
-        this->unk_850 = 1;
+        this->actionVar2 = 1;
     }
 
-    if ((this->unk_850 != 0) && (play->csCtx.curFrame >= 900)) {
+    if ((this->actionVar2 != 0) && (play->csCtx.curFrame >= 900)) {
         this->rightHandType = PLAYER_MODELTYPE_LH_OPEN;
     } else {
         this->rightHandType = PLAYER_MODELTYPE_RH_FF;
@@ -14568,7 +14572,7 @@ void func_80852388(PlayState* play, Player* this, CsCmdActorCue* cue) {
 
 void func_80852414(PlayState* play, Player* this, LinkAnimationHeader* anim, struct_80832924* arg3) {
     func_80851294(play, this, anim);
-    if (this->unk_850 == 0) {
+    if (this->actionVar2 == 0) {
         func_80832924(this, arg3);
     }
 }
@@ -14626,7 +14630,7 @@ static void (*D_808551FC[])(Player* this, PlayState* play) = {
 };
 
 void func_808525C0(PlayState* play, Player* this, CsCmdActorCue* cue) {
-    D_808551FC[this->unk_850](this, play);
+    D_808551FC[this->actionVar2](this, play);
 }
 
 void func_80852608(PlayState* play, Player* this, CsCmdActorCue* cue) {
@@ -14688,7 +14692,7 @@ void func_808526EC(PlayState* play, Player* this, CsCmdActorCue* cue) {
 void func_8085283C(PlayState* play, Player* this, CsCmdActorCue* cue) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         func_80852944(play, this, cue);
-    } else if (this->unk_850 == 0) {
+    } else if (this->actionVar2 == 0) {
         Item_Give(play, ITEM_SWORD_MASTER);
         func_80846720(play, this, 0);
     } else {
@@ -14803,8 +14807,8 @@ void func_80852C50(PlayState* play, Player* this, CsCmdActorCue* cueUnused) {
         func_80852C0C(play, this, ABS(csMode));
         func_80852B4C(play, this, cue, &D_80854B18[ABS(csMode)]);
 
-        this->unk_850 = 0;
-        this->unk_84F = 0;
+        this->actionVar2 = 0;
+        this->actionVar1 = 0;
         this->cueId = cue->id;
     }
 
@@ -14914,12 +14918,12 @@ void func_80853148(PlayState* play, Actor* actor) {
         }
 
         if (this->stateFlags1 & PLAYER_STATE1_23) {
-            s32 sp24 = this->unk_850;
+            s32 sp24 = this->actionVar2;
 
             func_80832528(play, this);
             func_8083A2F8(play, this);
 
-            this->unk_850 = sp24;
+            this->actionVar2 = sp24;
         } else {
             if (func_808332B8(this)) {
                 func_80836898(play, this, func_8083A2F8);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -7372,7 +7372,8 @@ void Player_Action_80840BC8(Player* this, PlayState* play) {
             if (DECR(this->actionVar2) == 0) {
                 this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
             }
-            this->skelAnime.jointTable[0].y = (this->skelAnime.jointTable[0].y + ((this->actionVar2 & 1) * 0x50)) - 0x28;
+            this->skelAnime.jointTable[0].y =
+                (this->skelAnime.jointTable[0].y + ((this->actionVar2 & 1) * 0x50)) - 0x28;
         } else {
             func_80832DBC(this);
             func_808409CC(play, this);
@@ -9259,7 +9260,7 @@ void Player_Action_80845CA4(Player* this, PlayState* play) {
             temp = func_80845BA0(play, this, &sp34, sp30);
 
             if ((this->actionVar2 == 0) || ((temp == 0) && (this->speedXZ == 0.0f) &&
-                                         (Play_GetCamera(play, CAM_ID_MAIN)->stateFlags & CAM_STATE_4))) {
+                                            (Play_GetCamera(play, CAM_ID_MAIN)->stateFlags & CAM_STATE_4))) {
 
                 func_8005B1A4(Play_GetCamera(play, CAM_ID_MAIN));
                 func_80845C68(play, gSaveContext.respawn[RESPAWN_MODE_DOWN].data);
@@ -11697,7 +11698,7 @@ void Player_Action_8084BDFC(Player* this, PlayState* play) {
 
 void func_8084BEE4(Player* this) {
     Player_PlaySfx(this, (this->actionVar1 != 0) ? NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_VINE
-                                              : NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD);
+                                                 : NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD);
 }
 
 void Player_Action_8084BF1C(Player* this, PlayState* play) {


### PR DESCRIPTION
Player unfortunately makes extensive use of generic context-dependent variables. There are two that get reset everytime a new action function is set up and constantly change meaning. One is a byte and one is a short.

We will eventually need to decide how we will move forward with giving it meaningful names. The `#define vName` approach exists, but would get very unruly with how often this variable changes meaning. 

Cdi uses unions in his personal docs, shown here: https://github.com/CDi-Fails/oot/blob/player_docs/include/z64player.h#L875
Though this is not nearly a complete list of all the names it will have. Something to consider