### PR TITLE
Remove Main_LogSystemHeap from functions.h

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1346,7 +1346,6 @@ ListAlloc* ListAlloc_Init(ListAlloc* this);
 void* ListAlloc_Alloc(ListAlloc* this, u32 size);
 void ListAlloc_Free(ListAlloc* this, void* data);
 void ListAlloc_FreeAll(ListAlloc* this);
-void Main_LogSystemHeap(void);
 void Main(void* arg);
 void SysCfb_Init(s32 n64dd);
 void* SysCfb_GetFbPtr(s32 idx);


### PR DESCRIPTION
Removed in retail, missed during review of #1645