### PR TITLE
Player Docs: Initial AnimSfx stuff

### DIFF
--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -75,15 +75,15 @@ typedef struct {
 } SpecialRespawnInfo; // size = 0x10
 
 typedef enum {
-    /*  1 */ ANIMSFX_TYPE_1 = 1,
-    /*  2 */ ANIMSFX_TYPE_2,
-    /*  3 */ ANIMSFX_TYPE_3,
-    /*  4 */ ANIMSFX_TYPE_4,
-    /*  5 */ ANIMSFX_TYPE_5,
-    /*  6 */ ANIMSFX_TYPE_6,
-    /*  7 */ ANIMSFX_TYPE_7,
-    /*  8 */ ANIMSFX_TYPE_8,
-    /*  9 */ ANIMSFX_TYPE_9
+    /* 1 */ ANIMSFX_TYPE_1 = 1,
+    /* 2 */ ANIMSFX_TYPE_2,
+    /* 3 */ ANIMSFX_TYPE_3,
+    /* 4 */ ANIMSFX_TYPE_4,
+    /* 5 */ ANIMSFX_TYPE_5,
+    /* 6 */ ANIMSFX_TYPE_6,
+    /* 7 */ ANIMSFX_TYPE_7,
+    /* 8 */ ANIMSFX_TYPE_8,
+    /* 9 */ ANIMSFX_TYPE_9
 } AnimSfxType;
 
 #define ANIMSFX_SHIFT_TYPE(type) ((type) << 11)

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1827,7 +1827,7 @@ void func_808328EC(Player* this, u16 sfxId) {
  * The list will stop being processed after an entry that has a negative value for the `data` field.
  *
  * Some types do not make use of `sfxId`, the SFX function called will pick a sound on its own.
- * The `sfxId` field is not used in this case and can be any value, but 0 is typiclly used.
+ * The `sfxId` field is not used in this case and can be any value, but 0 is typically used.
  *
  * @param entry  A pointer to the first entry of an `AnimSfx` list.
  */
@@ -1862,7 +1862,7 @@ void Player_ProcessAnimSfxList(Player* this, AnimSfxEntry* entry) {
             }
         }
         
-        cont = (entry->data >= 0); // continue processing if `data` is positive
+        cont = (entry->data >= 0); // stop processing if `data` is negative
         entry++;
     } while (cont);
 }

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -74,10 +74,29 @@ typedef struct {
     /* 0x0C */ s16 yaw;
 } SpecialRespawnInfo; // size = 0x10
 
+typedef enum {
+    /*  1 */ ANIMSFX_TYPE_1 = 1,
+    /*  2 */ ANIMSFX_TYPE_2,
+    /*  3 */ ANIMSFX_TYPE_3,
+    /*  4 */ ANIMSFX_TYPE_4,
+    /*  5 */ ANIMSFX_TYPE_5,
+    /*  6 */ ANIMSFX_TYPE_6,
+    /*  7 */ ANIMSFX_TYPE_7,
+    /*  8 */ ANIMSFX_TYPE_8,
+    /*  9 */ ANIMSFX_TYPE_9
+} AnimSfxType;
+
+#define ANIMSFX_SHIFT_TYPE(type) ((type) << 11)
+
+#define ANIMSFX_DATA(type, frame) ((ANIMSFX_SHIFT_TYPE(type) | ((frame)&0x7FF)))
+
+#define ANIMSFX_GET_TYPE(data) ((data)&0x7800)
+#define ANIMSFX_GET_FRAME(data) ((data)&0x7FF)
+
 typedef struct {
     /* 0x00 */ u16 sfxId;
-    /* 0x02 */ s16 field;
-} struct_80832924; // size = 0x04
+    /* 0x02 */ s16 data;
+} AnimSfxEntry; // size = 0x04
 
 typedef struct {
     /* 0x00 */ u16 unk_00;
@@ -1099,54 +1118,57 @@ static LinkAnimationHeader* D_80853D7C[][2] = {
     { &gPlayerAnim_link_wait_itemD2_20f, &gPlayerAnim_link_wait_itemD2_20f }
 };
 
-static struct_80832924 D_80853DEC[] = {
-    { NA_SE_VO_LI_SNEEZE, -0x2008 },
+static AnimSfxEntry D_80853DEC[] = {
+    { NA_SE_VO_LI_SNEEZE, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 8) },
 };
 
-static struct_80832924 D_80853DF0[] = {
-    { NA_SE_VO_LI_SWEAT, -0x2012 },
+static AnimSfxEntry D_80853DF0[] = {
+    { NA_SE_VO_LI_SWEAT, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 18) },
 };
 
-static struct_80832924 D_80853DF4[] = {
-    { NA_SE_VO_LI_BREATH_REST, -0x200D },
+static AnimSfxEntry D_80853DF4[] = {
+    { NA_SE_VO_LI_BREATH_REST, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 13) },
 };
 
-static struct_80832924 D_80853DF8[] = {
-    { NA_SE_VO_LI_BREATH_REST, -0x200A },
+static AnimSfxEntry D_80853DF8[] = {
+    { NA_SE_VO_LI_BREATH_REST, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 10) },
 };
 
-static struct_80832924 D_80853DFC[] = {
-    { NA_SE_PL_CALM_HIT, 0x82C }, { NA_SE_PL_CALM_HIT, 0x830 },  { NA_SE_PL_CALM_HIT, 0x834 },
-    { NA_SE_PL_CALM_HIT, 0x838 }, { NA_SE_PL_CALM_HIT, -0x83C },
+static AnimSfxEntry D_80853DFC[] = {
+    { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 44) },  { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 48) },
+    { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 52) },  { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 56) },
+    { NA_SE_PL_CALM_HIT, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 60) },
 };
 
