### PR TITLE
Player docs: Control Stick Input and Movement

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -856,7 +856,7 @@ s32 Math_StepUntilS(s16* pValue, s16 limit, s16 step);
 s32 Math_StepToAngleS(s16* pValue, s16 target, s16 step);
 s32 Math_StepUntilF(f32* pValue, f32 limit, f32 step);
 s32 Math_AsymStepToF(f32* pValue, f32 target, f32 incrStep, f32 decrStep);
-void func_80077D10(f32* arg0, s16* arg1, Input* input);
+void Lib_GetControlStickData(f32* arg0, s16* arg1, Input* input);
 s16 Rand_S16Offset(s16 base, s16 range);
 void Math_Vec3f_Copy(Vec3f* dest, Vec3f* src);
 void Math_Vec3s_ToVec3f(Vec3f* dest, Vec3s* src);

--- a/include/functions.h
+++ b/include/functions.h
@@ -856,7 +856,7 @@ s32 Math_StepUntilS(s16* pValue, s16 limit, s16 step);
 s32 Math_StepToAngleS(s16* pValue, s16 target, s16 step);
 s32 Math_StepUntilF(f32* pValue, f32 limit, f32 step);
 s32 Math_AsymStepToF(f32* pValue, f32 target, f32 incrStep, f32 decrStep);
-void Lib_GetControlStickData(f32* arg0, s16* arg1, Input* input);
+void Lib_GetControlStickData(f32* outMagnitude, s16* outAngle, Input* input);
 s16 Rand_S16Offset(s16 base, s16 range);
 void Math_Vec3f_Copy(Vec3f* dest, Vec3f* src);
 void Math_Vec3s_ToVec3f(Vec3f* dest, Vec3s* src);

