### PR TITLE
Match even more retail actors

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -187,6 +187,22 @@ extern struct GraphicsContext* __gfxCtx;
     }                                                   \
     (void)0
 
+#else
+
+#define OPEN_DISPS(gfxCtx, file, line)      \
+    {                                       \
+        GraphicsContext* __gfxCtx = gfxCtx; \
+        s32 __dispPad
+
+#define CLOSE_DISPS(gfxCtx, file, line) \
+    (void)0;                            \
+    }                                   \
+    (void)0
+
+#endif
+
+#if OOT_DEBUG
+
 #define GRAPH_ALLOC(gfxCtx, size) Graph_Alloc(gfxCtx, size)
 #define MATRIX_TO_MTX(gfxCtx, file, line) Matrix_ToMtx(gfxCtx, file, line)
 #define MATRIX_NEW(gfxCtx, file, line) Matrix_NewMtx(gfxCtx, file, line)
@@ -210,16 +226,6 @@ extern struct GraphicsContext* __gfxCtx;
 
 #else
 
-#define OPEN_DISPS(gfxCtx, file, line)      \
-    {                                       \
-        GraphicsContext* __gfxCtx = gfxCtx; \
-        s32 __dispPad
-
-#define CLOSE_DISPS(gfxCtx, file, line) \
-    (void)0;                            \
-    }                                   \
-    (void)0
-
 #define GRAPH_ALLOC(gfxCtx, size) ((void*)((gfxCtx)->polyOpa.d = (Gfx*)((u8*)(gfxCtx)->polyOpa.d - ALIGN16(size))))
 #define MATRIX_TO_MTX(gfxCtx, file, line) Matrix_ToMtx(gfxCtx)
 #define MATRIX_NEW(gfxCtx, file, line) Matrix_NewMtx(gfxCtx)
@@ -241,7 +247,18 @@ extern struct GraphicsContext* __gfxCtx;
 #define HUNGUP_AND_CRASH(file, line) LogUtils_HungupThread(file, line)
 #define GAME_ALLOC_MALLOC(alloc, size, file, line) GameAlloc_Malloc(alloc, size)
 
