### PR TITLE
Document a bug in Actor_ChangeCategory where actors may not be updated correctly

### DIFF
--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -3397,10 +3397,12 @@ Actor* func_80033684(PlayState* play, Actor* explosiveActor) {
  * This is done by moving it to the corresponding category list and setting its category variable accordingly.
  */
 void Actor_ChangeCategory(PlayState* play, ActorContext* actorCtx, Actor* actor, u8 actorCategory) {
-    //! @bug If Actor_ChangeCategory is called during an actor update function, the loop in
+    //! @bug Calling this function immediately moves an actor from one category list to the other.
+    //! So, if Actor_ChangeCategory is called during an actor update function, the inner loop in
     //! Actor_UpdateAll will continue from the next actor in the new category, rather than the next
-    //! actor in the old category. This might cause some actors in the old category to be skipped
-    //! over and not updated, or some actors in the new category to be updated twice.
+    //! actor in the old category. This will cause any actors after this one in the old category to
+    //! be skipped over and not updated, and any actors in the new category to be updated more than
+    //! once.
     Actor_RemoveFromCategory(play, actorCtx, actor);
     Actor_AddToCategory(actorCtx, actor, actorCategory);
 }

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -3397,6 +3397,10 @@ Actor* func_80033684(PlayState* play, Actor* explosiveActor) {
  * This is done by moving it to the corresponding category list and setting its category variable accordingly.
  */
 void Actor_ChangeCategory(PlayState* play, ActorContext* actorCtx, Actor* actor, u8 actorCategory) {
+    //! @bug If Actor_ChangeCategory is called during an actor update function, the loop in
+    //! Actor_UpdateAll will continue from the next actor in the new category, rather than the next
+    //! actor in the old category. This might cause some actors in the old category to be skipped
+    //! over and not updated, or some actors in the new category to be updated twice.
     Actor_RemoveFromCategory(play, actorCtx, actor);
     Actor_AddToCategory(actorCtx, actor, actorCategory);
 }

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -3398,7 +3398,7 @@ Actor* func_80033684(PlayState* play, Actor* explosiveActor) {
  */
 void Actor_ChangeCategory(PlayState* play, ActorContext* actorCtx, Actor* actor, u8 actorCategory) {
     //! @bug Calling this function immediately moves an actor from one category list to the other.
-    //! So, if Actor_ChangeCategory is called during an actor update function, the inner loop in
+    //! So, if Actor_ChangeCategory is called during an actor update, the inner loop in
     //! Actor_UpdateAll will continue from the next actor in the new category, rather than the next
     //! actor in the old category. This will cause any actors after this one in the old category to
     //! be skipped over and not updated, and any actors in the new category to be updated more than


### PR DESCRIPTION
If `Actor_ChangeCategory` is called during an actor update function, the loop in `Actor_UpdateAll` will continue from the next actor in the new category, rather than the next actor in the old category. This might cause some actors in the old category to be skipped over and not updated, or some actors in the new category to be updated twice.

I first noticed this with the pots in the spirit temple lobby:

https://github.com/zeldaret/oot/assets/146315916/fa1b4e39-cabc-4efa-ad72-916626670ce9

The two watches are the heights of the two pots, and here I activate the left pot before the right pot. When the right pot activates (and calls `Actor_ChangeCategory` to become an enemy), the left pot (which is already an enemy) gets updated twice, once when enemies are updated and once after the right pot is updated. So the left pot's y coordinate increases by 6 instead of 3 on this frame.

I think this is why this function was changed in MM: https://discord.com/channels/688807550715560050/688851976746041391/903481092508631091