### PR TITLE
Use virtualenv in Makefile for python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# asm-differ
+argcomplete
+colorama
+cxxfilt
+python-Levenshtein
+watchdog
+
+# decomp-permuter
+pycparser
+toml


### PR DESCRIPTION
`make setup` will create a virtualenv if it doesn't already exist, and all python commands in the Makefile will use the virtualenv without the user having to activate it. This is so the build system can use pip packages without the user having to learn about virtualenv, since that can be hard for beginners. (You will still have to activate the virtualenv if you want to run scripts like `diff.py` by hand, though.) To be honest I haven't really seen any project doing something like this, so I'm not sure if there will be unintended consequences.

I chose `venv` instead of `.venv` because I think it would be nice if this directory was not hidden (we're doing enough magic as it is), and because `venv/bin/python3 script.py` looks slightly prettier than `.venv/bin/python3 script.py` in the make log.

I'm not sure if `distclean` should nuke the virtualenv too. I chose not to here, because I couldn't find a way to automatically deactivate it (`deactivate` it is a shell function, not a command in the virtualenv), and it hopefully it doesn't get too messed up.

