### PR TITLE
rcp retail OK

### DIFF
--- a/src/code/z_rcp.c
+++ b/src/code/z_rcp.c
@@ -1482,7 +1482,7 @@ void Gfx_SetupFrame(GraphicsContext* gfxCtx, u8 r, u8 g, u8 b) {
     if ((R_PAUSE_BG_PRERENDER_STATE <= PAUSE_BG_PRERENDER_SETUP) && (gTransitionTileState <= TRANS_TILE_SETUP)) {
         s32 letterboxSize = Letterbox_GetSize();
 
-        #if OOT_DEBUG
+#if OOT_DEBUG
         if (R_HREG_MODE == HREG_MODE_SETUP_FRAME) {
             if (R_SETUP_FRAME_INIT != HREG_MODE_SETUP_FRAME) {
                 R_SETUP_FRAME_GET = (SETUP_FRAME_LETTERBOX_SIZE_FLAG | SETUP_FRAME_BASE_COLOR_FLAG);
@@ -1525,7 +1525,7 @@ void Gfx_SetupFrame(GraphicsContext* gfxCtx, u8 r, u8 g, u8 b) {
                 b = R_SETUP_FRAME_BASE_COLOR_B;
             }
         }
-        #endif
+#endif
 
         // Set the whole z buffer to maximum depth
         // Don't bother with pixels that are being covered by the letterbox

--- a/src/code/z_rcp.c
+++ b/src/code/z_rcp.c
@@ -1246,23 +1246,33 @@ Gfx* Gfx_SetupDL_69NoCD(Gfx* gfx) {
     return gfx;
 }
 
+#if OOT_DEBUG
+#define HREG_21 HREG(21)
+#define HREG_22 HREG(22)
+#else
+#define HREG_21 0
+#define HREG_22 0
+#endif
+
 Gfx* func_800947AC(Gfx* gfx) {
     gSPDisplayList(gfx++, sSetupDL[SETUPDL_65]);
     gDPSetColorDither(gfx++, G_CD_DISABLE);
 
     // clang-format off
-    switch (HREG(21)) {
+    switch (HREG_21) {
         case 1: gDPSetAlphaDither(gfx++, G_AD_DISABLE); break;
         case 2: gDPSetAlphaDither(gfx++, G_AD_PATTERN); break;
         case 3: gDPSetAlphaDither(gfx++, G_AD_NOTPATTERN); break;
         case 4: gDPSetAlphaDither(gfx++, G_AD_NOISE); break;
+        default: break;
     }
 
-    switch (HREG(22)) {
+    switch (HREG_22) {
         case 1: gDPSetColorDither(gfx++, G_CD_DISABLE); break;
         case 2: gDPSetColorDither(gfx++, G_CD_MAGICSQ); break;
         case 3: gDPSetColorDither(gfx++, G_CD_BAYER); break;
         case 4: gDPSetColorDither(gfx++, G_CD_NOISE); break;
+        default: break;
     }
     // clang-format on
 
@@ -1472,6 +1482,7 @@ void Gfx_SetupFrame(GraphicsContext* gfxCtx, u8 r, u8 g, u8 b) {
     if ((R_PAUSE_BG_PRERENDER_STATE <= PAUSE_BG_PRERENDER_SETUP) && (gTransitionTileState <= TRANS_TILE_SETUP)) {
         s32 letterboxSize = Letterbox_GetSize();
 
+        #if OOT_DEBUG
         if (R_HREG_MODE == HREG_MODE_SETUP_FRAME) {
             if (R_SETUP_FRAME_INIT != HREG_MODE_SETUP_FRAME) {
                 R_SETUP_FRAME_GET = (SETUP_FRAME_LETTERBOX_SIZE_FLAG | SETUP_FRAME_BASE_COLOR_FLAG);
@@ -1514,6 +1525,7 @@ void Gfx_SetupFrame(GraphicsContext* gfxCtx, u8 r, u8 g, u8 b) {
                 b = R_SETUP_FRAME_BASE_COLOR_B;
             }
         }
+        #endif
 
         // Set the whole z buffer to maximum depth
         // Don't bother with pixels that are being covered by the letterbox


### PR DESCRIPTION
Not sure how we want to actually handle the HREGs, but the only way I could get it to match retail was having the switch statements take 0s.

Note we could also do ternaries, but I think I like the defines approach better.