### PR TITLE
Reorder boot/code spec includes for retail

### DIFF
--- a/spec
+++ b/spec
@@ -383,7 +383,9 @@ beginseg
     include "$(BUILD_DIR)/src/code/z_sram.o"
     include "$(BUILD_DIR)/src/code/z_ss_sram.o"
     include "$(BUILD_DIR)/src/code/z_rumble.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/data/z_text.data.o"
+#endif
     include "$(BUILD_DIR)/data/unk_8012ABC0.data.o"
     include "$(BUILD_DIR)/src/code/z_view.o"
     include "$(BUILD_DIR)/src/code/z_vimode.o"

--- a/spec
+++ b/spec
@@ -20,13 +20,17 @@ beginseg
     include "$(BUILD_DIR)/src/boot/z_std_dma.o"
     include "$(BUILD_DIR)/src/boot/yaz0.o"
     include "$(BUILD_DIR)/src/boot/z_locale.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/boot/assert.o"
+#endif
     include "$(BUILD_DIR)/src/boot/is_debug.o"
     include "$(BUILD_DIR)/src/libultra/io/driverominit.o"
     include "$(BUILD_DIR)/src/boot/mio0.o"
     include "$(BUILD_DIR)/src/boot/stackcheck.o"
     include "$(BUILD_DIR)/src/boot/logutils.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/libc/sprintf.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/io/piacs.o"
     include "$(BUILD_DIR)/src/libultra/os/sendmesg.o"
     include "$(BUILD_DIR)/src/libultra/os/stopthread.o"
@@ -57,10 +61,14 @@ beginseg
     include "$(BUILD_DIR)/src/libultra/os/probetlb.o"
     include "$(BUILD_DIR)/src/libultra/os/getmemsize.o"
     include "$(BUILD_DIR)/src/libultra/os/seteventmesg.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/libc/xprintf.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/os/unmaptlball.o"
     include "$(BUILD_DIR)/src/libultra/io/epidma.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/libc/string.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/os/invalicache.o"
     include "$(BUILD_DIR)/src/libultra/os/createmesgqueue.o"
     include "$(BUILD_DIR)/src/libultra/os/invaldcache.o"
@@ -88,17 +96,23 @@ beginseg
     include "$(BUILD_DIR)/src/libultra/io/epiread.o"
     include "$(BUILD_DIR)/src/libultra/io/visetspecial.o"
     include "$(BUILD_DIR)/src/libultra/io/cartrominit.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/vimodefpallan1.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/os/setfpccsr.o"
     include "$(BUILD_DIR)/src/libultra/os/getfpccsr.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/epiwrite.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/os/maptlbrdb.o"
     include "$(BUILD_DIR)/src/libultra/os/yieldthread.o"
     include "$(BUILD_DIR)/src/libultra/os/getcause.o"
     include "$(BUILD_DIR)/src/libultra/io/epirawwrite.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/libc/xlitob.o"
     include "$(BUILD_DIR)/src/libultra/libc/ldiv.o"
     include "$(BUILD_DIR)/src/libultra/libc/xldtob.o"
+#endif
     include "$(BUILD_DIR)/src/boot/build.o"
     include "$(BUILD_DIR)/src/libultra/io/sirawwrite.o"
     include "$(BUILD_DIR)/src/libultra/io/vimgr.o"
@@ -385,9 +399,13 @@ beginseg
     include "$(BUILD_DIR)/src/code/z_fbdemo_circle.o"
     include "$(BUILD_DIR)/src/code/z_fbdemo_fade.o"
     include "$(BUILD_DIR)/src/code/shrink_window.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/code/db_camera.o"
+#endif
     include "$(BUILD_DIR)/src/code/code_800BB0A0.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/code/mempak.o"
+#endif
     include "$(BUILD_DIR)/src/code/z_kaleido_manager.o"
     include "$(BUILD_DIR)/src/code/z_kaleido_scope_call.o"
     include "$(BUILD_DIR)/src/code/z_play.o"
