### PR TITLE
Don't link z_moji.o in retail

### DIFF
--- a/spec
+++ b/spec
@@ -342,7 +342,9 @@ beginseg
     include "$(BUILD_DIR)/src/code/z_lights.o"
     include "$(BUILD_DIR)/src/code/z_malloc.o"
     include "$(BUILD_DIR)/src/code/z_map_mark.o"
+#if OOT_DEBUG
     include "$(BUILD_DIR)/src/code/z_moji.o"
+#endif
     include "$(BUILD_DIR)/src/code/z_prenmi_buff.o"
     include "$(BUILD_DIR)/src/code/z_nulltask.o"
     include "$(BUILD_DIR)/src/code/z_olib.o"


### PR DESCRIPTION
Fixup for #1667

This is what happens when you play spot-the-difference against git, git wins

(for reference https://github.com/Dragorn421/oot/blob/ootgceumq_hacky_OK/spec#L369 )