### PR TITLE
Check formatting in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,11 +65,9 @@ pipeline {
         failure {
             sh 'cat tools/check_format.txt'
         }
-        always {
+        cleanup {
             echo "Finished, deleting directory."
             deleteDir()
-        }
-        cleanup {
             echo "Clean up in post."
             cleanWs(cleanWhenNotBuilt: false,
                     deleteDirs: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         stage('Check formatting') {
             steps {
                 echo 'Checking formatting...'
-                sh 'bash -c "tools/check_format.sh 2>&1 >(tee tools/check_format.txt)"'
+                sh 'tools/check_format.sh'
             }
         }
         stage('Setup') {
@@ -62,9 +62,6 @@ pipeline {
         }
     }
     post {
-        failure {
-            sh 'cat tools/check_format.txt'
-        }
         always {
             echo "Finished, deleting directory."
             deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,12 @@ pipeline {
     }
 
     stages {
+        stage('Check formatting') {
+            steps {
+                echo 'Checking formatting...'
+                sh 'bash -c "tools/check_format.sh 2>&1 >(tee tools/check_format.txt)"'
+            }
+        }
         stage('Setup') {
             steps {
                 sh 'cp /usr/local/etc/roms/baserom_oot.z64 baseroms/gc-eu-mq-dbg/baserom.z64'
@@ -56,6 +62,9 @@ pipeline {
         }
     }
     post {
+        failure {
+            sh 'cat tools/check_format.txt'
+        }
         always {
             echo "Finished, deleting directory."
             deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,9 +65,11 @@ pipeline {
         failure {
             sh 'cat tools/check_format.txt'
         }
-        cleanup {
+        always {
             echo "Finished, deleting directory."
             deleteDir()
+        }
+        cleanup {
             echo "Clean up in post."
             cleanWs(cleanWhenNotBuilt: false,
                     deleteDirs: true,

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -54,7 +54,7 @@ void Main(void* arg) {
     // "System heap initalization"
     PRINTF("システムヒープ初期化 %08x-%08x %08x\n", systemHeapStart, fb, gSystemHeapSize);
     SystemHeap_Init((void*)systemHeapStart, gSystemHeapSize); // initializes the system heap
-    
+
 #ifdef OOT_DEBUG
     {
         void* debugHeapStart;
@@ -67,7 +67,7 @@ void Main(void* arg) {
             debugHeapSize = 0x400;
             debugHeapStart = SYSTEM_ARENA_MALLOC(debugHeapSize, "../main.c", 565);
         }
-        
+
         PRINTF("debug_InitArena(%08x, %08x)\n", debugHeapStart, debugHeapSize);
         DebugArena_Init(debugHeapStart, debugHeapSize);
     }

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+STATUSOLD=`git status --porcelain`
+./format.py -j
+if [ $? -ne 0 ]
+then
+   echo "Formatter failed. Exiting."
+   exit -1
+fi
+STATUSNEW=`git status --porcelain`
+
+if [ "${STATUSOLD}" != "${STATUSNEW}" ];
+then
+    echo ""
+    echo "Misformatted files found. Run ./format.py and verify codegen is not impacted."
+    echo ""
+    diff --unified=0  --label "Old git status" <(echo "${STATUSOLD}") --label "New git status" <(echo "${STATUSNEW}")
+    echo ""
+    echo "Exiting."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
`check_format.sh` is lifted directly from MM. Hopefully this will prevent random unrelated style changes in PRs. The downside is that this adds 21s to every build, and requires all contributors to set up clang-format 14 (which may not be trivial).

Example output:

```
[Pipeline] echo
Checking formatting...
[Pipeline] sh
+ tools/check_format.sh
Formatting files with 4 jobs
Running clang-format...
Running clang-tidy...
Adding missing final new lines...
Done formatting files.

Misformatted files found. Run ./format.py and verify codegen is not impacted.

--- Old git status
+++ New git status
@@ -0,0 +1 @@
+ M src/code/main.c

Exiting.
```