### PR TITLE
Changed gLinkChildSlinghotStringDL to gLinkChildSlingshotStringDL

### DIFF
--- a/assets/xml/objects/object_link_child.xml
+++ b/assets/xml/objects/object_link_child.xml
@@ -105,7 +105,7 @@
         <DList Name="gLinkChildBottleDL" Offset="0x18478"/>
         <DList Name="gLinkChildDL_18580" Offset="0x18580"/>
         <DList Name="gLinkChildBottle2DL" Offset="0x18648"/>
-        <DList Name="gLinkChildSlinghotStringDL" Offset="0x221A8"/>
+        <DList Name="gLinkChildSlingshotStringDL" Offset="0x221A8"/>
         <DList Name="gLinkChildDekuShieldDL" Offset="0x224F8"/>
         <Mtx Name="gLinkChildDekuShieldMtx"  Offset="0x22648"/>
         <DList Name="gLinkChildDekuShieldWithMatrixDL" Offset="0x22688"/>

--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -1410,8 +1410,8 @@ Color_RGB8 sBottleColors[] = {
 Vec3f D_80126128 = { 398.0f, 1419.0f, 244.0f };
 
 BowSlingshotStringData sBowSlingshotStringData[] = {
-    { gLinkAdultBowStringDL, { 0.0f, -360.4f, 0.0f } },       // Bow
-    { gLinkChildSlinghotStringDL, { 606.0f, 236.0f, 0.0f } }, // Slingshot
+    { gLinkAdultBowStringDL, { 0.0f, -360.4f, 0.0f } },        // Bow
+    { gLinkChildSlingshotStringDL, { 606.0f, 236.0f, 0.0f } }, // Slingshot
 };
 
 // Coordinates of the shield quad collider vertices, in the right hand limb's own model space.


### PR DESCRIPTION
I believe gLinkChildSlinghotStringDL in object_link_child.xml and referenced in z_player_lib.c to be a typo. As such, I have updated it to gLinkChildSlingshotStringDL in both the xml and c files.