### PR TITLE
Remove actor padding in non-debug versions

### DIFF
--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -305,7 +305,9 @@ typedef struct Actor {
     /* 0x130 */ ActorFunc update; // Update Routine. Called by `Actor_UpdateAll`
     /* 0x134 */ ActorFunc draw; // Draw Routine. Called by `Actor_Draw`
     /* 0x138 */ ActorOverlay* overlayEntry; // Pointer to the overlay table entry for this actor
+#ifdef OOT_DEBUG
     /* 0x13C */ char dbgPad[0x10]; // Padding that only exists in the debug rom
+#endif
 } Actor; // size = 0x14C
 
 typedef enum {

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -306,7 +306,7 @@ typedef struct Actor {
     /* 0x134 */ ActorFunc draw; // Draw Routine. Called by `Actor_Draw`
     /* 0x138 */ ActorOverlay* overlayEntry; // Pointer to the overlay table entry for this actor
 #ifdef OOT_DEBUG
-    /* 0x13C */ char dbgPad[0x10]; // Padding that only exists in the debug rom
+    /* 0x13C */ char dbgPad[0x10];
 #endif
 } Actor; // size = 0x14C
 


### PR DESCRIPTION
This causes diffs in basically all actor functions so I think it's important to change this early.