-#endif /* OOT_DEBUG */
+#endif
+
+#if OOT_DEBUG
+#define DEBUG_DISPLAY_ADD_OBJECT(posX, posY, posZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ,    \
+                                 red, green, blue, alpha, type, gfxCtx)                         \
+    if (BREG(0) != 0)                                                                           \
+        DebugDisplay_AddObject(posX, posY, posZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ,      \
+                               red, green, blue, alpha, type, gfxCtx)
+#else
+#define DEBUG_DISPLAY_ADD_OBJECT(posX, posY, posZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ,    \
+                                 red, green, blue, alpha, type, gfxCtx) (void)0
+#endif
 
 /**
  * `x` vertex x

--- a/include/macros.h
+++ b/include/macros.h
@@ -187,22 +187,6 @@ extern struct GraphicsContext* __gfxCtx;
     }                                                   \
     (void)0
 
-#else
-
-#define OPEN_DISPS(gfxCtx, file, line)      \
-    {                                       \
-        GraphicsContext* __gfxCtx = gfxCtx; \
-        s32 __dispPad
-
-#define CLOSE_DISPS(gfxCtx, file, line) \
-    (void)0;                            \
-    }                                   \
-    (void)0
-
-#endif
-
-#if OOT_DEBUG
-
 #define GRAPH_ALLOC(gfxCtx, size) Graph_Alloc(gfxCtx, size)
 #define MATRIX_TO_MTX(gfxCtx, file, line) Matrix_ToMtx(gfxCtx, file, line)
 #define MATRIX_NEW(gfxCtx, file, line) Matrix_NewMtx(gfxCtx, file, line)
@@ -226,6 +210,16 @@ extern struct GraphicsContext* __gfxCtx;
 
 #else
 
+#define OPEN_DISPS(gfxCtx, file, line)      \
+    {                                       \
+        GraphicsContext* __gfxCtx = gfxCtx; \
+        s32 __dispPad
+
+#define CLOSE_DISPS(gfxCtx, file, line) \
+    (void)0;                            \
+    }                                   \
+    (void)0
+
 #define GRAPH_ALLOC(gfxCtx, size) ((void*)((gfxCtx)->polyOpa.d = (Gfx*)((u8*)(gfxCtx)->polyOpa.d - ALIGN16(size))))
 #define MATRIX_TO_MTX(gfxCtx, file, line) Matrix_ToMtx(gfxCtx)
 #define MATRIX_NEW(gfxCtx, file, line) Matrix_NewMtx(gfxCtx)
@@ -247,18 +241,7 @@ extern struct GraphicsContext* __gfxCtx;
 #define HUNGUP_AND_CRASH(file, line) LogUtils_HungupThread(file, line)
 #define GAME_ALLOC_MALLOC(alloc, size, file, line) GameAlloc_Malloc(alloc, size)
 
-#endif
-
-#if OOT_DEBUG
-#define DEBUG_DISPLAY_ADD_OBJECT(posX, posY, posZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ,    \
-                                 red, green, blue, alpha, type, gfxCtx)                         \
-    if (BREG(0) != 0)                                                                           \
-        DebugDisplay_AddObject(posX, posY, posZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ,      \
-                               red, green, blue, alpha, type, gfxCtx)
-#else
-#define DEBUG_DISPLAY_ADD_OBJECT(posX, posY, posZ, rotX, rotY, rotZ, scaleX, scaleY, scaleZ,    \
-                                 red, green, blue, alpha, type, gfxCtx) (void)0
-#endif
+#endif /* OOT_DEBUG */
 
 /**
  * `x` vertex x

--- a/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
+++ b/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
@@ -99,7 +99,11 @@ void EnAnubiceTag_Update(Actor* thisx, PlayState* play) {
 void EnAnubiceTag_Draw(Actor* thisx, PlayState* play) {
     EnAnubiceTag* this = (EnAnubiceTag*)thisx;
 
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+    }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
+++ b/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
@@ -99,11 +99,7 @@ void EnAnubiceTag_Update(Actor* thisx, PlayState* play) {
 void EnAnubiceTag_Draw(Actor* thisx, PlayState* play) {
     EnAnubiceTag* this = (EnAnubiceTag*)thisx;
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
 }

--- a/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
+++ b/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
@@ -99,9 +99,11 @@ void EnAnubiceTag_Update(Actor* thisx, PlayState* play) {
 void EnAnubiceTag_Draw(Actor* thisx, PlayState* play) {
     EnAnubiceTag* this = (EnAnubiceTag*)thisx;
 
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
+++ b/src/overlays/actors/ovl_En_Anubice_Tag/z_en_anubice_tag.c
@@ -99,11 +99,9 @@ void EnAnubiceTag_Update(Actor* thisx, PlayState* play) {
 void EnAnubiceTag_Draw(Actor* thisx, PlayState* play) {
     EnAnubiceTag* this = (EnAnubiceTag*)thisx;
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.c
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.c
@@ -282,11 +282,9 @@ void EnChanger_Update(Actor* thisx, PlayState* play) {
         this->timer--;
     }
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.c
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.c
@@ -282,9 +282,11 @@ void EnChanger_Update(Actor* thisx, PlayState* play) {
         this->timer--;
     }
 
-    if (BREG(0)) {
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.c
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.c
@@ -282,7 +282,11 @@ void EnChanger_Update(Actor* thisx, PlayState* play) {
         this->timer--;
     }
 
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
+    }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.c
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.c
@@ -282,11 +282,7 @@ void EnChanger_Update(Actor* thisx, PlayState* play) {
         this->timer--;
     }
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
 }

--- a/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
+++ b/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
@@ -326,8 +326,7 @@ void EnDntDemo_Update(Actor* thisx, PlayState* play) {
     }
     this->actionFunc(this, play);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         if (this->debugArrowTimer != 0) {
             if (!(this->debugArrowTimer & 1)) {
                 DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
@@ -340,5 +339,4 @@ void EnDntDemo_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 255, 255, 255, 255, 4, play->state.gfxCtx);
         }
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
+++ b/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
@@ -185,8 +185,7 @@ void EnDntDemo_Judge(EnDntDemo* this, PlayState* play) {
                 case PLAYER_MASK_ZORA:
                 case PLAYER_MASK_GERUDO:
                     rand9 = Rand_ZeroFloat(8.99f);
-                    maskIdx = Player_GetMask(play);
-                    maskIdx--;
+                    maskIdx = (s16)Player_GetMask(play) - 1;
                     if (rand9 == 8) {
                         ignore = true;
                         delay = 8;
@@ -265,6 +264,9 @@ void EnDntDemo_Judge(EnDntDemo* this, PlayState* play) {
 
 void EnDntDemo_Results(EnDntDemo* this, PlayState* play) {
     s32 i;
+    s16 offsetAngle;
+    Vec3f leaderPos;
+    f32 offsetDist;
 
     if (this->leaderSignal != DNT_SIGNAL_NONE) {
         for (i = 0; i < 9; i++) {
@@ -284,9 +286,8 @@ void EnDntDemo_Results(EnDntDemo* this, PlayState* play) {
         this->actionFunc = EnDntDemo_Prize;
     } else if (this->prize == DNT_PRIZE_STICK) {
         for (i = 0; i < 9; i++) {
-            s16 offsetAngle = -this->leader->actor.shape.rot.y;
-            Vec3f leaderPos = this->leader->actor.world.pos;
-            f32 offsetDist;
+            offsetAngle = -this->leader->actor.shape.rot.y;
+            leaderPos = this->leader->actor.world.pos;
 
             if (!(i & 1)) {
                 offsetAngle -= 0x59D8;
@@ -324,7 +325,9 @@ void EnDntDemo_Update(Actor* thisx, PlayState* play) {
         this->unkTimer1--;
     }
     this->actionFunc(this, play);
-    if (BREG(0)) {
+
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
         if (this->debugArrowTimer != 0) {
             if (!(this->debugArrowTimer & 1)) {
                 DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
@@ -337,4 +340,5 @@ void EnDntDemo_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 255, 255, 255, 255, 4, play->state.gfxCtx);
         }
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
+++ b/src/overlays/actors/ovl_En_Dnt_Demo/z_en_dnt_demo.c
@@ -185,6 +185,7 @@ void EnDntDemo_Judge(EnDntDemo* this, PlayState* play) {
                 case PLAYER_MASK_ZORA:
                 case PLAYER_MASK_GERUDO:
                     rand9 = Rand_ZeroFloat(8.99f);
+                    // fake match, possible alternative is `maskIdx = Player_GetMask(play); maskIdx--;` on one line
                     maskIdx = (s16)Player_GetMask(play) - 1;
                     if (rand9 == 8) {
                         ignore = true;

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
@@ -324,8 +324,7 @@ void EnEncount1_Update(Actor* thisx, PlayState* play) {
 
     this->updateFunc(this, play);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         if (this->outOfRangeTimer != 0) {
             if ((this->outOfRangeTimer & 1) == 0) {
                 DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
@@ -338,5 +337,4 @@ void EnEncount1_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
         }
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
@@ -51,6 +51,8 @@ void EnEncount1_Init(Actor* thisx, PlayState* play) {
     spawnRange = 120.0f + (40.0f * this->actor.world.rot.z);
     this->spawnRange = spawnRange;
 
+    if (1) {}
+
     PRINTF("\n\n");
     // "It's an enemy spawner!"
     PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ 敵発生ゾーンでた！ ☆☆☆☆☆ %x\n" VT_RST, this->actor.params);
@@ -322,6 +324,7 @@ void EnEncount1_Update(Actor* thisx, PlayState* play) {
 
     this->updateFunc(this, play);
 
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         if (this->outOfRangeTimer != 0) {
             if ((this->outOfRangeTimer & 1) == 0) {
@@ -335,4 +338,5 @@ void EnEncount1_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
         }
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -284,13 +284,11 @@ void FireRock_WaitSpawnRocksFromCeiling(EnFireRock* this, PlayState* play) {
         this->playerNearby = 0;
     }
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
     }
-#endif
 }
 
 void FireRock_WaitOnFloor(EnFireRock* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -284,13 +284,9 @@ void FireRock_WaitSpawnRocksFromCeiling(EnFireRock* this, PlayState* play) {
         this->playerNearby = 0;
     }
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
 }
 
 void FireRock_WaitOnFloor(EnFireRock* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -284,9 +284,13 @@ void FireRock_WaitSpawnRocksFromCeiling(EnFireRock* this, PlayState* play) {
         this->playerNearby = 0;
     }
 
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
+    }
+#endif
 }
 
 void FireRock_WaitOnFloor(EnFireRock* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -283,11 +283,14 @@ void FireRock_WaitSpawnRocksFromCeiling(EnFireRock* this, PlayState* play) {
     } else {
         this->playerNearby = 0;
     }
+
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
     }
+#endif
 }
 
 void FireRock_WaitOnFloor(EnFireRock* this, PlayState* play) {
@@ -309,6 +312,7 @@ void EnFireRock_Update(Actor* thisx, PlayState* play) {
     s16 setCollision;
     Player* player = GET_PLAYER(play);
     Actor* playerActor = &GET_PLAYER(play)->actor;
+    f32 temp;
 
     if (this->timer2 != 0) {
         this->timer2--;
@@ -319,8 +323,6 @@ void EnFireRock_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
 
     if (this->type != FIRE_ROCK_CEILING_SPOT_SPAWNER) {
-        f32 temp;
-
         this->rockRotation.x += this->angularVelocity.x;
         this->rockRotation.y += this->angularVelocity.y;
         this->rockRotation.z += this->angularVelocity.z;

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -1029,13 +1029,11 @@ void EnFr_SetIdle(EnFr* this, PlayState* play) {
 void EnFr_UpdateIdle(Actor* thisx, PlayState* play) {
     EnFr* this = (EnFr*)thisx;
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
-#endif
 
     this->jumpCounter++;
     this->actionFunc(this, play);

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -723,20 +723,17 @@ void EnFr_ListeningToOcarinaNotes(EnFr* this, PlayState* play) {
 }
 
 void EnFr_ChildSong(EnFr* this, PlayState* play) {
-    EnFr* frog;
-    u8 songIndex;
-
     if (this->jumpCounter < 48) {
         if (this->jumpCounter % 4 == 0) {
             EnFr_SetupJumpingUp(this, sJumpOrder[(this->jumpCounter >> 2) & 7]);
         }
     } else {
-        songIndex = this->songIndex;
-        if (songIndex == FROG_STORMS) {
+        if (this->songIndex == FROG_STORMS) {
             this->actor.textId = 0x40AA;
             EnFr_SetupReward(this, play, false);
-        } else if (!FROG_HAS_SONG_BEEN_PLAYED(songIndex)) {
-            frog = sEnFrPointers.frogs[sSongToFrog[songIndex]];
+        } else if (!FROG_HAS_SONG_BEEN_PLAYED(this->songIndex)) {
+            EnFr* frog = sEnFrPointers.frogs[sSongToFrog[this->songIndex]];
+
             Sfx_PlaySfxCentered(NA_SE_SY_CORRECT_CHIME);
             if (frog->actionFunc == EnFr_ChooseJumpFromLogSpot) {
                 frog->isJumpingUp = true;
@@ -800,10 +797,10 @@ void EnFr_CheckOcarinaInputFrogSong(u8 ocarinaNote) {
 
 void EnFr_DeactivateButterfly(void) {
     s32 frogIndex;
-    EnFr* frog;
 
     for (frogIndex = 0; frogIndex < ARRAY_COUNT(sEnFrPointers.frogs); frogIndex++) {
-        frog = sEnFrPointers.frogs[frogIndex];
+        EnFr* frog = sEnFrPointers.frogs[frogIndex];
+
         frog->isButterflyDrawn = false;
     }
 }
@@ -863,21 +860,18 @@ void EnFr_OcarinaMistake(EnFr* this, PlayState* play) {
 }
 
 void EnFr_ContinueFrogSong(EnFr* this, PlayState* play) {
-    s32 counter;
-    EnFr* frog;
-    s32 i;
-
     if (this->frogSongTimer == 0) {
         EnFr_OcarinaMistake(this, play);
     } else {
         this->frogSongTimer--;
         if (play->msgCtx.msgMode == MSGMODE_FROGS_PLAYING) {
-            counter = 0;
+            s32 counter = 0;
+            s32 i;
+
             for (i = 0; i < ARRAY_COUNT(sEnFrPointers.frogs); i++) {
-                frog = sEnFrPointers.frogs[i];
-                if (frog != NULL && frog->actionFunc == EnFr_ChooseJumpFromLogSpot) {
-                    continue;
-                } else {
+                EnFr* frog = sEnFrPointers.frogs[i];
+
+                if (frog == NULL || frog->actionFunc != EnFr_ChooseJumpFromLogSpot) {
                     counter++;
                 }
             }
@@ -971,8 +965,6 @@ void EnFr_SetReward(EnFr* this, PlayState* play) {
 }
 
 void EnFr_Deactivate(EnFr* this, PlayState* play) {
-    EnFr* frogLoop1;
-    EnFr* frogLoop2;
     s32 frogIndex;
 
     // Originally was going to have separate butterfly actor
@@ -983,28 +975,30 @@ void EnFr_Deactivate(EnFr* this, PlayState* play) {
     }
 
     for (frogIndex = 0; frogIndex < ARRAY_COUNT(sEnFrPointers.frogs); frogIndex++) {
-        frogLoop1 = sEnFrPointers.frogs[frogIndex];
-        if (frogLoop1 == NULL) {
+        EnFr* frog = sEnFrPointers.frogs[frogIndex];
+
+        if (frog == NULL) {
             PRINTF(VT_COL(RED, WHITE));
             // "There are no frogs!?"
             PRINTF("%s[%d]カエルがいない！？\n", "../z_en_fr.c", 1604);
             PRINTF(VT_RST);
             return;
-        } else if (frogLoop1->isDeactivating != true) {
+        } else if (frog->isDeactivating != true) {
             return;
         }
     }
 
     for (frogIndex = 0; frogIndex < ARRAY_COUNT(sEnFrPointers.frogs); frogIndex++) {
-        frogLoop2 = sEnFrPointers.frogs[frogIndex];
-        if (frogLoop2 == NULL) {
+        EnFr* frog = sEnFrPointers.frogs[frogIndex];
+
+        if (frog == NULL) {
             PRINTF(VT_COL(RED, WHITE));
             // "There are no frogs!?"
             PRINTF("%s[%d]カエルがいない！？\n", "../z_en_fr.c", 1618);
             PRINTF(VT_RST);
             return;
         }
-        frogLoop2->isDeactivating = false;
+        frog->isDeactivating = false;
     }
 
     play->msgCtx.ocarinaMode = OCARINA_MODE_04;
@@ -1035,11 +1029,14 @@ void EnFr_SetIdle(EnFr* this, PlayState* play) {
 void EnFr_UpdateIdle(Actor* thisx, PlayState* play) {
     EnFr* this = (EnFr*)thisx;
 
-    if (BREG(0)) {
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
+#endif
+
     this->jumpCounter++;
     this->actionFunc(this, play);
 }

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -1029,14 +1029,9 @@ void EnFr_SetIdle(EnFr* this, PlayState* play) {
 void EnFr_UpdateIdle(Actor* thisx, PlayState* play) {
     EnFr* this = (EnFr*)thisx;
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
-    }
-#endif
-
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     this->jumpCounter++;
     this->actionFunc(this, play);
 }

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -1029,9 +1029,14 @@ void EnFr_SetIdle(EnFr* this, PlayState* play) {
 void EnFr_UpdateIdle(Actor* thisx, PlayState* play) {
     EnFr* this = (EnFr*)thisx;
 
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+    }
+#endif
+
     this->jumpCounter++;
     this->actionFunc(this, play);
 }

--- a/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
+++ b/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
@@ -80,6 +80,8 @@ void EnGSwitch_Init(Actor* thisx, PlayState* play) {
     s32 pad;
     EnGSwitch* this = (EnGSwitch*)thisx;
 
+    if (play) {}
+
     this->type = (this->actor.params >> 0xC) & 0xF;
     this->switchFlag = this->actor.params & 0x3F;
     this->numEffects = EN_GSWITCH_EFFECT_COUNT;
@@ -443,11 +445,14 @@ void EnGSwitch_Update(Actor* thisx, PlayState* play) {
             CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
         }
     }
-    if (BREG(0) && (this->type == ENGSWITCH_SILVER_TRACKER)) {
+
+#if OOT_DEBUG
+    if (BREG(0) != 0 && (this->type == ENGSWITCH_SILVER_TRACKER)) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
+#endif
 }
 
 void EnGSwitch_DrawPot(Actor* thisx, PlayState* play) {
@@ -456,6 +461,9 @@ void EnGSwitch_DrawPot(Actor* thisx, PlayState* play) {
 
     if (!this->broken) {
         OPEN_DISPS(play->state.gfxCtx, "../z_en_g_switch.c", 918);
+
+        if (1) {}
+
         Gfx_SetupDL_25Opa(play->state.gfxCtx);
         gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_en_g_switch.c", 925),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
@@ -491,12 +499,12 @@ void EnGSwitch_DrawRupee(Actor* thisx, PlayState* play) {
 void EnGSwitch_SpawnEffects(EnGSwitch* this, Vec3f* pos, s16 scale, s16 colorIdx) {
     EnGSwitchEffect* effect = this->effects;
     s16 i;
+    Vec3f baseVel;
+    f32 pitch;
+    f32 yaw;
 
     for (i = 0; i < this->numEffects; i++, effect++) {
         if (!effect->flag) {
-            Vec3f baseVel;
-            f32 pitch;
-            f32 yaw;
 
             effect->pos = *pos;
             effect->scale = scale;

--- a/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
+++ b/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
@@ -446,13 +446,11 @@ void EnGSwitch_Update(Actor* thisx, PlayState* play) {
         }
     }
 
-#if OOT_DEBUG
-    if (BREG(0) != 0 && (this->type == ENGSWITCH_SILVER_TRACKER)) {
+    if (OOT_DEBUG && BREG(0) != 0 && (this->type == ENGSWITCH_SILVER_TRACKER)) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
-#endif
 }
 
 void EnGSwitch_DrawPot(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
+++ b/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
@@ -182,7 +182,7 @@ void EnHeishi1_Walk(EnHeishi1* this, PlayState* play) {
 
         Math_ApproachF(&this->headAngle, this->headAngleTarget, this->headTurnSpeedScale, this->headTurnSpeedMax);
 
-        if ((this->path == BREG(1)) && (BREG(0) != 0)) {
+        if (OOT_DEBUG && (this->path == BREG(1)) && (BREG(0) != 0)) {
             PRINTF(VT_FGCOL(RED) " 種類  %d\n" VT_RST, this->path);
             PRINTF(VT_FGCOL(RED) " ぱす  %d\n" VT_RST, this->waypoint);
             PRINTF(VT_FGCOL(RED) " 反転  %d\n" VT_RST, this->bodyTurnSpeed);
@@ -300,15 +300,13 @@ void EnHeishi1_Wait(EnHeishi1* this, PlayState* play) {
         Math_ApproachF(&this->headAngle, this->headAngleTarget, this->headTurnSpeedScale,
                        this->headTurnSpeedMax + this->headTurnSpeedMax);
 
-#if OOT_DEBUG
-        if ((this->path == BREG(1)) && (BREG(0) != 0)) {
+        if (OOT_DEBUG && (this->path == BREG(1)) && (BREG(0) != 0)) {
             PRINTF(VT_FGCOL(GREEN) " 種類  %d\n" VT_RST, this->path);
             PRINTF(VT_FGCOL(GREEN) " ぱす  %d\n" VT_RST, this->waypoint);
             PRINTF(VT_FGCOL(GREEN) " 反転  %d\n" VT_RST, this->bodyTurnSpeed);
             PRINTF(VT_FGCOL(GREEN) " 時間  %d\n" VT_RST, this->waypointTimer);
             PRINTF("\n\n");
         }
-#endif
     }
 }
 
@@ -492,11 +490,9 @@ void EnHeishi1_Draw(Actor* thisx, PlayState* play) {
                       this);
     func_80033C30(&this->actor.world.pos, &matrixScale, 0xFF, play);
 
-#if OOT_DEBUG
-    if ((this->path == BREG(1)) && (BREG(0) != 0)) {
+    if (OOT_DEBUG && (this->path == BREG(1)) && (BREG(0) != 0)) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y + 100.0f, this->actor.world.pos.z,
                                17000, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f, 1.0f, 255, 0, 0,
                                255, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
+++ b/src/overlays/actors/ovl_En_Heishi1/z_en_heishi1.c
@@ -10,7 +10,7 @@
 
 #define FLAGS ACTOR_FLAG_4
 
-void EnHeishi1_Init(Actor* thisx, PlayState* play);
+void EnHeishi1_Init(Actor* thisx, PlayState* play2);
 void EnHeishi1_Destroy(Actor* thisx, PlayState* play);
 void EnHeishi1_Update(Actor* thisx, PlayState* play);
 void EnHeishi1_Draw(Actor* thisx, PlayState* play);
@@ -63,8 +63,8 @@ static s32 sBgCamIndices[] = {
 
 static s16 sWaypoints[] = { 0, 4, 1, 5, 2, 6, 3, 7 };
 
-void EnHeishi1_Init(Actor* thisx, PlayState* play) {
-    s32 pad;
+void EnHeishi1_Init(Actor* thisx, PlayState* play2) {
+    PlayState* play = play2;
     EnHeishi1* this = (EnHeishi1*)thisx;
     Vec3f rupeePos;
     s32 i;
@@ -300,6 +300,7 @@ void EnHeishi1_Wait(EnHeishi1* this, PlayState* play) {
         Math_ApproachF(&this->headAngle, this->headAngleTarget, this->headTurnSpeedScale,
                        this->headTurnSpeedMax + this->headTurnSpeedMax);
 
+#if OOT_DEBUG
         if ((this->path == BREG(1)) && (BREG(0) != 0)) {
             PRINTF(VT_FGCOL(GREEN) " 種類  %d\n" VT_RST, this->path);
             PRINTF(VT_FGCOL(GREEN) " ぱす  %d\n" VT_RST, this->waypoint);
@@ -307,6 +308,7 @@ void EnHeishi1_Wait(EnHeishi1* this, PlayState* play) {
             PRINTF(VT_FGCOL(GREEN) " 時間  %d\n" VT_RST, this->waypointTimer);
             PRINTF("\n\n");
         }
+#endif
     }
 }
 
@@ -490,9 +492,11 @@ void EnHeishi1_Draw(Actor* thisx, PlayState* play) {
                       this);
     func_80033C30(&this->actor.world.pos, &matrixScale, 0xFF, play);
 
+#if OOT_DEBUG
     if ((this->path == BREG(1)) && (BREG(0) != 0)) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y + 100.0f, this->actor.world.pos.z,
                                17000, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f, 1.0f, 255, 0, 0,
                                255, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
+++ b/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
@@ -214,8 +214,7 @@ void EnKakasi2_Update(Actor* thisx, PlayState* play2) {
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     }
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         if (BREG(5) != 0) {
             PRINTF(VT_FGCOL(YELLOW) "☆☆☆☆☆ this->actor.player_distance ☆☆☆☆☆ %f\n" VT_RST, this->actor.xzDistToPlayer);
             PRINTF(VT_FGCOL(YELLOW) "☆☆☆☆☆ this->hosei.x ☆☆☆☆☆ %f\n" VT_RST, this->maxSpawnDistance.x);
@@ -235,7 +234,6 @@ void EnKakasi2_Update(Actor* thisx, PlayState* play2) {
             }
         }
     }
-#endif
 }
 
 void func_80A90948(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
+++ b/src/overlays/actors/ovl_En_Kakasi2/z_en_kakasi2.c
@@ -116,7 +116,7 @@ void func_80A90264(EnKakasi2* this, PlayState* play) {
 
     this->unk_194++;
 
-    if ((BREG(1) != 0) && (this->actor.xzDistToPlayer < this->maxSpawnDistance.x) &&
+    if (OOT_DEBUG && (BREG(1) != 0) && (this->actor.xzDistToPlayer < this->maxSpawnDistance.x) &&
         (fabsf(player->actor.world.pos.y - this->actor.world.pos.y) < this->maxSpawnDistance.y)) {
 
         this->actor.draw = func_80A90948;
@@ -213,6 +213,8 @@ void EnKakasi2_Update(Actor* thisx, PlayState* play2) {
         CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     }
+
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         if (BREG(5) != 0) {
             PRINTF(VT_FGCOL(YELLOW) "☆☆☆☆☆ this->actor.player_distance ☆☆☆☆☆ %f\n" VT_RST, this->actor.xzDistToPlayer);
@@ -233,6 +235,7 @@ void EnKakasi2_Update(Actor* thisx, PlayState* play2) {
             }
         }
     }
+#endif
 }
 
 void func_80A90948(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -115,9 +115,12 @@ void EnOkarinaEffect_Update(Actor* thisx, PlayState* play) {
     EnOkarinaEffect* this = (EnOkarinaEffect*)thisx;
 
     this->actionFunc(this, play);
+
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 0xFF, 0, 0xFF, 0xFF, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -115,12 +115,7 @@ void EnOkarinaEffect_Update(Actor* thisx, PlayState* play) {
     EnOkarinaEffect* this = (EnOkarinaEffect*)thisx;
 
     this->actionFunc(this, play);
-
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 0xFF, 0, 0xFF, 0xFF, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 0xFF, 0, 0xFF, 0xFF, 4, play->state.gfxCtx);
 }

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -115,7 +115,12 @@ void EnOkarinaEffect_Update(Actor* thisx, PlayState* play) {
     EnOkarinaEffect* this = (EnOkarinaEffect*)thisx;
 
     this->actionFunc(this, play);
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 0xFF, 0, 0xFF, 0xFF, 4, play->state.gfxCtx);
+
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 0xFF, 0, 0xFF, 0xFF, 4, play->state.gfxCtx);
+    }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -116,11 +116,9 @@ void EnOkarinaEffect_Update(Actor* thisx, PlayState* play) {
 
     this->actionFunc(this, play);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 0xFF, 0, 0xFF, 0xFF, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -318,6 +318,8 @@ void EnOkarinaTag_Update(Actor* thisx, PlayState* play) {
     EnOkarinaTag* this = (EnOkarinaTag*)thisx;
 
     this->actionFunc(this, play);
+
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         if (this->unk_15A != 0) {
             if (!(this->unk_15A & 1)) {
@@ -331,4 +333,5 @@ void EnOkarinaTag_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
         }
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -319,8 +319,7 @@ void EnOkarinaTag_Update(Actor* thisx, PlayState* play) {
 
     this->actionFunc(this, play);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         if (this->unk_15A != 0) {
             if (!(this->unk_15A & 1)) {
                 DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
@@ -333,5 +332,4 @@ void EnOkarinaTag_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
         }
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -696,8 +696,7 @@ void EnReeba_Draw(Actor* thisx, PlayState* play) {
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_reeba.c", 1088);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         Vec3f debugPos;
 
         debugPos.x = (Math_SinS(this->actor.world.rot.y) * 30.0f) + this->actor.world.pos.x;
@@ -706,5 +705,4 @@ void EnReeba_Draw(Actor* thisx, PlayState* play) {
         DebugDisplay_AddObject(debugPos.x, debugPos.y, debugPos.z, this->actor.world.rot.x, this->actor.world.rot.y,
                                this->actor.world.rot.z, 1.0f, 1.0f, 1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -399,40 +399,39 @@ void EnReeba_SetupStunned(EnReeba* this, PlayState* play) {
 }
 
 void EnReeba_Stunned(EnReeba* this, PlayState* play) {
-    Vec3f pos;
-    f32 scale;
-
     if (this->waitTimer != 0) {
         if (this->actor.speed < 0.0f) {
             this->actor.speed += 1.0f;
         }
         return;
-    }
+    } else {
+        this->actor.speed = 0.0f;
 
-    this->actor.speed = 0.0f;
+        if ((this->stunType == LEEVER_STUN_OTHER) || (this->actor.colChkInfo.health != 0)) {
+            Vec3f pos;
+            f32 scale;
 
-    if ((this->stunType == LEEVER_STUN_OTHER) || (this->actor.colChkInfo.health != 0)) {
-        if (this->stunType == LEEVER_STUN_ICE) {
-            pos.x = this->actor.world.pos.x + Rand_CenteredFloat(20.0f);
-            pos.y = this->actor.world.pos.y + Rand_CenteredFloat(20.0f);
-            pos.z = this->actor.world.pos.z + Rand_CenteredFloat(20.0f);
-            scale = 3.0f;
+            if (this->stunType == LEEVER_STUN_ICE) {
+                pos.x = this->actor.world.pos.x + Rand_CenteredFloat(20.0f);
+                pos.y = this->actor.world.pos.y + Rand_CenteredFloat(20.0f);
+                pos.z = this->actor.world.pos.z + Rand_CenteredFloat(20.0f);
+                scale = 3.0f;
 
-            if (this->type != LEEVER_TYPE_SMALL) {
-                scale = 6.0f;
+                if (this->type != LEEVER_TYPE_SMALL) {
+                    scale = 6.0f;
+                }
+
+                EffectSsEnIce_SpawnFlyingVec3f(play, &this->actor, &pos, 150, 150, 150, 250, 235, 245, 255, scale);
             }
 
-            EffectSsEnIce_SpawnFlyingVec3f(play, &this->actor, &pos, 150, 150, 150, 250, 235, 245, 255, scale);
+            this->waitTimer = 66;
+            this->actionfunc = EnReeba_StunRecover;
+            return;
         }
 
-        this->waitTimer = 66;
-        this->actionfunc = EnReeba_StunRecover;
-        return;
+        this->waitTimer = 30;
+        this->actionfunc = EnReeba_StunDie;
     }
-
-setup_stun_die:
-    this->waitTimer = 30;
-    this->actionfunc = EnReeba_StunDie;
 }
 
 void EnReeba_StunDie(EnReeba* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
+++ b/src/overlays/actors/ovl_En_Reeba/z_en_reeba.c
@@ -126,9 +126,9 @@ void EnReeba_Init(Actor* thisx, PlayState* play) {
     this->scale = 0.04f;
 
     if (this->type != LEEVER_TYPE_SMALL) {
+        this->scale *= 1.5f;
         this->collider.dim.radius = 35;
         this->collider.dim.height = 45;
-        this->scale *= 1.5f;
         // "Reeba Boss Appears %f"
         PRINTF(VT_FGCOL(YELLOW) "☆☆☆☆☆ リーバぼす登場 ☆☆☆☆☆ %f\n" VT_RST, this->scale);
         this->actor.colChkInfo.health = 20;
@@ -406,30 +406,33 @@ void EnReeba_Stunned(EnReeba* this, PlayState* play) {
         if (this->actor.speed < 0.0f) {
             this->actor.speed += 1.0f;
         }
-    } else {
-        this->actor.speed = 0.0f;
+        return;
+    }
 
-        if ((this->stunType == LEEVER_STUN_OTHER) || (this->actor.colChkInfo.health != 0)) {
-            if (this->stunType == LEEVER_STUN_ICE) {
-                pos.x = this->actor.world.pos.x + Rand_CenteredFloat(20.0f);
-                pos.y = this->actor.world.pos.y + Rand_CenteredFloat(20.0f);
-                pos.z = this->actor.world.pos.z + Rand_CenteredFloat(20.0f);
-                scale = 3.0f;
+    this->actor.speed = 0.0f;
 
-                if (this->type != LEEVER_TYPE_SMALL) {
-                    scale = 6.0f;
-                }
+    if ((this->stunType == LEEVER_STUN_OTHER) || (this->actor.colChkInfo.health != 0)) {
+        if (this->stunType == LEEVER_STUN_ICE) {
+            pos.x = this->actor.world.pos.x + Rand_CenteredFloat(20.0f);
+            pos.y = this->actor.world.pos.y + Rand_CenteredFloat(20.0f);
+            pos.z = this->actor.world.pos.z + Rand_CenteredFloat(20.0f);
+            scale = 3.0f;
 
-                EffectSsEnIce_SpawnFlyingVec3f(play, &this->actor, &pos, 150, 150, 150, 250, 235, 245, 255, scale);
+            if (this->type != LEEVER_TYPE_SMALL) {
+                scale = 6.0f;
             }
 
-            this->waitTimer = 66;
-            this->actionfunc = EnReeba_StunRecover;
-        } else {
-            this->waitTimer = 30;
-            this->actionfunc = EnReeba_StunDie;
+            EffectSsEnIce_SpawnFlyingVec3f(play, &this->actor, &pos, 150, 150, 150, 250, 235, 245, 255, scale);
         }
+
+        this->waitTimer = 66;
+        this->actionfunc = EnReeba_StunRecover;
+        return;
     }
+
+setup_stun_die:
+    this->waitTimer = 30;
+    this->actionfunc = EnReeba_StunDie;
 }
 
 void EnReeba_StunDie(EnReeba* this, PlayState* play) {
@@ -693,7 +696,8 @@ void EnReeba_Draw(Actor* thisx, PlayState* play) {
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_reeba.c", 1088);
 
-    if (BREG(0)) {
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
         Vec3f debugPos;
 
         debugPos.x = (Math_SinS(this->actor.world.rot.y) * 30.0f) + this->actor.world.pos.x;
@@ -702,4 +706,5 @@ void EnReeba_Draw(Actor* thisx, PlayState* play) {
         DebugDisplay_AddObject(debugPos.x, debugPos.y, debugPos.z, this->actor.world.rot.x, this->actor.world.rot.y,
                                this->actor.world.rot.z, 1.0f, 1.0f, 1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -1348,13 +1348,11 @@ void EnSkj_SariasSongShortStumpUpdate(Actor* thisx, PlayState* play) {
 
     D_80B01EA0 = Actor_TalkOfferAccepted(&this->actor, play);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
-#endif
 }
 
 void EnSkj_TurnPlayer(EnSkj* this, Player* player) {

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -364,7 +364,6 @@ void EnSkj_Init(Actor* thisx, PlayState* play2) {
     EnSkj* this = (EnSkj*)thisx;
     PlayState* play = play2;
     s32 pad;
-    Player* player;
 
     Actor_ProcessInitChain(thisx, sInitChain);
     switch (type) {
@@ -445,13 +444,17 @@ void EnSkj_Init(Actor* thisx, PlayState* play2) {
             this->actor.gravity = -1.0f;
             EnSkj_CalculateCenter(this);
 
-            player = GET_PLAYER(play);
-            PRINTF("Player_X : %f\n", player->actor.world.pos.x);
-            PRINTF("Player_Z : %f\n", player->actor.world.pos.z);
-            PRINTF("World_X  : %f\n", this->actor.world.pos.x);
-            PRINTF("World_Z  : %f\n", this->actor.world.pos.z);
-            PRINTF("Center_X : %f\n", this->center.x);
-            PRINTF("Center_Z : %f\n\n", this->center.z);
+#if OOT_DEBUG
+            {
+                Player* player = GET_PLAYER(play);
+                PRINTF("Player_X : %f\n", player->actor.world.pos.x);
+                PRINTF("Player_Z : %f\n", player->actor.world.pos.z);
+                PRINTF("World_X  : %f\n", this->actor.world.pos.x);
+                PRINTF("World_Z  : %f\n", this->actor.world.pos.z);
+                PRINTF("Center_X : %f\n", this->center.x);
+                PRINTF("Center_Z : %f\n\n", this->center.z);
+            }
+#endif
 
             break;
     }
@@ -1345,11 +1348,13 @@ void EnSkj_SariasSongShortStumpUpdate(Actor* thisx, PlayState* play) {
 
     D_80B01EA0 = Actor_TalkOfferAccepted(&this->actor, play);
 
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
+#endif
 }
 
 void EnSkj_TurnPlayer(EnSkj* this, Player* player) {
@@ -1502,15 +1507,14 @@ void EnSkj_OfferNextRound(EnSkj* this, PlayState* play) {
 }
 
 void EnSkj_WaitForOfferResponse(EnSkj* this, PlayState* play) {
-    Player* player;
-
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CHOICE && Message_ShouldAdvance(play)) {
         switch (play->msgCtx.choiceIndex) {
-            case 0: // yes
-                player = GET_PLAYER(play);
+            case 0: { // yes
+                Player* player = GET_PLAYER(play);
                 player->stateFlags3 |= PLAYER_STATE3_5; // makes player take ocarina out right away after closing box
                 this->actionFunc = EnSkj_SetupWaitForOcarina;
                 break;
+            }
             case 1: // no
                 this->actionFunc = EnSkj_CleanupOcarinaGame;
                 break;
@@ -1587,11 +1591,13 @@ void EnSkj_OcarinaMinigameShortStumpUpdate(Actor* thisx, PlayState* play) {
     this->actor.focus.pos.y = -90.0f;
     this->actor.focus.pos.z = 450.0f;
 
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
+#endif
 
     this->actionFunc(this, play);
 

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -447,6 +447,7 @@ void EnSkj_Init(Actor* thisx, PlayState* play2) {
 #if OOT_DEBUG
             {
                 Player* player = GET_PLAYER(play);
+
                 PRINTF("Player_X : %f\n", player->actor.world.pos.x);
                 PRINTF("Player_Z : %f\n", player->actor.world.pos.z);
                 PRINTF("World_X  : %f\n", this->actor.world.pos.x);
@@ -1509,10 +1510,10 @@ void EnSkj_WaitForOfferResponse(EnSkj* this, PlayState* play) {
         switch (play->msgCtx.choiceIndex) {
             case 0: { // yes
                 Player* player = GET_PLAYER(play);
+
                 player->stateFlags3 |= PLAYER_STATE3_5; // makes player take ocarina out right away after closing box
                 this->actionFunc = EnSkj_SetupWaitForOcarina;
-                break;
-            }
+            } break;
             case 1: // no
                 this->actionFunc = EnSkj_CleanupOcarinaGame;
                 break;

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -1348,13 +1348,9 @@ void EnSkj_SariasSongShortStumpUpdate(Actor* thisx, PlayState* play) {
 
     D_80B01EA0 = Actor_TalkOfferAccepted(&this->actor, play);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
 }
 
 void EnSkj_TurnPlayer(EnSkj* this, Player* player) {
@@ -1591,13 +1587,9 @@ void EnSkj_OcarinaMinigameShortStumpUpdate(Actor* thisx, PlayState* play) {
     this->actor.focus.pos.y = -90.0f;
     this->actor.focus.pos.z = 450.0f;
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
 
     this->actionFunc(this, play);
 

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -1348,9 +1348,13 @@ void EnSkj_SariasSongShortStumpUpdate(Actor* thisx, PlayState* play) {
 
     D_80B01EA0 = Actor_TalkOfferAccepted(&this->actor, play);
 
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+    }
+#endif
 }
 
 void EnSkj_TurnPlayer(EnSkj* this, Player* player) {
@@ -1587,9 +1591,13 @@ void EnSkj_OcarinaMinigameShortStumpUpdate(Actor* thisx, PlayState* play) {
     this->actor.focus.pos.y = -90.0f;
     this->actor.focus.pos.z = 450.0f;
 
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+    }
+#endif
 
     this->actionFunc(this, play);
 

--- a/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
+++ b/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
@@ -342,9 +342,12 @@ void EnSyatekiItm_Update(Actor* thisx, PlayState* play) {
     if (this->unkTimer != 0) {
         this->unkTimer--;
     }
-    if (BREG(0)) {
+
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
+++ b/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
@@ -343,11 +343,9 @@ void EnSyatekiItm_Update(Actor* thisx, PlayState* play) {
         this->unkTimer--;
     }
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
+++ b/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
@@ -343,11 +343,7 @@ void EnSyatekiItm_Update(Actor* thisx, PlayState* play) {
         this->unkTimer--;
     }
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
 }

--- a/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
+++ b/src/overlays/actors/ovl_En_Syateki_Itm/z_en_syateki_itm.c
@@ -343,7 +343,11 @@ void EnSyatekiItm_Update(Actor* thisx, PlayState* play) {
         this->unkTimer--;
     }
 
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 255, 0, 0, 255, 4, play->state.gfxCtx);
+    }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
+++ b/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
@@ -146,7 +146,12 @@ void EnWallTubo_Update(Actor* thisx, PlayState* play) {
     }
 
     this->actionFunc(this, play);
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
+
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
+    }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
+++ b/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
@@ -146,12 +146,7 @@ void EnWallTubo_Update(Actor* thisx, PlayState* play) {
     }
 
     this->actionFunc(this, play);
-
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
 }

--- a/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
+++ b/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
@@ -147,11 +147,9 @@ void EnWallTubo_Update(Actor* thisx, PlayState* play) {
 
     this->actionFunc(this, play);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
+++ b/src/overlays/actors/ovl_En_Wall_Tubo/z_en_wall_tubo.c
@@ -147,9 +147,11 @@ void EnWallTubo_Update(Actor* thisx, PlayState* play) {
 
     this->actionFunc(this, play);
 
-    if (BREG(0)) {
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -326,12 +326,7 @@ void EnWeatherTag_Update(Actor* thisx, PlayState* play) {
     EnWeatherTag* this = (EnWeatherTag*)thisx;
 
     this->actionFunc(this, play);
-
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
 }

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -327,11 +327,9 @@ void EnWeatherTag_Update(Actor* thisx, PlayState* play) {
 
     this->actionFunc(this, play);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -326,7 +326,12 @@ void EnWeatherTag_Update(Actor* thisx, PlayState* play) {
     EnWeatherTag* this = (EnWeatherTag*)thisx;
 
     this->actionFunc(this, play);
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
+
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
+    }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -326,9 +326,12 @@ void EnWeatherTag_Update(Actor* thisx, PlayState* play) {
     EnWeatherTag* this = (EnWeatherTag*)thisx;
 
     this->actionFunc(this, play);
+
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
@@ -206,15 +206,18 @@ void EnWonderItem_Init(Actor* thisx, PlayState* play) {
 
 void EnWonderItem_MultitagFree(EnWonderItem* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
-    s32 prevTagFlags = this->tagFlags;
+    s16 prevTagFlags = this->tagFlags;
     s32 i;
     s32 mask;
+    f32 dx;
+    f32 dy;
+    f32 dz;
 
     for (i = 0, mask = 1; i < this->numTagPoints; i++, mask <<= 1) {
         if (!(prevTagFlags & mask)) {
-            f32 dx = player->actor.world.pos.x - sTagPointsFree[i].x;
-            f32 dy = player->actor.world.pos.y - sTagPointsFree[i].y;
-            f32 dz = player->actor.world.pos.z - sTagPointsFree[i].z;
+            dx = player->actor.world.pos.x - sTagPointsFree[i].x;
+            dy = player->actor.world.pos.y - sTagPointsFree[i].y;
+            dz = player->actor.world.pos.z - sTagPointsFree[i].z;
 
             if (sqrtf(SQ(dx) + SQ(dy) + SQ(dz)) < 50.0f) {
                 this->tagFlags |= mask;
@@ -222,11 +225,14 @@ void EnWonderItem_MultitagFree(EnWonderItem* this, PlayState* play) {
                 this->timer = this->timerMod + 81;
                 return;
             }
+
+#if OOT_DEBUG
             if (BREG(0) != 0) {
                 DebugDisplay_AddObject(sTagPointsFree[i].x, sTagPointsFree[i].y, sTagPointsFree[i].z,
                                        this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
                                        1.0f, 1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
             }
+#endif
         }
     }
     if (this->timer == 1) {
@@ -269,15 +275,18 @@ void EnWonderItem_ProximitySwitch(EnWonderItem* this, PlayState* play) {
 
 void EnWonderItem_MultitagOrdered(EnWonderItem* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
-    s32 prevTagFlags = this->tagFlags;
+    s16 prevTagFlags = this->tagFlags;
     s32 i;
     s32 mask;
+    f32 dx;
+    f32 dy;
+    f32 dz;
 
     for (i = 0, mask = 1; i < this->numTagPoints; i++, mask <<= 1) {
         if (!(prevTagFlags & mask)) {
-            f32 dx = player->actor.world.pos.x - sTagPointsOrdered[i].x;
-            f32 dy = player->actor.world.pos.y - sTagPointsOrdered[i].y;
-            f32 dz = player->actor.world.pos.z - sTagPointsOrdered[i].z;
+            dx = player->actor.world.pos.x - sTagPointsOrdered[i].x;
+            dy = player->actor.world.pos.y - sTagPointsOrdered[i].y;
+            dz = player->actor.world.pos.z - sTagPointsOrdered[i].z;
 
             if (sqrtf(SQ(dx) + SQ(dy) + SQ(dz)) < 50.0f) {
                 if (prevTagFlags & mask) {
@@ -292,11 +301,15 @@ void EnWonderItem_MultitagOrdered(EnWonderItem* this, PlayState* play) {
                     Actor_Kill(&this->actor);
                     return;
                 }
-            } else if (BREG(0) != 0) {
+            }
+
+#if OOT_DEBUG
+            if (BREG(0) != 0) {
                 DebugDisplay_AddObject(sTagPointsOrdered[i].x, sTagPointsOrdered[i].y, sTagPointsOrdered[i].z,
                                        this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
                                        1.0f, 1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
             }
+#endif
         }
     }
     if (this->timer == 1) {
@@ -358,10 +371,13 @@ void EnWonderItem_Update(Actor* thisx, PlayState* play) {
     if (this->wonderMode > 12) {
         colorIndex = 0;
     }
+
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, debugArrowColors[colorIndex], debugArrowColors[colorIndex + 1],
                                debugArrowColors[colorIndex + 2], 255, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
@@ -226,9 +226,13 @@ void EnWonderItem_MultitagFree(EnWonderItem* this, PlayState* play) {
                 return;
             }
 
-            DEBUG_DISPLAY_ADD_OBJECT(sTagPointsFree[i].x, sTagPointsFree[i].y, sTagPointsFree[i].z,
-                                     this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
-                                     1.0f, 1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+            if (BREG(0) != 0) {
+                DebugDisplay_AddObject(sTagPointsFree[i].x, sTagPointsFree[i].y, sTagPointsFree[i].z,
+                                       this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
+                                       1.0f, 1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
+            }
+#endif
         }
     }
     if (this->timer == 1) {
@@ -299,9 +303,13 @@ void EnWonderItem_MultitagOrdered(EnWonderItem* this, PlayState* play) {
                 }
             }
 
-            DEBUG_DISPLAY_ADD_OBJECT(sTagPointsOrdered[i].x, sTagPointsOrdered[i].y, sTagPointsOrdered[i].z,
-                                     this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
-                                     1.0f, 1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+            if (BREG(0) != 0) {
+                DebugDisplay_AddObject(sTagPointsOrdered[i].x, sTagPointsOrdered[i].y, sTagPointsOrdered[i].z,
+                                       this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
+                                       1.0f, 1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
+            }
+#endif
         }
     }
     if (this->timer == 1) {

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
@@ -226,13 +226,9 @@ void EnWonderItem_MultitagFree(EnWonderItem* this, PlayState* play) {
                 return;
             }
 
-#if OOT_DEBUG
-            if (BREG(0) != 0) {
-                DebugDisplay_AddObject(sTagPointsFree[i].x, sTagPointsFree[i].y, sTagPointsFree[i].z,
-                                       this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
-                                       1.0f, 1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
-            }
-#endif
+            DEBUG_DISPLAY_ADD_OBJECT(sTagPointsFree[i].x, sTagPointsFree[i].y, sTagPointsFree[i].z,
+                                     this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
+                                     1.0f, 1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
         }
     }
     if (this->timer == 1) {
@@ -303,13 +299,9 @@ void EnWonderItem_MultitagOrdered(EnWonderItem* this, PlayState* play) {
                 }
             }
 
-#if OOT_DEBUG
-            if (BREG(0) != 0) {
-                DebugDisplay_AddObject(sTagPointsOrdered[i].x, sTagPointsOrdered[i].y, sTagPointsOrdered[i].z,
-                                       this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
-                                       1.0f, 1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
-            }
-#endif
+            DEBUG_DISPLAY_ADD_OBJECT(sTagPointsOrdered[i].x, sTagPointsOrdered[i].y, sTagPointsOrdered[i].z,
+                                     this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
+                                     1.0f, 1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
         }
     }
     if (this->timer == 1) {

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
@@ -364,12 +364,10 @@ void EnWonderItem_Update(Actor* thisx, PlayState* play) {
         colorIndex = 0;
     }
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, debugArrowColors[colorIndex], debugArrowColors[colorIndex + 1],
                                debugArrowColors[colorIndex + 2], 255, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.h
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.h
@@ -18,7 +18,7 @@ typedef struct EnWonderItem {
     /* 0x015A */ s16 dropCount;
     /* 0x015C */ s16 timer;
     /* 0x015E */ s16 tagFlags;
