### PR TITLE
Create debug macros for LogUtils functions

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -189,6 +189,8 @@ extern struct GraphicsContext* __gfxCtx;
 #define ZELDA_ARENA_MALLOC(size, file, line) ZeldaArena_MallocDebug(size, file, line)
 #define ZELDA_ARENA_MALLOC_R(size, file, line) ZeldaArena_MallocRDebug(size, file, line)
 #define ZELDA_ARENA_FREE(size, file, line) ZeldaArena_FreeDebug(size, file, line)
+#define LOG_UTILS_CHECK_NULL_POINTER(exp, ptr, file, line) LogUtils_CheckNullPointer(exp, ptr, file, line)
+#define LOG_UTILS_CHECK_VALID_POINTER(exp, ptr, file, line) LogUtils_CheckValidPointer(exp, ptr, file, line)
 
 #else
 
@@ -215,6 +217,8 @@ extern struct GraphicsContext* __gfxCtx;
 #define ZELDA_ARENA_MALLOC(size, file, line) ZeldaArena_Malloc(size)
 #define ZELDA_ARENA_MALLOC_R(size, file, line) ZeldaArena_MallocR(size)
 #define ZELDA_ARENA_FREE(size, file, line) ZeldaArena_Free(size)
+#define LOG_UTILS_CHECK_NULL_POINTER(exp, ptr, file, line) (void)0
+#define LOG_UTILS_CHECK_VALID_POINTER(exp, ptr, file, line) (void)0
 
 #endif /* OOT_DEBUG */
 