@@ -415,7 +433,9 @@ beginseg
     include "$(BUILD_DIR)/src/code/sys_rumble.o"
     include "$(BUILD_DIR)/src/code/code_800D31A0.o"
     include "$(BUILD_DIR)/src/code/irqmgr.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/code/debug_malloc.o"
+#endif
     include "$(BUILD_DIR)/src/code/fault.o"
     include "$(BUILD_DIR)/src/code/fault_drawer.o"
 #ifndef NON_MATCHING
@@ -423,7 +443,9 @@ beginseg
     include "$(BUILD_DIR)/data/fault_drawer.bss.o"
 #endif
     include "$(BUILD_DIR)/src/code/kanread.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/code/ucode_disas.o"
+#endif
     pad_text // audio library aligned to 32 bytes?
     include "$(BUILD_DIR)/src/audio/lib/data.o"
     include "$(BUILD_DIR)/src/audio/lib/synthesis.o"
@@ -445,7 +467,9 @@ beginseg
     include "$(BUILD_DIR)/src/code/gfxprint.o"
     include "$(BUILD_DIR)/src/code/rcp_utils.o"
     include "$(BUILD_DIR)/src/code/loadfragment2.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/code/mtxuty-cvt.o"
+#endif
     include "$(BUILD_DIR)/src/code/relocation.o"
     include "$(BUILD_DIR)/src/code/load.o"
     include "$(BUILD_DIR)/src/code/code_800FC620.o"
@@ -456,11 +480,16 @@ beginseg
     include "$(BUILD_DIR)/src/code/system_malloc.o"
     include "$(BUILD_DIR)/src/code/code_800FD970.o"
     include "$(BUILD_DIR)/src/code/__osMalloc.o"
+#if !OOT_DEBUG
+    include "$(BUILD_DIR)/src/libultra/libc/sprintf.o"
+#endif
     include "$(BUILD_DIR)/src/code/printutils.o"
     include "$(BUILD_DIR)/src/code/sleep.o"
     include "$(BUILD_DIR)/src/code/jpegutils.o"
     include "$(BUILD_DIR)/src/code/jpegdecoder.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/pfsfreeblocks.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/mgu/scale.o"
     include "$(BUILD_DIR)/src/libultra/gu/sinf.o"
     include "$(BUILD_DIR)/src/libultra/gu/sins.o"
@@ -473,19 +502,29 @@ beginseg
     include "$(BUILD_DIR)/src/libultra/io/sprawdma.o"
     include "$(BUILD_DIR)/src/libultra/io/sirawdma.o"
     include "$(BUILD_DIR)/src/libultra/io/sptaskyield.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/pfsreadwritefile.o"
     include "$(BUILD_DIR)/src/libultra/io/pfsgetstatus.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/mgu/mtxidentf.o"
     include "$(BUILD_DIR)/src/libultra/gu/lookat.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/pfsallocatefile.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/os/stoptimer.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/contpfs.o"
     include "$(BUILD_DIR)/src/libultra/mgu/mtxl2f.o"
     include "$(BUILD_DIR)/src/libultra/io/pfsfindfile.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/gu/sqrtf.o"
     include "$(BUILD_DIR)/src/libultra/os/afterprenmi.o"
     include "$(BUILD_DIR)/src/libultra/io/contquery.o"
     include "$(BUILD_DIR)/src/libultra/gu/lookathil.o"
+#if !OOT_DEBUG
+    include "$(BUILD_DIR)/src/libultra/libc/xprintf.o"
+    include "$(BUILD_DIR)/src/libultra/libc/string.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/io/sp.o"
     include "$(BUILD_DIR)/src/libultra/mgu/mtxident.o"
     include "$(BUILD_DIR)/src/libultra/gu/position.o"
