### PR TITLE
Match retail Title and Sample gamestates

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1182,7 +1182,7 @@ void View_InitDistortion(View* view);
 void View_ClearDistortion(View* view);
 void View_SetDistortion(View* view, Vec3f orientation, Vec3f scale, f32 speed);
 s32 View_StepDistortion(View* view, Mtx* projectionMtx);
-void View_Apply(View* view, s32 mask);
+BAD_RETURN(s32) View_Apply(View* view, s32 mask);
 s32 View_ApplyOrthoToOverlay(View* view);
 s32 View_ApplyPerspectiveToOverlay(View* view);
 s32 View_UpdateViewingMatrix(View* view);

--- a/include/functions.h
+++ b/include/functions.h
@@ -1182,7 +1182,7 @@ void View_InitDistortion(View* view);
 void View_ClearDistortion(View* view);
 void View_SetDistortion(View* view, Vec3f orientation, Vec3f scale, f32 speed);
 s32 View_StepDistortion(View* view, Mtx* projectionMtx);
-BAD_RETURN(s32) View_Apply(View* view, s32 mask);
+s32 View_Apply(View* view, s32 mask);
 s32 View_ApplyOrthoToOverlay(View* view);
 s32 View_ApplyPerspectiveToOverlay(View* view);
 s32 View_UpdateViewingMatrix(View* view);

--- a/src/code/z_view.c
+++ b/src/code/z_view.c
@@ -275,13 +275,13 @@ s32 View_StepDistortion(View* view, Mtx* projectionMtx) {
 /**
  * Apply view to POLY_OPA_DISP, POLY_XLU_DISP (and OVERLAY_DISP if ortho)
  */
-BAD_RETURN(s32) View_Apply(View* view, s32 mask) {
+s32 View_Apply(View* view, s32 mask) {
     mask = (view->flags & mask) | (mask >> 4);
 
     if (mask & VIEW_PROJECTION_ORTHO) {
-        View_ApplyOrtho(view);
+        return View_ApplyOrtho(view);
     } else {
-        View_ApplyPerspective(view);
+        return View_ApplyPerspective(view);
     }
 }
 

--- a/src/code/z_view.c
+++ b/src/code/z_view.c
@@ -275,7 +275,7 @@ s32 View_StepDistortion(View* view, Mtx* projectionMtx) {
 /**
  * Apply view to POLY_OPA_DISP, POLY_XLU_DISP (and OVERLAY_DISP if ortho)
  */
-void View_Apply(View* view, s32 mask) {
+BAD_RETURN(s32) View_Apply(View* view, s32 mask) {
     mask = (view->flags & mask) | (mask >> 4);
 
     if (mask & VIEW_PROJECTION_ORTHO) {

--- a/src/overlays/gamestates/ovl_title/z_title.c
+++ b/src/overlays/gamestates/ovl_title/z_title.c
@@ -130,12 +130,14 @@ void ConsoleLogo_Main(GameState* thisx) {
     ConsoleLogo_Calc(this);
     ConsoleLogo_Draw(this);
 
-    if (OOT_DEBUG && gIsCtrlr2Valid) {
+#if OOT_DEBUG
+    if (gIsCtrlr2Valid) {
         Gfx* gfx = POLY_OPA_DISP;
 
         ConsoleLogo_PrintBuildInfo(&gfx);
         POLY_OPA_DISP = gfx;
     }
+#endif
 
     if (this->exit) {
         gSaveContext.seqId = (u8)NA_BGM_DISABLED;

--- a/src/overlays/gamestates/ovl_title/z_title.c
+++ b/src/overlays/gamestates/ovl_title/z_title.c
@@ -8,6 +8,7 @@
 #include "alloca.h"
 #include "assets/textures/nintendo_rogo_static/nintendo_rogo_static.h"
 
+#if OOT_DEBUG
 void ConsoleLogo_PrintBuildInfo(Gfx** gfxP) {
     Gfx* gfx;
     GfxPrint* printer;
@@ -29,6 +30,7 @@ void ConsoleLogo_PrintBuildInfo(Gfx** gfxP) {
     GfxPrint_Destroy(printer);
     *gfxP = gfx;
 }
+#endif
 
 // Note: In other rom versions this function also updates unk_1D4, coverAlpha, addAlpha, visibleDuration to calculate
 // the fade-in/fade-out + the duration of the n64 logo animation
@@ -130,7 +132,6 @@ void ConsoleLogo_Main(GameState* thisx) {
 
     if (OOT_DEBUG && gIsCtrlr2Valid) {
         Gfx* gfx = POLY_OPA_DISP;
-        s32 pad;
 
         ConsoleLogo_PrintBuildInfo(&gfx);
         POLY_OPA_DISP = gfx;


### PR DESCRIPTION
only gamestate left is file select which engineer has covered.

Not happy with yet another BAD_RETURN, but I think its reasonable to think that `View_Apply` could have returned some kind of status at some point in time? idk. MM doesnt run into this issue cause that game gets rid of the sample gamestate.
The permuter found this one and any other match was extremely fake.