### PR TITLE
Fix and simplify progress.py to account for src/audio/ files in 'code'

### DIFF
--- a/progress.py
+++ b/progress.py
@@ -86,15 +86,15 @@ for line in mapFile:
         objFile = lineSplit[3]
 
         if (section == ".text" and IsCFile(objFile)):
-            if (objFile.startswith("build/src")):
+            if objFile.startswith("build/src"):
                 src += size
 
-            if (objFile.startswith("build/src/code") or (objFile.startswith("build/src/libultra/") and curSegment == "code")):
-                code += size
-            elif (objFile.startswith("build/src/boot") or (objFile.startswith("build/src/libultra/") and curSegment == "boot")):
-                boot += size
-            elif (objFile.startswith("build/src/overlays")):
-                ovl += size
+                if curSegment == "code":
+                    code += size
+                elif curSegment == "boot":
+                    boot += size
+                else:
+                    ovl += size
 
 nonMatchingASM = GetNonMatchingSize("asm/non_matchings")
 nonMatchingASMBoot = GetNonMatchingSize("asm/non_matchings/boot")


### PR DESCRIPTION
Output without the changes (currently):
```
$ python3 progress.py

3843392 total bytes of decompilable code

3843392 bytes decompiled in src 100.0%

31408/31408 bytes decompiled in boot 100.0%

868240/999984 bytes decompiled in code 86.8253892062273%

2812000/2812000 bytes decompiled in overlays 100.0%

------------------------------------

You have 80/80 heart pieces.

```

With the changes:
```
$ python3 progress.py

3843392 total bytes of decompilable code

3843392 bytes decompiled in src 100.0%

31408/31408 bytes decompiled in boot 100.0%

999984/999984 bytes decompiled in code 100.0%

2812000/2812000 bytes decompiled in overlays 100.0%

------------------------------------

You have 80/80 heart pieces.

```