### PR TITLE
Overlay_Relocate and Overlay_Load retail OK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ $(BUILD_DIR)/src/code/code_800FD970.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/gfxprint.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/jpegutils.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/jpegdecoder.o: OPTFLAGS := -O2
+$(BUILD_DIR)/src/code/load.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/loadfragment2.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/logutils.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/mtxuty-cvt.o: OPTFLAGS := -O2

--- a/include/functions.h
+++ b/include/functions.h
@@ -1718,7 +1718,7 @@ void* Overlay_AllocateAndLoad(uintptr_t vromStart, uintptr_t vromEnd, void* vram
 void MtxConv_F2L(Mtx* m1, MtxF* m2);
 void MtxConv_L2F(MtxF* m1, Mtx* m2);
 void Overlay_Relocate(void* allocatedRamAddress, OverlayRelocationSection* ovlRelocs, void* vramStart);
-s32 Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* vramStart, void* vramEnd, void* allocatedRamAddr);
+size_t Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* vramStart, void* vramEnd, void* allocatedRamAddr);
 // ? func_800FC800(?);
 // ? func_800FC83C(?);
 // ? func_800FCAB4(?);

--- a/include/functions.h
+++ b/include/functions.h
@@ -1717,7 +1717,7 @@ void RcpUtils_Reset(void);
 void* Overlay_AllocateAndLoad(uintptr_t vromStart, uintptr_t vromEnd, void* vramStart, void* vramEnd);
 void MtxConv_F2L(Mtx* m1, MtxF* m2);
 void MtxConv_L2F(MtxF* m1, Mtx* m2);
-void Overlay_Relocate(void* allocatedRamAddress, OverlayRelocationSection* ovlRelocs, void* vramStart);
+void Overlay_Relocate(void* allocatedRamAddr, OverlayRelocationSection* ovlRelocs, void* vramStart);
 size_t Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* vramStart, void* vramEnd, void* allocatedRamAddr);
 // ? func_800FC800(?);
 // ? func_800FC83C(?);

--- a/include/ultra64/libc.h
+++ b/include/ultra64/libc.h
@@ -5,7 +5,7 @@
 
 void osSyncPrintf(const char* fmt, ...);
 
-void bzero(void* __s, size_t __n);
+void bzero(void* __s, int __n);
 int bcmp(const void* __sl, const void* __s2, size_t __n);
 void bcopy(const void* __src, void* __dest, size_t __n);
 

--- a/include/ultra64/libc.h
+++ b/include/ultra64/libc.h
@@ -6,7 +6,7 @@
 void osSyncPrintf(const char* fmt, ...);
 
 void bzero(void* __s, int __n);
-int bcmp(const void* __sl, const void* __s2, size_t __n);
-void bcopy(const void* __src, void* __dest, size_t __n);
+int bcmp(const void* __sl, const void* __s2, int __n);
+void bcopy(const void* __src, void* __dest, int __n);
 
 #endif

--- a/src/code/load.c
+++ b/src/code/load.c
@@ -1,13 +1,13 @@
 #include "global.h"
 
-s32 Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* vramStart, void* vramEnd, void* allocatedRamAddr) {
+size_t Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* vramStart, void* vramEnd, void* allocatedRamAddr) {
     s32 pad[3];
     uintptr_t end;
     OverlayRelocationSection* ovlRelocs;
     u32 relocSectionOffset;
-    size_t size;
+    s32 size = vromEnd - vromStart;
 
-    size = vromEnd - vromStart;
+    relocSectionOffset = gOverlayLogSeverity;
     end = (uintptr_t)allocatedRamAddr + size;
 
     if (gOverlayLogSeverity >= 3) {
@@ -46,10 +46,10 @@ s32 Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* vramStart, void* 
             // "Clear BSS area (% 08x-% 08x)"
             PRINTF("BSS領域をクリアします(%08x-%08x)\n", end, end + ovlRelocs->bssSize);
         }
-        bzero((void*)end, (s32)ovlRelocs->bssSize);
+        bzero((void*)end, ovlRelocs->bssSize);
     }
 
