### PR TITLE
Move __osPfsInodeCache and __osPfsPifRam

### DIFF
--- a/src/libultra/io/contpfs.c
+++ b/src/libultra/io/contpfs.c
@@ -4,6 +4,8 @@
 s32 __osPfsInodeCacheChannel = -1;
 u8 __osPfsInodeCacheBank = 250;
 
+__OSInode __osPfsInodeCache;
+
 u16 __osSumcalc(u8* ptr, s32 length) {
     s32 i;
     u32 sum = 0;

--- a/src/libultra/io/pfsgetstatus.c
+++ b/src/libultra/io/pfsgetstatus.c
@@ -1,6 +1,7 @@
 #include "ultra64.h"
 #include "global.h"
 
+__OSInode __osPfsInodeCache;
 OSPifRam __osPfsPifRam;
 
 s32 __osPfsGetStatus(OSMesgQueue* queue, s32 channel) {

--- a/src/libultra/io/pfsgetstatus.c
+++ b/src/libultra/io/pfsgetstatus.c
@@ -1,9 +1,6 @@
 #include "ultra64.h"
 #include "global.h"
 
-__OSInode __osPfsInodeCache;
-OSPifRam __osPfsPifRam;
-
 s32 __osPfsGetStatus(OSMesgQueue* queue, s32 channel) {
     s32 ret = 0;
     OSMesg msg;

--- a/src/libultra/io/pfsisplug.c
+++ b/src/libultra/io/pfsisplug.c
@@ -1,6 +1,8 @@
 #include "ultra64.h"
 #include "global.h"
 
+OSPifRam __osPfsPifRam;
+
 s32 osPfsIsPlug(OSMesgQueue* mq, u8* pattern) {
     s32 ret = 0;
     OSMesg msg;

--- a/src/libultra/io/pfsreadwritefile.c
+++ b/src/libultra/io/pfsreadwritefile.c
@@ -5,8 +5,6 @@
     (((p).ipage >= (pfs).inodeStartPage) && ((p).inode_t.bank < (pfs).banks) && ((p).inode_t.page >= 0x01) && \
      ((p).inode_t.page < 0x80))
 
-__OSInode __osPfsInodeCache;
-
 s32 __osPfsGetNextPage(OSPfs* pfs, u8* bank, __OSInode* inode, __OSInodeUnit* page) {
     s32 ret;
 

--- a/tools/disasm/gc-eu-mq/files_code.csv
+++ b/tools/disasm/gc-eu-mq/files_code.csv
@@ -457,7 +457,6 @@ offset,vram,.bss
 1195F0,8012A4F0,src/libultra/io/motor.s
 1196F0,8012A5F0,src/libultra/io/siacs.s
 119710,8012A610,src/libultra/io/controller.s
-1197A0,8012A6A0,src/libultra/io/pfsreadwritefile.s
-1198A0,8012A7A0,src/libultra/io/pfsgetstatus.s
+1197A0,8012A6A0,src/libultra/io/pfsgetstatus.s
 1198E0,8012A7E0,src/code/z_message_PAL.s
 119900,8012A800,.end

--- a/tools/disasm/gc-eu-mq/files_code.csv
+++ b/tools/disasm/gc-eu-mq/files_code.csv
@@ -457,6 +457,7 @@ offset,vram,.bss
 1195F0,8012A4F0,src/libultra/io/motor.s
 1196F0,8012A5F0,src/libultra/io/siacs.s
 119710,8012A610,src/libultra/io/controller.s
-1197A0,8012A6A0,src/libultra/io/pfsgetstatus.s
+1197A0,8012A6A0,src/libultra/io/contpfs.s
+1198A0,8012A7A0,src/libultra/io/pfsisplug.s
 1198E0,8012A7E0,src/code/z_message_PAL.s
 119900,8012A800,.end


### PR DESCRIPTION
In retail, `__osPfsInodeCache` is present (currently in `pfsreadwritefile.c` BSS) but none of the functions in `pfsreadwritefile.c` are present. This is strange because it seems like all of the other pfs* files are either entirely present or entirely removed. ~~I think it makes sense to put `__osPfsInodeCache` in `pfsgetstatus.c` instead, because `pfsgetstatus.c` already has `__osPfsPifRam` which is also used in many pfs-related files.~~ (edit: see @hensldm's comment below on where to put these)