### PR TITLE
[Faster CI] Make CI not run CC_CHECK

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,8 @@ pipeline {
                 branch 'main'
             }
             steps {
-                sh 'make -j ORIG_COMPILER=1'
+                // Do not run CC_CHECK to save time. @ makes Make not print the command and # starts a shell comment.
+                sh '''make -j ORIG_COMPILER=1 CC_CHECK='@#' '''
             }
         }
         stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,8 +45,7 @@ pipeline {
                 }
             }
             steps {
-                // Do not run CC_CHECK to save time. @ makes Make not print the command and # starts a shell comment.
-                sh '''make -j CC_CHECK='@#' '''
+                sh 'make -j RUN_CC_CHECK=0'
             }
         }
         stage('Report Progress') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,7 @@ pipeline {
                 branch 'main'
             }
             steps {
-                // Do not run CC_CHECK to save time. @ makes Make not print the command and # starts a shell comment.
-                sh '''make -j ORIG_COMPILER=1 CC_CHECK='@#' '''
+                sh 'make -j ORIG_COMPILER=1'
             }
         }
         stage('Build') {
@@ -46,7 +45,8 @@ pipeline {
                 }
             }
             steps {
-                sh 'make -j'
+                // Do not run CC_CHECK to save time. @ makes Make not print the command and # starts a shell comment.
+                sh '''make -j CC_CHECK='@#' '''
             }
         }
         stage('Report Progress') {

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ COMPILER := ido
 VERSION := gc-eu-mq-dbg
 # Number of threads to extract and compress with
 N_THREADS := $(shell nproc)
+# Check code syntax with host compiler
+RUN_CC_CHECK := 1
 
 CFLAGS ?=
 CPPFLAGS ?=
@@ -173,7 +175,7 @@ ifeq ($(COMPILER),ido)
     CC_CHECK += -m32
   endif
 else
-  CC_CHECK  = @:
+  RUN_CC_CHECK := 0
 endif
 
 OBJDUMP_FLAGS := -d -r -z -Mreg-names=32
@@ -456,18 +458,24 @@ $(BUILD_DIR)/src/code/z_game_dlftbls.o: include/tables/gamestate_table.h
 $(BUILD_DIR)/src/code/z_scene_table.o: include/tables/scene_table.h include/tables/entrance_table.h
 
 $(BUILD_DIR)/src/%.o: src/%.c
+ifneq ($(RUN_CC_CHECK),0)
 	$(CC_CHECK) $<
+endif
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
 	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > $(@:.o=.s)
 
 $(BUILD_DIR)/src/libultra/libc/ll.o: src/libultra/libc/ll.c
+ifneq ($(RUN_CC_CHECK),0)
 	$(CC_CHECK) $<
+endif
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
 	$(PYTHON) tools/set_o32abi_bit.py $@
 	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > $(@:.o=.s)
 
 $(BUILD_DIR)/src/libultra/libc/llcvt.o: src/libultra/libc/llcvt.c
+ifneq ($(RUN_CC_CHECK),0)
 	$(CC_CHECK) $<
+endif
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
 	$(PYTHON) tools/set_o32abi_bit.py $@
 	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > $(@:.o=.s)


### PR DESCRIPTION
CC_CHECK is a `gcc -fsyntax-only` call on the ido-compiled .c files to get better warnings/errors than ido's

it's very useful locally but mostly wastes time during CI builds, and a lot of it it turns out.

example times, from a done build:
`rm -rf build/gc-eu-mq-dbg/src/ && time make -j32` : 36s
`rm -rf build/gc-eu-mq-dbg/src/ && time make -j32 CC_CHECK='@#'` : 25s
-> 10s for cc_check over src/