-    /* 0x015A */ s16 tagCount;
+    /* 0x0160 */ s16 tagCount;
     /* 0x0162 */ s16 switchFlag;
     /* 0x0164 */ char unk_164[4];
     /* 0x0168 */ s16 nextTag;

--- a/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.c
+++ b/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.c
@@ -239,8 +239,7 @@ void EnWonderTalk_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
     Actor_SetFocus(&this->actor, this->height);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         if (this->unk_15A != 0) {
             if ((this->unk_15A & 1) == 0) {
                 DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
@@ -253,5 +252,4 @@ void EnWonderTalk_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
         }
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.c
+++ b/src/overlays/actors/ovl_En_Wonder_Talk/z_en_wonder_talk.c
@@ -85,8 +85,8 @@ void func_80B391CC(EnWonderTalk* this, PlayState* play) {
                 PRINTF(VT_FGCOL(GREEN) " ☆☆☆☆☆ 日記帳スタート！ ☆☆☆☆☆ \n" VT_RST);
                 this->actor.textId = 0x5002;
                 this->unk_156 = TEXT_STATE_CHOICE;
-                this->height = 30.0f;
                 this->unk_15C = 40.0f;
+                this->height = 30.0f;
                 // "Attention coordinates"
                 PRINTF(VT_FGCOL(MAGENTA) "☆☆☆☆☆ 注目座標\t       \t☆☆☆☆☆ %f\n" VT_RST, 30.0f);
                 break;
@@ -239,6 +239,7 @@ void EnWonderTalk_Update(Actor* thisx, PlayState* play) {
     this->actionFunc(this, play);
     Actor_SetFocus(&this->actor, this->height);
 
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         if (this->unk_15A != 0) {
             if ((this->unk_15A & 1) == 0) {
@@ -252,4 +253,5 @@ void EnWonderTalk_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 0, 255, 0, 255, 4, play->state.gfxCtx);
         }
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
+++ b/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
@@ -131,8 +131,7 @@ void func_80B3A15C(EnWonderTalk2* this, PlayState* play) {
         if (!((this->actor.xzDistToPlayer > 40.0f + this->triggerRange) ||
               (fabsf(player->actor.world.pos.y - this->actor.world.pos.y) > 100.0f) || (yawDiff >= 0x4000))) {
 
-#if OOT_DEBUG
-            if (this->unk_158 >= 2) {
+            if (OOT_DEBUG && this->unk_158 >= 2) {
                 PRINTF("\n\n");
                 // "Transparent Message Kimi Set"
                 PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ 透明メッセージ君せっと %x\n" VT_RST, this->actor.params);
@@ -161,7 +160,6 @@ void func_80B3A15C(EnWonderTalk2* this, PlayState* play) {
                         break;
                 }
             }
-#endif
 
             this->unk_158 = 0;
             Actor_OfferTalkExchange(&this->actor, play, this->triggerRange + 50.0f, 100.0f, EXCH_ITEM_NONE);
@@ -222,8 +220,7 @@ void func_80B3A4F8(EnWonderTalk2* this, PlayState* play) {
              (fabsf(player->actor.world.pos.y - this->actor.world.pos.y) < 100.0f)) &&
             !Play_InCsMode(play)) {
 
-#if OOT_DEBUG
-            if (this->unk_158 >= 2) {
+            if (OOT_DEBUG && this->unk_158 >= 2) {
                 PRINTF("\n\n");
                 // "Transparent Message Kimi Seto"
                 PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ 透明メッセージ君せっと %x\n" VT_RST, this->actor.params);
@@ -254,7 +251,6 @@ void func_80B3A4F8(EnWonderTalk2* this, PlayState* play) {
 
                 PRINTF("\n\n");
             }
-#endif
 
             this->unk_158 = 0;
             if (!this->unk_156) {
@@ -282,8 +278,7 @@ void EnWonderTalk2_Update(Actor* thisx, PlayState* play) {
 
     Actor_SetFocus(&this->actor, this->height);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         if (this->unk_158 != 0) {
             if ((this->unk_158 & 1) == 0) {
                 DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
@@ -296,5 +291,4 @@ void EnWonderTalk2_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
         }
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
+++ b/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
@@ -130,6 +130,8 @@ void func_80B3A15C(EnWonderTalk2* this, PlayState* play) {
 
         if (!((this->actor.xzDistToPlayer > 40.0f + this->triggerRange) ||
               (fabsf(player->actor.world.pos.y - this->actor.world.pos.y) > 100.0f) || (yawDiff >= 0x4000))) {
+
+#if OOT_DEBUG
             if (this->unk_158 >= 2) {
                 PRINTF("\n\n");
                 // "Transparent Message Kimi Set"
@@ -159,6 +161,7 @@ void func_80B3A15C(EnWonderTalk2* this, PlayState* play) {
                         break;
                 }
             }
+#endif
 
             this->unk_158 = 0;
             Actor_OfferTalkExchange(&this->actor, play, this->triggerRange + 50.0f, 100.0f, EXCH_ITEM_NONE);
@@ -218,6 +221,8 @@ void func_80B3A4F8(EnWonderTalk2* this, PlayState* play) {
         if (((this->actor.xzDistToPlayer < (40.0f + this->triggerRange)) &&
              (fabsf(player->actor.world.pos.y - this->actor.world.pos.y) < 100.0f)) &&
             !Play_InCsMode(play)) {
+
+#if OOT_DEBUG
             if (this->unk_158 >= 2) {
                 PRINTF("\n\n");
                 // "Transparent Message Kimi Seto"
@@ -249,6 +254,8 @@ void func_80B3A4F8(EnWonderTalk2* this, PlayState* play) {
 
                 PRINTF("\n\n");
             }
+#endif
+
             this->unk_158 = 0;
             if (!this->unk_156) {
                 Message_StartTextbox(play, this->actor.textId, NULL);
@@ -275,6 +282,7 @@ void EnWonderTalk2_Update(Actor* thisx, PlayState* play) {
 
     Actor_SetFocus(&this->actor, this->height);
 
+#if OOT_DEBUG
     if (BREG(0) != 0) {
         if (this->unk_158 != 0) {
             if ((this->unk_158 & 1) == 0) {
@@ -288,4 +296,5 @@ void EnWonderTalk2_Update(Actor* thisx, PlayState* play) {
                                    1.0f, 1.0f, 0, 0, 255, 255, 4, play->state.gfxCtx);
         }
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -306,18 +306,13 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     EnWood02* this = (EnWood02*)thisx;
     f32 wobbleAmplitude;
-    u8 new_var;
-    u8 phi_v0;
-    s32 pad;
-    Vec3f dropsSpawnPt;
-    s32 i;
-    s32 leavesParams;
 
     // Despawn extra trees in a group if out of range
     if ((this->spawnType == WOOD_SPAWN_SPAWNED) && (this->actor.parent != NULL)) {
         if (!(this->actor.flags & ACTOR_FLAG_6)) {
-            new_var = this->unk_14E[0];
-            phi_v0 = 0;
+            u8 new_var = this->unk_14E[0];
+            u8 phi_v0 = 0;
+            s32 pad;
 
             if (this->unk_14C < 0) {
                 phi_v0 = 0x80;
@@ -338,7 +333,8 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
         }
 
         if (this->actor.home.rot.y != 0) {
-            dropsSpawnPt = this->actor.world.pos;
+            Vec3f dropsSpawnPt = this->actor.world.pos;
+
             dropsSpawnPt.y += 200.0f;
 
             if ((this->unk_14C >= 0) && (this->unk_14C < 0x64)) {
@@ -355,7 +351,8 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
 
             // Spawn falling leaves
             if (this->unk_14C >= -1) {
-                leavesParams = WOOD_LEAF_GREEN;
+                s32 i;
+                s32 leavesParams = WOOD_LEAF_GREEN;
 
                 if ((this->actor.params == WOOD_TREE_OVAL_YELLOW_SPAWNER) ||
                     (this->actor.params == WOOD_TREE_OVAL_YELLOW_SPAWNED)) {

--- a/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
+++ b/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
@@ -215,11 +215,9 @@ void EnYabusameMark_Update(Actor* thisx, PlayState* play) {
     Collider_SetQuadVertices(&this->collider, &this->vertexA, &this->vertexB, &this->vertexC, &this->vertexD);
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
+    if (OOT_DEBUG && BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 0, 0xFF, 0, 0xFF, 4, play->state.gfxCtx);
     }
-#endif
 }

--- a/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
+++ b/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
@@ -194,6 +194,8 @@ void EnYabusameMark_Update(Actor* thisx, PlayState* play) {
     arrayIndex = this->typeIndex * 4;
     vertexArray = &sCollisionVertices[arrayIndex];
 
+    if (1) {}
+
     this->vertexA.x = vertexArray[0].x + this->actor.world.pos.x;
     this->vertexA.y = vertexArray[0].y + this->actor.world.pos.y;
     this->vertexA.z = vertexArray[0].z + this->actor.world.pos.z;
@@ -212,9 +214,12 @@ void EnYabusameMark_Update(Actor* thisx, PlayState* play) {
 
     Collider_SetQuadVertices(&this->collider, &this->vertexA, &this->vertexB, &this->vertexC, &this->vertexD);
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
-    if (BREG(0)) {
+
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
         DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
                                1.0f, 0, 0xFF, 0, 0xFF, 4, play->state.gfxCtx);
     }
+#endif
 }

--- a/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
+++ b/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
@@ -215,11 +215,7 @@ void EnYabusameMark_Update(Actor* thisx, PlayState* play) {
     Collider_SetQuadVertices(&this->collider, &this->vertexA, &this->vertexB, &this->vertexC, &this->vertexD);
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
 
-#if OOT_DEBUG
-    if (BREG(0) != 0) {
-        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                               1.0f, 0, 0xFF, 0, 0xFF, 4, play->state.gfxCtx);
-    }
-#endif
+    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                             1.0f, 0, 0xFF, 0, 0xFF, 4, play->state.gfxCtx);
 }

--- a/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
+++ b/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
@@ -215,7 +215,11 @@ void EnYabusameMark_Update(Actor* thisx, PlayState* play) {
     Collider_SetQuadVertices(&this->collider, &this->vertexA, &this->vertexB, &this->vertexC, &this->vertexD);
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
 
-    DEBUG_DISPLAY_ADD_OBJECT(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                             this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
-                             1.0f, 0, 0xFF, 0, 0xFF, 4, play->state.gfxCtx);
+#if OOT_DEBUG
+    if (BREG(0) != 0) {
+        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f, 1.0f,
+                               1.0f, 0, 0xFF, 0, 0xFF, 4, play->state.gfxCtx);
+    }
+#endif
 }

--- a/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
+++ b/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
@@ -32,7 +32,7 @@ typedef enum {
 } EnfHGIntroState;
 
 void EnfHG_Init(Actor* thisx, PlayState* play2);
-void EnfHG_Destroy(Actor* thisx, PlayState* play);
+void EnfHG_Destroy(Actor* thisx, PlayState* play2);
 void EnfHG_Update(Actor* thisx, PlayState* play);
 void EnfHG_Draw(Actor* thisx, PlayState* play);
 
@@ -89,8 +89,8 @@ void EnfHG_Init(Actor* thisx, PlayState* play2) {
     }
 }
 
-void EnfHG_Destroy(Actor* thisx, PlayState* play) {
-    s32 pad;
+void EnfHG_Destroy(Actor* thisx, PlayState* play2) {
+    PlayState* play = (PlayState*)play2;
     EnfHG* this = (EnfHG*)thisx;
 
     PRINTF("F DT1\n");
@@ -651,6 +651,7 @@ void EnfHG_Retreat(EnfHG* this, PlayState* play) {
         BossGanondrof* bossGnd = (BossGanondrof*)this->actor.parent;
         s16 paintingIdxReal;
         s16 paintingIdxFake;
+        Actor* child;
 
         if (this->actor.params != GND_REAL_BOSS) {
             this->killActor = true;
@@ -664,10 +665,11 @@ void EnfHG_Retreat(EnfHG* this, PlayState* play) {
             do {
                 paintingIdxFake = Rand_ZeroOne() * 5.99f;
             } while (paintingIdxFake == paintingIdxReal);
-            PRINTF("ac1 = %x `````````````````````````````````````````````````\n",
-                   Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_BOSS_GANONDROF,
-                                      this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z, 0, 0,
-                                      0, paintingIdxFake + GND_FAKE_BOSS));
+
+            child = Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_BOSS_GANONDROF,
+                                       this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z, 0, 0,
+                                       0, paintingIdxFake + GND_FAKE_BOSS);
+            PRINTF("ac1 = %x `````````````````````````````````````````````````\n", child);
         }
     }
 }

--- a/src/overlays/actors/ovl_End_Title/z_end_title.c
+++ b/src/overlays/actors/ovl_End_Title/z_end_title.c
@@ -31,9 +31,7 @@ ActorInit End_Title_InitVars = {
 void EndTitle_Init(Actor* thisx, PlayState* play) {
     EndTitle* this = (EndTitle*)thisx;
 
-    this->endAlpha = 0;
-    this->tlozAlpha = 0;
-    this->ootAlpha = 0;
+    this->endAlpha = this->tlozAlpha = this->ootAlpha = 0;
     if (this->actor.params == 1) {
         this->actor.draw = EndTitle_DrawNintendoLogo;
     }

--- a/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
+++ b/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
@@ -76,8 +76,6 @@ void MagicDark_DiamondUpdate(Actor* thisx, PlayState* play) {
     s16 nayrusLoveTimer = gSaveContext.nayrusLoveTimer;
     s32 msgMode = play->msgCtx.msgMode;
 
-    if (1) {}
-
     // See `ACTOROVL_ALLOC_ABSOLUTE`
     //! @bug This condition is too broad, the actor will also be killed by warp songs. But warp songs do not use an
     //! actor which uses `ACTOROVL_ALLOC_ABSOLUTE`. There is no reason to kill the actor in this case.
@@ -90,6 +88,8 @@ void MagicDark_DiamondUpdate(Actor* thisx, PlayState* play) {
     }
 
     if (nayrusLoveTimer >= 1200) {
+        if (1) {}
+
         player->invincibilityTimer = 0;
         gSaveContext.nayrusLoveTimer = 0;
         Actor_Kill(thisx);

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
@@ -373,8 +373,6 @@ void MirRay_ReflectedBeam(MirRay* this, PlayState* play, MirRayShieldReflection*
     f32 spE8[3];
     f32 polyNormal[3];
     MtxF* shieldMtx;
-    Vec3f vecA;
-    Vec3f vecC;
 
     shieldMtx = &player->shieldMf;
 
@@ -390,75 +388,80 @@ void MirRay_ReflectedBeam(MirRay* this, PlayState* play, MirRayShieldReflection*
     vecD.y = spE8[1] + vecB.y;
     vecD.z = spE8[2] + vecB.z;
 
-    vecA.x = vecB.x + (shieldMtx->xx * 300.0f);
-    vecA.y = vecB.y + (shieldMtx->yx * 300.0f);
-    vecA.z = vecB.z + (shieldMtx->zx * 300.0f);
+    {
+        Vec3f vecA;
+        Vec3f vecC;
 
-    vecC.x = vecD.x + (shieldMtx->xx * 300.0f);
-    vecC.y = vecD.y + (shieldMtx->yx * 300.0f);
-    vecC.z = vecD.z + (shieldMtx->zx * 300.0f);
+        vecA.x = vecB.x + (shieldMtx->xx * 300.0f);
+        vecA.y = vecB.y + (shieldMtx->yx * 300.0f);
+        vecA.z = vecB.z + (shieldMtx->zx * 300.0f);
 
-    Collider_SetQuadVertices(&this->shieldRay, &vecA, &vecB, &vecC, &vecD);
+        vecC.x = vecD.x + (shieldMtx->xx * 300.0f);
+        vecC.y = vecD.y + (shieldMtx->yx * 300.0f);
+        vecC.z = vecD.z + (shieldMtx->zx * 300.0f);
 
-    for (i = 0; i < 6; i++) {
-        if (reflection[i].reflectionPoly != NULL) {
-            polyNormal[0] = COLPOLY_GET_NORMAL(reflection[i].reflectionPoly->normal.x);
-            polyNormal[1] = COLPOLY_GET_NORMAL(reflection[i].reflectionPoly->normal.y);
-            polyNormal[2] = COLPOLY_GET_NORMAL(reflection[i].reflectionPoly->normal.z);
+        Collider_SetQuadVertices(&this->shieldRay, &vecA, &vecB, &vecC, &vecD);
 
-            if (Math3D_LineSegVsPlane(polyNormal[0], polyNormal[1], polyNormal[2], reflection[i].reflectionPoly->dist,
-                                      &vecB, &vecD, &sp118, 1)) {
+        for (i = 0; i < 6; i++) {
+            if (reflection[i].reflectionPoly != NULL) {
+                polyNormal[0] = COLPOLY_GET_NORMAL(reflection[i].reflectionPoly->normal.x);
+                polyNormal[1] = COLPOLY_GET_NORMAL(reflection[i].reflectionPoly->normal.y);
+                polyNormal[2] = COLPOLY_GET_NORMAL(reflection[i].reflectionPoly->normal.z);
 
-                reflection[i].pos.x = sp118.x;
-                reflection[i].pos.y = sp118.y;
-                reflection[i].pos.z = sp118.z;
+                if (Math3D_LineSegVsPlane(polyNormal[0], polyNormal[1], polyNormal[2],
+                                          reflection[i].reflectionPoly->dist, &vecB, &vecD, &sp118, 1)) {
 
-                temp_f0 = sqrtf(SQ(sp118.x - vecB.x) + SQ(sp118.y - vecB.y) + SQ(sp118.z - vecB.z));
+                    reflection[i].pos.x = sp118.x;
+                    reflection[i].pos.y = sp118.y;
+                    reflection[i].pos.z = sp118.z;
 
-                if (temp_f0 < (this->reflectIntensity * 600.0f)) {
-                    reflection[i].opacity = 200;
+                    temp_f0 = sqrtf(SQ(sp118.x - vecB.x) + SQ(sp118.y - vecB.y) + SQ(sp118.z - vecB.z));
+
+                    if (temp_f0 < (this->reflectIntensity * 600.0f)) {
+                        reflection[i].opacity = 200;
+                    } else {
+                        reflection[i].opacity = (s32)(800.0f - temp_f0);
+                    }
+
+                    sp10C.x = (shieldMtx->xx * 100.0f) + vecB.x;
+                    sp10C.y = (shieldMtx->yx * 100.0f) + vecB.y;
+                    sp10C.z = (shieldMtx->zx * 100.0f) + vecB.z;
+
+                    sp100.x = (spE8[0] * 4.0f) + sp10C.x;
+                    sp100.y = (spE8[1] * 4.0f) + sp10C.y;
+                    sp100.z = (spE8[2] * 4.0f) + sp10C.z;
+
+                    reflection[i].mtx.zw = 0.0f;
+
+                    reflection[i].mtx.xx = reflection[i].mtx.yy = reflection[i].mtx.zz = reflection[i].mtx.ww = 1.0f;
+                    reflection[i].mtx.yx = reflection[i].mtx.zx = reflection[i].mtx.wx = reflection[i].mtx.xy =
+                        reflection[i].mtx.zy = reflection[i].mtx.wy = reflection[i].mtx.xz = reflection[i].mtx.yz =
+                            reflection[i].mtx.wz = reflection[i].mtx.xw = reflection[i].mtx.yw = reflection[i].mtx.zw;
+
+                    if (Math3D_LineSegVsPlane(polyNormal[0], polyNormal[1], polyNormal[2],
+                                              reflection[i].reflectionPoly->dist, &sp10C, &sp100, &intersection, 1)) {
+                        reflection[i].mtx.xx = intersection.x - sp118.x;
+                        reflection[i].mtx.yx = intersection.y - sp118.y;
+                        reflection[i].mtx.zx = intersection.z - sp118.z;
+                    }
+
+                    sp10C.x = (shieldMtx->xy * 100.0f) + vecB.x;
+                    sp10C.y = (shieldMtx->yy * 100.0f) + vecB.y;
+                    sp10C.z = (shieldMtx->zy * 100.0f) + vecB.z;
+
+                    sp100.x = (spE8[0] * 4.0f) + sp10C.x;
+                    sp100.y = (spE8[1] * 4.0f) + sp10C.y;
+                    sp100.z = (spE8[2] * 4.0f) + sp10C.z;
+
+                    if (Math3D_LineSegVsPlane(polyNormal[0], polyNormal[1], polyNormal[2],
+                                              reflection[i].reflectionPoly->dist, &sp10C, &sp100, &intersection, 1)) {
+                        reflection[i].mtx.xy = intersection.x - sp118.x;
+                        reflection[i].mtx.yy = intersection.y - sp118.y;
+                        reflection[i].mtx.zy = intersection.z - sp118.z;
+                    }
                 } else {
-                    reflection[i].opacity = (s32)(800.0f - temp_f0);
+                    reflection[i].reflectionPoly = NULL;
                 }
-
-                sp10C.x = (shieldMtx->xx * 100.0f) + vecB.x;
-                sp10C.y = (shieldMtx->yx * 100.0f) + vecB.y;
-                sp10C.z = (shieldMtx->zx * 100.0f) + vecB.z;
-
-                sp100.x = (spE8[0] * 4.0f) + sp10C.x;
-                sp100.y = (spE8[1] * 4.0f) + sp10C.y;
-                sp100.z = (spE8[2] * 4.0f) + sp10C.z;
-
-                reflection[i].mtx.zw = 0.0f;
-
-                reflection[i].mtx.xx = reflection[i].mtx.yy = reflection[i].mtx.zz = reflection[i].mtx.ww = 1.0f;
-                reflection[i].mtx.yx = reflection[i].mtx.zx = reflection[i].mtx.wx = reflection[i].mtx.xy =
-                    reflection[i].mtx.zy = reflection[i].mtx.wy = reflection[i].mtx.xz = reflection[i].mtx.yz =
-                        reflection[i].mtx.wz = reflection[i].mtx.xw = reflection[i].mtx.yw = reflection[i].mtx.zw;
-
-                if (Math3D_LineSegVsPlane(polyNormal[0], polyNormal[1], polyNormal[2],
-                                          reflection[i].reflectionPoly->dist, &sp10C, &sp100, &intersection, 1)) {
-                    reflection[i].mtx.xx = intersection.x - sp118.x;
-                    reflection[i].mtx.yx = intersection.y - sp118.y;
-                    reflection[i].mtx.zx = intersection.z - sp118.z;
-                }
-
-                sp10C.x = (shieldMtx->xy * 100.0f) + vecB.x;
-                sp10C.y = (shieldMtx->yy * 100.0f) + vecB.y;
-                sp10C.z = (shieldMtx->zy * 100.0f) + vecB.z;
-
-                sp100.x = (spE8[0] * 4.0f) + sp10C.x;
-                sp100.y = (spE8[1] * 4.0f) + sp10C.y;
-                sp100.z = (spE8[2] * 4.0f) + sp10C.z;
-
-                if (Math3D_LineSegVsPlane(polyNormal[0], polyNormal[1], polyNormal[2],
-                                          reflection[i].reflectionPoly->dist, &sp10C, &sp100, &intersection, 1)) {
-                    reflection[i].mtx.xy = intersection.x - sp118.x;
-                    reflection[i].mtx.yy = intersection.y - sp118.y;
-                    reflection[i].mtx.zy = intersection.z - sp118.z;
-                }
-            } else {
-                reflection[i].reflectionPoly = NULL;
             }
         }
     }


### PR DESCRIPTION
EDIT: never mind, no macros here

~~I created a macro for `DebugDisplay_AddObject` since it's rather common and there are a few cases where `if (OOT_DEBUG && ...)` did not work. Unfortunately there are still a few special cases, and it doesn't work in `EnWonderItem_Update` due to same-line issues. Please suggest a better name for the macro, maybe it should really be called `DEBUG_DISPLAY_ADD_OBJECT_DEBUG` but that sounds a bit redundant.~~

~~It's also possible to go a bit farther with the macros, for example this block of code is used a few times:~~
```
    if (this->outOfRangeTimer != 0) {
        if (this->outOfRangeTimer % 2 == 0) {
            DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                   this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
                                   1.0f, 1.0f, 120, 120, 120, 255, 4, play->state.gfxCtx);
        }
    } else {
        DebugDisplay_AddObject(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                               this->actor.world.rot.x, this->actor.world.rot.y, this->actor.world.rot.z, 1.0f,
                               1.0f, 1.0f, 255, 0, 255, 255, 4, play->state.gfxCtx);
    }
```

~~I'll leave that as future work though.~~