### PR TITLE
Match retail padmgr.c and sys_rumble.c

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -117,14 +117,13 @@
 #endif
 
 #if OOT_DEBUG
-
 #define LOG(exp, value, format, file, line)         \
     do {                                            \
         LogUtils_LogThreadId(file, line);           \
         osSyncPrintf(exp " = " format "\n", value); \
     } while (0)
 #else
-#define LOG(exp, value, format, file, line) (void)0
+#define LOG(exp, value, format, file, line) (void)(value)
 #endif
 
 #define LOG_STRING(string, file, line) LOG(#string, string, "%s", file, line)

--- a/include/ultra64/motor.h
+++ b/include/ultra64/motor.h
@@ -9,7 +9,7 @@
 #define osMotorStart(x) __osMotorAccess((x), MOTOR_START)
 #define osMotorStop(x)  __osMotorAccess((x), MOTOR_STOP)
 
-s32 __osMotorAccess(OSPfs* pfs, u32 vibrate);
+s32 __osMotorAccess(OSPfs* pfs, s32 vibrate);
 s32 osMotorInit(OSMesgQueue* ctrlrqueue, OSPfs* pfs, s32 channel);
 
 #endif

--- a/src/code/sys_rumble.c
+++ b/src/code/sys_rumble.c
@@ -147,5 +147,7 @@ void RumbleMgr_Init(RumbleMgr* rumbleMgr) {
 }
 
 void RumbleMgr_Destroy(RumbleMgr* rumbleMgr) {
+#if OOT_DEBUG
     bzero(rumbleMgr, sizeof(RumbleMgr));
+#endif
 }

--- a/src/libultra/io/motor.c
+++ b/src/libultra/io/motor.c
@@ -4,7 +4,7 @@
 
 OSPifRam __MotorDataBuf[MAXCONTROLLERS];
 
-s32 __osMotorAccess(OSPfs* pfs, u32 vibrate) {
+s32 __osMotorAccess(OSPfs* pfs, s32 vibrate) {
     s32 i;
     s32 ret;
     u8* ptr = (u8*)&__MotorDataBuf[pfs->channel];


### PR DESCRIPTION
This includes the line 
```
LOG_NUM("++errcnt", ++sRumbleErrorCount, "../padmgr.c", 282);
```
where the `++sRumbleErrorCount` is preserved in retail. To handle this I changed the `LOG` macro to evaluate the value even in retail. This has the bonus of fixing `LOG_STRING` too, for example z_elf_message.c has the line
```
LOG_STRING("企画外 条件", "../z_elf_message.c", 156); // "Unplanned conditions"
```
where the string `"企画外 条件"` also exists in retail .rodata. I checked all the `LOG_STRING`s and it's the same for all of them.