### PR TITLE
Match retail z_sram.c

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1155,10 +1155,10 @@ void Sram_WriteSramHeader(SramContext* sramCtx);
 void Sram_InitSram(GameState* gameState, SramContext* sramCtx);
 void Sram_Alloc(GameState* gameState, SramContext* sramCtx);
 void Sram_Init(PlayState* play, SramContext* sramCtx);
-void SsSram_Init(u32 addr, u8 handleType, u8 handleDomain, u8 handleLatency, u8 handlePageSize, u8 handleRelDuration,
+void SsSram_Init(s32 addr, u8 handleType, u8 handleDomain, u8 handleLatency, u8 handlePageSize, u8 handleRelDuration,
                  u8 handlePulse, u32 handleSpeed);
 void SsSram_Dma(void* dramAddr, size_t size, s32 direction);
-void SsSram_ReadWrite(u32 addr, void* dramAddr, size_t size, s32 direction);
+void SsSram_ReadWrite(s32 addr, void* dramAddr, size_t size, s32 direction);
 View* View_New(GraphicsContext* gfxCtx);
 void View_Free(View* view);
 void View_Init(View*, GraphicsContext*);

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -511,8 +511,7 @@ void Sram_WriteSave(SramContext* sramCtx) {
     gSaveContext.save.info.checksum = 0;
 
     ptr = (u16*)&gSaveContext;
-    checksum = 0;
-    j = 0;
+    checksum = j = 0;
 
     for (offset = 0; offset < CHECKSUM_SIZE; offset++) {
         if (++j == 0x20) {
@@ -618,6 +617,7 @@ void Sram_VerifyAndLoadAllSaves(FileSelectState* fileSelect, SramContext* sramCt
                 bzero(&gSaveContext.save.totalDays, sizeof(s32));
                 bzero(&gSaveContext.save.bgsDayCount, sizeof(s32));
 
+#if OOT_DEBUG
                 if (!slotNum) {
                     Sram_InitDebugSave();
                     gSaveContext.save.info.playerData.newf[0] = 'Z';
@@ -633,6 +633,9 @@ void Sram_VerifyAndLoadAllSaves(FileSelectState* fileSelect, SramContext* sramCt
                 } else {
                     Sram_InitNewSave();
                 }
+#else
+                Sram_InitNewSave();
+#endif
 
                 ptr = (u16*)&gSaveContext;
                 PRINTF("\n--------------------------------------------------------------\n");
@@ -718,20 +721,26 @@ void Sram_InitSave(FileSelectState* fileSelect, SramContext* sramCtx) {
     u16* ptr;
     u16 checksum;
 
+#if OOT_DEBUG
     if (fileSelect->buttonIndex != 0) {
         Sram_InitNewSave();
     } else {
         Sram_InitDebugSave();
     }
+#else
+    Sram_InitNewSave();
+#endif
 
     gSaveContext.save.entranceIndex = ENTR_LINKS_HOUSE_0;
     gSaveContext.save.linkAge = LINK_AGE_CHILD;
     gSaveContext.save.dayTime = CLOCK_TIME(10, 0);
     gSaveContext.save.cutsceneIndex = 0xFFF1;
 
+#if OOT_DEBUG
     if (fileSelect->buttonIndex == 0) {
         gSaveContext.save.cutsceneIndex = 0;
     }
+#endif
 
     for (offset = 0; offset < 8; offset++) {
         gSaveContext.save.info.playerData.playerName[offset] = fileSelect->fileNames[fileSelect->buttonIndex][offset];
@@ -753,10 +762,8 @@ void Sram_InitSave(FileSelectState* fileSelect, SramContext* sramCtx) {
     PRINTF("\n$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$\n");
 
     ptr = (u16*)&gSaveContext;
-    j = 0;
-    checksum = 0;
 
-    for (offset = 0; offset < CHECKSUM_SIZE; offset++) {
+    for (j = 0, checksum = 0, offset = 0; offset < CHECKSUM_SIZE; offset++) {
         PRINTF("%x ", *ptr);
         checksum += *ptr++;
         if (++j == 0x20) {
@@ -893,6 +900,7 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
         Sram_WriteSramHeader(sramCtx);
     }
 
+#if OOT_DEBUG
     if (CHECK_BTN_ANY(gameState->input[2].cur.button, BTN_DRIGHT)) {
         bzero(sramCtx->readBuff, SRAM_SIZE);
         for (i = 0; i < CHECKSUM_SIZE; i++) {
@@ -901,6 +909,7 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, SRAM_SIZE, OS_WRITE);
         PRINTF("ＳＲＡＭ破壊！！！！！！\n"); // "SRAM destruction! ! ! ! ! !"
     }
+#endif
 
     // "GOOD! GOOD! Size = %d + %d = %d"
     PRINTF("ＧＯＯＤ！ＧＯＯＤ！ サイズ＝%d + %d ＝ %d\n", sizeof(SaveInfo), 4, sizeof(SaveInfo) + 4);

--- a/src/code/z_ss_sram.c
+++ b/src/code/z_ss_sram.c
@@ -9,7 +9,7 @@ typedef struct {
 
 SsSramContext sSsSramContext = { 0 };
 
-void SsSram_Init(u32 addr, u8 handleType, u8 handleDomain, u8 handleLatency, u8 handlePageSize, u8 handleRelDuration,
+void SsSram_Init(s32 addr, u8 handleType, u8 handleDomain, u8 handleLatency, u8 handlePageSize, u8 handleRelDuration,
                  u8 handlePulse, u32 handleSpeed) {
     u32 prevInt;
     OSPiHandle* handle = &sSsSramContext.piHandle;
@@ -49,7 +49,7 @@ void SsSram_Dma(void* dramAddr, size_t size, s32 direction) {
     osInvalDCache(dramAddr, size);
 }
 
-void SsSram_ReadWrite(u32 addr, void* dramAddr, size_t size, s32 direction) {
+void SsSram_ReadWrite(s32 addr, void* dramAddr, size_t size, s32 direction) {
     PRINTF("ssSRAMReadWrite:%08x %08x %08x %d\n", addr, dramAddr, size, direction);
     SsSram_Init(addr, DEVICE_TYPE_SRAM, PI_DOMAIN2, 5, 0xD, 2, 0xC, 0);
     SsSram_Dma(dramAddr, size, direction);


### PR DESCRIPTION
I had to change the `addr` argument of `SsSram_ReadWrite` to be signed so that the compiler would merge some constants in `Sram_VerifyAndLoadAllSaves`. Variations of `if (!OOT_DEBUG || ...)` did not work for `Sram_InitSave`, so I changed everything to `#if OOT_DEBUG` to be consistent within the file