@@ -496,25 +535,44 @@ beginseg
     include "$(BUILD_DIR)/src/libultra/mgu/normalize.o"
     include "$(BUILD_DIR)/src/libultra/io/dpgetstat.o"
     include "$(BUILD_DIR)/src/libultra/io/dpsetstat.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/pfsdeletefile.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/gu/ortho.o"
     include "$(BUILD_DIR)/src/libultra/gu/cosf.o"
     include "$(BUILD_DIR)/src/libultra/gu/libm_vals.o"
     include "$(BUILD_DIR)/src/libultra/gu/coss.o"
     include "$(BUILD_DIR)/src/libultra/io/visetevent.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/pfsisplug.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/gu/us2dex.o"
     include "$(BUILD_DIR)/src/libultra/io/pfsselectbank.o"
     include "$(BUILD_DIR)/src/libultra/io/contsetch.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/pfsfilestate.o"
     include "$(BUILD_DIR)/src/libultra/io/pfsinitpak.o"
     include "$(BUILD_DIR)/src/libultra/io/pfschecker.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/io/aigetlen.o"
     include "$(BUILD_DIR)/src/libultra/mgu/translate.o"
     include "$(BUILD_DIR)/src/libultra/io/contramwrite.o"
+#if !OOT_DEBUG
+    include "$(BUILD_DIR)/src/libultra/io/vimodefpallan1.o"
+    include "$(BUILD_DIR)/src/libultra/io/pfsgetstatus.o"
+    include "$(BUILD_DIR)/src/libultra/io/contpfs.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/io/contramread.o"
     include "$(BUILD_DIR)/src/libultra/io/crc.o"