-static struct_80832924 D_80853E10[] = {
-    { 0, 0x4019 }, { 0, 0x401E }, { 0, 0x402C }, { 0, 0x4030 }, { 0, 0x4034 }, { 0, -0x4038 },
+static AnimSfxEntry D_80853E10[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 25) }, { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 30) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 44) }, { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 48) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 52) }, { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_8, 56) },
 };
 
-static struct_80832924 D_80853E28[] = {
-    { NA_SE_IT_SHIELD_POSTURE, 0x810 },
-    { NA_SE_IT_SHIELD_POSTURE, 0x814 },
-    { NA_SE_IT_SHIELD_POSTURE, -0x846 },
+static AnimSfxEntry D_80853E28[] = {
+    { NA_SE_IT_SHIELD_POSTURE, ANIMSFX_DATA(ANIMSFX_TYPE_1, 16) },
+    { NA_SE_IT_SHIELD_POSTURE, ANIMSFX_DATA(ANIMSFX_TYPE_1, 20) },
+    { NA_SE_IT_SHIELD_POSTURE, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 70) },
 };
 
-static struct_80832924 D_80853E34[] = {
-    { NA_SE_IT_HAMMER_SWING, 0x80A },
-    { NA_SE_VO_LI_AUTO_JUMP, 0x200A },
-    { NA_SE_IT_SWORD_SWING, 0x816 },
-    { NA_SE_VO_LI_SWORD_N, -0x2016 },
+static AnimSfxEntry D_80853E34[] = {
+    { NA_SE_IT_HAMMER_SWING, ANIMSFX_DATA(ANIMSFX_TYPE_1, 10) },
+    { NA_SE_VO_LI_AUTO_JUMP, ANIMSFX_DATA(ANIMSFX_TYPE_4, 10) },
+    { NA_SE_IT_SWORD_SWING, ANIMSFX_DATA(ANIMSFX_TYPE_1, 22) },
+    { NA_SE_VO_LI_SWORD_N, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 22) },
 };
 
-static struct_80832924 D_80853E44[] = {
-    { NA_SE_IT_SWORD_SWING, 0x827 },
-    { NA_SE_VO_LI_SWORD_N, -0x2027 },
+static AnimSfxEntry D_80853E44[] = {
+    { NA_SE_IT_SWORD_SWING, ANIMSFX_DATA(ANIMSFX_TYPE_1, 39) },
+    { NA_SE_VO_LI_SWORD_N, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 39) },
 };
 
-static struct_80832924 D_80853E4C[] = {
-    { NA_SE_VO_LI_RELAX, -0x2014 },
+static AnimSfxEntry D_80853E4C[] = {
+    { NA_SE_VO_LI_RELAX, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 20) },
 };
 
-static struct_80832924* D_80853E50[] = {
+static AnimSfxEntry* D_80853E50[] = {
     D_80853DEC, D_80853DF0, D_80853DF4, D_80853DF8, D_80853DFC, D_80853E10,
     D_80853E28, D_80853E34, D_80853E44, D_80853E4C, NULL,
 };
@@ -1797,38 +1819,50 @@ void func_808328EC(Player* this, u16 sfxId) {
     this->stateFlags2 |= PLAYER_STATE2_3;
 }
 
-void func_80832924(Player* this, struct_80832924* entry) {
-    s32 data;
-    s32 flags;
-    u32 cont;
+/**
+ * Process a list of `AnimSfx` entries.
+ * An `AnimSfx` entry contains a sound effect to play, a frame number that indicates
+ * when during an animation it should play, and a type value that indicates how it should be played back.
+ * 
+ * The list will stop being processed after an entry that has a negative value for the `data` field.
+ *
+ * Some types do not make use of `sfxId`, the SFX function called will pick a sound on its own.
+ * The `sfxId` field is not used in this case and can be any value, but 0 is typiclly used.
+ *
+ * @param entry  A pointer to the first entry of an `AnimSfx` list.
+ */
+void Player_ProcessAnimSfxList(Player* this, AnimSfxEntry* entry) {
+    s32 cont;
     s32 pad;
 
     do {
-        data = ABS(entry->field);
-        flags = data & 0x7800;
-        if (LinkAnimation_OnFrame(&this->skelAnime, fabsf(data & 0x7FF))) {
-            if (flags == 0x800) {
+        s32 absData = ABS(entry->data);
+        s32 type = ANIMSFX_GET_TYPE(absData);
+
+        if (LinkAnimation_OnFrame(&this->skelAnime, fabsf(ANIMSFX_GET_FRAME(absData)))) {
+            if (type == ANIMSFX_SHIFT_TYPE(ANIMSFX_TYPE_1)) {
                 Player_PlaySfx(this, entry->sfxId);
-            } else if (flags == 0x1000) {
+            } else if (type == ANIMSFX_SHIFT_TYPE(ANIMSFX_TYPE_2)) {
                 func_80832770(this, entry->sfxId);
-            } else if (flags == 0x1800) {
+            } else if (type == ANIMSFX_SHIFT_TYPE(ANIMSFX_TYPE_3)) {
                 func_808327C4(this, entry->sfxId);
-            } else if (flags == 0x2000) {
+            } else if (type == ANIMSFX_SHIFT_TYPE(ANIMSFX_TYPE_4)) {
                 func_80832698(this, entry->sfxId);
-            } else if (flags == 0x2800) {
+            } else if (type == ANIMSFX_SHIFT_TYPE(ANIMSFX_TYPE_5)) {
                 func_808328A0(this);
-            } else if (flags == 0x3000) {
+            } else if (type == ANIMSFX_SHIFT_TYPE(ANIMSFX_TYPE_6)) {
                 func_808327F8(this, 6.0f);
-            } else if (flags == 0x3800) {
+            } else if (type == ANIMSFX_SHIFT_TYPE(ANIMSFX_TYPE_7)) {
                 func_80832854(this);
-            } else if (flags == 0x4000) {
+            } else if (type == ANIMSFX_SHIFT_TYPE(ANIMSFX_TYPE_8)) {
                 func_808327F8(this, 0.0f);
-            } else if (flags == 0x4800) {
+            } else if (type == ANIMSFX_SHIFT_TYPE(ANIMSFX_TYPE_9)) {
                 func_800F4010(&this->actor.projectedPos,
                               NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD + this->ageProperties->unk_94, 0.0f);
             }
         }
-        cont = (entry->field >= 0);
+        
+        cont = (entry->data >= 0); // continue processing if `data` is positive
         entry++;
     } while (cont);
 }
@@ -2043,7 +2077,7 @@ s32 func_80833350(Player* this) {
 
 void func_808333FC(Player* this, s32 arg1) {
     if (D_80853E7C[arg1] != 0) {
-        func_80832924(this, D_80853E50[D_80853E7C[arg1] - 1]);
+        Player_ProcessAnimSfxList(this, D_80853E50[D_80853E7C[arg1] - 1]);
     }
 }
 
@@ -8623,9 +8657,9 @@ void Player_Action_80843954(Player* this, PlayState* play) {
     }
 }
 
-static struct_80832924 D_808545DC[] = {
-    { 0, 0x4014 },
-    { 0, -0x401E },
+static AnimSfxEntry D_808545DC[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 20) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_8, 30) },
 };
 
 void Player_Action_80843A38(Player* this, PlayState* play) {
@@ -8643,7 +8677,7 @@ void Player_Action_80843A38(Player* this, PlayState* play) {
         }
     }
 
-    func_80832924(this, D_808545DC);
+    Player_ProcessAnimSfxList(this, D_808545DC);
 }
 
 static Vec3f D_808545E4 = { 0.0f, 0.0f, 5.0f };
@@ -8685,11 +8719,11 @@ void func_80843AE8(PlayState* play, Player* this) {
     }
 }
 
