### PR TITLE
Move roms to build folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,11 @@ DISASM_FLAGS += --config-dir $(DISASM_DATA_DIR) --symbol-addrs $(DISASM_DATA_DIR
 #### Files ####
 
 # ROM image
-ROMC := oot-$(VERSION)-compressed.z64
-ROM := oot-$(VERSION).z64
-ELF := $(ROM:.z64=.elf)
+ROM      := $(BUILD_DIR)/oot-$(VERSION).z64
+ROMC     := $(ROM:.z64=-compressed.z64)
+ELF      := $(ROM:.z64=.elf)
+MAP      := $(ROM:.z64=.map)
+LDSCRIPT := $(ROM:.z64=.ld)
 # description of ROM segments
 SPEC := spec
 
@@ -299,7 +301,7 @@ ifneq ($(COMPARE),0)
 endif
 
 clean:
-	$(RM) -r $(ROMC) $(ROM) $(ELF) $(BUILD_DIR)
+	$(RM) -r $(BUILD_DIR)
 
 assetclean:
 	$(RM) -r $(ASSET_BIN_DIRS)
@@ -349,8 +351,8 @@ $(ROMC): $(ROM) $(ELF) $(BUILD_DIR)/compress_ranges.txt
 	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dma-range `./tools/dmadata_range.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` --threads $(N_THREADS)
 	$(PYTHON) -m ipl3checksum sum --cic 6105 --update $@
 
-$(ELF): $(TEXTURE_FILES_OUT) $(ASSET_FILES_OUT) $(O_FILES) $(OVL_RELOC_FILES) $(BUILD_DIR)/ldscript.txt $(BUILD_DIR)/undefined_syms.txt
-	$(LD) -T $(BUILD_DIR)/undefined_syms.txt -T $(BUILD_DIR)/ldscript.txt --no-check-sections --accept-unknown-input-arch --emit-relocs -Map $(BUILD_DIR)/z64.map -o $@
+$(ELF): $(TEXTURE_FILES_OUT) $(ASSET_FILES_OUT) $(O_FILES) $(OVL_RELOC_FILES) $(LDSCRIPT) $(BUILD_DIR)/undefined_syms.txt
+	$(LD) -T $(LDSCRIPT) -T $(BUILD_DIR)/undefined_syms.txt --no-check-sections --accept-unknown-input-arch --emit-relocs -Map $(MAP) -o $@
 
 ## Order-only prerequisites
 # These ensure e.g. the O_FILES are built before the OVL_RELOC_FILES.
@@ -367,7 +369,7 @@ $(O_FILES): | asset_files
 $(BUILD_DIR)/$(SPEC): $(SPEC)
 	$(CPP) $(CPPFLAGS) $< | $(SPEC_REPLACE_VARS) > $@
 
-$(BUILD_DIR)/ldscript.txt: $(BUILD_DIR)/$(SPEC)
+$(LDSCRIPT): $(BUILD_DIR)/$(SPEC)
 	$(MKLDSCRIPT) $< $@
 
 $(BUILD_DIR)/undefined_syms.txt: undefined_syms.txt

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Make sure your path to the project is not too long, otherwise this process may e
 make
 ```
 
-If all goes well, a new ROM called "oot-gc-eu-mq-dbg.z64", located in build/gc-eu-mq-dbg/, should be built and the following text printed:
+If all goes well, a new ROM should be built at `build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.z64`, and the following text printed:
 
 ```bash
 build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.z64: OK

--- a/README.md
+++ b/README.md
@@ -127,16 +127,16 @@ Make sure your path to the project is not too long, otherwise this process may e
 make
 ```
 
-If all goes well, a new ROM called "oot-gc-eu-mq-dbg.z64" should be built and the following text should be printed:
+If all goes well, a new ROM called "oot-gc-eu-mq-dbg.z64", located in build/gc-eu-mq-dbg/, should be built and the following text printed:
 
 ```bash
-oot-gc-eu-mq-dbg.z64: OK
+build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.z64: OK
 ```
 
 If you instead see the following:
 
 ```bash
-oot-gc-eu-mq-dbg.z64: FAILED
+build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.z64: FAILED
 md5sum: WARNING: 1 computed checksum did NOT match
 ```
 

--- a/baseroms/gc-eu-mq-dbg/checksum-compressed.md5
+++ b/baseroms/gc-eu-mq-dbg/checksum-compressed.md5
@@ -1,1 +1,1 @@
-5831385a7f216370cdbea55616b12fed  oot-gc-eu-mq-dbg-compressed.z64
+5831385a7f216370cdbea55616b12fed  build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg-compressed.z64

--- a/baseroms/gc-eu-mq-dbg/checksum.md5
+++ b/baseroms/gc-eu-mq-dbg/checksum.md5
@@ -1,1 +1,1 @@
-f0b7f35375f9cc8ca1b2d59d78e35405  oot-gc-eu-mq-dbg.z64
+f0b7f35375f9cc8ca1b2d59d78e35405  build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.z64

--- a/baseroms/gc-eu-mq/checksum-compressed.md5
+++ b/baseroms/gc-eu-mq/checksum-compressed.md5
@@ -1,1 +1,1 @@
-1618403427e4344a57833043db5ce3c3  oot-gc-eu-mq-compressed.z64
+1618403427e4344a57833043db5ce3c3  build/gc-eu-mq/oot-gc-eu-mq-compressed.z64

--- a/baseroms/gc-eu-mq/checksum.md5
+++ b/baseroms/gc-eu-mq/checksum.md5
@@ -1,1 +1,1 @@
-1a438f4235f8038856971c14a798122a  oot-gc-eu-mq.z64
+1a438f4235f8038856971c14a798122a  build/gc-eu-mq/oot-gc-eu-mq.z64

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -3,8 +3,8 @@ def add_custom_arguments(parser):
 
 def apply(config, args):
     version = args.oot_version
-    config['mapfile'] = f'build/{version}/z64.map'
-    config['myimg'] = f'oot-{version}.z64'
+    config['mapfile'] = f'build/{version}/oot-{version}.map'
+    config['myimg'] = f'build/{version}/oot-{version}.z64'
     config['baseimg'] = f'baseroms/{version}/baserom-decompressed.z64'
     config['makeflags'] = [f'VERSION={version}']
     config['source_directories'] = ['src', 'include', 'spec']

--- a/docs/retail_versions.md
+++ b/docs/retail_versions.md
@@ -52,7 +52,7 @@ possible.
     ```
 
     where `N` is the number of cores on your machine. This will build into
-    `build/gc-eu-mq` and produce `oot-gc-eu-mq.z64`.
+    `build/gc-eu-mq` and produce `build/gc-eu-mq/oot-gc-eu-mq.z64`.
 
     If you later want to delete all output files, run
 

--- a/docs/tutorial/data.md
+++ b/docs/tutorial/data.md
@@ -601,7 +601,7 @@ Bytes: 27:BD:FF:E8 vs 8F:B0:00:34
 
 Over 1000 differing words, must be a shifted ROM.
 Map appears to have shifted just before D_80A88D40 (build/data/overlays/actors/z_en_jj.reloc.o) -- in unused?
-(Base map file expected/build/oot-gc-eu-mq-dbg.map out of date due to new or renamed symbols, so result may be imprecise.)
+(Base map file expected/build/z64.map out of date due to new or renamed symbols, so result may be imprecise.)
 ```
 We've managed to get rid of one issue, but there's still another one. Looking in vbindiff again,
 

--- a/docs/tutorial/data.md
+++ b/docs/tutorial/data.md
@@ -601,7 +601,7 @@ Bytes: 27:BD:FF:E8 vs 8F:B0:00:34
 
 Over 1000 differing words, must be a shifted ROM.
 Map appears to have shifted just before D_80A88D40 (build/data/overlays/actors/z_en_jj.reloc.o) -- in unused?
-(Base map file expected/build/z64.map out of date due to new or renamed symbols, so result may be imprecise.)
+(Base map file expected/build/oot-gc-eu-mq-dbg.map out of date due to new or renamed symbols, so result may be imprecise.)
 ```
 We've managed to get rid of one issue, but there's still another one. Looking in vbindiff again,
 

--- a/first_diff.py
+++ b/first_diff.py
@@ -37,8 +37,8 @@ def firstDiffMain():
 
     buildFolder = Path("build") / args.oot_version
 
-    BUILTROM = Path(f"oot-{args.oot_version}.z64")
-    BUILTMAP = buildFolder / "z64.map"
+    BUILTROM = buildFolder / f"oot-{args.oot_version}.z64"
+    BUILTMAP = buildFolder / f"oot-{args.oot_version}.map"
 
     EXPECTEDROM = Path(f"baseroms/{args.oot_version}/baserom-decompressed.z64")
     EXPECTEDMAP = "expected" / BUILTMAP

--- a/progress.py
+++ b/progress.py
@@ -61,7 +61,7 @@ def IsCFile(objfile):
     srcfile = objfile.strip().replace("build/gc-eu-mq-dbg/", "").replace(".o", ".c")
     return os.path.isfile(srcfile)
 
-mapFile = ReadAllLines("build/gc-eu-mq-dbg/z64.map")
+mapFile = ReadAllLines("build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.map")
 curSegment = None
 src = 0
 code = 0

--- a/sym_info.py
+++ b/sym_info.py
@@ -14,7 +14,7 @@ def symInfoMain():
 
     args = parser.parse_args()
 
-    BUILTMAP = Path("build") / args.oot_version / "oot-gc-eu-mq-dbg.map"
+    BUILTMAP = Path("build") / args.oot_version / f"oot-{args.oot_version}.map"
 
     mapPath = BUILTMAP
     if args.use_expected:

--- a/sym_info.py
+++ b/sym_info.py
@@ -14,7 +14,7 @@ def symInfoMain():
 
     args = parser.parse_args()
 
-    BUILTMAP = Path("build") / args.oot_version / "z64.map"
+    BUILTMAP = Path("build") / args.oot_version / "oot-gc-eu-mq-dbg.map"
 
     mapPath = BUILTMAP
     if args.use_expected:

--- a/tools/assist.py
+++ b/tools/assist.py
@@ -162,7 +162,7 @@ parser.add_argument("--num-out", help="number of functions to display", type=int
 args = parser.parse_args()
 
 rom_bytes = read_rom()
-map_syms = parse_map(build_dir + "z64.map")
+map_syms = parse_map(build_dir + "oot-gc-eu-mq-dbg.map")
 map_offsets = get_map_offsets(map_syms)
 
 s_files = get_all_s_files()


### PR DESCRIPTION
This changes things so the built roms end up in the build folder instead.

At the same time also renames the map and linkerscript to match the generated rom name but with a different file extension.