### PR TITLE
Diff .data size, .bss size, and .rodata contents in retail_progress.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -500,7 +500,7 @@ $(EXPECTED_DIR)/.disasm: $(DISASM_DATA_FILES)
 	touch $@
 
 $(EXPECTED_DIR)/%.o: $(EXPECTED_DIR)/.disasm
-	$(AS) $(ASFLAGS) $(@:.o=.s) -o $@
+	iconv --from UTF-8 --to EUC-JP $(@:.o=.s) | $(AS) $(ASFLAGS) -o $@
 
 -include $(DEP_FILES)
 

--- a/retail_progress.py
+++ b/retail_progress.py
@@ -295,7 +295,7 @@ def get_object_data_for_comparison(object1: Path, object2: Path):
     return ObjectDataForComparison(insts1, insts2, sizes1, sizes2, rodata1, rodata2)
 
 
-def print_summary(version: str, csv: bool):
+def print_summary(version: str, csv: bool, only_not_ok: bool):
     expected_dir = Path("expected/build") / version
     build_dir = Path("build") / version
 
@@ -348,6 +348,15 @@ def print_summary(version: str, csv: bool):
             data_size_matches = sizes1.get(".data", 0) == sizes2.get(".data", 0)
             bss_size_matches = sizes1.get(".bss", 0) == sizes2.get(".bss", 0)
 
+            if only_not_ok:
+                if (
+                    text_progress == 1
+                    and rodata_matches
+                    and data_size_matches
+                    and bss_size_matches
+                ):
+                    continue
+
             if csv:
                 print(
                     f"{c_path},{len(insts1)},{len(insts2)},{text_progress:.3f},{rodata_matches},{data_size_matches},{bss_size_matches}"
@@ -385,6 +394,12 @@ if __name__ == "__main__":
         help="diff .data size, .bss size, and .rodata contents instead of text",
         action="store_true",
     )
+    parser.add_argument(
+        "--not-ok",
+        help="only print non-OK files",
+        action="store_true",
+        dest="only_not_ok",
+    )
     parser.add_argument("--csv", help="print summary CSV", action="store_true")
     args = parser.parse_args()
 
@@ -394,4 +409,4 @@ if __name__ == "__main__":
         else:
             find_functions_with_diffs(args.version, args.file)
     else:
-        print_summary(args.version, args.csv)
+        print_summary(args.version, args.csv, args.only_not_ok)

--- a/retail_progress.py
+++ b/retail_progress.py
@@ -5,6 +5,7 @@
 
 import argparse
 import collections
+from colorama import Fore, Style
 from dataclasses import dataclass
 import difflib
 from enum import Enum
@@ -15,6 +16,14 @@ import re
 import subprocess
 import sys
 from typing import Dict, Iterator, List, Optional, Tuple
+
+
+def green(s: str) -> str:
+    return f"{Fore.GREEN}{s}{Style.RESET_ALL}"
+
+
+def red(s: str) -> str:
+    return f"{Fore.RED}{s}{Style.RESET_ALL}"
 
 
 @dataclass
@@ -299,11 +308,20 @@ def print_summary(version: str, csv: bool):
             print(
                 f"{c_path},{len(insts1)},{len(insts2)},{text_progress:.3f},{rodata_matches},{data_size_matches},{bss_size_matches}"
             )
-        elif text_progress == 1.0:
-            print(f"   OK {c_path}")
         else:
-            # TODO: show data diffs
-            print(f"  {math.floor(text_progress * 100):>2}% {c_path}")
+            ok = green("OK")
+            diff = red("diff")
+            text_progress_str = (
+                ok
+                if text_progress == 1
+                else red(f"{math.floor(text_progress * 100):>2}%")
+            )
+            rodata_str = ok if rodata_matches else diff
+            data_size_str = ok if data_size_matches else diff
+            bss_size_str = ok if bss_size_matches else diff
+            print(
+                f"text:{text_progress_str:<13} rodata:{rodata_str:<13} data size:{data_size_str:<13} bss size:{bss_size_str:<13} {c_path}"
+            )
         sys.stdout.flush()
 
 

--- a/retail_progress.py
+++ b/retail_progress.py
@@ -27,6 +27,14 @@ def red(s: str) -> str:
     return f"{Fore.RED}{s}{Style.RESET_ALL}"
 
 
+# Make interrupting the compression with ^C less jank
+# https://stackoverflow.com/questions/72967793/keyboardinterrupt-with-python-multiprocessing-pool
+def set_sigint_ignored():
+    import signal
+
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
 @dataclass
 class Inst:
     func_name: str
@@ -295,7 +303,7 @@ def print_summary(version: str, csv: bool):
 
     comparison_data_list: List[multiprocessing.pool.AsyncResult] = []
 
-    with multiprocessing.Pool() as p:
+    with multiprocessing.Pool(initializer=set_sigint_ignored) as p:
         for expected_object in expected_object_files:
             build_object = build_dir / expected_object.relative_to(expected_dir)
             comparison_data_list.append(

--- a/retail_progress.py
+++ b/retail_progress.py
@@ -27,7 +27,7 @@ def red(s: str) -> str:
     return f"{Fore.RED}{s}{Style.RESET_ALL}"
 
 
-# Make interrupting the compression with ^C less jank
+# Make interrupting with ^C less jank
 # https://stackoverflow.com/questions/72967793/keyboardinterrupt-with-python-multiprocessing-pool
 def set_sigint_ignored():
     import signal


### PR DESCRIPTION
Given that .text matching is proceeding at a blistering pace maybe it's time to start thinking about data.

This adds a `--data` flag to retail_progress.py that will compare .data size, .bss size, and .rodata contents between the disassembly and the built object, and adds new columns for these to the csv output for the spreadsheet ([preview](https://docs.google.com/spreadsheets/d/1iYl78EGsIzX5KpRing_qadngrXzTNkerwMh94CHy-LM/edit?usp=sharing)). 

Unfortunately comparing .data contents is probably not feasible because it's very hard to identify pointers, and this can't detect BSS ordering issues. However, if the sizes of all the sections are correct then it'll be much easier to compare the ROMs with vbindiff or first_diff.py to track down the remaining issues, since everything will line up.

In the process I discovered that the strings in .rodata sections were not being encoded correctly since spimdisasm will decode EUC-JP strings into UTF-8, so here we use `iconv` to turn them back before reassembling.