-static struct_80832924 D_808545F0[] = {
-    { NA_SE_PL_BOUND, 0x103C },
-    { 0, 0x408C },
-    { 0, 0x40A4 },
-    { 0, -0x40AA },
+static AnimSfxEntry D_808545F0[] = {
+    { NA_SE_PL_BOUND, ANIMSFX_DATA(ANIMSFX_TYPE_2, 60) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 140) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 164) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_8, 170) },
 };
 
 void Player_Action_80843CEC(Player* this, PlayState* play) {
@@ -8711,7 +8745,7 @@ void Player_Action_80843CEC(Player* this, PlayState* play) {
     }
 
     if (this->skelAnime.animation == &gPlayerAnim_link_derth_rebirth) {
-        func_80832924(this, D_808545F0);
+        Player_ProcessAnimSfxList(this, D_808545F0);
     } else if (this->skelAnime.animation == &gPlayerAnim_link_normal_electric_shock_end) {
         if (LinkAnimation_OnFrame(&this->skelAnime, 88.0f)) {
             func_80832770(this, NA_SE_PL_BOUND);
@@ -8916,11 +8950,11 @@ void Player_Action_8084411C(Player* this, PlayState* play) {
     }
 }
 
-static struct_80832924 D_8085460C[] = {
-    { NA_SE_VO_LI_SWORD_N, 0x2001 },
-    { NA_SE_PL_WALK_GROUND, 0x1806 },
-    { NA_SE_PL_ROLL, 0x806 },
-    { 0, -0x2812 },
+static AnimSfxEntry D_8085460C[] = {
+    { NA_SE_VO_LI_SWORD_N, ANIMSFX_DATA(ANIMSFX_TYPE_4, 1) },
+    { NA_SE_PL_WALK_GROUND, ANIMSFX_DATA(ANIMSFX_TYPE_3, 6) },
+    { NA_SE_PL_ROLL, ANIMSFX_DATA(ANIMSFX_TYPE_1, 6) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_5, 18) },
 };
 
 void Player_Action_80844708(Player* this, PlayState* play) {
@@ -8997,7 +9031,7 @@ void Player_Action_80844708(Player* this, PlayState* play) {
                     func_8002F8F0(&this->actor, NA_SE_PL_ROLL_DUST - SFX_FLAG);
                 }
 
-                func_80832924(this, D_8085460C);
+                Player_ProcessAnimSfxList(this, D_8085460C);
             }
         }
     }
@@ -9547,9 +9581,9 @@ void Player_Action_80846050(Player* this, PlayState* play) {
     Math_ScaledStepToS(&this->unk_3BC.y, 0, 4000);
 }
 
-static struct_80832924 D_8085461C[] = {
-    { NA_SE_VO_LI_SWORD_L, 0x2031 },
-    { NA_SE_VO_LI_SWORD_N, -0x20E6 },
+static AnimSfxEntry D_8085461C[] = {
+    { NA_SE_VO_LI_SWORD_L, ANIMSFX_DATA(ANIMSFX_TYPE_4, 49) },
+    { NA_SE_VO_LI_SWORD_N, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 230) },
 };
 
 void Player_Action_80846120(Player* this, PlayState* play) {
@@ -9581,7 +9615,7 @@ void Player_Action_80846120(Player* this, PlayState* play) {
         return;
     }
 
-    func_80832924(this, D_8085461C);
+    Player_ProcessAnimSfxList(this, D_8085461C);
 }
 
 void Player_Action_80846260(Player* this, PlayState* play) {
@@ -11735,9 +11769,9 @@ void func_8084B840(PlayState* play, Player* this, f32 arg2) {
     }
 }
 
