### PR TITLE
idle.c OK

### DIFF
--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -56,6 +56,9 @@ void Idle_ThreadEntry(void* arg) {
     gViConfigYScale = 1.0f;
 
     switch (osTvType) {
+#ifndef OOT_DEBUG
+        case OS_TV_PAL:
+#endif
         case OS_TV_NTSC:
             gViConfigModeType = OS_VI_NTSC_LAN1;
             gViConfigMode = osViModeNtscLan1;
@@ -66,11 +69,13 @@ void Idle_ThreadEntry(void* arg) {
             gViConfigMode = osViModeMpalLan1;
             break;
 
+#ifdef OOT_DEBUG
         case OS_TV_PAL:
             gViConfigModeType = OS_VI_FPAL_LAN1;
             gViConfigMode = osViModeFpalLan1;
             gViConfigYScale = 0.833f;
             break;
+#endif
     }
 
     D_80009430 = 1;
@@ -84,7 +89,5 @@ void Idle_ThreadEntry(void* arg) {
     osStartThread(&gMainThread);
     osSetThreadPri(NULL, OS_PRIORITY_IDLE);
 
-    while (1) {
-        ;
-    }
+    for (;;) {}
 }


### PR DESCRIPTION
I admit I don't really understand this. It looks like there's no reference here to `osViModeFpalLan1` in NTSC 1.0 either, so this might actually be a debug vs retail change, but maybe this will be clearer once we decomp other retail versions