### PR TITLE
z_collision_check.c OK

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -615,8 +615,10 @@ u16 WaterBox_GetBgCamSetting(CollisionContext* colCtx, WaterBox* waterBox);
 u32 WaterBox_GetLightIndex(CollisionContext* colCtx, WaterBox* waterBox);
 s32 func_80042708(CollisionPoly* polyA, CollisionPoly* polyB, Vec3f* point, Vec3f* closestPoint);
 s32 func_800427B4(CollisionPoly* polyA, CollisionPoly* polyB, Vec3f* pointA, Vec3f* pointB, Vec3f* closestPoint);
+#ifdef OOT_DEBUG
 void BgCheck_DrawDynaCollision(PlayState*, CollisionContext*);
 void BgCheck_DrawStaticCollision(PlayState*, CollisionContext*);
+#endif
 void func_80043334(CollisionContext* colCtx, Actor* actor, s32 bgId);
 s32 DynaPolyActor_TransformCarriedActor(CollisionContext* colCtx, s32 bgId, Actor* carriedActor);
 void DynaPolyActor_Init(DynaPolyActor* dynaActor, s32 transformFlags);
@@ -661,8 +663,10 @@ s32 func_8005B198(void);
 s16 Camera_SetFinishedFlag(Camera* camera);
 DamageTable* DamageTable_Get(s32 index);
 void DamageTable_Clear(DamageTable* table);
+#ifdef OOT_DEBUG
 void Collider_DrawRedPoly(GraphicsContext* gfxCtx, Vec3f* vA, Vec3f* vB, Vec3f* vC);
 void Collider_DrawPoly(GraphicsContext* gfxCtx, Vec3f* vA, Vec3f* vB, Vec3f* vC, u8 r, u8 g, u8 b);
+#endif
 s32 Collider_InitJntSph(PlayState* play, ColliderJntSph* jntSph);
 s32 Collider_FreeJntSph(PlayState* play, ColliderJntSph* jntSph);
 s32 Collider_DestroyJntSph(PlayState* play, ColliderJntSph* jntSph);
@@ -710,8 +714,10 @@ void CollisionCheck_DestroyContext(PlayState* play, CollisionCheckContext* colCh
 void CollisionCheck_ClearContext(PlayState* play, CollisionCheckContext* colChkCtx);
 void CollisionCheck_EnableSAC(PlayState* play, CollisionCheckContext* colChkCtx);
 void CollisionCheck_DisableSAC(PlayState* play, CollisionCheckContext* colChkCtx);
+#ifdef OOT_DEBUG
 void Collider_Draw(PlayState* play, Collider* col);
 void CollisionCheck_DrawCollision(PlayState* play, CollisionCheckContext* colChkCtx);
+#endif
 s32 CollisionCheck_SetAT(PlayState* play, CollisionCheckContext* colChkCtx, Collider* collider);
 s32 CollisionCheck_SetAT_SAC(PlayState* play, CollisionCheckContext* colChkCtx, Collider* collider, s32 index);
 s32 CollisionCheck_SetAC(PlayState* play, CollisionCheckContext* colChkCtx, Collider* collider);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2609,11 +2609,11 @@ void func_800315AC(PlayState* play, ActorContext* actorCtx) {
         TitleCard_Draw(play, &actorCtx->titleCtx);
     }
 
-    if ((HREG(64) != 1) || (HREG(76) != 0)) {
 #if OOT_DEBUG
+    if ((HREG(64) != 1) || (HREG(76) != 0)) {
         CollisionCheck_DrawCollision(play, &play->colChkCtx);
-#endif
     }
+#endif
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_actor.c", 6563);
 }

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2610,7 +2610,9 @@ void func_800315AC(PlayState* play, ActorContext* actorCtx) {
     }
 
     if ((HREG(64) != 1) || (HREG(76) != 0)) {
+#ifdef OOT_DEBUG
         CollisionCheck_DrawCollision(play, &play->colChkCtx);
+#endif
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_actor.c", 6563);

--- a/src/code/z_bgcheck.c
+++ b/src/code/z_bgcheck.c
@@ -4559,4 +4559,4 @@ void BgCheck_DrawStaticCollision(PlayState* play, CollisionContext* colCtx) {
     }
 }
 
-#endif /* OOT_DEBUG */
+#endif

--- a/src/code/z_bgcheck.c
+++ b/src/code/z_bgcheck.c
@@ -4409,6 +4409,8 @@ s32 func_800427B4(CollisionPoly* polyA, CollisionPoly* polyB, Vec3f* pointA, Vec
     return result;
 }
 
+#ifdef OOT_DEBUG
+
 /**
  * Draw a list of dyna polys, specified by `ssList`
  */
@@ -4556,3 +4558,5 @@ void BgCheck_DrawStaticCollision(PlayState* play, CollisionContext* colCtx) {
         BgCheck_DrawStaticPolyList(play, colCtx, &lookup->ceiling, 255, 0, 0);
     }
 }