-    size = (uintptr_t)&ovlRelocs->relocations[ovlRelocs->nRelocations] - (uintptr_t)ovlRelocs;
+    size = (uintptr_t)(ovlRelocs->relocations + ovlRelocs->nRelocations) - (uintptr_t)ovlRelocs;
 
     if (gOverlayLogSeverity >= 3) {
         // "Clear REL area (%08x-%08x)"

--- a/src/code/load.c
+++ b/src/code/load.c
@@ -4,16 +4,16 @@ size_t Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* vramStart, voi
     s32 pad[3];
     uintptr_t end;
     OverlayRelocationSection* ovlRelocs;
-    u32 relocSectionOffset;
+    u32 relocSectionOffset = 0;
     s32 size = vromEnd - vromStart;
-
-    relocSectionOffset = gOverlayLogSeverity;
-    end = (uintptr_t)allocatedRamAddr + size;
 
     if (gOverlayLogSeverity >= 3) {
         // "Start loading dynamic link function"
         PRINTF("\nダイナミックリンクファンクションのロードを開始します\n");
     }
+
+    size = vromEnd - vromStart;
+    end = (uintptr_t)allocatedRamAddr + size;
 
     if (gOverlayLogSeverity >= 3) {
         // "DMA transfer of TEXT, DATA, RODATA + rel (%08x-%08x)"
@@ -68,5 +68,6 @@ size_t Overlay_Load(uintptr_t vromStart, uintptr_t vromEnd, void* vramStart, voi
         // "Finish loading dynamic link function"
         PRINTF("ダイナミックリンクファンクションのロードを終了します\n\n");
     }
+
     return size;
 }

--- a/src/code/relocation.c
+++ b/src/code/relocation.c
@@ -33,19 +33,19 @@
  *  - [29:24]  6-bit relocation type describing which relocation operation should be performed. Same as ELF32 MIPS.
  *  - [23: 0]  24-bit section-relative offset indicating where in the section to apply this relocation.
  *
- * @param allocatedRamAddress Memory address the binary was loaded at.
+ * @param allocatedRamAddr Memory address the binary was loaded at.
  * @param ovlRelocs Overlay relocation section containing overlay section layout and runtime relocations.
  * @param vramStart Virtual RAM address that the overlay was compiled at.
  */
-void Overlay_Relocate(void* allocatedRamAddress, OverlayRelocationSection* ovlRelocs, void* vramStart) {
+void Overlay_Relocate(void* allocatedRamAddr, OverlayRelocationSection* ovlRelocs, void* vramStart) {
     uintptr_t sections[RELOC_SECTION_MAX];
-    u32 relocatedValue;
-    u32 dbg;
-    u32 relocOffset;
-    u32 relocData;
-    uintptr_t unrelocatedAddress;
-    u32 i;
     u32* relocDataP;
+    u32 reloc;
+    u32 relocData;
+    u32 isLoNeg;
+    uintptr_t allocu32 = (uintptr_t)allocatedRamAddr;
+    u32 i;
+    u32* regValP;
     //! MIPS ELF relocation does not generally require tracking register values, so at first glance it appears this
     //! register tracking was an unnecessary complication. However there is a bug in the IDO compiler that can cause
     //! relocations to be emitted in the wrong order under rare circumstances when the compiler attempts to reuse a
@@ -54,21 +54,16 @@ void Overlay_Relocate(void* allocatedRamAddress, OverlayRelocationSection* ovlRe
     //! due to the incorrect ordering.
     u32* luiRefs[32];
     u32 luiVals[32];
-    uintptr_t relocatedAddress;
-    u32 reloc;
     u32* luiInstRef;
-    uintptr_t allocu32 = (uintptr_t)allocatedRamAddress;
-    u32* regValP;
-    u32 isLoNeg;
+    u32 dbg;
+    s32 relocOffset = 0;
+    u32 relocatedValue = 0;
+    uintptr_t unrelocatedAddress = 0;
+    uintptr_t relocatedAddress = 0;
     s32 pad;
 
-    relocOffset = 0;
-    relocatedValue = 0;
-    unrelocatedAddress = 0;
-    relocatedAddress = 0;
-
     if (gOverlayLogSeverity >= 3) {
-        PRINTF("DoRelocation(%08x, %08x, %08x)\n", allocatedRamAddress, ovlRelocs, vramStart);
+        PRINTF("DoRelocation(%08x, %08x, %08x)\n", allocatedRamAddr, ovlRelocs, vramStart);
         PRINTF("text=%08x, data=%08x, rodata=%08x, bss=%08x\n", ovlRelocs->textSize, ovlRelocs->dataSize,
                ovlRelocs->rodataSize, ovlRelocs->bssSize);
     }
@@ -105,12 +100,13 @@ void Overlay_Relocate(void* allocatedRamAddress, OverlayRelocationSection* ovlRe
                 // Handles 26-bit address relocation, used for jumps and jals.
                 // Extract the address from the target field of the J-type MIPS instruction.
                 // Relocate the address and update the instruction.
-
-                unrelocatedAddress = PHYS_TO_K0(MIPS_JUMP_TARGET(*relocDataP));
-                relocOffset = unrelocatedAddress - (uintptr_t)vramStart;
-                relocatedValue = (*relocDataP & 0xFC000000) | (((allocu32 + relocOffset) & 0x0FFFFFFF) >> 2);
-                relocatedAddress = PHYS_TO_K0(MIPS_JUMP_TARGET(relocatedValue));
-                *relocDataP = relocatedValue;
+                if (1) {
+                    relocOffset = PHYS_TO_K0(MIPS_JUMP_TARGET(*relocDataP)) - (uintptr_t)vramStart;
+                    unrelocatedAddress = PHYS_TO_K0(MIPS_JUMP_TARGET(*relocDataP));
+                    relocatedValue = (*relocDataP & 0xFC000000) | (((allocu32 + relocOffset) & 0x0FFFFFFF) >> 2);
+                    relocatedAddress = PHYS_TO_K0(MIPS_JUMP_TARGET(relocatedValue));
+                    *relocDataP = relocatedValue;
+                }
                 break;
 
             case R_MIPS_HI16 << RELOC_TYPE_SHIFT:


### PR DESCRIPTION
No particularly happy with the fake match with `relocSectionOffset` and `gOverlayLogSeverity` I had to do in `Overlay_Load` but couldn't find anything better. `relocSectionOffset = 0` is close, but has compiler managed stack issues.