-static struct_80832924 D_80854870[] = {
-    { NA_SE_PL_SLIP, 0x1003 },
-    { NA_SE_PL_SLIP, -0x1015 },
+static AnimSfxEntry D_80854870[] = {
+    { NA_SE_PL_SLIP, ANIMSFX_DATA(ANIMSFX_TYPE_2, 3) },
+    { NA_SE_PL_SLIP, -ANIMSFX_DATA(ANIMSFX_TYPE_2, 21) },
 };
 
 void Player_Action_8084B898(Player* this, PlayState* play) {
@@ -11755,7 +11789,7 @@ void Player_Action_8084B898(Player* this, PlayState* play) {
         }
     }
 
-    func_80832924(this, D_80854870);
+    Player_ProcessAnimSfxList(this, D_80854870);
     func_8083F524(play, this);
 
     if (!func_8083F9D0(play, this)) {
@@ -11776,9 +11810,9 @@ void Player_Action_8084B898(Player* this, PlayState* play) {
     }
 }
 
-static struct_80832924 D_80854878[] = {
-    { NA_SE_PL_SLIP, 0x1004 },
-    { NA_SE_PL_SLIP, -0x1018 },
+static AnimSfxEntry D_80854878[] = {
+    { NA_SE_PL_SLIP, ANIMSFX_DATA(ANIMSFX_TYPE_2, 4) },
+    { NA_SE_PL_SLIP, -ANIMSFX_DATA(ANIMSFX_TYPE_2, 24) },
 };
 
 static Vec3f D_80854880 = { 0.0f, 26.0f, -40.0f };
@@ -11806,7 +11840,7 @@ void Player_Action_8084B9E4(Player* this, PlayState* play) {
                 func_80832698(this, NA_SE_VO_LI_PUSH);
             }
         } else {
-            func_80832924(this, D_80854878);
+            Player_ProcessAnimSfxList(this, D_80854878);
         }
     }
 