--- a/include/z64player.h
+++ b/include/z64player.h
@@ -758,8 +758,8 @@ typedef struct Player {
     /* 0x0A79 */ u8 floorTypeTimer; // counts up every frame the current floor type is the same as the last frame
     /* 0x0A7A */ u8 floorProperty;
     /* 0x0A7B */ u8 prevFloorType;
-    /* 0x0A7C */ f32 unk_A7C;
-    /* 0x0A80 */ s16 unk_A80;
+    /* 0x0A7C */ f32 prevControlStickMagnitude;
+    /* 0x0A80 */ s16 prevControlStickAngle;
     /* 0x0A82 */ u16 prevFloorSfxOffset;
     /* 0x0A84 */ s16 unk_A84;
     /* 0x0A86 */ s8 unk_A86;

--- a/src/code/z_lib.c
+++ b/src/code/z_lib.c
@@ -219,14 +219,14 @@ s32 Math_AsymStepToF(f32* pValue, f32 target, f32 incrStep, f32 decrStep) {
     return 0;
 }
 
-void func_80077D10(f32* arg0, s16* arg1, Input* input) {
+void Lib_GetControlStickData(f32* outMagnitude, s16* outAngle, Input* input) {
     f32 relX = input->rel.stick_x;
     f32 relY = input->rel.stick_y;
 
-    *arg0 = sqrtf(SQ(relX) + SQ(relY));
-    *arg0 = (60.0f < *arg0) ? 60.0f : *arg0;
+    *outMagnitude = sqrtf(SQ(relX) + SQ(relY));
+    *outMagnitude = (60.0f < *outMagnitude) ? 60.0f : *outMagnitude;
 
-    *arg1 = Math_Atan2S(relY, -relX);
+    *outAngle = Math_Atan2S(relY, -relX);
 }
 
 s16 Rand_S16Offset(s16 base, s16 range) {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3563,7 +3563,12 @@ void func_80836BEC(Player* this, PlayState* play) {
  * To see the difference between linear and curved mode, with interative toggles for
  * speed cap and floor pitch, see the following desmos graph: https://www.desmos.com/calculator/hri7dcws4c
  */
+
+// Linear mode is a straight line, increasing target speed at a steady rate relative to the control stick magnitude
 #define SPEED_MODE_LINEAR 0.0f
+
+// Curved mode drops any input below 20 units of magnitidue, resulting in zero for target speed. 
+// Beyond 20 units, a gradual curve slowly moves up until around the 40 unit mark when target speed ramps up very quickly.
 #define SPEED_MODE_CURVED 0.018f
 
 /**

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1712,9 +1712,10 @@ void func_80832564(PlayState* play, Player* this) {
 }
 
 s32 func_80832594(Player* this, s32 arg1, s32 arg2) {
-    s16 ctrlStickAngleDiff = this->prevControlStickAngle - sControlStickAngle;
+    s16 controlStickAngleDiff = this->prevControlStickAngle - sControlStickAngle;
 
-    this->actionVar2 += arg1 + (s16)(ABS(ctrlStickAngleDiff) * fabsf(sControlStickMagnitude) * 2.5415802156203426e-06f);
+    this->actionVar2 +=
+        arg1 + (s16)(ABS(controlStickAngleDiff) * fabsf(sControlStickMagnitude) * 2.5415802156203426e-06f);
 
     if (CHECK_BTN_ANY(sControlInput->press.button, BTN_A | BTN_B)) {
         this->actionVar2 += 5;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3557,18 +3557,19 @@ void func_80836BEC(Player* this, PlayState* play) {
  * It simply checks if the value is non-zero to toggle the "curved" mode.
  * In practice, 0.0f or 0.018f are the only values passed to this function.
  *
- * It's clear that this value was intended to mean something in the curved mofe calculation at
+ * It's clear that this value was intended to mean something in the curved mode calculation at
  * some point in development, but was either never implemented or removed.
  *
- * To see the difference between linear and curved mode, with interative toggles for
+ * To see the difference between linear and curved mode, with interactive toggles for
  * speed cap and floor pitch, see the following desmos graph: https://www.desmos.com/calculator/hri7dcws4c
  */
 
 // Linear mode is a straight line, increasing target speed at a steady rate relative to the control stick magnitude
 #define SPEED_MODE_LINEAR 0.0f
 
-// Curved mode drops any input below 20 units of magnitidue, resulting in zero for target speed. 
-// Beyond 20 units, a gradual curve slowly moves up until around the 40 unit mark when target speed ramps up very quickly.
+// Curved mode drops any input below 20 units of magnitude, resulting in zero for target speed.
+// Beyond 20 units, a gradual curve slowly moves up until around the 40 unit mark when target speed ramps up very
+// quickly.
 #define SPEED_MODE_CURVED 0.018f
 
 /**
@@ -3602,7 +3603,7 @@ s32 Player_CalcSpeedAndYawFromControlStick(PlayState* play, Player* this, f32* o
                 *outSpeedTarget = 0.0f;
             } else {
                 // Cosine of the control stick magnitude isn't exactly meaningful, but
-                // it happens to give a desireable curve for grounded movement speed relative
+                // it happens to give a desirable curve for grounded movement speed relative
                 // to control stick magnitude.
                 temp = 1.0f - Math_CosS(*outSpeedTarget * 450.0f);
                 *outSpeedTarget = (SQ(temp) * 30.0f) + 7.0f;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3553,17 +3553,17 @@ void func_80836BEC(Player* this, PlayState* play) {
  * These defines exist to simplify the variable used to toggle the different speed modes.
  * While the `speedMode` variable is a float and can contain a non-boolean value,
  * `Player_CalcSpeedAndYawFromControlStick` never actually uses the value for anything.
- * It simply checks if the value is non-zero to toggle the "curve" mode.
+ * It simply checks if the value is non-zero to toggle the "curved" mode.
  * In practice, 0.0f or 0.018f are the only values passed to this function.
  *
- * It's clear that this value was intended to mean something in the curve calculation at some point 
- * in development, but was either never implemented or removed.
+ * It's clear that this value was intended to mean something in the curved mofe calculation at
+ * some point in development, but was either never implemented or removed.
  *
- * To see the difference between linear and curve mode, with interative toggles for various variables
- * see the following desmos graph: https://www.desmos.com/calculator/hri7dcws4c
+ * To see the difference between linear and curved mode, with interative toggles for
+ * speed cap and floor pitch, see the following desmos graph: https://www.desmos.com/calculator/hri7dcws4c
  */
 #define SPEED_MODE_LINEAR 0.0f
-#define SPEED_MODE_CURVE 0.018f
+#define SPEED_MODE_CURVED 0.018f
 
 /**
  * Calculates target speed and yaw based on input from the control stick.
@@ -3587,7 +3587,7 @@ s32 Player_CalcSpeedAndYawFromControlStick(PlayState* play, Player* this, f32* o
         *outYawTarget = sControlStickAngle;
 
         // The value of `speedMode` is never actually used. It only toggles this condition.
-        // See the definition of `SPEED_MODE_LINEAR` and `SPEED_MODE_CURVE` for more information.
+        // See the definition of `SPEED_MODE_LINEAR` and `SPEED_MODE_CURVED` for more information.
         if (speedMode != SPEED_MODE_LINEAR) {
             *outSpeedTarget -= 20.0f;
 
@@ -3635,12 +3635,11 @@ s32 func_8083721C(Player* this) {
  * Control stick magnitude and angle are processed in `Player_CalcSpeedAndYawFromControlStick` to get target values.
  * Additionally, this function does extra processing on the target yaw value if the control stick is neutral.
  *
- * @param this            player instance
  * @param outSpeedTarget  a pointer to the variable that will hold the resulting target speed value
  * @param outYawTarget    a pointer to the variable that will hold the resulting target yaw value
  * @param speedMode       toggles between a linear and curved mode for the speed value
  *
- * See `Player_CalcSpeedAndYawFromControlStick` for more information on the linear vs curved speed mode.
+ * @see Player_CalcSpeedAndYawFromControlStick for more information on the linear vs curved speed mode.
  *
  * @return true if the control stick has any magnitude, false otherwise.
  */

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3568,8 +3568,8 @@ void func_80836BEC(Player* this, PlayState* play) {
 #define SPEED_MODE_LINEAR 0.0f
 
 // Curved mode drops any input below 20 units of magnitude, resulting in zero for target speed.
-// Beyond 20 units, a gradual curve slowly moves up until around the 40 unit mark when target speed ramps up very
-// quickly.
+// Beyond 20 units, a gradual curve slowly moves up until around the 40 unit mark
+// when target speed ramps up very quickly.
 #define SPEED_MODE_CURVED 0.018f
 
 /**

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3717,15 +3717,15 @@ s32 func_80837348(PlayState* play, Player* this, s8* arg2, s32 arg3) {
 }
 
 s32 func_808374A0(PlayState* play, Player* this, SkelAnime* skelAnime, f32 arg3) {
-    f32 sp24;
-    s16 sp22;
+    f32 speedTarget;
+    s16 yawTarget;
 
     if ((skelAnime->endFrame - arg3) <= skelAnime->curFrame) {
         if (func_80837348(play, this, D_80854418, 1)) {
             return 0;
         }
 
-        if (Player_GetMovementSpeedAndYaw(this, &sp24, &sp22, 0.018f, play)) {
+        if (Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_CURVED, play)) {
             return 1;
         }
     }
@@ -7259,8 +7259,8 @@ void func_8084029C(Player* this, f32 arg1) {
 }
 
 void Player_Action_80840450(Player* this, PlayState* play) {
-    f32 sp44;
-    s16 sp42;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp1;
     u32 temp2;
     s16 temp3;
@@ -7294,27 +7294,27 @@ void Player_Action_80840450(Player* this, PlayState* play) {
             return;
         }
 
-        Player_GetMovementSpeedAndYaw(this, &sp44, &sp42, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
-        temp1 = func_8083FC68(this, sp44, sp42);
+        temp1 = func_8083FC68(this, speedTarget, yawTarget);
 
         if (temp1 > 0) {
-            func_8083C8DC(this, play, sp42);
+            func_8083C8DC(this, play, yawTarget);
             return;
         }
 
         if (temp1 < 0) {
-            func_8083CBF0(this, sp42, play);
+            func_8083CBF0(this, yawTarget, play);
             return;
         }
 
-        if (sp44 > 4.0f) {
+        if (speedTarget > 4.0f) {
             func_8083CC9C(this, play);
             return;
         }
 
         func_8084029C(this, (this->speedXZ * 0.3f) + 1.0f);
-        func_80840138(this, sp44, sp42);
+        func_80840138(this, speedTarget, yawTarget);
 
         temp2 = this->unk_868;
         if ((temp2 < 6) || ((temp2 - 0xE) < 6)) {
@@ -7322,27 +7322,27 @@ void Player_Action_80840450(Player* this, PlayState* play) {
             return;
         }
 
-        temp3 = sp42 - this->yaw;
+        temp3 = yawTarget - this->yaw;
         temp4 = ABS(temp3);
 
         if (temp4 > 0x4000) {
             if (Math_StepToF(&this->speedXZ, 0.0f, 1.5f)) {
-                this->yaw = sp42;
+                this->yaw = yawTarget;
             }
             return;
         }
 
-        Math_AsymStepToF(&this->speedXZ, sp44 * 0.3f, 2.0f, 1.5f);
+        Math_AsymStepToF(&this->speedXZ, speedTarget * 0.3f, 2.0f, 1.5f);
 
         if (!(this->stateFlags3 & PLAYER_STATE3_3)) {
-            Math_ScaledStepToS(&this->yaw, sp42, temp4 * 0.1f);
+            Math_ScaledStepToS(&this->yaw, yawTarget, temp4 * 0.1f);
         }
     }
 }
 
 void Player_Action_808407CC(Player* this, PlayState* play) {
-    f32 sp3C;
-    s16 sp3A;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp1;
     s16 temp2;
     s32 temp3;
@@ -7371,35 +7371,35 @@ void Player_Action_808407CC(Player* this, PlayState* play) {
             return;
         }
 
-        Player_GetMovementSpeedAndYaw(this, &sp3C, &sp3A, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
-        temp1 = func_8083FD78(this, &sp3C, &sp3A, play);
+        temp1 = func_8083FD78(this, &speedTarget, &yawTarget, play);
 
         if (temp1 > 0) {
-            func_8083C8DC(this, play, sp3A);
+            func_8083C8DC(this, play, yawTarget);
             return;
         }
 
         if (temp1 < 0) {
-            func_8083CB2C(this, sp3A, play);
+            func_8083CB2C(this, yawTarget, play);
             return;
         }
 
-        if (sp3C > 4.9f) {
+        if (speedTarget > 4.9f) {
             func_8083CC9C(this, play);
             func_80833C3C(this);
             return;
         }
-        if (sp3C != 0.0f) {
+        if (speedTarget != 0.0f) {
             func_8083CB94(this, play);
             return;
         }
 
-        temp2 = sp3A - this->actor.shape.rot.y;
+        temp2 = yawTarget - this->actor.shape.rot.y;
         temp3 = ABS(temp2);
 
         if (temp3 > 800) {
-            func_8083CD54(play, this, sp3A);
+            func_8083CD54(play, this, yawTarget);
         }
     }
 }
@@ -7455,8 +7455,8 @@ void func_808409CC(PlayState* play, Player* this) {
 void Player_Action_80840BC8(Player* this, PlayState* play) {
     s32 sp44;
     s32 sp40;
-    f32 sp3C;
-    s16 sp3A;
+    f32 speedTarget;
+    s16 yawTarget;
     s16 temp;
 
     sp44 = func_80833350(this);
@@ -7493,20 +7493,20 @@ void Player_Action_80840BC8(Player* this, PlayState* play) {
                 return;
             }
 
-            Player_GetMovementSpeedAndYaw(this, &sp3C, &sp3A, 0.018f, play);
+            Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_CURVED, play);
 
-            if (sp3C != 0.0f) {
-                func_8083C8DC(this, play, sp3A);
+            if (speedTarget != 0.0f) {
+                func_8083C8DC(this, play, yawTarget);
                 return;
             }
 
-            temp = sp3A - this->actor.shape.rot.y;
+            temp = yawTarget - this->actor.shape.rot.y;
             if (ABS(temp) > 800) {
-                func_8083CD54(play, this, sp3A);
+                func_8083CD54(play, this, yawTarget);
                 return;
             }
 
-            Math_ScaledStepToS(&this->actor.shape.rot.y, sp3A, 1200);
+            Math_ScaledStepToS(&this->actor.shape.rot.y, yawTarget, 1200);
             this->yaw = this->actor.shape.rot.y;
             if (func_80833338(this) == this->skelAnime.animation) {
                 func_8083DC54(this, play);
@@ -7518,8 +7518,8 @@ void Player_Action_80840BC8(Player* this, PlayState* play) {
 void Player_Action_80840DE4(Player* this, PlayState* play) {
     f32 frames;
     f32 coeff;
-    f32 sp44;
-    s16 sp42;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp1;
     s16 temp2;
     s32 temp3;
@@ -7566,42 +7566,42 @@ void Player_Action_80840DE4(Player* this, PlayState* play) {
             return;
         }
 
-        Player_GetMovementSpeedAndYaw(this, &sp44, &sp42, 0.0f, play);
-        temp1 = func_8083FD78(this, &sp44, &sp42, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
+        temp1 = func_8083FD78(this, &speedTarget, &yawTarget, play);
 
         if (temp1 > 0) {
-            func_8083C8DC(this, play, sp42);
+            func_8083C8DC(this, play, yawTarget);
             return;
         }
 
         if (temp1 < 0) {
-            func_8083CB2C(this, sp42, play);
+            func_8083CB2C(this, yawTarget, play);
             return;
         }
 
-        if (sp44 > 4.9f) {
+        if (speedTarget > 4.9f) {
             func_8083CC9C(this, play);
             func_80833C3C(this);
             return;
         }
 
-        if ((sp44 == 0.0f) && (this->speedXZ == 0.0f)) {
+        if ((speedTarget == 0.0f) && (this->speedXZ == 0.0f)) {
             func_80839F30(this, play);
             return;
         }
 
-        temp2 = sp42 - this->yaw;
+        temp2 = yawTarget - this->yaw;
         temp3 = ABS(temp2);
 
         if (temp3 > 0x4000) {
             if (Math_StepToF(&this->speedXZ, 0.0f, 1.5f)) {
-                this->yaw = sp42;
+                this->yaw = yawTarget;
             }
             return;
         }
 
-        Math_AsymStepToF(&this->speedXZ, sp44 * 0.4f, 1.5f, 1.5f);
-        Math_ScaledStepToS(&this->yaw, sp42, temp3 * 0.1f);
+        Math_AsymStepToF(&this->speedXZ, speedTarget * 0.4f, 1.5f, 1.5f);
+        Math_ScaledStepToS(&this->yaw, yawTarget, temp3 * 0.1f);
     }
 }
 
@@ -7670,8 +7670,8 @@ s32 func_80841458(Player* this, f32* arg1, s16* arg2, PlayState* play) {
 }
 
 void Player_Action_808414F8(Player* this, PlayState* play) {
-    f32 sp34;
-    s16 sp32;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 sp2C;
     s16 sp2A;
 
@@ -7683,26 +7683,26 @@ void Player_Action_808414F8(Player* this, PlayState* play) {
             return;
         }
 
-        Player_GetMovementSpeedAndYaw(this, &sp34, &sp32, 0.0f, play);
-        sp2C = func_8083FD78(this, &sp34, &sp32, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
+        sp2C = func_8083FD78(this, &speedTarget, &yawTarget, play);
 
         if (sp2C >= 0) {
-            if (!func_80841458(this, &sp34, &sp32, play)) {
+            if (!func_80841458(this, &speedTarget, &yawTarget, play)) {
                 if (sp2C != 0) {
                     func_8083C858(this, play);
-                } else if (sp34 > 4.9f) {
+                } else if (speedTarget > 4.9f) {
                     func_8083CC9C(this, play);
                 } else {
                     func_8083CB94(this, play);
                 }
             }
         } else {
-            sp2A = sp32 - this->yaw;
+            sp2A = yawTarget - this->yaw;
 
-            Math_AsymStepToF(&this->speedXZ, sp34 * 1.5f, 1.5f, 2.0f);
-            Math_ScaledStepToS(&this->yaw, sp32, sp2A * 0.1f);
+            Math_AsymStepToF(&this->speedXZ, speedTarget * 1.5f, 1.5f, 2.0f);
+            Math_ScaledStepToS(&this->yaw, yawTarget, sp2A * 0.1f);
 
-            if ((sp34 == 0.0f) && (this->speedXZ == 0.0f)) {
+            if ((speedTarget == 0.0f) && (this->speedXZ == 0.0f)) {
                 func_80839F30(this, play);
             }
         }
@@ -7716,21 +7716,21 @@ void func_808416C0(Player* this, PlayState* play) {
 
 void Player_Action_8084170C(Player* this, PlayState* play) {
     s32 sp34;
-    f32 sp30;
-    s16 sp2E;
+    f32 speedTarget;
+    s16 yawTarget;
 
     sp34 = LinkAnimation_Update(play, &this->skelAnime);
     func_8083721C(this);
 
     if (!func_80837348(play, this, D_80854400, 1)) {
-        Player_GetMovementSpeedAndYaw(this, &sp30, &sp2E, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
         if (this->speedXZ == 0.0f) {
             this->yaw = this->actor.shape.rot.y;
 
-            if (func_8083FD78(this, &sp30, &sp2E, play) > 0) {
+            if (func_8083FD78(this, &speedTarget, &yawTarget, play) > 0) {
                 func_8083C858(this, play);
-            } else if ((sp30 != 0.0f) || (sp34 != 0)) {
+            } else if ((speedTarget != 0.0f) || (sp34 != 0)) {
                 func_808416C0(this, play);
             }
         }
@@ -7763,8 +7763,8 @@ void func_80841860(PlayState* play, Player* this) {
 }
 
 void Player_Action_8084193C(Player* this, PlayState* play) {
-    f32 sp3C;
-    s16 sp3A;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp1;
     s16 temp2;
     s32 temp3;
@@ -7777,12 +7777,12 @@ void Player_Action_8084193C(Player* this, PlayState* play) {
             return;
         }
 
-        Player_GetMovementSpeedAndYaw(this, &sp3C, &sp3A, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
         if (func_80833B2C(this)) {
-            temp1 = func_8083FD78(this, &sp3C, &sp3A, play);
+            temp1 = func_8083FD78(this, &speedTarget, &yawTarget, play);
         } else {
-            temp1 = func_8083FC68(this, sp3C, sp3A);
+            temp1 = func_8083FC68(this, speedTarget, yawTarget);
         }
 
         if (temp1 > 0) {
@@ -7792,14 +7792,14 @@ void Player_Action_8084193C(Player* this, PlayState* play) {
 
         if (temp1 < 0) {
             if (func_80833B2C(this)) {
-                func_8083CB2C(this, sp3A, play);
+                func_8083CB2C(this, yawTarget, play);
             } else {
-                func_8083CBF0(this, sp3A, play);
+                func_8083CBF0(this, yawTarget, play);
             }
             return;
         }
 
-        if ((this->speedXZ < 3.6f) && (sp3C < 4.0f)) {
+        if ((this->speedXZ < 3.6f) && (speedTarget < 4.0f)) {
             if (!func_8008E9C4(this) && func_80833B2C(this)) {
                 func_8083CB94(this, play);
             } else {
@@ -7808,27 +7808,27 @@ void Player_Action_8084193C(Player* this, PlayState* play) {
             return;
         }
 
-        func_80840138(this, sp3C, sp3A);
+        func_80840138(this, speedTarget, yawTarget);
 
-        temp2 = sp3A - this->yaw;
+        temp2 = yawTarget - this->yaw;
         temp3 = ABS(temp2);
 
         if (temp3 > 0x4000) {
             if (Math_StepToF(&this->speedXZ, 0.0f, 3.0f) != 0) {
-                this->yaw = sp3A;
+                this->yaw = yawTarget;
             }
             return;
         }
 
-        sp3C *= 0.9f;
-        Math_AsymStepToF(&this->speedXZ, sp3C, 2.0f, 3.0f);
-        Math_ScaledStepToS(&this->yaw, sp3A, temp3 * 0.1f);
+        speedTarget *= 0.9f;
+        Math_AsymStepToF(&this->speedXZ, speedTarget, 2.0f, 3.0f);
+        Math_ScaledStepToS(&this->yaw, yawTarget, temp3 * 0.1f);
     }
 }
 
 void Player_Action_80841BA8(Player* this, PlayState* play) {
-    f32 sp34;
-    s16 sp32;
+    f32 speedTarget;
+    s16 yawTarget;
 
     LinkAnimation_Update(play, &this->skelAnime);
 
@@ -7839,13 +7839,13 @@ void Player_Action_80841BA8(Player* this, PlayState* play) {
                                      this->skelAnime.morphTable, sUpperBodyLimbCopyMap);
     }
 
-    Player_GetMovementSpeedAndYaw(this, &sp34, &sp32, 0.018f, play);
+    Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_CURVED, play);
 
     if (!func_80837348(play, this, D_80854414, 1)) {
-        if (sp34 != 0.0f) {
-            this->actor.shape.rot.y = sp32;
+        if (speedTarget != 0.0f) {
+            this->actor.shape.rot.y = yawTarget;
             func_8083C858(this, play);
-        } else if (Math_ScaledStepToS(&this->actor.shape.rot.y, sp32, this->unk_87E)) {
+        } else if (Math_ScaledStepToS(&this->actor.shape.rot.y, yawTarget, this->unk_87E)) {
             func_8083C0E8(this, play);
         }
 
@@ -7951,8 +7951,8 @@ void func_80841EE4(Player* this, PlayState* play) {
 }
 
 void Player_Action_80842180(Player* this, PlayState* play) {
-    f32 sp2C;
-    s16 sp2A;
+    f32 speedTarget;
+    s16 yawTarget;
 
     this->stateFlags2 |= PLAYER_STATE2_5;
     func_80841EE4(this, play);
@@ -7963,13 +7963,13 @@ void Player_Action_80842180(Player* this, PlayState* play) {
             return;
         }
 
-        Player_GetMovementSpeedAndYaw(this, &sp2C, &sp2A, 0.018f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_CURVED, play);
 
-        if (!func_8083C484(this, &sp2C, &sp2A)) {
-            func_8083DF68(this, sp2C, sp2A);
+        if (!func_8083C484(this, &speedTarget, &yawTarget)) {
+            func_8083DF68(this, speedTarget, yawTarget);
             func_8083DDC8(this, play);
 
-            if ((this->speedXZ == 0.0f) && (sp2C == 0.0f)) {
+            if ((this->speedXZ == 0.0f) && (speedTarget == 0.0f)) {
                 func_8083C0B8(this, play);
             }
         }
@@ -7977,8 +7977,8 @@ void Player_Action_80842180(Player* this, PlayState* play) {
 }
 
 void Player_Action_8084227C(Player* this, PlayState* play) {
-    f32 sp2C;
-    s16 sp2A;
+    f32 speedTarget;
+    s16 yawTarget;
 
     this->stateFlags2 |= PLAYER_STATE2_5;
     func_80841EE4(this, play);
@@ -7989,19 +7989,20 @@ void Player_Action_8084227C(Player* this, PlayState* play) {
             return;
         }
 
-        Player_GetMovementSpeedAndYaw(this, &sp2C, &sp2A, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
-        if (!func_8083C484(this, &sp2C, &sp2A)) {
-            if ((func_80833B2C(this) && (sp2C != 0.0f) && (func_8083FD78(this, &sp2C, &sp2A, play) <= 0)) ||
-                (!func_80833B2C(this) && (func_8083FC68(this, sp2C, sp2A) <= 0))) {
+        if (!func_8083C484(this, &speedTarget, &yawTarget)) {
+            if ((func_80833B2C(this) && (speedTarget != 0.0f) &&
+                 (func_8083FD78(this, &speedTarget, &yawTarget, play) <= 0)) ||
+                (!func_80833B2C(this) && (func_8083FC68(this, speedTarget, yawTarget) <= 0))) {
                 func_80839F90(this, play);
                 return;
             }
 
-            func_8083DF68(this, sp2C, sp2A);
+            func_8083DF68(this, speedTarget, yawTarget);
             func_8083DDC8(this, play);
 
-            if ((this->speedXZ == 0) && (sp2C == 0)) {
+            if ((this->speedXZ == 0) && (speedTarget == 0)) {
                 func_80839F90(this, play);
             }
         }
@@ -8010,8 +8011,8 @@ void Player_Action_8084227C(Player* this, PlayState* play) {
 
 void Player_Action_808423EC(Player* this, PlayState* play) {
     s32 sp34;
-    f32 sp30;
-    s16 sp2E;
+    f32 speedTarget;
+    s16 yawTarget;
 
     sp34 = LinkAnimation_Update(play, &this->skelAnime);
 
@@ -8021,13 +8022,13 @@ void Player_Action_808423EC(Player* this, PlayState* play) {
             return;
         }
 
-        Player_GetMovementSpeedAndYaw(this, &sp30, &sp2E, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
         if ((this->skelAnime.morphWeight == 0.0f) && (this->skelAnime.curFrame > 5.0f)) {
             func_8083721C(this);
 
-            if ((this->skelAnime.curFrame > 10.0f) && (func_8083FC68(this, sp30, sp2E) < 0)) {
-                func_8083CBF0(this, sp2E, play);
+            if ((this->skelAnime.curFrame > 10.0f) && (func_8083FC68(this, speedTarget, yawTarget) < 0)) {
+                func_8083CBF0(this, yawTarget, play);
                 return;
             }
 
@@ -8040,25 +8041,25 @@ void Player_Action_808423EC(Player* this, PlayState* play) {
 
 void Player_Action_8084251C(Player* this, PlayState* play) {
     s32 sp34;
-    f32 sp30;
-    s16 sp2E;
+    f32 speedTarget;
+    s16 yawTarget;
 
     sp34 = LinkAnimation_Update(play, &this->skelAnime);
 
     func_8083721C(this);
 
     if (!func_80837348(play, this, D_80854440, 1)) {
-        Player_GetMovementSpeedAndYaw(this, &sp30, &sp2E, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
         if (this->speedXZ == 0.0f) {
             this->yaw = this->actor.shape.rot.y;
 
-            if (func_8083FC68(this, sp30, sp2E) > 0) {
+            if (func_8083FC68(this, speedTarget, yawTarget) > 0) {
                 func_8083C858(this, play);
                 return;
             }
 
-            if ((sp30 != 0.0f) || (sp34 != 0)) {
+            if ((speedTarget != 0.0f) || (sp34 != 0)) {
                 func_80839F90(this, play);
             }
         }
@@ -8690,8 +8691,8 @@ void func_8084409C(PlayState* play, Player* this, f32 speedXZ, f32 velocityY) {
 }
 
 void Player_Action_8084411C(Player* this, PlayState* play) {
-    f32 sp4C;
-    s16 sp4A;
+    f32 speedTarget;
+    s16 yawTarget;
 
     if (gSaveContext.respawn[RESPAWN_MODE_TOP].data > 40) {
         this->actor.gravity = 0.0f;
@@ -8699,7 +8700,7 @@ void Player_Action_8084411C(Player* this, PlayState* play) {
         this->actor.gravity = -1.2f;
     }
 
-    Player_GetMovementSpeedAndYaw(this, &sp4C, &sp4A, 0.0f, play);
+    Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
     if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         if (this->stateFlags1 & PLAYER_STATE1_11) {
@@ -8714,7 +8715,7 @@ void Player_Action_8084411C(Player* this, PlayState* play) {
         LinkAnimation_Update(play, &this->skelAnime);
 
         if (!(this->stateFlags2 & PLAYER_STATE2_19)) {
-            func_8083DFE0(this, &sp4C, &sp4A);
+            func_8083DFE0(this, &speedTarget, &yawTarget);
         }
 
         Player_UpdateUpperBody(this, play);
@@ -8815,8 +8816,8 @@ void Player_Action_80844708(Player* this, PlayState* play) {
     s32 sp44;
     DynaPolyActor* wallPolyActor;
     s32 pad;
-    f32 sp38;
-    s16 sp36;
+    f32 speedTarget;
+    s16 yawTarget;
 
     this->stateFlags2 |= PLAYER_STATE2_5;
 
@@ -8870,14 +8871,14 @@ void Player_Action_80844708(Player* this, PlayState* play) {
                     return;
                 }
 
-                Player_GetMovementSpeedAndYaw(this, &sp38, &sp36, 0.018f, play);
+                Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_CURVED, play);
 
-                sp38 *= 1.5f;
-                if ((sp38 < 3.0f) || (this->unk_84B[this->unk_846] != 0)) {
-                    sp38 = 3.0f;
+                speedTarget *= 1.5f;
+                if ((speedTarget < 3.0f) || (this->unk_84B[this->unk_846] != 0)) {
+                    speedTarget = 3.0f;
                 }
 
-                func_8083DF68(this, sp38, this->actor.shape.rot.y);
+                func_8083DF68(this, speedTarget, this->actor.shape.rot.y);
 
                 if (func_8084269C(play, this)) {
                     func_8002F8F0(&this->actor, NA_SE_PL_ROLL_DUST - SFX_FLAG);
@@ -8905,8 +8906,8 @@ void Player_Action_80844A44(Player* this, PlayState* play) {
 }
 
 void Player_Action_80844AF4(Player* this, PlayState* play) {
-    f32 sp2C;
-    s16 sp2A;
+    f32 speedTarget;
+    s16 yawTarget;
 
     this->stateFlags2 |= PLAYER_STATE2_5;
 
@@ -8917,8 +8918,8 @@ void Player_Action_80844AF4(Player* this, PlayState* play) {
         func_8084285C(this, 6.0f, 7.0f, 99.0f);
 
         if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
-            Player_GetMovementSpeedAndYaw(this, &sp2C, &sp2A, 0.0f, play);
-            func_8083DFE0(this, &sp2C, &this->yaw);
+            Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
+            func_8083DFE0(this, &speedTarget, &this->yaw);
             return;
         }
 
@@ -8986,8 +8987,8 @@ void func_80844E3C(Player* this) {
 }
 
 void Player_Action_80844E68(Player* this, PlayState* play) {
-    f32 sp34;
-    s16 sp32;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp;
 
     this->stateFlags1 |= PLAYER_STATE1_12;
@@ -9013,9 +9014,9 @@ void Player_Action_80844E68(Player* this, PlayState* play) {
                 func_80844D68(this, play);
             }
         } else if (!func_80844BE4(this, play)) {
-            Player_GetMovementSpeedAndYaw(this, &sp34, &sp32, 0.0f, play);
+            Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
-            temp = func_80840058(this, &sp34, &sp32, play);
+            temp = func_80840058(this, &speedTarget, &yawTarget, play);
             if (temp > 0) {
                 func_80844CF8(this, play);
             } else if (temp < 0) {
@@ -9030,8 +9031,8 @@ void Player_Action_80845000(Player* this, PlayState* play) {
     s32 temp2;
     f32 sp5C;
     f32 sp58;
-    f32 sp54;
-    s16 sp52;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp4;
     s16 temp5;
     s32 sp44;
@@ -9060,9 +9061,9 @@ void Player_Action_80845000(Player* this, PlayState* play) {
 
     if (!func_80842964(this, play) && !func_80844BE4(this, play)) {
         func_80844E3C(this);
-        Player_GetMovementSpeedAndYaw(this, &sp54, &sp52, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
-        temp4 = func_80840058(this, &sp54, &sp52, play);
+        temp4 = func_80840058(this, &speedTarget, &yawTarget, play);
 
         if (temp4 < 0) {
             func_80844D30(this, play);
@@ -9070,24 +9071,24 @@ void Player_Action_80845000(Player* this, PlayState* play) {
         }
 
         if (temp4 == 0) {
-            sp54 = 0.0f;
-            sp52 = this->yaw;
+            speedTarget = 0.0f;
+            yawTarget = this->yaw;
         }
 
-        temp5 = sp52 - this->yaw;
+        temp5 = yawTarget - this->yaw;
         sp44 = ABS(temp5);
 
         if (sp44 > 0x4000) {
             if (Math_StepToF(&this->speedXZ, 0.0f, 1.0f)) {
-                this->yaw = sp52;
+                this->yaw = yawTarget;
             }
             return;
         }
 
-        Math_AsymStepToF(&this->speedXZ, sp54 * 0.2f, 1.0f, 0.5f);
-        Math_ScaledStepToS(&this->yaw, sp52, sp44 * 0.1f);
+        Math_AsymStepToF(&this->speedXZ, speedTarget * 0.2f, 1.0f, 0.5f);
+        Math_ScaledStepToS(&this->yaw, yawTarget, sp44 * 0.1f);
 
-        if ((sp54 == 0.0f) && (this->speedXZ == 0.0f)) {
+        if ((speedTarget == 0.0f) && (this->speedXZ == 0.0f)) {
             func_80844DC8(this, play);
         }
     }
@@ -9096,8 +9097,8 @@ void Player_Action_80845000(Player* this, PlayState* play) {
 void Player_Action_80845308(Player* this, PlayState* play) {
     f32 sp5C;
     f32 sp58;
-    f32 sp54;
-    s16 sp52;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp4;
     s16 temp5;
     s32 sp44;
@@ -9128,9 +9129,9 @@ void Player_Action_80845308(Player* this, PlayState* play) {
 
     if (!func_80842964(this, play) && !func_80844BE4(this, play)) {
         func_80844E3C(this);
-        Player_GetMovementSpeedAndYaw(this, &sp54, &sp52, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
-        temp4 = func_80840058(this, &sp54, &sp52, play);
+        temp4 = func_80840058(this, &speedTarget, &yawTarget, play);
 
         if (temp4 > 0) {
             func_80844CF8(this, play);
@@ -9138,24 +9139,24 @@ void Player_Action_80845308(Player* this, PlayState* play) {
         }
 
         if (temp4 == 0) {
-            sp54 = 0.0f;
-            sp52 = this->yaw;
+            speedTarget = 0.0f;
+            yawTarget = this->yaw;
         }
 
-        temp5 = sp52 - this->yaw;
+        temp5 = yawTarget - this->yaw;
         sp44 = ABS(temp5);
 
         if (sp44 > 0x4000) {
             if (Math_StepToF(&this->speedXZ, 0.0f, 1.0f)) {
-                this->yaw = sp52;
+                this->yaw = yawTarget;
             }
             return;
         }
 
-        Math_AsymStepToF(&this->speedXZ, sp54 * 0.2f, 1.0f, 0.5f);
-        Math_ScaledStepToS(&this->yaw, sp52, sp44 * 0.1f);
+        Math_AsymStepToF(&this->speedXZ, speedTarget * 0.2f, 1.0f, 0.5f);
+        Math_ScaledStepToS(&this->yaw, yawTarget, sp44 * 0.1f);
 
-        if ((sp54 == 0.0f) && (this->speedXZ == 0.0f) && (sp5C == 0.0f)) {
+        if ((speedTarget == 0.0f) && (this->speedXZ == 0.0f) && (sp5C == 0.0f)) {
             func_80844DC8(this, play);
         }
     }
@@ -9558,13 +9559,14 @@ void Player_Action_808464B0(Player* this, PlayState* play) {
 }
 
 void Player_Action_80846578(Player* this, PlayState* play) {
-    f32 sp34;
-    s16 sp32;
+    f32 speedTarget;
+    s16 yawTarget;
 
     func_8083721C(this);
 
     if (LinkAnimation_Update(play, &this->skelAnime) ||
-        ((this->skelAnime.curFrame >= 8.0f) && Player_GetMovementSpeedAndYaw(this, &sp34, &sp32, 0.018f, play))) {
+        ((this->skelAnime.curFrame >= 8.0f) &&
+         Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_CURVED, play))) {
         func_80839F90(this, play);
         return;
     }
@@ -11587,8 +11589,8 @@ void Player_Action_8084B530(Player* this, PlayState* play) {
 }
 
 void Player_Action_8084B78C(Player* this, PlayState* play) {
-    f32 sp34;
-    s16 sp32;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp;
 
     this->stateFlags2 |= PLAYER_STATE2_0 | PLAYER_STATE2_6 | PLAYER_STATE2_8;
@@ -11596,8 +11598,8 @@ void Player_Action_8084B78C(Player* this, PlayState* play) {
 
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         if (!func_8083F9D0(play, this)) {
-            Player_GetMovementSpeedAndYaw(this, &sp34, &sp32, 0.0f, play);
-            temp = func_8083FFB8(this, &sp34, &sp32);
+            Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
+            temp = func_8083FFB8(this, &speedTarget, &yawTarget);
             if (temp > 0) {
                 func_8083FAB8(this, play);
             } else if (temp < 0) {
@@ -11623,8 +11625,8 @@ static struct_80832924 D_80854870[] = {
 };
 
 void Player_Action_8084B898(Player* this, PlayState* play) {
-    f32 sp34;
-    s16 sp32;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp;
 
     this->stateFlags2 |= PLAYER_STATE2_0 | PLAYER_STATE2_6 | PLAYER_STATE2_8;
@@ -11641,8 +11643,8 @@ void Player_Action_8084B898(Player* this, PlayState* play) {
     func_8083F524(play, this);
 
     if (!func_8083F9D0(play, this)) {
-        Player_GetMovementSpeedAndYaw(this, &sp34, &sp32, 0.0f, play);
-        temp = func_8083FFB8(this, &sp34, &sp32);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
+        temp = func_8083FFB8(this, &speedTarget, &yawTarget);
         if (temp < 0) {
             func_8083FB14(this, play);
         } else if (temp == 0) {
@@ -11667,8 +11669,8 @@ static Vec3f D_80854880 = { 0.0f, 26.0f, -40.0f };
 
 void Player_Action_8084B9E4(Player* this, PlayState* play) {
     LinkAnimationHeader* anim;
-    f32 sp70;
-    s16 sp6E;
+    f32 speedTarget;
+    s16 yawTarget;
     s32 temp1;
     Vec3f sp5C;
     f32 temp2;
@@ -11695,8 +11697,8 @@ void Player_Action_8084B9E4(Player* this, PlayState* play) {
     func_8083F524(play, this);
 
     if (!func_8083F9D0(play, this)) {
-        Player_GetMovementSpeedAndYaw(this, &sp70, &sp6E, 0.0f, play);
-        temp1 = func_8083FFB8(this, &sp70, &sp6E);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
+        temp1 = func_8083FFB8(this, &speedTarget, &yawTarget);
         if (temp1 > 0) {
             func_8083FAB8(this, play);
         } else if (temp1 == 0) {
@@ -11722,8 +11724,8 @@ void Player_Action_8084B9E4(Player* this, PlayState* play) {
 }
 
 void Player_Action_8084BBE4(Player* this, PlayState* play) {
-    f32 sp3C;
-    s16 sp3A;
+    f32 speedTarget;
+    s16 yawTarget;
     LinkAnimationHeader* anim;
     f32 temp;
 
@@ -11753,7 +11755,7 @@ void Player_Action_8084BBE4(Player* this, PlayState* play) {
     Math_ScaledStepToS(&this->actor.shape.rot.y, this->yaw, 0x800);
 
     if (this->actionVar1 != 0) {
-        Player_GetMovementSpeedAndYaw(this, &sp3C, &sp3A, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
         if (this->unk_847[this->unk_846] >= 0) {
             if (this->actionVar1 > 0) {
                 anim = GET_PLAYER_ANIM(PLAYER_ANIMGROUP_fall_up, this->modelAnimType);
@@ -12413,8 +12415,8 @@ void func_8084D5CC(PlayState* play, Player* this) {
 }
 
 void Player_Action_8084D610(Player* this, PlayState* play) {
-    f32 sp34;
-    s16 sp32;
+    f32 speedTarget;
+    s16 yawTarget;
 
     func_80832CB0(play, this, &gPlayerAnim_link_swimer_swim_wait);
     func_8084B000(this);
@@ -12426,18 +12428,18 @@ void Player_Action_8084D610(Player* this, PlayState* play) {
         }
 
         if (this->currentBoots == PLAYER_BOOTS_IRON) {
-            sp34 = 0.0f;
-            sp32 = this->actor.shape.rot.y;
+            speedTarget = 0.0f;
+            yawTarget = this->actor.shape.rot.y;
 
             if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
                 func_8083A098(this, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_short_landing, this->modelAnimType), play);
                 func_808328A0(this);
             }
         } else {
-            Player_GetMovementSpeedAndYaw(this, &sp34, &sp32, 0.0f, play);
+            Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
-            if (sp34 != 0.0f) {
-                s16 temp = this->actor.shape.rot.y - sp32;
+            if (speedTarget != 0.0f) {
+                s16 temp = this->actor.shape.rot.y - yawTarget;
 
                 if ((ABS(temp) > 0x6000) && !Math_StepToF(&this->speedXZ, 0.0f, 1.0f)) {
                     return;
@@ -12446,12 +12448,12 @@ void Player_Action_8084D610(Player* this, PlayState* play) {
                 if (func_80833C04(this)) {
                     func_8084D5CC(play, this);
                 } else {
-                    func_8084D574(play, this, sp32);
+                    func_8084D574(play, this, yawTarget);
                 }
             }
         }
 
-        func_8084AEEC(this, &this->speedXZ, sp34, sp32);
+        func_8084AEEC(this, &this->speedXZ, speedTarget, yawTarget);
     }
 }
 
@@ -12469,8 +12471,8 @@ void Player_Action_8084D7C4(Player* this, PlayState* play) {
 }
 
 void Player_Action_8084D84C(Player* this, PlayState* play) {
-    f32 sp34;
-    s16 sp32;
+    f32 speedTarget;
+    s16 yawTarget;
     s16 temp;
 
     this->stateFlags2 |= PLAYER_STATE2_5;
@@ -12479,16 +12481,16 @@ void Player_Action_8084D84C(Player* this, PlayState* play) {
     func_8084B000(this);
 
     if (!func_80837348(play, this, D_80854444, 1) && !func_8083D12C(play, this, sControlInput)) {
-        Player_GetMovementSpeedAndYaw(this, &sp34, &sp32, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
-        temp = this->actor.shape.rot.y - sp32;
-        if ((sp34 == 0.0f) || (ABS(temp) > 0x6000) || (this->currentBoots == PLAYER_BOOTS_IRON)) {
+        temp = this->actor.shape.rot.y - yawTarget;
+        if ((speedTarget == 0.0f) || (ABS(temp) > 0x6000) || (this->currentBoots == PLAYER_BOOTS_IRON)) {
             func_80838F18(play, this);
         } else if (func_80833C04(this)) {
             func_8084D5CC(play, this);
         }
 
-        func_8084D530(this, &this->speedXZ, sp34, sp32);
+        func_8084D530(this, &this->speedXZ, speedTarget, yawTarget);
     }
 }
 
@@ -12531,33 +12533,33 @@ s32 func_8084D980(PlayState* play, Player* this, f32* arg2, s16* arg3) {
 }
 
 void Player_Action_8084DAB4(Player* this, PlayState* play) {
-    f32 sp2C;
-    s16 sp2A;
+    f32 speedTarget;
+    s16 yawTarget;
 
     func_8084B158(play, this, sControlInput, this->speedXZ);
     func_8084B000(this);
 
     if (!func_80837348(play, this, D_80854444, 1) && !func_8083D12C(play, this, sControlInput)) {
-        Player_GetMovementSpeedAndYaw(this, &sp2C, &sp2A, 0.0f, play);
+        Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
 
-        if (sp2C == 0.0f) {
+        if (speedTarget == 0.0f) {
             func_80838F18(play, this);
         } else if (!func_80833C04(this)) {
-            func_8084D574(play, this, sp2A);
+            func_8084D574(play, this, yawTarget);
         } else {
-            func_8084D980(play, this, &sp2C, &sp2A);
+            func_8084D980(play, this, &speedTarget, &yawTarget);
         }
 
-        func_8084D530(this, &this->speedXZ, sp2C, sp2A);
+        func_8084D530(this, &this->speedXZ, speedTarget, yawTarget);
     }
 }
 
 void func_8084DBC4(PlayState* play, Player* this, f32 arg2) {
-    f32 sp2C;
-    s16 sp2A;
+    f32 speedTarget;
+    s16 yawTarget;
 
-    Player_GetMovementSpeedAndYaw(this, &sp2C, &sp2A, 0.0f, play);
-    func_8084AEEC(this, &this->speedXZ, sp2C * 0.5f, sp2A);
+    Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
+    func_8084AEEC(this, &this->speedXZ, speedTarget * 0.5f, yawTarget);
     func_8084AEEC(this, &this->actor.velocity.y, arg2, this->yaw);
 }
 


### PR DESCRIPTION
This documents the player code relevant to the control stick, and calculating speed and yaw based on the control stick.

Main function renames:
`func_80077D10` -> `Lib_GetControlStickData`
`func_8083315C` -> `Player_ProcessControlStick`
`func_80836FAC` -> `Player_CalcSpeedAndYawFromControlStick`
`func_80837268` -> `Player_GetMovementSpeedAndYaw`

`Player_GetMovementSpeedAndYaw` is a wrapper for `Player_CalcSpeedAndYawFromControlStick` which does the actual calculation. The more detailed function description was placed on the wrapper as that is the function that gets "publicly" used. 

The "speed mode" stuff is really strange, and took alot of figuring out from me and @Thar0. If there are any questions on how it works feel free to ask, but hopefully the comments that were added help to explain the weirdness.

Theres alot of diff noise from renaming the temps passed to `Player_GetMovementSpeedAndYaw`. Apologies.
