### PR TITLE
Track most header dependencies for `include/tables` headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,9 +335,11 @@ build/src/boot/z_std_dma.o: build/dmadata_table_spec.h
 build/src/dmadata/dmadata.o: build/dmadata_table_spec.h
 
 # Dependencies for files including from include/tables/
-# TODO rmeove when full header dependencies are used
+# Note z_actor is made dependent on actor_table.h so ACTOR_ID_MAX updates when the table length changes.
+# TODO remove when full header dependencies are used.
 build/src/code/graph.o: include/tables/gamestate_table.h
 build/src/code/object_table.o: include/tables/object_table.h
+build/src/code/z_actor.o: include/tables/actor_table.h
 build/src/code/z_actor_dlftbls.o: include/tables/actor_table.h
 build/src/code/z_effect_soft_sprite_dlftbls.o: include/tables/effect_ss_table.h
 build/src/code/z_game_dlftbls.o: include/tables/gamestate_table.h

--- a/Makefile
+++ b/Makefile
@@ -334,6 +334,15 @@ build/dmadata_table_spec.h: build/$(SPEC)
 build/src/boot/z_std_dma.o: build/dmadata_table_spec.h
 build/src/dmadata/dmadata.o: build/dmadata_table_spec.h
 
+# Dependencies for files including from include/tables/
+# TODO rmeove when full header dependencies are used
+build/src/code/graph.o: include/tables/gamestate_table.h
+build/src/code/object_table.o: include/tables/object_table.h
+build/src/code/z_actor_dlftbls.o: include/tables/actor_table.h
+build/src/code/z_effect_soft_sprite_dlftbls.o: include/tables/effect_ss_table.h
+build/src/code/z_game_dlftbls.o: include/tables/gamestate_table.h
+build/src/code/z_scene_table.o: include/tables/scene_table.h include/tables/entrance_table.h
+
 build/src/%.o: src/%.c
 	$(CC_CHECK) $<
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -316,10 +316,13 @@ build/data/%.o: data/%.s
 build/assets/text/%.enc.h: assets/text/%.h assets/text/charmap.txt
 	python3 tools/msgenc.py assets/text/charmap.txt $< $@
 
+# Dependencies for files including message data headers
+# TODO remove when full header dependencies are used.
 build/assets/text/fra_message_data_static.o: build/assets/text/message_data.enc.h
 build/assets/text/ger_message_data_static.o: build/assets/text/message_data.enc.h
 build/assets/text/nes_message_data_static.o: build/assets/text/message_data.enc.h
 build/assets/text/staff_message_data_static.o: build/assets/text/message_data_staff.enc.h
+build/src/code/z_message_PAL.o: build/assets/text/message_data.enc.h build/assets/text/message_data_staff.enc.h
 
 build/assets/%.o: assets/%.c
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
@@ -331,15 +334,15 @@ build/src/%.o: src/%.s
 build/dmadata_table_spec.h: build/$(SPEC)
 	$(MKDMADATA) $< $@
 
+# Dependencies for files that may include the dmadata header automatically generated from the spec file
 build/src/boot/z_std_dma.o: build/dmadata_table_spec.h
 build/src/dmadata/dmadata.o: build/dmadata_table_spec.h
 
 # Dependencies for files including from include/tables/
-# Note z_actor is made dependent on actor_table.h so ACTOR_ID_MAX updates when the table length changes.
 # TODO remove when full header dependencies are used.
 build/src/code/graph.o: include/tables/gamestate_table.h
 build/src/code/object_table.o: include/tables/object_table.h
-build/src/code/z_actor.o: include/tables/actor_table.h
+build/src/code/z_actor.o: include/tables/actor_table.h # so uses of ACTOR_ID_MAX update when the table length changes
 build/src/code/z_actor_dlftbls.o: include/tables/actor_table.h
 build/src/code/z_effect_soft_sprite_dlftbls.o: include/tables/effect_ss_table.h
 build/src/code/z_game_dlftbls.o: include/tables/gamestate_table.h


### PR DESCRIPTION
So that source files that include these tables are automatically rebuilt when they are modified.

I think this is worthwhile to have as a temporary measure until full header dependencies happens, since updating these tables is central to modding use-cases.

("Most" meaning all but `include/tables/sfx` headers)
