### PR TITLE
Test for __sgi instead of __GNUC__ for PRINTF macro

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -103,14 +103,14 @@
 #ifdef OOT_DEBUG
 #define PRINTF osSyncPrintf
 #else
-#ifdef __GNUC__
-#define PRINTF(format, ...) (void)0
-#else
+#ifdef __sgi /* IDO compiler */
 // IDO doesn't support variadic macros, but it merely throws a warning for the
 // number of arguments not matching the definition (warning 609) instead of
 // throwing an error. We suppress this warning and rely on GCC to catch macro
 // argument errors instead.
 #define PRINTF(args) (void)0
+#else
+#define PRINTF(format, ...) (void)0
 #endif
 #endif
 


### PR DESCRIPTION
Currently, running decomp-permuter's import.py fails with

```
<stdin>:25417:104: error: macro "PRINTF" passed 4 arguments, but takes just 1
<stdin>:7476: note: macro "PRINTF" defined here
Failed to preprocess input file, when running command:
cpp-13 -P -undef '-D_Static_assert(x, y)=' '-D__attribute__(x)=' '-DGLOBAL_ASM(...)=' '-D__asm__(...)='
```

because it runs the preprocessor directly without defining `__GNUC__`. Testing for IDO instead seems better anyway though since most other compilers should support variadic macros.