### PR TITLE
Retail Player_Update/Noclip mode + some docs

### DIFF
--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13634,7 +13634,7 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
 
 #if OOT_DEBUG
 /**
- * Updates the "Noclip" debug feature, which allows the player to fly around anywhere 
+ * Updates the "Noclip" debug feature, which allows the player to fly around anywhere
  * in the world and clip through any collision.
  *
  * Noclip can be enabled with two different button combos:

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13656,7 +13656,7 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
 s32 Player_UpdateNoclip(Player* this, PlayState* play) {
     sControlInput = &play->state.input[0];
 
-    if ((CHECK_BTN_ALL(sControlInput->cur.button, BTN_A | BTN_L | BTN_R) &&
+    if ((CHECK_BTN_ALL(sControlInput->cur.button, BTN_L | BTN_R | BTN_A) &&
          CHECK_BTN_ALL(sControlInput->press.button, BTN_B)) ||
         (CHECK_BTN_ALL(sControlInput->cur.button, BTN_L) && CHECK_BTN_ALL(sControlInput->press.button, BTN_DRIGHT))) {
 

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13634,6 +13634,19 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
 /**
  * Updates the "Noclip" debug feature, which allows the player to
  * fly around anywhere in the world and clip through any collision.
+ * It can be enabled with two seperate button combos:
+ * A + L + R held down and then B
+ * or
+ * L held down and then D-pad right
+ *
+ * To control Noclip mode:
+ * - Move horizontally with the 4 D-pad directions
+ * - Move up with B
+ * - Move down with A
+ * - Hold R to move faster
+ *
+ * With Noclip enabled, another button combination can be pressed to set all "temp clear" flags
+ * in the current room. To do so Hold L and press D-pad right.
  *
  * @return  true if Noclip is disabled, false if enabled
  */

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11352,14 +11352,15 @@ void Player_Update(Actor* thisx, PlayState* play) {
 
     Player_UpdateCommon(this, play, &sp44);
 
-skip_update : {
-    s32 pad;
+skip_update:;
+    {
+        s32 pad;
 
-    MREG(52) = this->actor.world.pos.x;
-    MREG(53) = this->actor.world.pos.y;
-    MREG(54) = this->actor.world.pos.z;
-    MREG(55) = this->actor.world.rot.y;
-}
+        MREG(52) = this->actor.world.pos.x;
+        MREG(53) = this->actor.world.pos.y;
+        MREG(54) = this->actor.world.pos.z;
+        MREG(55) = this->actor.world.rot.y;
+    }
 }
 
 typedef struct {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11323,6 +11323,7 @@ void Player_Update(Actor* thisx, PlayState* play) {
             gSaveContext.dogParams = 0;
         } else {
             Actor* dog;
+            
             gSaveContext.dogParams &= 0x7FFF;
             Player_GetRelativePosition(this, &this->actor.world.pos, &sDogSpawnOffset, &sDogSpawnPos);
             dogParams = gSaveContext.dogParams;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -493,7 +493,7 @@ static PlayerAgeProperties sAgeProperties[] = {
     },
 };
 
-static u32 D_808535D0 = false;
+static u32 sNoclipEnabled = false;
 static f32 sControlStickMagnitude = 0.0f;
 static s16 sControlStickAngle = 0;
 static s16 D_808535DC = 0;
@@ -11308,59 +11308,58 @@ void Player_Update(Actor* thisx, PlayState* play) {
     s32 dogParams;
     s32 pad;
     Input sp44;
-    
+
 #if OOT_DEBUG
-    if (func_8084FCAC(this, play)) {
+    if (!func_8084FCAC(this, play)) {
+        goto skip_update;
+    }
 #endif
-        if (gSaveContext.dogParams < 0) {
-            if (Object_GetSlot(&play->objectCtx, OBJECT_DOG) < 0) {
-                gSaveContext.dogParams = 0;
-            } else {
-                Actor* dog;
-                gSaveContext.dogParams &= 0x7FFF;
-                Player_GetRelativePosition(this, &this->actor.world.pos, &sDogSpawnOffset, &sDogSpawnPos);
-                dogParams = gSaveContext.dogParams;
 
-                dog = Actor_Spawn(&play->actorCtx, play, ACTOR_EN_DOG, sDogSpawnPos.x, sDogSpawnPos.y, sDogSpawnPos.z,
-                                  0, this->actor.shape.rot.y, 0, dogParams | 0x8000);
-                if (dog != NULL) {
-                    dog->room = 0;
-                }
-            }
-        }
-
-        if ((this->interactRangeActor != NULL) && (this->interactRangeActor->update == NULL)) {
-            this->interactRangeActor = NULL;
-        }
-
-        if ((this->heldActor != NULL) && (this->heldActor->update == NULL)) {
-            Player_DetachHeldActor(play, this);
-        }
-
-        if (this->stateFlags1 & (PLAYER_STATE1_5 | PLAYER_STATE1_29)) {
-            bzero(&sp44, sizeof(sp44));
+    if (gSaveContext.dogParams < 0) {
+        if (Object_GetSlot(&play->objectCtx, OBJECT_DOG) < 0) {
+            gSaveContext.dogParams = 0;
         } else {
-            sp44 = play->state.input[0];
-            if (this->unk_88E != 0) {
-                sp44.cur.button &= ~(BTN_A | BTN_B | BTN_CUP);
-                sp44.press.button &= ~(BTN_A | BTN_B | BTN_CUP);
+            Actor* dog;
+            gSaveContext.dogParams &= 0x7FFF;
+            Player_GetRelativePosition(this, &this->actor.world.pos, &sDogSpawnOffset, &sDogSpawnPos);
+            dogParams = gSaveContext.dogParams;
+
+            dog = Actor_Spawn(&play->actorCtx, play, ACTOR_EN_DOG, sDogSpawnPos.x, sDogSpawnPos.y, sDogSpawnPos.z, 0,
+                              this->actor.shape.rot.y, 0, dogParams | 0x8000);
+            if (dog != NULL) {
+                dog->room = 0;
             }
         }
-
-        Player_UpdateCommon(this, play, &sp44);
-        
-#if OOT_DEBUG
     }
-#endif
 
-    {
-        s32 pad;
-
-        MREG(52) = this->actor.world.pos.x;
-        MREG(53) = this->actor.world.pos.y;
-        MREG(54) = this->actor.world.pos.z;
-        MREG(55) = this->actor.world.rot.y;
+    if ((this->interactRangeActor != NULL) && (this->interactRangeActor->update == NULL)) {
+        this->interactRangeActor = NULL;
     }
+
+    if ((this->heldActor != NULL) && (this->heldActor->update == NULL)) {
+        Player_DetachHeldActor(play, this);
+    }
+
+    if (this->stateFlags1 & (PLAYER_STATE1_5 | PLAYER_STATE1_29)) {
+        bzero(&sp44, sizeof(sp44));
+    } else {
+        sp44 = play->state.input[0];
+        if (this->unk_88E != 0) {
+            sp44.cur.button &= ~(BTN_A | BTN_B | BTN_CUP);
+            sp44.press.button &= ~(BTN_A | BTN_B | BTN_CUP);
+        }
+    }
+
+    Player_UpdateCommon(this, play, &sp44);
+
+skip_update : {
+    s32 pad;
+
+    MREG(52) = this->actor.world.pos.x;
+    MREG(53) = this->actor.world.pos.y;
+    MREG(54) = this->actor.world.pos.z;
+    MREG(55) = this->actor.world.rot.y;
+}
 }
 
 typedef struct {
@@ -13633,14 +13632,14 @@ s32 func_8084FCAC(Player* this, PlayState* play) {
          CHECK_BTN_ALL(sControlInput->press.button, BTN_B)) ||
         (CHECK_BTN_ALL(sControlInput->cur.button, BTN_L) && CHECK_BTN_ALL(sControlInput->press.button, BTN_DRIGHT))) {
 
-        D_808535D0 ^= 1;
+        sNoclipEnabled ^= 1;
 
-        if (D_808535D0) {
+        if (sNoclipEnabled) {
             Camera_RequestMode(Play_GetCamera(play, CAM_ID_MAIN), CAM_MODE_Z_AIM);
         }
     }
 
-    if (D_808535D0) {
+    if (sNoclipEnabled) {
         f32 speed;
 
         if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_R)) {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13634,12 +13634,13 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
 
 #if OOT_DEBUG
 /**
- * Updates the "Noclip" debug feature, which allows the player to
- * fly around anywhere in the world and clip through any collision.
- * It can be enabled with two seperate button combos:
- * A + L + R held down and then B
+ * Updates the "Noclip" debug feature, which allows the player to fly around anywhere 
+ * in the world and clip through any collision.
+ *
+ * Noclip can be enabled with two different button combos:
+ * Hold A + L + R and press B
  * or
- * L held down and then D-pad right
+ * Hold L and press D-pad right
  *
  * To control Noclip mode:
  * - Move horizontally with the 4 D-pad directions
@@ -13648,7 +13649,7 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
  * - Hold R to move faster
  *
  * With Noclip enabled, another button combination can be pressed to set all "temp clear" flags
- * in the current room. To do so Hold L and press D-pad right.
+ * in the current room. To do so hold L and press D-pad left.
  *
  * @return  true if Noclip is disabled, false if enabled
  */

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11323,7 +11323,7 @@ void Player_Update(Actor* thisx, PlayState* play) {
             gSaveContext.dogParams = 0;
         } else {
             Actor* dog;
-            
+
             gSaveContext.dogParams &= 0x7FFF;
             Player_GetRelativePosition(this, &this->actor.world.pos, &sDogSpawnOffset, &sDogSpawnPos);
             dogParams = gSaveContext.dogParams;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13631,6 +13631,7 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
     func_8002F8F0(&this->actor, NA_SE_VO_LI_TAKEN_AWAY - SFX_FLAG + this->ageProperties->unk_92);
 }
 
+#if OOT_DEBUG
 /**
  * Updates the "Noclip" debug feature, which allows the player to
  * fly around anywhere in the world and clip through any collision.
@@ -13717,6 +13718,7 @@ s32 Player_UpdateNoclip(Player* this, PlayState* play) {
 
     return true;
 }
+#endif
 
 void func_8084FF7C(Player* this) {
     this->unk_858 += this->unk_85C;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11301,23 +11301,24 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
     Collider_ResetQuadAT(play, &this->shieldQuad.base);
 }
 
-static Vec3f D_80854838 = { 0.0f, 0.0f, -30.0f };
-
 void Player_Update(Actor* thisx, PlayState* play) {
+    static Vec3f sDogSpawnOffset = { 0.0f, 0.0f, -30.0f };
     static Vec3f sDogSpawnPos;
     Player* this = (Player*)thisx;
     s32 dogParams;
     s32 pad;
     Input sp44;
-    Actor* dog;
-
+    
+#if OOT_DEBUG
     if (func_8084FCAC(this, play)) {
+#endif
         if (gSaveContext.dogParams < 0) {
             if (Object_GetSlot(&play->objectCtx, OBJECT_DOG) < 0) {
                 gSaveContext.dogParams = 0;
             } else {
+                Actor* dog;
                 gSaveContext.dogParams &= 0x7FFF;
-                Player_GetRelativePosition(this, &this->actor.world.pos, &D_80854838, &sDogSpawnPos);
+                Player_GetRelativePosition(this, &this->actor.world.pos, &sDogSpawnOffset, &sDogSpawnPos);
                 dogParams = gSaveContext.dogParams;
 
                 dog = Actor_Spawn(&play->actorCtx, play, ACTOR_EN_DOG, sDogSpawnPos.x, sDogSpawnPos.y, sDogSpawnPos.z,
@@ -11347,12 +11348,19 @@ void Player_Update(Actor* thisx, PlayState* play) {
         }
 
         Player_UpdateCommon(this, play, &sp44);
+        
+#if OOT_DEBUG
     }
+#endif
 
-    MREG(52) = this->actor.world.pos.x;
-    MREG(53) = this->actor.world.pos.y;
-    MREG(54) = this->actor.world.pos.z;
-    MREG(55) = this->actor.world.rot.y;
+    {
+        s32 pad;
+
+        MREG(52) = this->actor.world.pos.x;
+        MREG(53) = this->actor.world.pos.y;
+        MREG(54) = this->actor.world.pos.z;
+        MREG(55) = this->actor.world.rot.y;
+    }
 }
 
 typedef struct {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13637,8 +13637,8 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
  * Updates the "Noclip" debug feature, which allows the player to fly around anywhere
  * in the world and clip through any collision.
  *
- * Noclip can be enabled with two different button combos:
- * Hold A + L + R and press B
+ * Noclip can be toggled on and off with two different button combos:
+ * Hold L + R + A and press B
  * or
  * Hold L and press D-pad right
  *


### PR DESCRIPTION
This matches retail things related to Noclip mode and does some documentation with it. Some notes:
- I moved the declaration down to where it is relevant 
- I used the goto method of matching to keep the ifdef stuff confined in one area. 
- The semicolon on the skip_update label is purely to make the formatter play nice
- I spell it as "Noclip" because that seems to be the common spelling in other game contexts. 
- The return on the noclip mode is unfortunately backwards with regards to "true" and "false", so the naming is a bit weird