+
+#endif /* OOT_DEBUG */

--- a/src/code/z_bgcheck.c
+++ b/src/code/z_bgcheck.c
@@ -4410,7 +4410,6 @@ s32 func_800427B4(CollisionPoly* polyA, CollisionPoly* polyB, Vec3f* pointA, Vec
 }
 
 #ifdef OOT_DEBUG
-
 /**
  * Draw a list of dyna polys, specified by `ssList`
  */
@@ -4558,5 +4557,4 @@ void BgCheck_DrawStaticCollision(PlayState* play, CollisionContext* colCtx) {
         BgCheck_DrawStaticPolyList(play, colCtx, &lookup->ceiling, 255, 0, 0);
     }
 }
-
 #endif

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -7,6 +7,8 @@ typedef void (*ColChkApplyFunc)(PlayState*, CollisionCheckContext*, Collider*);
 typedef void (*ColChkVsFunc)(PlayState*, CollisionCheckContext*, Collider*, Collider*);
 typedef s32 (*ColChkLineFunc)(PlayState*, CollisionCheckContext*, Collider*, Vec3f*, Vec3f*);
 
+#ifdef OOT_DEBUG
+
 /**
  * Draws a red triangle with vertices vA, vB, and vC.
  */
@@ -69,6 +71,8 @@ void Collider_DrawPoly(GraphicsContext* gfxCtx, Vec3f* vA, Vec3f* vB, Vec3f* vC,
 
     CLOSE_DISPS(gfxCtx, "../z_collision_check.c", 757);
 }
