### PR TITLE
Fixup vscode settings

### DIFF
--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -51,11 +51,12 @@ You can create a `.vscode/c_cpp_properties.json` file with `C/C++: Edit Configur
                 "${workspaceFolder}/**",
                 "src",
                 "build/gc-eu-mq-dbg",
-                "include"
+                "include",
+                "include/libc"
             ],
             "defines": [
                 "_LANGUAGE_C", // For gbi.h
-                "OOT_DEBUG" // If targeting a debug version
+                "OOT_DEBUG=1" // If targeting a debug version
             ],
             "cStandard": "gnu89", // C89 + some GNU extensions from C99 like C++ comments
             "cppStandard": "${default}" // Only ZAPD uses C++, so doesn't really matter

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -41,7 +41,7 @@ You can create a `.vscode/c_cpp_properties.json` file with `C/C++: Edit Configur
 {
     "configurations": [
         {
-            "name": "Linux",
+            "name": "OoT64 gc-eu-mq-dbg",
             "compilerPath": "${default}", // Needs to not be "" for -m32 to work
             "compilerArgs": [
                 "-m32" // Removes integer truncation warnings with gbi macros

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -41,7 +41,7 @@ You can create a `.vscode/c_cpp_properties.json` file with `C/C++: Edit Configur
 {
     "configurations": [
         {
-            "name": "OoT64 gc-eu-mq-dbg",
+            "name": "N64 oot-gc-eu-mq-dbg",
             "compilerPath": "${default}", // Needs to not be "" for -m32 to work
             "compilerArgs": [
                 "-m32" // Removes integer truncation warnings with gbi macros


### PR DESCRIPTION
- add missing include
- explicitly define OOT_DEBUG to 1
- change configuration name to `N64 oot-gc-eu-mq-dbg` (maybe we have several eventually for the different versions idk. better than "Linux" anyway)