### PR TITLE
Move Scene_SetTransitionForNextEntrance from z_scene_table.c to z_scene.c

### DIFF
--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -483,6 +483,26 @@ void Scene_CommandMiscSettings(PlayState* play, SceneCmd* cmd) {
     }
 }
 
+void Scene_SetTransitionForNextEntrance(PlayState* play) {
+    s16 entranceIndex;
+
+    if (!IS_DAY) {
+        if (!LINK_IS_ADULT) {
+            entranceIndex = play->nextEntranceIndex + 1;
+        } else {
+            entranceIndex = play->nextEntranceIndex + 3;
+        }
+    } else {
+        if (!LINK_IS_ADULT) {
+            entranceIndex = play->nextEntranceIndex;
+        } else {
+            entranceIndex = play->nextEntranceIndex + 2;
+        }
+    }
+
+    play->transitionType = ENTRANCE_INFO_START_TRANS_TYPE(gEntranceTable[entranceIndex].field);
+}
+
 void (*gSceneCmdHandlers[SCENE_CMD_ID_MAX])(PlayState*, SceneCmd*) = {
     Scene_CommandPlayerEntryList,          // SCENE_CMD_ID_SPAWN_LIST
     Scene_CommandActorEntryList,           // SCENE_CMD_ID_ACTOR_LIST

--- a/src/code/z_scene_table.c
+++ b/src/code/z_scene_table.c
@@ -77,26 +77,6 @@ Gfx sDefaultDisplayList[] = {
     gsSPEndDisplayList(),
 };
 
-void Scene_SetTransitionForNextEntrance(PlayState* play) {
-    s16 entranceIndex;
-
-    if (!IS_DAY) {
-        if (!LINK_IS_ADULT) {
-            entranceIndex = play->nextEntranceIndex + 1;
-        } else {
-            entranceIndex = play->nextEntranceIndex + 3;
-        }
-    } else {
-        if (!LINK_IS_ADULT) {
-            entranceIndex = play->nextEntranceIndex;
-        } else {
-            entranceIndex = play->nextEntranceIndex + 2;
-        }
-    }
-
-    play->transitionType = ENTRANCE_INFO_START_TRANS_TYPE(gEntranceTable[entranceIndex].field);
-}
-
 void Scene_DrawConfigDefault(PlayState* play) {
     OPEN_DISPS(play->state.gfxCtx, "../z_scene_table.c", 4725);
 


### PR DESCRIPTION
`Scene_SetTransitionForNextEntrance` is currently the first function in `z_scene_table.c`, but it can't be the first function in a compilation unit because it is not 0x10-aligned on gc-eu-mq. I believe moving it to `z_scene.c` is the correct file split because `Scene_SetTransitionForNextEntrance` has padding after it in gc-eu-mq, and the following function (`Scene_DrawConfigDefault` on GC or `Scene_Draw` on N64) is 0x10-aligned on all versions according to the [zelda64_compare spreadsheet](https://docs.google.com/spreadsheets/d/17yPD3DqqH5lZeR7c_QmJfgxWgVyYkGgTLZoKcvLTwtw/edit#gid=1299953822).