### PR TITLE
Suggest pip install -U -r requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Keep in mind that for each new terminal session, you will need to **activate** t
 Now you can install the Python dependencies, to do so run:
 
 ```bash
-python3 -m pip install -U -r requirements.txt
+pip install -r requirements.txt
 ```
 
 #### 4. Prepare a base ROM

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Keep in mind that for each new terminal session, you will need to **activate** t
 Now you can install the Python dependencies, to do so run:
 
 ```bash
-pip install -r requirements.txt
+pip install -U -r requirements.txt
 ```
 
 #### 4. Prepare a base ROM


### PR DESCRIPTION
This is what's used for the vast majority of Python projects, so I think the more complicated command is just needlessly confusing to newcomers. Note that `pip` is not more unsafe than `python3 -m pip` because pip is always installed by virtualenv since Python 3.4