+
+#endif /* OOT_DEBUG */
 
 s32 Collider_InitBase(PlayState* play, Collider* col) {
     static Collider init = {
@@ -1000,9 +1004,11 @@ s32 Collider_ResetLineOC(PlayState* play, OcLine* line) {
 void CollisionCheck_InitContext(PlayState* play, CollisionCheckContext* colChkCtx) {
     colChkCtx->sacFlags = 0;
     CollisionCheck_ClearContext(play, colChkCtx);
+#ifdef OOT_DEBUG
     AREG(21) = true;
     AREG(22) = true;
     AREG(23) = true;
+#endif
 }
 
 void CollisionCheck_DestroyContext(PlayState* play, CollisionCheckContext* colChkCtx) {
@@ -1051,6 +1057,8 @@ void CollisionCheck_EnableSAC(PlayState* play, CollisionCheckContext* colChkCtx)
 void CollisionCheck_DisableSAC(PlayState* play, CollisionCheckContext* colChkCtx) {
     colChkCtx->sacFlags &= ~SAC_ENABLE;
 }
+
+#ifdef OOT_DEBUG
 
 /**
  * Draws a collider of any shape.
@@ -1130,6 +1138,8 @@ void CollisionCheck_DrawCollision(PlayState* play, CollisionCheckContext* colChk
         }
     }
 }
+
+#endif /* OOT_DEBUG */
 
 static ColChkResetFunc sATResetFuncs[] = {
     Collider_ResetJntSphAT,
@@ -2153,8 +2163,6 @@ void CollisionCheck_ATTrisVsACCyl(PlayState* play, CollisionCheckContext* colChk
     ColliderTris* atTris = (ColliderTris*)atCol;
     ColliderTrisElement* atTrisElem;
     ColliderCylinder* acCyl = (ColliderCylinder*)acCol;
-    Vec3f atPos;
-    Vec3f acPos;
 
     if (acCyl->dim.radius > 0 && acCyl->dim.height > 0 && atTris->count > 0 && atTris->elements != NULL) {
         if (CollisionCheck_SkipElementBump(&acCyl->elem) == true) {
@@ -2169,6 +2177,8 @@ void CollisionCheck_ATTrisVsACCyl(PlayState* play, CollisionCheckContext* colChk
             }
 
             if (Math3D_CylTriVsIntersect(&acCyl->dim, &atTrisElem->dim, &hitPos) == true) {
+                Vec3f atPos;
+                Vec3f acPos;
                 atPos.x = (atTrisElem->dim.vtx[0].x + atTrisElem->dim.vtx[1].x + atTrisElem->dim.vtx[2].x) * (1.0f / 3);
                 atPos.y = (atTrisElem->dim.vtx[0].y + atTrisElem->dim.vtx[1].y + atTrisElem->dim.vtx[2].y) * (1.0f / 3);
                 atPos.z = (atTrisElem->dim.vtx[0].z + atTrisElem->dim.vtx[1].z + atTrisElem->dim.vtx[2].z) * (1.0f / 3);
@@ -2512,11 +2522,11 @@ void CollisionCheck_ATQuadVsACQuad(PlayState* play, CollisionCheckContext* colCh
 void CollisionCheck_SetJntSphHitFX(PlayState* play, CollisionCheckContext* colChkCtx, Collider* col) {
     ColliderJntSph* jntSph = (ColliderJntSph*)col;
     ColliderJntSphElement* jntSphElem;
-    Vec3f hitPos;
 
     for (jntSphElem = jntSph->elements; jntSphElem < jntSph->elements + jntSph->count; jntSphElem++) {
         if ((jntSphElem->base.bumperFlags & BUMP_DRAW_HITMARK) && (jntSphElem->base.acHitElem != NULL) &&
             !(jntSphElem->base.acHitElem->toucherFlags & TOUCH_DREW_HITMARK)) {
+            Vec3f hitPos;
             Math_Vec3s_ToVec3f(&hitPos, &jntSphElem->base.bumper.hitPos);
             CollisionCheck_HitEffects(play, jntSphElem->base.acHit, jntSphElem->base.acHitElem, &jntSph->base,
                                       &jntSphElem->base, &hitPos);
@@ -2528,10 +2538,10 @@ void CollisionCheck_SetJntSphHitFX(PlayState* play, CollisionCheckContext* colCh
 
 void CollisionCheck_SetCylHitFX(PlayState* play, CollisionCheckContext* colChkCtx, Collider* col) {
     ColliderCylinder* cyl = (ColliderCylinder*)col;
-    Vec3f hitPos;
 
     if ((cyl->elem.bumperFlags & BUMP_DRAW_HITMARK) && (cyl->elem.acHitElem != NULL) &&
         !(cyl->elem.acHitElem->toucherFlags & TOUCH_DREW_HITMARK)) {
+        Vec3f hitPos;
         Math_Vec3s_ToVec3f(&hitPos, &cyl->elem.bumper.hitPos);
         CollisionCheck_HitEffects(play, cyl->elem.acHit, cyl->elem.acHitElem, &cyl->base, &cyl->elem, &hitPos);
         cyl->elem.acHitElem->toucherFlags |= TOUCH_DREW_HITMARK;
@@ -2541,11 +2551,11 @@ void CollisionCheck_SetCylHitFX(PlayState* play, CollisionCheckContext* colChkCt
 void CollisionCheck_SetTrisHitFX(PlayState* play, CollisionCheckContext* colChkCtx, Collider* col) {
     ColliderTris* tris = (ColliderTris*)col;
     ColliderTrisElement* trisElem;
-    Vec3f hitPos;
 
     for (trisElem = tris->elements; trisElem < tris->elements + tris->count; trisElem++) {
         if ((trisElem->base.bumperFlags & BUMP_DRAW_HITMARK) && (trisElem->base.acHitElem != NULL) &&
             !(trisElem->base.acHitElem->toucherFlags & TOUCH_DREW_HITMARK)) {
+            Vec3f hitPos;
             Math_Vec3s_ToVec3f(&hitPos, &trisElem->base.bumper.hitPos);
             CollisionCheck_HitEffects(play, trisElem->base.acHit, trisElem->base.acHitElem, &tris->base,
                                       &trisElem->base, &hitPos);
@@ -3689,6 +3699,8 @@ u8 CollisionCheck_GetSwordDamage(s32 dmgFlags) {
         damage = 8;
     }
 
+#ifdef OOT_DEBUG
     KREG(7) = damage;
+#endif
     return damage;
 }

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -72,7 +72,7 @@ void Collider_DrawPoly(GraphicsContext* gfxCtx, Vec3f* vA, Vec3f* vB, Vec3f* vC,
     CLOSE_DISPS(gfxCtx, "../z_collision_check.c", 757);
 }
 
-#endif /* OOT_DEBUG */
+#endif
 
 s32 Collider_InitBase(PlayState* play, Collider* col) {
     static Collider init = {
@@ -1139,7 +1139,7 @@ void CollisionCheck_DrawCollision(PlayState* play, CollisionCheckContext* colChk
     }
 }
 
-#endif /* OOT_DEBUG */
+#endif
 
 static ColChkResetFunc sATResetFuncs[] = {
     Collider_ResetJntSphAT,

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -8,7 +8,6 @@ typedef void (*ColChkVsFunc)(PlayState*, CollisionCheckContext*, Collider*, Coll
 typedef s32 (*ColChkLineFunc)(PlayState*, CollisionCheckContext*, Collider*, Vec3f*, Vec3f*);
 
 #ifdef OOT_DEBUG
-
 /**
  * Draws a red triangle with vertices vA, vB, and vC.
  */
@@ -1059,7 +1058,6 @@ void CollisionCheck_DisableSAC(PlayState* play, CollisionCheckContext* colChkCtx
 }
 
 #ifdef OOT_DEBUG
-
 /**
  * Draws a collider of any shape.
  * Math3D_DrawSphere and Math3D_DrawCylinder are noops, so JntSph and Cylinder are not drawn.
@@ -1138,7 +1136,6 @@ void CollisionCheck_DrawCollision(PlayState* play, CollisionCheckContext* colChk
         }
     }
 }
-
 #endif
 
 static ColChkResetFunc sATResetFuncs[] = {

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -70,7 +70,6 @@ void Collider_DrawPoly(GraphicsContext* gfxCtx, Vec3f* vA, Vec3f* vB, Vec3f* vC,
 
     CLOSE_DISPS(gfxCtx, "../z_collision_check.c", 757);
 }
-
 #endif
 
 s32 Collider_InitBase(PlayState* play, Collider* col) {
@@ -1003,6 +1002,7 @@ s32 Collider_ResetLineOC(PlayState* play, OcLine* line) {
 void CollisionCheck_InitContext(PlayState* play, CollisionCheckContext* colChkCtx) {
     colChkCtx->sacFlags = 0;
     CollisionCheck_ClearContext(play, colChkCtx);
+
 #ifdef OOT_DEBUG
     AREG(21) = true;
     AREG(22) = true;
@@ -2176,6 +2176,7 @@ void CollisionCheck_ATTrisVsACCyl(PlayState* play, CollisionCheckContext* colChk
             if (Math3D_CylTriVsIntersect(&acCyl->dim, &atTrisElem->dim, &hitPos) == true) {
                 Vec3f atPos;
                 Vec3f acPos;
+
                 atPos.x = (atTrisElem->dim.vtx[0].x + atTrisElem->dim.vtx[1].x + atTrisElem->dim.vtx[2].x) * (1.0f / 3);
                 atPos.y = (atTrisElem->dim.vtx[0].y + atTrisElem->dim.vtx[1].y + atTrisElem->dim.vtx[2].y) * (1.0f / 3);
                 atPos.z = (atTrisElem->dim.vtx[0].z + atTrisElem->dim.vtx[1].z + atTrisElem->dim.vtx[2].z) * (1.0f / 3);
@@ -2524,6 +2525,7 @@ void CollisionCheck_SetJntSphHitFX(PlayState* play, CollisionCheckContext* colCh
         if ((jntSphElem->base.bumperFlags & BUMP_DRAW_HITMARK) && (jntSphElem->base.acHitElem != NULL) &&
             !(jntSphElem->base.acHitElem->toucherFlags & TOUCH_DREW_HITMARK)) {
             Vec3f hitPos;
+
             Math_Vec3s_ToVec3f(&hitPos, &jntSphElem->base.bumper.hitPos);
             CollisionCheck_HitEffects(play, jntSphElem->base.acHit, jntSphElem->base.acHitElem, &jntSph->base,
                                       &jntSphElem->base, &hitPos);
@@ -2539,6 +2541,7 @@ void CollisionCheck_SetCylHitFX(PlayState* play, CollisionCheckContext* colChkCt
     if ((cyl->elem.bumperFlags & BUMP_DRAW_HITMARK) && (cyl->elem.acHitElem != NULL) &&
         !(cyl->elem.acHitElem->toucherFlags & TOUCH_DREW_HITMARK)) {
         Vec3f hitPos;
+
         Math_Vec3s_ToVec3f(&hitPos, &cyl->elem.bumper.hitPos);
         CollisionCheck_HitEffects(play, cyl->elem.acHit, cyl->elem.acHitElem, &cyl->base, &cyl->elem, &hitPos);
         cyl->elem.acHitElem->toucherFlags |= TOUCH_DREW_HITMARK;
@@ -2553,6 +2556,7 @@ void CollisionCheck_SetTrisHitFX(PlayState* play, CollisionCheckContext* colChkC
         if ((trisElem->base.bumperFlags & BUMP_DRAW_HITMARK) && (trisElem->base.acHitElem != NULL) &&
             !(trisElem->base.acHitElem->toucherFlags & TOUCH_DREW_HITMARK)) {
             Vec3f hitPos;
+
             Math_Vec3s_ToVec3f(&hitPos, &trisElem->base.bumper.hitPos);
             CollisionCheck_HitEffects(play, trisElem->base.acHit, trisElem->base.acHitElem, &tris->base,
                                       &trisElem->base, &hitPos);
@@ -3699,5 +3703,6 @@ u8 CollisionCheck_GetSwordDamage(s32 dmgFlags) {
 #ifdef OOT_DEBUG
     KREG(7) = damage;
 #endif
+
     return damage;
 }


### PR DESCRIPTION
These functions were removed in retail:
```
Collider_DrawRedPoly
Collider_DrawPoly
Collider_Draw
CollisionCheck_DrawCollision
```

Some of these functions were used in other places, so I had to remove those calls. The z_bgcheck.c changes are probably correct, while the z_actor.c one will have to be cleaned up by whoever does that file.