### PR TITLE
Remove `(ActorFunc)` casts in initvars

### DIFF
--- a/docs/tutorial/beginning_decomp.md
+++ b/docs/tutorial/beginning_decomp.md
@@ -638,19 +638,19 @@ void func_80A87F44(Actor* thisx, PlayState* play);
 void func_80A87BEC(EnJj* this, PlayState* play);
 void func_80A87C30(EnJj* this, PlayState* play);
 
-/*
+#if 0
 ActorInit En_Jj_InitVars = {
-    ACTOR_EN_JJ,
-    ACTORTYPE_ITEMACTION,
-    FLAGS,
-    OBJECT_JJ,
-    sizeof(EnJj),
-    (ActorFunc)EnJj_Init,
-    (ActorFunc)EnJj_Destroy,
-    (ActorFunc)EnJj_Update,
-    (ActorFunc)EnJj_Draw,
+    /**/ ACTOR_EN_JJ,
+    /**/ ACTORTYPE_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_JJ,
+    /**/ sizeof(EnJj),
+    /**/ EnJj_Init,
+    /**/ EnJj_Destroy,
+    /**/ EnJj_Update,
+    /**/ EnJj_Draw,
 };
-*/
+#endif
 
 extern ColliderCylinderInit D_80A88CB4;
 // static ColliderCylinderInit sCylinderInit = {

--- a/docs/tutorial/data.md
+++ b/docs/tutorial/data.md
@@ -94,15 +94,15 @@ s32 D_80B18910[] = { 0x0A000039, 0x20010000, 0x00000000, 0x00000000, 0x00000000,
 s32 D_80B1893C[] = { 0x00000000, 0x00000000, 0xFF000000 };
 
 ActorInit En_Tg_InitVars = {
-    ACTOR_EN_TG,
-    ACTORTYPE_NPC,
-    FLAGS,
-    OBJECT_MU,
-    sizeof(EnTg),
-    (ActorFunc)EnTg_Init,
-    (ActorFunc)EnTg_Destroy,
-    (ActorFunc)EnTg_Update,
-    (ActorFunc)EnTg_Draw,
+    /**/ ACTOR_EN_TG,
+    /**/ ACTORTYPE_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MU,
+    /**/ sizeof(EnTg),
+    /**/ EnTg_Init,
+    /**/ EnTg_Destroy,
+    /**/ EnTg_Update,
+    /**/ EnTg_Draw,
 };
 
 s32 D_80B18968[] = { 0x00000000, 0x44480000, 0x00000000, 0x00000000, 0x00000000, 0x00000000 };
@@ -490,15 +490,15 @@ To replace the `extern`, because the data is in a separate file, we include the 
 Lastly, uncomment the InitVars block that's been sitting there the whole time. The data section of the file now looks like
 ```C
 ActorInit En_Jj_InitVars = {
-    ACTOR_EN_JJ,
-    ACTORTYPE_ITEMACTION,
-    FLAGS,
-    OBJECT_JJ,
-    sizeof(EnJj),
-    (ActorFunc)EnJj_Init,
-    (ActorFunc)EnJj_Destroy,
-    (ActorFunc)EnJj_Update,
-    (ActorFunc)EnJj_Draw,
+    /**/ ACTOR_EN_JJ,
+    /**/ ACTORTYPE_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_JJ,
+    /**/ sizeof(EnJj),
+    /**/ EnJj_Init,
+    /**/ EnJj_Destroy,
+    /**/ EnJj_Update,
+    /**/ EnJj_Draw,
 };
 
 #include "en_jj_cutscene_data.c" EARLY
@@ -567,15 +567,15 @@ Notice that the numbers in the bottom pane is all shifted one word to the left. 
 
 ```C
 ActorInit En_Jj_InitVars = {
-    ACTOR_EN_JJ,
-    ACTORTYPE_ITEMACTION,
-    FLAGS,
-    OBJECT_JJ,
-    sizeof(EnJj),
-    (ActorFunc)EnJj_Init,
-    (ActorFunc)EnJj_Destroy,
-    (ActorFunc)EnJj_Update,
-    (ActorFunc)EnJj_Draw,
+    /**/ ACTOR_EN_JJ,
+    /**/ ACTORTYPE_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_JJ,
+    /**/ sizeof(EnJj),
+    /**/ EnJj_Init,
+    /**/ EnJj_Destroy,
+    /**/ EnJj_Update,
+    /**/ EnJj_Draw,
 };
 
 s32 usused = 0;

--- a/src/code/z_en_a_keep.c
+++ b/src/code/z_en_a_keep.c
@@ -21,15 +21,15 @@ void EnAObj_SetupBoulderFragment(EnAObj* this, s16 type);
 void EnAObj_SetupBlock(EnAObj* this, s16 type);
 
 ActorInit En_A_Obj_InitVars = {
-    ACTOR_EN_A_OBJ,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnAObj),
-    (ActorFunc)EnAObj_Init,
-    (ActorFunc)EnAObj_Destroy,
-    (ActorFunc)EnAObj_Update,
-    (ActorFunc)EnAObj_Draw,
+    /**/ ACTOR_EN_A_OBJ,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnAObj),
+    /**/ EnAObj_Init,
+    /**/ EnAObj_Destroy,
+    /**/ EnAObj_Update,
+    /**/ EnAObj_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -21,15 +21,15 @@ void EnItem00_DrawHeartContainer(EnItem00* this, PlayState* play);
 void EnItem00_DrawHeartPiece(EnItem00* this, PlayState* play);
 
 ActorInit En_Item00_InitVars = {
-    ACTOR_EN_ITEM00,
-    ACTORCAT_MISC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnItem00),
-    (ActorFunc)EnItem00_Init,
-    (ActorFunc)EnItem00_Destroy,
-    (ActorFunc)EnItem00_Update,
-    (ActorFunc)EnItem00_Draw,
+    /**/ ACTOR_EN_ITEM00,
+    /**/ ACTORCAT_MISC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnItem00),
+    /**/ EnItem00_Init,
+    /**/ EnItem00_Destroy,
+    /**/ EnItem00_Update,
+    /**/ EnItem00_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/code/z_player_call.c
+++ b/src/code/z_player_call.c
@@ -18,15 +18,15 @@ void Player_Update(Actor* thisx, PlayState* play);
 void Player_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Player_InitVars = {
-    ACTOR_PLAYER,
-    ACTORCAT_PLAYER,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(Player),
-    (ActorFunc)PlayerCall_Init,
-    (ActorFunc)PlayerCall_Destroy,
-    (ActorFunc)PlayerCall_Update,
-    (ActorFunc)PlayerCall_Draw,
+    /**/ ACTOR_PLAYER,
+    /**/ ACTORCAT_PLAYER,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(Player),
+    /**/ PlayerCall_Init,
+    /**/ PlayerCall_Destroy,
+    /**/ PlayerCall_Update,
+    /**/ PlayerCall_Draw,
 };
 
 void PlayerCall_InitFuncPtrs(void) {

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -12,15 +12,15 @@ void ArmsHook_Wait(ArmsHook* this, PlayState* play);
 void ArmsHook_Shoot(ArmsHook* this, PlayState* play);
 
 ActorInit Arms_Hook_InitVars = {
-    ACTOR_ARMS_HOOK,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_LINK_BOY,
-    sizeof(ArmsHook),
-    (ActorFunc)ArmsHook_Init,
-    (ActorFunc)ArmsHook_Destroy,
-    (ActorFunc)ArmsHook_Update,
-    (ActorFunc)ArmsHook_Draw,
+    /**/ ACTOR_ARMS_HOOK,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_LINK_BOY,
+    /**/ sizeof(ArmsHook),
+    /**/ ArmsHook_Init,
+    /**/ ArmsHook_Destroy,
+    /**/ ArmsHook_Update,
+    /**/ ArmsHook_Draw,
 };
 
 static ColliderQuadInit sQuadInit = {

--- a/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
+++ b/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
@@ -21,15 +21,15 @@ void ArrowFire_Hit(ArrowFire* this, PlayState* play);
 #include "assets/overlays/ovl_Arrow_Fire/ovl_Arrow_Fire.c"
 
 ActorInit Arrow_Fire_InitVars = {
-    ACTOR_ARROW_FIRE,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ArrowFire),
-    (ActorFunc)ArrowFire_Init,
-    (ActorFunc)ArrowFire_Destroy,
-    (ActorFunc)ArrowFire_Update,
-    (ActorFunc)ArrowFire_Draw,
+    /**/ ACTOR_ARROW_FIRE,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ArrowFire),
+    /**/ ArrowFire_Init,
+    /**/ ArrowFire_Destroy,
+    /**/ ArrowFire_Update,
+    /**/ ArrowFire_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
@@ -22,15 +22,15 @@ void ArrowIce_Hit(ArrowIce* this, PlayState* play);
 #include "assets/overlays/ovl_Arrow_Ice/ovl_Arrow_Ice.c"
 
 ActorInit Arrow_Ice_InitVars = {
-    ACTOR_ARROW_ICE,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ArrowIce),
-    (ActorFunc)ArrowIce_Init,
-    (ActorFunc)ArrowIce_Destroy,
-    (ActorFunc)ArrowIce_Update,
-    (ActorFunc)ArrowIce_Draw,
+    /**/ ACTOR_ARROW_ICE,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ArrowIce),
+    /**/ ArrowIce_Init,
+    /**/ ArrowIce_Destroy,
+    /**/ ArrowIce_Update,
+    /**/ ArrowIce_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
+++ b/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
@@ -22,15 +22,15 @@ void ArrowLight_Hit(ArrowLight* this, PlayState* play);
 #include "assets/overlays/ovl_Arrow_Light/ovl_Arrow_Light.c"
 
 ActorInit Arrow_Light_InitVars = {
-    ACTOR_ARROW_LIGHT,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ArrowLight),
-    (ActorFunc)ArrowLight_Init,
-    (ActorFunc)ArrowLight_Destroy,
-    (ActorFunc)ArrowLight_Update,
-    (ActorFunc)ArrowLight_Draw,
+    /**/ ACTOR_ARROW_LIGHT,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ArrowLight),
+    /**/ ArrowLight_Init,
+    /**/ ArrowLight_Destroy,
+    /**/ ArrowLight_Update,
+    /**/ ArrowLight_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
@@ -33,15 +33,15 @@ void func_8086CB10(BgBdanObjects* this, PlayState* play);
 void func_8086CB8C(BgBdanObjects* this, PlayState* play);
 
 ActorInit Bg_Bdan_Objects_InitVars = {
-    ACTOR_BG_BDAN_OBJECTS,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_BDAN_OBJECTS,
-    sizeof(BgBdanObjects),
-    (ActorFunc)BgBdanObjects_Init,
-    (ActorFunc)BgBdanObjects_Destroy,
-    (ActorFunc)BgBdanObjects_Update,
-    (ActorFunc)BgBdanObjects_Draw,
+    /**/ ACTOR_BG_BDAN_OBJECTS,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_BDAN_OBJECTS,
+    /**/ sizeof(BgBdanObjects),
+    /**/ BgBdanObjects_Init,
+    /**/ BgBdanObjects_Destroy,
+    /**/ BgBdanObjects_Update,
+    /**/ BgBdanObjects_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Switch/z_bg_bdan_switch.c
@@ -43,15 +43,15 @@ void func_8086DDA8(BgBdanSwitch* this);
 void func_8086DDC0(BgBdanSwitch* this, PlayState* play);
 
 ActorInit Bg_Bdan_Switch_InitVars = {
-    ACTOR_BG_BDAN_SWITCH,
-    ACTORCAT_SWITCH,
-    FLAGS,
-    OBJECT_BDAN_OBJECTS,
-    sizeof(BgBdanSwitch),
-    (ActorFunc)BgBdanSwitch_Init,
-    (ActorFunc)BgBdanSwitch_Destroy,
-    (ActorFunc)BgBdanSwitch_Update,
-    (ActorFunc)BgBdanSwitch_Draw,
+    /**/ ACTOR_BG_BDAN_SWITCH,
+    /**/ ACTORCAT_SWITCH,
+    /**/ FLAGS,
+    /**/ OBJECT_BDAN_OBJECTS,
+    /**/ sizeof(BgBdanSwitch),
+    /**/ BgBdanSwitch_Init,
+    /**/ BgBdanSwitch_Destroy,
+    /**/ BgBdanSwitch_Update,
+    /**/ BgBdanSwitch_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[] = {

--- a/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.c
+++ b/src/overlays/actors/ovl_Bg_Bom_Guard/z_bg_bom_guard.c
@@ -18,15 +18,15 @@ void BgBomGuard_Update(Actor* thisx, PlayState* play);
 void func_8086E638(BgBomGuard* this, PlayState* play);
 
 ActorInit Bg_Bom_Guard_InitVars = {
-    ACTOR_BG_BOM_GUARD,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_BOWL,
-    sizeof(BgBomGuard),
-    (ActorFunc)BgBomGuard_Init,
-    (ActorFunc)BgBomGuard_Destroy,
-    (ActorFunc)BgBomGuard_Update,
-    NULL,
+    /**/ ACTOR_BG_BOM_GUARD,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_BOWL,
+    /**/ sizeof(BgBomGuard),
+    /**/ BgBomGuard_Init,
+    /**/ BgBomGuard_Destroy,
+    /**/ BgBomGuard_Update,
+    /**/ NULL,
 };
 
 void BgBomGuard_SetupAction(BgBomGuard* this, BgBomGuardActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.c
@@ -70,15 +70,15 @@ static ColliderTrisInit sTrisInit = {
 };
 
 ActorInit Bg_Bombwall_InitVars = {
-    ACTOR_BG_BOMBWALL,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_FIELD_KEEP,
-    sizeof(BgBombwall),
-    (ActorFunc)BgBombwall_Init,
-    (ActorFunc)BgBombwall_Destroy,
-    (ActorFunc)BgBombwall_Update,
-    (ActorFunc)BgBombwall_Draw,
+    /**/ ACTOR_BG_BOMBWALL,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_FIELD_KEEP,
+    /**/ sizeof(BgBombwall),
+    /**/ BgBombwall_Init,
+    /**/ BgBombwall_Destroy,
+    /**/ BgBombwall_Update,
+    /**/ BgBombwall_Draw,
 };
 
 void BgBombwall_InitDynapoly(BgBombwall* this, PlayState* play) {

--- a/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.c
+++ b/src/overlays/actors/ovl_Bg_Bowl_Wall/z_bg_bowl_wall.c
@@ -25,15 +25,15 @@ void BgBowlWall_FinishFall(BgBowlWall* this, PlayState* play);
 void BgBowlWall_Reset(BgBowlWall* this, PlayState* play);
 
 ActorInit Bg_Bowl_Wall_InitVars = {
-    ACTOR_BG_BOWL_WALL,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_BOWL,
-    sizeof(BgBowlWall),
-    (ActorFunc)BgBowlWall_Init,
-    (ActorFunc)BgBowlWall_Destroy,
-    (ActorFunc)BgBowlWall_Update,
-    (ActorFunc)BgBowlWall_Draw,
+    /**/ ACTOR_BG_BOWL_WALL,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_BOWL,
+    /**/ sizeof(BgBowlWall),
+    /**/ BgBowlWall_Init,
+    /**/ BgBowlWall_Destroy,
+    /**/ BgBowlWall_Update,
+    /**/ BgBowlWall_Draw,
 };
 
 static Vec3f sBullseyeOffset[] = {

--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -27,15 +27,15 @@ void BgBreakwall_Wait(BgBreakwall* this, PlayState* play);
 void BgBreakwall_LavaCoverMove(BgBreakwall* this, PlayState* play);
 
 ActorInit Bg_Breakwall_InitVars = {
-    ACTOR_BG_BREAKWALL,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(BgBreakwall),
-    (ActorFunc)BgBreakwall_Init,
-    (ActorFunc)BgBreakwall_Destroy,
-    (ActorFunc)BgBreakwall_Update,
-    NULL,
+    /**/ ACTOR_BG_BREAKWALL,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(BgBreakwall),
+    /**/ BgBreakwall_Init,
+    /**/ BgBreakwall_Destroy,
+    /**/ BgBreakwall_Update,
+    /**/ NULL,
 };
 
 static ColliderQuadInit sQuadInit = {

--- a/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.c
+++ b/src/overlays/actors/ovl_Bg_Ddan_Jd/z_bg_ddan_jd.c
@@ -18,15 +18,15 @@ void BgDdanJd_Idle(BgDdanJd* this, PlayState* play);
 void BgDdanJd_Move(BgDdanJd* this, PlayState* play);
 
 ActorInit Bg_Ddan_Jd_InitVars = {
-    ACTOR_BG_DDAN_JD,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_DDAN_OBJECTS,
-    sizeof(BgDdanJd),
-    (ActorFunc)BgDdanJd_Init,
-    (ActorFunc)BgDdanJd_Destroy,
-    (ActorFunc)BgDdanJd_Update,
-    (ActorFunc)BgDdanJd_Draw,
+    /**/ ACTOR_BG_DDAN_JD,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_DDAN_OBJECTS,
+    /**/ sizeof(BgDdanJd),
+    /**/ BgDdanJd_Init,
+    /**/ BgDdanJd_Destroy,
+    /**/ BgDdanJd_Update,
+    /**/ BgDdanJd_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.c
+++ b/src/overlays/actors/ovl_Bg_Ddan_Kd/z_bg_ddan_kd.c
@@ -19,15 +19,15 @@ void BgDdanKd_LowerStairs(BgDdanKd* this, PlayState* play);
 void BgDdanKd_DoNothing(BgDdanKd* this, PlayState* play);
 
 ActorInit Bg_Ddan_Kd_InitVars = {
-    ACTOR_BG_DDAN_KD,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_DDAN_OBJECTS,
-    sizeof(BgDdanKd),
-    (ActorFunc)BgDdanKd_Init,
-    (ActorFunc)BgDdanKd_Destroy,
-    (ActorFunc)BgDdanKd_Update,
-    (ActorFunc)BgDdanKd_Draw,
+    /**/ ACTOR_BG_DDAN_KD,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_DDAN_OBJECTS,
+    /**/ sizeof(BgDdanKd),
+    /**/ BgDdanKd_Init,
+    /**/ BgDdanKd_Destroy,
+    /**/ BgDdanKd_Update,
+    /**/ BgDdanKd_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
+++ b/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
@@ -21,15 +21,15 @@ void BgDodoago_DoNothing(BgDodoago* this, PlayState* play);
 void BgDodoago_LightOneEye(BgDodoago* this, PlayState* play);
 
 ActorInit Bg_Dodoago_InitVars = {
-    ACTOR_BG_DODOAGO,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_DDAN_OBJECTS,
-    sizeof(BgDodoago),
-    (ActorFunc)BgDodoago_Init,
-    (ActorFunc)BgDodoago_Destroy,
-    (ActorFunc)BgDodoago_Update,
-    (ActorFunc)BgDodoago_Draw,
+    /**/ ACTOR_BG_DODOAGO,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_DDAN_OBJECTS,
+    /**/ sizeof(BgDodoago),
+    /**/ BgDodoago_Init,
+    /**/ BgDodoago_Destroy,
+    /**/ BgDodoago_Update,
+    /**/ BgDodoago_Draw,
 };
 
 static ColliderCylinderInit sColCylinderInitMain = {

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -55,15 +55,15 @@ void BgDyYoseizo_DrawEffects(BgDyYoseizo* this, PlayState* play);
 static s32 sUnusedGetItemIds[] = { GI_FARORES_WIND, GI_NAYRUS_LOVE, GI_DINS_FIRE };
 
 ActorInit Bg_Dy_Yoseizo_InitVars = {
-    ACTOR_BG_DY_YOSEIZO,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_DY_OBJ,
-    sizeof(BgDyYoseizo),
-    (ActorFunc)BgDyYoseizo_Init,
-    (ActorFunc)BgDyYoseizo_Destroy,
-    (ActorFunc)BgDyYoseizo_Update,
-    NULL,
+    /**/ ACTOR_BG_DY_YOSEIZO,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_DY_OBJ,
+    /**/ sizeof(BgDyYoseizo),
+    /**/ BgDyYoseizo_Init,
+    /**/ BgDyYoseizo_Destroy,
+    /**/ BgDyYoseizo_Update,
+    /**/ NULL,
 };
 
 void BgDyYoseizo_Init(Actor* thisx, PlayState* play2) {

--- a/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.c
+++ b/src/overlays/actors/ovl_Bg_Ganon_Otyuka/z_bg_ganon_otyuka.c
@@ -26,15 +26,15 @@ void BgGanonOtyuka_Fall(BgGanonOtyuka* this, PlayState* play);
 void BgGanonOtyuka_DoNothing(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Ganon_Otyuka_InitVars = {
-    ACTOR_BG_GANON_OTYUKA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GANON,
-    sizeof(BgGanonOtyuka),
-    (ActorFunc)BgGanonOtyuka_Init,
-    (ActorFunc)BgGanonOtyuka_Destroy,
-    (ActorFunc)BgGanonOtyuka_Update,
-    (ActorFunc)BgGanonOtyuka_Draw,
+    /**/ ACTOR_BG_GANON_OTYUKA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GANON,
+    /**/ sizeof(BgGanonOtyuka),
+    /**/ BgGanonOtyuka_Init,
+    /**/ BgGanonOtyuka_Destroy,
+    /**/ BgGanonOtyuka_Update,
+    /**/ BgGanonOtyuka_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Gate_Shutter/z_bg_gate_shutter.c
@@ -21,15 +21,15 @@ void func_808783AC(BgGateShutter* this, PlayState* play);
 void func_808783D4(BgGateShutter* this, PlayState* play);
 
 ActorInit Bg_Gate_Shutter_InitVars = {
-    ACTOR_BG_GATE_SHUTTER,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_SPOT01_MATOYAB,
-    sizeof(BgGateShutter),
-    (ActorFunc)BgGateShutter_Init,
-    (ActorFunc)BgGateShutter_Destroy,
-    (ActorFunc)BgGateShutter_Update,
-    (ActorFunc)BgGateShutter_Draw,
+    /**/ ACTOR_BG_GATE_SHUTTER,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT01_MATOYAB,
+    /**/ sizeof(BgGateShutter),
+    /**/ BgGateShutter_Init,
+    /**/ BgGateShutter_Destroy,
+    /**/ BgGateShutter_Update,
+    /**/ BgGateShutter_Draw,
 };
 
 void BgGateShutter_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.c
+++ b/src/overlays/actors/ovl_Bg_Gjyo_Bridge/z_bg_gjyo_bridge.c
@@ -20,15 +20,15 @@ void BgGjyoBridge_TriggerCutscene(BgGjyoBridge* this, PlayState* play);
 void BgGjyoBridge_SpawnBridge(BgGjyoBridge* this, PlayState* play);
 
 ActorInit Bg_Gjyo_Bridge_InitVars = {
-    ACTOR_BG_GJYO_BRIDGE,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GJYO_OBJECTS,
-    sizeof(BgGjyoBridge),
-    (ActorFunc)BgGjyoBridge_Init,
-    (ActorFunc)BgGjyoBridge_Destroy,
-    (ActorFunc)BgGjyoBridge_Update,
-    (ActorFunc)BgGjyoBridge_Draw,
+    /**/ ACTOR_BG_GJYO_BRIDGE,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GJYO_OBJECTS,
+    /**/ sizeof(BgGjyoBridge),
+    /**/ BgGjyoBridge_Init,
+    /**/ BgGjyoBridge_Destroy,
+    /**/ BgGjyoBridge_Update,
+    /**/ BgGjyoBridge_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Darkmeiro/z_bg_gnd_darkmeiro.c
@@ -22,15 +22,15 @@ void BgGndDarkmeiro_UpdateStaticBlock(BgGndDarkmeiro* this, PlayState* play);
 void BgGndDarkmeiro_UpdateSwitchBlock(BgGndDarkmeiro* this, PlayState* play);
 
 ActorInit Bg_Gnd_Darkmeiro_InitVars = {
-    ACTOR_BG_GND_DARKMEIRO,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_DEMO_KEKKAI,
-    sizeof(BgGndDarkmeiro),
-    (ActorFunc)BgGndDarkmeiro_Init,
-    (ActorFunc)BgGndDarkmeiro_Destroy,
-    (ActorFunc)BgGndDarkmeiro_Update,
-    NULL,
+    /**/ ACTOR_BG_GND_DARKMEIRO,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_DEMO_KEKKAI,
+    /**/ sizeof(BgGndDarkmeiro),
+    /**/ BgGndDarkmeiro_Init,
+    /**/ BgGndDarkmeiro_Destroy,
+    /**/ BgGndDarkmeiro_Update,
+    /**/ NULL,
 };
 
 void BgGndDarkmeiro_ToggleBlock(BgGndDarkmeiro* this, PlayState* play) {

--- a/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Firemeiro/z_bg_gnd_firemeiro.c
@@ -19,15 +19,15 @@ void BgGndFiremeiro_Shake(BgGndFiremeiro* this, PlayState* play);
 void BgGndFiremeiro_Rise(BgGndFiremeiro* this, PlayState* play);
 
 ActorInit Bg_Gnd_Firemeiro_InitVars = {
-    ACTOR_BG_GND_FIREMEIRO,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_DEMO_KEKKAI,
-    sizeof(BgGndFiremeiro),
-    (ActorFunc)BgGndFiremeiro_Init,
-    (ActorFunc)BgGndFiremeiro_Destroy,
-    (ActorFunc)BgGndFiremeiro_Update,
-    (ActorFunc)BgGndFiremeiro_Draw,
+    /**/ ACTOR_BG_GND_FIREMEIRO,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_DEMO_KEKKAI,
+    /**/ sizeof(BgGndFiremeiro),
+    /**/ BgGndFiremeiro_Init,
+    /**/ BgGndFiremeiro_Destroy,
+    /**/ BgGndFiremeiro_Update,
+    /**/ BgGndFiremeiro_Draw,
 };
 
 void BgGndFiremeiro_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
@@ -24,15 +24,15 @@ void BgGndIceblock_Idle(BgGndIceblock* this, PlayState* play);
 void BgGndIceblock_Slide(BgGndIceblock* this, PlayState* play);
 
 ActorInit Bg_Gnd_Iceblock_InitVars = {
-    ACTOR_BG_GND_ICEBLOCK,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_DEMO_KEKKAI,
-    sizeof(BgGndIceblock),
-    (ActorFunc)BgGndIceblock_Init,
-    (ActorFunc)BgGndIceblock_Destroy,
-    (ActorFunc)BgGndIceblock_Update,
-    (ActorFunc)BgGndIceblock_Draw,
+    /**/ ACTOR_BG_GND_ICEBLOCK,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_DEMO_KEKKAI,
+    /**/ sizeof(BgGndIceblock),
+    /**/ BgGndIceblock_Init,
+    /**/ BgGndIceblock_Destroy,
+    /**/ BgGndIceblock_Update,
+    /**/ BgGndIceblock_Draw,
 };
 
 static Color_RGBA8 sWhite = { 250, 250, 250, 255 };

--- a/src/overlays/actors/ovl_Bg_Gnd_Nisekabe/z_bg_gnd_nisekabe.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Nisekabe/z_bg_gnd_nisekabe.c
@@ -15,15 +15,15 @@ void BgGndNisekabe_Update(Actor* thisx, PlayState* play);
 void BgGndNisekabe_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Gnd_Nisekabe_InitVars = {
-    ACTOR_BG_GND_NISEKABE,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_DEMO_KEKKAI,
-    sizeof(BgGndNisekabe),
-    (ActorFunc)BgGndNisekabe_Init,
-    (ActorFunc)BgGndNisekabe_Destroy,
-    (ActorFunc)BgGndNisekabe_Update,
-    (ActorFunc)BgGndNisekabe_Draw,
+    /**/ ACTOR_BG_GND_NISEKABE,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_DEMO_KEKKAI,
+    /**/ sizeof(BgGndNisekabe),
+    /**/ BgGndNisekabe_Init,
+    /**/ BgGndNisekabe_Destroy,
+    /**/ BgGndNisekabe_Update,
+    /**/ BgGndNisekabe_Draw,
 };
 
 void BgGndNisekabe_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Bg_Gnd_Soulmeiro/z_bg_gnd_soulmeiro.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Soulmeiro/z_bg_gnd_soulmeiro.c
@@ -20,15 +20,15 @@ void func_8087B284(BgGndSoulmeiro* this, PlayState* play);
 void func_8087B350(BgGndSoulmeiro* this, PlayState* play);
 
 ActorInit Bg_Gnd_Soulmeiro_InitVars = {
-    ACTOR_BG_GND_SOULMEIRO,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_DEMO_KEKKAI,
-    sizeof(BgGndSoulmeiro),
-    (ActorFunc)BgGndSoulmeiro_Init,
-    (ActorFunc)BgGndSoulmeiro_Destroy,
-    (ActorFunc)BgGndSoulmeiro_Update,
-    (ActorFunc)BgGndSoulmeiro_Draw,
+    /**/ ACTOR_BG_GND_SOULMEIRO,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_DEMO_KEKKAI,
+    /**/ sizeof(BgGndSoulmeiro),
+    /**/ BgGndSoulmeiro_Init,
+    /**/ BgGndSoulmeiro_Destroy,
+    /**/ BgGndSoulmeiro_Update,
+    /**/ BgGndSoulmeiro_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
+++ b/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
@@ -21,15 +21,15 @@ void func_8087BAAC(BgHaka* this, PlayState* play);
 void func_8087BAE4(BgHaka* this, PlayState* play);
 
 ActorInit Bg_Haka_InitVars = {
-    ACTOR_BG_HAKA,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HAKA,
-    sizeof(BgHaka),
-    (ActorFunc)BgHaka_Init,
-    (ActorFunc)BgHaka_Destroy,
-    (ActorFunc)BgHaka_Update,
-    (ActorFunc)BgHaka_Draw,
+    /**/ ACTOR_BG_HAKA,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HAKA,
+    /**/ sizeof(BgHaka),
+    /**/ BgHaka_Init,
+    /**/ BgHaka_Destroy,
+    /**/ BgHaka_Update,
+    /**/ BgHaka_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
@@ -53,15 +53,15 @@ static f32 sStatueDistToPlayer = 0;
 static s16 sStatueRotY;
 
 ActorInit Bg_Haka_Gate_InitVars = {
-    ACTOR_BG_HAKA_GATE,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_HAKA_OBJECTS,
-    sizeof(BgHakaGate),
-    (ActorFunc)BgHakaGate_Init,
-    (ActorFunc)BgHakaGate_Destroy,
-    (ActorFunc)BgHakaGate_Update,
-    (ActorFunc)BgHakaGate_Draw,
+    /**/ ACTOR_BG_HAKA_GATE,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_HAKA_OBJECTS,
+    /**/ sizeof(BgHakaGate),
+    /**/ BgHakaGate_Init,
+    /**/ BgHakaGate_Destroy,
+    /**/ BgHakaGate_Update,
+    /**/ BgHakaGate_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Haka_Huta/z_bg_haka_huta.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Huta/z_bg_haka_huta.c
@@ -25,15 +25,15 @@ void func_8087D720(BgHakaHuta* this, PlayState* play);
 void BgHakaHuta_DoNothing(BgHakaHuta* this, PlayState* play);
 
 ActorInit Bg_Haka_Huta_InitVars = {
-    ACTOR_BG_HAKA_HUTA,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HAKACH_OBJECTS,
-    sizeof(BgHakaHuta),
-    (ActorFunc)BgHakaHuta_Init,
-    (ActorFunc)BgHakaHuta_Destroy,
-    (ActorFunc)BgHakaHuta_Update,
-    (ActorFunc)BgHakaHuta_Draw,
+    /**/ ACTOR_BG_HAKA_HUTA,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HAKACH_OBJECTS,
+    /**/ sizeof(BgHakaHuta),
+    /**/ BgHakaHuta_Init,
+    /**/ BgHakaHuta_Destroy,
+    /**/ BgHakaHuta_Update,
+    /**/ BgHakaHuta_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Haka_Megane/z_bg_haka_megane.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Megane/z_bg_haka_megane.c
@@ -20,15 +20,15 @@ void func_8087DBF0(BgHakaMegane* this, PlayState* play);
 void BgHakaMegane_DoNothing(BgHakaMegane* this, PlayState* play);
 
 ActorInit Bg_Haka_Megane_InitVars = {
-    ACTOR_BG_HAKA_MEGANE,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(BgHakaMegane),
-    (ActorFunc)BgHakaMegane_Init,
-    (ActorFunc)BgHakaMegane_Destroy,
-    (ActorFunc)BgHakaMegane_Update,
-    NULL,
+    /**/ ACTOR_BG_HAKA_MEGANE,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(BgHakaMegane),
+    /**/ BgHakaMegane_Init,
+    /**/ BgHakaMegane_Destroy,
+    /**/ BgHakaMegane_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.c
+++ b/src/overlays/actors/ovl_Bg_Haka_MeganeBG/z_bg_haka_meganebg.c
@@ -24,15 +24,15 @@ void func_8087E2D8(BgHakaMeganeBG* this, PlayState* play);
 void func_8087E34C(BgHakaMeganeBG* this, PlayState* play);
 
 ActorInit Bg_Haka_MeganeBG_InitVars = {
-    ACTOR_BG_HAKA_MEGANEBG,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HAKA_OBJECTS,
-    sizeof(BgHakaMeganeBG),
-    (ActorFunc)BgHakaMeganeBG_Init,
-    (ActorFunc)BgHakaMeganeBG_Destroy,
-    (ActorFunc)BgHakaMeganeBG_Update,
-    (ActorFunc)BgHakaMeganeBG_Draw,
+    /**/ ACTOR_BG_HAKA_MEGANEBG,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HAKA_OBJECTS,
+    /**/ sizeof(BgHakaMeganeBG),
+    /**/ BgHakaMeganeBG_Init,
+    /**/ BgHakaMeganeBG_Destroy,
+    /**/ BgHakaMeganeBG_Update,
+    /**/ BgHakaMeganeBG_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.c
@@ -27,15 +27,15 @@ void BgHakaSgami_SetupSpin(BgHakaSgami* this, PlayState* play);
 void BgHakaSgami_Spin(BgHakaSgami* this, PlayState* play);
 
 ActorInit Bg_Haka_Sgami_InitVars = {
-    ACTOR_BG_HAKA_SGAMI,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(BgHakaSgami),
-    (ActorFunc)BgHakaSgami_Init,
-    (ActorFunc)BgHakaSgami_Destroy,
-    (ActorFunc)BgHakaSgami_Update,
-    NULL,
+    /**/ ACTOR_BG_HAKA_SGAMI,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(BgHakaSgami),
+    /**/ BgHakaSgami_Init,
+    /**/ BgHakaSgami_Destroy,
+    /**/ BgHakaSgami_Update,
+    /**/ NULL,
 };
 
 static ColliderTrisElementInit sTrisElementsInit[4] = {

--- a/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Ship/z_bg_haka_ship.c
@@ -22,15 +22,15 @@ void BgHakaShip_CrashShake(BgHakaShip* this, PlayState* play);
 void BgHakaShip_CrashFall(BgHakaShip* this, PlayState* play);
 
 ActorInit Bg_Haka_Ship_InitVars = {
-    ACTOR_BG_HAKA_SHIP,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HAKA_OBJECTS,
-    sizeof(BgHakaShip),
-    (ActorFunc)BgHakaShip_Init,
-    (ActorFunc)BgHakaShip_Destroy,
-    (ActorFunc)BgHakaShip_Update,
-    (ActorFunc)BgHakaShip_Draw,
+    /**/ ACTOR_BG_HAKA_SHIP,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HAKA_OBJECTS,
+    /**/ sizeof(BgHakaShip),
+    /**/ BgHakaShip_Init,
+    /**/ BgHakaShip_Destroy,
+    /**/ BgHakaShip_Update,
+    /**/ BgHakaShip_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
@@ -30,15 +30,15 @@ void func_80880D68(BgHakaTrap* this);
 static UNK_TYPE D_80880F30 = 0;
 
 ActorInit Bg_Haka_Trap_InitVars = {
-    ACTOR_BG_HAKA_TRAP,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HAKA_OBJECTS,
-    sizeof(BgHakaTrap),
-    (ActorFunc)BgHakaTrap_Init,
-    (ActorFunc)BgHakaTrap_Destroy,
-    (ActorFunc)BgHakaTrap_Update,
-    (ActorFunc)BgHakaTrap_Draw,
+    /**/ ACTOR_BG_HAKA_TRAP,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HAKA_OBJECTS,
+    /**/ sizeof(BgHakaTrap),
+    /**/ BgHakaTrap_Init,
+    /**/ BgHakaTrap_Destroy,
+    /**/ BgHakaTrap_Update,
+    /**/ BgHakaTrap_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.c
@@ -19,15 +19,15 @@ void BgHakaTubo_Idle(BgHakaTubo* this, PlayState* play);
 void BgHakaTubo_DropCollectible(BgHakaTubo* this, PlayState* play);
 
 ActorInit Bg_Haka_Tubo_InitVars = {
-    ACTOR_BG_HAKA_TUBO,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HAKA_OBJECTS,
-    sizeof(BgHakaTubo),
-    (ActorFunc)BgHakaTubo_Init,
-    (ActorFunc)BgHakaTubo_Destroy,
-    (ActorFunc)BgHakaTubo_Update,
-    (ActorFunc)BgHakaTubo_Draw,
+    /**/ ACTOR_BG_HAKA_TUBO,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HAKA_OBJECTS,
+    /**/ sizeof(BgHakaTubo),
+    /**/ BgHakaTubo_Init,
+    /**/ BgHakaTubo_Destroy,
+    /**/ BgHakaTubo_Update,
+    /**/ BgHakaTubo_Draw,
 };
 
 static ColliderCylinderInit sPotColliderInit = {

--- a/src/overlays/actors/ovl_Bg_Haka_Water/z_bg_haka_water.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Water/z_bg_haka_water.c
@@ -19,15 +19,15 @@ void BgHakaWater_Wait(BgHakaWater* this, PlayState* play);
 void BgHakaWater_ChangeWaterLevel(BgHakaWater* this, PlayState* play);
 
 ActorInit Bg_Haka_Water_InitVars = {
-    ACTOR_BG_HAKA_WATER,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_HAKACH_OBJECTS,
-    sizeof(BgHakaWater),
-    (ActorFunc)BgHakaWater_Init,
-    (ActorFunc)BgHakaWater_Destroy,
-    (ActorFunc)BgHakaWater_Update,
-    (ActorFunc)BgHakaWater_Draw,
+    /**/ ACTOR_BG_HAKA_WATER,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_HAKACH_OBJECTS,
+    /**/ sizeof(BgHakaWater),
+    /**/ BgHakaWater_Init,
+    /**/ BgHakaWater_Destroy,
+    /**/ BgHakaWater_Update,
+    /**/ BgHakaWater_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Zou/z_bg_haka_zou.c
@@ -55,15 +55,15 @@ static ColliderCylinderInit sCylinderInit = {
 static Vec3f sZeroVec = { 0.0f, 0.0f, 0.0f };
 
 ActorInit Bg_Haka_Zou_InitVars = {
-    ACTOR_BG_HAKA_ZOU,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(BgHakaZou),
-    (ActorFunc)BgHakaZou_Init,
-    (ActorFunc)BgHakaZou_Destroy,
-    (ActorFunc)BgHakaZou_Update,
-    NULL,
+    /**/ ACTOR_BG_HAKA_ZOU,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(BgHakaZou),
+    /**/ BgHakaZou_Init,
+    /**/ BgHakaZou_Destroy,
+    /**/ BgHakaZou_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.c
+++ b/src/overlays/actors/ovl_Bg_Heavy_Block/z_bg_heavy_block.c
@@ -28,15 +28,15 @@ void BgHeavyBlock_Land(BgHeavyBlock* this, PlayState* play);
 void BgHeavyBlock_DoNothing(BgHeavyBlock* this, PlayState* play);
 
 ActorInit Bg_Heavy_Block_InitVars = {
-    ACTOR_BG_HEAVY_BLOCK,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HEAVY_OBJECT,
-    sizeof(BgHeavyBlock),
-    (ActorFunc)BgHeavyBlock_Init,
-    (ActorFunc)BgHeavyBlock_Destroy,
-    (ActorFunc)BgHeavyBlock_Update,
-    (ActorFunc)BgHeavyBlock_Draw,
+    /**/ ACTOR_BG_HEAVY_BLOCK,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HEAVY_OBJECT,
+    /**/ sizeof(BgHeavyBlock),
+    /**/ BgHeavyBlock_Init,
+    /**/ BgHeavyBlock_Destroy,
+    /**/ BgHeavyBlock_Update,
+    /**/ BgHeavyBlock_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Curtain/z_bg_hidan_curtain.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Curtain/z_bg_hidan_curtain.c
@@ -54,15 +54,15 @@ static CollisionCheckInfoInit sCcInfoInit = { 1, 80, 100, MASS_IMMOVABLE };
 static BgHidanCurtainParams sHCParams[] = { { 81, 144, 0.090f, 144.0f, 5.0f }, { 46, 88, 0.055f, 88.0f, 3.0f } };
 
 ActorInit Bg_Hidan_Curtain_InitVars = {
-    ACTOR_BG_HIDAN_CURTAIN,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(BgHidanCurtain),
-    (ActorFunc)BgHidanCurtain_Init,
-    (ActorFunc)BgHidanCurtain_Destroy,
-    (ActorFunc)BgHidanCurtain_Update,
-    (ActorFunc)BgHidanCurtain_Draw,
+    /**/ ACTOR_BG_HIDAN_CURTAIN,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(BgHidanCurtain),
+    /**/ BgHidanCurtain_Init,
+    /**/ BgHidanCurtain_Destroy,
+    /**/ BgHidanCurtain_Update,
+    /**/ BgHidanCurtain_Draw,
 };
 
 void BgHidanCurtain_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
@@ -18,15 +18,15 @@ void BgHidanDalm_Wait(BgHidanDalm* this, PlayState* play);
 void BgHidanDalm_Shrink(BgHidanDalm* this, PlayState* play);
 
 ActorInit Bg_Hidan_Dalm_InitVars = {
-    ACTOR_BG_HIDAN_DALM,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanDalm),
-    (ActorFunc)BgHidanDalm_Init,
-    (ActorFunc)BgHidanDalm_Destroy,
-    (ActorFunc)BgHidanDalm_Update,
-    (ActorFunc)BgHidanDalm_Draw,
+    /**/ ACTOR_BG_HIDAN_DALM,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanDalm),
+    /**/ BgHidanDalm_Init,
+    /**/ BgHidanDalm_Destroy,
+    /**/ BgHidanDalm_Update,
+    /**/ BgHidanDalm_Draw,
 };
 
 static ColliderTrisElementInit sTrisElementInit[4] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
@@ -22,15 +22,15 @@ void BgHidanFirewall_Collide(BgHidanFirewall* this, PlayState* play);
 void BgHidanFirewall_ColliderFollowPlayer(BgHidanFirewall* this, PlayState* play);
 
 ActorInit Bg_Hidan_Firewall_InitVars = {
-    ACTOR_BG_HIDAN_FIREWALL,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanFirewall),
-    (ActorFunc)BgHidanFirewall_Init,
-    (ActorFunc)BgHidanFirewall_Destroy,
-    (ActorFunc)BgHidanFirewall_Update,
-    NULL,
+    /**/ ACTOR_BG_HIDAN_FIREWALL,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanFirewall),
+    /**/ BgHidanFirewall_Init,
+    /**/ BgHidanFirewall_Destroy,
+    /**/ BgHidanFirewall_Update,
+    /**/ NULL,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Fslift/z_bg_hidan_fslift.c
@@ -19,15 +19,15 @@ void func_8088706C(BgHidanFslift* this, PlayState* play);
 void func_808870D8(BgHidanFslift* this, PlayState* play);
 
 ActorInit Bg_Hidan_Fslift_InitVars = {
-    ACTOR_BG_HIDAN_FSLIFT,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanFslift),
-    (ActorFunc)BgHidanFslift_Init,
-    (ActorFunc)BgHidanFslift_Destroy,
-    (ActorFunc)BgHidanFslift_Update,
-    (ActorFunc)BgHidanFslift_Draw,
+    /**/ ACTOR_BG_HIDAN_FSLIFT,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanFslift),
+    /**/ BgHidanFslift_Init,
+    /**/ BgHidanFslift_Destroy,
+    /**/ BgHidanFslift_Update,
+    /**/ BgHidanFslift_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Fwbig/z_bg_hidan_fwbig.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Fwbig/z_bg_hidan_fwbig.c
@@ -32,15 +32,15 @@ void BgHidanFwbig_WaitForPlayer(BgHidanFwbig* this, PlayState* play);
 void BgHidanFwbig_Move(BgHidanFwbig* this, PlayState* play);
 
 ActorInit Bg_Hidan_Fwbig_InitVars = {
-    ACTOR_BG_HIDAN_FWBIG,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanFwbig),
-    (ActorFunc)BgHidanFwbig_Init,
-    (ActorFunc)BgHidanFwbig_Destroy,
-    (ActorFunc)BgHidanFwbig_Update,
-    (ActorFunc)BgHidanFwbig_Draw,
+    /**/ ACTOR_BG_HIDAN_FWBIG,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanFwbig),
+    /**/ BgHidanFwbig_Init,
+    /**/ BgHidanFwbig_Destroy,
+    /**/ BgHidanFwbig_Update,
+    /**/ BgHidanFwbig_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.c
@@ -64,15 +64,15 @@ static ColliderTrisInit sTrisInit = {
 };
 
 ActorInit Bg_Hidan_Hamstep_InitVars = {
-    ACTOR_BG_HIDAN_HAMSTEP,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanHamstep),
-    (ActorFunc)BgHidanHamstep_Init,
-    (ActorFunc)BgHidanHamstep_Destroy,
-    (ActorFunc)BgHidanHamstep_Update,
-    (ActorFunc)BgHidanHamstep_Draw,
+    /**/ ACTOR_BG_HIDAN_HAMSTEP,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanHamstep),
+    /**/ BgHidanHamstep_Init,
+    /**/ BgHidanHamstep_Destroy,
+    /**/ BgHidanHamstep_Update,
+    /**/ BgHidanHamstep_Draw,
 };
 
 static BgHidanHamstepActionFunc sActionFuncs[] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.c
@@ -19,15 +19,15 @@ void func_808896B8(BgHidanHrock* this, PlayState* play);
 void func_808894A4(BgHidanHrock* this, PlayState* play);
 
 ActorInit Bg_Hidan_Hrock_InitVars = {
-    ACTOR_BG_HIDAN_HROCK,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanHrock),
-    (ActorFunc)BgHidanHrock_Init,
-    (ActorFunc)BgHidanHrock_Destroy,
-    (ActorFunc)BgHidanHrock_Update,
-    (ActorFunc)BgHidanHrock_Draw,
+    /**/ ACTOR_BG_HIDAN_HROCK,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanHrock),
+    /**/ BgHidanHrock_Init,
+    /**/ BgHidanHrock_Destroy,
+    /**/ BgHidanHrock_Update,
+    /**/ BgHidanHrock_Draw,
 };
 
 static ColliderTrisElementInit sTrisElementsInit[2] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kousi/z_bg_hidan_kousi.c
@@ -24,15 +24,15 @@ void func_80889D28(BgHidanKousi* this, PlayState* play);
 static f32 D_80889E40[] = { 120.0f, 150.0f, 150.0f };
 
 ActorInit Bg_Hidan_Kousi_InitVars = {
-    ACTOR_BG_HIDAN_KOUSI,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanKousi),
-    (ActorFunc)BgHidanKousi_Init,
-    (ActorFunc)BgHidanKousi_Destroy,
-    (ActorFunc)BgHidanKousi_Update,
-    (ActorFunc)BgHidanKousi_Draw,
+    /**/ ACTOR_BG_HIDAN_KOUSI,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanKousi),
+    /**/ BgHidanKousi_Init,
+    /**/ BgHidanKousi_Destroy,
+    /**/ BgHidanKousi_Update,
+    /**/ BgHidanKousi_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.c
@@ -23,15 +23,15 @@ void BgHidanKowarerukabe_Update(Actor* thisx, PlayState* play);
 void BgHidanKowarerukabe_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Hidan_Kowarerukabe_InitVars = {
-    ACTOR_BG_HIDAN_KOWARERUKABE,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanKowarerukabe),
-    (ActorFunc)BgHidanKowarerukabe_Init,
-    (ActorFunc)BgHidanKowarerukabe_Destroy,
-    (ActorFunc)BgHidanKowarerukabe_Update,
-    (ActorFunc)BgHidanKowarerukabe_Draw,
+    /**/ ACTOR_BG_HIDAN_KOWARERUKABE,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanKowarerukabe),
+    /**/ BgHidanKowarerukabe_Init,
+    /**/ BgHidanKowarerukabe_Destroy,
+    /**/ BgHidanKowarerukabe_Update,
+    /**/ BgHidanKowarerukabe_Draw,
 };
 
 static Gfx* sBreakableWallDLists[] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rock/z_bg_hidan_rock.c
@@ -30,15 +30,15 @@ void func_8088BC40(PlayState* play, BgHidanRock* this);
 static Vec3f D_8088BF60 = { 3310.0f, 120.0f, 0.0f };
 
 ActorInit Bg_Hidan_Rock_InitVars = {
-    ACTOR_BG_HIDAN_ROCK,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanRock),
-    (ActorFunc)BgHidanRock_Init,
-    (ActorFunc)BgHidanRock_Destroy,
-    (ActorFunc)BgHidanRock_Update,
-    (ActorFunc)BgHidanRock_Draw,
+    /**/ ACTOR_BG_HIDAN_ROCK,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanRock),
+    /**/ BgHidanRock_Init,
+    /**/ BgHidanRock_Destroy,
+    /**/ BgHidanRock_Update,
+    /**/ BgHidanRock_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
@@ -15,15 +15,15 @@ void BgHidanRsekizou_Update(Actor* thisx, PlayState* play);
 void BgHidanRsekizou_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Hidan_Rsekizou_InitVars = {
-    ACTOR_BG_HIDAN_RSEKIZOU,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanRsekizou),
-    (ActorFunc)BgHidanRsekizou_Init,
-    (ActorFunc)BgHidanRsekizou_Destroy,
-    (ActorFunc)BgHidanRsekizou_Update,
-    (ActorFunc)BgHidanRsekizou_Draw,
+    /**/ ACTOR_BG_HIDAN_RSEKIZOU,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanRsekizou),
+    /**/ BgHidanRsekizou_Init,
+    /**/ BgHidanRsekizou_Destroy,
+    /**/ BgHidanRsekizou_Update,
+    /**/ BgHidanRsekizou_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[6] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
@@ -18,15 +18,15 @@ void func_8088D434(BgHidanSekizou* this, PlayState* play);
 void func_8088D720(BgHidanSekizou* this, PlayState* play);
 
 ActorInit Bg_Hidan_Sekizou_InitVars = {
-    ACTOR_BG_HIDAN_SEKIZOU,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanSekizou),
-    (ActorFunc)BgHidanSekizou_Init,
-    (ActorFunc)BgHidanSekizou_Destroy,
-    (ActorFunc)BgHidanSekizou_Update,
-    (ActorFunc)BgHidanSekizou_Draw,
+    /**/ ACTOR_BG_HIDAN_SEKIZOU,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanSekizou),
+    /**/ BgHidanSekizou_Init,
+    /**/ BgHidanSekizou_Destroy,
+    /**/ BgHidanSekizou_Update,
+    /**/ BgHidanSekizou_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[6] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
@@ -22,15 +22,15 @@ void func_8088E7A8(BgHidanSima* this, PlayState* play);
 void func_8088E90C(BgHidanSima* this);
 
 ActorInit Bg_Hidan_Sima_InitVars = {
-    ACTOR_BG_HIDAN_SIMA,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanSima),
-    (ActorFunc)BgHidanSima_Init,
-    (ActorFunc)BgHidanSima_Destroy,
-    (ActorFunc)BgHidanSima_Update,
-    (ActorFunc)BgHidanSima_Draw,
+    /**/ ACTOR_BG_HIDAN_SIMA,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanSima),
+    /**/ BgHidanSima_Init,
+    /**/ BgHidanSima_Destroy,
+    /**/ BgHidanSima_Update,
+    /**/ BgHidanSima_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[2] = {

--- a/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Syoku/z_bg_hidan_syoku.c
@@ -19,15 +19,15 @@ void func_8088F514(BgHidanSyoku* this, PlayState* play);
 void func_8088F62C(BgHidanSyoku* this, PlayState* play);
 
 ActorInit Bg_Hidan_Syoku_InitVars = {
-    ACTOR_BG_HIDAN_SYOKU,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HIDAN_OBJECTS,
-    sizeof(BgHidanSyoku),
-    (ActorFunc)BgHidanSyoku_Init,
-    (ActorFunc)BgHidanSyoku_Destroy,
-    (ActorFunc)BgHidanSyoku_Update,
-    (ActorFunc)BgHidanSyoku_Draw,
+    /**/ ACTOR_BG_HIDAN_SYOKU,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HIDAN_OBJECTS,
+    /**/ sizeof(BgHidanSyoku),
+    /**/ BgHidanSyoku_Init,
+    /**/ BgHidanSyoku_Destroy,
+    /**/ BgHidanSyoku_Update,
+    /**/ BgHidanSyoku_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Objects/z_bg_ice_objects.c
@@ -24,15 +24,15 @@ static Color_RGBA8 sGray = { 180, 180, 180, 255 };
 static Vec3f sZeroVec = { 0.0f, 0.0f, 0.0f };
 
 ActorInit Bg_Ice_Objects_InitVars = {
-    ACTOR_BG_ICE_OBJECTS,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_ICE_OBJECTS,
-    sizeof(BgIceObjects),
-    (ActorFunc)BgIceObjects_Init,
-    (ActorFunc)BgIceObjects_Destroy,
-    (ActorFunc)BgIceObjects_Update,
-    (ActorFunc)BgIceObjects_Draw,
+    /**/ ACTOR_BG_ICE_OBJECTS,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_ICE_OBJECTS,
+    /**/ sizeof(BgIceObjects),
+    /**/ BgIceObjects_Init,
+    /**/ BgIceObjects_Destroy,
+    /**/ BgIceObjects_Update,
+    /**/ BgIceObjects_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
@@ -24,15 +24,15 @@ void BgIceShelter_Idle(BgIceShelter* this, PlayState* play);
 void BgIceShelter_Melt(BgIceShelter* this, PlayState* play);
 
 ActorInit Bg_Ice_Shelter_InitVars = {
-    ACTOR_BG_ICE_SHELTER,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_ICE_OBJECTS,
-    sizeof(BgIceShelter),
-    (ActorFunc)BgIceShelter_Init,
-    (ActorFunc)BgIceShelter_Destroy,
-    (ActorFunc)BgIceShelter_Update,
-    (ActorFunc)BgIceShelter_Draw,
+    /**/ ACTOR_BG_ICE_SHELTER,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_ICE_OBJECTS,
+    /**/ sizeof(BgIceShelter),
+    /**/ BgIceShelter_Init,
+    /**/ BgIceShelter_Destroy,
+    /**/ BgIceShelter_Update,
+    /**/ BgIceShelter_Draw,
 };
 
 static f32 sRedIceScales[] = { 0.1f, 0.06f, 0.1f, 0.1f, 0.25f };

--- a/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Shutter/z_bg_ice_shutter.c
@@ -19,15 +19,15 @@ void func_80891D6C(BgIceShutter* this, PlayState* play);
 void func_80891DD4(BgIceShutter* this, PlayState* play);
 
 ActorInit Bg_Ice_Shutter_InitVars = {
-    ACTOR_BG_ICE_SHUTTER,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_ICE_OBJECTS,
-    sizeof(BgIceShutter),
-    (ActorFunc)BgIceShutter_Init,
-    (ActorFunc)BgIceShutter_Destroy,
-    (ActorFunc)BgIceShutter_Update,
-    (ActorFunc)BgIceShutter_Draw,
+    /**/ ACTOR_BG_ICE_SHUTTER,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_ICE_OBJECTS,
+    /**/ sizeof(BgIceShutter),
+    /**/ BgIceShutter_Init,
+    /**/ BgIceShutter_Destroy,
+    /**/ BgIceShutter_Update,
+    /**/ BgIceShutter_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.c
+++ b/src/overlays/actors/ovl_Bg_Ice_Turara/z_bg_ice_turara.c
@@ -41,15 +41,15 @@ static ColliderCylinderInit sCylinderInit = {
 };
 
 ActorInit Bg_Ice_Turara_InitVars = {
-    ACTOR_BG_ICE_TURARA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_ICE_OBJECTS,
-    sizeof(BgIceTurara),
-    (ActorFunc)BgIceTurara_Init,
-    (ActorFunc)BgIceTurara_Destroy,
-    (ActorFunc)BgIceTurara_Update,
-    (ActorFunc)BgIceTurara_Draw,
+    /**/ ACTOR_BG_ICE_TURARA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_ICE_OBJECTS,
+    /**/ sizeof(BgIceTurara),
+    /**/ BgIceTurara_Init,
+    /**/ BgIceTurara_Destroy,
+    /**/ BgIceTurara_Update,
+    /**/ BgIceTurara_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
+++ b/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
@@ -18,15 +18,15 @@ void func_80892890(BgInGate* this, PlayState* play);
 void BgInGate_DoNothing(BgInGate* this, PlayState* play);
 
 ActorInit Bg_Ingate_InitVars = {
-    ACTOR_BG_INGATE,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_INGATE,
-    sizeof(BgInGate),
-    (ActorFunc)BgInGate_Init,
-    (ActorFunc)BgInGate_Destroy,
-    (ActorFunc)BgInGate_Update,
-    (ActorFunc)BgInGate_Draw,
+    /**/ ACTOR_BG_INGATE,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_INGATE,
+    /**/ sizeof(BgInGate),
+    /**/ BgInGate_Init,
+    /**/ BgInGate_Destroy,
+    /**/ BgInGate_Update,
+    /**/ BgInGate_Draw,
 };
 
 void BgInGate_SetupAction(BgInGate* this, BgInGateActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.c
+++ b/src/overlays/actors/ovl_Bg_Jya_1flift/z_bg_jya_1flift.c
@@ -26,15 +26,15 @@ void BgJya1flift_DelayMove(BgJya1flift* this, PlayState* play);
 static u8 sIsSpawned = false;
 
 ActorInit Bg_Jya_1flift_InitVars = {
-    ACTOR_BG_JYA_1FLIFT,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJya1flift),
-    (ActorFunc)BgJya1flift_Init,
-    (ActorFunc)BgJya1flift_Destroy,
-    (ActorFunc)BgJya1flift_Update,
-    (ActorFunc)BgJya1flift_Draw,
+    /**/ ACTOR_BG_JYA_1FLIFT,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJya1flift),
+    /**/ BgJya1flift_Init,
+    /**/ BgJya1flift_Destroy,
+    /**/ BgJya1flift_Update,
+    /**/ BgJya1flift_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Amishutter/z_bg_jya_amishutter.c
@@ -24,15 +24,15 @@ void func_808934FC(BgJyaAmishutter* this);
 void func_8089350C(BgJyaAmishutter* this);
 
 ActorInit Bg_Jya_Amishutter_InitVars = {
-    ACTOR_BG_JYA_AMISHUTTER,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJyaAmishutter),
-    (ActorFunc)BgJyaAmishutter_Init,
-    (ActorFunc)BgJyaAmishutter_Destroy,
-    (ActorFunc)BgJyaAmishutter_Update,
-    (ActorFunc)BgJyaAmishutter_Draw,
+    /**/ ACTOR_BG_JYA_AMISHUTTER,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJyaAmishutter),
+    /**/ BgJyaAmishutter_Init,
+    /**/ BgJyaAmishutter_Destroy,
+    /**/ BgJyaAmishutter_Update,
+    /**/ BgJyaAmishutter_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.c
@@ -17,15 +17,15 @@ void BgJyaBigmirror_Draw(Actor* thisx, PlayState* play);
 static u8 sIsSpawned = false;
 
 ActorInit Bg_Jya_Bigmirror_InitVars = {
-    ACTOR_BG_JYA_BIGMIRROR,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJyaBigmirror),
-    (ActorFunc)BgJyaBigmirror_Init,
-    (ActorFunc)BgJyaBigmirror_Destroy,
-    (ActorFunc)BgJyaBigmirror_Update,
-    (ActorFunc)BgJyaBigmirror_Draw,
+    /**/ ACTOR_BG_JYA_BIGMIRROR,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJyaBigmirror),
+    /**/ BgJyaBigmirror_Init,
+    /**/ BgJyaBigmirror_Destroy,
+    /**/ BgJyaBigmirror_Update,
+    /**/ BgJyaBigmirror_Draw,
 };
 
 typedef struct {

--- a/src/overlays/actors/ovl_Bg_Jya_Block/z_bg_jya_block.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Block/z_bg_jya_block.c
@@ -15,15 +15,15 @@ void BgJyaBlock_Update(Actor* thisx, PlayState* play);
 void BgJyaBlock_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Jya_Block_InitVars = {
-    ACTOR_BG_JYA_BLOCK,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_DANGEON_KEEP,
-    sizeof(BgJyaBlock),
-    (ActorFunc)BgJyaBlock_Init,
-    (ActorFunc)BgJyaBlock_Destroy,
-    (ActorFunc)BgJyaBlock_Update,
-    (ActorFunc)BgJyaBlock_Draw,
+    /**/ ACTOR_BG_JYA_BLOCK,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_DANGEON_KEEP,
+    /**/ sizeof(BgJyaBlock),
+    /**/ BgJyaBlock_Init,
+    /**/ BgJyaBlock_Destroy,
+    /**/ BgJyaBlock_Update,
+    /**/ BgJyaBlock_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.c
@@ -15,15 +15,15 @@ void BgJyaBombchuiwa_CleanUpAfterExplosion(BgJyaBombchuiwa* this, PlayState* pla
 void BgJyaBombchuiwa_SpawnLightRay(BgJyaBombchuiwa* this, PlayState* play);
 
 ActorInit Bg_Jya_Bombchuiwa_InitVars = {
-    ACTOR_BG_JYA_BOMBCHUIWA,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJyaBombchuiwa),
-    (ActorFunc)BgJyaBombchuiwa_Init,
-    (ActorFunc)BgJyaBombchuiwa_Destroy,
-    (ActorFunc)BgJyaBombchuiwa_Update,
-    (ActorFunc)BgJyaBombchuiwa_Draw,
+    /**/ ACTOR_BG_JYA_BOMBCHUIWA,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJyaBombchuiwa),
+    /**/ BgJyaBombchuiwa_Init,
+    /**/ BgJyaBombchuiwa_Destroy,
+    /**/ BgJyaBombchuiwa_Update,
+    /**/ BgJyaBombchuiwa_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_Bg_Jya_Bombiwa/z_bg_jya_bombiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombiwa/z_bg_jya_bombiwa.c
@@ -17,15 +17,15 @@ void BgJyaBombiwa_Update(Actor* thisx, PlayState* play);
 void BgJyaBombiwa_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Jya_Bombiwa_InitVars = {
-    ACTOR_BG_JYA_BOMBIWA,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJyaBombiwa),
-    (ActorFunc)BgJyaBombiwa_Init,
-    (ActorFunc)BgJyaBombiwa_Destroy,
-    (ActorFunc)BgJyaBombiwa_Update,
-    (ActorFunc)BgJyaBombiwa_Draw,
+    /**/ ACTOR_BG_JYA_BOMBIWA,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJyaBombiwa),
+    /**/ BgJyaBombiwa_Init,
+    /**/ BgJyaBombiwa_Destroy,
+    /**/ BgJyaBombiwa_Update,
+    /**/ BgJyaBombiwa_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[] = {

--- a/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Cobra/z_bg_jya_cobra.c
@@ -19,15 +19,15 @@ void func_80896ABC(BgJyaCobra* this, PlayState* play);
 #include "assets/overlays/ovl_Bg_Jya_Cobra/ovl_Bg_Jya_Cobra.c"
 
 ActorInit Bg_Jya_Cobra_InitVars = {
-    ACTOR_BG_JYA_COBRA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJyaCobra),
-    (ActorFunc)BgJyaCobra_Init,
-    (ActorFunc)BgJyaCobra_Destroy,
-    (ActorFunc)BgJyaCobra_Update,
-    (ActorFunc)BgJyaCobra_Draw,
+    /**/ ACTOR_BG_JYA_COBRA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJyaCobra),
+    /**/ BgJyaCobra_Init,
+    /**/ BgJyaCobra_Destroy,
+    /**/ BgJyaCobra_Update,
+    /**/ BgJyaCobra_Draw,
 };
 
 static s16 D_80897308[] = { 0, 0, 0, 0 };

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
@@ -24,15 +24,15 @@ void BgJyaGoroiwa_UpdateRotation(BgJyaGoroiwa* this);
 void BgJyaGoroiwa_UpdateCollider(BgJyaGoroiwa* this);
 
 ActorInit Bg_Jya_Goroiwa_InitVars = {
-    ACTOR_BG_JYA_GOROIWA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GOROIWA,
-    sizeof(BgJyaGoroiwa),
-    (ActorFunc)BgJyaGoroiwa_Init,
-    (ActorFunc)BgJyaGoroiwa_Destroy,
-    (ActorFunc)BgJyaGoroiwa_Update,
-    (ActorFunc)BgJyaGoroiwa_Draw,
+    /**/ ACTOR_BG_JYA_GOROIWA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GOROIWA,
+    /**/ sizeof(BgJyaGoroiwa),
+    /**/ BgJyaGoroiwa_Init,
+    /**/ BgJyaGoroiwa_Destroy,
+    /**/ BgJyaGoroiwa_Update,
+    /**/ BgJyaGoroiwa_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[] = {

--- a/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.c
@@ -23,15 +23,15 @@ void BgJyaHaheniron_SetupRubbleCollide(BgJyaHaheniron* this);
 void BgJyaHaheniron_RubbleCollide(BgJyaHaheniron* this, PlayState* play);
 
 ActorInit Bg_Jya_Haheniron_InitVars = {
-    ACTOR_BG_JYA_HAHENIRON,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_JYA_IRON,
-    sizeof(BgJyaHaheniron),
-    (ActorFunc)BgJyaHaheniron_Init,
-    (ActorFunc)BgJyaHaheniron_Destroy,
-    (ActorFunc)BgJyaHaheniron_Update,
-    (ActorFunc)BgJyaHaheniron_Draw,
+    /**/ ACTOR_BG_JYA_HAHENIRON,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_IRON,
+    /**/ sizeof(BgJyaHaheniron),
+    /**/ BgJyaHaheniron_Init,
+    /**/ BgJyaHaheniron_Destroy,
+    /**/ BgJyaHaheniron_Update,
+    /**/ BgJyaHaheniron_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
@@ -25,15 +25,15 @@ void BgJyaIronobj_SpawnThroneParticles(BgJyaIronobj* this, PlayState* play, EnIk
 static int sUnused = 0;
 
 ActorInit Bg_Jya_Ironobj_InitVars = {
-    ACTOR_BG_JYA_IRONOBJ,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_JYA_IRON,
-    sizeof(BgJyaIronobj),
-    (ActorFunc)BgJyaIronobj_Init,
-    (ActorFunc)BgJyaIronobj_Destroy,
-    (ActorFunc)BgJyaIronobj_Update,
-    (ActorFunc)BgJyaIronobj_Draw,
+    /**/ ACTOR_BG_JYA_IRONOBJ,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_IRON,
+    /**/ sizeof(BgJyaIronobj),
+    /**/ BgJyaIronobj_Init,
+    /**/ BgJyaIronobj_Destroy,
+    /**/ BgJyaIronobj_Update,
+    /**/ BgJyaIronobj_Draw,
 };
 
 static Gfx* sOpaDL[] = { gPillarDL, gThroneDL };

--- a/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Kanaami/z_bg_jya_kanaami.c
@@ -22,15 +22,15 @@ void func_80899950(BgJyaKanaami* this, PlayState* play);
 void func_80899A08(BgJyaKanaami* this);
 
 ActorInit Bg_Jya_Kanaami_InitVars = {
-    ACTOR_BG_JYA_KANAAMI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJyaKanaami),
-    (ActorFunc)BgJyaKanaami_Init,
-    (ActorFunc)BgJyaKanaami_Destroy,
-    (ActorFunc)BgJyaKanaami_Update,
-    (ActorFunc)BgJyaKanaami_Draw,
+    /**/ ACTOR_BG_JYA_KANAAMI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJyaKanaami),
+    /**/ BgJyaKanaami_Init,
+    /**/ BgJyaKanaami_Destroy,
+    /**/ BgJyaKanaami_Update,
+    /**/ BgJyaKanaami_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
@@ -23,15 +23,15 @@ void BgJyaLift_Move(BgJyaLift* this, PlayState* play);
 static s16 sIsSpawned = false;
 
 ActorInit Bg_Jya_Lift_InitVars = {
-    ACTOR_BG_JYA_LIFT,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJyaLift),
-    (ActorFunc)BgJyaLift_Init,
-    (ActorFunc)BgJyaLift_Destroy,
-    (ActorFunc)BgJyaLift_Update,
-    (ActorFunc)BgJyaLift_Draw,
+    /**/ ACTOR_BG_JYA_LIFT,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJyaLift),
+    /**/ BgJyaLift_Init,
+    /**/ BgJyaLift_Destroy,
+    /**/ BgJyaLift_Update,
+    /**/ BgJyaLift_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.c
@@ -21,15 +21,15 @@ void BgJyaMegami_SetupExplode(BgJyaMegami* this);
 void BgJyaMegami_Explode(BgJyaMegami* this, PlayState* play);
 
 ActorInit Bg_Jya_Megami_InitVars = {
-    ACTOR_BG_JYA_MEGAMI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJyaMegami),
-    (ActorFunc)BgJyaMegami_Init,
-    (ActorFunc)BgJyaMegami_Destroy,
-    (ActorFunc)BgJyaMegami_Update,
-    (ActorFunc)BgJyaMegami_Draw,
+    /**/ ACTOR_BG_JYA_MEGAMI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJyaMegami),
+    /**/ BgJyaMegami_Init,
+    /**/ BgJyaMegami_Destroy,
+    /**/ BgJyaMegami_Update,
+    /**/ BgJyaMegami_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[] = {

--- a/src/overlays/actors/ovl_Bg_Jya_Zurerukabe/z_bg_jya_zurerukabe.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Zurerukabe/z_bg_jya_zurerukabe.c
@@ -24,15 +24,15 @@ void func_8089B870(BgJyaZurerukabe* this, PlayState* play);
 static f32 D_8089B9C0[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
 ActorInit Bg_Jya_Zurerukabe_InitVars = {
-    ACTOR_BG_JYA_ZURERUKABE,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_JYA_OBJ,
-    sizeof(BgJyaZurerukabe),
-    (ActorFunc)BgJyaZurerukabe_Init,
-    (ActorFunc)BgJyaZurerukabe_Destroy,
-    (ActorFunc)BgJyaZurerukabe_Update,
-    (ActorFunc)BgJyaZurerukabe_Draw,
+    /**/ ACTOR_BG_JYA_ZURERUKABE,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_JYA_OBJ,
+    /**/ sizeof(BgJyaZurerukabe),
+    /**/ BgJyaZurerukabe_Init,
+    /**/ BgJyaZurerukabe_Destroy,
+    /**/ BgJyaZurerukabe_Update,
+    /**/ BgJyaZurerukabe_Draw,
 };
 
 static s16 D_8089B9F0[4] = { 943, 1043, 1243, 1343 };

--- a/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
@@ -15,15 +15,15 @@ void BgMenkuriEye_Update(Actor* thisx, PlayState* play);
 void BgMenkuriEye_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Menkuri_Eye_InitVars = {
-    ACTOR_BG_MENKURI_EYE,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MENKURI_OBJECTS,
-    sizeof(BgMenkuriEye),
-    (ActorFunc)BgMenkuriEye_Init,
-    (ActorFunc)BgMenkuriEye_Destroy,
-    (ActorFunc)BgMenkuriEye_Update,
-    (ActorFunc)BgMenkuriEye_Draw,
+    /**/ ACTOR_BG_MENKURI_EYE,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MENKURI_OBJECTS,
+    /**/ sizeof(BgMenkuriEye),
+    /**/ BgMenkuriEye_Init,
+    /**/ BgMenkuriEye_Destroy,
+    /**/ BgMenkuriEye_Update,
+    /**/ BgMenkuriEye_Draw,
 };
 
 static s32 D_8089C1A0;

--- a/src/overlays/actors/ovl_Bg_Menkuri_Kaiten/z_bg_menkuri_kaiten.c
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Kaiten/z_bg_menkuri_kaiten.c
@@ -15,15 +15,15 @@ void BgMenkuriKaiten_Update(Actor* thisx, PlayState* play);
 void BgMenkuriKaiten_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Menkuri_Kaiten_InitVars = {
-    ACTOR_BG_MENKURI_KAITEN,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MENKURI_OBJECTS,
-    sizeof(BgMenkuriKaiten),
-    (ActorFunc)BgMenkuriKaiten_Init,
-    (ActorFunc)BgMenkuriKaiten_Destroy,
-    (ActorFunc)BgMenkuriKaiten_Update,
-    (ActorFunc)BgMenkuriKaiten_Draw,
+    /**/ ACTOR_BG_MENKURI_KAITEN,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MENKURI_OBJECTS,
+    /**/ sizeof(BgMenkuriKaiten),
+    /**/ BgMenkuriKaiten_Init,
+    /**/ BgMenkuriKaiten_Destroy,
+    /**/ BgMenkuriKaiten_Update,
+    /**/ BgMenkuriKaiten_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Menkuri_Nisekabe/z_bg_menkuri_nisekabe.c
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Nisekabe/z_bg_menkuri_nisekabe.c
@@ -15,15 +15,15 @@ void BgMenkuriNisekabe_Update(Actor* thisx, PlayState* play);
 void BgMenkuriNisekabe_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Menkuri_Nisekabe_InitVars = {
-    ACTOR_BG_MENKURI_NISEKABE,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_MENKURI_OBJECTS,
-    sizeof(BgMenkuriNisekabe),
-    (ActorFunc)BgMenkuriNisekabe_Init,
-    (ActorFunc)BgMenkuriNisekabe_Destroy,
-    (ActorFunc)BgMenkuriNisekabe_Update,
-    (ActorFunc)BgMenkuriNisekabe_Draw,
+    /**/ ACTOR_BG_MENKURI_NISEKABE,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_MENKURI_OBJECTS,
+    /**/ sizeof(BgMenkuriNisekabe),
+    /**/ BgMenkuriNisekabe_Init,
+    /**/ BgMenkuriNisekabe_Destroy,
+    /**/ BgMenkuriNisekabe_Update,
+    /**/ BgMenkuriNisekabe_Draw,
 };
 
 static Gfx* sDLists[] = { gGTGFakeWallDL, gGTGFakeCeilingDL };

--- a/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
@@ -20,15 +20,15 @@ void BgMizuBwall_Break(BgMizuBwall* this, PlayState* play);
 void BgMizuBwall_DoNothing(BgMizuBwall* this, PlayState* play);
 
 ActorInit Bg_Mizu_Bwall_InitVars = {
-    ACTOR_BG_MIZU_BWALL,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MIZU_OBJECTS,
-    sizeof(BgMizuBwall),
-    (ActorFunc)BgMizuBwall_Init,
-    (ActorFunc)BgMizuBwall_Destroy,
-    (ActorFunc)BgMizuBwall_Update,
-    (ActorFunc)BgMizuBwall_Draw,
+    /**/ ACTOR_BG_MIZU_BWALL,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MIZU_OBJECTS,
+    /**/ sizeof(BgMizuBwall),
+    /**/ BgMizuBwall_Init,
+    /**/ BgMizuBwall_Destroy,
+    /**/ BgMizuBwall_Update,
+    /**/ BgMizuBwall_Draw,
 };
 
 static ColliderTrisElementInit sTrisElementInitFloor[2] = {

--- a/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.c
@@ -26,15 +26,15 @@ void func_8089E650(BgMizuMovebg* this, PlayState* play);
 s32 func_8089E108(Path* pathList, Vec3f* pos, s32 pathId, s32 pointId);
 
 ActorInit Bg_Mizu_Movebg_InitVars = {
-    ACTOR_BG_MIZU_MOVEBG,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MIZU_OBJECTS,
-    sizeof(BgMizuMovebg),
-    (ActorFunc)BgMizuMovebg_Init,
-    (ActorFunc)BgMizuMovebg_Destroy,
-    (ActorFunc)BgMizuMovebg_Update,
-    (ActorFunc)BgMizuMovebg_Draw,
+    /**/ ACTOR_BG_MIZU_MOVEBG,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MIZU_OBJECTS,
+    /**/ sizeof(BgMizuMovebg),
+    /**/ BgMizuMovebg_Init,
+    /**/ BgMizuMovebg_Destroy,
+    /**/ BgMizuMovebg_Update,
+    /**/ BgMizuMovebg_Draw,
 };
 
 static f32 D_8089EB40[] = { -115.200005f, -115.200005f, -115.200005f, 0.0f };

--- a/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Shutter/z_bg_mizu_shutter.c
@@ -14,15 +14,15 @@ void BgMizuShutter_Move(BgMizuShutter* this, PlayState* play);
 void BgMizuShutter_WaitForCutscene(BgMizuShutter* this, PlayState* play);
 
 ActorInit Bg_Mizu_Shutter_InitVars = {
-    ACTOR_BG_MIZU_SHUTTER,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_MIZU_OBJECTS,
-    sizeof(BgMizuShutter),
-    (ActorFunc)BgMizuShutter_Init,
-    (ActorFunc)BgMizuShutter_Destroy,
-    (ActorFunc)BgMizuShutter_Update,
-    (ActorFunc)BgMizuShutter_Draw,
+    /**/ ACTOR_BG_MIZU_SHUTTER,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_MIZU_OBJECTS,
+    /**/ sizeof(BgMizuShutter),
+    /**/ BgMizuShutter_Init,
+    /**/ BgMizuShutter_Destroy,
+    /**/ BgMizuShutter_Update,
+    /**/ BgMizuShutter_Draw,
 };
 
 static Gfx* sDisplayLists[] = { gObjectMizuObjectsShutterDL_007130, gObjectMizuObjectsShutterDL_0072D0 };

--- a/src/overlays/actors/ovl_Bg_Mizu_Uzu/z_bg_mizu_uzu.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Uzu/z_bg_mizu_uzu.c
@@ -17,15 +17,15 @@ void BgMizuUzu_Draw(Actor* thisx, PlayState* play);
 void func_8089F788(BgMizuUzu* this, PlayState* play);
 
 ActorInit Bg_Mizu_Uzu_InitVars = {
-    ACTOR_BG_MIZU_UZU,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_MIZU_OBJECTS,
-    sizeof(BgMizuUzu),
-    (ActorFunc)BgMizuUzu_Init,
-    (ActorFunc)BgMizuUzu_Destroy,
-    (ActorFunc)BgMizuUzu_Update,
-    (ActorFunc)BgMizuUzu_Draw,
+    /**/ ACTOR_BG_MIZU_UZU,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_MIZU_OBJECTS,
+    /**/ sizeof(BgMizuUzu),
+    /**/ BgMizuUzu_Init,
+    /**/ BgMizuUzu_Destroy,
+    /**/ BgMizuUzu_Update,
+    /**/ BgMizuUzu_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Water/z_bg_mizu_water.c
@@ -30,15 +30,15 @@ static WaterLevel sWaterLevels[] = {
 };
 
 ActorInit Bg_Mizu_Water_InitVars = {
-    ACTOR_BG_MIZU_WATER,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MIZU_OBJECTS,
-    sizeof(BgMizuWater),
-    (ActorFunc)BgMizuWater_Init,
-    (ActorFunc)BgMizuWater_Destroy,
-    (ActorFunc)BgMizuWater_Update,
-    (ActorFunc)BgMizuWater_Draw,
+    /**/ ACTOR_BG_MIZU_WATER,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MIZU_OBJECTS,
+    /**/ sizeof(BgMizuWater),
+    /**/ BgMizuWater_Init,
+    /**/ BgMizuWater_Destroy,
+    /**/ BgMizuWater_Update,
+    /**/ BgMizuWater_Draw,
 };
 
 static f32 sUnused1 = 0;

--- a/src/overlays/actors/ovl_Bg_Mjin/z_bg_mjin.c
+++ b/src/overlays/actors/ovl_Bg_Mjin/z_bg_mjin.c
@@ -25,15 +25,15 @@ void func_808A0850(BgMjin* this, PlayState* play);
 void BgMjin_DoNothing(BgMjin* this, PlayState* play);
 
 ActorInit Bg_Mjin_InitVars = {
-    ACTOR_BG_MJIN,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(BgMjin),
-    (ActorFunc)BgMjin_Init,
-    (ActorFunc)BgMjin_Destroy,
-    (ActorFunc)BgMjin_Update,
-    NULL,
+    /**/ ACTOR_BG_MJIN,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(BgMjin),
+    /**/ BgMjin_Init,
+    /**/ BgMjin_Destroy,
+    /**/ BgMjin_Update,
+    /**/ NULL,
 };
 
 extern UNK_TYPE D_06000000;

--- a/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Bigst/z_bg_mori_bigst.c
@@ -29,15 +29,15 @@ void BgMoriBigst_StalfosPairFight(BgMoriBigst* this, PlayState* play);
 void BgMoriBigst_SetupDone(BgMoriBigst* this, PlayState* play);
 
 ActorInit Bg_Mori_Bigst_InitVars = {
-    ACTOR_BG_MORI_BIGST,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MORI_OBJECTS,
-    sizeof(BgMoriBigst),
-    (ActorFunc)BgMoriBigst_Init,
-    (ActorFunc)BgMoriBigst_Destroy,
-    (ActorFunc)BgMoriBigst_Update,
-    NULL,
+    /**/ ACTOR_BG_MORI_BIGST,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MORI_OBJECTS,
+    /**/ sizeof(BgMoriBigst),
+    /**/ BgMoriBigst_Init,
+    /**/ BgMoriBigst_Destroy,
+    /**/ BgMoriBigst_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Elevator/z_bg_mori_elevator.c
@@ -20,15 +20,15 @@ void BgMoriElevator_MoveAboveGround(BgMoriElevator* this, PlayState* play);
 static s16 sIsSpawned = false;
 
 ActorInit Bg_Mori_Elevator_InitVars = {
-    ACTOR_BG_MORI_ELEVATOR,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MORI_OBJECTS,
-    sizeof(BgMoriElevator),
-    (ActorFunc)BgMoriElevator_Init,
-    (ActorFunc)BgMoriElevator_Destroy,
-    (ActorFunc)BgMoriElevator_Update,
-    NULL,
+    /**/ ACTOR_BG_MORI_ELEVATOR,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MORI_OBJECTS,
+    /**/ sizeof(BgMoriElevator),
+    /**/ BgMoriElevator_Init,
+    /**/ BgMoriElevator_Destroy,
+    /**/ BgMoriElevator_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.c
@@ -25,15 +25,15 @@ void BgMoriHashigo_LadderFall(BgMoriHashigo* this, PlayState* play);
 void BgMoriHashigo_SetupLadderRest(BgMoriHashigo* this);
 
 ActorInit Bg_Mori_Hashigo_InitVars = {
-    ACTOR_BG_MORI_HASHIGO,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MORI_OBJECTS,
-    sizeof(BgMoriHashigo),
-    (ActorFunc)BgMoriHashigo_Init,
-    (ActorFunc)BgMoriHashigo_Destroy,
-    (ActorFunc)BgMoriHashigo_Update,
-    NULL,
+    /**/ ACTOR_BG_MORI_HASHIGO,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MORI_OBJECTS,
+    /**/ sizeof(BgMoriHashigo),
+    /**/ BgMoriHashigo_Init,
+    /**/ BgMoriHashigo_Destroy,
+    /**/ BgMoriHashigo_Update,
+    /**/ NULL,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashira4/z_bg_mori_hashira4.c
@@ -22,15 +22,15 @@ void BgMoriHashira4_GateWait(BgMoriHashira4* this, PlayState* play);
 void BgMoriHashira4_GateOpen(BgMoriHashira4* this, PlayState* play);
 
 ActorInit Bg_Mori_Hashira4_InitVars = {
-    ACTOR_BG_MORI_HASHIRA4,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MORI_OBJECTS,
-    sizeof(BgMoriHashira4),
-    (ActorFunc)BgMoriHashira4_Init,
-    (ActorFunc)BgMoriHashira4_Destroy,
-    (ActorFunc)BgMoriHashira4_Update,
-    NULL,
+    /**/ ACTOR_BG_MORI_HASHIRA4,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MORI_OBJECTS,
+    /**/ sizeof(BgMoriHashira4),
+    /**/ BgMoriHashira4_Init,
+    /**/ BgMoriHashira4_Destroy,
+    /**/ BgMoriHashira4_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Mori_Hineri/z_bg_mori_hineri.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Hineri/z_bg_mori_hineri.c
@@ -30,15 +30,15 @@ void func_808A3D58(BgMoriHineri* this, PlayState* play);
 static s16 sSubCamId = CAM_ID_NONE;
 
 ActorInit Bg_Mori_Hineri_InitVars = {
-    ACTOR_BG_MORI_HINERI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(BgMoriHineri),
-    (ActorFunc)BgMoriHineri_Init,
-    (ActorFunc)BgMoriHineri_Destroy,
-    (ActorFunc)BgMoriHineri_Update,
-    NULL,
+    /**/ ACTOR_BG_MORI_HINERI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(BgMoriHineri),
+    /**/ BgMoriHineri_Init,
+    /**/ BgMoriHineri_Destroy,
+    /**/ BgMoriHineri_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Mori_Idomizu/z_bg_mori_idomizu.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Idomizu/z_bg_mori_idomizu.c
@@ -22,15 +22,15 @@ void BgMoriIdomizu_Main(BgMoriIdomizu* this, PlayState* play);
 static s16 sIsSpawned = false;
 
 ActorInit Bg_Mori_Idomizu_InitVars = {
-    ACTOR_BG_MORI_IDOMIZU,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MORI_OBJECTS,
-    sizeof(BgMoriIdomizu),
-    (ActorFunc)BgMoriIdomizu_Init,
-    (ActorFunc)BgMoriIdomizu_Destroy,
-    (ActorFunc)BgMoriIdomizu_Update,
-    NULL,
+    /**/ ACTOR_BG_MORI_IDOMIZU,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MORI_OBJECTS,
+    /**/ sizeof(BgMoriIdomizu),
+    /**/ BgMoriIdomizu_Init,
+    /**/ BgMoriIdomizu_Destroy,
+    /**/ BgMoriIdomizu_Update,
+    /**/ NULL,
 };
 
 void BgMoriIdomizu_SetupAction(BgMoriIdomizu* this, BgMoriIdomizuActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
@@ -21,15 +21,15 @@ void BgMoriKaitenkabe_SetupRotate(BgMoriKaitenkabe* this);
 void BgMoriKaitenkabe_Rotate(BgMoriKaitenkabe* this, PlayState* play);
 
 ActorInit Bg_Mori_Kaitenkabe_InitVars = {
-    ACTOR_BG_MORI_KAITENKABE,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MORI_OBJECTS,
-    sizeof(BgMoriKaitenkabe),
-    (ActorFunc)BgMoriKaitenkabe_Init,
-    (ActorFunc)BgMoriKaitenkabe_Destroy,
-    (ActorFunc)BgMoriKaitenkabe_Update,
-    NULL,
+    /**/ ACTOR_BG_MORI_KAITENKABE,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MORI_OBJECTS,
+    /**/ sizeof(BgMoriKaitenkabe),
+    /**/ BgMoriKaitenkabe_Init,
+    /**/ BgMoriKaitenkabe_Destroy,
+    /**/ BgMoriKaitenkabe_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Mori_Rakkatenjo/z_bg_mori_rakkatenjo.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Rakkatenjo/z_bg_mori_rakkatenjo.c
@@ -29,15 +29,15 @@ void BgMoriRakkatenjo_Rise(BgMoriRakkatenjo* this, PlayState* play);
 static s16 sCamSetting = CAM_SET_NONE;
 
 ActorInit Bg_Mori_Rakkatenjo_InitVars = {
-    ACTOR_BG_MORI_RAKKATENJO,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MORI_OBJECTS,
-    sizeof(BgMoriRakkatenjo),
-    (ActorFunc)BgMoriRakkatenjo_Init,
-    (ActorFunc)BgMoriRakkatenjo_Destroy,
-    (ActorFunc)BgMoriRakkatenjo_Update,
-    NULL,
+    /**/ ACTOR_BG_MORI_RAKKATENJO,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MORI_OBJECTS,
+    /**/ sizeof(BgMoriRakkatenjo),
+    /**/ BgMoriRakkatenjo_Init,
+    /**/ BgMoriRakkatenjo_Destroy,
+    /**/ BgMoriRakkatenjo_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
+++ b/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
@@ -29,15 +29,15 @@ void BgPoEvent_PaintingPresent(BgPoEvent* this, PlayState* play);
 void BgPoEvent_PaintingBurn(BgPoEvent* this, PlayState* play);
 
 ActorInit Bg_Po_Event_InitVars = {
-    ACTOR_BG_PO_EVENT,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_PO_SISTERS,
-    sizeof(BgPoEvent),
-    (ActorFunc)BgPoEvent_Init,
-    (ActorFunc)BgPoEvent_Destroy,
-    (ActorFunc)BgPoEvent_Update,
-    (ActorFunc)BgPoEvent_Draw,
+    /**/ ACTOR_BG_PO_EVENT,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_PO_SISTERS,
+    /**/ sizeof(BgPoEvent),
+    /**/ BgPoEvent_Init,
+    /**/ BgPoEvent_Destroy,
+    /**/ BgPoEvent_Update,
+    /**/ BgPoEvent_Draw,
 };
 
 static ColliderTrisElementInit sTrisElementsInit[2] = {

--- a/src/overlays/actors/ovl_Bg_Po_Syokudai/z_bg_po_syokudai.c
+++ b/src/overlays/actors/ovl_Bg_Po_Syokudai/z_bg_po_syokudai.c
@@ -59,15 +59,15 @@ static Color_RGBA8 sEnvColors[] = {
 };
 
 ActorInit Bg_Po_Syokudai_InitVars = {
-    ACTOR_BG_PO_SYOKUDAI,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SYOKUDAI,
-    sizeof(BgPoSyokudai),
-    (ActorFunc)BgPoSyokudai_Init,
-    (ActorFunc)BgPoSyokudai_Destroy,
-    (ActorFunc)BgPoSyokudai_Update,
-    (ActorFunc)BgPoSyokudai_Draw,
+    /**/ ACTOR_BG_PO_SYOKUDAI,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SYOKUDAI,
+    /**/ sizeof(BgPoSyokudai),
+    /**/ BgPoSyokudai_Init,
+    /**/ BgPoSyokudai_Destroy,
+    /**/ BgPoSyokudai_Update,
+    /**/ BgPoSyokudai_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
+++ b/src/overlays/actors/ovl_Bg_Pushbox/z_bg_pushbox.c
@@ -17,16 +17,16 @@ void BgPushbox_Draw(Actor* thisx, PlayState* play);
 void BgPushbox_UpdateImpl(BgPushbox* this, PlayState* play);
 
 ActorInit Bg_Pushbox_InitVars = {
-    ACTOR_BG_PUSHBOX,
-    ACTORCAT_BG,
-    FLAGS,
+    /**/ ACTOR_BG_PUSHBOX,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
     //! @bug fixing this actor would involve using OBJECT_PU_BOX
-    OBJECT_GAMEPLAY_DANGEON_KEEP,
-    sizeof(BgPushbox),
-    (ActorFunc)BgPushbox_Init,
-    (ActorFunc)BgPushbox_Destroy,
-    (ActorFunc)BgPushbox_Update,
-    (ActorFunc)BgPushbox_Draw,
+    /**/ OBJECT_GAMEPLAY_DANGEON_KEEP,
+    /**/ sizeof(BgPushbox),
+    /**/ BgPushbox_Init,
+    /**/ BgPushbox_Destroy,
+    /**/ BgPushbox_Update,
+    /**/ BgPushbox_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
+++ b/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
@@ -27,15 +27,15 @@ void func_808A932C(BgRelayObjects* this, PlayState* play);
 void func_808A939C(BgRelayObjects* this, PlayState* play);
 
 ActorInit Bg_Relay_Objects_InitVars = {
-    ACTOR_BG_RELAY_OBJECTS,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_RELAY_OBJECTS,
-    sizeof(BgRelayObjects),
-    (ActorFunc)BgRelayObjects_Init,
-    (ActorFunc)BgRelayObjects_Destroy,
-    (ActorFunc)BgRelayObjects_Update,
-    (ActorFunc)BgRelayObjects_Draw,
+    /**/ ACTOR_BG_RELAY_OBJECTS,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_RELAY_OBJECTS,
+    /**/ sizeof(BgRelayObjects),
+    /**/ BgRelayObjects_Init,
+    /**/ BgRelayObjects_Destroy,
+    /**/ BgRelayObjects_Update,
+    /**/ BgRelayObjects_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot00_Break/z_bg_spot00_break.c
+++ b/src/overlays/actors/ovl_Bg_Spot00_Break/z_bg_spot00_break.c
@@ -15,15 +15,15 @@ void BgSpot00Break_Update(Actor* thisx, PlayState* play);
 void BgSpot00Break_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Spot00_Break_InitVars = {
-    ACTOR_BG_SPOT00_BREAK,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SPOT00_BREAK,
-    sizeof(BgSpot00Break),
-    (ActorFunc)BgSpot00Break_Init,
-    (ActorFunc)BgSpot00Break_Destroy,
-    (ActorFunc)BgSpot00Break_Update,
-    (ActorFunc)BgSpot00Break_Draw,
+    /**/ ACTOR_BG_SPOT00_BREAK,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT00_BREAK,
+    /**/ sizeof(BgSpot00Break),
+    /**/ BgSpot00Break_Init,
+    /**/ BgSpot00Break_Destroy,
+    /**/ BgSpot00Break_Update,
+    /**/ BgSpot00Break_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
+++ b/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
@@ -26,15 +26,15 @@ void BgSpot00Hanebasi_DrawbridgeRiseAndFall(BgSpot00Hanebasi* this, PlayState* p
 void BgSpot00Hanebasi_SetTorchLightInfo(BgSpot00Hanebasi* this, PlayState* play);
 
 ActorInit Bg_Spot00_Hanebasi_InitVars = {
-    ACTOR_BG_SPOT00_HANEBASI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT00_OBJECTS,
-    sizeof(BgSpot00Hanebasi),
-    (ActorFunc)BgSpot00Hanebasi_Init,
-    (ActorFunc)BgSpot00Hanebasi_Destroy,
-    (ActorFunc)BgSpot00Hanebasi_Update,
-    (ActorFunc)BgSpot00Hanebasi_Draw,
+    /**/ ACTOR_BG_SPOT00_HANEBASI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT00_OBJECTS,
+    /**/ sizeof(BgSpot00Hanebasi),
+    /**/ BgSpot00Hanebasi_Init,
+    /**/ BgSpot00Hanebasi_Destroy,
+    /**/ BgSpot00Hanebasi_Update,
+    /**/ BgSpot00Hanebasi_Draw,
 };
 
 static f32 sTorchFlameScale = 0.0f;

--- a/src/overlays/actors/ovl_Bg_Spot01_Fusya/z_bg_spot01_fusya.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Fusya/z_bg_spot01_fusya.c
@@ -17,15 +17,15 @@ void BgSpot01Fusya_Draw(Actor* thisx, PlayState* play);
 void func_808AAA50(BgSpot01Fusya* this, PlayState* play);
 
 ActorInit Bg_Spot01_Fusya_InitVars = {
-    ACTOR_BG_SPOT01_FUSYA,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT01_OBJECTS,
-    sizeof(BgSpot01Fusya),
-    (ActorFunc)BgSpot01Fusya_Init,
-    (ActorFunc)BgSpot01Fusya_Destroy,
-    (ActorFunc)BgSpot01Fusya_Update,
-    (ActorFunc)BgSpot01Fusya_Draw,
+    /**/ ACTOR_BG_SPOT01_FUSYA,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT01_OBJECTS,
+    /**/ sizeof(BgSpot01Fusya),
+    /**/ BgSpot01Fusya_Init,
+    /**/ BgSpot01Fusya_Destroy,
+    /**/ BgSpot01Fusya_Update,
+    /**/ BgSpot01Fusya_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot01_Idohashira/z_bg_spot01_idohashira.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idohashira/z_bg_spot01_idohashira.c
@@ -37,15 +37,15 @@ static BgSpot01IdohashiraDrawFunc sDrawFuncs[] = {
 };
 
 ActorInit Bg_Spot01_Idohashira_InitVars = {
-    ACTOR_BG_SPOT01_IDOHASHIRA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SPOT01_OBJECTS,
-    sizeof(BgSpot01Idohashira),
-    (ActorFunc)BgSpot01Idohashira_Init,
-    (ActorFunc)BgSpot01Idohashira_Destroy,
-    (ActorFunc)BgSpot01Idohashira_Update,
-    (ActorFunc)BgSpot01Idohashira_Draw,
+    /**/ ACTOR_BG_SPOT01_IDOHASHIRA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT01_OBJECTS,
+    /**/ sizeof(BgSpot01Idohashira),
+    /**/ BgSpot01Idohashira_Init,
+    /**/ BgSpot01Idohashira_Destroy,
+    /**/ BgSpot01Idohashira_Update,
+    /**/ BgSpot01Idohashira_Draw,
 };
 
 void BgSpot01Idohashira_PlayBreakSfx1(BgSpot01Idohashira* this) {

--- a/src/overlays/actors/ovl_Bg_Spot01_Idomizu/z_bg_spot01_idomizu.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idomizu/z_bg_spot01_idomizu.c
@@ -17,15 +17,15 @@ void BgSpot01Idomizu_Draw(Actor* thisx, PlayState* play);
 void func_808ABB84(BgSpot01Idomizu* this, PlayState* play);
 
 ActorInit Bg_Spot01_Idomizu_InitVars = {
-    ACTOR_BG_SPOT01_IDOMIZU,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT01_OBJECTS,
-    sizeof(BgSpot01Idomizu),
-    (ActorFunc)BgSpot01Idomizu_Init,
-    (ActorFunc)BgSpot01Idomizu_Destroy,
-    (ActorFunc)BgSpot01Idomizu_Update,
-    (ActorFunc)BgSpot01Idomizu_Draw,
+    /**/ ACTOR_BG_SPOT01_IDOMIZU,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT01_OBJECTS,
+    /**/ sizeof(BgSpot01Idomizu),
+    /**/ BgSpot01Idomizu_Init,
+    /**/ BgSpot01Idomizu_Destroy,
+    /**/ BgSpot01Idomizu_Update,
+    /**/ BgSpot01Idomizu_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot01_Idosoko/z_bg_spot01_idosoko.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Idosoko/z_bg_spot01_idosoko.c
@@ -17,15 +17,15 @@ void BgSpot01Idosoko_Draw(Actor* thisx, PlayState* play);
 void func_808ABF54(BgSpot01Idosoko* this, PlayState* play);
 
 ActorInit Bg_Spot01_Idosoko_InitVars = {
-    ACTOR_BG_SPOT01_IDOSOKO,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT01_MATOYA,
-    sizeof(BgSpot01Idosoko),
-    (ActorFunc)BgSpot01Idosoko_Init,
-    (ActorFunc)BgSpot01Idosoko_Destroy,
-    (ActorFunc)BgSpot01Idosoko_Update,
-    (ActorFunc)BgSpot01Idosoko_Draw,
+    /**/ ACTOR_BG_SPOT01_IDOSOKO,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT01_MATOYA,
+    /**/ sizeof(BgSpot01Idosoko),
+    /**/ BgSpot01Idosoko_Init,
+    /**/ BgSpot01Idosoko_Destroy,
+    /**/ BgSpot01Idosoko_Update,
+    /**/ BgSpot01Idosoko_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot01_Objects2/z_bg_spot01_objects2.c
+++ b/src/overlays/actors/ovl_Bg_Spot01_Objects2/z_bg_spot01_objects2.c
@@ -19,15 +19,15 @@ void func_808AC474(BgSpot01Objects2* this, PlayState* play);
 void func_808AC4A4(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Spot01_Objects2_InitVars = {
-    ACTOR_BG_SPOT01_OBJECTS2,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(BgSpot01Objects2),
-    (ActorFunc)BgSpot01Objects2_Init,
-    (ActorFunc)BgSpot01Objects2_Destroy,
-    (ActorFunc)BgSpot01Objects2_Update,
-    NULL,
+    /**/ ACTOR_BG_SPOT01_OBJECTS2,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(BgSpot01Objects2),
+    /**/ BgSpot01Objects2_Init,
+    /**/ BgSpot01Objects2_Destroy,
+    /**/ BgSpot01Objects2_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.c
+++ b/src/overlays/actors/ovl_Bg_Spot02_Objects/z_bg_spot02_objects.c
@@ -32,15 +32,15 @@ static void* D_808AD850[] = {
 };
 
 ActorInit Bg_Spot02_Objects_InitVars = {
-    ACTOR_BG_SPOT02_OBJECTS,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT02_OBJECTS,
-    sizeof(BgSpot02Objects),
-    (ActorFunc)BgSpot02Objects_Init,
-    (ActorFunc)BgSpot02Objects_Destroy,
-    (ActorFunc)BgSpot02Objects_Update,
-    (ActorFunc)BgSpot02Objects_Draw,
+    /**/ ACTOR_BG_SPOT02_OBJECTS,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT02_OBJECTS,
+    /**/ sizeof(BgSpot02Objects),
+    /**/ BgSpot02Objects_Init,
+    /**/ BgSpot02Objects_Destroy,
+    /**/ BgSpot02Objects_Update,
+    /**/ BgSpot02Objects_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
+++ b/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
@@ -17,15 +17,15 @@ void BgSpot03Taki_Draw(Actor* thisx, PlayState* play);
 void func_808ADEF0(BgSpot03Taki* this, PlayState* play);
 
 ActorInit Bg_Spot03_Taki_InitVars = {
-    ACTOR_BG_SPOT03_TAKI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT03_OBJECT,
-    sizeof(BgSpot03Taki),
-    (ActorFunc)BgSpot03Taki_Init,
-    (ActorFunc)BgSpot03Taki_Destroy,
-    (ActorFunc)BgSpot03Taki_Update,
-    (ActorFunc)BgSpot03Taki_Draw,
+    /**/ ACTOR_BG_SPOT03_TAKI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT03_OBJECT,
+    /**/ sizeof(BgSpot03Taki),
+    /**/ BgSpot03Taki_Init,
+    /**/ BgSpot03Taki_Destroy,
+    /**/ BgSpot03Taki_Update,
+    /**/ BgSpot03Taki_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.c
+++ b/src/overlays/actors/ovl_Bg_Spot05_Soko/z_bg_spot05_soko.c
@@ -18,15 +18,15 @@ void func_808AE5B4(BgSpot05Soko* this, PlayState* play);
 void func_808AE630(BgSpot05Soko* this, PlayState* play);
 
 ActorInit Bg_Spot05_Soko_InitVars = {
-    ACTOR_BG_SPOT05_SOKO,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SPOT05_OBJECTS,
-    sizeof(BgSpot05Soko),
-    (ActorFunc)BgSpot05Soko_Init,
-    (ActorFunc)BgSpot05Soko_Destroy,
-    (ActorFunc)BgSpot05Soko_Update,
-    (ActorFunc)BgSpot05Soko_Draw,
+    /**/ ACTOR_BG_SPOT05_SOKO,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT05_OBJECTS,
+    /**/ sizeof(BgSpot05Soko),
+    /**/ BgSpot05Soko_Init,
+    /**/ BgSpot05Soko_Destroy,
+    /**/ BgSpot05Soko_Update,
+    /**/ BgSpot05Soko_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
+++ b/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
@@ -45,15 +45,15 @@ void BgSpot06Objects_WaterPlaneCutsceneWait(BgSpot06Objects* this, PlayState* pl
 void BgSpot06Objects_WaterPlaneCutsceneRise(BgSpot06Objects* this, PlayState* play);
 
 ActorInit Bg_Spot06_Objects_InitVars = {
-    ACTOR_BG_SPOT06_OBJECTS,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SPOT06_OBJECTS,
-    sizeof(BgSpot06Objects),
-    (ActorFunc)BgSpot06Objects_Init,
-    (ActorFunc)BgSpot06Objects_Destroy,
-    (ActorFunc)BgSpot06Objects_Update,
-    (ActorFunc)BgSpot06Objects_Draw,
+    /**/ ACTOR_BG_SPOT06_OBJECTS,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT06_OBJECTS,
+    /**/ sizeof(BgSpot06Objects),
+    /**/ BgSpot06Objects_Init,
+    /**/ BgSpot06Objects_Destroy,
+    /**/ BgSpot06Objects_Update,
+    /**/ BgSpot06Objects_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphItemsInit[1] = {

--- a/src/overlays/actors/ovl_Bg_Spot07_Taki/z_bg_spot07_taki.c
+++ b/src/overlays/actors/ovl_Bg_Spot07_Taki/z_bg_spot07_taki.c
@@ -17,15 +17,15 @@ void BgSpot07Taki_Draw(Actor* thisx, PlayState* play);
 void BgSpot07Taki_DoNothing(BgSpot07Taki* this, PlayState* play);
 
 ActorInit Bg_Spot07_Taki_InitVars = {
-    ACTOR_BG_SPOT07_TAKI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT07_OBJECT,
-    sizeof(BgSpot07Taki),
-    (ActorFunc)BgSpot07Taki_Init,
-    (ActorFunc)BgSpot07Taki_Destroy,
-    (ActorFunc)BgSpot07Taki_Update,
-    (ActorFunc)BgSpot07Taki_Draw,
+    /**/ ACTOR_BG_SPOT07_TAKI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT07_OBJECT,
+    /**/ sizeof(BgSpot07Taki),
+    /**/ BgSpot07Taki_Init,
+    /**/ BgSpot07Taki_Destroy,
+    /**/ BgSpot07Taki_Update,
+    /**/ BgSpot07Taki_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot08_Bakudankabe/z_bg_spot08_bakudankabe.c
+++ b/src/overlays/actors/ovl_Bg_Spot08_Bakudankabe/z_bg_spot08_bakudankabe.c
@@ -20,15 +20,15 @@ void func_808B02D0(BgSpot08Bakudankabe* this, PlayState* play);
 void func_808B0324(BgSpot08Bakudankabe* this, PlayState* play);
 
 ActorInit Bg_Spot08_Bakudankabe_InitVars = {
-    ACTOR_BG_SPOT08_BAKUDANKABE,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT08_OBJ,
-    sizeof(BgSpot08Bakudankabe),
-    (ActorFunc)BgSpot08Bakudankabe_Init,
-    (ActorFunc)BgSpot08Bakudankabe_Destroy,
-    (ActorFunc)BgSpot08Bakudankabe_Update,
-    (ActorFunc)BgSpot08Bakudankabe_Draw,
+    /**/ ACTOR_BG_SPOT08_BAKUDANKABE,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT08_OBJ,
+    /**/ sizeof(BgSpot08Bakudankabe),
+    /**/ BgSpot08Bakudankabe_Init,
+    /**/ BgSpot08Bakudankabe_Destroy,
+    /**/ BgSpot08Bakudankabe_Update,
+    /**/ BgSpot08Bakudankabe_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[] = {

--- a/src/overlays/actors/ovl_Bg_Spot08_Iceblock/z_bg_spot08_iceblock.c
+++ b/src/overlays/actors/ovl_Bg_Spot08_Iceblock/z_bg_spot08_iceblock.c
@@ -23,15 +23,15 @@ void BgSpot08Iceblock_FloatOrbitingTwins(BgSpot08Iceblock* this, PlayState* play
 void BgSpot08Iceblock_SetupNoAction(BgSpot08Iceblock* this);
 
 ActorInit Bg_Spot08_Iceblock_InitVars = {
-    ACTOR_BG_SPOT08_ICEBLOCK,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT08_OBJ,
-    sizeof(BgSpot08Iceblock),
-    (ActorFunc)BgSpot08Iceblock_Init,
-    (ActorFunc)BgSpot08Iceblock_Destroy,
-    (ActorFunc)BgSpot08Iceblock_Update,
-    (ActorFunc)BgSpot08Iceblock_Draw,
+    /**/ ACTOR_BG_SPOT08_ICEBLOCK,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT08_OBJ,
+    /**/ sizeof(BgSpot08Iceblock),
+    /**/ BgSpot08Iceblock_Init,
+    /**/ BgSpot08Iceblock_Destroy,
+    /**/ BgSpot08Iceblock_Update,
+    /**/ BgSpot08Iceblock_Draw,
 };
 
 void BgSpot08Iceblock_SetupAction(BgSpot08Iceblock* this, BgSpot08IceblockActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_Bg_Spot09_Obj/z_bg_spot09_obj.c
+++ b/src/overlays/actors/ovl_Bg_Spot09_Obj/z_bg_spot09_obj.c
@@ -19,15 +19,15 @@ s32 func_808B1BA0(BgSpot09Obj* this, PlayState* play);
 s32 func_808B1BEC(BgSpot09Obj* this, PlayState* play);
 
 ActorInit Bg_Spot09_Obj_InitVars = {
-    ACTOR_BG_SPOT09_OBJ,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT09_OBJ,
-    sizeof(BgSpot09Obj),
-    (ActorFunc)BgSpot09Obj_Init,
-    (ActorFunc)BgSpot09Obj_Destroy,
-    (ActorFunc)BgSpot09Obj_Update,
-    (ActorFunc)BgSpot09Obj_Draw,
+    /**/ ACTOR_BG_SPOT09_OBJ,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT09_OBJ,
+    /**/ sizeof(BgSpot09Obj),
+    /**/ BgSpot09Obj_Init,
+    /**/ BgSpot09Obj_Destroy,
+    /**/ BgSpot09Obj_Update,
+    /**/ BgSpot09Obj_Draw,
 };
 
 static CollisionHeader* D_808B1F90[] = {

--- a/src/overlays/actors/ovl_Bg_Spot11_Bakudankabe/z_bg_spot11_bakudankabe.c
+++ b/src/overlays/actors/ovl_Bg_Spot11_Bakudankabe/z_bg_spot11_bakudankabe.c
@@ -17,15 +17,15 @@ void BgSpot11Bakudankabe_Update(Actor* thisx, PlayState* play);
 void BgSpot11Bakudankabe_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Spot11_Bakudankabe_InitVars = {
-    ACTOR_BG_SPOT11_BAKUDANKABE,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT11_OBJ,
-    sizeof(BgSpot11Bakudankabe),
-    (ActorFunc)BgSpot11Bakudankabe_Init,
-    (ActorFunc)BgSpot11Bakudankabe_Destroy,
-    (ActorFunc)BgSpot11Bakudankabe_Update,
-    (ActorFunc)BgSpot11Bakudankabe_Draw,
+    /**/ ACTOR_BG_SPOT11_BAKUDANKABE,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT11_OBJ,
+    /**/ sizeof(BgSpot11Bakudankabe),
+    /**/ BgSpot11Bakudankabe_Init,
+    /**/ BgSpot11Bakudankabe_Destroy,
+    /**/ BgSpot11Bakudankabe_Update,
+    /**/ BgSpot11Bakudankabe_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Spot11_Oasis/z_bg_spot11_oasis.c
+++ b/src/overlays/actors/ovl_Bg_Spot11_Oasis/z_bg_spot11_oasis.c
@@ -21,15 +21,15 @@ void func_808B2AA8(BgSpot11Oasis* this);
 void func_808B2AB8(BgSpot11Oasis* this, PlayState* play);
 
 ActorInit Bg_Spot11_Oasis_InitVars = {
-    ACTOR_BG_SPOT11_OASIS,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT11_OBJ,
-    sizeof(BgSpot11Oasis),
-    (ActorFunc)BgSpot11Oasis_Init,
-    (ActorFunc)Actor_Noop,
-    (ActorFunc)BgSpot11Oasis_Update,
-    NULL,
+    /**/ ACTOR_BG_SPOT11_OASIS,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT11_OBJ,
+    /**/ sizeof(BgSpot11Oasis),
+    /**/ BgSpot11Oasis_Init,
+    /**/ Actor_Noop,
+    /**/ BgSpot11Oasis_Update,
+    /**/ NULL,
 };
 
 static s16 D_808B2E10[][2] = {

--- a/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.c
+++ b/src/overlays/actors/ovl_Bg_Spot12_Gate/z_bg_spot12_gate.c
@@ -25,15 +25,15 @@ void func_808B3274(BgSpot12Gate* this);
 void func_808B3298(BgSpot12Gate* this, PlayState* play);
 
 ActorInit Bg_Spot12_Gate_InitVars = {
-    ACTOR_BG_SPOT12_GATE,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT12_OBJ,
-    sizeof(BgSpot12Gate),
-    (ActorFunc)BgSpot12Gate_Init,
-    (ActorFunc)BgSpot12Gate_Destroy,
-    (ActorFunc)BgSpot12Gate_Update,
-    (ActorFunc)BgSpot12Gate_Draw,
+    /**/ ACTOR_BG_SPOT12_GATE,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT12_OBJ,
+    /**/ sizeof(BgSpot12Gate),
+    /**/ BgSpot12Gate_Init,
+    /**/ BgSpot12Gate_Destroy,
+    /**/ BgSpot12Gate_Update,
+    /**/ BgSpot12Gate_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.c
+++ b/src/overlays/actors/ovl_Bg_Spot12_Saku/z_bg_spot12_saku.c
@@ -22,15 +22,15 @@ void func_808B3714(BgSpot12Saku* this);
 void func_808B37AC(BgSpot12Saku* this, PlayState* play);
 
 ActorInit Bg_Spot12_Saku_InitVars = {
-    ACTOR_BG_SPOT12_SAKU,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT12_OBJ,
-    sizeof(BgSpot12Saku),
-    (ActorFunc)BgSpot12Saku_Init,
-    (ActorFunc)BgSpot12Saku_Destroy,
-    (ActorFunc)BgSpot12Saku_Update,
-    (ActorFunc)BgSpot12Saku_Draw,
+    /**/ ACTOR_BG_SPOT12_SAKU,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT12_OBJ,
+    /**/ sizeof(BgSpot12Saku),
+    /**/ BgSpot12Saku_Init,
+    /**/ BgSpot12Saku_Destroy,
+    /**/ BgSpot12Saku_Update,
+    /**/ BgSpot12Saku_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.c
+++ b/src/overlays/actors/ovl_Bg_Spot15_Rrbox/z_bg_spot15_rrbox.c
@@ -26,15 +26,15 @@ void func_808B44CC(BgSpot15Rrbox* this, PlayState* play);
 static s16 D_808B4590 = 0;
 
 ActorInit Bg_Spot15_Rrbox_InitVars = {
-    ACTOR_BG_SPOT15_RRBOX,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT15_OBJ,
-    sizeof(BgSpot15Rrbox),
-    (ActorFunc)BgSpot15Rrbox_Init,
-    (ActorFunc)BgSpot15Rrbox_Destroy,
-    (ActorFunc)BgSpot15Rrbox_Update,
-    (ActorFunc)BgSpot15Rrbox_Draw,
+    /**/ ACTOR_BG_SPOT15_RRBOX,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT15_OBJ,
+    /**/ sizeof(BgSpot15Rrbox),
+    /**/ BgSpot15Rrbox_Init,
+    /**/ BgSpot15Rrbox_Destroy,
+    /**/ BgSpot15Rrbox_Update,
+    /**/ BgSpot15Rrbox_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot15_Saku/z_bg_spot15_saku.c
+++ b/src/overlays/actors/ovl_Bg_Spot15_Saku/z_bg_spot15_saku.c
@@ -19,15 +19,15 @@ void func_808B4978(BgSpot15Saku* this, PlayState* play);
 void func_808B4A04(BgSpot15Saku* this, PlayState* play);
 
 ActorInit Bg_Spot15_Saku_InitVars = {
-    ACTOR_BG_SPOT15_SAKU,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_SPOT15_OBJ,
-    sizeof(BgSpot15Saku),
-    (ActorFunc)BgSpot15Saku_Init,
-    (ActorFunc)BgSpot15Saku_Destroy,
-    (ActorFunc)BgSpot15Saku_Update,
-    (ActorFunc)BgSpot15Saku_Draw,
+    /**/ ACTOR_BG_SPOT15_SAKU,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT15_OBJ,
+    /**/ sizeof(BgSpot15Saku),
+    /**/ BgSpot15Saku_Init,
+    /**/ BgSpot15Saku_Destroy,
+    /**/ BgSpot15Saku_Update,
+    /**/ BgSpot15Saku_Draw,
 };
 
 void BgSpot15Saku_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.c
+++ b/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.c
@@ -110,15 +110,15 @@ static s16 D_808B5EB0[][7] = {
 };
 
 ActorInit Bg_Spot16_Bombstone_InitVars = {
-    ACTOR_BG_SPOT16_BOMBSTONE,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SPOT16_OBJ,
-    sizeof(BgSpot16Bombstone),
-    (ActorFunc)BgSpot16Bombstone_Init,
-    (ActorFunc)BgSpot16Bombstone_Destroy,
-    (ActorFunc)BgSpot16Bombstone_Update,
-    (ActorFunc)BgSpot16Bombstone_Draw,
+    /**/ ACTOR_BG_SPOT16_BOMBSTONE,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT16_OBJ,
+    /**/ sizeof(BgSpot16Bombstone),
+    /**/ BgSpot16Bombstone_Init,
+    /**/ BgSpot16Bombstone_Destroy,
+    /**/ BgSpot16Bombstone_Update,
+    /**/ BgSpot16Bombstone_Draw,
 };
 
 static InitChainEntry sInitChainBoulder[] = {

--- a/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.c
+++ b/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.c
@@ -19,15 +19,15 @@ void BgSpot16Doughnut_UpdateExpanding(Actor* thisx, PlayState* play);
 void BgSpot16Doughnut_DrawExpanding(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Spot16_Doughnut_InitVars = {
-    ACTOR_BG_SPOT16_DOUGHNUT,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_EFC_DOUGHNUT,
-    sizeof(BgSpot16Doughnut),
-    (ActorFunc)BgSpot16Doughnut_Init,
-    (ActorFunc)BgSpot16Doughnut_Destroy,
-    (ActorFunc)BgSpot16Doughnut_Update,
-    (ActorFunc)BgSpot16Doughnut_Draw,
+    /**/ ACTOR_BG_SPOT16_DOUGHNUT,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_EFC_DOUGHNUT,
+    /**/ sizeof(BgSpot16Doughnut),
+    /**/ BgSpot16Doughnut_Init,
+    /**/ BgSpot16Doughnut_Destroy,
+    /**/ BgSpot16Doughnut_Update,
+    /**/ BgSpot16Doughnut_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.c
+++ b/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.c
@@ -17,15 +17,15 @@ void BgSpot17Bakudankabe_Update(Actor* thisx, PlayState* play);
 void BgSpot17Bakudankabe_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Spot17_Bakudankabe_InitVars = {
-    ACTOR_BG_SPOT17_BAKUDANKABE,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT17_OBJ,
-    sizeof(BgSpot17Bakudankabe),
-    (ActorFunc)BgSpot17Bakudankabe_Init,
-    (ActorFunc)BgSpot17Bakudankabe_Destroy,
-    (ActorFunc)BgSpot17Bakudankabe_Update,
-    (ActorFunc)BgSpot17Bakudankabe_Draw,
+    /**/ ACTOR_BG_SPOT17_BAKUDANKABE,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT17_OBJ,
+    /**/ sizeof(BgSpot17Bakudankabe),
+    /**/ BgSpot17Bakudankabe_Init,
+    /**/ BgSpot17Bakudankabe_Destroy,
+    /**/ BgSpot17Bakudankabe_Update,
+    /**/ BgSpot17Bakudankabe_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.c
+++ b/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.c
@@ -16,15 +16,15 @@ void func_808B746C(Actor* thisx, PlayState* play);
 void func_808B7478(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Spot17_Funen_InitVars = {
-    ACTOR_BG_SPOT17_FUNEN,
-    ACTORCAT_SWITCH,
-    FLAGS,
-    OBJECT_SPOT17_OBJ,
-    sizeof(BgSpot17Funen),
-    (ActorFunc)BgSpot17Funen_Init,
-    (ActorFunc)BgSpot17Funen_Destroy,
-    (ActorFunc)BgSpot17Funen_Update,
-    NULL,
+    /**/ ACTOR_BG_SPOT17_FUNEN,
+    /**/ ACTORCAT_SWITCH,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT17_OBJ,
+    /**/ sizeof(BgSpot17Funen),
+    /**/ BgSpot17Funen_Init,
+    /**/ BgSpot17Funen_Destroy,
+    /**/ BgSpot17Funen_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
@@ -23,15 +23,15 @@ void func_808B7FC0(BgSpot18Basket* this, PlayState* play);
 void func_808B81A0(BgSpot18Basket* this, PlayState* play);
 
 ActorInit Bg_Spot18_Basket_InitVars = {
-    ACTOR_BG_SPOT18_BASKET,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SPOT18_OBJ,
-    sizeof(BgSpot18Basket),
-    (ActorFunc)BgSpot18Basket_Init,
-    (ActorFunc)BgSpot18Basket_Destroy,
-    (ActorFunc)BgSpot18Basket_Update,
-    (ActorFunc)BgSpot18Basket_Draw,
+    /**/ ACTOR_BG_SPOT18_BASKET,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT18_OBJ,
+    /**/ sizeof(BgSpot18Basket),
+    /**/ BgSpot18Basket_Init,
+    /**/ BgSpot18Basket_Destroy,
+    /**/ BgSpot18Basket_Update,
+    /**/ BgSpot18Basket_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[2] = {

--- a/src/overlays/actors/ovl_Bg_Spot18_Futa/z_bg_spot18_futa.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Futa/z_bg_spot18_futa.c
@@ -15,15 +15,15 @@ void BgSpot18Futa_Update(Actor* thisx, PlayState* play);
 void BgSpot18Futa_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Spot18_Futa_InitVars = {
-    ACTOR_BG_SPOT18_FUTA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SPOT18_OBJ,
-    sizeof(BgSpot18Futa),
-    (ActorFunc)BgSpot18Futa_Init,
-    (ActorFunc)BgSpot18Futa_Destroy,
-    (ActorFunc)BgSpot18Futa_Update,
-    (ActorFunc)BgSpot18Futa_Draw,
+    /**/ ACTOR_BG_SPOT18_FUTA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT18_OBJ,
+    /**/ sizeof(BgSpot18Futa),
+    /**/ BgSpot18Futa_Init,
+    /**/ BgSpot18Futa_Destroy,
+    /**/ BgSpot18Futa_Update,
+    /**/ BgSpot18Futa_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Obj/z_bg_spot18_obj.c
@@ -31,15 +31,15 @@ void func_808B9030(BgSpot18Obj* this);
 void func_808B9040(BgSpot18Obj* this, PlayState* play);
 
 ActorInit Bg_Spot18_Obj_InitVars = {
-    ACTOR_BG_SPOT18_OBJ,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT18_OBJ,
-    sizeof(BgSpot18Obj),
-    (ActorFunc)BgSpot18Obj_Init,
-    (ActorFunc)BgSpot18Obj_Destroy,
-    (ActorFunc)BgSpot18Obj_Update,
-    (ActorFunc)BgSpot18Obj_Draw,
+    /**/ ACTOR_BG_SPOT18_OBJ,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT18_OBJ,
+    /**/ sizeof(BgSpot18Obj),
+    /**/ BgSpot18Obj_Init,
+    /**/ BgSpot18Obj_Destroy,
+    /**/ BgSpot18Obj_Update,
+    /**/ BgSpot18Obj_Draw,
 };
 
 static u8 D_808B90F0[2][2] = { { 0x01, 0x01 }, { 0x01, 0x00 } };

--- a/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Shutter/z_bg_spot18_shutter.c
@@ -21,15 +21,15 @@ void func_808B9698(BgSpot18Shutter* this, PlayState* play);
 void func_808B971C(BgSpot18Shutter* this, PlayState* play);
 
 ActorInit Bg_Spot18_Shutter_InitVars = {
-    ACTOR_BG_SPOT18_SHUTTER,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SPOT18_OBJ,
-    sizeof(BgSpot18Shutter),
-    (ActorFunc)BgSpot18Shutter_Init,
-    (ActorFunc)BgSpot18Shutter_Destroy,
-    (ActorFunc)BgSpot18Shutter_Update,
-    (ActorFunc)BgSpot18Shutter_Draw,
+    /**/ ACTOR_BG_SPOT18_SHUTTER,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT18_OBJ,
+    /**/ sizeof(BgSpot18Shutter),
+    /**/ BgSpot18Shutter_Init,
+    /**/ BgSpot18Shutter_Destroy,
+    /**/ BgSpot18Shutter_Update,
+    /**/ BgSpot18Shutter_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.c
+++ b/src/overlays/actors/ovl_Bg_Sst_Floor/z_bg_sst_floor.c
@@ -17,15 +17,15 @@ void BgSstFloor_Draw(Actor* thisx, PlayState* play);
 static s32 sUnkValues[] = { 0, 0, 0 }; // Unused, probably a zero vector
 
 ActorInit Bg_Sst_Floor_InitVars = {
-    ACTOR_BG_SST_FLOOR,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SST,
-    sizeof(BgSstFloor),
-    (ActorFunc)BgSstFloor_Init,
-    (ActorFunc)BgSstFloor_Destroy,
-    (ActorFunc)BgSstFloor_Update,
-    (ActorFunc)BgSstFloor_Draw,
+    /**/ ACTOR_BG_SST_FLOOR,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SST,
+    /**/ sizeof(BgSstFloor),
+    /**/ BgSstFloor_Init,
+    /**/ BgSstFloor_Destroy,
+    /**/ BgSstFloor_Update,
+    /**/ BgSstFloor_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.c
+++ b/src/overlays/actors/ovl_Bg_Toki_Hikari/z_bg_toki_hikari.c
@@ -22,15 +22,15 @@ void func_808BA274(BgTokiHikari* this, PlayState* play);
 void func_808BA2CC(BgTokiHikari* this, PlayState* play);
 
 ActorInit Bg_Toki_Hikari_InitVars = {
-    ACTOR_BG_TOKI_HIKARI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_TOKI_OBJECTS,
-    sizeof(BgTokiHikari),
-    (ActorFunc)BgTokiHikari_Init,
-    (ActorFunc)BgTokiHikari_Destroy,
-    (ActorFunc)BgTokiHikari_Update,
-    (ActorFunc)BgTokiHikari_Draw,
+    /**/ ACTOR_BG_TOKI_HIKARI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_TOKI_OBJECTS,
+    /**/ sizeof(BgTokiHikari),
+    /**/ BgTokiHikari_Init,
+    /**/ BgTokiHikari_Destroy,
+    /**/ BgTokiHikari_Update,
+    /**/ BgTokiHikari_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -23,15 +23,15 @@ extern CutsceneData D_808BB7A0[];
 extern CutsceneData D_808BBD90[];
 
 ActorInit Bg_Toki_Swd_InitVars = {
-    ACTOR_BG_TOKI_SWD,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_TOKI_OBJECTS,
-    sizeof(BgTokiSwd),
-    (ActorFunc)BgTokiSwd_Init,
-    (ActorFunc)BgTokiSwd_Destroy,
-    (ActorFunc)BgTokiSwd_Update,
-    (ActorFunc)BgTokiSwd_Draw,
+    /**/ ACTOR_BG_TOKI_SWD,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_TOKI_OBJECTS,
+    /**/ sizeof(BgTokiSwd),
+    /**/ BgTokiSwd_Init,
+    /**/ BgTokiSwd_Destroy,
+    /**/ BgTokiSwd_Update,
+    /**/ BgTokiSwd_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.c
+++ b/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth.c
@@ -30,15 +30,15 @@ extern CutsceneData D_808BD520[];
 extern CutsceneData D_808BD790[];
 
 ActorInit Bg_Treemouth_InitVars = {
-    ACTOR_BG_TREEMOUTH,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SPOT04_OBJECTS,
-    sizeof(BgTreemouth),
-    (ActorFunc)BgTreemouth_Init,
-    (ActorFunc)BgTreemouth_Destroy,
-    (ActorFunc)BgTreemouth_Update,
-    (ActorFunc)BgTreemouth_Draw,
+    /**/ ACTOR_BG_TREEMOUTH,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SPOT04_OBJECTS,
+    /**/ sizeof(BgTreemouth),
+    /**/ BgTreemouth_Init,
+    /**/ BgTreemouth_Destroy,
+    /**/ BgTreemouth_Update,
+    /**/ BgTreemouth_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Umajump/z_bg_umajump.c
+++ b/src/overlays/actors/ovl_Bg_Umajump/z_bg_umajump.c
@@ -15,15 +15,15 @@ void BgUmaJump_Update(Actor* thisx, PlayState* play);
 void BgUmaJump_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Umajump_InitVars = {
-    ACTOR_BG_UMAJUMP,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_UMAJUMP,
-    sizeof(BgUmaJump),
-    (ActorFunc)BgUmaJump_Init,
-    (ActorFunc)BgUmaJump_Destroy,
-    (ActorFunc)BgUmaJump_Update,
-    (ActorFunc)BgUmaJump_Draw,
+    /**/ ACTOR_BG_UMAJUMP,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_UMAJUMP,
+    /**/ sizeof(BgUmaJump),
+    /**/ BgUmaJump_Init,
+    /**/ BgUmaJump_Destroy,
+    /**/ BgUmaJump_Update,
+    /**/ BgUmaJump_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Vb_Sima/z_bg_vb_sima.c
+++ b/src/overlays/actors/ovl_Bg_Vb_Sima/z_bg_vb_sima.c
@@ -16,15 +16,15 @@ void BgVbSima_Update(Actor* thisx, PlayState* play);
 void BgVbSima_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Bg_Vb_Sima_InitVars = {
-    ACTOR_BG_VB_SIMA,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_FD,
-    sizeof(BgVbSima),
-    (ActorFunc)BgVbSima_Init,
-    (ActorFunc)BgVbSima_Destroy,
-    (ActorFunc)BgVbSima_Update,
-    (ActorFunc)BgVbSima_Draw,
+    /**/ ACTOR_BG_VB_SIMA,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_FD,
+    /**/ sizeof(BgVbSima),
+    /**/ BgVbSima_Init,
+    /**/ BgVbSima_Destroy,
+    /**/ BgVbSima_Update,
+    /**/ BgVbSima_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Ydan_Hasi/z_bg_ydan_hasi.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Hasi/z_bg_ydan_hasi.c
@@ -22,15 +22,15 @@ void BgYdanHasi_DecWaterTimer(BgYdanHasi* this, PlayState* play);
 void BgYdanHasi_UpdateThreeBlocks(BgYdanHasi* this, PlayState* play);
 
 ActorInit Bg_Ydan_Hasi_InitVars = {
-    ACTOR_BG_YDAN_HASI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_YDAN_OBJECTS,
-    sizeof(BgYdanHasi),
-    (ActorFunc)BgYdanHasi_Init,
-    (ActorFunc)BgYdanHasi_Destroy,
-    (ActorFunc)BgYdanHasi_Update,
-    (ActorFunc)BgYdanHasi_Draw,
+    /**/ ACTOR_BG_YDAN_HASI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_YDAN_OBJECTS,
+    /**/ sizeof(BgYdanHasi),
+    /**/ BgYdanHasi_Init,
+    /**/ BgYdanHasi_Destroy,
+    /**/ BgYdanHasi_Update,
+    /**/ BgYdanHasi_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.c
@@ -21,15 +21,15 @@ void func_808BF108(BgYdanMaruta* this, PlayState* play);
 void func_808BF1EC(BgYdanMaruta* this, PlayState* play);
 
 ActorInit Bg_Ydan_Maruta_InitVars = {
-    ACTOR_BG_YDAN_MARUTA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_YDAN_OBJECTS,
-    sizeof(BgYdanMaruta),
-    (ActorFunc)BgYdanMaruta_Init,
-    (ActorFunc)BgYdanMaruta_Destroy,
-    (ActorFunc)BgYdanMaruta_Update,
-    (ActorFunc)BgYdanMaruta_Draw,
+    /**/ ACTOR_BG_YDAN_MARUTA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_YDAN_OBJECTS,
+    /**/ sizeof(BgYdanMaruta),
+    /**/ BgYdanMaruta_Init,
+    /**/ BgYdanMaruta_Destroy,
+    /**/ BgYdanMaruta_Update,
+    /**/ BgYdanMaruta_Draw,
 };
 
 static ColliderTrisElementInit sTrisElementsInit[2] = {

--- a/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
@@ -25,15 +25,15 @@ typedef enum {
 } BgYdanSpType;
 
 ActorInit Bg_Ydan_Sp_InitVars = {
-    ACTOR_BG_YDAN_SP,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_YDAN_OBJECTS,
-    sizeof(BgYdanSp),
-    (ActorFunc)BgYdanSp_Init,
-    (ActorFunc)BgYdanSp_Destroy,
-    (ActorFunc)BgYdanSp_Update,
-    (ActorFunc)BgYdanSp_Draw,
+    /**/ ACTOR_BG_YDAN_SP,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_YDAN_OBJECTS,
+    /**/ sizeof(BgYdanSp),
+    /**/ BgYdanSp_Init,
+    /**/ BgYdanSp_Destroy,
+    /**/ BgYdanSp_Update,
+    /**/ BgYdanSp_Draw,
 };
 
 static ColliderTrisElementInit sTrisItemsInit[2] = {

--- a/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
+++ b/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
@@ -36,15 +36,15 @@ static BgZgDrawFunc sDrawFuncs[] = {
 };
 
 ActorInit Bg_Zg_InitVars = {
-    ACTOR_BG_ZG,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ZG,
-    sizeof(BgZg),
-    (ActorFunc)BgZg_Init,
-    (ActorFunc)BgZg_Destroy,
-    (ActorFunc)BgZg_Update,
-    (ActorFunc)BgZg_Draw,
+    /**/ ACTOR_BG_ZG,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ZG,
+    /**/ sizeof(BgZg),
+    /**/ BgZg_Init,
+    /**/ BgZg_Destroy,
+    /**/ BgZg_Update,
+    /**/ BgZg_Draw,
 };
 
 void BgZg_Destroy(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -34,15 +34,15 @@ void BossDodongo_DrawEffects(PlayState* play);
 void BossDodongo_UpdateEffects(PlayState* play);
 
 ActorInit Boss_Dodongo_InitVars = {
-    ACTOR_EN_DODONGO,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_KINGDODONGO,
-    sizeof(BossDodongo),
-    (ActorFunc)BossDodongo_Init,
-    (ActorFunc)BossDodongo_Destroy,
-    (ActorFunc)BossDodongo_Update,
-    (ActorFunc)BossDodongo_Draw,
+    /**/ ACTOR_EN_DODONGO,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_KINGDODONGO,
+    /**/ sizeof(BossDodongo),
+    /**/ BossDodongo_Init,
+    /**/ BossDodongo_Destroy,
+    /**/ BossDodongo_Update,
+    /**/ BossDodongo_Draw,
 };
 
 #include "z_boss_dodongo_data.inc.c"

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -45,15 +45,15 @@ void BossFd_UpdateEffects(BossFd* this, PlayState* play);
 void BossFd_DrawBody(PlayState* play, BossFd* this);
 
 ActorInit Boss_Fd_InitVars = {
-    ACTOR_BOSS_FD,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_FD,
-    sizeof(BossFd),
-    (ActorFunc)BossFd_Init,
-    (ActorFunc)BossFd_Destroy,
-    (ActorFunc)BossFd_Update,
-    (ActorFunc)BossFd_Draw,
+    /**/ ACTOR_BOSS_FD,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_FD,
+    /**/ sizeof(BossFd),
+    /**/ BossFd_Init,
+    /**/ BossFd_Destroy,
+    /**/ BossFd_Update,
+    /**/ BossFd_Draw,
 };
 
 #include "z_boss_fd_colchk.inc.c"

--- a/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
+++ b/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
@@ -47,15 +47,15 @@ void BossFd2_Death(BossFd2* this, PlayState* play);
 void BossFd2_Wait(BossFd2* this, PlayState* play);
 
 ActorInit Boss_Fd2_InitVars = {
-    ACTOR_BOSS_FD2,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_FD2,
-    sizeof(BossFd2),
-    (ActorFunc)BossFd2_Init,
-    (ActorFunc)BossFd2_Destroy,
-    (ActorFunc)BossFd2_Update,
-    (ActorFunc)BossFd2_Draw,
+    /**/ ACTOR_BOSS_FD2,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_FD2,
+    /**/ sizeof(BossFd2),
+    /**/ BossFd2_Init,
+    /**/ BossFd2_Destroy,
+    /**/ BossFd2_Update,
+    /**/ BossFd2_Draw,
 };
 
 #include "z_boss_fd2_colchk.inc.c"

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -46,15 +46,15 @@ void BossGanon_UpdateEffects(PlayState* play);
 s32 BossGanon_CheckFallingPlatforms(BossGanon* this, PlayState* play, Vec3f* checkPos);
 
 ActorInit Boss_Ganon_InitVars = {
-    ACTOR_BOSS_GANON,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_GANON,
-    sizeof(BossGanon),
-    (ActorFunc)BossGanon_Init,
-    (ActorFunc)BossGanon_Destroy,
-    (ActorFunc)BossGanon_Update,
-    (ActorFunc)BossGanon_Draw,
+    /**/ ACTOR_BOSS_GANON,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_GANON,
+    /**/ sizeof(BossGanon),
+    /**/ BossGanon_Init,
+    /**/ BossGanon_Destroy,
+    /**/ BossGanon_Update,
+    /**/ BossGanon_Draw,
 };
 
 static ColliderCylinderInit sDorfCylinderInit = {

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -33,15 +33,15 @@ void BossGanon2_GenShadowTexture(void* shadowTexture, BossGanon2* this, PlayStat
 void BossGanon2_DrawShadowTexture(void* shadowTexture, BossGanon2* this, PlayState* play);
 
 ActorInit Boss_Ganon2_InitVars = {
-    ACTOR_BOSS_GANON2,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_GANON2,
-    sizeof(BossGanon2),
-    (ActorFunc)BossGanon2_Init,
-    (ActorFunc)BossGanon2_Destroy,
-    (ActorFunc)BossGanon2_Update,
-    (ActorFunc)BossGanon2_Draw,
+    /**/ ACTOR_BOSS_GANON2,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_GANON2,
+    /**/ sizeof(BossGanon2),
+    /**/ BossGanon2_Init,
+    /**/ BossGanon2_Destroy,
+    /**/ BossGanon2_Update,
+    /**/ BossGanon2_Draw,
 };
 
 #include "z_boss_ganon2_data.inc.c"

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -70,15 +70,15 @@ void BossGanondrof_Stunned(BossGanondrof* this, PlayState* play);
 void BossGanondrof_Death(BossGanondrof* this, PlayState* play);
 
 ActorInit Boss_Ganondrof_InitVars = {
-    ACTOR_BOSS_GANONDROF,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_GND,
-    sizeof(BossGanondrof),
-    (ActorFunc)BossGanondrof_Init,
-    (ActorFunc)BossGanondrof_Destroy,
-    (ActorFunc)BossGanondrof_Update,
-    (ActorFunc)BossGanondrof_Draw,
+    /**/ ACTOR_BOSS_GANONDROF,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_GND,
+    /**/ sizeof(BossGanondrof),
+    /**/ BossGanondrof_Init,
+    /**/ BossGanondrof_Destroy,
+    /**/ BossGanondrof_Update,
+    /**/ BossGanondrof_Draw,
 };
 
 static ColliderCylinderInit sCylinderInitBody = {

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -50,15 +50,15 @@ void BossGoma_CeilingMoveToCenter(BossGoma* this, PlayState* play);
 void BossGoma_SpawnChildGohma(BossGoma* this, PlayState* play, s16 i);
 
 ActorInit Boss_Goma_InitVars = {
-    ACTOR_BOSS_GOMA,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_GOMA,
-    sizeof(BossGoma),
-    (ActorFunc)BossGoma_Init,
-    (ActorFunc)BossGoma_Destroy,
-    (ActorFunc)BossGoma_Update,
-    (ActorFunc)BossGoma_Draw,
+    /**/ ACTOR_BOSS_GOMA,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_GOMA,
+    /**/ sizeof(BossGoma),
+    /**/ BossGoma_Init,
+    /**/ BossGoma_Destroy,
+    /**/ BossGoma_Update,
+    /**/ BossGoma_Draw,
 };
 
 static ColliderJntSphElementInit sColliderJntSphElementInit[13] = {

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -119,15 +119,15 @@ typedef enum {
 } BossMoCsState;
 
 ActorInit Boss_Mo_InitVars = {
-    ACTOR_BOSS_MO,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_MO,
-    sizeof(BossMo),
-    (ActorFunc)BossMo_Init,
-    (ActorFunc)BossMo_Destroy,
-    (ActorFunc)BossMo_UpdateTent,
-    (ActorFunc)BossMo_DrawTent,
+    /**/ ACTOR_BOSS_MO,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_MO,
+    /**/ sizeof(BossMo),
+    /**/ BossMo_Init,
+    /**/ BossMo_Destroy,
+    /**/ BossMo_UpdateTent,
+    /**/ BossMo_DrawTent,
 };
 
 static BossMo* sMorphaCore = NULL;

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -235,15 +235,15 @@ static Color_RGBA8 sStaticColor = { 0, 0, 0, 255 };
 static s32 sHandState[] = { HAND_WAIT, HAND_WAIT };
 
 ActorInit Boss_Sst_InitVars = {
-    ACTOR_BOSS_SST,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_SST,
-    sizeof(BossSst),
-    (ActorFunc)BossSst_Init,
-    (ActorFunc)BossSst_Destroy,
-    (ActorFunc)BossSst_UpdateHand,
-    (ActorFunc)BossSst_DrawHand,
+    /**/ ACTOR_BOSS_SST,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_SST,
+    /**/ sizeof(BossSst),
+    /**/ BossSst_Init,
+    /**/ BossSst_Destroy,
+    /**/ BossSst_UpdateHand,
+    /**/ BossSst_DrawHand,
 };
 
 #include "z_boss_sst_colchk.inc.c"

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -117,15 +117,15 @@ void BossTw_TwinrovaSetupSpin(BossTw* this, PlayState* play);
 void BossTw_UpdateEffects(PlayState* play);
 
 ActorInit Boss_Tw_InitVars = {
-    ACTOR_BOSS_TW,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_TW,
-    sizeof(BossTw),
-    (ActorFunc)BossTw_Init,
-    (ActorFunc)BossTw_Destroy,
-    (ActorFunc)BossTw_Update,
-    (ActorFunc)BossTw_Draw,
+    /**/ ACTOR_BOSS_TW,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_TW,
+    /**/ sizeof(BossTw),
+    /**/ BossTw_Init,
+    /**/ BossTw_Destroy,
+    /**/ BossTw_Update,
+    /**/ BossTw_Draw,
 };
 
 static Vec3f D_8094A7D0 = { 0.0f, 0.0f, 1000.0f };

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -189,15 +189,15 @@ void BossVa_Tumor(PlayState* play, BossVa* this, s32 count, s16 scale, f32 xzSpr
                   u8 fixed);
 
 ActorInit Boss_Va_InitVars = {
-    ACTOR_BOSS_VA,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_BV,
-    sizeof(BossVa),
-    (ActorFunc)BossVa_Init,
-    (ActorFunc)BossVa_Destroy,
-    (ActorFunc)BossVa_Update,
-    (ActorFunc)BossVa_Draw,
+    /**/ ACTOR_BOSS_VA,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_BV,
+    /**/ sizeof(BossVa),
+    /**/ BossVa_Init,
+    /**/ BossVa_Destroy,
+    /**/ BossVa_Update,
+    /**/ BossVa_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
+++ b/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
@@ -38,15 +38,15 @@ void func_80968FB0(Actor* thisx, PlayState* play);
 void func_809691BC(Demo6K* this, PlayState* play, s32 cueChannel);
 
 ActorInit Demo_6K_InitVars = {
-    ACTOR_DEMO_6K,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(Demo6K),
-    (ActorFunc)Demo6K_Init,
-    (ActorFunc)Demo6K_Destroy,
-    (ActorFunc)Demo6K_Update,
-    NULL,
+    /**/ ACTOR_DEMO_6K,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(Demo6K),
+    /**/ Demo6K_Init,
+    /**/ Demo6K_Destroy,
+    /**/ Demo6K_Update,
+    /**/ NULL,
 };
 
 static s16 sObjectIds[] = {

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
@@ -1034,13 +1034,13 @@ void DemoDu_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit Demo_Du_InitVars = {
-    ACTOR_DEMO_DU,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_DU,
-    sizeof(DemoDu),
-    (ActorFunc)DemoDu_Init,
-    (ActorFunc)DemoDu_Destroy,
-    (ActorFunc)DemoDu_Update,
-    (ActorFunc)DemoDu_Draw,
+    /**/ ACTOR_DEMO_DU,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_DU,
+    /**/ sizeof(DemoDu),
+    /**/ DemoDu_Init,
+    /**/ DemoDu_Destroy,
+    /**/ DemoDu_Update,
+    /**/ DemoDu_Draw,
 };

--- a/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
+++ b/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
@@ -1368,13 +1368,13 @@ void DemoEc_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit Demo_Ec_InitVars = {
-    ACTOR_DEMO_EC,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_EC,
-    sizeof(DemoEc),
-    (ActorFunc)DemoEc_Init,
-    (ActorFunc)DemoEc_Destroy,
-    (ActorFunc)DemoEc_Update,
-    (ActorFunc)DemoEc_Draw,
+    /**/ ACTOR_DEMO_EC,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_EC,
+    /**/ sizeof(DemoEc),
+    /**/ DemoEc_Init,
+    /**/ DemoEc_Destroy,
+    /**/ DemoEc_Update,
+    /**/ DemoEc_Draw,
 };

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -63,15 +63,15 @@ void DemoEffect_SetPosRotFromCue(DemoEffect* this, PlayState* play, s32 cueChann
 void DemoEffect_MoveTowardCuePos(DemoEffect* this, PlayState* play, s32 cueChannel, f32 speed);
 
 ActorInit Demo_Effect_InitVars = {
-    ACTOR_DEMO_EFFECT,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(DemoEffect),
-    (ActorFunc)DemoEffect_Init,
-    (ActorFunc)DemoEffect_Destroy,
-    (ActorFunc)DemoEffect_Update,
-    NULL,
+    /**/ ACTOR_DEMO_EFFECT,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(DemoEffect),
+    /**/ DemoEffect_Init,
+    /**/ DemoEffect_Destroy,
+    /**/ DemoEffect_Update,
+    /**/ NULL,
 };
 
 // This variable assures only one jewel will play SFX

--- a/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.c
+++ b/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.c
@@ -235,13 +235,13 @@ void DemoExt_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit Demo_Ext_InitVars = {
-    ACTOR_DEMO_EXT,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_FHG,
-    sizeof(DemoExt),
-    (ActorFunc)DemoExt_Init,
-    (ActorFunc)DemoExt_Destroy,
-    (ActorFunc)DemoExt_Update,
-    (ActorFunc)DemoExt_Draw,
+    /**/ ACTOR_DEMO_EXT,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_FHG,
+    /**/ sizeof(DemoExt),
+    /**/ DemoExt_Init,
+    /**/ DemoExt_Destroy,
+    /**/ DemoExt_Update,
+    /**/ DemoExt_Draw,
 };

--- a/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.c
+++ b/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.c
@@ -43,15 +43,15 @@ static DemoGeffDrawFunc sDrawFuncs[] = {
 };
 
 ActorInit Demo_Geff_InitVars = {
-    ACTOR_DEMO_GEFF,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_GEFF,
-    sizeof(DemoGeff),
-    (ActorFunc)DemoGeff_Init,
-    (ActorFunc)DemoGeff_Destroy,
-    (ActorFunc)DemoGeff_Update,
-    (ActorFunc)DemoGeff_Draw,
+    /**/ ACTOR_DEMO_GEFF,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_GEFF,
+    /**/ sizeof(DemoGeff),
+    /**/ DemoGeff_Init,
+    /**/ DemoGeff_Destroy,
+    /**/ DemoGeff_Update,
+    /**/ DemoGeff_Draw,
 };
 
 void DemoGeff_Destroy(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
@@ -1445,13 +1445,13 @@ void DemoGj_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit Demo_Gj_InitVars = {
-    ACTOR_DEMO_GJ,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GJ,
-    sizeof(DemoGj),
-    (ActorFunc)DemoGj_Init,
-    (ActorFunc)DemoGj_Destroy,
-    (ActorFunc)DemoGj_Update,
-    (ActorFunc)DemoGj_Draw,
+    /**/ ACTOR_DEMO_GJ,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GJ,
+    /**/ sizeof(DemoGj),
+    /**/ DemoGj_Init,
+    /**/ DemoGj_Destroy,
+    /**/ DemoGj_Update,
+    /**/ DemoGj_Draw,
 };

--- a/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
+++ b/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
@@ -38,15 +38,15 @@ static DemoGoDrawFunc D_8097D468[] = {
 };
 
 ActorInit Demo_Go_InitVars = {
-    ACTOR_DEMO_GO,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_OF1D_MAP,
-    sizeof(DemoGo),
-    (ActorFunc)DemoGo_Init,
-    (ActorFunc)DemoGo_Destroy,
-    (ActorFunc)DemoGo_Update,
-    (ActorFunc)DemoGo_Draw,
+    /**/ ACTOR_DEMO_GO,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_OF1D_MAP,
+    /**/ sizeof(DemoGo),
+    /**/ DemoGo_Init,
+    /**/ DemoGo_Destroy,
+    /**/ DemoGo_Update,
+    /**/ DemoGo_Draw,
 };
 
 s32 DemoGo_GetCueChannel(DemoGo* this) {

--- a/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.c
+++ b/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.c
@@ -1769,13 +1769,13 @@ void DemoGt_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit Demo_Gt_InitVars = {
-    ACTOR_DEMO_GT,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GT,
-    sizeof(DemoGt),
-    (ActorFunc)DemoGt_Init,
-    (ActorFunc)DemoGt_Destroy,
-    (ActorFunc)DemoGt_Update,
-    (ActorFunc)DemoGt_Draw,
+    /**/ ACTOR_DEMO_GT,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GT,
+    /**/ sizeof(DemoGt),
+    /**/ DemoGt_Init,
+    /**/ DemoGt_Destroy,
+    /**/ DemoGt_Update,
+    /**/ DemoGt_Draw,
 };

--- a/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
+++ b/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
@@ -501,15 +501,15 @@ void DemoIk_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit Demo_Ik_InitVars = {
-    ACTOR_DEMO_IK,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_IK,
-    sizeof(DemoIk),
-    (ActorFunc)DemoIk_Init,
-    (ActorFunc)DemoIk_Destroy,
-    (ActorFunc)DemoIk_Update,
-    (ActorFunc)DemoIk_Draw,
+    /**/ ACTOR_DEMO_IK,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_IK,
+    /**/ sizeof(DemoIk),
+    /**/ DemoIk_Init,
+    /**/ DemoIk_Destroy,
+    /**/ DemoIk_Update,
+    /**/ DemoIk_Draw,
 };
 
 void DemoIk_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -92,15 +92,15 @@ static DemoImDrawFunc sDrawFuncs[] = {
 };
 
 ActorInit Demo_Im_InitVars = {
-    ACTOR_DEMO_IM,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_IM,
-    sizeof(DemoIm),
-    (ActorFunc)DemoIm_Init,
-    (ActorFunc)DemoIm_Destroy,
-    (ActorFunc)DemoIm_Update,
-    (ActorFunc)DemoIm_Draw,
+    /**/ ACTOR_DEMO_IM,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_IM,
+    /**/ sizeof(DemoIm),
+    /**/ DemoIm_Init,
+    /**/ DemoIm_Destroy,
+    /**/ DemoIm_Update,
+    /**/ DemoIm_Draw,
 };
 
 void func_80984BE0(DemoIm* this) {

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -41,15 +41,15 @@ extern CutsceneData gChildWarpInToTCS[];
 extern CutsceneData gChildWarpOutToTCS[];
 
 ActorInit Demo_Kankyo_InitVars = {
-    ACTOR_DEMO_KANKYO,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(DemoKankyo),
-    (ActorFunc)DemoKankyo_Init,
-    (ActorFunc)DemoKankyo_Destroy,
-    (ActorFunc)DemoKankyo_Update,
-    (ActorFunc)DemoKankyo_Draw,
+    /**/ ACTOR_DEMO_KANKYO,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(DemoKankyo),
+    /**/ DemoKankyo_Init,
+    /**/ DemoKankyo_Destroy,
+    /**/ DemoKankyo_Update,
+    /**/ DemoKankyo_Draw,
 };
 
 static s16 sObjectIds[] = {

--- a/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.c
+++ b/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.c
@@ -22,15 +22,15 @@ void DemoKekkai_DrawTrialBarrier(Actor* thisx, PlayState* play2);
 void DemoKekkai_TowerBarrier(DemoKekkai* this, PlayState* play);
 
 ActorInit Demo_Kekkai_InitVars = {
-    ACTOR_DEMO_KEKKAI,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_DEMO_KEKKAI,
-    sizeof(DemoKekkai),
-    (ActorFunc)DemoKekkai_Init,
-    (ActorFunc)DemoKekkai_Destroy,
-    (ActorFunc)DemoKekkai_Update,
-    (ActorFunc)DemoKekkai_DrawTowerBarrier,
+    /**/ ACTOR_DEMO_KEKKAI,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_DEMO_KEKKAI,
+    /**/ sizeof(DemoKekkai),
+    /**/ DemoKekkai_Init,
+    /**/ DemoKekkai_Destroy,
+    /**/ DemoKekkai_Update,
+    /**/ DemoKekkai_DrawTowerBarrier,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
@@ -87,15 +87,15 @@ static DemoSaDrawFunc sDrawFuncs[] = {
 };
 
 ActorInit Demo_Sa_InitVars = {
-    ACTOR_DEMO_SA,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_SA,
-    sizeof(DemoSa),
-    (ActorFunc)DemoSa_Init,
-    (ActorFunc)DemoSa_Destroy,
-    (ActorFunc)DemoSa_Update,
-    (ActorFunc)DemoSa_Draw,
+    /**/ ACTOR_DEMO_SA,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_SA,
+    /**/ sizeof(DemoSa),
+    /**/ DemoSa_Init,
+    /**/ DemoSa_Destroy,
+    /**/ DemoSa_Update,
+    /**/ DemoSa_Draw,
 };
 
 void DemoSa_Destroy(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
+++ b/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
@@ -16,15 +16,15 @@ void DemoShd_Draw(Actor* thisx, PlayState* play);
 void func_80991298(DemoShd* this, PlayState* play);
 
 ActorInit Demo_Shd_InitVars = {
-    ACTOR_DEMO_SHD,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(DemoShd),
-    (ActorFunc)DemoShd_Init,
-    (ActorFunc)DemoShd_Destroy,
-    (ActorFunc)DemoShd_Update,
-    (ActorFunc)DemoShd_Draw,
+    /**/ ACTOR_DEMO_SHD,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(DemoShd),
+    /**/ DemoShd_Init,
+    /**/ DemoShd_Destroy,
+    /**/ DemoShd_Update,
+    /**/ DemoShd_Draw,
 };
 
 #include "assets/overlays/ovl_Demo_Shd/ovl_Demo_Shd.c"

--- a/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.c
+++ b/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.c
@@ -27,15 +27,15 @@ static DemoTreLgtInfo sDemoTreLgtInfo[] = {
 };
 
 ActorInit Demo_Tre_Lgt_InitVars = {
-    ACTOR_DEMO_TRE_LGT,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_BOX,
-    sizeof(DemoTreLgt),
-    (ActorFunc)DemoTreLgt_Init,
-    (ActorFunc)DemoTreLgt_Destroy,
-    (ActorFunc)DemoTreLgt_Update,
-    (ActorFunc)DemoTreLgt_Draw,
+    /**/ ACTOR_DEMO_TRE_LGT,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_BOX,
+    /**/ sizeof(DemoTreLgt),
+    /**/ DemoTreLgt_Init,
+    /**/ DemoTreLgt_Destroy,
+    /**/ DemoTreLgt_Update,
+    /**/ DemoTreLgt_Draw,
 };
 
 static CurveAnimationHeader* sAnimations[] = { &gTreasureChestCurveAnim_4B60, &gTreasureChestCurveAnim_4F70 };

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -19,15 +19,15 @@ void DoorAna_WaitOpen(DoorAna* this, PlayState* play);
 void DoorAna_GrabPlayer(DoorAna* this, PlayState* play);
 
 ActorInit Door_Ana_InitVars = {
-    ACTOR_DOOR_ANA,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_FIELD_KEEP,
-    sizeof(DoorAna),
-    (ActorFunc)DoorAna_Init,
-    (ActorFunc)DoorAna_Destroy,
-    (ActorFunc)DoorAna_Update,
-    (ActorFunc)DoorAna_Draw,
+    /**/ ACTOR_DOOR_ANA,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_FIELD_KEEP,
+    /**/ sizeof(DoorAna),
+    /**/ DoorAna_Init,
+    /**/ DoorAna_Destroy,
+    /**/ DoorAna_Update,
+    /**/ DoorAna_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.c
+++ b/src/overlays/actors/ovl_Door_Gerudo/z_door_gerudo.c
@@ -20,15 +20,15 @@ void func_8099496C(DoorGerudo* this, PlayState* play);
 void func_809949C8(DoorGerudo* this, PlayState* play);
 
 ActorInit Door_Gerudo_InitVars = {
-    ACTOR_DOOR_GERUDO,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_DOOR_GERUDO,
-    sizeof(DoorGerudo),
-    (ActorFunc)DoorGerudo_Init,
-    (ActorFunc)DoorGerudo_Destroy,
-    (ActorFunc)DoorGerudo_Update,
-    (ActorFunc)DoorGerudo_Draw,
+    /**/ ACTOR_DOOR_GERUDO,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_DOOR_GERUDO,
+    /**/ sizeof(DoorGerudo),
+    /**/ DoorGerudo_Init,
+    /**/ DoorGerudo_Destroy,
+    /**/ DoorGerudo_Update,
+    /**/ DoorGerudo_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -30,15 +30,15 @@ void DoorKiller_DrawDoor(Actor* thisx, PlayState* play);
 void DoorKiller_DrawRubble(Actor* thisx, PlayState* play);
 
 ActorInit Door_Killer_InitVars = {
-    ACTOR_DOOR_KILLER,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_DOOR_KILLER,
-    sizeof(DoorKiller),
-    (ActorFunc)DoorKiller_Init,
-    (ActorFunc)DoorKiller_Destroy,
-    (ActorFunc)DoorKiller_Update,
-    NULL,
+    /**/ ACTOR_DOOR_KILLER,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_DOOR_KILLER,
+    /**/ sizeof(DoorKiller),
+    /**/ DoorKiller_Init,
+    /**/ DoorKiller_Destroy,
+    /**/ DoorKiller_Update,
+    /**/ NULL,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -49,15 +49,15 @@ void DoorShutter_GohmaBlockBounce(DoorShutter* this, PlayState* play);
 void DoorShutter_PhantomGanonBarsRaise(DoorShutter* this, PlayState* play);
 
 ActorInit Door_Shutter_InitVars = {
-    ACTOR_DOOR_SHUTTER,
-    ACTORCAT_DOOR,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(DoorShutter),
-    (ActorFunc)DoorShutter_Init,
-    (ActorFunc)DoorShutter_Destroy,
-    (ActorFunc)DoorShutter_Update,
-    (ActorFunc)DoorShutter_Draw,
+    /**/ ACTOR_DOOR_SHUTTER,
+    /**/ ACTORCAT_DOOR,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(DoorShutter),
+    /**/ DoorShutter_Init,
+    /**/ DoorShutter_Destroy,
+    /**/ DoorShutter_Update,
+    /**/ DoorShutter_Draw,
 };
 
 typedef enum {

--- a/src/overlays/actors/ovl_Door_Toki/z_door_toki.c
+++ b/src/overlays/actors/ovl_Door_Toki/z_door_toki.c
@@ -14,15 +14,15 @@ void DoorToki_Destroy(Actor* thisx, PlayState* play);
 void DoorToki_Update(Actor* thisx, PlayState* play);
 
 ActorInit Door_Toki_InitVars = {
-    ACTOR_DOOR_TOKI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_TOKI_OBJECTS,
-    sizeof(DoorToki),
-    (ActorFunc)DoorToki_Init,
-    (ActorFunc)DoorToki_Destroy,
-    (ActorFunc)DoorToki_Update,
-    NULL,
+    /**/ ACTOR_DOOR_TOKI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_TOKI_OBJECTS,
+    /**/ sizeof(DoorToki),
+    /**/ DoorToki_Init,
+    /**/ DoorToki_Destroy,
+    /**/ DoorToki_Update,
+    /**/ NULL,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -33,15 +33,15 @@ void DoorWarp1_ChooseInitialAction(DoorWarp1* this, PlayState* play);
 void DoorWarp1_FloatPlayer(DoorWarp1* this, PlayState* play);
 
 ActorInit Door_Warp1_InitVars = {
-    ACTOR_DOOR_WARP1,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_WARP1,
-    sizeof(DoorWarp1),
-    (ActorFunc)DoorWarp1_Init,
-    (ActorFunc)DoorWarp1_Destroy,
-    (ActorFunc)DoorWarp1_Update,
-    (ActorFunc)DoorWarp1_Draw,
+    /**/ ACTOR_DOOR_WARP1,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_WARP1,
+    /**/ sizeof(DoorWarp1),
+    /**/ DoorWarp1_Init,
+    /**/ DoorWarp1_Destroy,
+    /**/ DoorWarp1_Update,
+    /**/ DoorWarp1_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.c
+++ b/src/overlays/actors/ovl_Efc_Erupc/z_efc_erupc.c
@@ -15,15 +15,15 @@ void EfcErupc_SpawnEffect(EfcErupcEffect* effect, Vec3f* pos, Vec3f* vel, Vec3f*
 void EfcErupc_InitEffects(EfcErupcEffect* effect);
 
 ActorInit Efc_Erupc_InitVars = {
-    ACTOR_EFC_ERUPC,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_EFC_ERUPC,
-    sizeof(EfcErupc),
-    (ActorFunc)EfcErupc_Init,
-    (ActorFunc)EfcErupc_Destroy,
-    (ActorFunc)EfcErupc_Update,
-    (ActorFunc)EfcErupc_Draw,
+    /**/ ACTOR_EFC_ERUPC,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_EFC_ERUPC,
+    /**/ sizeof(EfcErupc),
+    /**/ EfcErupc_Init,
+    /**/ EfcErupc_Destroy,
+    /**/ EfcErupc_Update,
+    /**/ EfcErupc_Draw,
 };
 
 void EfcErupc_SetupAction(EfcErupc* this, EfcErupcActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
+++ b/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
@@ -23,15 +23,15 @@ void EffDust_DrawFunc_8099E4F4(Actor* thisx, PlayState* play2);
 void EffDust_DrawFunc_8099E784(Actor* thisx, PlayState* play2);
 
 ActorInit Eff_Dust_InitVars = {
-    ACTOR_EFF_DUST,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EffDust),
-    (ActorFunc)EffDust_Init,
-    (ActorFunc)EffDust_Destroy,
-    (ActorFunc)EffDust_Update,
-    (ActorFunc)EffDust_Draw,
+    /**/ ACTOR_EFF_DUST,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EffDust),
+    /**/ EffDust_Init,
+    /**/ EffDust_Destroy,
+    /**/ EffDust_Update,
+    /**/ EffDust_Draw,
 };
 
 static Gfx sEmptyDL[] = {

--- a/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
+++ b/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
@@ -19,15 +19,15 @@ void ElfMsg_CallNaviCuboid(ElfMsg* this, PlayState* play);
 void ElfMsg_CallNaviCylinder(ElfMsg* this, PlayState* play);
 
 ActorInit Elf_Msg_InitVars = {
-    ACTOR_ELF_MSG,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ElfMsg),
-    (ActorFunc)ElfMsg_Init,
-    (ActorFunc)ElfMsg_Destroy,
-    (ActorFunc)ElfMsg_Update,
-    (ActorFunc)ElfMsg_Draw,
+    /**/ ACTOR_ELF_MSG,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ElfMsg),
+    /**/ ElfMsg_Init,
+    /**/ ElfMsg_Destroy,
+    /**/ ElfMsg_Update,
+    /**/ ElfMsg_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
+++ b/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
@@ -19,15 +19,15 @@ void ElfMsg2_WaitUntilActivated(ElfMsg2* this, PlayState* play);
 void ElfMsg2_WaitForTextRead(ElfMsg2* this, PlayState* play);
 
 ActorInit Elf_Msg2_InitVars = {
-    ACTOR_ELF_MSG2,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ElfMsg2),
-    (ActorFunc)ElfMsg2_Init,
-    (ActorFunc)ElfMsg2_Destroy,
-    (ActorFunc)ElfMsg2_Update,
-    (ActorFunc)ElfMsg2_Draw,
+    /**/ ACTOR_ELF_MSG2,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ElfMsg2),
+    /**/ ElfMsg2_Init,
+    /**/ ElfMsg2_Destroy,
+    /**/ ElfMsg2_Update,
+    /**/ ElfMsg2_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Am/z_en_am.c
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.c
@@ -40,15 +40,15 @@ typedef enum {
 } ArmosBehavior;
 
 ActorInit En_Am_InitVars = {
-    ACTOR_EN_AM,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_AM,
-    sizeof(EnAm),
-    (ActorFunc)EnAm_Init,
-    (ActorFunc)EnAm_Destroy,
-    (ActorFunc)EnAm_Update,
-    (ActorFunc)EnAm_Draw,
+    /**/ ACTOR_EN_AM,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_AM,
+    /**/ sizeof(EnAm),
+    /**/ EnAm_Init,
+    /**/ EnAm_Destroy,
+    /**/ EnAm_Update,
+    /**/ EnAm_Draw,
 };
 
 static ColliderCylinderInit sHurtCylinderInit = {

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -27,15 +27,15 @@ void func_809B0A28(EnAni* this, PlayState* play);
 void func_809B0A6C(EnAni* this, PlayState* play);
 
 ActorInit En_Ani_InitVars = {
-    ACTOR_EN_ANI,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ANI,
-    sizeof(EnAni),
-    (ActorFunc)EnAni_Init,
-    (ActorFunc)EnAni_Destroy,
-    (ActorFunc)EnAni_Update,
-    (ActorFunc)EnAni_Draw,
+    /**/ ACTOR_EN_ANI,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ANI,
+    /**/ sizeof(EnAni),
+    /**/ EnAni_Init,
+    /**/ EnAni_Destroy,
+    /**/ EnAni_Update,
+    /**/ EnAni_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Anubice/z_en_anubice.c
+++ b/src/overlays/actors/ovl_En_Anubice/z_en_anubice.c
@@ -26,15 +26,15 @@ void EnAnubice_ShootFireball(EnAnubice* this, PlayState* play);
 void EnAnubice_Die(EnAnubice* this, PlayState* play);
 
 ActorInit En_Anubice_InitVars = {
-    ACTOR_EN_ANUBICE,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_ANUBICE,
-    sizeof(EnAnubice),
-    (ActorFunc)EnAnubice_Init,
-    (ActorFunc)EnAnubice_Destroy,
-    (ActorFunc)EnAnubice_Update,
-    (ActorFunc)EnAnubice_Draw,
+    /**/ ACTOR_EN_ANUBICE,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_ANUBICE,
+    /**/ sizeof(EnAnubice),
+    /**/ EnAnubice_Init,
+    /**/ EnAnubice_Destroy,
+    /**/ EnAnubice_Update,
+    /**/ EnAnubice_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
+++ b/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
@@ -20,15 +20,15 @@ void func_809B27D8(EnAnubiceFire* this, PlayState* play);
 void func_809B2B48(EnAnubiceFire* this, PlayState* play);
 
 ActorInit En_Anubice_Fire_InitVars = {
-    ACTOR_EN_ANUBICE_FIRE,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_ANUBICE,
-    sizeof(EnAnubiceFire),
-    (ActorFunc)EnAnubiceFire_Init,
-    (ActorFunc)EnAnubiceFire_Destroy,
-    (ActorFunc)EnAnubiceFire_Update,
-    (ActorFunc)EnAnubiceFire_Draw,
+    /**/ ACTOR_EN_ANUBICE_FIRE,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_ANUBICE,
+    /**/ sizeof(EnAnubiceFire),
+    /**/ EnAnubiceFire_Init,
+    /**/ EnAnubiceFire_Destroy,
+    /**/ EnAnubiceFire_Update,
+    /**/ EnAnubiceFire_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
+++ b/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
@@ -18,15 +18,15 @@ void EnAnubiceTag_SpawnAnubis(EnAnubiceTag* this, PlayState* play);
 void EnAnubiceTag_ManageAnubis(EnAnubiceTag* this, PlayState* play);
 
 ActorInit En_Anubice_Tag_InitVars = {
-    ACTOR_EN_ANUBICE_TAG,
-    ACTORCAT_SWITCH,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnAnubiceTag),
-    (ActorFunc)EnAnubiceTag_Init,
-    (ActorFunc)EnAnubiceTag_Destroy,
-    (ActorFunc)EnAnubiceTag_Update,
-    (ActorFunc)EnAnubiceTag_Draw,
+    /**/ ACTOR_EN_ANUBICE_TAG,
+    /**/ ACTORCAT_SWITCH,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnAnubiceTag),
+    /**/ EnAnubiceTag_Init,
+    /**/ EnAnubiceTag_Destroy,
+    /**/ EnAnubiceTag_Update,
+    /**/ EnAnubiceTag_Draw,
 };
 
 void EnAnubiceTag_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Arow_Trap/z_en_arow_trap.c
+++ b/src/overlays/actors/ovl_En_Arow_Trap/z_en_arow_trap.c
@@ -13,15 +13,15 @@ void EnArowTrap_Destroy(Actor* thisx, PlayState* play);
 void EnArowTrap_Update(Actor* thisx, PlayState* play);
 
 ActorInit En_Arow_Trap_InitVars = {
-    ACTOR_EN_AROW_TRAP,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnArowTrap),
-    (ActorFunc)EnArowTrap_Init,
-    (ActorFunc)EnArowTrap_Destroy,
-    (ActorFunc)EnArowTrap_Update,
-    NULL,
+    /**/ ACTOR_EN_AROW_TRAP,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnArowTrap),
+    /**/ EnArowTrap_Init,
+    /**/ EnArowTrap_Destroy,
+    /**/ EnArowTrap_Update,
+    /**/ NULL,
 };
 
 void EnArowTrap_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -20,15 +20,15 @@ void func_809B45E0(EnArrow* this, PlayState* play);
 void func_809B4640(EnArrow* this, PlayState* play);
 
 ActorInit En_Arrow_InitVars = {
-    ACTOR_EN_ARROW,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnArrow),
-    (ActorFunc)EnArrow_Init,
-    (ActorFunc)EnArrow_Destroy,
-    (ActorFunc)EnArrow_Update,
-    (ActorFunc)EnArrow_Draw,
+    /**/ ACTOR_EN_ARROW,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnArrow),
+    /**/ EnArrow_Init,
+    /**/ EnArrow_Destroy,
+    /**/ EnArrow_Update,
+    /**/ EnArrow_Draw,
 };
 
 static ColliderQuadInit sColliderInit = {

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -20,15 +20,15 @@ void func_809B5C18(EnAttackNiw* this, PlayState* play);
 void func_809B59B0(EnAttackNiw* this, PlayState* play);
 
 ActorInit En_Attack_Niw_InitVars = {
-    ACTOR_EN_ATTACK_NIW,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_NIW,
-    sizeof(EnAttackNiw),
-    (ActorFunc)EnAttackNiw_Init,
-    (ActorFunc)EnAttackNiw_Destroy,
-    (ActorFunc)EnAttackNiw_Update,
-    (ActorFunc)EnAttackNiw_Draw,
+    /**/ ACTOR_EN_ATTACK_NIW,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_NIW,
+    /**/ sizeof(EnAttackNiw),
+    /**/ EnAttackNiw_Init,
+    /**/ EnAttackNiw_Destroy,
+    /**/ EnAttackNiw_Update,
+    /**/ EnAttackNiw_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.c
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.c
@@ -24,15 +24,15 @@ void EnBa_Die(EnBa* this, PlayState* play);
 void EnBa_SetupSwingAtPlayer(EnBa* this);
 
 ActorInit En_Ba_InitVars = {
-    ACTOR_EN_BA,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_BXA,
-    sizeof(EnBa),
-    (ActorFunc)EnBa_Init,
-    (ActorFunc)EnBa_Destroy,
-    (ActorFunc)EnBa_Update,
-    (ActorFunc)EnBa_Draw,
+    /**/ ACTOR_EN_BA,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_BXA,
+    /**/ sizeof(EnBa),
+    /**/ EnBa_Init,
+    /**/ EnBa_Destroy,
+    /**/ EnBa_Update,
+    /**/ EnBa_Draw,
 };
 
 static Vec3f D_809B8080 = { 0.0f, 0.0f, 32.0f };

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -196,15 +196,15 @@ static DamageTable sDamageTableWhite = {
 };
 
 ActorInit En_Bb_InitVars = {
-    ACTOR_EN_BB,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_BB,
-    sizeof(EnBb),
-    (ActorFunc)EnBb_Init,
-    (ActorFunc)EnBb_Destroy,
-    (ActorFunc)EnBb_Update,
-    (ActorFunc)EnBb_Draw,
+    /**/ ACTOR_EN_BB,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_BB,
+    /**/ sizeof(EnBb),
+    /**/ EnBb_Init,
+    /**/ EnBb_Destroy,
+    /**/ EnBb_Update,
+    /**/ EnBb_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementInit[1] = {

--- a/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
+++ b/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
@@ -19,15 +19,15 @@ void func_809BC2A4(EnBdfire* this, PlayState* play);
 void func_809BC598(EnBdfire* this, PlayState* play);
 
 ActorInit En_Bdfire_InitVars = {
-    0,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_KINGDODONGO,
-    sizeof(EnBdfire),
-    (ActorFunc)EnBdfire_Init,
-    (ActorFunc)EnBdfire_Destroy,
-    (ActorFunc)EnBdfire_Update,
-    (ActorFunc)EnBdfire_Draw,
+    /**/ 0,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_KINGDODONGO,
+    /**/ sizeof(EnBdfire),
+    /**/ EnBdfire_Init,
+    /**/ EnBdfire_Destroy,
+    /**/ EnBdfire_Update,
+    /**/ EnBdfire_Draw,
 };
 
 void EnBdfire_SetupAction(EnBdfire* this, EnBdfireActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -31,15 +31,15 @@ static Color_RGBA8 sEffectEnvColor = { 100, 255, 255, 255 };
 static Vec3f sEffectPosAccel = { 0.0f, 0.0f, 0.0f };
 
 ActorInit En_Bigokuta_InitVars = {
-    ACTOR_EN_BIGOKUTA,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_BIGOKUTA,
-    sizeof(EnBigokuta),
-    (ActorFunc)EnBigokuta_Init,
-    (ActorFunc)EnBigokuta_Destroy,
-    (ActorFunc)EnBigokuta_Update,
-    (ActorFunc)EnBigokuta_Draw,
+    /**/ ACTOR_EN_BIGOKUTA,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_BIGOKUTA,
+    /**/ sizeof(EnBigokuta),
+    /**/ EnBigokuta_Init,
+    /**/ EnBigokuta_Destroy,
+    /**/ EnBigokuta_Update,
+    /**/ EnBigokuta_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementInit[1] = {

--- a/src/overlays/actors/ovl_En_Bili/z_en_bili.c
+++ b/src/overlays/actors/ovl_En_Bili/z_en_bili.c
@@ -29,15 +29,15 @@ void EnBili_Stunned(EnBili* this, PlayState* play);
 void EnBili_Frozen(EnBili* this, PlayState* play);
 
 ActorInit En_Bili_InitVars = {
-    ACTOR_EN_BILI,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_BL,
-    sizeof(EnBili),
-    (ActorFunc)EnBili_Init,
-    (ActorFunc)EnBili_Destroy,
-    (ActorFunc)EnBili_Update,
-    (ActorFunc)EnBili_Draw,
+    /**/ ACTOR_EN_BILI,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_BL,
+    /**/ sizeof(EnBili),
+    /**/ EnBili_Init,
+    /**/ EnBili_Destroy,
+    /**/ EnBili_Update,
+    /**/ EnBili_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Bird/z_en_bird.c
+++ b/src/overlays/actors/ovl_En_Bird/z_en_bird.c
@@ -20,15 +20,15 @@ void EnBird_Idle(EnBird* this, PlayState* play);
 void EnBird_SetupIdle(EnBird* this, s16 params);
 
 ActorInit En_Bird_InitVars = {
-    ACTOR_EN_BIRD,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_BIRD,
-    sizeof(EnBird),
-    (ActorFunc)EnBird_Init,
-    (ActorFunc)EnBird_Destroy,
-    (ActorFunc)EnBird_Update,
-    (ActorFunc)EnBird_Draw,
+    /**/ ACTOR_EN_BIRD,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_BIRD,
+    /**/ sizeof(EnBird),
+    /**/ EnBird_Init,
+    /**/ EnBird_Destroy,
+    /**/ EnBird_Update,
+    /**/ EnBird_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.c
+++ b/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.c
@@ -20,15 +20,15 @@ void EnBlkobj_DarkLinkFight(EnBlkobj* this, PlayState* play);
 void EnBlkobj_DoNothing(EnBlkobj* this, PlayState* play);
 
 ActorInit En_Blkobj_InitVars = {
-    ACTOR_EN_BLKOBJ,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_BLKOBJ,
-    sizeof(EnBlkobj),
-    (ActorFunc)EnBlkobj_Init,
-    (ActorFunc)EnBlkobj_Destroy,
-    (ActorFunc)EnBlkobj_Update,
-    (ActorFunc)EnBlkobj_Draw,
+    /**/ ACTOR_EN_BLKOBJ,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_BLKOBJ,
+    /**/ sizeof(EnBlkobj),
+    /**/ EnBlkobj_Init,
+    /**/ EnBlkobj_Destroy,
+    /**/ EnBlkobj_Update,
+    /**/ EnBlkobj_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -19,15 +19,15 @@ void EnBom_Move(EnBom* this, PlayState* play);
 void EnBom_WaitForRelease(EnBom* this, PlayState* play);
 
 ActorInit En_Bom_InitVars = {
-    ACTOR_EN_BOM,
-    ACTORCAT_EXPLOSIVE,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnBom),
-    (ActorFunc)EnBom_Init,
-    (ActorFunc)EnBom_Destroy,
-    (ActorFunc)EnBom_Update,
-    (ActorFunc)EnBom_Draw,
+    /**/ ACTOR_EN_BOM,
+    /**/ ACTORCAT_EXPLOSIVE,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnBom),
+    /**/ EnBom_Init,
+    /**/ EnBom_Destroy,
+    /**/ EnBom_Update,
+    /**/ EnBom_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -35,15 +35,15 @@ void EnBomBowMan_ChooseShowPrize(EnBomBowlMan* this, PlayState* play);
 void EnBomBowlMan_BeginPlayGame(EnBomBowlMan* this, PlayState* play);
 
 ActorInit En_Bom_Bowl_Man_InitVars = {
-    ACTOR_EN_BOM_BOWL_MAN,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_BG,
-    sizeof(EnBomBowlMan),
-    (ActorFunc)EnBomBowlMan_Init,
-    (ActorFunc)EnBomBowlMan_Destroy,
-    (ActorFunc)EnBomBowlMan_Update,
-    (ActorFunc)EnBomBowlMan_Draw,
+    /**/ ACTOR_EN_BOM_BOWL_MAN,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_BG,
+    /**/ sizeof(EnBomBowlMan),
+    /**/ EnBomBowlMan_Init,
+    /**/ EnBomBowlMan_Destroy,
+    /**/ EnBomBowlMan_Update,
+    /**/ EnBomBowlMan_Draw,
 };
 
 void EnBomBowlMan_Init(Actor* thisx, PlayState* play2) {

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Pit/z_en_bom_bowl_pit.c
@@ -21,15 +21,15 @@ void EnBomBowlPit_Reset(EnBomBowlPit* this, PlayState* play);
 static s32 sGetItemIds[] = { GI_BOMB_BAG_30, GI_HEART_PIECE, GI_BOMBCHUS_10, GI_BOMBS_1, GI_RUPEE_PURPLE };
 
 ActorInit En_Bom_Bowl_Pit_InitVars = {
-    ACTOR_EN_BOM_BOWL_PIT,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnBomBowlPit),
-    (ActorFunc)EnBomBowlPit_Init,
-    (ActorFunc)EnBomBowlPit_Destroy,
-    (ActorFunc)EnBomBowlPit_Update,
-    NULL,
+    /**/ ACTOR_EN_BOM_BOWL_PIT,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnBomBowlPit),
+    /**/ EnBomBowlPit_Init,
+    /**/ EnBomBowlPit_Destroy,
+    /**/ EnBomBowlPit_Update,
+    /**/ NULL,
 };
 
 void EnBomBowlPit_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
@@ -16,15 +16,15 @@ void EnBomChu_Move(EnBomChu* this, PlayState* play);
 void EnBomChu_WaitForKill(EnBomChu* this, PlayState* play);
 
 ActorInit En_Bom_Chu_InitVars = {
-    ACTOR_EN_BOM_CHU,
-    ACTORCAT_EXPLOSIVE,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnBomChu),
-    (ActorFunc)EnBomChu_Init,
-    (ActorFunc)EnBomChu_Destroy,
-    (ActorFunc)EnBomChu_Update,
-    (ActorFunc)EnBomChu_Draw,
+    /**/ ACTOR_EN_BOM_CHU,
+    /**/ ACTORCAT_EXPLOSIVE,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnBomChu),
+    /**/ EnBomChu_Init,
+    /**/ EnBomChu_Destroy,
+    /**/ EnBomChu_Update,
+    /**/ EnBomChu_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElemInit[] = {

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -22,15 +22,15 @@ void EnBombf_Explode(EnBombf* this, PlayState* play);
 void EnBombf_SetupGrowBomb(EnBombf* this, s16 params);
 
 ActorInit En_Bombf_InitVars = {
-    ACTOR_EN_BOMBF,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_BOMBF,
-    sizeof(EnBombf),
-    (ActorFunc)EnBombf_Init,
-    (ActorFunc)EnBombf_Destroy,
-    (ActorFunc)EnBombf_Update,
-    (ActorFunc)EnBombf_Draw,
+    /**/ ACTOR_EN_BOMBF,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_BOMBF,
+    /**/ sizeof(EnBombf),
+    /**/ EnBombf_Init,
+    /**/ EnBombf_Destroy,
+    /**/ EnBombf_Update,
+    /**/ EnBombf_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -17,15 +17,15 @@ void EnBoom_Draw(Actor* thisx, PlayState* play);
 void EnBoom_Fly(EnBoom* this, PlayState* play);
 
 ActorInit En_Boom_InitVars = {
-    ACTOR_EN_BOOM,
-    ACTORCAT_MISC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnBoom),
-    (ActorFunc)EnBoom_Init,
-    (ActorFunc)EnBoom_Destroy,
-    (ActorFunc)EnBoom_Update,
-    (ActorFunc)EnBoom_Draw,
+    /**/ ACTOR_EN_BOOM,
+    /**/ ACTORCAT_MISC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnBoom),
+    /**/ EnBoom_Init,
+    /**/ EnBoom_Destroy,
+    /**/ EnBoom_Update,
+    /**/ EnBoom_Draw,
 };
 
 static ColliderQuadInit sQuadInit = {

--- a/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -51,15 +51,15 @@ void EnBox_WaitOpen(EnBox* this, PlayState* play);
 void EnBox_Open(EnBox* this, PlayState* play);
 
 ActorInit En_Box_InitVars = {
-    ACTOR_EN_BOX,
-    ACTORCAT_CHEST,
-    FLAGS,
-    OBJECT_BOX,
-    sizeof(EnBox),
-    (ActorFunc)EnBox_Init,
-    (ActorFunc)EnBox_Destroy,
-    (ActorFunc)EnBox_Update,
-    (ActorFunc)EnBox_Draw,
+    /**/ ACTOR_EN_BOX,
+    /**/ ACTORCAT_CHEST,
+    /**/ FLAGS,
+    /**/ OBJECT_BOX,
+    /**/ sizeof(EnBox),
+    /**/ EnBox_Init,
+    /**/ EnBox_Destroy,
+    /**/ EnBox_Update,
+    /**/ EnBox_Draw,
 };
 
 static AnimationHeader* sAnimations[4] = { &gTreasureChestAnim_00024C, &gTreasureChestAnim_000128,

--- a/src/overlays/actors/ovl_En_Brob/z_en_brob.c
+++ b/src/overlays/actors/ovl_En_Brob/z_en_brob.c
@@ -23,15 +23,15 @@ void func_809CB354(EnBrob* this, PlayState* play);
 void func_809CB458(EnBrob* this, PlayState* play);
 
 ActorInit En_Brob_InitVars = {
-    ACTOR_EN_BROB,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_BROB,
-    sizeof(EnBrob),
-    (ActorFunc)EnBrob_Init,
-    (ActorFunc)EnBrob_Destroy,
-    (ActorFunc)EnBrob_Update,
-    (ActorFunc)EnBrob_Draw,
+    /**/ ACTOR_EN_BROB,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_BROB,
+    /**/ sizeof(EnBrob),
+    /**/ EnBrob_Init,
+    /**/ EnBrob_Destroy,
+    /**/ EnBrob_Update,
+    /**/ EnBrob_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -13,15 +13,15 @@ void EnBubble_Pop(EnBubble* this, PlayState* play);
 void EnBubble_Regrow(EnBubble* this, PlayState* play);
 
 ActorInit En_Bubble_InitVars = {
-    ACTOR_EN_BUBBLE,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_BUBBLE,
-    sizeof(EnBubble),
-    (ActorFunc)EnBubble_Init,
-    (ActorFunc)EnBubble_Destroy,
-    (ActorFunc)EnBubble_Update,
-    (ActorFunc)EnBubble_Draw,
+    /**/ ACTOR_EN_BUBBLE,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_BUBBLE,
+    /**/ sizeof(EnBubble),
+    /**/ EnBubble_Init,
+    /**/ EnBubble_Destroy,
+    /**/ EnBubble_Update,
+    /**/ EnBubble_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[2] = {

--- a/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -50,15 +50,15 @@ static ColliderJntSphInit sColliderInit = {
 };
 
 ActorInit En_Butte_InitVars = {
-    ACTOR_EN_BUTTE,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_FIELD_KEEP,
-    sizeof(EnButte),
-    (ActorFunc)EnButte_Init,
-    (ActorFunc)EnButte_Destroy,
-    (ActorFunc)EnButte_Update,
-    (ActorFunc)EnButte_Draw,
+    /**/ ACTOR_EN_BUTTE,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_FIELD_KEEP,
+    /**/ sizeof(EnButte),
+    /**/ EnButte_Init,
+    /**/ EnButte_Destroy,
+    /**/ EnButte_Update,
+    /**/ EnButte_Draw,
 };
 
 typedef struct {

--- a/src/overlays/actors/ovl_En_Bw/z_en_bw.c
+++ b/src/overlays/actors/ovl_En_Bw/z_en_bw.c
@@ -34,15 +34,15 @@ void func_809D03CC(EnBw* this);
 void func_809D0424(EnBw* this, PlayState* play);
 
 ActorInit En_Bw_InitVars = {
-    ACTOR_EN_BW,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_BW,
-    sizeof(EnBw),
-    (ActorFunc)EnBw_Init,
-    (ActorFunc)EnBw_Destroy,
-    (ActorFunc)EnBw_Update,
-    (ActorFunc)EnBw_Draw,
+    /**/ ACTOR_EN_BW,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_BW,
+    /**/ sizeof(EnBw),
+    /**/ EnBw_Init,
+    /**/ EnBw_Destroy,
+    /**/ EnBw_Update,
+    /**/ EnBw_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit1 = {

--- a/src/overlays/actors/ovl_En_Bx/z_en_bx.c
+++ b/src/overlays/actors/ovl_En_Bx/z_en_bx.c
@@ -15,15 +15,15 @@ void EnBx_Update(Actor* thisx, PlayState* play);
 void EnBx_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Bx_InitVars = {
-    ACTOR_EN_BX,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_BXA,
-    sizeof(EnBx),
-    (ActorFunc)EnBx_Init,
-    (ActorFunc)EnBx_Destroy,
-    (ActorFunc)EnBx_Update,
-    (ActorFunc)EnBx_Draw,
+    /**/ ACTOR_EN_BX,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_BXA,
+    /**/ sizeof(EnBx),
+    /**/ EnBx_Init,
+    /**/ EnBx_Destroy,
+    /**/ EnBx_Update,
+    /**/ EnBx_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.c
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.c
@@ -25,15 +25,15 @@ void EnChanger_OpenChests(EnChanger* this, PlayState* play);
 void EnChanger_SetHeartPieceFlag(EnChanger* this, PlayState* play);
 
 ActorInit En_Changer_InitVars = {
-    ACTOR_EN_CHANGER,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnChanger),
-    (ActorFunc)EnChanger_Init,
-    (ActorFunc)EnChanger_Destroy,
-    (ActorFunc)EnChanger_Update,
-    NULL,
+    /**/ ACTOR_EN_CHANGER,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnChanger),
+    /**/ EnChanger_Init,
+    /**/ EnChanger_Destroy,
+    /**/ EnChanger_Update,
+    /**/ NULL,
 };
 
 static Vec3f sLeftChestPos[] = {

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -19,15 +19,15 @@ void EnClearTag_CreateFlashEffect(PlayState* play, Vec3f* position, f32 scale, f
 void EnClearTag_CalculateFloorTangent(EnClearTag* this);
 
 ActorInit En_Clear_Tag_InitVars = {
-    ACTOR_EN_CLEAR_TAG,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnClearTag),
-    (ActorFunc)EnClearTag_Init,
-    (ActorFunc)EnClearTag_Destroy,
-    (ActorFunc)EnClearTag_Update,
-    (ActorFunc)EnClearTag_Draw,
+    /**/ ACTOR_EN_CLEAR_TAG,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnClearTag),
+    /**/ EnClearTag_Init,
+    /**/ EnClearTag_Destroy,
+    /**/ EnClearTag_Update,
+    /**/ EnClearTag_Draw,
 };
 
 static u8 sIsEffectsInitialized = false;

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -27,15 +27,15 @@ void EnCow_UpdateTail(Actor* thisx, PlayState* play);
 void EnCow_IdleTail(EnCow* this, PlayState* play);
 
 ActorInit En_Cow_InitVars = {
-    ACTOR_EN_COW,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_COW,
-    sizeof(EnCow),
-    (ActorFunc)EnCow_Init,
-    (ActorFunc)EnCow_Destroy,
-    (ActorFunc)EnCow_Update,
-    (ActorFunc)EnCow_Draw,
+    /**/ ACTOR_EN_COW,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_COW,
+    /**/ sizeof(EnCow),
+    /**/ EnCow_Init,
+    /**/ EnCow_Destroy,
+    /**/ EnCow_Update,
+    /**/ EnCow_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -19,15 +19,15 @@ void EnCrow_Damaged(EnCrow* this, PlayState* play);
 static Vec3f sZeroVecAccel = { 0.0f, 0.0f, 0.0f };
 
 ActorInit En_Crow_InitVars = {
-    ACTOR_EN_CROW,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_CROW,
-    sizeof(EnCrow),
-    (ActorFunc)EnCrow_Init,
-    (ActorFunc)EnCrow_Destroy,
-    (ActorFunc)EnCrow_Update,
-    (ActorFunc)EnCrow_Draw,
+    /**/ ACTOR_EN_CROW,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_CROW,
+    /**/ sizeof(EnCrow),
+    /**/ EnCrow_Init,
+    /**/ EnCrow_Destroy,
+    /**/ EnCrow_Update,
+    /**/ EnCrow_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_En_Cs/z_en_cs.c
+++ b/src/overlays/actors/ovl_En_Cs/z_en_cs.c
@@ -16,15 +16,15 @@ s32 EnCs_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
 void EnCs_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx);
 
 ActorInit En_Cs_InitVars = {
-    ACTOR_EN_CS,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_CS,
-    sizeof(EnCs),
-    (ActorFunc)EnCs_Init,
-    (ActorFunc)EnCs_Destroy,
-    (ActorFunc)EnCs_Update,
-    (ActorFunc)EnCs_Draw,
+    /**/ ACTOR_EN_CS,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_CS,
+    /**/ sizeof(EnCs),
+    /**/ EnCs_Init,
+    /**/ EnCs_Destroy,
+    /**/ EnCs_Update,
+    /**/ EnCs_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
+++ b/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
@@ -42,15 +42,15 @@ s32 EnDaiku_OverrideLimbDraw(PlayState* play, s32 limb, Gfx** dList, Vec3f* pos,
 void EnDaiku_PostLimbDraw(PlayState* play, s32 limb, Gfx** dList, Vec3s* rot, void* thisx);
 
 ActorInit En_Daiku_InitVars = {
-    ACTOR_EN_DAIKU,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_DAIKU,
-    sizeof(EnDaiku),
-    (ActorFunc)EnDaiku_Init,
-    (ActorFunc)EnDaiku_Destroy,
-    (ActorFunc)EnDaiku_Update,
-    (ActorFunc)EnDaiku_Draw,
+    /**/ ACTOR_EN_DAIKU,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_DAIKU,
+    /**/ sizeof(EnDaiku),
+    /**/ EnDaiku_Init,
+    /**/ EnDaiku_Destroy,
+    /**/ EnDaiku_Update,
+    /**/ EnDaiku_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
+++ b/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
@@ -25,15 +25,15 @@ void EnDaikuKakariko_Wait(EnDaikuKakariko* this, PlayState* play);
 void EnDaikuKakariko_Run(EnDaikuKakariko* this, PlayState* play);
 
 ActorInit En_Daiku_Kakariko_InitVars = {
-    ACTOR_EN_DAIKU_KAKARIKO,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_DAIKU,
-    sizeof(EnDaikuKakariko),
-    (ActorFunc)EnDaikuKakariko_Init,
-    (ActorFunc)EnDaikuKakariko_Destroy,
-    (ActorFunc)EnDaikuKakariko_Update,
-    (ActorFunc)EnDaikuKakariko_Draw,
+    /**/ ACTOR_EN_DAIKU_KAKARIKO,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_DAIKU,
+    /**/ sizeof(EnDaikuKakariko),
+    /**/ EnDaikuKakariko_Init,
+    /**/ EnDaikuKakariko_Destroy,
+    /**/ EnDaikuKakariko_Update,
+    /**/ EnDaikuKakariko_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
@@ -30,15 +30,15 @@ void EnDekubaba_DeadStickDrop(EnDekubaba* this, PlayState* play);
 static Vec3f sZeroVec = { 0.0f, 0.0f, 0.0f };
 
 ActorInit En_Dekubaba_InitVars = {
-    ACTOR_EN_DEKUBABA,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_DEKUBABA,
-    sizeof(EnDekubaba),
-    (ActorFunc)EnDekubaba_Init,
-    (ActorFunc)EnDekubaba_Destroy,
-    (ActorFunc)EnDekubaba_Update,
-    (ActorFunc)EnDekubaba_Draw,
+    /**/ ACTOR_EN_DEKUBABA,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_DEKUBABA,
+    /**/ sizeof(EnDekubaba),
+    /**/ EnDekubaba_Init,
+    /**/ EnDekubaba_Destroy,
+    /**/ EnDekubaba_Update,
+    /**/ EnDekubaba_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[7] = {

--- a/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
+++ b/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
@@ -31,15 +31,15 @@ void EnDekunuts_BeStunned(EnDekunuts* this, PlayState* play);
 void EnDekunuts_Die(EnDekunuts* this, PlayState* play);
 
 ActorInit En_Dekunuts_InitVars = {
-    ACTOR_EN_DEKUNUTS,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_DEKUNUTS,
-    sizeof(EnDekunuts),
-    (ActorFunc)EnDekunuts_Init,
-    (ActorFunc)EnDekunuts_Destroy,
-    (ActorFunc)EnDekunuts_Update,
-    (ActorFunc)EnDekunuts_Draw,
+    /**/ ACTOR_EN_DEKUNUTS,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_DEKUNUTS,
+    /**/ sizeof(EnDekunuts),
+    /**/ EnDekunuts_Init,
+    /**/ EnDekunuts_Destroy,
+    /**/ EnDekunuts_Update,
+    /**/ EnDekunuts_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.c
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.c
@@ -32,15 +32,15 @@ void EnDh_Damage(EnDh* this, PlayState* play);
 void EnDh_Death(EnDh* this, PlayState* play);
 
 ActorInit En_Dh_InitVars = {
-    ACTOR_EN_DH,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_DH,
-    sizeof(EnDh),
-    (ActorFunc)EnDh_Init,
-    (ActorFunc)EnDh_Destroy,
-    (ActorFunc)EnDh_Update,
-    (ActorFunc)EnDh_Draw,
+    /**/ ACTOR_EN_DH,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_DH,
+    /**/ sizeof(EnDh),
+    /**/ EnDh_Init,
+    /**/ EnDh_Destroy,
+    /**/ EnDh_Update,
+    /**/ EnDh_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Dha/z_en_dha.c
+++ b/src/overlays/actors/ovl_En_Dha/z_en_dha.c
@@ -24,15 +24,15 @@ void EnDha_Die(EnDha* this, PlayState* play);
 void EnDha_UpdateHealth(EnDha* this, PlayState* play);
 
 ActorInit En_Dha_InitVars = {
-    ACTOR_EN_DHA,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_DH,
-    sizeof(EnDha),
-    (ActorFunc)EnDha_Init,
-    (ActorFunc)EnDha_Destroy,
-    (ActorFunc)EnDha_Update,
-    (ActorFunc)EnDha_Draw,
+    /**/ ACTOR_EN_DHA,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_DH,
+    /**/ sizeof(EnDha),
+    /**/ EnDha_Init,
+    /**/ EnDha_Destroy,
+    /**/ EnDha_Update,
+    /**/ EnDha_Draw,
 };
 
 static DamageTable sDamageTable = {

--- a/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
+++ b/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
@@ -34,15 +34,15 @@ void func_809EEA90(EnDivingGame* this, PlayState* play);
 void func_809EEAF8(EnDivingGame* this, PlayState* play);
 
 ActorInit En_Diving_Game_InitVars = {
-    ACTOR_EN_DIVING_GAME,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ZO,
-    sizeof(EnDivingGame),
-    (ActorFunc)EnDivingGame_Init,
-    (ActorFunc)EnDivingGame_Destroy,
-    (ActorFunc)EnDivingGame_Update,
-    (ActorFunc)EnDivingGame_Draw,
+    /**/ ACTOR_EN_DIVING_GAME,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ZO,
+    /**/ sizeof(EnDivingGame),
+    /**/ EnDivingGame_Init,
+    /**/ EnDivingGame_Destroy,
+    /**/ EnDivingGame_Update,
+    /**/ EnDivingGame_Draw,
 };
 
 // used to ensure there's only one instance of this actor.

--- a/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -43,15 +43,15 @@ void EnDns_Burrow(EnDns* this, PlayState* play);
 void EnDns_PostBurrow(EnDns* this, PlayState* play);
 
 ActorInit En_Dns_InitVars = {
-    ACTOR_EN_DNS,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SHOPNUTS,
-    sizeof(EnDns),
-    (ActorFunc)EnDns_Init,
-    (ActorFunc)EnDns_Destroy,
-    (ActorFunc)EnDns_Update,
-    (ActorFunc)EnDns_Draw,
+    /**/ ACTOR_EN_DNS,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SHOPNUTS,
+    /**/ sizeof(EnDns),
+    /**/ EnDns_Init,
+    /**/ EnDns_Destroy,
+    /**/ EnDns_Update,
+    /**/ EnDns_Draw,
 };
 
 static ColliderCylinderInitType1 sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
+++ b/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
@@ -27,15 +27,15 @@ void EnDntDemo_Results(EnDntDemo* this, PlayState* play);
 void EnDntDemo_Prize(EnDntDemo* this, PlayState* play);
 
 ActorInit En_Dnt_Demo_InitVars = {
-    ACTOR_EN_DNT_DEMO,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnDntDemo),
-    (ActorFunc)EnDntDemo_Init,
-    (ActorFunc)EnDntDemo_Destroy,
-    (ActorFunc)EnDntDemo_Update,
-    NULL,
+    /**/ ACTOR_EN_DNT_DEMO,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnDntDemo),
+    /**/ EnDntDemo_Init,
+    /**/ EnDntDemo_Destroy,
+    /**/ EnDntDemo_Update,
+    /**/ NULL,
 };
 
 //! @bug

--- a/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
+++ b/src/overlays/actors/ovl_En_Dnt_Jiji/z_en_dnt_jiji.c
@@ -40,15 +40,15 @@ void EnDntJiji_Hide(EnDntJiji* this, PlayState* play);
 void EnDntJiji_Return(EnDntJiji* this, PlayState* play);
 
 ActorInit En_Dnt_Jiji_InitVars = {
-    ACTOR_EN_DNT_JIJI,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_DNS,
-    sizeof(EnDntJiji),
-    (ActorFunc)EnDntJiji_Init,
-    (ActorFunc)EnDntJiji_Destroy,
-    (ActorFunc)EnDntJiji_Update,
-    (ActorFunc)EnDntJiji_Draw,
+    /**/ ACTOR_EN_DNT_JIJI,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_DNS,
+    /**/ sizeof(EnDntJiji),
+    /**/ EnDntJiji_Init,
+    /**/ EnDntJiji_Destroy,
+    /**/ EnDntJiji_Update,
+    /**/ EnDntJiji_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -57,15 +57,15 @@ void EnDntNomal_StageAttack(EnDntNomal* this, PlayState* play);
 void EnDntNomal_StageReturn(EnDntNomal* this, PlayState* play);
 
 ActorInit En_Dnt_Nomal_InitVars = {
-    ACTOR_EN_DNT_NOMAL,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnDntNomal),
-    (ActorFunc)EnDntNomal_Init,
-    (ActorFunc)EnDntNomal_Destroy,
-    (ActorFunc)EnDntNomal_Update,
-    NULL,
+    /**/ ACTOR_EN_DNT_NOMAL,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnDntNomal),
+    /**/ EnDntNomal_Init,
+    /**/ EnDntNomal_Destroy,
+    /**/ EnDntNomal_Update,
+    /**/ NULL,
 };
 
 static ColliderCylinderInit sBodyCylinderInit = {

--- a/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
+++ b/src/overlays/actors/ovl_En_Dodojr/z_en_dodojr.c
@@ -32,15 +32,15 @@ void EnDodojr_WaitFreezeFrames(EnDodojr* this, PlayState* play);
 void EnDodojr_EatBomb(EnDodojr* this, PlayState* play);
 
 ActorInit En_Dodojr_InitVars = {
-    ACTOR_EN_DODOJR,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_DODOJR,
-    sizeof(EnDodojr),
-    (ActorFunc)EnDodojr_Init,
-    (ActorFunc)EnDodojr_Destroy,
-    (ActorFunc)EnDodojr_Update,
-    (ActorFunc)EnDodojr_Draw,
+    /**/ ACTOR_EN_DODOJR,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_DODOJR,
+    /**/ sizeof(EnDodojr),
+    /**/ EnDodojr_Init,
+    /**/ EnDodojr_Destroy,
+    /**/ EnDodojr_Update,
+    /**/ EnDodojr_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -37,15 +37,15 @@ void EnDodongo_Death(EnDodongo* this, PlayState* play);
 void EnDodongo_SweepTail(EnDodongo* this, PlayState* play);
 
 ActorInit En_Dodongo_InitVars = {
-    ACTOR_EN_DODONGO,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_DODONGO,
-    sizeof(EnDodongo),
-    (ActorFunc)EnDodongo_Init,
-    (ActorFunc)EnDodongo_Destroy,
-    (ActorFunc)EnDodongo_Update,
-    (ActorFunc)EnDodongo_Draw,
+    /**/ ACTOR_EN_DODONGO,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_DODONGO,
+    /**/ sizeof(EnDodongo),
+    /**/ EnDodongo_Init,
+    /**/ EnDodongo_Destroy,
+    /**/ EnDodongo_Update,
+    /**/ EnDodongo_Draw,
 };
 
 static ColliderJntSphElementInit sBodyElementsInit[6] = {

--- a/src/overlays/actors/ovl_En_Dog/z_en_dog.c
+++ b/src/overlays/actors/ovl_En_Dog/z_en_dog.c
@@ -22,15 +22,15 @@ void EnDog_FaceLink(EnDog* this, PlayState* play);
 void EnDog_Wait(EnDog* this, PlayState* play);
 
 ActorInit En_Dog_InitVars = {
-    ACTOR_EN_DOG,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_DOG,
-    sizeof(EnDog),
-    (ActorFunc)EnDog_Init,
-    (ActorFunc)EnDog_Destroy,
-    (ActorFunc)EnDog_Update,
-    (ActorFunc)EnDog_Draw,
+    /**/ ACTOR_EN_DOG,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_DOG,
+    /**/ sizeof(EnDog),
+    /**/ EnDog_Init,
+    /**/ EnDog_Destroy,
+    /**/ EnDog_Update,
+    /**/ EnDog_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Door/z_en_door.c
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.c
@@ -33,15 +33,15 @@ void EnDoor_AjarClose(EnDoor* this, PlayState* play);
 void EnDoor_Open(EnDoor* this, PlayState* play);
 
 ActorInit En_Door_InitVars = {
-    ACTOR_EN_DOOR,
-    ACTORCAT_DOOR,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnDoor),
-    (ActorFunc)EnDoor_Init,
-    (ActorFunc)EnDoor_Destroy,
-    (ActorFunc)EnDoor_Update,
-    (ActorFunc)EnDoor_Draw,
+    /**/ ACTOR_EN_DOOR,
+    /**/ ACTORCAT_DOOR,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnDoor),
+    /**/ EnDoor_Init,
+    /**/ EnDoor_Destroy,
+    /**/ EnDoor_Update,
+    /**/ EnDoor_Draw,
 };
 
 typedef struct {

--- a/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -17,15 +17,15 @@ void EnDs_Draw(Actor* thisx, PlayState* play);
 void EnDs_Wait(EnDs* this, PlayState* play);
 
 ActorInit En_Ds_InitVars = {
-    ACTOR_EN_DS,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_DS,
-    sizeof(EnDs),
-    (ActorFunc)EnDs_Init,
-    (ActorFunc)EnDs_Destroy,
-    (ActorFunc)EnDs_Update,
-    (ActorFunc)EnDs_Draw,
+    /**/ ACTOR_EN_DS,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_DS,
+    /**/ sizeof(EnDs),
+    /**/ EnDs_Init,
+    /**/ EnDs_Destroy,
+    /**/ EnDs_Update,
+    /**/ EnDs_Draw,
 };
 
 void EnDs_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -23,15 +23,15 @@ void func_809FECE4(EnDu* this, PlayState* play);
 void func_809FEB08(EnDu* this, PlayState* play);
 
 ActorInit En_Du_InitVars = {
-    ACTOR_EN_DU,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_DU,
-    sizeof(EnDu),
-    (ActorFunc)EnDu_Init,
-    (ActorFunc)EnDu_Destroy,
-    (ActorFunc)EnDu_Update,
-    (ActorFunc)EnDu_Draw,
+    /**/ ACTOR_EN_DU,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_DU,
+    /**/ sizeof(EnDu),
+    /**/ EnDu_Init,
+    /**/ EnDu_Destroy,
+    /**/ EnDu_Update,
+    /**/ EnDu_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.c
+++ b/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.c
@@ -19,15 +19,15 @@ void EnDyExtra_WaitForTrigger(EnDyExtra* this, PlayState* play);
 void EnDyExtra_FallAndKill(EnDyExtra* this, PlayState* play);
 
 ActorInit En_Dy_Extra_InitVars = {
-    ACTOR_EN_DY_EXTRA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_DY_OBJ,
-    sizeof(EnDyExtra),
-    (ActorFunc)EnDyExtra_Init,
-    (ActorFunc)EnDyExtra_Destroy,
-    (ActorFunc)EnDyExtra_Update,
-    (ActorFunc)EnDyExtra_Draw,
+    /**/ ACTOR_EN_DY_EXTRA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_DY_OBJ,
+    /**/ sizeof(EnDyExtra),
+    /**/ EnDyExtra_Init,
+    /**/ EnDyExtra_Destroy,
+    /**/ EnDyExtra_Update,
+    /**/ EnDyExtra_Draw,
 };
 
 void EnDyExtra_Destroy(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Eg/z_en_eg.c
+++ b/src/overlays/actors/ovl_En_Eg/z_en_eg.c
@@ -23,15 +23,15 @@ static EnEgActionFunc sActionFuncs[] = {
 };
 
 ActorInit En_Eg_InitVars = {
-    ACTOR_EN_EG,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_ZL2,
-    sizeof(EnEg),
-    (ActorFunc)EnEg_Init,
-    (ActorFunc)EnEg_Destroy,
-    (ActorFunc)EnEg_Update,
-    (ActorFunc)EnEg_Draw,
+    /**/ ACTOR_EN_EG,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_ZL2,
+    /**/ sizeof(EnEg),
+    /**/ EnEg_Init,
+    /**/ EnEg_Destroy,
+    /**/ EnEg_Update,
+    /**/ EnEg_Draw,
 };
 
 void EnEg_PlayVoidOutSFX(void) {

--- a/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
+++ b/src/overlays/actors/ovl_En_Eiyer/z_en_eiyer.c
@@ -36,15 +36,15 @@ void EnEiyer_Dead(EnEiyer* this, PlayState* play);
 void EnEiyer_Stunned(EnEiyer* this, PlayState* play);
 
 ActorInit En_Eiyer_InitVars = {
-    ACTOR_EN_EIYER,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_EI,
-    sizeof(EnEiyer),
-    (ActorFunc)EnEiyer_Init,
-    (ActorFunc)EnEiyer_Destroy,
-    (ActorFunc)EnEiyer_Update,
-    (ActorFunc)EnEiyer_Draw,
+    /**/ ACTOR_EN_EIYER,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_EI,
+    /**/ sizeof(EnEiyer),
+    /**/ EnEiyer_Init,
+    /**/ EnEiyer_Destroy,
+    /**/ EnEiyer_Update,
+    /**/ EnEiyer_Draw,
 };
 
 static ColliderCylinderInit sColCylInit = {

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -55,15 +55,15 @@ void EnElf_SpawnSparkles(EnElf* this, PlayState* play, s32 sparkleLife);
 void EnElf_GetCuePos(Vec3f* dest, PlayState* play, s32 cueChannel);
 
 ActorInit En_Elf_InitVars = {
-    ACTOR_EN_ELF,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnElf),
-    (ActorFunc)EnElf_Init,
-    (ActorFunc)EnElf_Destroy,
-    (ActorFunc)EnElf_Update,
-    (ActorFunc)EnElf_Draw,
+    /**/ ACTOR_EN_ELF,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnElf),
+    /**/ EnElf_Init,
+    /**/ EnElf_Destroy,
+    /**/ EnElf_Update,
+    /**/ EnElf_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
@@ -15,15 +15,15 @@ static s16 sLeeverAngles[] = { 0x0000, 0x2710, 0x7148, 0x8EB8, 0xD8F0 };
 static f32 sLeeverDists[] = { 200.0f, 170.0f, 120.0f, 120.0f, 170.0f };
 
 ActorInit En_Encount1_InitVars = {
-    ACTOR_EN_ENCOUNT1,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnEncount1),
-    (ActorFunc)EnEncount1_Init,
-    NULL,
-    (ActorFunc)EnEncount1_Update,
-    NULL,
+    /**/ ACTOR_EN_ENCOUNT1,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnEncount1),
+    /**/ EnEncount1_Init,
+    /**/ NULL,
+    /**/ EnEncount1_Update,
+    /**/ NULL,
 };
 
 void EnEncount1_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
+++ b/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
@@ -24,15 +24,15 @@ void EnEncount2_DrawEffects(Actor* thisx, PlayState* play);
 void EnEncount2_UpdateEffects(EnEncount2* this, PlayState* play);
 
 ActorInit En_Encount2_InitVars = {
-    ACTOR_EN_ENCOUNT2,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_EFC_STAR_FIELD,
-    sizeof(EnEncount2),
-    (ActorFunc)EnEncount2_Init,
-    NULL,
-    (ActorFunc)EnEncount2_Update,
-    (ActorFunc)EnEncount2_Draw,
+    /**/ ACTOR_EN_ENCOUNT2,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_EFC_STAR_FIELD,
+    /**/ sizeof(EnEncount2),
+    /**/ EnEncount2_Init,
+    /**/ NULL,
+    /**/ EnEncount2_Update,
+    /**/ EnEncount2_Draw,
 };
 
 void EnEncount2_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
+++ b/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.c
@@ -33,15 +33,15 @@ void EnExItem_TargetPrizeGive(EnExItem* this, PlayState* play);
 void EnExItem_TargetPrizeFinish(EnExItem* this, PlayState* play);
 
 ActorInit En_Ex_Item_InitVars = {
-    ACTOR_EN_EX_ITEM,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnExItem),
-    (ActorFunc)EnExItem_Init,
-    (ActorFunc)EnExItem_Destroy,
-    (ActorFunc)EnExItem_Update,
-    (ActorFunc)EnExItem_Draw,
+    /**/ ACTOR_EN_EX_ITEM,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnExItem),
+    /**/ EnExItem_Init,
+    /**/ EnExItem_Destroy,
+    /**/ EnExItem_Update,
+    /**/ EnExItem_Draw,
 };
 
 void EnExItem_Destroy(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
+++ b/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
@@ -29,15 +29,15 @@ static s16 sRupeeValues[] = {
 };
 
 ActorInit En_Ex_Ruppy_InitVars = {
-    ACTOR_EN_EX_RUPPY,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnExRuppy),
-    (ActorFunc)EnExRuppy_Init,
-    (ActorFunc)EnExRuppy_Destroy,
-    (ActorFunc)EnExRuppy_Update,
-    (ActorFunc)EnExRuppy_Draw,
+    /**/ ACTOR_EN_EX_RUPPY,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnExRuppy),
+    /**/ EnExRuppy_Init,
+    /**/ EnExRuppy_Destroy,
+    /**/ EnExRuppy_Update,
+    /**/ EnExRuppy_Draw,
 };
 
 void EnExRuppy_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -31,15 +31,15 @@ void EnFd_DrawEffectsFlames(EnFd* this, PlayState* play);
 void EnFd_Land(EnFd* this, PlayState* play);
 
 ActorInit En_Fd_InitVars = {
-    ACTOR_EN_FD,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_FW,
-    sizeof(EnFd),
-    (ActorFunc)EnFd_Init,
-    (ActorFunc)EnFd_Destroy,
-    (ActorFunc)EnFd_Update,
-    (ActorFunc)EnFd_Draw,
+    /**/ ACTOR_EN_FD,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_FW,
+    /**/ sizeof(EnFd),
+    /**/ EnFd_Init,
+    /**/ EnFd_Destroy,
+    /**/ EnFd_Update,
+    /**/ EnFd_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[12] = {

--- a/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.c
+++ b/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.c
@@ -13,15 +13,15 @@ void EnFdFire_DanceTowardsPlayer(EnFdFire* this, PlayState* play);
 void EnFdFire_WaitToDie(EnFdFire* this, PlayState* play);
 
 ActorInit En_Fd_Fire_InitVars = {
-    ACTOR_EN_FD_FIRE,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_GAMEPLAY_DANGEON_KEEP,
-    sizeof(EnFdFire),
-    (ActorFunc)EnFdFire_Init,
-    (ActorFunc)EnFdFire_Destroy,
-    (ActorFunc)EnFdFire_Update,
-    (ActorFunc)EnFdFire_Draw,
+    /**/ ACTOR_EN_FD_FIRE,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_DANGEON_KEEP,
+    /**/ sizeof(EnFdFire),
+    /**/ EnFdFire_Init,
+    /**/ EnFdFire_Destroy,
+    /**/ EnFdFire_Update,
+    /**/ EnFdFire_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
+++ b/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
@@ -45,15 +45,15 @@ void EnFhgFire_EnergyBall(EnFhgFire* this, PlayState* play);
 void EnFhgFire_PhantomWarp(EnFhgFire* this, PlayState* play);
 
 ActorInit En_Fhg_Fire_InitVars = {
-    0,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_FHG,
-    sizeof(EnFhgFire),
-    (ActorFunc)EnFhgFire_Init,
-    (ActorFunc)EnFhgFire_Destroy,
-    (ActorFunc)EnFhgFire_Update,
-    (ActorFunc)EnFhgFire_Draw,
+    /**/ 0,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_FHG,
+    /**/ sizeof(EnFhgFire),
+    /**/ EnFhgFire_Init,
+    /**/ EnFhgFire_Destroy,
+    /**/ EnFhgFire_Update,
+    /**/ EnFhgFire_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -16,15 +16,15 @@ void EnFireRock_Fall(EnFireRock* this, PlayState* play);
 void EnFireRock_SpawnMoreBrokenPieces(EnFireRock* this, PlayState* play);
 
 ActorInit En_Fire_Rock_InitVars = {
-    ACTOR_EN_FIRE_ROCK,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_EFC_STAR_FIELD,
-    sizeof(EnFireRock),
-    (ActorFunc)EnFireRock_Init,
-    (ActorFunc)EnFireRock_Destroy,
-    (ActorFunc)EnFireRock_Update,
-    (ActorFunc)EnFireRock_Draw,
+    /**/ ACTOR_EN_FIRE_ROCK,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_EFC_STAR_FIELD,
+    /**/ sizeof(EnFireRock),
+    /**/ EnFireRock_Init,
+    /**/ EnFireRock_Destroy,
+    /**/ EnFireRock_Update,
+    /**/ EnFireRock_Draw,
 };
 
 static ColliderCylinderInit D_80A12CA0 = {

--- a/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
+++ b/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
@@ -35,15 +35,15 @@ typedef enum {
 } KeeseAuraType;
 
 ActorInit En_Firefly_InitVars = {
-    ACTOR_EN_FIREFLY,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_FIREFLY,
-    sizeof(EnFirefly),
-    (ActorFunc)EnFirefly_Init,
-    (ActorFunc)EnFirefly_Destroy,
-    (ActorFunc)EnFirefly_Update,
-    (ActorFunc)EnFirefly_Draw,
+    /**/ ACTOR_EN_FIREFLY,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_FIREFLY,
+    /**/ sizeof(EnFirefly),
+    /**/ EnFirefly_Init,
+    /**/ EnFirefly_Destroy,
+    /**/ EnFirefly_Update,
+    /**/ EnFirefly_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -65,15 +65,15 @@ static ColliderJntSphInit sJntSphInit = {
 };
 
 ActorInit En_Fish_InitVars = {
-    ACTOR_EN_FISH,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnFish),
-    (ActorFunc)EnFish_Init,
-    (ActorFunc)EnFish_Destroy,
-    (ActorFunc)EnFish_Update,
-    (ActorFunc)EnFish_Draw,
+    /**/ ACTOR_EN_FISH,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnFish),
+    /**/ EnFish_Init,
+    /**/ EnFish_Destroy,
+    /**/ EnFish_Update,
+    /**/ EnFish_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -45,15 +45,15 @@ void EnFloormas_BigDecideAction(EnFloormas* this, PlayState* play);
 void EnFloormas_Charge(EnFloormas* this, PlayState* play);
 
 ActorInit En_Floormas_InitVars = {
-    ACTOR_EN_FLOORMAS,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_WALLMASTER,
-    sizeof(EnFloormas),
-    (ActorFunc)EnFloormas_Init,
-    (ActorFunc)EnFloormas_Destroy,
-    (ActorFunc)EnFloormas_Update,
-    (ActorFunc)EnFloormas_Draw,
+    /**/ ACTOR_EN_FLOORMAS,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_WALLMASTER,
+    /**/ sizeof(EnFloormas),
+    /**/ EnFloormas_Init,
+    /**/ EnFloormas_Destroy,
+    /**/ EnFloormas_Update,
+    /**/ EnFloormas_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -134,15 +134,15 @@ static s32 sSongToFrog[] = {
 };
 
 ActorInit En_Fr_InitVars = {
-    ACTOR_EN_FR,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_FR,
-    sizeof(EnFr),
-    (ActorFunc)EnFr_Init,
-    (ActorFunc)EnFr_Destroy,
-    (ActorFunc)EnFr_Update,
-    NULL,
+    /**/ ACTOR_EN_FR,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_FR,
+    /**/ sizeof(EnFr),
+    /**/ EnFr_Init,
+    /**/ EnFr_Destroy,
+    /**/ EnFr_Update,
+    /**/ NULL,
 };
 
 static Color_RGBA8 sEnFrColor[] = {

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -29,15 +29,15 @@ void func_80A1DBD4(EnFu* this, PlayState* play);
 void func_80A1DB60(EnFu* this, PlayState* play);
 
 ActorInit En_Fu_InitVars = {
-    ACTOR_EN_FU,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_FU,
-    sizeof(EnFu),
-    (ActorFunc)EnFu_Init,
-    (ActorFunc)EnFu_Destroy,
-    (ActorFunc)EnFu_Update,
-    (ActorFunc)EnFu_Draw,
+    /**/ ACTOR_EN_FU,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_FU,
+    /**/ sizeof(EnFu),
+    /**/ EnFu_Init,
+    /**/ EnFu_Destroy,
+    /**/ EnFu_Update,
+    /**/ EnFu_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Fw/z_en_fw.c
+++ b/src/overlays/actors/ovl_En_Fw/z_en_fw.c
@@ -25,15 +25,15 @@ void EnFw_JumpToParentInitPos(EnFw* this, PlayState* play);
 void EnFw_TurnToParentInitPos(EnFw* this, PlayState* play);
 
 ActorInit En_Fw_InitVars = {
-    ACTOR_EN_FW,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_FW,
-    sizeof(EnFw),
-    (ActorFunc)EnFw_Init,
-    (ActorFunc)EnFw_Destroy,
-    (ActorFunc)EnFw_Update,
-    (ActorFunc)EnFw_Draw,
+    /**/ ACTOR_EN_FW,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_FW,
+    /**/ sizeof(EnFw),
+    /**/ EnFw_Init,
+    /**/ EnFw_Destroy,
+    /**/ EnFw_Update,
+    /**/ EnFw_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_En_Fz/z_en_fz.c
+++ b/src/overlays/actors/ovl_En_Fz/z_en_fz.c
@@ -46,15 +46,15 @@ void EnFz_UpdateIceSmoke(EnFz* this, PlayState* play);
 void EnFz_DrawEffects(EnFz* this, PlayState* play);
 
 ActorInit En_Fz_InitVars = {
-    ACTOR_EN_FZ,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_FZ,
-    sizeof(EnFz),
-    (ActorFunc)EnFz_Init,
-    (ActorFunc)EnFz_Destroy,
-    (ActorFunc)EnFz_Update,
-    (ActorFunc)EnFz_Draw,
+    /**/ ACTOR_EN_FZ,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_FZ,
+    /**/ sizeof(EnFz),
+    /**/ EnFz_Init,
+    /**/ EnFz_Destroy,
+    /**/ EnFz_Update,
+    /**/ EnFz_Draw,
 };
 
 static ColliderCylinderInitType1 sCylinderInit1 = {

--- a/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
+++ b/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
@@ -65,15 +65,15 @@ static s16 sRupeeTypes[] = {
 };
 
 ActorInit En_G_Switch_InitVars = {
-    ACTOR_EN_G_SWITCH,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnGSwitch),
-    (ActorFunc)EnGSwitch_Init,
-    (ActorFunc)EnGSwitch_Destroy,
-    (ActorFunc)EnGSwitch_Update,
-    NULL,
+    /**/ ACTOR_EN_G_SWITCH,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnGSwitch),
+    /**/ EnGSwitch_Init,
+    /**/ EnGSwitch_Destroy,
+    /**/ EnGSwitch_Update,
+    /**/ NULL,
 };
 
 void EnGSwitch_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.c
+++ b/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.c
@@ -15,15 +15,15 @@ void EnGanonMant_Update(Actor* thisx, PlayState* play);
 void EnGanonMant_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Ganon_Mant_InitVars = {
-    ACTOR_EN_GANON_MANT,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnGanonMant),
-    (ActorFunc)EnGanonMant_Init,
-    (ActorFunc)EnGanonMant_Destroy,
-    (ActorFunc)EnGanonMant_Update,
-    (ActorFunc)EnGanonMant_Draw,
+    /**/ ACTOR_EN_GANON_MANT,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnGanonMant),
+    /**/ EnGanonMant_Init,
+    /**/ EnGanonMant_Destroy,
+    /**/ EnGanonMant_Update,
+    /**/ EnGanonMant_Draw,
 };
 
 static s16 sTearSizesMedium[] = {

--- a/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.c
+++ b/src/overlays/actors/ovl_En_Ganon_Organ/z_en_ganon_organ.c
@@ -15,15 +15,15 @@ void EnGanonOrgan_Update(Actor* thisx, PlayState* play);
 void EnGanonOrgan_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Ganon_Organ_InitVars = {
-    ACTOR_EN_GANON_ORGAN,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_GANON,
-    sizeof(EnGanonOrgan),
-    (ActorFunc)EnGanonOrgan_Init,
-    (ActorFunc)EnGanonOrgan_Destroy,
-    (ActorFunc)EnGanonOrgan_Update,
-    (ActorFunc)EnGanonOrgan_Draw,
+    /**/ ACTOR_EN_GANON_ORGAN,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_GANON,
+    /**/ sizeof(EnGanonOrgan),
+    /**/ EnGanonOrgan_Init,
+    /**/ EnGanonOrgan_Destroy,
+    /**/ EnGanonOrgan_Update,
+    /**/ EnGanonOrgan_Draw,
 };
 
 static u64 sForceAlignment = 0;

--- a/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -27,15 +27,15 @@ void EnGb_DrawCagedSouls(EnGb* this, PlayState* play);
 void EnGb_UpdateCagedSouls(EnGb* this, PlayState* play);
 
 ActorInit En_Gb_InitVars = {
-    ACTOR_EN_GB,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_PS,
-    sizeof(EnGb),
-    (ActorFunc)EnGb_Init,
-    (ActorFunc)EnGb_Destroy,
-    (ActorFunc)EnGb_Update,
-    (ActorFunc)EnGb_Draw,
+    /**/ ACTOR_EN_GB,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_PS,
+    /**/ sizeof(EnGb),
+    /**/ EnGb_Init,
+    /**/ EnGb_Destroy,
+    /**/ EnGb_Update,
+    /**/ EnGb_Draw,
 };
 
 static EnGbCagedSoulInfo sCagedSoulInfo[] = {

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -40,15 +40,15 @@ void EnGe1_CueUpAnimation(EnGe1* this);
 void EnGe1_StopFidget(EnGe1* this);
 
 ActorInit En_Ge1_InitVars = {
-    ACTOR_EN_GE1,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GE1,
-    sizeof(EnGe1),
-    (ActorFunc)EnGe1_Init,
-    (ActorFunc)EnGe1_Destroy,
-    (ActorFunc)EnGe1_Update,
-    (ActorFunc)EnGe1_Draw,
+    /**/ ACTOR_EN_GE1,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GE1,
+    /**/ sizeof(EnGe1),
+    /**/ EnGe1_Init,
+    /**/ EnGe1_Destroy,
+    /**/ EnGe1_Update,
+    /**/ EnGe1_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -56,15 +56,15 @@ void EnGe2_UpdateAfterTalk(Actor* thisx, PlayState* play);
 void EnGe2_UpdateStunned(Actor* thisx, PlayState* play2);
 
 ActorInit En_Ge2_InitVars = {
-    ACTOR_EN_GE2,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GLA,
-    sizeof(EnGe2),
-    (ActorFunc)EnGe2_Init,
-    (ActorFunc)EnGe2_Destroy,
-    (ActorFunc)EnGe2_Update,
-    (ActorFunc)EnGe2_Draw,
+    /**/ ACTOR_EN_GE2,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GLA,
+    /**/ sizeof(EnGe2),
+    /**/ EnGe2_Init,
+    /**/ EnGe2_Destroy,
+    /**/ EnGe2_Update,
+    /**/ EnGe2_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -19,15 +19,15 @@ void EnGe3_ForceTalk(EnGe3* this, PlayState* play);
 void EnGe3_UpdateWhenNotTalking(Actor* thisx, PlayState* play);
 
 ActorInit En_Ge3_InitVars = {
-    ACTOR_EN_GE3,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GELDB,
-    sizeof(EnGe3),
-    (ActorFunc)EnGe3_Init,
-    (ActorFunc)EnGe3_Destroy,
-    (ActorFunc)EnGe3_Update,
-    (ActorFunc)EnGe3_Draw,
+    /**/ ACTOR_EN_GE3,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GELDB,
+    /**/ sizeof(EnGe3),
+    /**/ EnGe3_Init,
+    /**/ EnGe3_Destroy,
+    /**/ EnGe3_Update,
+    /**/ EnGe3_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -70,15 +70,15 @@ void EnGeldB_Sidestep(EnGeldB* this, PlayState* play);
 void EnGeldB_Defeated(EnGeldB* this, PlayState* play);
 
 ActorInit En_GeldB_InitVars = {
-    ACTOR_EN_GELDB,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_GELDB,
-    sizeof(EnGeldB),
-    (ActorFunc)EnGeldB_Init,
-    (ActorFunc)EnGeldB_Destroy,
-    (ActorFunc)EnGeldB_Update,
-    (ActorFunc)EnGeldB_Draw,
+    /**/ ACTOR_EN_GELDB,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_GELDB,
+    /**/ sizeof(EnGeldB),
+    /**/ EnGeldB_Init,
+    /**/ EnGeldB_Destroy,
+    /**/ EnGeldB_Update,
+    /**/ EnGeldB_Draw,
 };
 
 static ColliderCylinderInit sBodyCylInit = {

--- a/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
+++ b/src/overlays/actors/ovl_En_GirlA/z_en_girla.c
@@ -68,15 +68,15 @@ void EnGirlA_BuyEvent_GoronTunic(PlayState* play, EnGirlA* this);
 void EnGirlA_BuyEvent_ZoraTunic(PlayState* play, EnGirlA* this);
 
 ActorInit En_GirlA_InitVars = {
-    ACTOR_EN_GIRLA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnGirlA),
-    (ActorFunc)EnGirlA_Init,
-    (ActorFunc)EnGirlA_Destroy,
-    (ActorFunc)EnGirlA_Update,
-    NULL,
+    /**/ ACTOR_EN_GIRLA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnGirlA),
+    /**/ EnGirlA_Init,
+    /**/ EnGirlA_Destroy,
+    /**/ EnGirlA_Update,
+    /**/ NULL,
 };
 
 static char* sShopItemDescriptions[] = {

--- a/src/overlays/actors/ovl_En_Gm/z_en_gm.c
+++ b/src/overlays/actors/ovl_En_Gm/z_en_gm.c
@@ -27,15 +27,15 @@ void func_80A3DF00(EnGm* this, PlayState* play);
 void func_80A3DF60(EnGm* this, PlayState* play);
 
 ActorInit En_Gm_InitVars = {
-    ACTOR_EN_GM,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_OF1D_MAP,
-    sizeof(EnGm),
-    (ActorFunc)EnGm_Init,
-    (ActorFunc)EnGm_Destroy,
-    (ActorFunc)EnGm_Update,
-    NULL,
+    /**/ ACTOR_EN_GM,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_OF1D_MAP,
+    /**/ sizeof(EnGm),
+    /**/ EnGm_Init,
+    /**/ EnGm_Destroy,
+    /**/ EnGm_Update,
+    /**/ NULL,
 };
 
 static ColliderCylinderInitType1 sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -35,15 +35,15 @@ void EnGo_UpdateEffects(EnGo* this);
 void EnGo_DrawEffects(EnGo* this, PlayState* play);
 
 ActorInit En_Go_InitVars = {
-    ACTOR_EN_GO,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_OF1D_MAP,
-    sizeof(EnGo),
-    (ActorFunc)EnGo_Init,
-    (ActorFunc)EnGo_Destroy,
-    (ActorFunc)EnGo_Update,
-    (ActorFunc)EnGo_Draw,
+    /**/ ACTOR_EN_GO,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_OF1D_MAP,
+    /**/ sizeof(EnGo),
+    /**/ EnGo_Init,
+    /**/ EnGo_Destroy,
+    /**/ EnGo_Update,
+    /**/ EnGo_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -97,15 +97,15 @@ static CollisionCheckInfoInit2 sColChkInfoInit = {
 };
 
 ActorInit En_Go2_InitVars = {
-    ACTOR_EN_GO2,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_OF1D_MAP,
-    sizeof(EnGo2),
-    (ActorFunc)EnGo2_Init,
-    (ActorFunc)EnGo2_Destroy,
-    (ActorFunc)EnGo2_Update,
-    (ActorFunc)EnGo2_Draw,
+    /**/ ACTOR_EN_GO2,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_OF1D_MAP,
+    /**/ sizeof(EnGo2),
+    /**/ EnGo2_Init,
+    /**/ EnGo2_Destroy,
+    /**/ EnGo2_Update,
+    /**/ EnGo2_Draw,
 };
 
 static EnGo2DataStruct1 D_80A4816C[14] = {

--- a/src/overlays/actors/ovl_En_Goma/z_en_goma.c
+++ b/src/overlays/actors/ovl_En_Goma/z_en_goma.c
@@ -43,15 +43,15 @@ void EnGoma_SetupJump(EnGoma* this);
 void EnGoma_SetupStunned(EnGoma* this, PlayState* play);
 
 ActorInit En_Goma_InitVars = {
-    ACTOR_BOSS_GOMA,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_GOL,
-    sizeof(EnGoma),
-    (ActorFunc)EnGoma_Init,
-    (ActorFunc)EnGoma_Destroy,
-    (ActorFunc)EnGoma_Update,
-    (ActorFunc)EnGoma_Draw,
+    /**/ ACTOR_BOSS_GOMA,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_GOL,
+    /**/ sizeof(EnGoma),
+    /**/ EnGoma_Init,
+    /**/ EnGoma_Destroy,
+    /**/ EnGoma_Update,
+    /**/ EnGoma_Draw,
 };
 
 static ColliderCylinderInit D_80A4B7A0 = {

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
@@ -44,15 +44,15 @@ void EnGoroiwa_SetupMoveDown(EnGoroiwa* this);
 void EnGoroiwa_MoveDown(EnGoroiwa* this, PlayState* play);
 
 ActorInit En_Goroiwa_InitVars = {
-    ACTOR_EN_GOROIWA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GOROIWA,
-    sizeof(EnGoroiwa),
-    (ActorFunc)EnGoroiwa_Init,
-    (ActorFunc)EnGoroiwa_Destroy,
-    (ActorFunc)EnGoroiwa_Update,
-    (ActorFunc)EnGoroiwa_Draw,
+    /**/ ACTOR_EN_GOROIWA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GOROIWA,
+    /**/ sizeof(EnGoroiwa),
+    /**/ EnGoroiwa_Init,
+    /**/ EnGoroiwa_Destroy,
+    /**/ EnGoroiwa_Update,
+    /**/ EnGoroiwa_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[] = {

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.c
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.c
@@ -22,15 +22,15 @@ void func_80A4F700(EnGs* this, PlayState* play);
 void func_80A4F77C(EnGs* this);
 
 ActorInit En_Gs_InitVars = {
-    ACTOR_EN_GS,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GS,
-    sizeof(EnGs),
-    (ActorFunc)EnGs_Init,
-    (ActorFunc)EnGs_Destroy,
-    (ActorFunc)EnGs_Update,
-    (ActorFunc)EnGs_Draw,
+    /**/ ACTOR_EN_GS,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GS,
+    /**/ sizeof(EnGs),
+    /**/ EnGs_Init,
+    /**/ EnGs_Destroy,
+    /**/ EnGs_Update,
+    /**/ EnGs_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Guest/z_en_guest.c
+++ b/src/overlays/actors/ovl_En_Guest/z_en_guest.c
@@ -21,15 +21,15 @@ void func_80A5057C(EnGuest* this, PlayState* play);
 void func_80A505CC(Actor* thisx, PlayState* play);
 
 ActorInit En_Guest_InitVars = {
-    ACTOR_EN_GUEST,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_BOJ,
-    sizeof(EnGuest),
-    (ActorFunc)EnGuest_Init,
-    (ActorFunc)EnGuest_Destroy,
-    (ActorFunc)EnGuest_Update,
-    NULL,
+    /**/ ACTOR_EN_GUEST,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_BOJ,
+    /**/ sizeof(EnGuest),
+    /**/ EnGuest_Init,
+    /**/ EnGuest_Destroy,
+    /**/ EnGuest_Update,
+    /**/ NULL,
 };
 
 static ColliderCylinderInitType1 sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Hata/z_en_hata.c
+++ b/src/overlays/actors/ovl_En_Hata/z_en_hata.c
@@ -15,15 +15,15 @@ void EnHata_Update(Actor* thisx, PlayState* play2);
 void EnHata_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Hata_InitVars = {
-    ACTOR_EN_HATA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_HATA,
-    sizeof(EnHata),
-    (ActorFunc)EnHata_Init,
-    (ActorFunc)EnHata_Destroy,
-    (ActorFunc)EnHata_Update,
-    (ActorFunc)EnHata_Draw,
+    /**/ ACTOR_EN_HATA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_HATA,
+    /**/ sizeof(EnHata),
+    /**/ EnHata_Init,
+    /**/ EnHata_Destroy,
+    /**/ EnHata_Update,
+    /**/ EnHata_Draw,
 };
 
 // Unused Collider and CollisionCheck data

--- a/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
+++ b/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
@@ -32,15 +32,15 @@ void EnHeishi1_WaitNight(EnHeishi1* this, PlayState* play);
 static s32 sPlayerIsCaught = false;
 
 ActorInit En_Heishi1_InitVars = {
-    0,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_SD,
-    sizeof(EnHeishi1),
-    (ActorFunc)EnHeishi1_Init,
-    (ActorFunc)EnHeishi1_Destroy,
-    (ActorFunc)EnHeishi1_Update,
-    (ActorFunc)EnHeishi1_Draw,
+    /**/ 0,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_SD,
+    /**/ sizeof(EnHeishi1),
+    /**/ EnHeishi1_Init,
+    /**/ EnHeishi1_Destroy,
+    /**/ EnHeishi1_Update,
+    /**/ EnHeishi1_Draw,
 };
 
 static f32 sAnimParamsInit[][8] = {

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -51,15 +51,15 @@ void func_80A541FC(EnHeishi2* this, PlayState* play);
 void func_80A53DF8(EnHeishi2* this, PlayState* play);
 
 ActorInit En_Heishi2_InitVars = {
-    ACTOR_EN_HEISHI2,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_SD,
-    sizeof(EnHeishi2),
-    (ActorFunc)EnHeishi2_Init,
-    (ActorFunc)EnHeishi2_Destroy,
-    (ActorFunc)EnHeishi2_Update,
-    (ActorFunc)EnHeishi2_Draw,
+    /**/ ACTOR_EN_HEISHI2,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_SD,
+    /**/ sizeof(EnHeishi2),
+    /**/ EnHeishi2_Init,
+    /**/ EnHeishi2_Destroy,
+    /**/ EnHeishi2_Update,
+    /**/ EnHeishi2_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
+++ b/src/overlays/actors/ovl_En_Heishi3/z_en_heishi3.c
@@ -26,15 +26,15 @@ void func_80A55BD4(EnHeishi3* this, PlayState* play);
 static s16 sPlayerCaught = 0;
 
 ActorInit En_Heishi3_InitVars = {
-    ACTOR_EN_HEISHI3,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_SD,
-    sizeof(EnHeishi3),
-    (ActorFunc)EnHeishi3_Init,
-    (ActorFunc)EnHeishi3_Destroy,
-    (ActorFunc)EnHeishi3_Update,
-    (ActorFunc)EnHeishi3_Draw,
+    /**/ ACTOR_EN_HEISHI3,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_SD,
+    /**/ sizeof(EnHeishi3),
+    /**/ EnHeishi3_Init,
+    /**/ EnHeishi3_Destroy,
+    /**/ EnHeishi3_Update,
+    /**/ EnHeishi3_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
+++ b/src/overlays/actors/ovl_En_Heishi4/z_en_heishi4.c
@@ -22,15 +22,15 @@ void func_80A56A50(EnHeishi4* this, PlayState* play);
 void func_80A56ACC(EnHeishi4* this, PlayState* play);
 
 ActorInit En_Heishi4_InitVars = {
-    ACTOR_EN_HEISHI4,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_SD,
-    sizeof(EnHeishi4),
-    (ActorFunc)EnHeishi4_Init,
-    (ActorFunc)EnHeishi4_Destroy,
-    (ActorFunc)EnHeishi4_Update,
-    (ActorFunc)EnHeishi4_Draw,
+    /**/ ACTOR_EN_HEISHI4,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_SD,
+    /**/ sizeof(EnHeishi4),
+    /**/ EnHeishi4_Init,
+    /**/ EnHeishi4_Destroy,
+    /**/ EnHeishi4_Update,
+    /**/ EnHeishi4_Draw,
 };
 
 static u32 sFaceReactionSets[] = { 6, 7 };

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
@@ -28,15 +28,15 @@ void EnHintnuts_Leave(EnHintnuts* this, PlayState* play);
 void EnHintnuts_Freeze(EnHintnuts* this, PlayState* play);
 
 ActorInit En_Hintnuts_InitVars = {
-    ACTOR_EN_HINTNUTS,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_HINTNUTS,
-    sizeof(EnHintnuts),
-    (ActorFunc)EnHintnuts_Init,
-    (ActorFunc)EnHintnuts_Destroy,
-    (ActorFunc)EnHintnuts_Update,
-    (ActorFunc)EnHintnuts_Draw,
+    /**/ ACTOR_EN_HINTNUTS,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_HINTNUTS,
+    /**/ sizeof(EnHintnuts),
+    /**/ EnHintnuts_Init,
+    /**/ EnHintnuts_Destroy,
+    /**/ EnHintnuts_Update,
+    /**/ EnHintnuts_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Holl/z_en_holl.c
+++ b/src/overlays/actors/ovl_En_Holl/z_en_holl.c
@@ -77,15 +77,15 @@ void EnHoll_VerticalInvisible(EnHoll* this, PlayState* play);
 void EnHoll_HorizontalBgCoverSwitchFlag(EnHoll* this, PlayState* play);
 
 ActorInit En_Holl_InitVars = {
-    ACTOR_EN_HOLL,
-    ACTORCAT_DOOR,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnHoll),
-    (ActorFunc)EnHoll_Init,
-    (ActorFunc)EnHoll_Destroy,
-    (ActorFunc)EnHoll_Update,
-    (ActorFunc)EnHoll_Draw,
+    /**/ ACTOR_EN_HOLL,
+    /**/ ACTORCAT_DOOR,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnHoll),
+    /**/ EnHoll_Init,
+    /**/ EnHoll_Destroy,
+    /**/ EnHoll_Update,
+    /**/ EnHoll_Draw,
 };
 
 static EnHollActionFunc sActionFuncs[] = {

--- a/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
+++ b/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
@@ -48,15 +48,15 @@ void EnHonotrap_SetupFlameVanish(EnHonotrap* this);
 void EnHonotrap_FlameVanish(EnHonotrap* this, PlayState* play);
 
 ActorInit En_Honotrap_InitVars = {
-    ACTOR_EN_HONOTRAP,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_DANGEON_KEEP,
-    sizeof(EnHonotrap),
-    (ActorFunc)EnHonotrap_Init,
-    (ActorFunc)EnHonotrap_Destroy,
-    (ActorFunc)EnHonotrap_Update,
-    (ActorFunc)EnHonotrap_Draw,
+    /**/ ACTOR_EN_HONOTRAP,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_DANGEON_KEEP,
+    /**/ sizeof(EnHonotrap),
+    /**/ EnHonotrap_Init,
+    /**/ EnHonotrap_Destroy,
+    /**/ EnHonotrap_Update,
+    /**/ EnHonotrap_Draw,
 };
 
 static ColliderTrisElementInit sTrisElementsInit[2] = {

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -67,15 +67,15 @@ static f32 sPlaybackSpeeds[] = { 2.0f / 3.0f, 2.0f / 3.0f, 1.0f, 1.0f, 1.0f, 1.0
 static SkeletonHeader* sSkeletonHeaders[] = { &gEponaSkel, &gHorseIngoSkel };
 
 ActorInit En_Horse_InitVars = {
-    ACTOR_EN_HORSE,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HORSE,
-    sizeof(EnHorse),
-    (ActorFunc)EnHorse_Init,
-    (ActorFunc)EnHorse_Destroy,
-    (ActorFunc)EnHorse_Update,
-    (ActorFunc)EnHorse_Draw,
+    /**/ ACTOR_EN_HORSE,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HORSE,
+    /**/ sizeof(EnHorse),
+    /**/ EnHorse_Init,
+    /**/ EnHorse_Destroy,
+    /**/ EnHorse_Update,
+    /**/ EnHorse_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit1 = {

--- a/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
+++ b/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
@@ -49,15 +49,15 @@ void EnHorseGameCheck_Update(Actor* thisx, PlayState* play);
 void EnHorseGameCheck_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Horse_Game_Check_InitVars = {
-    ACTOR_EN_HORSE_GAME_CHECK,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnHorseGameCheck),
-    (ActorFunc)EnHorseGameCheck_Init,
-    (ActorFunc)EnHorseGameCheck_Destroy,
-    (ActorFunc)EnHorseGameCheck_Update,
-    (ActorFunc)EnHorseGameCheck_Draw,
+    /**/ ACTOR_EN_HORSE_GAME_CHECK,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnHorseGameCheck),
+    /**/ EnHorseGameCheck_Init,
+    /**/ EnHorseGameCheck_Destroy,
+    /**/ EnHorseGameCheck_Update,
+    /**/ EnHorseGameCheck_Draw,
 };
 
 static Vec3f sIngoRaceCheckpoints[] = {

--- a/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
+++ b/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
@@ -24,15 +24,15 @@ void func_80A68AF0(EnHorseGanon* this, PlayState* play);
 void func_80A68DB0(EnHorseGanon* this, PlayState* play);
 
 ActorInit En_Horse_Ganon_InitVars = {
-    ACTOR_EN_HORSE_GANON,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HORSE_GANON,
-    sizeof(EnHorseGanon),
-    (ActorFunc)EnHorseGanon_Init,
-    (ActorFunc)EnHorseGanon_Destroy,
-    (ActorFunc)EnHorseGanon_Update,
-    (ActorFunc)EnHorseGanon_Draw,
+    /**/ ACTOR_EN_HORSE_GANON,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HORSE_GANON,
+    /**/ sizeof(EnHorseGanon),
+    /**/ EnHorseGanon_Init,
+    /**/ EnHorseGanon_Destroy,
+    /**/ EnHorseGanon_Update,
+    /**/ EnHorseGanon_Draw,
 };
 
 static AnimationHeader* sAnimations[] = {

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
@@ -20,15 +20,15 @@ void func_80A6A4DC(EnHorseLinkChild* this);
 void func_80A6A724(EnHorseLinkChild* this);
 
 ActorInit En_Horse_Link_Child_InitVars = {
-    ACTOR_EN_HORSE_LINK_CHILD,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HORSE_LINK_CHILD,
-    sizeof(EnHorseLinkChild),
-    (ActorFunc)EnHorseLinkChild_Init,
-    (ActorFunc)EnHorseLinkChild_Destroy,
-    (ActorFunc)EnHorseLinkChild_Update,
-    (ActorFunc)EnHorseLinkChild_Draw,
+    /**/ ACTOR_EN_HORSE_LINK_CHILD,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HORSE_LINK_CHILD,
+    /**/ sizeof(EnHorseLinkChild),
+    /**/ EnHorseLinkChild_Init,
+    /**/ EnHorseLinkChild_Destroy,
+    /**/ EnHorseLinkChild_Update,
+    /**/ EnHorseLinkChild_Draw,
 };
 
 static AnimationHeader* sAnimations[] = {

--- a/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
+++ b/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
@@ -40,15 +40,15 @@ void func_80A6C4CC(EnHorseNormal* this);
 void func_80A6C6B0(EnHorseNormal* this);
 
 ActorInit En_Horse_Normal_InitVars = {
-    ACTOR_EN_HORSE_NORMAL,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HORSE_NORMAL,
-    sizeof(EnHorseNormal),
-    (ActorFunc)EnHorseNormal_Init,
-    (ActorFunc)EnHorseNormal_Destroy,
-    (ActorFunc)EnHorseNormal_Update,
-    (ActorFunc)EnHorseNormal_Draw,
+    /**/ ACTOR_EN_HORSE_NORMAL,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HORSE_NORMAL,
+    /**/ sizeof(EnHorseNormal),
+    /**/ EnHorseNormal_Init,
+    /**/ EnHorseNormal_Destroy,
+    /**/ EnHorseNormal_Update,
+    /**/ EnHorseNormal_Draw,
 };
 
 static AnimationHeader* sAnimations[] = {

--- a/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
+++ b/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
@@ -19,15 +19,15 @@ void EnHorseZelda_Gallop(EnHorseZelda* this, PlayState* play);
 void EnHorseZelda_SetupStop(EnHorseZelda* this);
 
 ActorInit En_Horse_Zelda_InitVars = {
-    ACTOR_EN_HORSE_ZELDA,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_HORSE_ZELDA,
-    sizeof(EnHorseZelda),
-    (ActorFunc)EnHorseZelda_Init,
-    (ActorFunc)EnHorseZelda_Destroy,
-    (ActorFunc)EnHorseZelda_Update,
-    (ActorFunc)EnHorseZelda_Draw,
+    /**/ ACTOR_EN_HORSE_ZELDA,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_HORSE_ZELDA,
+    /**/ sizeof(EnHorseZelda),
+    /**/ EnHorseZelda_Init,
+    /**/ EnHorseZelda_Destroy,
+    /**/ EnHorseZelda_Update,
+    /**/ EnHorseZelda_Draw,
 };
 
 static AnimationHeader* sAnimationHeaders[] = { &gHorseZeldaGallopingAnim };

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -19,15 +19,15 @@ void func_80A6E9AC(EnHs* this, PlayState* play);
 void func_80A6E6B0(EnHs* this, PlayState* play);
 
 ActorInit En_Hs_InitVars = {
-    ACTOR_EN_HS,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_HS,
-    sizeof(EnHs),
-    (ActorFunc)EnHs_Init,
-    (ActorFunc)EnHs_Destroy,
-    (ActorFunc)EnHs_Update,
-    (ActorFunc)EnHs_Draw,
+    /**/ ACTOR_EN_HS,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_HS,
+    /**/ sizeof(EnHs),
+    /**/ EnHs_Init,
+    /**/ EnHs_Destroy,
+    /**/ EnHs_Update,
+    /**/ EnHs_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
+++ b/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
@@ -17,15 +17,15 @@ void EnHs2_Draw(Actor* thisx, PlayState* play);
 void func_80A6F1A4(EnHs2* this, PlayState* play);
 
 ActorInit En_Hs2_InitVars = {
-    ACTOR_EN_HS2,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_HS,
-    sizeof(EnHs2),
-    (ActorFunc)EnHs2_Init,
-    (ActorFunc)EnHs2_Destroy,
-    (ActorFunc)EnHs2_Update,
-    (ActorFunc)EnHs2_Draw,
+    /**/ ACTOR_EN_HS2,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_HS,
+    /**/ sizeof(EnHs2),
+    /**/ EnHs2_Init,
+    /**/ EnHs2_Destroy,
+    /**/ EnHs2_Update,
+    /**/ EnHs2_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -33,15 +33,15 @@ void EnHy_DoNothing(EnHy* this, PlayState* play);
 void func_80A714C4(EnHy* this, PlayState* play);
 
 ActorInit En_Hy_InitVars = {
-    ACTOR_EN_HY,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnHy),
-    (ActorFunc)EnHy_Init,
-    (ActorFunc)EnHy_Destroy,
-    (ActorFunc)EnHy_Update,
-    (ActorFunc)EnHy_Draw,
+    /**/ ACTOR_EN_HY,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnHy),
+    /**/ EnHy_Init,
+    /**/ EnHy_Destroy,
+    /**/ EnHy_Update,
+    /**/ EnHy_Draw,
 };
 
 static ColliderCylinderInit sColCylInit = {

--- a/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
+++ b/src/overlays/actors/ovl_En_Ice_Hono/z_en_ice_hono.c
@@ -25,15 +25,15 @@ void EnIceHono_SetupActionSpreadFlames(EnIceHono* this);
 void EnIceHono_SetupActionSmallFlame(EnIceHono* this);
 
 ActorInit En_Ice_Hono_InitVars = {
-    ACTOR_EN_ICE_HONO,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnIceHono),
-    (ActorFunc)EnIceHono_Init,
-    (ActorFunc)EnIceHono_Destroy,
-    (ActorFunc)EnIceHono_Update,
-    (ActorFunc)EnIceHono_Draw,
+    /**/ ACTOR_EN_ICE_HONO,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnIceHono),
+    /**/ EnIceHono_Init,
+    /**/ EnIceHono_Destroy,
+    /**/ EnIceHono_Update,
+    /**/ EnIceHono_Draw,
 };
 
 static ColliderCylinderInit sCylinderInitCapturableFlame = {

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -1558,13 +1558,13 @@ void EnIk_Init(Actor* thisx, PlayState* play) {
 }
 
 ActorInit En_Ik_InitVars = {
-    ACTOR_EN_IK,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_IK,
-    sizeof(EnIk),
-    (ActorFunc)EnIk_Init,
-    (ActorFunc)EnIk_Destroy,
-    (ActorFunc)EnIk_UpdateCutscene,
-    (ActorFunc)EnIk_DrawCutscene,
+    /**/ ACTOR_EN_IK,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_IK,
+    /**/ sizeof(EnIk),
+    /**/ EnIk_Init,
+    /**/ EnIk_Destroy,
+    /**/ EnIk_UpdateCutscene,
+    /**/ EnIk_DrawCutscene,
 };

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -25,15 +25,15 @@ void func_80A7AA40(EnIn* this, PlayState* play);
 void func_80A7A4BC(EnIn* this, PlayState* play);
 
 ActorInit En_In_InitVars = {
-    ACTOR_EN_IN,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_IN,
-    sizeof(EnIn),
-    (ActorFunc)EnIn_Init,
-    (ActorFunc)EnIn_Destroy,
-    (ActorFunc)EnIn_Update,
-    (ActorFunc)EnIn_Draw,
+    /**/ ACTOR_EN_IN,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_IN,
+    /**/ sizeof(EnIn),
+    /**/ EnIn_Init,
+    /**/ EnIn_Destroy,
+    /**/ EnIn_Update,
+    /**/ EnIn_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -43,15 +43,15 @@ static s16 sCaughtCount = 0;
 static s16 sDroppedCount = 0;
 
 ActorInit En_Insect_InitVars = {
-    ACTOR_EN_INSECT,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnInsect),
-    (ActorFunc)EnInsect_Init,
-    (ActorFunc)EnInsect_Destroy,
-    (ActorFunc)EnInsect_Update,
-    (ActorFunc)EnInsect_Draw,
+    /**/ ACTOR_EN_INSECT,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnInsect),
+    /**/ EnInsect_Init,
+    /**/ EnInsect_Destroy,
+    /**/ EnInsect_Update,
+    /**/ EnInsect_Draw,
 };
 
 static ColliderJntSphElementInit sColliderItemInit[1] = {

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
@@ -33,15 +33,15 @@ static s16 sRotSpeedX = 0;
 static s16 sRotSpeedY = 0;
 
 ActorInit En_Ishi_InitVars = {
-    ACTOR_EN_ISHI,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_FIELD_KEEP,
-    sizeof(EnIshi),
-    (ActorFunc)EnIshi_Init,
-    (ActorFunc)EnIshi_Destroy,
-    (ActorFunc)EnIshi_Update,
-    (ActorFunc)EnIshi_Draw,
+    /**/ ACTOR_EN_ISHI,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_FIELD_KEEP,
+    /**/ sizeof(EnIshi),
+    /**/ EnIshi_Init,
+    /**/ EnIshi_Destroy,
+    /**/ EnIshi_Update,
+    /**/ EnIshi_Draw,
 };
 
 static f32 sRockScales[] = { 0.1f, 0.4f };

--- a/src/overlays/actors/ovl_En_It/z_en_it.c
+++ b/src/overlays/actors/ovl_En_It/z_en_it.c
@@ -35,15 +35,15 @@ static ColliderCylinderInit sCylinderInit = {
 static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 ActorInit En_It_InitVars = {
-    ACTOR_EN_IT,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnIt),
-    (ActorFunc)EnIt_Init,
-    (ActorFunc)EnIt_Destroy,
-    (ActorFunc)EnIt_Update,
-    (ActorFunc)NULL,
+    /**/ ACTOR_EN_IT,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnIt),
+    /**/ EnIt_Init,
+    /**/ EnIt_Destroy,
+    /**/ EnIt_Update,
+    /**/ NULL,
 };
 
 void EnIt_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Jj/z_en_jj.c
+++ b/src/overlays/actors/ovl_En_Jj/z_en_jj.c
@@ -29,15 +29,15 @@ void EnJj_BeginCutscene(EnJj* this, PlayState* play);
 void EnJj_RemoveDust(EnJj* this, PlayState* play);
 
 ActorInit En_Jj_InitVars = {
-    ACTOR_EN_JJ,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_JJ,
-    sizeof(EnJj),
-    (ActorFunc)EnJj_Init,
-    (ActorFunc)EnJj_Destroy,
-    (ActorFunc)EnJj_Update,
-    (ActorFunc)EnJj_Draw,
+    /**/ ACTOR_EN_JJ,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_JJ,
+    /**/ sizeof(EnJj),
+    /**/ EnJj_Init,
+    /**/ EnJj_Destroy,
+    /**/ EnJj_Update,
+    /**/ EnJj_Draw,
 };
 
 static s32 sUnused = 0;

--- a/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -17,15 +17,15 @@ void EnJs_Draw(Actor* thisx, PlayState* play);
 void func_80A89304(EnJs* this, PlayState* play);
 
 ActorInit En_Js_InitVars = {
-    ACTOR_EN_JS,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_JS,
-    sizeof(EnJs),
-    (ActorFunc)EnJs_Init,
-    (ActorFunc)EnJs_Destroy,
-    (ActorFunc)EnJs_Update,
-    (ActorFunc)EnJs_Draw,
+    /**/ ACTOR_EN_JS,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_JS,
+    /**/ sizeof(EnJs),
+    /**/ EnJs_Init,
+    /**/ EnJs_Destroy,
+    /**/ EnJs_Update,
+    /**/ EnJs_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.c
+++ b/src/overlays/actors/ovl_En_Jsjutan/z_en_jsjutan.c
@@ -15,15 +15,15 @@ void EnJsjutan_Update(Actor* thisx, PlayState* play2);
 void EnJsjutan_Draw(Actor* thisx, PlayState* play2);
 
 ActorInit En_Jsjutan_InitVars = {
-    ACTOR_EN_JSJUTAN,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnJsjutan),
-    (ActorFunc)EnJsjutan_Init,
-    (ActorFunc)EnJsjutan_Destroy,
-    (ActorFunc)EnJsjutan_Update,
-    (ActorFunc)EnJsjutan_Draw,
+    /**/ ACTOR_EN_JSJUTAN,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnJsjutan),
+    /**/ EnJsjutan_Init,
+    /**/ EnJsjutan_Destroy,
+    /**/ EnJsjutan_Update,
+    /**/ EnJsjutan_Draw,
 };
 
 // Shadow texture. 32x64 I8.

--- a/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
+++ b/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
@@ -43,15 +43,15 @@ static ColliderCylinderInit sCylinderInit = {
 };
 
 ActorInit En_Kakasi_InitVars = {
-    ACTOR_EN_KAKASI,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_KA,
-    sizeof(EnKakasi),
-    (ActorFunc)EnKakasi_Init,
-    (ActorFunc)EnKakasi_Destroy,
-    (ActorFunc)EnKakasi_Update,
-    (ActorFunc)EnKakasi_Draw,
+    /**/ ACTOR_EN_KAKASI,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_KA,
+    /**/ sizeof(EnKakasi),
+    /**/ EnKakasi_Init,
+    /**/ EnKakasi_Destroy,
+    /**/ EnKakasi_Update,
+    /**/ EnKakasi_Draw,
 };
 
 void EnKakasi_Destroy(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
+++ b/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
@@ -42,15 +42,15 @@ void func_80A90578(EnKakasi2* this, PlayState* play);
 void func_80A906C4(EnKakasi2* this, PlayState* play);
 
 ActorInit En_Kakasi2_InitVars = {
-    ACTOR_EN_KAKASI2,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_KA,
-    sizeof(EnKakasi2),
-    (ActorFunc)EnKakasi2_Init,
-    (ActorFunc)EnKakasi2_Destroy,
-    (ActorFunc)EnKakasi2_Update,
-    NULL,
+    /**/ ACTOR_EN_KAKASI2,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_KA,
+    /**/ sizeof(EnKakasi2),
+    /**/ EnKakasi2_Init,
+    /**/ EnKakasi2_Destroy,
+    /**/ EnKakasi2_Update,
+    /**/ NULL,
 };
 
 void EnKakasi2_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.c
+++ b/src/overlays/actors/ovl_En_Kakasi3/z_en_kakasi3.c
@@ -47,15 +47,15 @@ static ColliderCylinderInit sCylinderInit = {
 };
 
 ActorInit En_Kakasi3_InitVars = {
-    ACTOR_EN_KAKASI3,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_KA,
-    sizeof(EnKakasi3),
-    (ActorFunc)EnKakasi3_Init,
-    (ActorFunc)EnKakasi3_Destroy,
-    (ActorFunc)EnKakasi3_Update,
-    (ActorFunc)EnKakasi3_Draw,
+    /**/ ACTOR_EN_KAKASI3,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_KA,
+    /**/ sizeof(EnKakasi3),
+    /**/ EnKakasi3_Init,
+    /**/ EnKakasi3_Destroy,
+    /**/ EnKakasi3_Update,
+    /**/ EnKakasi3_Draw,
 };
 
 void EnKakasi3_Destroy(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
+++ b/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
@@ -76,15 +76,15 @@ void EnKanban_Update(Actor* thisx, PlayState* play2);
 void EnKanban_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Kanban_InitVars = {
-    ACTOR_EN_KANBAN,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_KANBAN,
-    sizeof(EnKanban),
-    (ActorFunc)EnKanban_Init,
-    (ActorFunc)EnKanban_Destroy,
-    (ActorFunc)EnKanban_Update,
-    (ActorFunc)EnKanban_Draw,
+    /**/ ACTOR_EN_KANBAN,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_KANBAN,
+    /**/ sizeof(EnKanban),
+    /**/ EnKanban_Init,
+    /**/ EnKanban_Destroy,
+    /**/ EnKanban_Update,
+    /**/ EnKanban_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
+++ b/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
@@ -30,15 +30,15 @@ void EnKarebaba_Regrow(EnKarebaba* this, PlayState* play);
 void EnKarebaba_Upright(EnKarebaba* this, PlayState* play);
 
 ActorInit En_Karebaba_InitVars = {
-    ACTOR_EN_KAREBABA,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_DEKUBABA,
-    sizeof(EnKarebaba),
-    (ActorFunc)EnKarebaba_Init,
-    (ActorFunc)EnKarebaba_Destroy,
-    (ActorFunc)EnKarebaba_Update,
-    (ActorFunc)EnKarebaba_Draw,
+    /**/ ACTOR_EN_KAREBABA,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_DEKUBABA,
+    /**/ sizeof(EnKarebaba),
+    /**/ EnKarebaba_Init,
+    /**/ EnKarebaba_Destroy,
+    /**/ EnKarebaba_Update,
+    /**/ EnKarebaba_Draw,
 };
 
 static ColliderCylinderInit sBodyColliderInit = {

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -31,15 +31,15 @@ void func_80A99560(EnKo* this, PlayState* play);
 s32 func_80A98ECC(EnKo* this, PlayState* play);
 
 ActorInit En_Ko_InitVars = {
-    ACTOR_EN_KO,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnKo),
-    (ActorFunc)EnKo_Init,
-    (ActorFunc)EnKo_Destroy,
-    (ActorFunc)EnKo_Update,
-    (ActorFunc)EnKo_Draw,
+    /**/ ACTOR_EN_KO,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnKo),
+    /**/ EnKo_Init,
+    /**/ EnKo_Destroy,
+    /**/ EnKo_Update,
+    /**/ EnKo_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
+++ b/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
@@ -42,15 +42,15 @@ static s16 rotSpeedYtarget = 0;
 static s16 rotSpeedY = 0;
 
 ActorInit En_Kusa_InitVars = {
-    ACTOR_EN_KUSA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnKusa),
-    (ActorFunc)EnKusa_Init,
-    (ActorFunc)EnKusa_Destroy,
-    (ActorFunc)EnKusa_Update,
-    NULL,
+    /**/ ACTOR_EN_KUSA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnKusa),
+    /**/ EnKusa_Init,
+    /**/ EnKusa_Destroy,
+    /**/ EnKusa_Update,
+    /**/ NULL,
 };
 
 static s16 sObjectIds[] = { OBJECT_GAMEPLAY_FIELD_KEEP, OBJECT_KUSA, OBJECT_KUSA };

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -23,15 +23,15 @@ void EnKz_SetupGetItem(EnKz* this, PlayState* play);
 void EnKz_StartTimer(EnKz* this, PlayState* play);
 
 ActorInit En_Kz_InitVars = {
-    ACTOR_EN_KZ,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_KZ,
-    sizeof(EnKz),
-    (ActorFunc)EnKz_Init,
-    (ActorFunc)EnKz_Destroy,
-    (ActorFunc)EnKz_Update,
-    (ActorFunc)EnKz_Draw,
+    /**/ ACTOR_EN_KZ,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_KZ,
+    /**/ sizeof(EnKz),
+    /**/ EnKz_Init,
+    /**/ EnKz_Destroy,
+    /**/ EnKz_Update,
+    /**/ EnKz_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Light/z_en_light.c
+++ b/src/overlays/actors/ovl_En_Light/z_en_light.c
@@ -17,15 +17,15 @@ void EnLight_Draw(Actor* thisx, PlayState* play);
 void EnLight_UpdateSwitch(Actor* thisx, PlayState* play);
 
 ActorInit En_Light_InitVars = {
-    ACTOR_EN_LIGHT,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnLight),
-    (ActorFunc)EnLight_Init,
-    (ActorFunc)EnLight_Destroy,
-    (ActorFunc)EnLight_Update,
-    (ActorFunc)EnLight_Draw,
+    /**/ ACTOR_EN_LIGHT,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnLight),
+    /**/ EnLight_Init,
+    /**/ EnLight_Destroy,
+    /**/ EnLight_Update,
+    /**/ EnLight_Draw,
 };
 
 typedef struct {

--- a/src/overlays/actors/ovl_En_Lightbox/z_en_lightbox.c
+++ b/src/overlays/actors/ovl_En_Lightbox/z_en_lightbox.c
@@ -15,15 +15,15 @@ void EnLightbox_Update(Actor* thisx, PlayState* play);
 void EnLightbox_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Lightbox_InitVars = {
-    ACTOR_EN_LIGHTBOX,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_LIGHTBOX,
-    sizeof(EnLightbox),
-    (ActorFunc)EnLightbox_Init,
-    (ActorFunc)EnLightbox_Destroy,
-    (ActorFunc)EnLightbox_Update,
-    (ActorFunc)EnLightbox_Draw,
+    /**/ ACTOR_EN_LIGHTBOX,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_LIGHTBOX,
+    /**/ sizeof(EnLightbox),
+    /**/ EnLightbox_Init,
+    /**/ EnLightbox_Destroy,
+    /**/ EnLightbox_Update,
+    /**/ EnLightbox_Draw,
 };
 
 void EnLightbox_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.c
+++ b/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.c
@@ -13,15 +13,15 @@ void EnMFire1_Destroy(Actor* thisx, PlayState* play);
 void EnMFire1_Update(Actor* thisx, PlayState* play);
 
 ActorInit En_M_Fire1_InitVars = {
-    ACTOR_EN_M_FIRE1,
-    ACTORCAT_MISC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnMFire1),
-    (ActorFunc)EnMFire1_Init,
-    (ActorFunc)EnMFire1_Destroy,
-    (ActorFunc)EnMFire1_Update,
-    NULL,
+    /**/ ACTOR_EN_M_FIRE1,
+    /**/ ACTORCAT_MISC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnMFire1),
+    /**/ EnMFire1_Init,
+    /**/ EnMFire1_Destroy,
+    /**/ EnMFire1_Update,
+    /**/ NULL,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -13,15 +13,15 @@ void func_80A9F408(EnMThunder* this, PlayState* play);
 void func_80A9F9B4(EnMThunder* this, PlayState* play);
 
 ActorInit En_M_Thunder_InitVars = {
-    ACTOR_EN_M_THUNDER,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnMThunder),
-    (ActorFunc)EnMThunder_Init,
-    (ActorFunc)EnMThunder_Destroy,
-    (ActorFunc)EnMThunder_Update,
-    (ActorFunc)EnMThunder_Draw,
+    /**/ ACTOR_EN_M_THUNDER,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnMThunder),
+    /**/ EnMThunder_Init,
+    /**/ EnMThunder_Destroy,
+    /**/ EnMThunder_Update,
+    /**/ EnMThunder_Draw,
 };
 
 static ColliderCylinderInit D_80AA0420 = {

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -24,15 +24,15 @@ void func_80AA1150(EnMa1* this, PlayState* play);
 void EnMa1_DoNothing(EnMa1* this, PlayState* play);
 
 ActorInit En_Ma1_InitVars = {
-    ACTOR_EN_MA1,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MA1,
-    sizeof(EnMa1),
-    (ActorFunc)EnMa1_Init,
-    (ActorFunc)EnMa1_Destroy,
-    (ActorFunc)EnMa1_Update,
-    (ActorFunc)EnMa1_Draw,
+    /**/ ACTOR_EN_MA1,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MA1,
+    /**/ sizeof(EnMa1),
+    /**/ EnMa1_Init,
+    /**/ EnMa1_Destroy,
+    /**/ EnMa1_Update,
+    /**/ EnMa1_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
@@ -18,15 +18,15 @@ void func_80AA20E4(EnMa2* this, PlayState* play);
 void func_80AA21C8(EnMa2* this, PlayState* play);
 
 ActorInit En_Ma2_InitVars = {
-    ACTOR_EN_MA2,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MA2,
-    sizeof(EnMa2),
-    (ActorFunc)EnMa2_Init,
-    (ActorFunc)EnMa2_Destroy,
-    (ActorFunc)EnMa2_Update,
-    (ActorFunc)EnMa2_Draw,
+    /**/ ACTOR_EN_MA2,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MA2,
+    /**/ sizeof(EnMa2),
+    /**/ EnMa2_Init,
+    /**/ EnMa2_Destroy,
+    /**/ EnMa2_Update,
+    /**/ EnMa2_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -21,15 +21,15 @@ void EnMa3_UpdateEyes(EnMa3* this);
 void func_80AA3200(EnMa3* this, PlayState* play);
 
 ActorInit En_Ma3_InitVars = {
-    ACTOR_EN_MA3,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MA2,
-    sizeof(EnMa3),
-    (ActorFunc)EnMa3_Init,
-    (ActorFunc)EnMa3_Destroy,
-    (ActorFunc)EnMa3_Update,
-    (ActorFunc)EnMa3_Draw,
+    /**/ ACTOR_EN_MA3,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MA2,
+    /**/ sizeof(EnMa3),
+    /**/ EnMa3_Init,
+    /**/ EnMa3_Destroy,
+    /**/ EnMa3_Update,
+    /**/ EnMa3_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -15,15 +15,15 @@ void EnMag_Update(Actor* thisx, PlayState* play);
 void EnMag_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Mag_InitVars = {
-    ACTOR_EN_MAG,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_MAG,
-    sizeof(EnMag),
-    (ActorFunc)EnMag_Init,
-    (ActorFunc)EnMag_Destroy,
-    (ActorFunc)EnMag_Update,
-    (ActorFunc)EnMag_Draw,
+    /**/ ACTOR_EN_MAG,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_MAG,
+    /**/ sizeof(EnMag),
+    /**/ EnMag_Init,
+    /**/ EnMag_Destroy,
+    /**/ EnMag_Update,
+    /**/ EnMag_Draw,
 };
 
 static s16 sDelayTimer = 0;

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -54,15 +54,15 @@ void EnMb_Update(Actor* thisx, PlayState* play);
 void EnMb_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Mb_InitVars = {
-    ACTOR_EN_MB,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_MB,
-    sizeof(EnMb),
-    (ActorFunc)EnMb_Init,
-    (ActorFunc)EnMb_Destroy,
-    (ActorFunc)EnMb_Update,
-    (ActorFunc)EnMb_Draw,
+    /**/ ACTOR_EN_MB,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_MB,
+    /**/ sizeof(EnMb),
+    /**/ EnMb_Init,
+    /**/ EnMb_Destroy,
+    /**/ EnMb_Update,
+    /**/ EnMb_Draw,
 };
 
 void EnMb_SetupSpearPatrolTurnTowardsWaypoint(EnMb* this, PlayState* play);

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -22,15 +22,15 @@ void func_80AABC10(EnMd* this, PlayState* play);
 void func_80AABD0C(EnMd* this, PlayState* play);
 
 ActorInit En_Md_InitVars = {
-    ACTOR_EN_MD,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MD,
-    sizeof(EnMd),
-    (ActorFunc)EnMd_Init,
-    (ActorFunc)EnMd_Destroy,
-    (ActorFunc)EnMd_Update,
-    (ActorFunc)EnMd_Draw,
+    /**/ ACTOR_EN_MD,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MD,
+    /**/ sizeof(EnMd),
+    /**/ EnMd_Init,
+    /**/ EnMd_Destroy,
+    /**/ EnMd_Update,
+    /**/ EnMd_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -17,15 +17,15 @@ void EnMk_Draw(Actor* thisx, PlayState* play);
 void EnMk_Wait(EnMk* this, PlayState* play);
 
 ActorInit En_Mk_InitVars = {
-    ACTOR_EN_MK,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MK,
-    sizeof(EnMk),
-    (ActorFunc)EnMk_Init,
-    (ActorFunc)EnMk_Destroy,
-    (ActorFunc)EnMk_Update,
-    (ActorFunc)EnMk_Draw,
+    /**/ ACTOR_EN_MK,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MK,
+    /**/ sizeof(EnMk),
+    /**/ EnMk_Init,
+    /**/ EnMk_Destroy,
+    /**/ EnMk_Update,
+    /**/ EnMk_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -40,15 +40,15 @@ s32 EnMm_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
 void EnMm_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void*);
 
 ActorInit En_Mm_InitVars = {
-    ACTOR_EN_MM,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MM,
-    sizeof(EnMm),
-    (ActorFunc)EnMm_Init,
-    (ActorFunc)EnMm_Destroy,
-    (ActorFunc)EnMm_Update,
-    (ActorFunc)EnMm_Draw,
+    /**/ ACTOR_EN_MM,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MM,
+    /**/ sizeof(EnMm),
+    /**/ EnMm_Init,
+    /**/ EnMm_Destroy,
+    /**/ EnMm_Update,
+    /**/ EnMm_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
@@ -36,15 +36,15 @@ s32 EnMm2_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* p
 void EnMm2_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx);
 
 ActorInit En_Mm2_InitVars = {
-    ACTOR_EN_MM2,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MM,
-    sizeof(EnMm2),
-    (ActorFunc)EnMm2_Init,
-    (ActorFunc)EnMm2_Destroy,
-    (ActorFunc)EnMm2_Update,
-    (ActorFunc)EnMm2_Draw,
+    /**/ ACTOR_EN_MM2,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MM,
+    /**/ sizeof(EnMm2),
+    /**/ EnMm2_Init,
+    /**/ EnMm2_Destroy,
+    /**/ EnMm2_Update,
+    /**/ EnMm2_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -21,15 +21,15 @@ void EnMs_Sell(EnMs* this, PlayState* play);
 void EnMs_TalkAfterPurchase(EnMs* this, PlayState* play);
 
 ActorInit En_Ms_InitVars = {
-    ACTOR_EN_MS,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MS,
-    sizeof(EnMs),
-    (ActorFunc)EnMs_Init,
-    (ActorFunc)EnMs_Destroy,
-    (ActorFunc)EnMs_Update,
-    (ActorFunc)EnMs_Draw,
+    /**/ ACTOR_EN_MS,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MS,
+    /**/ sizeof(EnMs),
+    /**/ EnMs_Init,
+    /**/ EnMs_Destroy,
+    /**/ EnMs_Update,
+    /**/ EnMs_Draw,
 };
 
 static ColliderCylinderInitType1 sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.c
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.c
@@ -40,15 +40,15 @@ static ColliderCylinderInit D_80AB0BD0 = {
 static CollisionCheckInfoInit2 D_80AB0BFC = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 ActorInit En_Mu_InitVars = {
-    ACTOR_EN_MU,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MU,
-    sizeof(EnMu),
-    (ActorFunc)EnMu_Init,
-    (ActorFunc)EnMu_Destroy,
-    (ActorFunc)EnMu_Update,
-    (ActorFunc)EnMu_Draw,
+    /**/ ACTOR_EN_MU,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MU,
+    /**/ sizeof(EnMu),
+    /**/ EnMu_Init,
+    /**/ EnMu_Destroy,
+    /**/ EnMu_Update,
+    /**/ EnMu_Draw,
 };
 
 void EnMu_SetupAction(EnMu* this, EnMuActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -1540,13 +1540,13 @@ void EnNb_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit En_Nb_InitVars = {
-    ACTOR_EN_NB,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_NB,
-    sizeof(EnNb),
-    (ActorFunc)EnNb_Init,
-    (ActorFunc)EnNb_Destroy,
-    (ActorFunc)EnNb_Update,
-    (ActorFunc)EnNb_Draw,
+    /**/ ACTOR_EN_NB,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_NB,
+    /**/ sizeof(EnNb),
+    /**/ EnNb_Init,
+    /**/ EnNb_Destroy,
+    /**/ EnNb_Update,
+    /**/ EnNb_Draw,
 };

--- a/src/overlays/actors/ovl_En_Niw/z_en_niw.c
+++ b/src/overlays/actors/ovl_En_Niw/z_en_niw.c
@@ -37,15 +37,15 @@ void EnNiw_DrawEffects(EnNiw* this, PlayState* play);
 static s16 D_80AB85E0 = 0;
 
 ActorInit En_Niw_InitVars = {
-    ACTOR_EN_NIW,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_NIW,
-    sizeof(EnNiw),
-    (ActorFunc)EnNiw_Init,
-    (ActorFunc)EnNiw_Destroy,
-    (ActorFunc)EnNiw_Update,
-    (ActorFunc)EnNiw_Draw,
+    /**/ ACTOR_EN_NIW,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_NIW,
+    /**/ sizeof(EnNiw),
+    /**/ EnNiw_Init,
+    /**/ EnNiw_Destroy,
+    /**/ EnNiw_Update,
+    /**/ EnNiw_Draw,
 };
 
 static f32 D_80AB8604[] = {

--- a/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.c
+++ b/src/overlays/actors/ovl_En_Niw_Girl/z_en_niw_girl.c
@@ -20,15 +20,15 @@ void func_80AB94D0(EnNiwGirl* this, PlayState* play);
 void func_80AB9210(EnNiwGirl* this, PlayState* play);
 
 ActorInit En_Niw_Girl_InitVars = {
-    ACTOR_EN_NIW_GIRL,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GR,
-    sizeof(EnNiwGirl),
-    (ActorFunc)EnNiwGirl_Init,
-    (ActorFunc)EnNiwGirl_Destroy,
-    (ActorFunc)EnNiwGirl_Update,
-    (ActorFunc)EnNiwGirl_Draw,
+    /**/ ACTOR_EN_NIW_GIRL,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GR,
+    /**/ sizeof(EnNiwGirl),
+    /**/ EnNiwGirl_Init,
+    /**/ EnNiwGirl_Destroy,
+    /**/ EnNiwGirl_Update,
+    /**/ EnNiwGirl_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -26,15 +26,15 @@ void func_80ABA654(EnNiwLady* this, PlayState* play);
 void func_80ABAD7C(EnNiwLady* this, PlayState* play);
 
 ActorInit En_Niw_Lady_InitVars = {
-    ACTOR_EN_NIW_LADY,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ANE,
-    sizeof(EnNiwLady),
-    (ActorFunc)EnNiwLady_Init,
-    (ActorFunc)EnNiwLady_Destroy,
-    (ActorFunc)EnNiwLady_Update,
-    NULL,
+    /**/ ACTOR_EN_NIW_LADY,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ANE,
+    /**/ sizeof(EnNiwLady),
+    /**/ EnNiwLady_Init,
+    /**/ EnNiwLady_Destroy,
+    /**/ EnNiwLady_Update,
+    /**/ NULL,
 };
 
 static s16 sMissingCuccoTextIds[] = {

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
@@ -23,15 +23,15 @@ void func_80ABBB34(EnNutsball* this, PlayState* play);
 void func_80ABBBA8(EnNutsball* this, PlayState* play);
 
 ActorInit En_Nutsball_InitVars = {
-    ACTOR_EN_NUTSBALL,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnNutsball),
-    (ActorFunc)EnNutsball_Init,
-    (ActorFunc)EnNutsball_Destroy,
-    (ActorFunc)EnNutsball_Update,
-    (ActorFunc)NULL,
+    /**/ ACTOR_EN_NUTSBALL,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnNutsball),
+    /**/ EnNutsball_Init,
+    /**/ EnNutsball_Destroy,
+    /**/ EnNutsball_Update,
+    /**/ NULL,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Nwc/z_en_nwc.c
+++ b/src/overlays/actors/ovl_En_Nwc/z_en_nwc.c
@@ -31,15 +31,15 @@ typedef enum {
 } ChickTypes;
 
 ActorInit En_Nwc_InitVars = {
-    ACTOR_EN_NWC,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_NWC,
-    sizeof(EnNwc),
-    (ActorFunc)EnNwc_Init,
-    (ActorFunc)EnNwc_Destroy,
-    (ActorFunc)EnNwc_Update,
-    (ActorFunc)EnNwc_Draw,
+    /**/ ACTOR_EN_NWC,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_NWC,
+    /**/ sizeof(EnNwc),
+    /**/ EnNwc_Init,
+    /**/ EnNwc_Destroy,
+    /**/ EnNwc_Update,
+    /**/ EnNwc_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementInit = {

--- a/src/overlays/actors/ovl_En_Ny/z_en_ny.c
+++ b/src/overlays/actors/ovl_En_Ny/z_en_ny.c
@@ -24,15 +24,15 @@ void EnNy_DrawDeathEffect(Actor* thisx, PlayState* play);
 void func_80ABD3B8(EnNy* this, f32, f32);
 
 ActorInit En_Ny_InitVars = {
-    ACTOR_EN_NY,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_NY,
-    sizeof(EnNy),
-    (ActorFunc)EnNy_Init,
-    (ActorFunc)EnNy_Destroy,
-    (ActorFunc)EnNy_Update,
-    (ActorFunc)EnNy_Draw,
+    /**/ ACTOR_EN_NY,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_NY,
+    /**/ sizeof(EnNy),
+    /**/ EnNy_Init,
+    /**/ EnNy_Destroy,
+    /**/ EnNy_Update,
+    /**/ EnNy_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_En_OE2/z_en_oe2.c
+++ b/src/overlays/actors/ovl_En_OE2/z_en_oe2.c
@@ -16,15 +16,15 @@ void EnOE2_Draw(Actor* thisx, PlayState* play);
 void EnOE2_DoNothing(EnOE2* this, PlayState* play);
 
 ActorInit En_OE2_InitVars = {
-    ACTOR_EN_OE2,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_OE2,
-    sizeof(EnOE2),
-    (ActorFunc)EnOE2_Init,
-    (ActorFunc)EnOE2_Destroy,
-    (ActorFunc)EnOE2_Update,
-    (ActorFunc)EnOE2_Draw,
+    /**/ ACTOR_EN_OE2,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_OE2,
+    /**/ sizeof(EnOE2),
+    /**/ EnOE2_Init,
+    /**/ EnOE2_Destroy,
+    /**/ EnOE2_Update,
+    /**/ EnOE2_Draw,
 };
 
 void EnOE2_SetupAction(EnOE2* this, EnOE2ActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -17,15 +17,15 @@ void EnOkarinaEffect_TriggerStorm(EnOkarinaEffect* this, PlayState* play);
 void EnOkarinaEffect_ManageStorm(EnOkarinaEffect* this, PlayState* play);
 
 ActorInit En_Okarina_Effect_InitVars = {
-    ACTOR_EN_OKARINA_EFFECT,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnOkarinaEffect),
-    (ActorFunc)EnOkarinaEffect_Init,
-    (ActorFunc)EnOkarinaEffect_Destroy,
-    (ActorFunc)EnOkarinaEffect_Update,
-    NULL,
+    /**/ ACTOR_EN_OKARINA_EFFECT,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnOkarinaEffect),
+    /**/ EnOkarinaEffect_Init,
+    /**/ EnOkarinaEffect_Destroy,
+    /**/ EnOkarinaEffect_Update,
+    /**/ NULL,
 };
 
 void EnOkarinaEffect_SetupAction(EnOkarinaEffect* this, EnOkarinaEffectActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -23,15 +23,15 @@ void func_80ABF4C8(EnOkarinaTag* this, PlayState* play);
 void func_80ABF7CC(EnOkarinaTag* this, PlayState* play);
 
 ActorInit En_Okarina_Tag_InitVars = {
-    ACTOR_EN_OKARINA_TAG,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnOkarinaTag),
-    (ActorFunc)EnOkarinaTag_Init,
-    (ActorFunc)EnOkarinaTag_Destroy,
-    (ActorFunc)EnOkarinaTag_Update,
-    NULL,
+    /**/ ACTOR_EN_OKARINA_TAG,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnOkarinaTag),
+    /**/ EnOkarinaTag_Init,
+    /**/ EnOkarinaTag_Destroy,
+    /**/ EnOkarinaTag_Update,
+    /**/ NULL,
 };
 
 extern CutsceneData D_80ABF9D0[];

--- a/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
+++ b/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
@@ -20,15 +20,15 @@ void EnOkuta_Freeze(EnOkuta* this, PlayState* play);
 void EnOkuta_ProjectileFly(EnOkuta* this, PlayState* play);
 
 ActorInit En_Okuta_InitVars = {
-    ACTOR_EN_OKUTA,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_OKUTA,
-    sizeof(EnOkuta),
-    (ActorFunc)EnOkuta_Init,
-    (ActorFunc)EnOkuta_Destroy,
-    (ActorFunc)EnOkuta_Update,
-    (ActorFunc)EnOkuta_Draw,
+    /**/ ACTOR_EN_OKUTA,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_OKUTA,
+    /**/ sizeof(EnOkuta),
+    /**/ EnOkuta_Init,
+    /**/ EnOkuta_Destroy,
+    /**/ EnOkuta_Update,
+    /**/ EnOkuta_Draw,
 };
 
 static ColliderCylinderInit sProjectileColliderInit = {

--- a/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -101,15 +101,15 @@ void EnOssan_SetStateGiveDiscountDialog(PlayState* play, EnOssan* this);
 #define CURSOR_INVALID 0xFF
 
 ActorInit En_Ossan_InitVars = {
-    ACTOR_EN_OSSAN,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnOssan),
-    (ActorFunc)EnOssan_Init,
-    (ActorFunc)EnOssan_Destroy,
-    (ActorFunc)EnOssan_Update,
-    NULL,
+    /**/ ACTOR_EN_OSSAN,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnOssan),
+    /**/ EnOssan_Init,
+    /**/ EnOssan_Destroy,
+    /**/ EnOssan_Update,
+    /**/ NULL,
 };
 
 // Unused collider

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -66,15 +66,15 @@ typedef enum {
 } EnOwlMessageChoice;
 
 ActorInit En_Owl_InitVars = {
-    ACTOR_EN_OWL,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_OWL,
-    sizeof(EnOwl),
-    (ActorFunc)EnOwl_Init,
-    (ActorFunc)EnOwl_Destroy,
-    (ActorFunc)EnOwl_Update,
-    (ActorFunc)EnOwl_Draw,
+    /**/ ACTOR_EN_OWL,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_OWL,
+    /**/ sizeof(EnOwl),
+    /**/ EnOwl_Init,
+    /**/ EnOwl_Destroy,
+    /**/ EnOwl_Update,
+    /**/ EnOwl_Draw,
 };
 
 static ColliderCylinderInit sOwlCylinderInit = {

--- a/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -16,15 +16,15 @@ void EnPart_Update(Actor* thisx, PlayState* play);
 void EnPart_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Part_InitVars = {
-    ACTOR_EN_PART,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnPart),
-    (ActorFunc)EnPart_Init,
-    (ActorFunc)EnPart_Destroy,
-    (ActorFunc)EnPart_Update,
-    (ActorFunc)EnPart_Draw,
+    /**/ ACTOR_EN_PART,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnPart),
+    /**/ EnPart_Init,
+    /**/ EnPart_Destroy,
+    /**/ EnPart_Update,
+    /**/ EnPart_Draw,
 };
 
 void EnPart_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -41,15 +41,15 @@ void EnPeehat_SetStateExplode(EnPeehat* this);
 void EnPeehat_StateExplode(EnPeehat* this, PlayState* play);
 
 ActorInit En_Peehat_InitVars = {
-    ACTOR_EN_PEEHAT,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_PEEHAT,
-    sizeof(EnPeehat),
-    (ActorFunc)EnPeehat_Init,
-    (ActorFunc)EnPeehat_Destroy,
-    (ActorFunc)EnPeehat_Update,
-    (ActorFunc)EnPeehat_Draw,
+    /**/ ACTOR_EN_PEEHAT,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_PEEHAT,
+    /**/ sizeof(EnPeehat),
+    /**/ EnPeehat_Init,
+    /**/ EnPeehat_Destroy,
+    /**/ EnPeehat_Update,
+    /**/ EnPeehat_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
+++ b/src/overlays/actors/ovl_En_Po_Desert/z_en_po_desert.c
@@ -20,15 +20,15 @@ void EnPoDesert_MoveToNextPoint(EnPoDesert* this, PlayState* play);
 void EnPoDesert_Disappear(EnPoDesert* this, PlayState* play);
 
 ActorInit En_Po_Desert_InitVars = {
-    ACTOR_EN_PO_DESERT,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_PO_FIELD,
-    sizeof(EnPoDesert),
-    (ActorFunc)EnPoDesert_Init,
-    (ActorFunc)EnPoDesert_Destroy,
-    (ActorFunc)EnPoDesert_Update,
-    (ActorFunc)EnPoDesert_Draw,
+    /**/ ACTOR_EN_PO_DESERT,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_PO_FIELD,
+    /**/ sizeof(EnPoDesert),
+    /**/ EnPoDesert_Init,
+    /**/ EnPoDesert_Destroy,
+    /**/ EnPoDesert_Update,
+    /**/ EnPoDesert_Draw,
 };
 
 static ColliderCylinderInit sColliderInit = {

--- a/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
+++ b/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
@@ -34,15 +34,15 @@ void EnPoField_SoulInteract(EnPoField* this, PlayState* play);
 void EnPoField_SpawnFlame(EnPoField* this);
 
 ActorInit En_Po_Field_InitVars = {
-    ACTOR_EN_PO_FIELD,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_PO_FIELD,
-    sizeof(EnPoField),
-    (ActorFunc)EnPoField_Init,
-    (ActorFunc)EnPoField_Destroy,
-    (ActorFunc)EnPoField_Update,
-    (ActorFunc)EnPoField_Draw,
+    /**/ ACTOR_EN_PO_FIELD,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_PO_FIELD,
+    /**/ sizeof(EnPoField),
+    /**/ EnPoField_Init,
+    /**/ EnPoField_Destroy,
+    /**/ EnPoField_Update,
+    /**/ EnPoField_Draw,
 };
 
 static ColliderCylinderInit D_80AD7080 = {

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -34,15 +34,15 @@ static Vec3s D_80AD8C30[] = {
 };
 
 ActorInit En_Po_Relay_InitVars = {
-    ACTOR_EN_PO_RELAY,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_TK,
-    sizeof(EnPoRelay),
-    (ActorFunc)EnPoRelay_Init,
-    (ActorFunc)EnPoRelay_Destroy,
-    (ActorFunc)EnPoRelay_Update,
-    (ActorFunc)EnPoRelay_Draw,
+    /**/ ACTOR_EN_PO_RELAY,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_TK,
+    /**/ sizeof(EnPoRelay),
+    /**/ EnPoRelay_Init,
+    /**/ EnPoRelay_Destroy,
+    /**/ EnPoRelay_Update,
+    /**/ EnPoRelay_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
+++ b/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.c
@@ -62,15 +62,15 @@ static Color_RGBA8 D_80ADD700[4] = {
 };
 
 ActorInit En_Po_Sisters_InitVars = {
-    ACTOR_EN_PO_SISTERS,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_PO_SISTERS,
-    sizeof(EnPoSisters),
-    (ActorFunc)EnPoSisters_Init,
-    (ActorFunc)EnPoSisters_Destroy,
-    (ActorFunc)EnPoSisters_Update,
-    (ActorFunc)EnPoSisters_Draw,
+    /**/ ACTOR_EN_PO_SISTERS,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_PO_SISTERS,
+    /**/ sizeof(EnPoSisters),
+    /**/ EnPoSisters_Init,
+    /**/ EnPoSisters_Destroy,
+    /**/ EnPoSisters_Update,
+    /**/ EnPoSisters_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -43,15 +43,15 @@ void EnPoh_TalkComposer(EnPoh* this, PlayState* play);
 static s16 D_80AE1A50 = 0;
 
 ActorInit En_Poh_InitVars = {
-    ACTOR_EN_POH,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnPoh),
-    (ActorFunc)EnPoh_Init,
-    (ActorFunc)EnPoh_Destroy,
-    (ActorFunc)EnPoh_Update,
-    NULL,
+    /**/ ACTOR_EN_POH,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnPoh),
+    /**/ EnPoh_Init,
+    /**/ EnPoh_Destroy,
+    /**/ EnPoh_Update,
+    /**/ NULL,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.c
+++ b/src/overlays/actors/ovl_En_Pu_box/z_en_pu_box.c
@@ -15,15 +15,15 @@ void EnPubox_Update(Actor* thisx, PlayState* play);
 void EnPubox_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Pu_box_InitVars = {
-    ACTOR_EN_PU_BOX,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_PU_BOX,
-    sizeof(EnPubox),
-    (ActorFunc)EnPubox_Init,
-    (ActorFunc)EnPubox_Destroy,
-    (ActorFunc)EnPubox_Update,
-    (ActorFunc)EnPubox_Draw,
+    /**/ ACTOR_EN_PU_BOX,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_PU_BOX,
+    /**/ sizeof(EnPubox),
+    /**/ EnPubox_Init,
+    /**/ EnPubox_Destroy,
+    /**/ EnPubox_Update,
+    /**/ EnPubox_Draw,
 };
 
 void EnPubox_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -53,15 +53,15 @@ typedef enum {
 } EnRdGrabState;
 
 ActorInit En_Rd_InitVars = {
-    ACTOR_EN_RD,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_RD,
-    sizeof(EnRd),
-    (ActorFunc)EnRd_Init,
-    (ActorFunc)EnRd_Destroy,
-    (ActorFunc)EnRd_Update,
-    (ActorFunc)EnRd_Draw,
+    /**/ ACTOR_EN_RD,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_RD,
+    /**/ sizeof(EnRd),
+    /**/ EnRd_Init,
+    /**/ EnRd_Destroy,
+    /**/ EnRd_Update,
+    /**/ EnRd_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -76,15 +76,15 @@ static DamageTable sDamageTable = {
 };
 
 ActorInit En_Reeba_InitVars = {
-    ACTOR_EN_REEBA,
-    ACTORCAT_MISC,
-    FLAGS,
-    OBJECT_REEBA,
-    sizeof(EnReeba),
-    (ActorFunc)EnReeba_Init,
-    (ActorFunc)EnReeba_Destroy,
-    (ActorFunc)EnReeba_Update,
-    (ActorFunc)EnReeba_Draw,
+    /**/ ACTOR_EN_REEBA,
+    /**/ ACTORCAT_MISC,
+    /**/ FLAGS,
+    /**/ OBJECT_REEBA,
+    /**/ sizeof(EnReeba),
+    /**/ EnReeba_Init,
+    /**/ EnReeba_Destroy,
+    /**/ EnReeba_Update,
+    /**/ EnReeba_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
+++ b/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
@@ -14,15 +14,15 @@ void EnRiverSound_Update(Actor* thisx, PlayState* play);
 void EnRiverSound_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_River_Sound_InitVars = {
-    ACTOR_EN_RIVER_SOUND,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnRiverSound),
-    (ActorFunc)EnRiverSound_Init,
-    (ActorFunc)EnRiverSound_Destroy,
-    (ActorFunc)EnRiverSound_Update,
-    (ActorFunc)EnRiverSound_Draw,
+    /**/ ACTOR_EN_RIVER_SOUND,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnRiverSound),
+    /**/ EnRiverSound_Init,
+    /**/ EnRiverSound_Destroy,
+    /**/ EnRiverSound_Update,
+    /**/ EnRiverSound_Draw,
 };
 
 void EnRiverSound_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Rl/z_en_rl.c
+++ b/src/overlays/actors/ovl_En_Rl/z_en_rl.c
@@ -384,13 +384,13 @@ void EnRl_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit En_Rl_InitVars = {
-    ACTOR_EN_RL,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_RL,
-    sizeof(EnRl),
-    (ActorFunc)EnRl_Init,
-    (ActorFunc)EnRl_Destroy,
-    (ActorFunc)EnRl_Update,
-    (ActorFunc)EnRl_Draw,
+    /**/ ACTOR_EN_RL,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_RL,
+    /**/ sizeof(EnRl),
+    /**/ EnRl_Init,
+    /**/ EnRl_Destroy,
+    /**/ EnRl_Update,
+    /**/ EnRl_Draw,
 };

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -65,15 +65,15 @@ void EnRr_Retreat(EnRr* this, PlayState* play);
 void EnRr_Stunned(EnRr* this, PlayState* play);
 
 ActorInit En_Rr_InitVars = {
-    ACTOR_EN_RR,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_RR,
-    sizeof(EnRr),
-    (ActorFunc)EnRr_Init,
-    (ActorFunc)EnRr_Destroy,
-    (ActorFunc)EnRr_Update,
-    (ActorFunc)EnRr_Draw,
+    /**/ ACTOR_EN_RR,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_RR,
+    /**/ sizeof(EnRr),
+    /**/ EnRr_Init,
+    /**/ EnRr_Destroy,
+    /**/ EnRr_Update,
+    /**/ EnRr_Draw,
 };
 
 static char* sDropNames[] = {

--- a/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
+++ b/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
@@ -134,15 +134,15 @@ static EnRu1DrawFunc sDrawFuncs[] = {
 };
 
 ActorInit En_Ru1_InitVars = {
-    ACTOR_EN_RU1,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_RU1,
-    sizeof(EnRu1),
-    (ActorFunc)EnRu1_Init,
-    (ActorFunc)EnRu1_Destroy,
-    (ActorFunc)EnRu1_Update,
-    (ActorFunc)EnRu1_Draw,
+    /**/ ACTOR_EN_RU1,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_RU1,
+    /**/ sizeof(EnRu1),
+    /**/ EnRu1_Init,
+    /**/ EnRu1_Destroy,
+    /**/ EnRu1_Update,
+    /**/ EnRu1_Draw,
 };
 
 void func_80AEAC10(EnRu1* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -79,15 +79,15 @@ static EnRu2DrawFunc sDrawFuncs[] = {
 };
 
 ActorInit En_Ru2_InitVars = {
-    ACTOR_EN_RU2,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_RU2,
-    sizeof(EnRu2),
-    (ActorFunc)EnRu2_Init,
-    (ActorFunc)EnRu2_Destroy,
-    (ActorFunc)EnRu2_Update,
-    (ActorFunc)EnRu2_Draw,
+    /**/ ACTOR_EN_RU2,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_RU2,
+    /**/ sizeof(EnRu2),
+    /**/ EnRu2_Init,
+    /**/ EnRu2_Destroy,
+    /**/ EnRu2_Update,
+    /**/ EnRu2_Draw,
 };
 
 void func_80AF2550(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -34,15 +34,15 @@ typedef enum {
 } SariaMouthState;
 
 ActorInit En_Sa_InitVars = {
-    ACTOR_EN_SA,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_SA,
-    sizeof(EnSa),
-    (ActorFunc)EnSa_Init,
-    (ActorFunc)EnSa_Destroy,
-    (ActorFunc)EnSa_Update,
-    (ActorFunc)EnSa_Draw,
+    /**/ ACTOR_EN_SA,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_SA,
+    /**/ sizeof(EnSa),
+    /**/ EnSa_Init,
+    /**/ EnSa_Destroy,
+    /**/ EnSa_Update,
+    /**/ EnSa_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Sb/z_en_sb.c
+++ b/src/overlays/actors/ovl_En_Sb/z_en_sb.c
@@ -26,15 +26,15 @@ void EnSb_Bounce(EnSb* this, PlayState* play);
 void EnSb_Cooldown(EnSb* this, PlayState* play);
 
 ActorInit En_Sb_InitVars = {
-    ACTOR_EN_SB,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_SB,
-    sizeof(EnSb),
-    (ActorFunc)EnSb_Init,
-    (ActorFunc)EnSb_Destroy,
-    (ActorFunc)EnSb_Update,
-    (ActorFunc)EnSb_Draw,
+    /**/ ACTOR_EN_SB,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_SB,
+    /**/ sizeof(EnSb),
+    /**/ EnSb_Init,
+    /**/ EnSb_Destroy,
+    /**/ EnSb_Update,
+    /**/ EnSb_Draw,
 };
 
 static ColliderCylinderInitType1 sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.c
+++ b/src/overlays/actors/ovl_En_Scene_Change/z_en_scene_change.c
@@ -16,15 +16,15 @@ void EnSceneChange_Draw(Actor* thisx, PlayState* play);
 void EnSceneChange_DoNothing(EnSceneChange* this, PlayState* play);
 
 ActorInit En_Scene_Change_InitVars = {
-    ACTOR_EN_SCENE_CHANGE,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_JJ,
-    sizeof(EnSceneChange),
-    (ActorFunc)EnSceneChange_Init,
-    (ActorFunc)EnSceneChange_Destroy,
-    (ActorFunc)EnSceneChange_Update,
-    (ActorFunc)EnSceneChange_Draw,
+    /**/ ACTOR_EN_SCENE_CHANGE,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_JJ,
+    /**/ sizeof(EnSceneChange),
+    /**/ EnSceneChange_Init,
+    /**/ EnSceneChange_Destroy,
+    /**/ EnSceneChange_Update,
+    /**/ EnSceneChange_Draw,
 };
 
 void EnSceneChange_SetupAction(EnSceneChange* this, EnSceneChangeActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -18,15 +18,15 @@ void func_80AF9C70(u8* shadowTexture, Player* player, PlayState* play);
 void func_80AF8F60(Player* player, u8* shadowTexture, f32 arg2);
 
 ActorInit En_Sda_InitVars = {
-    ACTOR_EN_SDA,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnSda),
-    (ActorFunc)EnSda_Init,
-    (ActorFunc)EnSda_Destroy,
-    (ActorFunc)EnSda_Update,
-    (ActorFunc)EnSda_Draw,
+    /**/ ACTOR_EN_SDA,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnSda),
+    /**/ EnSda_Init,
+    /**/ EnSda_Destroy,
+    /**/ EnSda_Update,
+    /**/ EnSda_Draw,
 };
 
 static Vec3f D_80AFA0D0 = { 0.0f, 0.0f, 0.0f };

--- a/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
+++ b/src/overlays/actors/ovl_En_Shopnuts/z_en_shopnuts.c
@@ -22,15 +22,15 @@ void EnShopnuts_Burrow(EnShopnuts* this, PlayState* play);
 void EnShopnuts_SpawnSalesman(EnShopnuts* this, PlayState* play);
 
 ActorInit En_Shopnuts_InitVars = {
-    ACTOR_EN_SHOPNUTS,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_SHOPNUTS,
-    sizeof(EnShopnuts),
-    (ActorFunc)EnShopnuts_Init,
-    (ActorFunc)EnShopnuts_Destroy,
-    (ActorFunc)EnShopnuts_Update,
-    (ActorFunc)EnShopnuts_Draw,
+    /**/ ACTOR_EN_SHOPNUTS,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_SHOPNUTS,
+    /**/ sizeof(EnShopnuts),
+    /**/ EnShopnuts_Init,
+    /**/ EnShopnuts_Destroy,
+    /**/ EnShopnuts_Update,
+    /**/ EnShopnuts_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -41,15 +41,15 @@ static ColliderCylinderInit sCylinderInit = {
 static CollisionCheckInfoInit2 D_80AFBADC = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 ActorInit En_Si_InitVars = {
-    ACTOR_EN_SI,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_ST,
-    sizeof(EnSi),
-    (ActorFunc)EnSi_Init,
-    (ActorFunc)EnSi_Destroy,
-    (ActorFunc)EnSi_Update,
-    (ActorFunc)EnSi_Draw,
+    /**/ ACTOR_EN_SI,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_ST,
+    /**/ sizeof(EnSi),
+    /**/ EnSi_Init,
+    /**/ EnSi_Destroy,
+    /**/ EnSi_Update,
+    /**/ EnSi_Draw,
 };
 
 void EnSi_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.c
+++ b/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.c
@@ -19,15 +19,15 @@ void func_80AFC544(EnSiofuki* this, PlayState* play);
 void func_80AFC478(EnSiofuki* this, PlayState* play);
 
 ActorInit En_Siofuki_InitVars = {
-    ACTOR_EN_SIOFUKI,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_SIOFUKI,
-    sizeof(EnSiofuki),
-    (ActorFunc)EnSiofuki_Init,
-    (ActorFunc)EnSiofuki_Destroy,
-    (ActorFunc)EnSiofuki_Update,
-    (ActorFunc)EnSiofuki_Draw,
+    /**/ ACTOR_EN_SIOFUKI,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_SIOFUKI,
+    /**/ sizeof(EnSiofuki),
+    /**/ EnSiofuki_Init,
+    /**/ EnSiofuki_Destroy,
+    /**/ EnSiofuki_Update,
+    /**/ EnSiofuki_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.c
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.c
@@ -114,15 +114,15 @@ static DamageTable sDamageTable = {
 };
 
 ActorInit En_Skb_InitVars = {
-    ACTOR_EN_SKB,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_SKB,
-    sizeof(EnSkb),
-    (ActorFunc)EnSkb_Init,
-    (ActorFunc)EnSkb_Destroy,
-    (ActorFunc)EnSkb_Update,
-    (ActorFunc)EnSkb_Draw,
+    /**/ ACTOR_EN_SKB,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_SKB,
+    /**/ sizeof(EnSkb),
+    /**/ EnSkb_Init,
+    /**/ EnSkb_Destroy,
+    /**/ EnSkb_Update,
+    /**/ EnSkb_Draw,
 };
 
 void EnSkb_SetupAction(EnSkb* this, EnSkbActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -160,15 +160,15 @@ static EnSkjUnkStruct sSmallStumpSkullKid = { 0, NULL };
 static EnSkjUnkStruct sOcarinaMinigameSkullKids[] = { { 0, NULL }, { 0, NULL } };
 
 ActorInit En_Skj_InitVars = {
-    ACTOR_EN_SKJ,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_SKJ,
-    sizeof(EnSkj),
-    (ActorFunc)EnSkj_Init,
-    (ActorFunc)EnSkj_Destroy,
-    (ActorFunc)EnSkj_Update,
-    (ActorFunc)EnSkj_Draw,
+    /**/ ACTOR_EN_SKJ,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_SKJ,
+    /**/ sizeof(EnSkj),
+    /**/ EnSkj_Init,
+    /**/ EnSkj_Destroy,
+    /**/ EnSkj_Update,
+    /**/ EnSkj_Draw,
 };
 
 static ColliderCylinderInitType1 D_80B01678 = {

--- a/src/overlays/actors/ovl_En_Skjneedle/z_en_skjneedle.c
+++ b/src/overlays/actors/ovl_En_Skjneedle/z_en_skjneedle.c
@@ -17,15 +17,15 @@ void EnSkjneedle_Draw(Actor* thisx, PlayState* play);
 s32 EnSkjNeedle_CollisionCheck(EnSkjneedle* this);
 
 ActorInit En_Skjneedle_InitVars = {
-    ACTOR_EN_SKJNEEDLE,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_SKJ,
-    sizeof(EnSkjneedle),
-    (ActorFunc)EnSkjneedle_Init,
-    (ActorFunc)EnSkjneedle_Destroy,
-    (ActorFunc)EnSkjneedle_Update,
-    (ActorFunc)EnSkjneedle_Draw,
+    /**/ ACTOR_EN_SKJNEEDLE,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_SKJ,
+    /**/ sizeof(EnSkjneedle),
+    /**/ EnSkjneedle_Init,
+    /**/ EnSkjneedle_Destroy,
+    /**/ EnSkjneedle_Update,
+    /**/ EnSkjneedle_Draw,
 };
 
 static ColliderCylinderInitType1 sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -31,15 +31,15 @@ void EnSsh_Start(EnSsh* this, PlayState* play);
 #include "assets/overlays/ovl_En_Ssh/ovl_En_Ssh.c"
 
 ActorInit En_Ssh_InitVars = {
-    ACTOR_EN_SSH,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_SSH,
-    sizeof(EnSsh),
-    (ActorFunc)EnSsh_Init,
-    (ActorFunc)EnSsh_Destroy,
-    (ActorFunc)EnSsh_Update,
-    (ActorFunc)EnSsh_Draw,
+    /**/ ACTOR_EN_SSH,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_SSH,
+    /**/ sizeof(EnSsh),
+    /**/ EnSsh_Init,
+    /**/ EnSsh_Destroy,
+    /**/ EnSsh_Update,
+    /**/ EnSsh_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit1 = {

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -24,15 +24,15 @@ void EnSt_FinishBouncing(EnSt* this, PlayState* play);
 #include "assets/overlays/ovl_En_St/ovl_En_St.c"
 
 ActorInit En_St_InitVars = {
-    ACTOR_EN_ST,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_ST,
-    sizeof(EnSt),
-    (ActorFunc)EnSt_Init,
-    (ActorFunc)EnSt_Destroy,
-    (ActorFunc)EnSt_Update,
-    (ActorFunc)EnSt_Draw,
+    /**/ ACTOR_EN_ST,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_ST,
+    /**/ sizeof(EnSt),
+    /**/ EnSt_Init,
+    /**/ EnSt_Destroy,
+    /**/ EnSt_Update,
+    /**/ EnSt_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -23,15 +23,15 @@ void EnSth_RewardUnobtainedWait(EnSth* this, PlayState* play);
 void EnSth_ChildRewardObtainedWait(EnSth* this, PlayState* play);
 
 ActorInit En_Sth_InitVars = {
-    ACTOR_EN_STH,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnSth),
-    (ActorFunc)EnSth_Init,
-    (ActorFunc)EnSth_Destroy,
-    (ActorFunc)EnSth_Update,
-    NULL,
+    /**/ ACTOR_EN_STH,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnSth),
+    /**/ EnSth_Init,
+    /**/ EnSth_Destroy,
+    /**/ EnSth_Update,
+    /**/ NULL,
 };
 
 #include "assets/overlays/ovl_En_Sth/ovl_En_Sth.c"

--- a/src/overlays/actors/ovl_En_Stream/z_en_stream.c
+++ b/src/overlays/actors/ovl_En_Stream/z_en_stream.c
@@ -16,15 +16,15 @@ void EnStream_Draw(Actor* thisx, PlayState* play);
 void EnStream_WaitForPlayer(EnStream* this, PlayState* play);
 
 ActorInit En_Stream_InitVars = {
-    ACTOR_EN_STREAM,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_STREAM,
-    sizeof(EnStream),
-    (ActorFunc)EnStream_Init,
-    (ActorFunc)EnStream_Destroy,
-    (ActorFunc)EnStream_Update,
-    (ActorFunc)EnStream_Draw,
+    /**/ ACTOR_EN_STREAM,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_STREAM,
+    /**/ sizeof(EnStream),
+    /**/ EnStream_Init,
+    /**/ EnStream_Destroy,
+    /**/ EnStream_Update,
+    /**/ EnStream_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -21,15 +21,15 @@ void func_80B0DB00(EnSw* this, PlayState* play);
 void func_80B0D878(EnSw* this, PlayState* play);
 
 ActorInit En_Sw_InitVars = {
-    ACTOR_EN_SW,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ST,
-    sizeof(EnSw),
-    (ActorFunc)EnSw_Init,
-    (ActorFunc)EnSw_Destroy,
-    (ActorFunc)EnSw_Update,
-    (ActorFunc)EnSw_Draw,
+    /**/ ACTOR_EN_SW,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ST,
+    /**/ sizeof(EnSw),
+    /**/ EnSw_Init,
+    /**/ EnSw_Destroy,
+    /**/ EnSw_Update,
+    /**/ EnSw_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphItemsInit[1] = {

--- a/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
+++ b/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
@@ -28,15 +28,15 @@ void EnSyatekiItm_CleanupGame(EnSyatekiItm* this, PlayState* play);
 void EnSyatekiItm_EndGame(EnSyatekiItm* this, PlayState* play);
 
 ActorInit En_Syateki_Itm_InitVars = {
-    ACTOR_EN_SYATEKI_ITM,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnSyatekiItm),
-    (ActorFunc)EnSyatekiItm_Init,
-    (ActorFunc)EnSyatekiItm_Destroy,
-    (ActorFunc)EnSyatekiItm_Update,
-    NULL,
+    /**/ ACTOR_EN_SYATEKI_ITM,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnSyatekiItm),
+    /**/ EnSyatekiItm_Init,
+    /**/ EnSyatekiItm_Destroy,
+    /**/ EnSyatekiItm_Update,
+    /**/ NULL,
 };
 
 static Vec3f sGreenAppearHome = { 0.0f, -10.0f, -270.0f };

--- a/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -43,15 +43,15 @@ void EnSyatekiMan_Blink(EnSyatekiMan* this);
 void EnSyatekiMan_SetBgm(void);
 
 ActorInit En_Syateki_Man_InitVars = {
-    ACTOR_EN_SYATEKI_MAN,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_OSSAN,
-    sizeof(EnSyatekiMan),
-    (ActorFunc)EnSyatekiMan_Init,
-    (ActorFunc)EnSyatekiMan_Destroy,
-    (ActorFunc)EnSyatekiMan_Update,
-    (ActorFunc)EnSyatekiMan_Draw,
+    /**/ ACTOR_EN_SYATEKI_MAN,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_OSSAN,
+    /**/ sizeof(EnSyatekiMan),
+    /**/ EnSyatekiMan_Init,
+    /**/ EnSyatekiMan_Destroy,
+    /**/ EnSyatekiMan_Update,
+    /**/ EnSyatekiMan_Draw,
 };
 
 static u16 sBgmList[] = {

--- a/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
+++ b/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.c
@@ -27,15 +27,15 @@ void EnSyatekiNiw_ExitArchery(EnSyatekiNiw* this, PlayState* play);
 void EnSyatekiNiw_SpawnFeather(EnSyatekiNiw* this, Vec3f* pos, Vec3f* vel, Vec3f* accel, f32 scale);
 
 ActorInit En_Syateki_Niw_InitVars = {
-    ACTOR_EN_SYATEKI_NIW,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_NIW,
-    sizeof(EnSyatekiNiw),
-    (ActorFunc)EnSyatekiNiw_Init,
-    (ActorFunc)EnSyatekiNiw_Destroy,
-    (ActorFunc)EnSyatekiNiw_Update,
-    (ActorFunc)EnSyatekiNiw_Draw,
+    /**/ ACTOR_EN_SYATEKI_NIW,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_NIW,
+    /**/ sizeof(EnSyatekiNiw),
+    /**/ EnSyatekiNiw_Init,
+    /**/ EnSyatekiNiw_Destroy,
+    /**/ EnSyatekiNiw_Update,
+    /**/ EnSyatekiNiw_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -60,15 +60,15 @@ void EnTa_AnimSitSleeping(EnTa* this);
 void EnTa_AnimRunToEnd(EnTa* this);
 
 ActorInit En_Ta_InitVars = {
-    ACTOR_EN_TA,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_TA,
-    sizeof(EnTa),
-    (ActorFunc)EnTa_Init,
-    (ActorFunc)EnTa_Destroy,
-    (ActorFunc)EnTa_Update,
-    (ActorFunc)EnTa_Draw,
+    /**/ ACTOR_EN_TA,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_TA,
+    /**/ sizeof(EnTa),
+    /**/ EnTa_Init,
+    /**/ EnTa_Destroy,
+    /**/ EnTa_Update,
+    /**/ EnTa_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
+++ b/src/overlays/actors/ovl_En_Takara_Man/z_en_takara_man.c
@@ -23,15 +23,15 @@ void func_80B17A6C(EnTakaraMan* this, PlayState* play);
 void func_80B17AC4(EnTakaraMan* this, PlayState* play);
 
 ActorInit En_Takara_Man_InitVars = {
-    ACTOR_EN_TAKARA_MAN,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_TS,
-    sizeof(EnTakaraMan),
-    (ActorFunc)EnTakaraMan_Init,
-    (ActorFunc)EnTakaraMan_Destroy,
-    (ActorFunc)EnTakaraMan_Update,
-    (ActorFunc)EnTakaraMan_Draw,
+    /**/ ACTOR_EN_TAKARA_MAN,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_TS,
+    /**/ sizeof(EnTakaraMan),
+    /**/ EnTakaraMan_Init,
+    /**/ EnTakaraMan_Destroy,
+    /**/ EnTakaraMan_Update,
+    /**/ EnTakaraMan_Draw,
 };
 
 static u8 sTakaraIsInitialized = false;

--- a/src/overlays/actors/ovl_En_Tana/z_en_tana.c
+++ b/src/overlays/actors/ovl_En_Tana/z_en_tana.c
@@ -16,15 +16,15 @@ void EnTana_DrawWoodenShelves(Actor* thisx, PlayState* play);
 void EnTana_DrawStoneShelves(Actor* thisx, PlayState* play);
 
 ActorInit En_Tana_InitVars = {
-    ACTOR_EN_TANA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SHOP_DUNGEN,
-    sizeof(EnTana),
-    (ActorFunc)EnTana_Init,
-    (ActorFunc)EnTana_Destroy,
-    (ActorFunc)EnTana_Update,
-    NULL,
+    /**/ ACTOR_EN_TANA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SHOP_DUNGEN,
+    /**/ sizeof(EnTana),
+    /**/ EnTana_Init,
+    /**/ EnTana_Destroy,
+    /**/ EnTana_Update,
+    /**/ NULL,
 };
 
 //! @bug A third entry is missing here. When printing the string indexed by `params` for type 2, the

--- a/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -126,15 +126,15 @@ static u8 sJointCopyFlags[] = {
 };
 
 ActorInit En_Test_InitVars = {
-    ACTOR_EN_TEST,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_SK2,
-    sizeof(EnTest),
-    (ActorFunc)EnTest_Init,
-    (ActorFunc)EnTest_Destroy,
-    (ActorFunc)EnTest_Update,
-    (ActorFunc)EnTest_Draw,
+    /**/ ACTOR_EN_TEST,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_SK2,
+    /**/ sizeof(EnTest),
+    /**/ EnTest_Init,
+    /**/ EnTest_Destroy,
+    /**/ EnTest_Update,
+    /**/ EnTest_Draw,
 };
 
 static ColliderCylinderInit sBodyColliderInit = {

--- a/src/overlays/actors/ovl_En_Tg/z_en_tg.c
+++ b/src/overlays/actors/ovl_En_Tg/z_en_tg.c
@@ -39,15 +39,15 @@ static ColliderCylinderInit sCylinderInit = {
 static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 ActorInit En_Tg_InitVars = {
-    ACTOR_EN_TG,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_MU,
-    sizeof(EnTg),
-    (ActorFunc)EnTg_Init,
-    (ActorFunc)EnTg_Destroy,
-    (ActorFunc)EnTg_Update,
-    (ActorFunc)EnTg_Draw,
+    /**/ ACTOR_EN_TG,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_MU,
+    /**/ sizeof(EnTg),
+    /**/ EnTg_Init,
+    /**/ EnTg_Destroy,
+    /**/ EnTg_Update,
+    /**/ EnTg_Draw,
 };
 
 u16 EnTg_GetTextId(PlayState* play, Actor* thisx) {

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -75,15 +75,15 @@ void EnTite_FlipOnBack(EnTite* this, PlayState* play);
 void EnTite_FlipUpright(EnTite* this, PlayState* play);
 
 ActorInit En_Tite_InitVars = {
-    ACTOR_EN_TITE,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_TITE,
-    sizeof(EnTite),
-    (ActorFunc)EnTite_Init,
-    (ActorFunc)EnTite_Destroy,
-    (ActorFunc)EnTite_Update,
-    (ActorFunc)EnTite_Draw,
+    /**/ ACTOR_EN_TITE,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_TITE,
+    /**/ sizeof(EnTite),
+    /**/ EnTite_Init,
+    /**/ EnTite_Destroy,
+    /**/ EnTite_Update,
+    /**/ EnTite_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -21,15 +21,15 @@ void EnTk_Walk(EnTk* this, PlayState* play);
 void EnTk_Dig(EnTk* this, PlayState* play);
 
 ActorInit En_Tk_InitVars = {
-    ACTOR_EN_TK,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_TK,
-    sizeof(EnTk),
-    (ActorFunc)EnTk_Init,
-    (ActorFunc)EnTk_Destroy,
-    (ActorFunc)EnTk_Update,
-    (ActorFunc)EnTk_Draw,
+    /**/ ACTOR_EN_TK,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_TK,
+    /**/ sizeof(EnTk),
+    /**/ EnTk_Init,
+    /**/ EnTk_Destroy,
+    /**/ EnTk_Update,
+    /**/ EnTk_Draw,
 };
 
 void EnTkEff_Create(EnTk* this, Vec3f* pos, Vec3f* speed, Vec3f* accel, u8 duration, f32 size, f32 growth) {

--- a/src/overlays/actors/ovl_En_Torch/z_en_torch.c
+++ b/src/overlays/actors/ovl_En_Torch/z_en_torch.c
@@ -11,15 +11,15 @@
 void EnTorch_Init(Actor* thisx, PlayState* play);
 
 ActorInit En_Torch_InitVars = {
-    ACTOR_EN_TORCH,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnTorch),
-    (ActorFunc)EnTorch_Init,
-    NULL,
-    NULL,
-    NULL,
+    /**/ ACTOR_EN_TORCH,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnTorch),
+    /**/ EnTorch_Init,
+    /**/ NULL,
+    /**/ NULL,
+    /**/ NULL,
 };
 
 static u8 sChestContents[] = {

--- a/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -22,15 +22,15 @@ void EnTorch2_Update(Actor* thisx, PlayState* play2);
 void EnTorch2_Draw(Actor* thisx, PlayState* play2);
 
 ActorInit En_Torch2_InitVars = {
-    ACTOR_EN_TORCH2,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_TORCH2,
-    sizeof(Player),
-    (ActorFunc)EnTorch2_Init,
-    (ActorFunc)EnTorch2_Destroy,
-    (ActorFunc)EnTorch2_Update,
-    (ActorFunc)EnTorch2_Draw,
+    /**/ ACTOR_EN_TORCH2,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_TORCH2,
+    /**/ sizeof(Player),
+    /**/ EnTorch2_Init,
+    /**/ EnTorch2_Destroy,
+    /**/ EnTorch2_Update,
+    /**/ EnTorch2_Draw,
 };
 
 static f32 sStickTilt = 0.0f;

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -19,15 +19,15 @@ s32 EnToryo_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f*
 void EnToryo_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx);
 
 ActorInit En_Toryo_InitVars = {
-    ACTOR_EN_TORYO,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_TORYO,
-    sizeof(EnToryo),
-    (ActorFunc)EnToryo_Init,
-    (ActorFunc)EnToryo_Destroy,
-    (ActorFunc)EnToryo_Update,
-    (ActorFunc)EnToryo_Draw,
+    /**/ ACTOR_EN_TORYO,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_TORYO,
+    /**/ sizeof(EnToryo),
+    /**/ EnToryo_Init,
+    /**/ EnToryo_Destroy,
+    /**/ EnToryo_Update,
+    /**/ EnToryo_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Tp/z_en_tp.c
+++ b/src/overlays/actors/ovl_En_Tp/z_en_tp.c
@@ -40,15 +40,15 @@ typedef enum {
 } TailpasaranAction;
 
 ActorInit En_Tp_InitVars = {
-    ACTOR_EN_TP,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_TP,
-    sizeof(EnTp),
-    (ActorFunc)EnTp_Init,
-    (ActorFunc)EnTp_Destroy,
-    (ActorFunc)EnTp_Update,
-    (ActorFunc)EnTp_Draw,
+    /**/ ACTOR_EN_TP,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_TP,
+    /**/ sizeof(EnTp),
+    /**/ EnTp_Init,
+    /**/ EnTp_Destroy,
+    /**/ EnTp_Update,
+    /**/ EnTp_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_En_Tr/z_en_tr.c
+++ b/src/overlays/actors/ovl_En_Tr/z_en_tr.c
@@ -24,15 +24,15 @@ void func_80B24038(EnTr* this, PlayState* play, s32 cueChannel);
 void EnTr_SetStartPosRotFromCue(EnTr* this, PlayState* play, s32 cueChannel);
 
 ActorInit En_Tr_InitVars = {
-    ACTOR_EN_TR,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_TR,
-    sizeof(EnTr),
-    (ActorFunc)EnTr_Init,
-    (ActorFunc)EnTr_Destroy,
-    (ActorFunc)EnTr_Update,
-    (ActorFunc)EnTr_Draw,
+    /**/ ACTOR_EN_TR,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_TR,
+    /**/ sizeof(EnTr),
+    /**/ EnTr_Init,
+    /**/ EnTr_Destroy,
+    /**/ EnTr_Update,
+    /**/ EnTr_Draw,
 };
 
 // The first elements of these animation arrays are for Koume, the second for Kotake

--- a/src/overlays/actors/ovl_En_Trap/z_en_trap.c
+++ b/src/overlays/actors/ovl_En_Trap/z_en_trap.c
@@ -35,15 +35,15 @@ void EnTrap_Update(Actor* thisx, PlayState* play);
 void EnTrap_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Trap_InitVars = {
-    ACTOR_EN_TRAP,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_TRAP,
-    sizeof(EnTrap),
-    (ActorFunc)EnTrap_Init,
-    (ActorFunc)EnTrap_Destroy,
-    (ActorFunc)EnTrap_Update,
-    (ActorFunc)EnTrap_Draw,
+    /**/ ACTOR_EN_TRAP,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_TRAP,
+    /**/ sizeof(EnTrap),
+    /**/ EnTrap_Init,
+    /**/ EnTrap_Destroy,
+    /**/ EnTrap_Update,
+    /**/ EnTrap_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
@@ -41,15 +41,15 @@ static ColliderCylinderInit sCylinderInit = {
 };
 
 ActorInit En_Tubo_Trap_InitVars = {
-    ACTOR_EN_TUBO_TRAP,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_DANGEON_KEEP,
-    sizeof(EnTuboTrap),
-    (ActorFunc)EnTuboTrap_Init,
-    (ActorFunc)EnTuboTrap_Destroy,
-    (ActorFunc)EnTuboTrap_Update,
-    (ActorFunc)EnTuboTrap_Draw,
+    /**/ ACTOR_EN_TUBO_TRAP,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_DANGEON_KEEP,
+    /**/ sizeof(EnTuboTrap),
+    /**/ EnTuboTrap_Init,
+    /**/ EnTuboTrap_Destroy,
+    /**/ EnTuboTrap_Update,
+    /**/ EnTuboTrap_Draw,
 };
 
 void EnTuboTrap_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Vali/z_en_vali.c
+++ b/src/overlays/actors/ovl_En_Vali/z_en_vali.c
@@ -30,15 +30,15 @@ void EnVali_Frozen(EnVali* this, PlayState* play);
 void EnVali_ReturnToLurk(EnVali* this, PlayState* play);
 
 ActorInit En_Vali_InitVars = {
-    ACTOR_EN_VALI,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_VALI,
-    sizeof(EnVali),
-    (ActorFunc)EnVali_Init,
-    (ActorFunc)EnVali_Destroy,
-    (ActorFunc)EnVali_Update,
-    (ActorFunc)EnVali_Draw,
+    /**/ ACTOR_EN_VALI,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_VALI,
+    /**/ sizeof(EnVali),
+    /**/ EnVali_Init,
+    /**/ EnVali_Destroy,
+    /**/ EnVali_Update,
+    /**/ EnVali_Draw,
 };
 
 static ColliderQuadInit sQuadInit = {

--- a/src/overlays/actors/ovl_En_Vase/z_en_vase.c
+++ b/src/overlays/actors/ovl_En_Vase/z_en_vase.c
@@ -14,15 +14,15 @@ void EnVase_Destroy(Actor* thisx, PlayState* play);
 void EnVase_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Vase_InitVars = {
-    ACTOR_EN_VASE,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_VASE,
-    sizeof(EnVase),
-    (ActorFunc)EnVase_Init,
-    (ActorFunc)EnVase_Destroy,
-    (ActorFunc)Actor_Noop,
-    (ActorFunc)EnVase_Draw,
+    /**/ ACTOR_EN_VASE,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_VASE,
+    /**/ sizeof(EnVase),
+    /**/ EnVase_Init,
+    /**/ EnVase_Destroy,
+    /**/ Actor_Noop,
+    /**/ EnVase_Draw,
 };
 
 void EnVase_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.c
+++ b/src/overlays/actors/ovl_En_Vb_Ball/z_en_vb_ball.c
@@ -17,15 +17,15 @@ void EnVbBall_Update(Actor* thisx, PlayState* play2);
 void EnVbBall_Draw(Actor* thisx, PlayState* play);
 
 ActorInit En_Vb_Ball_InitVars = {
-    0,
-    ACTORCAT_BOSS,
-    FLAGS,
-    OBJECT_FD,
-    sizeof(EnVbBall),
-    (ActorFunc)EnVbBall_Init,
-    (ActorFunc)EnVbBall_Destroy,
-    (ActorFunc)EnVbBall_Update,
-    (ActorFunc)EnVbBall_Draw,
+    /**/ 0,
+    /**/ ACTORCAT_BOSS,
+    /**/ FLAGS,
+    /**/ OBJECT_FD,
+    /**/ sizeof(EnVbBall),
+    /**/ EnVbBall_Init,
+    /**/ EnVbBall_Destroy,
+    /**/ EnVbBall_Update,
+    /**/ EnVbBall_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
+++ b/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
@@ -32,15 +32,15 @@ void EnViewer_UpdateImpl(EnViewer* this, PlayState* play);
 static u8 sHorseSfxPlayed = false;
 
 ActorInit En_Viewer_InitVars = {
-    ACTOR_EN_VIEWER,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnViewer),
-    (ActorFunc)EnViewer_Init,
-    (ActorFunc)EnViewer_Destroy,
-    (ActorFunc)EnViewer_Update,
-    (ActorFunc)EnViewer_Draw,
+    /**/ ACTOR_EN_VIEWER,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnViewer),
+    /**/ EnViewer_Init,
+    /**/ EnViewer_Destroy,
+    /**/ EnViewer_Update,
+    /**/ EnViewer_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Vm/z_en_vm.c
+++ b/src/overlays/actors/ovl_En_Vm/z_en_vm.c
@@ -24,15 +24,15 @@ void EnVm_Stun(EnVm* this, PlayState* play);
 void EnVm_Die(EnVm* this, PlayState* play);
 
 ActorInit En_Vm_InitVars = {
-    ACTOR_EN_VM,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_VM,
-    sizeof(EnVm),
-    (ActorFunc)EnVm_Init,
-    (ActorFunc)EnVm_Destroy,
-    (ActorFunc)EnVm_Update,
-    (ActorFunc)EnVm_Draw,
+    /**/ ACTOR_EN_VM,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_VM,
+    /**/ sizeof(EnVm),
+    /**/ EnVm_Init,
+    /**/ EnVm_Destroy,
+    /**/ EnVm_Update,
+    /**/ EnVm_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
+++ b/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
@@ -22,15 +22,15 @@ void EnWallTubo_DetectChu(EnWallTubo* this, PlayState* play);
 void EnWallTubo_SetWallFall(EnWallTubo* this, PlayState* play);
 
 ActorInit En_Wall_Tubo_InitVars = {
-    ACTOR_EN_WALL_TUBO,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnWallTubo),
-    (ActorFunc)EnWallTubo_Init,
-    (ActorFunc)EnWallTubo_Destroy,
-    (ActorFunc)EnWallTubo_Update,
-    NULL,
+    /**/ ACTOR_EN_WALL_TUBO,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnWallTubo),
+    /**/ EnWallTubo_Init,
+    /**/ EnWallTubo_Destroy,
+    /**/ EnWallTubo_Update,
+    /**/ NULL,
 };
 
 void EnWallTubo_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -39,15 +39,15 @@ void EnWallmas_Stun(EnWallmas* this, PlayState* play);
 void EnWallmas_Walk(EnWallmas* this, PlayState* play);
 
 ActorInit En_Wallmas_InitVars = {
-    ACTOR_EN_WALLMAS,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_WALLMASTER,
-    sizeof(EnWallmas),
-    (ActorFunc)EnWallmas_Init,
-    (ActorFunc)EnWallmas_Destroy,
-    (ActorFunc)EnWallmas_Update,
-    (ActorFunc)EnWallmas_Draw,
+    /**/ ACTOR_EN_WALLMAS,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_WALLMASTER,
+    /**/ sizeof(EnWallmas),
+    /**/ EnWallmas_Init,
+    /**/ EnWallmas_Destroy,
+    /**/ EnWallmas_Update,
+    /**/ EnWallmas_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -32,15 +32,15 @@ void EnWeatherTag_EnabledRainThunder(EnWeatherTag* this, PlayState* play);
 #define WEATHER_TAG_RANGE100(x) ((x >> 8) * 100.0f)
 
 ActorInit En_Weather_Tag_InitVars = {
-    ACTOR_EN_WEATHER_TAG,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnWeatherTag),
-    (ActorFunc)EnWeatherTag_Init,
-    (ActorFunc)EnWeatherTag_Destroy,
-    (ActorFunc)EnWeatherTag_Update,
-    NULL,
+    /**/ ACTOR_EN_WEATHER_TAG,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnWeatherTag),
+    /**/ EnWeatherTag_Init,
+    /**/ EnWeatherTag_Destroy,
+    /**/ EnWeatherTag_Update,
+    /**/ NULL,
 };
 
 void EnWeatherTag_SetupAction(EnWeatherTag* this, EnWeatherTagActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
+++ b/src/overlays/actors/ovl_En_Weiyer/z_en_weiyer.c
@@ -27,15 +27,15 @@ void func_80B33338(EnWeiyer* this, PlayState* play);
 void func_80B3349C(EnWeiyer* this, PlayState* play);
 
 ActorInit En_Weiyer_InitVars = {
-    ACTOR_EN_WEIYER,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_EI,
-    sizeof(EnWeiyer),
-    (ActorFunc)EnWeiyer_Init,
-    (ActorFunc)EnWeiyer_Destroy,
-    (ActorFunc)EnWeiyer_Update,
-    (ActorFunc)EnWeiyer_Draw,
+    /**/ ACTOR_EN_WEIYER,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_EI,
+    /**/ sizeof(EnWeiyer),
+    /**/ EnWeiyer_Init,
+    /**/ EnWeiyer_Destroy,
+    /**/ EnWeiyer_Update,
+    /**/ EnWeiyer_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -188,15 +188,15 @@ static DamageTable sDamageTable = {
 };
 
 ActorInit En_Wf_InitVars = {
-    ACTOR_EN_WF,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_WF,
-    sizeof(EnWf),
-    (ActorFunc)EnWf_Init,
-    (ActorFunc)EnWf_Destroy,
-    (ActorFunc)EnWf_Update,
-    (ActorFunc)EnWf_Draw,
+    /**/ ACTOR_EN_WF,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_WF,
+    /**/ sizeof(EnWf),
+    /**/ EnWf_Init,
+    /**/ EnWf_Destroy,
+    /**/ EnWf_Update,
+    /**/ EnWf_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
@@ -42,15 +42,15 @@ static ColliderCylinderInit sCylinderInit = {
 };
 
 ActorInit En_Wonder_Item_InitVars = {
-    ACTOR_EN_WONDER_ITEM,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnWonderItem),
-    (ActorFunc)EnWonderItem_Init,
-    (ActorFunc)EnWonderItem_Destroy,
-    (ActorFunc)EnWonderItem_Update,
-    NULL,
+    /**/ ACTOR_EN_WONDER_ITEM,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnWonderItem),
+    /**/ EnWonderItem_Init,
+    /**/ EnWonderItem_Destroy,
+    /**/ EnWonderItem_Update,
+    /**/ NULL,
 };
 
 static Vec3f sTagPointsFree[9];

--- a/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.c
+++ b/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.c
@@ -18,15 +18,15 @@ void func_80B395F0(EnWonderTalk* this, PlayState* play);
 void func_80B3943C(EnWonderTalk* this, PlayState* play);
 
 ActorInit En_Wonder_Talk_InitVars = {
-    ACTOR_EN_WONDER_TALK,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnWonderTalk),
-    (ActorFunc)EnWonderTalk_Init,
-    (ActorFunc)EnWonderTalk_Destroy,
-    (ActorFunc)EnWonderTalk_Update,
-    NULL,
+    /**/ ACTOR_EN_WONDER_TALK,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnWonderTalk),
+    /**/ EnWonderTalk_Init,
+    /**/ EnWonderTalk_Destroy,
+    /**/ EnWonderTalk_Update,
+    /**/ NULL,
 };
 
 void EnWonderTalk_Destroy(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
+++ b/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
@@ -20,15 +20,15 @@ void func_80B3A3D4(EnWonderTalk2* this, PlayState* play);
 void EnWonderTalk2_DoNothing(EnWonderTalk2* this, PlayState* play);
 
 ActorInit En_Wonder_Talk2_InitVars = {
-    ACTOR_EN_WONDER_TALK2,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnWonderTalk2),
-    (ActorFunc)EnWonderTalk2_Init,
-    (ActorFunc)EnWonderTalk2_Destroy,
-    (ActorFunc)EnWonderTalk2_Update,
-    NULL,
+    /**/ ACTOR_EN_WONDER_TALK2,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnWonderTalk2),
+    /**/ EnWonderTalk2_Init,
+    /**/ EnWonderTalk2_Destroy,
+    /**/ EnWonderTalk2_Update,
+    /**/ NULL,
 };
 
 static s16 D_80B3A8E0[] = { 6, 0, 1, 2, 3, 4, 5 };

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -34,15 +34,15 @@ typedef enum {
 } WoodDrawType;
 
 ActorInit En_Wood02_InitVars = {
-    ACTOR_EN_WOOD02,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_WOOD02,
-    sizeof(EnWood02),
-    (ActorFunc)EnWood02_Init,
-    (ActorFunc)EnWood02_Destroy,
-    (ActorFunc)EnWood02_Update,
-    (ActorFunc)EnWood02_Draw,
+    /**/ ACTOR_EN_WOOD02,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_WOOD02,
+    /**/ sizeof(EnWood02),
+    /**/ EnWood02_Init,
+    /**/ EnWood02_Destroy,
+    /**/ EnWood02_Update,
+    /**/ EnWood02_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -2418,13 +2418,13 @@ void EnXc_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit En_Xc_InitVars = {
-    ACTOR_EN_XC,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_XC,
-    sizeof(EnXc),
-    (ActorFunc)EnXc_Init,
-    (ActorFunc)EnXc_Destroy,
-    (ActorFunc)EnXc_Update,
-    (ActorFunc)EnXc_Draw,
+    /**/ ACTOR_EN_XC,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_XC,
+    /**/ sizeof(EnXc),
+    /**/ EnXc_Init,
+    /**/ EnXc_Destroy,
+    /**/ EnXc_Update,
+    /**/ EnXc_Draw,
 };

--- a/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
+++ b/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
@@ -35,15 +35,15 @@ static ColliderQuadInit sQuadInit = {
 };
 
 ActorInit En_Yabusame_Mark_InitVars = {
-    ACTOR_EN_YABUSAME_MARK,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EnYabusameMark),
-    (ActorFunc)EnYabusameMark_Init,
-    (ActorFunc)EnYabusameMark_Destroy,
-    (ActorFunc)EnYabusameMark_Update,
-    NULL,
+    /**/ ACTOR_EN_YABUSAME_MARK,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EnYabusameMark),
+    /**/ EnYabusameMark_Init,
+    /**/ EnYabusameMark_Destroy,
+    /**/ EnYabusameMark_Update,
+    /**/ NULL,
 };
 
 static Vec3f sCollisionVertices[] = {

--- a/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.c
+++ b/src/overlays/actors/ovl_En_Yukabyun/z_en_yukabyun.c
@@ -19,15 +19,15 @@ void func_80B43AD4(EnYukabyun* this, PlayState* play);
 void func_80B43B6C(EnYukabyun* this, PlayState* play);
 
 ActorInit En_Yukabyun_InitVars = {
-    ACTOR_EN_YUKABYUN,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_YUKABYUN,
-    sizeof(EnYukabyun),
-    (ActorFunc)EnYukabyun_Init,
-    (ActorFunc)EnYukabyun_Destroy,
-    (ActorFunc)EnYukabyun_Update,
-    (ActorFunc)EnYukabyun_Draw,
+    /**/ ACTOR_EN_YUKABYUN,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_YUKABYUN,
+    /**/ sizeof(EnYukabyun),
+    /**/ EnYukabyun_Init,
+    /**/ EnYukabyun_Destroy,
+    /**/ EnYukabyun_Update,
+    /**/ EnYukabyun_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Zf/z_en_zf.c
+++ b/src/overlays/actors/ovl_En_Zf/z_en_zf.c
@@ -100,15 +100,15 @@ static s16 D_80B4A1B0 = 0;
 static s16 D_80B4A1B4 = 1;
 
 ActorInit En_Zf_InitVars = {
-    ACTOR_EN_ZF,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_ZF,
-    sizeof(EnZf),
-    (ActorFunc)EnZf_Init,
-    (ActorFunc)EnZf_Destroy,
-    (ActorFunc)EnZf_Update,
-    (ActorFunc)EnZf_Draw,
+    /**/ ACTOR_EN_ZF,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_ZF,
+    /**/ sizeof(EnZf),
+    /**/ EnZf_Init,
+    /**/ EnZf_Destroy,
+    /**/ EnZf_Update,
+    /**/ EnZf_Draw,
 };
 
 static ColliderCylinderInit sBodyCylinderInit = {

--- a/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
+++ b/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
@@ -28,15 +28,15 @@ extern CutsceneData D_80B4C5D0[];
 #include "z_en_zl1_camera_data.inc.c"
 
 ActorInit En_Zl1_InitVars = {
-    ACTOR_EN_ZL1,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ZL1,
-    sizeof(EnZl1),
-    (ActorFunc)EnZl1_Init,
-    (ActorFunc)EnZl1_Destroy,
-    (ActorFunc)EnZl1_Update,
-    (ActorFunc)EnZl1_Draw,
+    /**/ ACTOR_EN_ZL1,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ZL1,
+    /**/ sizeof(EnZl1),
+    /**/ EnZl1_Init,
+    /**/ EnZl1_Destroy,
+    /**/ EnZl1_Update,
+    /**/ EnZl1_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Zl2/z_en_zl2.c
+++ b/src/overlays/actors/ovl_En_Zl2/z_en_zl2.c
@@ -86,15 +86,15 @@ static EnZl2DrawFunc sDrawFuncs[] = {
 };
 
 ActorInit En_Zl2_InitVars = {
-    ACTOR_EN_ZL2,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ZL2,
-    sizeof(EnZl2),
-    (ActorFunc)EnZl2_Init,
-    (ActorFunc)EnZl2_Destroy,
-    (ActorFunc)EnZl2_Update,
-    (ActorFunc)EnZl2_Draw,
+    /**/ ACTOR_EN_ZL2,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ZL2,
+    /**/ sizeof(EnZl2),
+    /**/ EnZl2_Init,
+    /**/ EnZl2_Destroy,
+    /**/ EnZl2_Update,
+    /**/ EnZl2_Draw,
 };
 
 void EnZl2_Destroy(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Zl3/z_en_zl3.c
+++ b/src/overlays/actors/ovl_En_Zl3/z_en_zl3.c
@@ -2757,13 +2757,13 @@ void EnZl3_Draw(Actor* thisx, PlayState* play) {
 }
 
 ActorInit En_Zl3_InitVars = {
-    ACTOR_EN_ZL3,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ZL2,
-    sizeof(EnZl3),
-    (ActorFunc)EnZl3_Init,
-    (ActorFunc)EnZl3_Destroy,
-    (ActorFunc)EnZl3_Update,
-    (ActorFunc)EnZl3_Draw,
+    /**/ ACTOR_EN_ZL3,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ZL2,
+    /**/ sizeof(EnZl3),
+    /**/ EnZl3_Init,
+    /**/ EnZl3_Destroy,
+    /**/ EnZl3_Update,
+    /**/ EnZl3_Draw,
 };

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -59,15 +59,15 @@ void EnZl4_Idle(EnZl4* this, PlayState* play);
 void EnZl4_TheEnd(EnZl4* this, PlayState* play);
 
 ActorInit En_Zl4_InitVars = {
-    ACTOR_EN_ZL4,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ZL4,
-    sizeof(EnZl4),
-    (ActorFunc)EnZl4_Init,
-    (ActorFunc)EnZl4_Destroy,
-    (ActorFunc)EnZl4_Update,
-    (ActorFunc)EnZl4_Draw,
+    /**/ ACTOR_EN_ZL4,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ZL4,
+    /**/ sizeof(EnZl4),
+    /**/ EnZl4_Init,
+    /**/ EnZl4_Destroy,
+    /**/ EnZl4_Update,
+    /**/ EnZl4_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -300,15 +300,15 @@ static ColliderCylinderInit sCylinderInit = {
 static CollisionCheckInfoInit2 sColChkInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 ActorInit En_Zo_InitVars = {
-    ACTOR_EN_ZO,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_ZO,
-    sizeof(EnZo),
-    (ActorFunc)EnZo_Init,
-    (ActorFunc)EnZo_Destroy,
-    (ActorFunc)EnZo_Update,
-    (ActorFunc)EnZo_Draw,
+    /**/ ACTOR_EN_ZO,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_ZO,
+    /**/ sizeof(EnZo),
+    /**/ EnZo_Init,
+    /**/ EnZo_Destroy,
+    /**/ EnZo_Update,
+    /**/ EnZo_Draw,
 };
 
 typedef enum {

--- a/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
+++ b/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
@@ -46,15 +46,15 @@ void EnfHG_Retreat(EnfHG* this, PlayState* play);
 void EnfHG_Done(EnfHG* this, PlayState* play);
 
 ActorInit En_fHG_InitVars = {
-    ACTOR_EN_FHG,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_FHG,
-    sizeof(EnfHG),
-    (ActorFunc)EnfHG_Init,
-    (ActorFunc)EnfHG_Destroy,
-    (ActorFunc)EnfHG_Update,
-    (ActorFunc)EnfHG_Draw,
+    /**/ ACTOR_EN_FHG,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_FHG,
+    /**/ sizeof(EnfHG),
+    /**/ EnfHG_Init,
+    /**/ EnfHG_Destroy,
+    /**/ EnfHG_Update,
+    /**/ EnfHG_Draw,
 };
 
 static EnfHGPainting sPaintings[] = {

--- a/src/overlays/actors/ovl_End_Title/z_end_title.c
+++ b/src/overlays/actors/ovl_End_Title/z_end_title.c
@@ -15,15 +15,15 @@ void EndTitle_DrawFull(Actor* thisx, PlayState* play);
 void EndTitle_DrawNintendoLogo(Actor* thisx, PlayState* play);
 
 ActorInit End_Title_InitVars = {
-    ACTOR_END_TITLE,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(EndTitle),
-    (ActorFunc)EndTitle_Init,
-    (ActorFunc)EndTitle_Destroy,
-    (ActorFunc)EndTitle_Update,
-    (ActorFunc)EndTitle_DrawFull,
+    /**/ ACTOR_END_TITLE,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(EndTitle),
+    /**/ EndTitle_Init,
+    /**/ EndTitle_Destroy,
+    /**/ EndTitle_Update,
+    /**/ EndTitle_DrawFull,
 };
 
 #include "assets/overlays/ovl_End_Title/ovl_End_Title.c"

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -122,15 +122,15 @@ typedef enum {
 #define SINKING_LURE_SEG_COUNT 20
 
 ActorInit Fishing_InitVars = {
-    ACTOR_FISHING,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_FISH,
-    sizeof(Fishing),
-    (ActorFunc)Fishing_Init,
-    (ActorFunc)Fishing_Destroy,
-    (ActorFunc)Fishing_UpdateFish,
-    (ActorFunc)Fishing_DrawFish,
+    /**/ ACTOR_FISHING,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_FISH,
+    /**/ sizeof(Fishing),
+    /**/ Fishing_Init,
+    /**/ Fishing_Destroy,
+    /**/ Fishing_UpdateFish,
+    /**/ Fishing_DrawFish,
 };
 
 static f32 sStormStrength = 0.0f;

--- a/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.c
+++ b/src/overlays/actors/ovl_Item_B_Heart/z_item_b_heart.c
@@ -17,15 +17,15 @@ void ItemBHeart_Draw(Actor* thisx, PlayState* play);
 void func_80B85264(ItemBHeart* this, PlayState* play);
 
 ActorInit Item_B_Heart_InitVars = {
-    ACTOR_ITEM_B_HEART,
-    ACTORCAT_MISC,
-    FLAGS,
-    OBJECT_GI_HEARTS,
-    sizeof(ItemBHeart),
-    (ActorFunc)ItemBHeart_Init,
-    (ActorFunc)ItemBHeart_Destroy,
-    (ActorFunc)ItemBHeart_Update,
-    (ActorFunc)ItemBHeart_Draw,
+    /**/ ACTOR_ITEM_B_HEART,
+    /**/ ACTORCAT_MISC,
+    /**/ FLAGS,
+    /**/ OBJECT_GI_HEARTS,
+    /**/ sizeof(ItemBHeart),
+    /**/ ItemBHeart_Init,
+    /**/ ItemBHeart_Destroy,
+    /**/ ItemBHeart_Update,
+    /**/ ItemBHeart_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
+++ b/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
@@ -23,15 +23,15 @@ void func_80B85B28(ItemEtcetera* this, PlayState* play);
 void ItemEtcetera_UpdateFireArrow(ItemEtcetera* this, PlayState* play);
 
 ActorInit Item_Etcetera_InitVars = {
-    ACTOR_ITEM_ETCETERA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ItemEtcetera),
-    (ActorFunc)ItemEtcetera_Init,
-    (ActorFunc)ItemEtcetera_Destroy,
-    (ActorFunc)ItemEtcetera_Update,
-    NULL,
+    /**/ ACTOR_ITEM_ETCETERA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ItemEtcetera),
+    /**/ ItemEtcetera_Init,
+    /**/ ItemEtcetera_Destroy,
+    /**/ ItemEtcetera_Update,
+    /**/ NULL,
 };
 
 static s16 sObjectIds[] = {

--- a/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.c
+++ b/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.c
@@ -16,15 +16,15 @@ void ItemInbox_Draw(Actor* thisx, PlayState* play);
 void ItemInbox_Wait(ItemInbox* this, PlayState* play);
 
 ActorInit Item_Inbox_InitVars = {
-    ACTOR_ITEM_INBOX,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ItemInbox),
-    (ActorFunc)ItemInbox_Init,
-    (ActorFunc)ItemInbox_Destroy,
-    (ActorFunc)ItemInbox_Update,
-    (ActorFunc)ItemInbox_Draw,
+    /**/ ACTOR_ITEM_INBOX,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ItemInbox),
+    /**/ ItemInbox_Init,
+    /**/ ItemInbox_Destroy,
+    /**/ ItemInbox_Update,
+    /**/ ItemInbox_Draw,
 };
 
 void ItemInbox_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
+++ b/src/overlays/actors/ovl_Item_Ocarina/z_item_ocarina.c
@@ -23,15 +23,15 @@ void func_80B865E0(ItemOcarina* this, PlayState* play);
 void ItemOcarina_DoNothing(ItemOcarina* this, PlayState* play);
 
 ActorInit Item_Ocarina_InitVars = {
-    ACTOR_ITEM_OCARINA,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GI_OCARINA,
-    sizeof(ItemOcarina),
-    (ActorFunc)ItemOcarina_Init,
-    (ActorFunc)ItemOcarina_Destroy,
-    (ActorFunc)ItemOcarina_Update,
-    (ActorFunc)ItemOcarina_Draw,
+    /**/ ACTOR_ITEM_OCARINA,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GI_OCARINA,
+    /**/ sizeof(ItemOcarina),
+    /**/ ItemOcarina_Init,
+    /**/ ItemOcarina_Destroy,
+    /**/ ItemOcarina_Update,
+    /**/ ItemOcarina_Draw,
 };
 
 void ItemOcarina_SetupAction(ItemOcarina* this, ItemOcarinaActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_Item_Shield/z_item_shield.c
+++ b/src/overlays/actors/ovl_Item_Shield/z_item_shield.c
@@ -39,15 +39,15 @@ static ColliderCylinderInit sCylinderInit = {
 };
 
 ActorInit Item_Shield_InitVars = {
-    ACTOR_ITEM_SHIELD,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_LINK_CHILD,
-    sizeof(ItemShield),
-    (ActorFunc)ItemShield_Init,
-    (ActorFunc)ItemShield_Destroy,
-    (ActorFunc)ItemShield_Update,
-    (ActorFunc)ItemShield_Draw,
+    /**/ ACTOR_ITEM_SHIELD,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_LINK_CHILD,
+    /**/ sizeof(ItemShield),
+    /**/ ItemShield_Init,
+    /**/ ItemShield_Destroy,
+    /**/ ItemShield_Update,
+    /**/ ItemShield_Draw,
 };
 
 static Color_RGBA8 unused = { 255, 255, 0, 255 };

--- a/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
+++ b/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
@@ -19,15 +19,15 @@ void MagicDark_DiamondDraw(Actor* thisx, PlayState* play);
 void MagicDark_DimLighting(PlayState* play, f32 intensity);
 
 ActorInit Magic_Dark_InitVars = {
-    ACTOR_MAGIC_DARK,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(MagicDark),
-    (ActorFunc)MagicDark_Init,
-    (ActorFunc)MagicDark_Destroy,
-    (ActorFunc)MagicDark_OrbUpdate,
-    (ActorFunc)MagicDark_OrbDraw,
+    /**/ ACTOR_MAGIC_DARK,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(MagicDark),
+    /**/ MagicDark_Init,
+    /**/ MagicDark_Destroy,
+    /**/ MagicDark_OrbUpdate,
+    /**/ MagicDark_OrbDraw,
 };
 
 #include "assets/overlays/ovl_Magic_Dark/ovl_Magic_Dark.c"

--- a/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.c
+++ b/src/overlays/actors/ovl_Magic_Fire/z_magic_fire.c
@@ -31,15 +31,15 @@ typedef enum {
 } MagicFireScreenTint;
 
 ActorInit Magic_Fire_InitVars = {
-    ACTOR_MAGIC_FIRE,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(MagicFire),
-    (ActorFunc)MagicFire_Init,
-    (ActorFunc)MagicFire_Destroy,
-    (ActorFunc)MagicFire_Update,
-    (ActorFunc)MagicFire_Draw,
+    /**/ ACTOR_MAGIC_FIRE,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(MagicFire),
+    /**/ MagicFire_Init,
+    /**/ MagicFire_Destroy,
+    /**/ MagicFire_Update,
+    /**/ MagicFire_Draw,
 };
 
 #include "assets/overlays/ovl_Magic_Fire/ovl_Magic_Fire.c"

--- a/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.c
+++ b/src/overlays/actors/ovl_Magic_Wind/z_magic_wind.c
@@ -20,15 +20,15 @@ void MagicWind_WaitAtFullSize(MagicWind* this, PlayState* play);
 void MagicWind_Grow(MagicWind* this, PlayState* play);
 
 ActorInit Magic_Wind_InitVars = {
-    ACTOR_MAGIC_WIND,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(MagicWind),
-    (ActorFunc)MagicWind_Init,
-    (ActorFunc)MagicWind_Destroy,
-    (ActorFunc)MagicWind_Update,
-    (ActorFunc)MagicWind_Draw,
+    /**/ ACTOR_MAGIC_WIND,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(MagicWind),
+    /**/ MagicWind_Init,
+    /**/ MagicWind_Destroy,
+    /**/ MagicWind_Update,
+    /**/ MagicWind_Draw,
 };
 
 #include "assets/overlays/ovl_Magic_Wind/ovl_Magic_Wind.c"

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
@@ -31,15 +31,15 @@ typedef enum {
 } MirRayBeamLocations;
 
 ActorInit Mir_Ray_InitVars = {
-    ACTOR_MIR_RAY,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_MIR_RAY,
-    sizeof(MirRay),
-    (ActorFunc)MirRay_Init,
-    (ActorFunc)MirRay_Destroy,
-    (ActorFunc)MirRay_Update,
-    (ActorFunc)MirRay_Draw,
+    /**/ ACTOR_MIR_RAY,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_MIR_RAY,
+    /**/ sizeof(MirRay),
+    /**/ MirRay_Init,
+    /**/ MirRay_Destroy,
+    /**/ MirRay_Update,
+    /**/ MirRay_Draw,
 };
 
 static u8 D_80B8E670 = 0;

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -73,15 +73,15 @@ void ObjBean_WaitForStepOff(ObjBean* this, PlayState* play);
 static ObjBean* D_80B90E30 = NULL;
 
 ActorInit Obj_Bean_InitVars = {
-    ACTOR_OBJ_BEAN,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_MAMENOKI,
-    sizeof(ObjBean),
-    (ActorFunc)ObjBean_Init,
-    (ActorFunc)ObjBean_Destroy,
-    (ActorFunc)ObjBean_Update,
-    (ActorFunc)ObjBean_Draw,
+    /**/ ACTOR_OBJ_BEAN,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_MAMENOKI,
+    /**/ sizeof(ObjBean),
+    /**/ ObjBean_Init,
+    /**/ ObjBean_Destroy,
+    /**/ ObjBean_Update,
+    /**/ ObjBean_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
+++ b/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
@@ -14,15 +14,15 @@ void ObjBlockstop_Destroy(Actor* thisx, PlayState* play);
 void ObjBlockstop_Update(Actor* thisx, PlayState* play);
 
 ActorInit Obj_Blockstop_InitVars = {
-    ACTOR_OBJ_BLOCKSTOP,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ObjBlockstop),
-    (ActorFunc)ObjBlockstop_Init,
-    (ActorFunc)ObjBlockstop_Destroy,
-    (ActorFunc)ObjBlockstop_Update,
-    NULL,
+    /**/ ACTOR_OBJ_BLOCKSTOP,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ObjBlockstop),
+    /**/ ObjBlockstop_Init,
+    /**/ ObjBlockstop_Destroy,
+    /**/ ObjBlockstop_Update,
+    /**/ NULL,
 };
 
 void ObjBlockstop_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
+++ b/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
@@ -19,15 +19,15 @@ void ObjBombiwa_Draw(Actor* thisx, PlayState* play);
 void ObjBombiwa_Break(ObjBombiwa* this, PlayState* play);
 
 ActorInit Obj_Bombiwa_InitVars = {
-    ACTOR_OBJ_BOMBIWA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_BOMBIWA,
-    sizeof(ObjBombiwa),
-    (ActorFunc)ObjBombiwa_Init,
-    (ActorFunc)ObjBombiwa_Destroy,
-    (ActorFunc)ObjBombiwa_Update,
-    (ActorFunc)ObjBombiwa_Draw,
+    /**/ ACTOR_OBJ_BOMBIWA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_BOMBIWA,
+    /**/ sizeof(ObjBombiwa),
+    /**/ ObjBombiwa_Init,
+    /**/ ObjBombiwa_Destroy,
+    /**/ ObjBombiwa_Update,
+    /**/ ObjBombiwa_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
@@ -21,15 +21,15 @@ void ObjComb_SetupWait(ObjComb* this);
 void ObjComb_Wait(ObjComb* this, PlayState* play);
 
 ActorInit Obj_Comb_InitVars = {
-    ACTOR_OBJ_COMB,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_FIELD_KEEP,
-    sizeof(ObjComb),
-    (ActorFunc)ObjComb_Init,
-    (ActorFunc)ObjComb_Destroy,
-    (ActorFunc)ObjComb_Update,
-    (ActorFunc)ObjComb_Draw,
+    /**/ ACTOR_OBJ_COMB,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_FIELD_KEEP,
+    /**/ sizeof(ObjComb),
+    /**/ ObjComb_Init,
+    /**/ ObjComb_Destroy,
+    /**/ ObjComb_Update,
+    /**/ ObjComb_Draw,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[1] = {

--- a/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
+++ b/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
@@ -17,15 +17,15 @@ void ObjDekujr_Draw(Actor* thisx, PlayState* play);
 void ObjDekujr_ComeUp(ObjDekujr* this, PlayState* play);
 
 ActorInit Obj_Dekujr_InitVars = {
-    ACTOR_OBJ_DEKUJR,
-    ACTORCAT_NPC,
-    FLAGS,
-    OBJECT_DEKUJR,
-    sizeof(ObjDekujr),
-    (ActorFunc)ObjDekujr_Init,
-    (ActorFunc)ObjDekujr_Destroy,
-    (ActorFunc)ObjDekujr_Update,
-    (ActorFunc)ObjDekujr_Draw,
+    /**/ ACTOR_OBJ_DEKUJR,
+    /**/ ACTORCAT_NPC,
+    /**/ FLAGS,
+    /**/ OBJECT_DEKUJR,
+    /**/ sizeof(ObjDekujr),
+    /**/ ObjDekujr_Init,
+    /**/ ObjDekujr_Destroy,
+    /**/ ObjDekujr_Update,
+    /**/ ObjDekujr_Draw,
 };
 
 static ColliderCylinderInitToActor sCylinderInit = {

--- a/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.c
+++ b/src/overlays/actors/ovl_Obj_Elevator/z_obj_elevator.c
@@ -20,15 +20,15 @@ void func_80B92D20(ObjElevator* this);
 void func_80B92D44(ObjElevator* this, PlayState* play);
 
 ActorInit Obj_Elevator_InitVars = {
-    ACTOR_OBJ_ELEVATOR,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_D_ELEVATOR,
-    sizeof(ObjElevator),
-    (ActorFunc)ObjElevator_Init,
-    (ActorFunc)ObjElevator_Destroy,
-    (ActorFunc)ObjElevator_Update,
-    (ActorFunc)ObjElevator_Draw,
+    /**/ ACTOR_OBJ_ELEVATOR,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_D_ELEVATOR,
+    /**/ sizeof(ObjElevator),
+    /**/ ObjElevator_Init,
+    /**/ ObjElevator_Destroy,
+    /**/ ObjElevator_Update,
+    /**/ ObjElevator_Draw,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
+++ b/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
@@ -15,15 +15,15 @@ void ObjHamishi_Update(Actor* thisx, PlayState* play);
 void ObjHamishi_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Obj_Hamishi_InitVars = {
-    ACTOR_OBJ_HAMISHI,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_FIELD_KEEP,
-    sizeof(ObjHamishi),
-    (ActorFunc)ObjHamishi_Init,
-    (ActorFunc)ObjHamishi_Destroy,
-    (ActorFunc)ObjHamishi_Update,
-    (ActorFunc)ObjHamishi_Draw,
+    /**/ ACTOR_OBJ_HAMISHI,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_FIELD_KEEP,
+    /**/ sizeof(ObjHamishi),
+    /**/ ObjHamishi_Init,
+    /**/ ObjHamishi_Destroy,
+    /**/ ObjHamishi_Update,
+    /**/ ObjHamishi_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Obj_Hana/z_obj_hana.c
+++ b/src/overlays/actors/ovl_Obj_Hana/z_obj_hana.c
@@ -15,15 +15,15 @@ void ObjHana_Update(Actor* thisx, PlayState* play);
 void ObjHana_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Obj_Hana_InitVars = {
-    ACTOR_OBJ_HANA,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_FIELD_KEEP,
-    sizeof(ObjHana),
-    (ActorFunc)ObjHana_Init,
-    (ActorFunc)ObjHana_Destroy,
-    (ActorFunc)ObjHana_Update,
-    (ActorFunc)ObjHana_Draw,
+    /**/ ACTOR_OBJ_HANA,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_FIELD_KEEP,
+    /**/ sizeof(ObjHana),
+    /**/ ObjHana_Init,
+    /**/ ObjHana_Destroy,
+    /**/ ObjHana_Update,
+    /**/ ObjHana_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.c
+++ b/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.c
@@ -22,15 +22,15 @@ void func_80B93DB0(ObjHsblock* this);
 void func_80B93E38(ObjHsblock* this);
 
 ActorInit Obj_Hsblock_InitVars = {
-    ACTOR_OBJ_HSBLOCK,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_D_HSBLOCK,
-    sizeof(ObjHsblock),
-    (ActorFunc)ObjHsblock_Init,
-    (ActorFunc)ObjHsblock_Destroy,
-    (ActorFunc)ObjHsblock_Update,
-    (ActorFunc)ObjHsblock_Draw,
+    /**/ ACTOR_OBJ_HSBLOCK,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_D_HSBLOCK,
+    /**/ sizeof(ObjHsblock),
+    /**/ ObjHsblock_Init,
+    /**/ ObjHsblock_Destroy,
+    /**/ ObjHsblock_Update,
+    /**/ ObjHsblock_Draw,
 };
 
 static f32 D_80B940C0[] = { 85.0f, 85.0f, 0.0f };

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
@@ -18,15 +18,15 @@ void ObjIcePoly_Idle(ObjIcePoly* this, PlayState* play);
 void ObjIcePoly_Melt(ObjIcePoly* this, PlayState* play);
 
 ActorInit Obj_Ice_Poly_InitVars = {
-    ACTOR_OBJ_ICE_POLY,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ObjIcePoly),
-    (ActorFunc)ObjIcePoly_Init,
-    (ActorFunc)ObjIcePoly_Destroy,
-    (ActorFunc)ObjIcePoly_Update,
-    (ActorFunc)ObjIcePoly_Draw,
+    /**/ ACTOR_OBJ_ICE_POLY,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ObjIcePoly),
+    /**/ ObjIcePoly_Init,
+    /**/ ObjIcePoly_Destroy,
+    /**/ ObjIcePoly_Update,
+    /**/ ObjIcePoly_Draw,
 };
 
 static ColliderCylinderInit sCylinderInitIce = {

--- a/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
+++ b/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
@@ -23,15 +23,15 @@ void ObjKibako_SetupThrown(ObjKibako* this);
 void ObjKibako_Thrown(ObjKibako* this, PlayState* play);
 
 ActorInit Obj_Kibako_InitVars = {
-    ACTOR_OBJ_KIBAKO,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_DANGEON_KEEP,
-    sizeof(ObjKibako),
-    (ActorFunc)ObjKibako_Init,
-    (ActorFunc)ObjKibako_Destroy,
-    (ActorFunc)ObjKibako_Update,
-    (ActorFunc)ObjKibako_Draw,
+    /**/ ACTOR_OBJ_KIBAKO,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_DANGEON_KEEP,
+    /**/ sizeof(ObjKibako),
+    /**/ ObjKibako_Init,
+    /**/ ObjKibako_Destroy,
+    /**/ ObjKibako_Update,
+    /**/ ObjKibako_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.c
+++ b/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.c
@@ -18,15 +18,15 @@ void ObjKibako2_Idle(ObjKibako2* this, PlayState* play);
 void ObjKibako2_Kill(ObjKibako2* this, PlayState* play);
 
 ActorInit Obj_Kibako2_InitVars = {
-    ACTOR_OBJ_KIBAKO2,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_KIBAKO2,
-    sizeof(ObjKibako2),
-    (ActorFunc)ObjKibako2_Init,
-    (ActorFunc)ObjKibako2_Destroy,
-    (ActorFunc)ObjKibako2_Update,
-    (ActorFunc)ObjKibako2_Draw,
+    /**/ ACTOR_OBJ_KIBAKO2,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_KIBAKO2,
+    /**/ sizeof(ObjKibako2),
+    /**/ ObjKibako2_Init,
+    /**/ ObjKibako2_Destroy,
+    /**/ ObjKibako2_Update,
+    /**/ ObjKibako2_Draw,
 };
 
 static ColliderCylinderInit sCylinderInit = {

--- a/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.c
+++ b/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.c
@@ -25,15 +25,15 @@ void ObjLift_Shake(ObjLift* this, PlayState* play);
 void ObjLift_Fall(ObjLift* this, PlayState* play);
 
 ActorInit Obj_Lift_InitVars = {
-    ACTOR_OBJ_LIFT,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_D_LIFT,
-    sizeof(ObjLift),
-    (ActorFunc)ObjLift_Init,
-    (ActorFunc)ObjLift_Destroy,
-    (ActorFunc)ObjLift_Update,
-    (ActorFunc)ObjLift_Draw,
+    /**/ ACTOR_OBJ_LIFT,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_D_LIFT,
+    /**/ sizeof(ObjLift),
+    /**/ ObjLift_Init,
+    /**/ ObjLift_Destroy,
+    /**/ ObjLift_Update,
+    /**/ ObjLift_Draw,
 };
 
 static s16 sFallTimerDurations[] = { 0, 10, 20, 30, 40, 50, 60 };

--- a/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
+++ b/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
@@ -36,15 +36,15 @@ void ObjLightswitch_SetupDisappear(ObjLightswitch* this);
 void ObjLightswitch_Disappear(ObjLightswitch* this, PlayState* play);
 
 ActorInit Obj_Lightswitch_InitVars = {
-    ACTOR_OBJ_LIGHTSWITCH,
-    ACTORCAT_SWITCH,
-    FLAGS,
-    OBJECT_LIGHTSWITCH,
-    sizeof(ObjLightswitch),
-    (ActorFunc)ObjLightswitch_Init,
-    (ActorFunc)ObjLightswitch_Destroy,
-    (ActorFunc)ObjLightswitch_Update,
-    (ActorFunc)ObjLightswitch_Draw,
+    /**/ ACTOR_OBJ_LIGHTSWITCH,
+    /**/ ACTORCAT_SWITCH,
+    /**/ FLAGS,
+    /**/ OBJECT_LIGHTSWITCH,
+    /**/ sizeof(ObjLightswitch),
+    /**/ ObjLightswitch_Init,
+    /**/ ObjLightswitch_Destroy,
+    /**/ ObjLightswitch_Update,
+    /**/ ObjLightswitch_Draw,
 };
 
 static ColliderJntSphElementInit sColliderJntSphElementInit[] = {

--- a/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
+++ b/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
@@ -16,15 +16,15 @@ void func_80B98320(ObjMakekinsuta* this, PlayState* play);
 void ObjMakekinsuta_DoNothing(ObjMakekinsuta* this, PlayState* play);
 
 ActorInit Obj_Makekinsuta_InitVars = {
-    ACTOR_OBJ_MAKEKINSUTA,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ObjMakekinsuta),
-    (ActorFunc)ObjMakekinsuta_Init,
-    (ActorFunc)Actor_Noop,
-    (ActorFunc)ObjMakekinsuta_Update,
-    NULL,
+    /**/ ACTOR_OBJ_MAKEKINSUTA,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ObjMakekinsuta),
+    /**/ ObjMakekinsuta_Init,
+    /**/ Actor_Noop,
+    /**/ ObjMakekinsuta_Update,
+    /**/ NULL,
 };
 
 void ObjMakekinsuta_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Obj_Makeoshihiki/z_obj_makeoshihiki.c
+++ b/src/overlays/actors/ovl_Obj_Makeoshihiki/z_obj_makeoshihiki.c
@@ -14,9 +14,15 @@ void ObjMakeoshihiki_Init(Actor* thisx, PlayState* play);
 void ObjMakeoshihiki_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Obj_Makeoshihiki_InitVars = {
-    ACTOR_OBJ_MAKEOSHIHIKI,       ACTORCAT_PROP,           FLAGS,
-    OBJECT_GAMEPLAY_DANGEON_KEEP, sizeof(ObjMakeoshihiki), (ActorFunc)ObjMakeoshihiki_Init,
-    (ActorFunc)Actor_Noop,        (ActorFunc)Actor_Noop,   (ActorFunc)ObjMakeoshihiki_Draw,
+    /**/ ACTOR_OBJ_MAKEOSHIHIKI,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_DANGEON_KEEP,
+    /**/ sizeof(ObjMakeoshihiki),
+    /**/ ObjMakeoshihiki_Init,
+    /**/ Actor_Noop,
+    /**/ Actor_Noop,
+    /**/ ObjMakeoshihiki_Draw,
 };
 
 typedef struct {

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -20,15 +20,15 @@ void ObjMure_ActiveState(ObjMure* this, PlayState* play);
 s32 ObjMure_GetMaxChildSpawns(ObjMure* this);
 
 ActorInit Obj_Mure_InitVars = {
-    ACTOR_OBJ_MURE,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ObjMure),
-    (ActorFunc)ObjMure_Init,
-    (ActorFunc)ObjMure_Destroy,
-    (ActorFunc)ObjMure_Update,
-    NULL,
+    /**/ ACTOR_OBJ_MURE,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ObjMure),
+    /**/ ObjMure_Init,
+    /**/ ObjMure_Destroy,
+    /**/ ObjMure_Update,
+    /**/ NULL,
 };
 
 typedef enum {

--- a/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
+++ b/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
@@ -29,15 +29,15 @@ void func_80B9A658(ObjMure2* this);
 void func_80B9A6E8(ObjMure2* this);
 
 ActorInit Obj_Mure2_InitVars = {
-    ACTOR_OBJ_MURE2,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ObjMure2),
-    (ActorFunc)ObjMure2_Init,
-    (ActorFunc)Actor_Noop,
-    (ActorFunc)ObjMure2_Update,
-    NULL,
+    /**/ ACTOR_OBJ_MURE2,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ObjMure2),
+    /**/ ObjMure2_Init,
+    /**/ Actor_Noop,
+    /**/ ObjMure2_Update,
+    /**/ NULL,
 };
 
 static f32 sDistSquared1[] = { SQ(1600.0f), SQ(1600.0f), SQ(1600.0f) };

--- a/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.c
+++ b/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.c
@@ -20,15 +20,15 @@ void func_80B9AFEC(ObjMure3* this);
 void func_80B9AFFC(ObjMure3* this, PlayState* play);
 
 ActorInit Obj_Mure3_InitVars = {
-    ACTOR_OBJ_MURE3,
-    ACTORCAT_BG,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ObjMure3),
-    (ActorFunc)ObjMure3_Init,
-    (ActorFunc)ObjMure3_Destroy,
-    (ActorFunc)ObjMure3_Update,
-    NULL,
+    /**/ ACTOR_OBJ_MURE3,
+    /**/ ACTORCAT_BG,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ObjMure3),
+    /**/ ObjMure3_Init,
+    /**/ ObjMure3_Destroy,
+    /**/ ObjMure3_Update,
+    /**/ NULL,
 };
 
 static s16 sRupeeCounts[] = { 5, 5, 7, 0 };

--- a/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
+++ b/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
@@ -25,15 +25,15 @@ void ObjOshihiki_SetupFall(ObjOshihiki* this, PlayState* play);
 void ObjOshihiki_Fall(ObjOshihiki* this, PlayState* play);
 
 ActorInit Obj_Oshihiki_InitVars = {
-    ACTOR_OBJ_OSHIHIKI,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_DANGEON_KEEP,
-    sizeof(ObjOshihiki),
-    (ActorFunc)ObjOshihiki_Init,
-    (ActorFunc)ObjOshihiki_Destroy,
-    (ActorFunc)ObjOshihiki_Update,
-    (ActorFunc)ObjOshihiki_Draw,
+    /**/ ACTOR_OBJ_OSHIHIKI,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_DANGEON_KEEP,
+    /**/ sizeof(ObjOshihiki),
+    /**/ ObjOshihiki_Init,
+    /**/ ObjOshihiki_Destroy,
+    /**/ ObjOshihiki_Update,
+    /**/ ObjOshihiki_Draw,
 };
 
 static f32 sScales[] = {

--- a/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
+++ b/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
@@ -16,15 +16,15 @@ void func_80B9D054(ObjRoomtimer* this, PlayState* play);
 void func_80B9D0B0(ObjRoomtimer* this, PlayState* play);
 
 ActorInit Obj_Roomtimer_InitVars = {
-    ACTOR_OBJ_ROOMTIMER,
-    ACTORCAT_ENEMY,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ObjRoomtimer),
-    (ActorFunc)ObjRoomtimer_Init,
-    (ActorFunc)ObjRoomtimer_Destroy,
-    (ActorFunc)ObjRoomtimer_Update,
-    (ActorFunc)NULL,
+    /**/ ACTOR_OBJ_ROOMTIMER,
+    /**/ ACTORCAT_ENEMY,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ObjRoomtimer),
+    /**/ ObjRoomtimer_Init,
+    /**/ ObjRoomtimer_Destroy,
+    /**/ ObjRoomtimer_Update,
+    /**/ NULL,
 };
 
 void ObjRoomtimer_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -51,15 +51,15 @@ void ObjSwitch_CrystalTurnOffInit(ObjSwitch* this);
 void ObjSwitch_CrystalTurnOff(ObjSwitch* this, PlayState* play);
 
 ActorInit Obj_Switch_InitVars = {
-    ACTOR_OBJ_SWITCH,
-    ACTORCAT_SWITCH,
-    FLAGS,
-    OBJECT_GAMEPLAY_DANGEON_KEEP,
-    sizeof(ObjSwitch),
-    (ActorFunc)ObjSwitch_Init,
-    (ActorFunc)ObjSwitch_Destroy,
-    (ActorFunc)ObjSwitch_Update,
-    (ActorFunc)ObjSwitch_Draw,
+    /**/ ACTOR_OBJ_SWITCH,
+    /**/ ACTORCAT_SWITCH,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_DANGEON_KEEP,
+    /**/ sizeof(ObjSwitch),
+    /**/ ObjSwitch_Init,
+    /**/ ObjSwitch_Destroy,
+    /**/ ObjSwitch_Update,
+    /**/ ObjSwitch_Draw,
 };
 
 static f32 sFocusHeights[] = {

--- a/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
+++ b/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
@@ -17,15 +17,15 @@ void ObjSyokudai_Update(Actor* thisx, PlayState* play2);
 void ObjSyokudai_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Obj_Syokudai_InitVars = {
-    ACTOR_OBJ_SYOKUDAI,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_SYOKUDAI,
-    sizeof(ObjSyokudai),
-    (ActorFunc)ObjSyokudai_Init,
-    (ActorFunc)ObjSyokudai_Destroy,
-    (ActorFunc)ObjSyokudai_Update,
-    (ActorFunc)ObjSyokudai_Draw,
+    /**/ ACTOR_OBJ_SYOKUDAI,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_SYOKUDAI,
+    /**/ sizeof(ObjSyokudai),
+    /**/ ObjSyokudai_Init,
+    /**/ ObjSyokudai_Destroy,
+    /**/ ObjSyokudai_Update,
+    /**/ ObjSyokudai_Draw,
 };
 
 static ColliderCylinderInit sCylInitStand = {

--- a/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.c
+++ b/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.c
@@ -26,15 +26,15 @@ void ObjTimeblock_AltBehaviorVisible(ObjTimeblock* this, PlayState* play);
 void ObjTimeblock_AltBehaviourNotVisible(ObjTimeblock* this, PlayState* play);
 
 ActorInit Obj_Timeblock_InitVars = {
-    ACTOR_OBJ_TIMEBLOCK,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_TIMEBLOCK,
-    sizeof(ObjTimeblock),
-    (ActorFunc)ObjTimeblock_Init,
-    (ActorFunc)ObjTimeblock_Destroy,
-    (ActorFunc)ObjTimeblock_Update,
-    (ActorFunc)ObjTimeblock_Draw,
+    /**/ ACTOR_OBJ_TIMEBLOCK,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_TIMEBLOCK,
+    /**/ sizeof(ObjTimeblock),
+    /**/ ObjTimeblock_Init,
+    /**/ ObjTimeblock_Destroy,
+    /**/ ObjTimeblock_Update,
+    /**/ ObjTimeblock_Draw,
 };
 
 typedef struct {

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
@@ -37,15 +37,15 @@ static s16 D_80BA1B58 = 0;
 static s16 D_80BA1B5C = 0;
 
 ActorInit Obj_Tsubo_InitVars = {
-    ACTOR_OBJ_TSUBO,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ObjTsubo),
-    (ActorFunc)ObjTsubo_Init,
-    (ActorFunc)ObjTsubo_Destroy,
-    (ActorFunc)ObjTsubo_Update,
-    NULL,
+    /**/ ACTOR_OBJ_TSUBO,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ObjTsubo),
+    /**/ ObjTsubo_Init,
+    /**/ ObjTsubo_Destroy,
+    /**/ ObjTsubo_Update,
+    /**/ NULL,
 };
 
 static s16 sObjectIds[] = { OBJECT_GAMEPLAY_DANGEON_KEEP, OBJECT_TSUBO };

--- a/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.c
+++ b/src/overlays/actors/ovl_Obj_Warp2block/z_obj_warp2block.c
@@ -29,15 +29,15 @@ void func_80BA2600(ObjWarp2block* this);
 void func_80BA2610(ObjWarp2block* this, PlayState* play);
 
 ActorInit Obj_Warp2block_InitVars = {
-    ACTOR_OBJ_WARP2BLOCK,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_TIMEBLOCK,
-    sizeof(ObjWarp2block),
-    (ActorFunc)ObjWarp2block_Init,
-    (ActorFunc)ObjWarp2block_Destroy,
-    (ActorFunc)ObjWarp2block_Update,
-    (ActorFunc)ObjWarp2block_Draw,
+    /**/ ACTOR_OBJ_WARP2BLOCK,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_TIMEBLOCK,
+    /**/ sizeof(ObjWarp2block),
+    /**/ ObjWarp2block_Init,
+    /**/ ObjWarp2block_Destroy,
+    /**/ ObjWarp2block_Update,
+    /**/ ObjWarp2block_Draw,
 };
 
 typedef struct {

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -44,15 +44,15 @@ static void* D_80BA5900[] = {
 };
 
 ActorInit Object_Kankyo_InitVars = {
-    ACTOR_OBJECT_KANKYO,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ObjectKankyo),
-    (ActorFunc)ObjectKankyo_Init,
-    (ActorFunc)ObjectKankyo_Destroy,
-    (ActorFunc)ObjectKankyo_Update,
-    (ActorFunc)ObjectKankyo_Draw,
+    /**/ ACTOR_OBJECT_KANKYO,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ObjectKankyo),
+    /**/ ObjectKankyo_Init,
+    /**/ ObjectKankyo_Destroy,
+    /**/ ObjectKankyo_Update,
+    /**/ ObjectKankyo_Draw,
 };
 
 static u8 sIsSpawned = false;

--- a/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.c
+++ b/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.c
@@ -17,15 +17,15 @@ void OceffSpot_Draw(Actor* thisx, PlayState* play);
 void OceffSpot_GrowCylinder(OceffSpot* this, PlayState* play);
 
 ActorInit Oceff_Spot_InitVars = {
-    ACTOR_OCEFF_SPOT,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(OceffSpot),
-    (ActorFunc)OceffSpot_Init,
-    (ActorFunc)OceffSpot_Destroy,
-    (ActorFunc)OceffSpot_Update,
-    (ActorFunc)OceffSpot_Draw,
+    /**/ ACTOR_OCEFF_SPOT,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(OceffSpot),
+    /**/ OceffSpot_Init,
+    /**/ OceffSpot_Destroy,
+    /**/ OceffSpot_Update,
+    /**/ OceffSpot_Draw,
 };
 
 #include "assets/overlays/ovl_Oceff_Spot/ovl_Oceff_Spot.c"

--- a/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
+++ b/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
@@ -19,15 +19,15 @@ void OceffStorm_DefaultAction(OceffStorm* this, PlayState* play);
 void OceffStorm_UnkAction(OceffStorm* this, PlayState* play);
 
 ActorInit Oceff_Storm_InitVars = {
-    ACTOR_OCEFF_STORM,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(OceffStorm),
-    (ActorFunc)OceffStorm_Init,
-    (ActorFunc)OceffStorm_Destroy,
-    (ActorFunc)OceffStorm_Update,
-    (ActorFunc)OceffStorm_Draw,
+    /**/ ACTOR_OCEFF_STORM,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(OceffStorm),
+    /**/ OceffStorm_Init,
+    /**/ OceffStorm_Destroy,
+    /**/ OceffStorm_Update,
+    /**/ OceffStorm_Draw,
 };
 
 void OceffStorm_SetupAction(OceffStorm* this, OceffStormActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
@@ -15,15 +15,15 @@ void OceffWipe_Update(Actor* thisx, PlayState* play);
 void OceffWipe_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Oceff_Wipe_InitVars = {
-    ACTOR_OCEFF_WIPE,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(OceffWipe),
-    (ActorFunc)OceffWipe_Init,
-    (ActorFunc)OceffWipe_Destroy,
-    (ActorFunc)OceffWipe_Update,
-    (ActorFunc)OceffWipe_Draw,
+    /**/ ACTOR_OCEFF_WIPE,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(OceffWipe),
+    /**/ OceffWipe_Init,
+    /**/ OceffWipe_Destroy,
+    /**/ OceffWipe_Update,
+    /**/ OceffWipe_Draw,
 };
 
 void OceffWipe_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
@@ -15,15 +15,15 @@ void OceffWipe2_Update(Actor* thisx, PlayState* play);
 void OceffWipe2_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Oceff_Wipe2_InitVars = {
-    ACTOR_OCEFF_WIPE2,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(OceffWipe2),
-    (ActorFunc)OceffWipe2_Init,
-    (ActorFunc)OceffWipe2_Destroy,
-    (ActorFunc)OceffWipe2_Update,
-    (ActorFunc)OceffWipe2_Draw,
+    /**/ ACTOR_OCEFF_WIPE2,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(OceffWipe2),
+    /**/ OceffWipe2_Init,
+    /**/ OceffWipe2_Destroy,
+    /**/ OceffWipe2_Update,
+    /**/ OceffWipe2_Draw,
 };
 
 void OceffWipe2_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
@@ -15,15 +15,15 @@ void OceffWipe3_Update(Actor* thisx, PlayState* play);
 void OceffWipe3_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Oceff_Wipe3_InitVars = {
-    ACTOR_OCEFF_WIPE3,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(OceffWipe3),
-    (ActorFunc)OceffWipe3_Init,
-    (ActorFunc)OceffWipe3_Destroy,
-    (ActorFunc)OceffWipe3_Update,
-    (ActorFunc)OceffWipe3_Draw,
+    /**/ ACTOR_OCEFF_WIPE3,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(OceffWipe3),
+    /**/ OceffWipe3_Init,
+    /**/ OceffWipe3_Destroy,
+    /**/ OceffWipe3_Update,
+    /**/ OceffWipe3_Draw,
 };
 
 #include "assets/overlays/ovl_Oceff_Wipe3/ovl_Oceff_Wipe3.c"

--- a/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
@@ -15,15 +15,15 @@ void OceffWipe4_Update(Actor* thisx, PlayState* play);
 void OceffWipe4_Draw(Actor* thisx, PlayState* play);
 
 ActorInit Oceff_Wipe4_InitVars = {
-    ACTOR_OCEFF_WIPE4,
-    ACTORCAT_ITEMACTION,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(OceffWipe4),
-    (ActorFunc)OceffWipe4_Init,
-    (ActorFunc)OceffWipe4_Destroy,
-    (ActorFunc)OceffWipe4_Update,
-    (ActorFunc)OceffWipe4_Draw,
+    /**/ ACTOR_OCEFF_WIPE4,
+    /**/ ACTORCAT_ITEMACTION,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(OceffWipe4),
+    /**/ OceffWipe4_Init,
+    /**/ OceffWipe4_Destroy,
+    /**/ OceffWipe4_Update,
+    /**/ OceffWipe4_Draw,
 };
 
 void OceffWipe4_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
+++ b/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
@@ -22,15 +22,15 @@ void ShotSun_UpdateFairySpawner(ShotSun* this, PlayState* play);
 void ShotSun_UpdateHyliaSun(ShotSun* this, PlayState* play);
 
 ActorInit Shot_Sun_InitVars = {
-    ACTOR_SHOT_SUN,
-    ACTORCAT_PROP,
-    FLAGS,
-    OBJECT_GAMEPLAY_KEEP,
-    sizeof(ShotSun),
-    (ActorFunc)ShotSun_Init,
-    (ActorFunc)ShotSun_Destroy,
-    (ActorFunc)ShotSun_Update,
-    NULL,
+    /**/ ACTOR_SHOT_SUN,
+    /**/ ACTORCAT_PROP,
+    /**/ FLAGS,
+    /**/ OBJECT_GAMEPLAY_KEEP,
+    /**/ sizeof(ShotSun),
+    /**/ ShotSun_Init,
+    /**/ ShotSun_Destroy,
+    /**/ ShotSun_Update,
+    /**/ NULL,
 };
 
 typedef enum {


### PR DESCRIPTION
Follows MM's https://github.com/zeldaret/mm/pull/1148

Achieved by using the following regex:

```regex
(ActorInit.*)(\n\s+)(.*)(\n\s+)(.*)(\n\s+)(.*)(\n\s+)(.*)(\n\s+)(.*)(\n\s+)(?:\(ActorFunc\))?(.*)(\n\s+)(?:\(ActorFunc\))?(.*)(\n\s+)(?:\(ActorFunc\))?(.*)(\n\s+)(?:\(ActorFunc\))?(.*\n\};)
```

replaced with

```
$1$2/**/ $3$4/**/ $5$6/**/ $7$8/**/ $9$10/**/ $11$12/**/ $13$14/**/ $15$16/**/ $17$18/**/ $19
```

plus a change from `/**/` to `#if 0 #endif` in docs/