### PR TITLE
Player Docs: Body Shock and Body Burn

### DIFF
--- a/include/z64player.h
+++ b/include/z64player.h
@@ -822,7 +822,7 @@ typedef struct Player {
     /* 0x088E */ u8 unk_88E;
     /* 0x088F */ u8 unk_88F;
     /* 0x0890 */ u8 unk_890;
-    /* 0x0891 */ u8 shockTimer;
+    /* 0x0891 */ u8 bodyShockTimer;
     /* 0x0892 */ u8 unk_892;
     /* 0x0893 */ u8 hoverBootsTimer;
     /* 0x0894 */ s16 fallStartHeight; // last truncated Y position before falling
@@ -842,8 +842,8 @@ typedef struct Player {
     /* 0x0908 */ Vec3f bodyPartsPos[PLAYER_BODYPART_MAX];
     /* 0x09E0 */ MtxF mf_9E0;
     /* 0x0A20 */ MtxF shieldMf;
-    /* 0x0A60 */ u8 isBurning;
-    /* 0x0A61 */ u8 flameTimers[PLAYER_BODYPART_MAX]; // one flame per body part
+    /* 0x0A60 */ u8 bodyIsBurning;
+    /* 0x0A61 */ u8 bodyFlameTimers[PLAYER_BODYPART_MAX]; // one flame per body part
     /* 0x0A73 */ u8 unk_A73;
     /* 0x0A74 */ PlayerFuncA74 func_A74;
     /* 0x0A78 */ s8 invincibilityTimer; // prevents damage when nonzero (positive = visible, counts towards zero each frame)

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -1476,11 +1476,11 @@ void BossFd_UpdateEffects(BossFd* this, PlayState* play) {
                 if ((this->timers[3] == 0) && (sqrtf(SQ(diff.x) + SQ(diff.y) + SQ(diff.z)) < 20.0f)) {
                     this->timers[3] = 50;
                     func_8002F6D4(play, NULL, 5.0f, effect->kbAngle, 0.0f, 0x30);
-                    if (!player->isBurning) {
+                    if (!player->bodyIsBurning) {
                         for (i2 = 0; i2 < PLAYER_BODYPART_MAX; i2++) {
-                            player->flameTimers[i2] = Rand_S16Offset(0, 200);
+                            player->bodyFlameTimers[i2] = Rand_S16Offset(0, 200);
                         }
-                        player->isBurning = true;
+                        player->bodyIsBurning = true;
                     }
                 }
                 if (effect->timer2 == 0) {

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -1868,10 +1868,10 @@ void func_80902348(BossGanon2* this, PlayState* play) {
 
         if (sqrtf(SQ(temp_f2) + SQ(temp_f12)) > 784.0f) {
             for (j = 0; j < PLAYER_BODYPART_MAX; j++) {
-                player->flameTimers[j] = Rand_S16Offset(0, 200);
+                player->bodyFlameTimers[j] = Rand_S16Offset(0, 200);
             }
 
-            player->isBurning = true;
+            player->bodyIsBurning = true;
             func_8002F6D4(play, &this->actor, 10.0f, Math_Atan2S(temp_f12, temp_f2), 0.0f, 0x10);
             sZelda->unk_3C8 = 8;
         }

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -811,12 +811,12 @@ s32 BossTw_BeamHitPlayerCheck(BossTw* this, PlayState* play) {
                 if (sFreezeState == 0) {
                     sFreezeState = 1;
                 }
-            } else if (!player->isBurning) {
+            } else if (!player->bodyIsBurning) {
                 for (i = 0; i < PLAYER_BODYPART_MAX; i++) {
-                    player->flameTimers[i] = Rand_S16Offset(0, 200);
+                    player->bodyFlameTimers[i] = Rand_S16Offset(0, 200);
                 }
 
-                player->isBurning = true;
+                player->bodyIsBurning = true;
                 Player_PlaySfx(player, player->ageProperties->unk_92 + NA_SE_VO_LI_DEMO_DAMAGE);
             }
         }
@@ -3172,7 +3172,7 @@ void BossTw_TwinrovaUpdate(Actor* thisx, PlayState* play2) {
         }
     }
 
-    if (player->isBurning && sShieldIceCharge != 0) {
+    if (player->bodyIsBurning && sShieldIceCharge != 0) {
         sShieldIceCharge = 4;
     }
 }
@@ -4055,15 +4055,15 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
                 yDiff = sKoumePtr->groundBlastPos2.y - player->actor.world.pos.y;
                 zDiff = sKoumePtr->groundBlastPos2.z - player->actor.world.pos.z;
 
-                if (!player->isBurning && (player->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (fabsf(yDiff) < 10.0f) &&
-                    (sqrtf(SQ(xDiff) + SQ(zDiff)) < (sKoumePtr->workf[UNK_F13] * 4550.0f))) {
+                if (!player->bodyIsBurning && (player->actor.bgCheckFlags & BGCHECKFLAG_GROUND) &&
+                    (fabsf(yDiff) < 10.0f) && (sqrtf(SQ(xDiff) + SQ(zDiff)) < (sKoumePtr->workf[UNK_F13] * 4550.0f))) {
                     s16 j;
 
                     for (j = 0; j < 18; j++) {
-                        player->flameTimers[j] = Rand_S16Offset(0, 200);
+                        player->bodyFlameTimers[j] = Rand_S16Offset(0, 200);
                     }
 
-                    player->isBurning = 1;
+                    player->bodyIsBurning = true;
 
                     if (this->work[BURN_TMR] == 0) {
                         Player_PlaySfx(player, player->ageProperties->unk_92 + NA_SE_VO_LI_DEMO_DAMAGE);

--- a/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
+++ b/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
@@ -163,13 +163,13 @@ void func_809BC598(EnBdfire* this, PlayState* play) {
             Actor_Kill(&this->actor);
             return;
         }
-    } else if (!player->isBurning) {
+    } else if (!player->bodyIsBurning) {
         distToBurn = (this->actor.scale.x * 130.0f) / 4.2000003f;
         if (this->actor.xyzDistToPlayerSq < SQ(distToBurn)) {
             for (i = 0; i < 18; i++) {
-                player->flameTimers[i] = Rand_S16Offset(0, 200);
+                player->bodyFlameTimers[i] = Rand_S16Offset(0, 200);
             }
-            player->isBurning = true;
+            player->bodyIsBurning = true;
             func_8002F6D4(play, &this->actor, 20.0f, this->actor.world.rot.y, 0.0f, 8);
             osSyncPrintf("POWER\n");
         }

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4277,10 +4277,10 @@ void func_8083821C(Player* this) {
     s32 i;
 
     // clang-format off
-    for (i = 0; i < PLAYER_BODYPART_MAX; i++) { this->flameTimers[i] = Rand_S16Offset(0, 200); }
+    for (i = 0; i < PLAYER_BODYPART_MAX; i++) { this->bodyFlameTimers[i] = Rand_S16Offset(0, 200); }
     // clang-format on
 
-    this->isBurning = true;
+    this->bodyIsBurning = true;
 }
 
 void func_80838280(Player* this) {
@@ -4348,7 +4348,7 @@ s32 func_808382DC(Player* this, PlayState* play) {
             func_80838280(this);
 
             if (this->unk_8A1 == 3) {
-                this->shockTimer = 40;
+                this->bodyShockTimer = 40;
             }
 
             this->actor.colChkInfo.damage += this->unk_8A0;
@@ -10709,16 +10709,16 @@ void func_80848A04(PlayState* play, Player* this) {
                   temp * 200.0f, 0, 8);
 }
 
-void func_80848B44(PlayState* play, Player* this) {
+void Player_UpdateBodyShock(PlayState* play, Player* this) {
     Vec3f shockPos;
     Vec3f* randBodyPart;
     s32 shockScale;
 
-    this->shockTimer--;
-    this->unk_892 += this->shockTimer;
+    this->bodyShockTimer--;
+    this->unk_892 += this->bodyShockTimer;
 
     if (this->unk_892 > 20) {
-        shockScale = this->shockTimer * 2;
+        shockScale = this->bodyShockTimer * 2;
         this->unk_892 -= 20;
 
         if (shockScale > 40) {
@@ -10735,7 +10735,7 @@ void func_80848B44(PlayState* play, Player* this) {
     }
 }
 
-void func_80848C74(PlayState* play, Player* this) {
+void Player_UpdateBodyBurn(PlayState* play, Player* this) {
     s32 spawnedFlame;
     u8* timerPtr;
     s32 timerStep;
@@ -10753,7 +10753,7 @@ void func_80848C74(PlayState* play, Player* this) {
     }
 
     spawnedFlame = false;
-    timerPtr = this->flameTimers;
+    timerPtr = this->bodyFlameTimers;
 
     if (this->stateFlags2 & PLAYER_STATE2_3) {
         sp58 = 100;
@@ -10798,7 +10798,7 @@ void func_80848C74(PlayState* play, Player* this) {
             Player_InflictDamage(play, -1);
         }
     } else {
-        this->isBurning = false;
+        this->bodyIsBurning = false;
     }
 }
 
@@ -10958,12 +10958,12 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
         this->unk_860++;
     }
 
-    if (this->shockTimer != 0) {
-        func_80848B44(play, this);
+    if (this->bodyShockTimer != 0) {
+        Player_UpdateBodyShock(play, this);
     }
 
-    if (this->isBurning) {
-        func_80848C74(play, this);
+    if (this->bodyIsBurning) {
+        Player_UpdateBodyBurn(play, this);
     }
 
     if ((this->stateFlags3 & PLAYER_STATE3_RESTORE_NAYRUS_LOVE) && (gSaveContext.nayrusLoveTimer != 0) &&
@@ -11147,9 +11147,9 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
                     func_80837B9C(this, play);
                 } else if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) || (this->stateFlags1 & PLAYER_STATE1_27)) {
                     func_80836448(play, this,
-                                  func_808332B8(this)       ? &gPlayerAnim_link_swimer_swim_down
-                                  : (this->shockTimer != 0) ? &gPlayerAnim_link_normal_electric_shock_end
-                                                            : &gPlayerAnim_link_derth_rebirth);
+                                  func_808332B8(this)           ? &gPlayerAnim_link_swimer_swim_down
+                                  : (this->bodyShockTimer != 0) ? &gPlayerAnim_link_normal_electric_shock_end
+                                                                : &gPlayerAnim_link_derth_rebirth);
                 }
             } else {
                 if ((this->actor.parent == NULL) && ((play->transitionTrigger == TRANS_TRIGGER_START) ||
@@ -13629,7 +13629,7 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
         }
     }
 
-    this->shockTimer = 40;
+    this->bodyShockTimer = 40;
     func_8002F8F0(&this->actor, NA_SE_VO_LI_TAKEN_AWAY - SFX_FLAG + this->ageProperties->unk_92);
 }
 


### PR DESCRIPTION
This in the same spirit as https://github.com/zeldaret/oot/pull/1593 , but it required some more in depth changes, so I made it a seperate PR.

I changed things like `shockTimer` and `isBurning` to `bodyShockTimer` and `bodyIsBurning`.
This is because when I went to name the functions that update these things, `Player_UpdateBurn` and `Player_UpdateShock` sounded a little funny. I added "body" to make it clear the shock and flames appear on his body. And it is in line with the fact that these functions concern his BodyPart array.

So, with the small terminology change, the functions are now `Player_UpdateBodyBurn` and `Player_UpdateBodyShock`.