@@ -12064,10 +12098,10 @@ void Player_Action_8084BF1C(Player* this, PlayState* play) {
 static f32 D_80854898[] = { 10.0f, 20.0f };
 static f32 D_808548A0[] = { 40.0f, 50.0f };
 
-static struct_80832924 D_808548A8[] = {
-    { NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD, 0x80A },
-    { NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD, 0x814 },
-    { NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD, -0x81E },
+static AnimSfxEntry D_808548A8[] = {
+    { NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD, ANIMSFX_DATA(ANIMSFX_TYPE_1, 10) },
+    { NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD, ANIMSFX_DATA(ANIMSFX_TYPE_1, 20) },
+    { NA_SE_PL_WALK_GROUND + SURFACE_SFX_OFFSET_WOOD, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 30) },
 };
 
 void Player_Action_8084C5F8(Player* this, PlayState* play) {
@@ -12095,7 +12129,7 @@ void Player_Action_8084C5F8(Player* this, PlayState* play) {
     sp38 = D_80854898;
 
     if (this->actionVar2 != 0) {
-        func_80832924(this, D_808548A8);
+        Player_ProcessAnimSfxList(this, D_808548A8);
         sp38 = D_808548A0;
     }
 
@@ -12113,9 +12147,12 @@ void Player_Action_8084C5F8(Player* this, PlayState* play) {
     }
 }
 
-static struct_80832924 D_808548B4[] = {
-    { 0, 0x3028 }, { 0, 0x3030 }, { 0, 0x3038 }, { 0, 0x3040 },  { 0, 0x3048 },
-    { 0, 0x3050 }, { 0, 0x3058 }, { 0, 0x3060 }, { 0, -0x3068 },
+static AnimSfxEntry D_808548B4[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 40) },   { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 48) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 56) },   { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 64) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 72) },   { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 80) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 88) },   { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 96) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_6, 104) },
 };
 
 /**
@@ -12142,12 +12179,15 @@ void Player_Action_8084C760(Player* this, PlayState* play) {
     }
 
     // Still entering crawlspace
-    func_80832924(this, D_808548B4);
+    Player_ProcessAnimSfxList(this, D_808548B4);
 }
 
-static struct_80832924 D_808548D8[] = {
-    { 0, 0x300A }, { 0, 0x3012 }, { 0, 0x301A }, { 0, 0x3022 },  { 0, 0x3034 },
-    { 0, 0x303C }, { 0, 0x3044 }, { 0, 0x304C }, { 0, -0x3054 },
+static AnimSfxEntry D_808548D8[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 10) },  { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 18) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 26) },  { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 34) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 52) },  { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 60) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 68) },  { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 76) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_6, 84) },
 };
 
 /**
@@ -12164,7 +12204,7 @@ void Player_Action_8084C81C(Player* this, PlayState* play) {
     }
 
     // Continue animation of leaving crawlspace
-    func_80832924(this, D_808548D8);
+    Player_ProcessAnimSfxList(this, D_808548D8);
 }
 
 static Vec3f D_808548FC[] = {
@@ -12296,10 +12336,11 @@ static u8 D_80854998[2][2] = {
 
 static Vec3s D_8085499C = { -69, 7146, -266 };
 
-static struct_80832924 D_808549A4[] = {
-    { NA_SE_PL_CALM_HIT, 0x830 }, { NA_SE_PL_CALM_HIT, 0x83A },  { NA_SE_PL_CALM_HIT, 0x844 },
-    { NA_SE_PL_CALM_PAT, 0x85C }, { NA_SE_PL_CALM_PAT, 0x86E },  { NA_SE_PL_CALM_PAT, 0x87E },
-    { NA_SE_PL_CALM_PAT, 0x884 }, { NA_SE_PL_CALM_PAT, -0x888 },
+static AnimSfxEntry D_808549A4[] = {
+    { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 48) },  { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 58) },
+    { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 68) },  { NA_SE_PL_CALM_PAT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 92) },
+    { NA_SE_PL_CALM_PAT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 110) }, { NA_SE_PL_CALM_PAT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 126) },
+    { NA_SE_PL_CALM_PAT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 132) }, { NA_SE_PL_CALM_PAT, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 136) },
 };
 
 void Player_Action_8084CC98(Player* this, PlayState* play) {
@@ -12365,7 +12406,7 @@ void Player_Action_8084CC98(Player* this, PlayState* play) {
         } else if (LinkAnimation_Update(play, &this->skelAnime)) {
             this->actionVar2 = 99;
         } else if (this->skelAnime.animation == &gPlayerAnim_link_uma_wait_1) {
-            func_80832924(this, D_808549A4);
+            Player_ProcessAnimSfxList(this, D_808549A4);
         }
     } else {
         this->skelAnime.curFrame = rideActor->curFrame;
@@ -12475,10 +12516,10 @@ void Player_Action_8084CC98(Player* this, PlayState* play) {
     }
 }
 
-static struct_80832924 D_808549C4[] = {
-    { 0, 0x2800 },
-    { NA_SE_PL_GET_OFF_HORSE, 0x80A },
-    { NA_SE_PL_SLIPDOWN, -0x819 },
+static AnimSfxEntry D_808549C4[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_5, 0) },
+    { NA_SE_PL_GET_OFF_HORSE, ANIMSFX_DATA(ANIMSFX_TYPE_1, 10) },
+    { NA_SE_PL_SLIPDOWN, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 25) },
 };
 
 void Player_Action_8084D3E4(Player* this, PlayState* play) {
@@ -12503,21 +12544,21 @@ void Player_Action_8084D3E4(Player* this, PlayState* play) {
         Camera_ChangeSetting(Play_GetCamera(play, CAM_ID_MAIN), CAM_SET_NORMAL0);
 
         if (this->mountSide < 0) {
-            D_808549C4[0].field = 0x2828;
+            D_808549C4[0].data = ANIMSFX_DATA(ANIMSFX_TYPE_5, 40);
         } else {
-            D_808549C4[0].field = 0x281D;
+            D_808549C4[0].data = ANIMSFX_DATA(ANIMSFX_TYPE_5, 29);
         }
-        func_80832924(this, D_808549C4);
+        Player_ProcessAnimSfxList(this, D_808549C4);
     }
 }
 
-static struct_80832924 D_808549D0[] = {
-    { NA_SE_PL_SWIM, -0x800 },
+static AnimSfxEntry D_808549D0[] = {
+    { NA_SE_PL_SWIM, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 0) },
 };
 
 void func_8084D530(Player* this, f32* arg1, f32 arg2, s16 arg3) {
     func_8084AEEC(this, arg1, arg2, arg3);
-    func_80832924(this, D_808549D0);
+    Player_ProcessAnimSfxList(this, D_808549D0);
 }
 
 void func_8084D574(PlayState* play, Player* this, s16 arg2) {
@@ -12931,11 +12972,11 @@ void Player_Action_8084E604(Player* this, PlayState* play) {
     func_8083721C(this);
 }
 
-static struct_80832924 D_808549E0[] = {
-    { 0, 0x3857 },
-    { NA_SE_VO_LI_CLIMB_END, 0x2057 },
-    { NA_SE_VO_LI_AUTO_JUMP, 0x2045 },
-    { 0, -0x287B },
+static AnimSfxEntry D_808549E0[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_7, 87) },
+    { NA_SE_VO_LI_CLIMB_END, ANIMSFX_DATA(ANIMSFX_TYPE_4, 87) },
+    { NA_SE_VO_LI_AUTO_JUMP, ANIMSFX_DATA(ANIMSFX_TYPE_4, 69) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_5, 123) },
 };
 
 void Player_Action_8084E6D4(Player* this, PlayState* play) {
@@ -12993,7 +13034,7 @@ void Player_Action_8084E6D4(Player* this, PlayState* play) {
     } else {
         if (this->actionVar2 == 0) {
             if (!LINK_IS_ADULT) {
-                func_80832924(this, D_808549E0);
+                Player_ProcessAnimSfxList(this, D_808549E0);
             }
             return;
         }
@@ -13008,17 +13049,17 @@ void Player_Action_8084E6D4(Player* this, PlayState* play) {
     }
 }
 
-static struct_80832924 D_808549F0[] = {
-    { NA_SE_IT_MASTER_SWORD_SWING, -0x83C },
+static AnimSfxEntry D_808549F0[] = {
+    { NA_SE_IT_MASTER_SWORD_SWING, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 60) },
 };
 
 void func_8084E988(Player* this) {
-    func_80832924(this, D_808549F0);
+    Player_ProcessAnimSfxList(this, D_808549F0);
 }
 
-static struct_80832924 D_808549F4[] = {
-    { NA_SE_VO_LI_AUTO_JUMP, 0x2005 },
-    { 0, -0x280F },
+static AnimSfxEntry D_808549F4[] = {
+    { NA_SE_VO_LI_AUTO_JUMP, ANIMSFX_DATA(ANIMSFX_TYPE_4, 5) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_5, 15) },
 };
 
 void Player_Action_8084E9AC(Player* this, PlayState* play) {
@@ -13038,7 +13079,7 @@ void Player_Action_8084E9AC(Player* this, PlayState* play) {
         }
 
         if (!LINK_IS_ADULT) {
-            func_80832924(this, D_808549F4);
+            Player_ProcessAnimSfxList(this, D_808549F4);
         } else {
             func_8084E988(this);
         }
@@ -13200,9 +13241,9 @@ static BottleDropInfo D_80854A28[] = {
     { ACTOR_EN_INSECT, INSECT_TYPE_FIRST_DROPPED },
 };
 
-static struct_80832924 D_80854A34[] = {
-    { NA_SE_VO_LI_AUTO_JUMP, 0x2026 },
-    { NA_SE_EV_BOTTLE_CAP_OPEN, -0x828 },
+static AnimSfxEntry D_80854A34[] = {
+    { NA_SE_VO_LI_AUTO_JUMP, ANIMSFX_DATA(ANIMSFX_TYPE_4, 38) },
+    { NA_SE_EV_BOTTLE_CAP_OPEN, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 40) },
 };
 
 void Player_Action_8084EFC0(Player* this, PlayState* play) {
@@ -13226,11 +13267,11 @@ void Player_Action_8084EFC0(Player* this, PlayState* play) {
         return;
     }
 
-    func_80832924(this, D_80854A34);
+    Player_ProcessAnimSfxList(this, D_80854A34);
 }
 
-static struct_80832924 D_80854A3C[] = {
-    { NA_SE_PL_PUT_OUT_ITEM, -0x81E },
+static AnimSfxEntry D_80854A3C[] = {
+    { NA_SE_PL_PUT_OUT_ITEM, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 30) },
 };
 
 void Player_Action_8084F104(Player* this, PlayState* play) {
@@ -13278,7 +13319,7 @@ void Player_Action_8084F104(Player* this, PlayState* play) {
             }
         }
     } else if (this->actionVar2 >= 0) {
-        func_80832924(this, D_80854A3C);
+        Player_ProcessAnimSfxList(this, D_80854A3C);
     }
 
     if ((this->actionVar1 == 0) && (this->unk_664 != NULL)) {
@@ -13815,24 +13856,24 @@ static LinkAnimationHeader* D_80854A70[] = {
 
 static u8 D_80854A7C[] = { 70, 10, 10 };
 
-static struct_80832924 D_80854A80[] = {
-    { NA_SE_PL_SKIP, 0x814 },
-    { NA_SE_VO_LI_SWORD_N, 0x2014 },
-    { 0, -0x301A },
+static AnimSfxEntry D_80854A80[] = {
+    { NA_SE_PL_SKIP, ANIMSFX_DATA(ANIMSFX_TYPE_1, 20) },
+    { NA_SE_VO_LI_SWORD_N, ANIMSFX_DATA(ANIMSFX_TYPE_4, 20) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_6, 26) },
 };
 
-static struct_80832924 D_80854A8C[][2] = {
+static AnimSfxEntry D_80854A8C[][2] = {
     {
-        { 0, 0x4014 },
-        { NA_SE_VO_LI_MAGIC_FROL, -0x201E },
+        { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 20) },
+        { NA_SE_VO_LI_MAGIC_FROL, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 30) },
     },
     {
-        { 0, 0x4014 },
-        { NA_SE_VO_LI_MAGIC_NALE, -0x202C },
+        { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 20) },
+        { NA_SE_VO_LI_MAGIC_NALE, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 44) },
     },
     {
-        { NA_SE_VO_LI_MAGIC_ATTACK, 0x2014 },
-        { NA_SE_IT_SWORD_SWING_HARD, -0x814 },
+        { NA_SE_VO_LI_MAGIC_ATTACK, ANIMSFX_DATA(ANIMSFX_TYPE_4, 20) },
+        { NA_SE_IT_SWORD_SWING_HARD, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 20) },
     },
 };
 
@@ -13886,9 +13927,9 @@ void Player_Action_808507F4(Player* this, PlayState* play) {
             }
         } else if (this->actionVar1 >= 0) {
             if (this->actionVar2 == 0) {
-                func_80832924(this, D_80854A80);
+                Player_ProcessAnimSfxList(this, D_80854A80);
             } else if (this->actionVar2 == 1) {
-                func_80832924(this, D_80854A8C[this->actionVar1]);
+                Player_ProcessAnimSfxList(this, D_80854A8C[this->actionVar1]);
                 if ((this->actionVar1 == 2) && LinkAnimation_OnFrame(&this->skelAnime, 30.0f)) {
                     this->stateFlags1 &= ~(PLAYER_STATE1_28 | PLAYER_STATE1_29);
                 }
@@ -13987,19 +14028,23 @@ static void (*D_80854AA4[])(PlayState*, Player*, void*) = {
     func_80851050, func_80851194, func_808511B4, func_80851248, func_808512E0,
 };
 
-static struct_80832924 D_80854AF0[] = {
-    { 0, 0x2822 },
-    { NA_SE_PL_CALM_HIT, 0x82D },
-    { NA_SE_PL_CALM_HIT, 0x833 },
-    { NA_SE_PL_CALM_HIT, -0x840 },
+static AnimSfxEntry D_80854AF0[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_5, 34) },
+    { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 45) },
+    { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_1, 51) },
+    { NA_SE_PL_CALM_HIT, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 64) },
 };
 
-static struct_80832924 D_80854B00[] = {
-    { NA_SE_VO_LI_SURPRISE, 0x2003 }, { 0, 0x300F }, { 0, 0x3018 }, { 0, 0x301E }, { NA_SE_VO_LI_FALL_L, -0x201F },
+static AnimSfxEntry D_80854B00[] = {
+    { NA_SE_VO_LI_SURPRISE, ANIMSFX_DATA(ANIMSFX_TYPE_4, 3) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 15) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 24) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 30) },
+    { NA_SE_VO_LI_FALL_L, -ANIMSFX_DATA(ANIMSFX_TYPE_4, 31) },
 };
 
-static struct_80832924 D_80854B14[] = {
-    { 0, -0x300A },
+static AnimSfxEntry D_80854B14[] = {
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_6, 10) },
 };
 
 static struct_80854B18 D_80854B18[PLAYER_CSACTION_MAX] = {
@@ -14316,7 +14361,7 @@ void func_80851294(PlayState* play, Player* this, void* anim) {
 
 void func_808512E0(PlayState* play, Player* this, void* arg2) {
     LinkAnimation_Update(play, &this->skelAnime);
-    func_80832924(this, arg2);
+    Player_ProcessAnimSfxList(this, arg2);
 }
 
 void func_80851314(Player* this) {
@@ -14430,14 +14475,14 @@ void func_80851688(PlayState* play, Player* this, CsCmdActorCue* cue) {
     }
 }
 
-static struct_80832924 D_80855188[] = {
-    { 0, 0x302A },
-    { 0, -0x3030 },
+static AnimSfxEntry D_80855188[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 42) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_6, 48) },
 };
 
 void func_80851750(PlayState* play, Player* this, CsCmdActorCue* cue) {
     LinkAnimation_Update(play, &this->skelAnime);
-    func_80832924(this, D_80855188);
+    Player_ProcessAnimSfxList(this, D_80855188);
 }
 
 void func_80851788(PlayState* play, Player* this, CsCmdActorCue* cue) {
@@ -14525,9 +14570,9 @@ static struct_808551A4 D_808551A4[] = {
     { NA_SE_IT_SWORD_STICK_STN, NA_SE_VO_LI_SWORD_N },
 };
 
-static struct_80832924 D_808551AC[] = {
-    { 0, 0x401D },
-    { 0, -0x4027 },
+static AnimSfxEntry D_808551AC[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 29) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_8, 39) },
 };
 
 void func_80851A50(PlayState* play, Player* this, CsCmdActorCue* cue) {
@@ -14557,7 +14602,7 @@ void func_80851A50(PlayState* play, Player* this, CsCmdActorCue* cue) {
             func_80832698(this, NA_SE_VO_LI_SWORD_L);
         }
     } else {
-        func_80832924(this, D_808551AC);
+        Player_ProcessAnimSfxList(this, D_808551AC);
     }
 }
 
@@ -14566,8 +14611,8 @@ void func_80851B90(PlayState* play, Player* this, CsCmdActorCue* cue) {
                          ANIMMODE_ONCE, 0.0f);
 }
 
-static struct_80832924 D_808551B4[] = {
-    { 0, -0x281E },
+static AnimSfxEntry D_808551B4[] = {
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_5, 30) },
 };
 
 void func_80851BE8(PlayState* play, Player* this, CsCmdActorCue* cue) {
@@ -14580,7 +14625,7 @@ void func_80851BE8(PlayState* play, Player* this, CsCmdActorCue* cue) {
             LinkAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_okarina_warp_goal, (2.0f / 3.0f), 10.0f,
                                  Animation_GetLastFrame(&gPlayerAnim_link_okarina_warp_goal), ANIMMODE_ONCE, -8.0f);
         }
-        func_80832924(this, D_808551B4);
+        Player_ProcessAnimSfxList(this, D_808551B4);
     }
 }
 
@@ -14602,8 +14647,8 @@ void func_80851D2C(PlayState* play, Player* this, CsCmdActorCue* cue) {
     Player_SetModels(this, Player_ActionToModelGroup(this, this->itemAction));
 }
 
-static struct_80832924 D_808551B8[] = {
-    { NA_SE_IT_SWORD_PICKOUT, -0x80C },
+static AnimSfxEntry D_808551B8[] = {
+    { NA_SE_IT_SWORD_PICKOUT, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 12) },
 };
 
 void func_80851D80(PlayState* play, Player* this, CsCmdActorCue* cue) {
@@ -14612,7 +14657,7 @@ void func_80851D80(PlayState* play, Player* this, CsCmdActorCue* cue) {
     if (LinkAnimation_OnFrame(&this->skelAnime, 6.0f)) {
         func_80846720(play, this, 0);
     } else {
-        func_80832924(this, D_808551B8);
+        Player_ProcessAnimSfxList(this, D_808551B8);
     }
 }
 
@@ -14645,12 +14690,12 @@ void func_80851ECC(PlayState* play, Player* this, CsCmdActorCue* cue) {
     }
 }
 
-void func_80851F14(PlayState* play, Player* this, LinkAnimationHeader* anim, struct_80832924* arg3) {
+void func_80851F14(PlayState* play, Player* this, LinkAnimationHeader* anim, AnimSfxEntry* arg3) {
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_AnimPlayLoopAdjusted(play, this, anim);
         this->actionVar2 = 1;
     } else if (this->actionVar2 == 0) {
-        func_80832924(this, arg3);
+        Player_ProcessAnimSfxList(this, arg3);
     }
 }
 
@@ -14659,10 +14704,10 @@ void func_80851F84(PlayState* play, Player* this, CsCmdActorCue* cue) {
     func_80851134(play, this, &gPlayerAnim_clink_op3_wait1);
 }
 
-static struct_80832924 D_808551BC[] = {
-    { NA_SE_VO_LI_RELAX, 0x2023 },
-    { NA_SE_PL_SLIPDOWN, 0x8EC },
-    { NA_SE_PL_SLIPDOWN, -0x900 },
+static AnimSfxEntry D_808551BC[] = {
+    { NA_SE_VO_LI_RELAX, ANIMSFX_DATA(ANIMSFX_TYPE_4, 35) },
+    { NA_SE_PL_SLIPDOWN, ANIMSFX_DATA(ANIMSFX_TYPE_1, 236) },
+    { NA_SE_PL_SLIPDOWN, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 256) },
 };
 
 void func_80851FB0(PlayState* play, Player* this, CsCmdActorCue* cue) {
@@ -14672,23 +14717,23 @@ void func_80851FB0(PlayState* play, Player* this, CsCmdActorCue* cue) {
                                        ANIM_FLAG_PLAYER_7);
         this->actionVar2 = 1;
     } else if (this->actionVar2 == 0) {
-        func_80832924(this, D_808551BC);
+        Player_ProcessAnimSfxList(this, D_808551BC);
         if (LinkAnimation_OnFrame(&this->skelAnime, 240.0f)) {
             this->actor.shape.shadowDraw = ActorShadow_DrawFeet;
         }
     }
 }
 
-static struct_80832924 D_808551C8[] = {
-    { NA_SE_PL_LAND + SURFACE_SFX_OFFSET_WOOD, 0x843 },
-    { 0, 0x4854 },
-    { 0, 0x485A },
-    { 0, -0x4860 },
+static AnimSfxEntry D_808551C8[] = {
+    { NA_SE_PL_LAND + SURFACE_SFX_OFFSET_WOOD, ANIMSFX_DATA(ANIMSFX_TYPE_1, 67) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_9, 84) },
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_9, 90) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_9, 96) },
 };
 
 void func_80852048(PlayState* play, Player* this, CsCmdActorCue* cue) {
     LinkAnimation_Update(play, &this->skelAnime);
-    func_80832924(this, D_808551C8);
+    Player_ProcessAnimSfxList(this, D_808551C8);
 }
 
 void func_80852080(PlayState* play, Player* this, CsCmdActorCue* cue) {
@@ -14714,15 +14759,15 @@ void func_808520BC(PlayState* play, Player* this, CsCmdActorCue* cue) {
     this->actor.world.pos.z = distZ * sp4 + startZ;
 }
 
-static struct_80832924 D_808551D8[] = {
-    { NA_SE_PL_BOUND, 0x1014 },
-    { NA_SE_PL_BOUND, -0x101E },
+static AnimSfxEntry D_808551D8[] = {
+    { NA_SE_PL_BOUND, ANIMSFX_DATA(ANIMSFX_TYPE_2, 20) },
+    { NA_SE_PL_BOUND, -ANIMSFX_DATA(ANIMSFX_TYPE_2, 30) },
 };
 
 void func_80852174(PlayState* play, Player* this, CsCmdActorCue* cue) {
     func_808520BC(play, this, cue);
     LinkAnimation_Update(play, &this->skelAnime);
-    func_80832924(this, D_808551D8);
+    Player_ProcessAnimSfxList(this, D_808551D8);
 }
 
 void func_808521B8(PlayState* play, Player* this, CsCmdActorCue* cue) {
@@ -14760,18 +14805,18 @@ void func_80852298(PlayState* play, Player* this, CsCmdActorCue* cue) {
     }
 }
 
-static struct_80832924 D_808551E0[] = {
-    { 0, 0x300A },
-    { 0, -0x3018 },
+static AnimSfxEntry D_808551E0[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 10) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_6, 24) },
 };
 
 void func_80852328(PlayState* play, Player* this, CsCmdActorCue* cue) {
     func_80851F14(play, this, &gPlayerAnim_link_demo_furimuki2_wait, D_808551E0);
 }
 
-static struct_80832924 D_808551E8[] = {
-    { 0, 0x400F },
-    { 0, -0x4023 },
+static AnimSfxEntry D_808551E8[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_8, 15) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_8, 35) },
 };
 
 void func_80852358(PlayState* play, Player* this, CsCmdActorCue* cue) {
@@ -14791,24 +14836,24 @@ void func_80852388(PlayState* play, Player* this, CsCmdActorCue* cue) {
     }
 }
 
-void func_80852414(PlayState* play, Player* this, LinkAnimationHeader* anim, struct_80832924* arg3) {
+void func_80852414(PlayState* play, Player* this, LinkAnimationHeader* anim, AnimSfxEntry* arg3) {
     func_80851294(play, this, anim);
     if (this->actionVar2 == 0) {
-        func_80832924(this, arg3);
+        Player_ProcessAnimSfxList(this, arg3);
     }
 }
 
-static struct_80832924 D_808551F0[] = {
-    { 0, 0x300F },
-    { 0, -0x3021 },
+static AnimSfxEntry D_808551F0[] = {
+    { 0, ANIMSFX_DATA(ANIMSFX_TYPE_6, 15) },
+    { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_6, 33) },
 };
 
 void func_80852450(PlayState* play, Player* this, CsCmdActorCue* cue) {
     func_80852414(play, this, &gPlayerAnim_clink_demo_koutai_wait, D_808551F0);
 }
 
-static struct_80832924 D_808551F8[] = {
-    { NA_SE_PL_KNOCK, -0x84E },
+static AnimSfxEntry D_808551F8[] = {
+    { NA_SE_PL_KNOCK, -ANIMSFX_DATA(ANIMSFX_TYPE_1, 78) },
 };
 
 void func_80852480(PlayState* play, Player* this, CsCmdActorCue* cue) {


### PR DESCRIPTION
The idea behind this system is incredibly based, and I wish something like it existed more globally.

These docs don't name any of the types or functions involved with sfx playback, that can be done in a future pass.

I took inspiration from MM's current docs but did not copy it verbatim.
Mainly, I chose to make a macro for only the bit-packed `data` field, and not the whole entry. 
I didn't feel it was needed to abstract the structure of the original data away behind the macro. Additionally, the "negative entry is the last one" is a common construct of the Player dev, and feel like its fine to expose that mechanism in the data itself.