--- a/src/code/PreRender.c
+++ b/src/code/PreRender.c
@@ -53,10 +53,10 @@ void PreRender_CopyImage(PreRender* this, Gfx** gfxP, void* img, void* imgDst) {
     s32 curRow;
     s32 nRows;
 
-    LogUtils_CheckNullPointer("this", this, "../PreRender.c", 215);
-    LogUtils_CheckNullPointer("glistpp", gfxP, "../PreRender.c", 216);
+    LOG_UTILS_CHECK_NULL_POINTER("this", this, "../PreRender.c", 215);
+    LOG_UTILS_CHECK_NULL_POINTER("glistpp", gfxP, "../PreRender.c", 216);
     gfx = *gfxP;
-    LogUtils_CheckNullPointer("glistp", gfx, "../PreRender.c", 218);
+    LOG_UTILS_CHECK_NULL_POINTER("glistp", gfx, "../PreRender.c", 218);
 
     gDPPipeSync(gfx++);
     // Configure the cycle type to COPY mode, disable blending
@@ -114,10 +114,10 @@ void PreRender_CopyImageRegionImpl(PreRender* this, Gfx** gfxP) {
     s32 curRow;
     s32 nRows;
 
-    LogUtils_CheckNullPointer("this", this, "../PreRender.c", 278);
-    LogUtils_CheckNullPointer("glistpp", gfxP, "../PreRender.c", 279);
+    LOG_UTILS_CHECK_NULL_POINTER("this", this, "../PreRender.c", 278);
+    LOG_UTILS_CHECK_NULL_POINTER("glistpp", gfxP, "../PreRender.c", 279);
     gfx = *gfxP;
-    LogUtils_CheckNullPointer("glistp", gfx, "../PreRender.c", 281);
+    LOG_UTILS_CHECK_NULL_POINTER("glistp", gfx, "../PreRender.c", 281);
 
     gDPPipeSync(gfx++);
     // Configure the cycle type to COPY mode, disable blending
@@ -177,10 +177,10 @@ void func_800C170C(PreRender* this, Gfx** gfxP, void* buf, void* bufSave, u32 r,
     s32 curRow;
     s32 nRows;
 
-    LogUtils_CheckNullPointer("this", this, "../PreRender.c", 343);
-    LogUtils_CheckNullPointer("glistpp", gfxP, "../PreRender.c", 344);
+    LOG_UTILS_CHECK_NULL_POINTER("this", this, "../PreRender.c", 343);
+    LOG_UTILS_CHECK_NULL_POINTER("glistpp", gfxP, "../PreRender.c", 344);
     gfx = *gfxP;
-    LogUtils_CheckNullPointer("glistp", gfx, "../PreRender.c", 346);
+    LOG_UTILS_CHECK_NULL_POINTER("glistp", gfx, "../PreRender.c", 346);
 
     gDPPipeSync(gfx++);
     // Set the cycle type to 1-cycle mode to use the color combiner
@@ -256,10 +256,10 @@ void PreRender_CoverageRgba16ToI8(PreRender* this, Gfx** gfxP, void* img, void* 
     s32 curRow;
     s32 nRows;
 
-    LogUtils_CheckNullPointer("this", this, "../PreRender.c", 422);
-    LogUtils_CheckNullPointer("glistpp", gfxP, "../PreRender.c", 423);
+    LOG_UTILS_CHECK_NULL_POINTER("this", this, "../PreRender.c", 422);
+    LOG_UTILS_CHECK_NULL_POINTER("glistpp", gfxP, "../PreRender.c", 423);
     gfx = *gfxP;
-    LogUtils_CheckNullPointer("glistp", gfx, "../PreRender.c", 425);
+    LOG_UTILS_CHECK_NULL_POINTER("glistp", gfx, "../PreRender.c", 425);
 
     gDPPipeSync(gfx++);
     gDPSetOtherMode(gfx++,
@@ -333,8 +333,8 @@ void PreRender_CoverageRgba16ToI8(PreRender* this, Gfx** gfxP, void* img, void* 
  * Saves zbuf to zbufSave
  */
 void PreRender_SaveZBuffer(PreRender* this, Gfx** gfxP) {
-    LogUtils_CheckNullPointer("this->zbuf_save", this->zbufSave, "../PreRender.c", 481);
-    LogUtils_CheckNullPointer("this->zbuf", this->zbuf, "../PreRender.c", 482);
+    LOG_UTILS_CHECK_NULL_POINTER("this->zbuf_save", this->zbufSave, "../PreRender.c", 481);
+    LOG_UTILS_CHECK_NULL_POINTER("this->zbuf", this->zbuf, "../PreRender.c", 482);
 
     if ((this->zbufSave != NULL) && (this->zbuf != NULL)) {
         PreRender_CopyImage(this, gfxP, this->zbuf, this->zbufSave);
@@ -345,8 +345,8 @@ void PreRender_SaveZBuffer(PreRender* this, Gfx** gfxP) {
  * Saves fbuf to fbufSave
  */
 void PreRender_SaveFramebuffer(PreRender* this, Gfx** gfxP) {
-    LogUtils_CheckNullPointer("this->fbuf_save", this->fbufSave, "../PreRender.c", 495);
-    LogUtils_CheckNullPointer("this->fbuf", this->fbuf, "../PreRender.c", 496);
+    LOG_UTILS_CHECK_NULL_POINTER("this->fbuf_save", this->fbufSave, "../PreRender.c", 495);
+    LOG_UTILS_CHECK_NULL_POINTER("this->fbuf", this->fbuf, "../PreRender.c", 496);
 
     if ((this->fbufSave != NULL) && (this->fbuf != NULL)) {
         func_800C1AE8(this, gfxP, this->fbuf, this->fbufSave);
@@ -401,7 +401,7 @@ void PreRender_FetchFbufCoverage(PreRender* this, Gfx** gfxP) {
  */
 void PreRender_DrawCoverage(PreRender* this, Gfx** gfxP) {
     PreRender_FetchFbufCoverage(this, gfxP);
-    LogUtils_CheckNullPointer("this->cvg_save", this->cvgSave, "../PreRender.c", 532);
+    LOG_UTILS_CHECK_NULL_POINTER("this->cvg_save", this->cvgSave, "../PreRender.c", 532);
     if (this->cvgSave != NULL) {
         PreRender_CoverageRgba16ToI8(this, gfxP, this->fbuf, this->cvgSave);
     }
@@ -426,10 +426,10 @@ void func_800C213C(PreRender* this, Gfx** gfxP) {
     s32 rtile = 1;
 
     if (this->cvgSave != NULL) {
-        LogUtils_CheckNullPointer("this", this, "../PreRender.c", 563);
-        LogUtils_CheckNullPointer("glistpp", gfxP, "../PreRender.c", 564);
+        LOG_UTILS_CHECK_NULL_POINTER("this", this, "../PreRender.c", 563);
+        LOG_UTILS_CHECK_NULL_POINTER("glistpp", gfxP, "../PreRender.c", 564);
         gfx = *gfxP;
-        LogUtils_CheckNullPointer("glistp", gfx, "../PreRender.c", 566);
+        LOG_UTILS_CHECK_NULL_POINTER("glistp", gfx, "../PreRender.c", 566);
 
         gDPPipeSync(gfx++);
         gDPSetEnvColor(gfx++, 255, 255, 255, 32);

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -415,7 +415,7 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
     PRINTF("init 処理時間 %d us\n", OS_CYCLES_TO_USEC(endTime - startTime));
 
     startTime = endTime;
-    LogUtils_CheckNullPointer("this->cleanup", gameState->destroy, "../game.c", 1088);
+    LOG_UTILS_CHECK_NULL_POINTER("this->cleanup", gameState->destroy, "../game.c", 1088);
     VisCvg_Init(&sVisCvg);
     VisZBuf_Init(&sVisZBuf);
     VisMono_Init(&sVisMono);
@@ -440,7 +440,7 @@ void GameState_Destroy(GameState* gameState) {
     AudioMgr_StopAllSfx();
     func_800F3054();
     osRecvMesg(&gameState->gfxCtx->queue, NULL, OS_MESG_BLOCK);
-    LogUtils_CheckNullPointer("this->cleanup", gameState->destroy, "../game.c", 1139);
+    LOG_UTILS_CHECK_NULL_POINTER("this->cleanup", gameState->destroy, "../game.c", 1139);
     if (gameState->destroy != NULL) {
         gameState->destroy(gameState);
     }

--- a/src/code/gamealloc.c
+++ b/src/code/gamealloc.c
@@ -49,8 +49,8 @@ void GameAlloc_Free(GameAlloc* this, void* data) {
 
     if (data != NULL) {
         ptr = &((GameAllocEntry*)data)[-1];
-        LogUtils_CheckNullPointer("ptr->prev", ptr->prev, "../gamealloc.c", 120);
-        LogUtils_CheckNullPointer("ptr->next", ptr->next, "../gamealloc.c", 121);
+        LOG_UTILS_CHECK_NULL_POINTER("ptr->prev", ptr->prev, "../gamealloc.c", 120);
+        LOG_UTILS_CHECK_NULL_POINTER("ptr->next", ptr->next, "../gamealloc.c", 121);
         ptr->prev->next = ptr->next;
         ptr->next->prev = ptr->prev;
         this->head = this->base.prev;

--- a/src/code/irqmgr.c
+++ b/src/code/irqmgr.c
@@ -59,9 +59,9 @@ u32 sIrqMgrRetraceCount = 0;
 void IrqMgr_AddClient(IrqMgr* irqMgr, IrqMgrClient* client, OSMesgQueue* msgQueue) {
     OSIntMask prevInt;
 
-    LogUtils_CheckNullPointer("this", irqMgr, "../irqmgr.c", 96);
-    LogUtils_CheckNullPointer("c", client, "../irqmgr.c", 97);
-    LogUtils_CheckNullPointer("msgQ", msgQueue, "../irqmgr.c", 98);
+    LOG_UTILS_CHECK_NULL_POINTER("this", irqMgr, "../irqmgr.c", 96);
+    LOG_UTILS_CHECK_NULL_POINTER("c", client, "../irqmgr.c", 97);
+    LOG_UTILS_CHECK_NULL_POINTER("msgQ", msgQueue, "../irqmgr.c", 98);
 
     prevInt = osSetIntMask(OS_IM_NONE);
 
@@ -85,8 +85,8 @@ void IrqMgr_RemoveClient(IrqMgr* irqMgr, IrqMgrClient* client) {
     IrqMgrClient* lastClient = NULL;
     OSIntMask prevInt;
 
-    LogUtils_CheckNullPointer("this", irqMgr, "../irqmgr.c", 129);
-    LogUtils_CheckNullPointer("c", client, "../irqmgr.c", 130);
+    LOG_UTILS_CHECK_NULL_POINTER("this", irqMgr, "../irqmgr.c", 129);
+    LOG_UTILS_CHECK_NULL_POINTER("c", client, "../irqmgr.c", 130);
 
     // Disable interrupts to prevent a thread context switch while the linked list is modified
     prevInt = osSetIntMask(OS_IM_NONE);
@@ -290,8 +290,8 @@ void IrqMgr_ThreadEntry(void* arg) {
 }
 
 void IrqMgr_Init(IrqMgr* irqMgr, void* stack, OSPri pri, u8 retraceCount) {
-    LogUtils_CheckNullPointer("this", irqMgr, "../irqmgr.c", 346);
-    LogUtils_CheckNullPointer("stack", stack, "../irqmgr.c", 347);
+    LOG_UTILS_CHECK_NULL_POINTER("this", irqMgr, "../irqmgr.c", 346);
+    LOG_UTILS_CHECK_NULL_POINTER("stack", stack, "../irqmgr.c", 347);
 
     irqMgr->clients = NULL;
     // Messages to send to each client message queue on each interrupt event

--- a/src/code/mtxuty-cvt.c
+++ b/src/code/mtxuty-cvt.c
@@ -4,8 +4,8 @@ void MtxConv_F2L(Mtx* m1, MtxF* m2) {
     s32 i;
     s32 j;
 
-    LogUtils_CheckNullPointer("m1", m1, "../mtxuty-cvt.c", 31);
-    LogUtils_CheckNullPointer("m2", m2, "../mtxuty-cvt.c", 32);
+    LOG_UTILS_CHECK_NULL_POINTER("m1", m1, "../mtxuty-cvt.c", 31);
+    LOG_UTILS_CHECK_NULL_POINTER("m2", m2, "../mtxuty-cvt.c", 32);
 
     for (i = 0; i < 4; i++) {
         for (j = 0; j < 4; j++) {
@@ -18,7 +18,7 @@ void MtxConv_F2L(Mtx* m1, MtxF* m2) {
 }
 
 void MtxConv_L2F(MtxF* m1, Mtx* m2) {
-    LogUtils_CheckNullPointer("m1", m1, "../mtxuty-cvt.c", 55);
-    LogUtils_CheckNullPointer("m2", m2, "../mtxuty-cvt.c", 56);
+    LOG_UTILS_CHECK_NULL_POINTER("m1", m1, "../mtxuty-cvt.c", 55);
+    LOG_UTILS_CHECK_NULL_POINTER("m2", m2, "../mtxuty-cvt.c", 56);
     guMtxL2F(m1, m2);
 }

--- a/src/code/padmgr.c
+++ b/src/code/padmgr.c
@@ -477,7 +477,7 @@ void PadMgr_ThreadEntry(PadMgr* padMgr) {
         }
 
         osRecvMesg(&padMgr->interruptQueue, (OSMesg*)&msg, OS_MESG_BLOCK);
-        LogUtils_CheckNullPointer("msg", msg, "../padmgr.c", 563);
+        LOG_UTILS_CHECK_NULL_POINTER("msg", msg, "../padmgr.c", 563);
 
         switch (*msg) {
             case OS_SC_RETRACE_MSG:

--- a/src/code/sched.c
+++ b/src/code/sched.c
@@ -58,7 +58,7 @@ OSTime sRDPTimeStart;
 void Sched_SwapFrameBufferImpl(CfbInfo* cfbInfo) {
     u16 width;
 
-    LogUtils_CheckValidPointer("cfbinfo->swapbuffer", cfbInfo->swapBuffer, "../sched.c", 340);
+    LOG_UTILS_CHECK_VALID_POINTER("cfbinfo->swapbuffer", cfbInfo->swapBuffer, "../sched.c", 340);
 
     if (cfbInfo->swapBuffer != NULL) {
         // Register the swapbuffer to display on next VI
@@ -330,7 +330,7 @@ void Sched_SetNextFramebufferFromTask(Scheduler* sc, OSScTask* task) {
     if (sc->pendingSwapBuf1 == NULL) {
         sc->pendingSwapBuf1 = task->framebuffer;
 
-        LogUtils_CheckValidPointer("sc->pending_swapbuffer1", sc->pendingSwapBuf1, "../sched.c", 618);
+        LOG_UTILS_CHECK_VALID_POINTER("sc->pending_swapbuffer1", sc->pendingSwapBuf1, "../sched.c", 618);
 
         if (sc->curBuf == NULL || sc->curBuf->updateTimer <= 0) {
             Sched_SwapFrameBuffer(sc, task->framebuffer);

--- a/src/code/speed_meter.c
+++ b/src/code/speed_meter.c
@@ -92,7 +92,7 @@ typedef struct {
     gDPPipeSync(gfx)
 
 void SpeedMeter_InitImpl(SpeedMeter* this, u32 x, u32 y) {
-    LogUtils_CheckNullPointer("this", this, "../speed_meter.c", 181);
+    LOG_UTILS_CHECK_NULL_POINTER("this", this, "../speed_meter.c", 181);
     this->x = x;
     this->y = y;
 }

--- a/src/code/z_kaleido_manager.c
+++ b/src/code/z_kaleido_manager.c
@@ -17,7 +17,7 @@ KaleidoMgrOverlay* gKaleidoMgrCurOvl = NULL;
 u8 gBossMarkState = 0;
 
 void KaleidoManager_LoadOvl(KaleidoMgrOverlay* ovl) {
-    LogUtils_CheckNullPointer("KaleidoArea_allocp", sKaleidoAreaPtr, "../z_kaleido_manager.c", 99);
+    LOG_UTILS_CHECK_NULL_POINTER("KaleidoArea_allocp", sKaleidoAreaPtr, "../z_kaleido_manager.c", 99);
 
     ovl->loadedRamAddr = sKaleidoAreaPtr;
     Overlay_Load(ovl->vromStart, ovl->vromEnd, ovl->vramStart, ovl->vramEnd, ovl->loadedRamAddr);
@@ -58,7 +58,7 @@ void KaleidoManager_Init(PlayState* play) {
     PRINTF(VT_RST);
 
     sKaleidoAreaPtr = GAME_STATE_ALLOC(&play->state, largestSize, "../z_kaleido_manager.c", 150);
-    LogUtils_CheckNullPointer("KaleidoArea_allocp", sKaleidoAreaPtr, "../z_kaleido_manager.c", 151);
+    LOG_UTILS_CHECK_NULL_POINTER("KaleidoArea_allocp", sKaleidoAreaPtr, "../z_kaleido_manager.c", 151);
 
     PRINTF(VT_FGCOL(GREEN));
     PRINTF("KaleidoArea %08x - %08x\n", sKaleidoAreaPtr, (uintptr_t)sKaleidoAreaPtr + largestSize);

--- a/src/code/z_map_mark.c
+++ b/src/code/z_map_mark.c
@@ -58,7 +58,7 @@ void MapMark_Init(PlayState* play) {
     u32 overlaySize = (uintptr_t)overlay->vramEnd - (uintptr_t)overlay->vramStart;
 
     overlay->loadedRamAddr = GAME_STATE_ALLOC(&play->state, overlaySize, "../z_map_mark.c", 235);
-    LogUtils_CheckNullPointer("dlftbl->allocp", overlay->loadedRamAddr, "../z_map_mark.c", 236);
+    LOG_UTILS_CHECK_NULL_POINTER("dlftbl->allocp", overlay->loadedRamAddr, "../z_map_mark.c", 236);
 
     Overlay_Load(overlay->vromStart, overlay->vromEnd, overlay->vramStart, overlay->vramEnd, overlay->loadedRamAddr);
 

--- a/src/code/z_view.c
+++ b/src/code/z_view.c
@@ -292,7 +292,7 @@ s32 View_ApplyPerspective(View* view) {
 
     // Viewport
     vp = GRAPH_ALLOC(gfxCtx, sizeof(Vp));
-    LogUtils_CheckNullPointer("vp", vp, "../z_view.c", 601);
+    LOG_UTILS_CHECK_NULL_POINTER("vp", vp, "../z_view.c", 601);
     View_ViewportToVp(vp, &view->viewport);
     view->vp = *vp;
 
@@ -303,7 +303,7 @@ s32 View_ApplyPerspective(View* view) {
 
     // Perspective projection
     projection = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
-    LogUtils_CheckNullPointer("projection", projection, "../z_view.c", 616);
+    LOG_UTILS_CHECK_NULL_POINTER("projection", projection, "../z_view.c", 616);
     view->projectionPtr = projection;
 
     width = view->viewport.rightX - view->viewport.leftX;
@@ -351,7 +351,7 @@ s32 View_ApplyPerspective(View* view) {
 
     // View matrix (look-at)
     viewing = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
-    LogUtils_CheckNullPointer("viewing", viewing, "../z_view.c", 667);
+    LOG_UTILS_CHECK_NULL_POINTER("viewing", viewing, "../z_view.c", 667);
     view->viewingPtr = viewing;
 
     if (view->eye.x == view->at.x && view->eye.y == view->at.y && view->eye.z == view->at.z) {
@@ -395,7 +395,7 @@ s32 View_ApplyOrtho(View* view) {
     OPEN_DISPS(gfxCtx, "../z_view.c", 726);
 
     vp = GRAPH_ALLOC(gfxCtx, sizeof(Vp));
-    LogUtils_CheckNullPointer("vp", vp, "../z_view.c", 730);
+    LOG_UTILS_CHECK_NULL_POINTER("vp", vp, "../z_view.c", 730);
     View_ViewportToVp(vp, &view->viewport);
     view->vp = *vp;
 
@@ -406,7 +406,7 @@ s32 View_ApplyOrtho(View* view) {
     gSPViewport(OVERLAY_DISP++, vp);
 
     projection = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
-    LogUtils_CheckNullPointer("projection", projection, "../z_view.c", 744);
+    LOG_UTILS_CHECK_NULL_POINTER("projection", projection, "../z_view.c", 744);
     view->projectionPtr = projection;
 
     guOrtho(projection, -(f32)gScreenWidth * 0.5f, (f32)gScreenWidth * 0.5f, -(f32)gScreenHeight * 0.5f,
@@ -435,7 +435,7 @@ s32 View_ApplyOrthoToOverlay(View* view) {
     OPEN_DISPS(gfxCtx, "../z_view.c", 777);
 
     vp = GRAPH_ALLOC(gfxCtx, sizeof(Vp));
-    LogUtils_CheckNullPointer("vp", vp, "../z_view.c", 781);
+    LOG_UTILS_CHECK_NULL_POINTER("vp", vp, "../z_view.c", 781);
     View_ViewportToVp(vp, &view->viewport);
     view->vp = *vp;
 
@@ -445,7 +445,7 @@ s32 View_ApplyOrthoToOverlay(View* view) {
     gSPViewport(OVERLAY_DISP++, vp);
 
     projection = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
-    LogUtils_CheckNullPointer("projection", projection, "../z_view.c", 791);
+    LOG_UTILS_CHECK_NULL_POINTER("projection", projection, "../z_view.c", 791);
     view->projectionPtr = projection;
 
     guOrtho(projection, -(f32)gScreenWidth * 0.5f, (f32)gScreenWidth * 0.5f, -(f32)gScreenHeight * 0.5f,
@@ -476,7 +476,7 @@ s32 View_ApplyPerspectiveToOverlay(View* view) {
     OPEN_DISPS(gfxCtx, "../z_view.c", 816);
 
     vp = GRAPH_ALLOC(gfxCtx, sizeof(Vp));
-    LogUtils_CheckNullPointer("vp", vp, "../z_view.c", 821);
+    LOG_UTILS_CHECK_NULL_POINTER("vp", vp, "../z_view.c", 821);
     View_ViewportToVp(vp, &view->viewport);
     view->vp = *vp;
 
@@ -486,7 +486,7 @@ s32 View_ApplyPerspectiveToOverlay(View* view) {
     gSPViewport(OVERLAY_DISP++, vp);
 
     projection = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
-    LogUtils_CheckNullPointer("projection", projection, "../z_view.c", 833);
+    LOG_UTILS_CHECK_NULL_POINTER("projection", projection, "../z_view.c", 833);
     view->projectionPtr = projection;
 
     width = view->viewport.rightX - view->viewport.leftX;
@@ -501,7 +501,7 @@ s32 View_ApplyPerspectiveToOverlay(View* view) {
     gSPMatrix(OVERLAY_DISP++, projection, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
 
     viewing = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
-    LogUtils_CheckNullPointer("viewing", viewing, "../z_view.c", 848);
+    LOG_UTILS_CHECK_NULL_POINTER("viewing", viewing, "../z_view.c", 848);
     view->viewingPtr = viewing;
 
     // This check avoids a divide-by-zero in guLookAt if eye == at
@@ -552,7 +552,7 @@ s32 View_ApplyTo(View* view, s32 mask, Gfx** gfxP) {
 
     if (mask & VIEW_VIEWPORT) {
         vp = GRAPH_ALLOC(gfxCtx, sizeof(Vp));
-        LogUtils_CheckNullPointer("vp", vp, "../z_view.c", 910);
+        LOG_UTILS_CHECK_NULL_POINTER("vp", vp, "../z_view.c", 910);
         View_ViewportToVp(vp, &view->viewport);
 
         view->vp = *vp;
@@ -565,7 +565,7 @@ s32 View_ApplyTo(View* view, s32 mask, Gfx** gfxP) {
 
     if (mask & VIEW_PROJECTION_ORTHO) {
         projection = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
-        LogUtils_CheckNullPointer("projection", projection, "../z_view.c", 921);
+        LOG_UTILS_CHECK_NULL_POINTER("projection", projection, "../z_view.c", 921);
         view->projectionPtr = projection;
 
         guOrtho(projection, -(f32)gScreenWidth * 0.5f, (f32)gScreenWidth * 0.5f, -(f32)gScreenHeight * 0.5f,
@@ -576,7 +576,7 @@ s32 View_ApplyTo(View* view, s32 mask, Gfx** gfxP) {
         gSPMatrix(gfx++, projection, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
     } else if (mask & (VIEW_PROJECTION_PERSPECTIVE | VIEW_VIEWPORT)) {
         projection = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
-        LogUtils_CheckNullPointer("projection", projection, "../z_view.c", 932);
+        LOG_UTILS_CHECK_NULL_POINTER("projection", projection, "../z_view.c", 932);
         view->projectionPtr = projection;
 
         width = view->viewport.rightX - view->viewport.leftX;
@@ -593,7 +593,7 @@ s32 View_ApplyTo(View* view, s32 mask, Gfx** gfxP) {
 
     if (mask & VIEW_VIEWING) {
         viewing = GRAPH_ALLOC(gfxCtx, sizeof(Mtx));
-        LogUtils_CheckNullPointer("viewing", viewing, "../z_view.c", 948);
+        LOG_UTILS_CHECK_NULL_POINTER("viewing", viewing, "../z_view.c", 948);
         view->viewingPtr = viewing;
 
         View_ErrorCheckEyePosition(view->eye.x, view->eye.y, view->eye.z);


### PR DESCRIPTION
I've replaced `LogUtils_CheckNullPointer` and `LogUtils_CheckValidPointer` with debug macros. All the other `LogUtils` functions that take a `file` and `line` aren't actually used anywhere, except for `LogUtils_HungupThread` which is still called retail versions.

These functions might be useful for modding, so maybe they should have a friendlier name, like `CHECK_VALID` and `CHECK_NULL`? Although the inconsistency between `CHECK_VALID` (which checks that a pointer is valid) and `CHECK_NULL` (which checks that a pointer is *not* null) would bother me a bit.