+#if !OOT_DEBUG
+    include "$(BUILD_DIR)/src/libultra/io/pfsisplug.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/os/settimer.o"
+#if !OOT_DEBUG
+    include "$(BUILD_DIR)/src/libultra/libc/xldtob.o"
+    include "$(BUILD_DIR)/src/libultra/libc/ldiv.o"
+    include "$(BUILD_DIR)/src/libultra/libc/xlitob.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/io/spgetstat.o"
     include "$(BUILD_DIR)/src/libultra/io/spsetstat.o"
     include "$(BUILD_DIR)/src/libultra/os/writebackdcacheall.o"

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -7281,7 +7281,6 @@ void Camera_PrintSettings(Camera* camera) {
         sp48[i] = '\0';
 
         sp48[camera->play->activeCamId] = 'a';
-#if OOT_DEBUG
         DebugCamera_ScreenTextColored(3, 22, DEBUG_CAM_TEXT_WHITE, sp58);
         DebugCamera_ScreenTextColored(3, 22, DEBUG_CAM_TEXT_PEACH, sp48);
         DebugCamera_ScreenTextColored(3, 23, DEBUG_CAM_TEXT_WHITE, "S:");
@@ -7292,7 +7291,6 @@ void Camera_PrintSettings(Camera* camera) {
         DebugCamera_ScreenTextColored(
             5, 25, DEBUG_CAM_TEXT_GOLD,
             sCameraFunctionNames[sCameraSettings[camera->setting].cameraModes[camera->mode].funcIdx]);
-#endif
 
         i = 0;
         if (camera->bgCamIndex < 0) {
@@ -7316,10 +7314,8 @@ void Camera_PrintSettings(Camera* camera) {
         sp50[i++] = ' ';
         sp50[i++] = ' ';
         sp50[i] = '\0';
-#if OOT_DEBUG
         DebugCamera_ScreenTextColored(3, 26, DEBUG_CAM_TEXT_WHITE, "I:");
         DebugCamera_ScreenTextColored(5, 26, DEBUG_CAM_TEXT_GOLD, sp50);
-#endif
     }
 }
 

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -7048,12 +7048,16 @@ void Camera_Init(Camera* camera, View* view, CollisionContext* colCtx, PlayState
             R_CAM_DATA(i) = sCamDataRegsInit[i];
         }
 
+#if OOT_DEBUG
         DebugCamera_Reset(camera, &D_8015BD80);
+#endif
         sInitRegs = false;
         PREG(88) = -1;
     }
     camera->play = D_8015BD7C = play;
+#if OOT_DEBUG
     DebugCamera_Init(&D_8015BD80, camera);
+#endif
     curUID = sNextUID;
     sNextUID++;
     while (curUID != 0) {
@@ -7277,6 +7281,7 @@ void Camera_PrintSettings(Camera* camera) {
         sp48[i] = '\0';
 
         sp48[camera->play->activeCamId] = 'a';
+#if OOT_DEBUG
         DebugCamera_ScreenTextColored(3, 22, DEBUG_CAM_TEXT_WHITE, sp58);
         DebugCamera_ScreenTextColored(3, 22, DEBUG_CAM_TEXT_PEACH, sp48);
         DebugCamera_ScreenTextColored(3, 23, DEBUG_CAM_TEXT_WHITE, "S:");
@@ -7287,6 +7292,7 @@ void Camera_PrintSettings(Camera* camera) {
         DebugCamera_ScreenTextColored(
             5, 25, DEBUG_CAM_TEXT_GOLD,
             sCameraFunctionNames[sCameraSettings[camera->setting].cameraModes[camera->mode].funcIdx]);
+#endif
 
         i = 0;
         if (camera->bgCamIndex < 0) {
@@ -7310,8 +7316,10 @@ void Camera_PrintSettings(Camera* camera) {
         sp50[i++] = ' ';
         sp50[i++] = ' ';
         sp50[i] = '\0';
+#if OOT_DEBUG
         DebugCamera_ScreenTextColored(3, 26, DEBUG_CAM_TEXT_WHITE, "I:");
         DebugCamera_ScreenTextColored(5, 26, DEBUG_CAM_TEXT_GOLD, sp50);
+#endif
     }
 }
 
@@ -7722,7 +7730,9 @@ Vec3s Camera_Update(Camera* camera) {
     if (CHECK_BTN_ALL(D_8015BD7C->state.input[2].press.button, BTN_START)) {
         gDebugCamEnabled ^= 1;
         if (gDebugCamEnabled) {
+#if OOT_DEBUG
             DebugCamera_Enable(&D_8015BD80, camera);
+#endif
         } else if (camera->play->csCtx.state != CS_STATE_IDLE) {
             Cutscene_StopManual(camera->play, &camera->play->csCtx);
         }
@@ -7731,7 +7741,9 @@ Vec3s Camera_Update(Camera* camera) {
     // Debug cam update
     if (gDebugCamEnabled) {
         camera->play->view.fovy = D_8015BD80.fov;
+#if OOT_DEBUG
         DebugCamera_Update(&D_8015BD80, camera);
+#endif
         View_LookAt(&camera->play->view, &D_8015BD80.eye, &D_8015BD80.at, &D_8015BD80.unk_1C);
         if (R_DEBUG_CAM_UPDATE) {
             PRINTF("camera: debug out\n");


### PR DESCRIPTION
Unfortunately this makes things a bit of a mess. I'm not sure if the original devs' tooling did this automatically.

For functions that are no longer linked, I chose not to `#if` the declarations. The function definitions themselves are not `#if`'d out, so a linker error seems more appropriate if you use one of these functions without updating the spec.

I made some temporary changes to camera.c to avoid referencing unlinked functions. These will have to be cleaned up for real when we decomp those files.

Moved from `boot` to `code`:
```
ldiv
sprintf
string
vimodefpallan1
xldtob
xlitob
xprintf
```
Moved around within `code`:
```
contpfs
pfsgetstatus
pfsisplug
```
No longer linked:
```
assert
db_camera
debug_malloc
epiwrite
mempak
mtxl2f
mtxuty-cvt
pfsallocatefile
pfschecker
pfsdeletefile
pfsfilestate
pfsfindfile
pfsfreeblocks
pfsinitpak
pfsreadwritefile
ucode_disas
z_text
```