### PR TITLE
Fixed minor style inconsistencies for CollisionCheckInfoInit

### DIFF
--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -62,9 +62,7 @@ static ColliderJntSphInit sJntSphInit = {
     sJntSphElementsInit,
 };
 
-static CollisionCheckInfoInit2 sColChkInfoInit2 = {
-    1, 2, 25, 25, MASS_IMMOVABLE,
-};
+static CollisionCheckInfoInit2 sColChkInfoInit2 = { 1, 2, 25, 25, MASS_IMMOVABLE };
 
 static Vec3f sEffectAccel = { 0.0f, -0.5f, 0.0f };
 

--- a/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
+++ b/src/overlays/actors/ovl_En_Dekunuts/z_en_dekunuts.c
@@ -62,7 +62,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 18, 32, 0, { 0, 0, 0 } },
 };
 
-static CollisionCheckInfoInit sColChkInfoInit = { 0x01, 0x0012, 0x0020, MASS_IMMOVABLE };
+static CollisionCheckInfoInit sColChkInfoInit = { 1, 18, 32, MASS_IMMOVABLE };
 
 static DamageTable sDamageTable = {
     /* Deku nut      */ DMG_ENTRY(0, 0x1),

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -54,9 +54,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 20, 46, 0, { 0, 0, 0 } },
 };
 
-static CollisionCheckInfoInit2 sColChkInfoInit = {
-    0, 0, 0, 0, MASS_IMMOVABLE,
-};
+static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 typedef enum {
     /*  0 */ ENDU_ANIM_0,

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -66,9 +66,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 20, 46, 0, { 0, 0, 0 } },
 };
 
-static CollisionCheckInfoInit2 sColChkInfoInit = {
-    0, 0, 0, 0, MASS_IMMOVABLE,
-};
+static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 typedef enum {
     /* 0 */ ENGO_ANIM_0,

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -92,9 +92,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 40, 65, 0, { 0, 0, 0 } },
 };
 
-static CollisionCheckInfoInit2 sColChkInfoInit = {
-    0, 0, 0, 0, MASS_IMMOVABLE,
-};
+static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 ActorInit En_Go2_InitVars = {
     /**/ ACTOR_EN_GO2,

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -56,9 +56,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 18, 46, 0, { 0, 0, 0 } },
 };
 
-static CollisionCheckInfoInit2 sColChkInfoInit = {
-    0, 0, 0, 0, MASS_IMMOVABLE,
-};
+static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 typedef enum {
     /* 0 */ ENIN_ANIM_0,

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -65,9 +65,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 20, 46, 0, { 0, 0, 0 } },
 };
 
-static CollisionCheckInfoInit2 sColChkInfoInit = {
-    0, 0, 0, 0, MASS_IMMOVABLE,
-};
+static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 typedef enum {
     /*  0 */ ENSA_ANIM1_0,


### PR DESCRIPTION
Removed newlines and trailing commas for 6 enemy actors and replaced en_dekunuts hex with decimal