### PR TITLE
Match stackcheck.c and code_800FC620.c

### DIFF
--- a/src/boot/stackcheck.c
+++ b/src/boot/stackcheck.c
@@ -102,9 +102,11 @@ u32 StackCheck_GetState(StackEntry* entry) {
            entry->name != NULL ? entry->name : "(null)");
     PRINTF(VT_RST);
 
+#ifdef OOT_DEBUG
     if (ret != STACK_STATUS_OK) {
         LogUtils_LogHexDump(entry->head, (uintptr_t)entry->tail - (uintptr_t)entry->head);
     }
+#endif
 
     return ret;
 }

--- a/src/code/code_800FC620.c
+++ b/src/code/code_800FC620.c
@@ -26,7 +26,11 @@ void* func_800FC800(u32 size) {
         size = 1;
     }
 
+#ifdef OOT_DEBUG
     return __osMallocDebug(&gSystemArena, size, sNew, 0);
+#else
+    return __osMalloc(&gSystemArena, size);
+#endif
 }
 
 // possibly some kind of delete() function


### PR DESCRIPTION
Is it worth making a debug macro for __osMalloc? This is the only place it would be used