### PR TITLE
Rename `make compressed` to `make compress`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ ifneq ($(COMPARE),0)
 	@md5sum -c baseroms/$(VERSION)/checksum.md5
 endif
 
-compressed: $(ROMC)
+compress: $(ROMC)
 ifneq ($(COMPARE),0)
 	@md5sum $(ROMC)
 	@md5sum -c baseroms/$(VERSION)/checksum-compressed.md5
@@ -300,9 +300,9 @@ endif
 	$(N64_EMULATOR) $<
 
 
-.PHONY: all rom compressed clean setup run distclean assetclean
+.PHONY: all rom compress clean setup run distclean assetclean
 .DEFAULT_GOAL := rom
-all: rom compressed
+all: rom compress
 
 #### Various Recipes ####
 


### PR DESCRIPTION
Phony make targets are usually verbs e.g. `run` or `install`. Sorry for not thinking about this during review