### PR TITLE
Match retail code data sizes

### DIFF
--- a/data/fault_drawer.bss.s
+++ b/data/fault_drawer.bss.s
@@ -12,7 +12,7 @@
 .balign 16
 
 glabel sFaultDrawer
-    .space 0x3C
+    .space 0x40
 
-glabel D_8016B6BC
-    .space 0x24
+glabel D_8016B6C0
+    .space 0x20

--- a/data/fault_drawer.bss.s
+++ b/data/fault_drawer.bss.s
@@ -12,7 +12,8 @@
 .balign 16
 
 glabel sFaultDrawer
-    .space 0x40
+    .space 0x3C
+    .space 0x04 # padding
 
 glabel D_8016B6C0
     .space 0x20

--- a/include/terminal.h
+++ b/include/terminal.h
@@ -28,11 +28,23 @@
 #define VT_SGR(n) VT_ESC VT_CSI n "m"
 
 // Add more macros if necessary
+#if OOT_DEBUG
+
 #define VT_COL(back, fore) VT_SGR(VT_COLOR(BACKGROUND, back) ";" VT_COLOR(FOREGROUND, fore))
 #define VT_FGCOL(color) VT_SGR(VT_COLOR(FOREGROUND, color))
 #define VT_BGCOL(color) VT_SGR(VT_COLOR(BACKGROUND, color))
 #define VT_RST VT_SGR("")
 #define VT_CLS VT_ED(2)
+
+#else
+
+#define VT_COL(back, fore) ""
+#define VT_FGCOL(color) ""
+#define VT_BGCOL(color) ""
+#define VT_RST ""
+#define VT_CLS ""
+
+#endif
 
 // ASCII BEL character, plays an alert tone
 #define BEL '\a'

--- a/include/variables.h
+++ b/include/variables.h
@@ -143,13 +143,17 @@ extern u16 D_801333D0;
 extern Vec3f gSfxDefaultPos;
 extern f32 gSfxDefaultFreqAndVolScale;
 extern s8 gSfxDefaultReverb;
+#if OOT_DEBUG
 extern u8 D_801333F0;
 extern u8 gAudioSfxSwapOff;
 extern u8 D_801333F8;
+#endif
 extern u8 gSeqCmdWritePos;
 extern u8 gSeqCmdReadPos;
 extern u8 gStartSeqDisabled;
+#if OOT_DEBUG
 extern u8 gAudioDebugPrintSeqCmd;
+#endif
 extern u8 gSoundModeList[];
 extern u8 gAudioSpecId;
 extern u8 D_80133418;

--- a/src/audio/data.c
+++ b/src/audio/data.c
@@ -44,18 +44,20 @@ s8 gSfxDefaultReverb = 0;
 
 s32 D_801333EC = 0; // unused
 
+#if OOT_DEBUG
 u8 D_801333F0 = 0;
-
 u8 gAudioSfxSwapOff = 0;
-
 u8 D_801333F8 = 0;
-
 s32 D_801333FC = 0; // unused
+#endif
 
 u8 gSeqCmdWritePos = 0;
 u8 gSeqCmdReadPos = 0;
 u8 gStartSeqDisabled = false;
+
+#if OOT_DEBUG
 u8 gAudioDebugPrintSeqCmd = true;
+#endif
 
 u8 gSoundModeList[] = {
     SOUNDMODE_STEREO,

--- a/src/audio/general.c
+++ b/src/audio/general.c
@@ -1212,8 +1212,10 @@ OcarinaSongButtons gOcarinaSongButtons[OCARINA_SONG_MAX] = {
     { 0, { 0 } },
 };
 
+#if OOT_DEBUG
 u32 sAudioUpdateStartTime;
 u32 sAudioUpdateEndTime;
+#endif
 f32 D_8016B7A8;
 f32 D_8016B7AC;
 f32 D_8016B7B0;
@@ -1223,20 +1225,26 @@ FreqLerp sWaterfallFreqScaleLerp;
 f32 D_8016B7D8;
 s8 D_8016B7DC;
 f32 D_8016B7E0;
+#if OOT_DEBUG
 u16 D_8016B7E4;
 struct {
     char str[5];
     u16 num;
 } sAudioScrPrtBuf[SCROLL_PRINT_BUF_SIZE];
+#endif
 u8 sRiverSoundMainBgmVol;
 u8 sRiverSoundMainBgmCurrentVol;
 u8 sRiverSoundMainBgmLower;
 u8 sRiverSoundMainBgmRestore;
 u8 sGanonsTowerVol;
 SfxPlayerState sSfxChannelState[0x10];
+#if OOT_DEBUG
 char sBinToStrBuf[0x20];
+#endif
 u8 sMalonSingingTimer;
+#if OOT_DEBUG
 u8 sAudioSpecPeakNumNotes[0x12];
+#endif
 u8 sMalonSingingDisabled;
 u8 D_8016B9F3;
 u8 sFanfareStartTimer;
@@ -1264,8 +1272,10 @@ u16 sMusicStaffCurHeldLength[OCARINA_SONG_MAX];
 u16 sMusicStaffExpectedLength[OCARINA_SONG_MAX];
 u8 sMusicStaffExpectedPitch[OCARINA_SONG_MAX];
 OcarinaNote sScarecrowsLongSongSecondNote;
+#if OOT_DEBUG
 u8 sIsMalonSinging;
 f32 sMalonSingingDist;
+#endif
 
 void PadMgr_RequestPadData(PadMgr* padMgr, Input* inputs, s32 gameRequest);
 

--- a/src/audio/sfx.c
+++ b/src/audio/sfx.c
@@ -33,9 +33,12 @@ ActiveSfx gActiveSfx[7][3];
 u8 sCurSfxPlayerChannelIndex;
 u8 gSfxBankMuted[7];
 UnusedBankLerp sUnusedBankLerp[7];
+
+#if OOT_DEBUG
 u16 gAudioSfxSwapSource[10];
 u16 gAudioSfxSwapTarget[10];
 u8 gAudioSfxSwapMode[10];
+#endif
 
 void Audio_SetSfxBanksMute(u16 muteMask) {
     u8 bankId;

--- a/src/code/fault_drawer.c
+++ b/src/code/fault_drawer.c
@@ -102,11 +102,11 @@ FaultDrawer sFaultDrawerDefault = {
 #ifndef NON_MATCHING
 // TODO: match .bss (has reordering issues)
 extern FaultDrawer sFaultDrawer;
-extern char D_8016B6BC[0x24];
+extern char D_8016B6C0[0x20];
 #else
 // Non-matching version for struct shiftability
 FaultDrawer sFaultDrawer;
-char D_8016B6BC[0x24];
+char D_8016B6C0[0x20];
 #endif
 
 void FaultDrawer_SetOsSyncPrintfEnabled(u32 enabled) {

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -6,10 +6,11 @@ VisCvg sVisCvg;
 VisZBuf sVisZBuf;
 VisMono sVisMono;
 ViMode sViMode;
+
+#if OOT_DEBUG
 FaultClient sGameFaultClient;
 u16 sLastButtonPressed;
 
-#if OOT_DEBUG
 void GameState_FaultPrint(void) {
     static char sBtnChars[] = "ABZSuldr*+LRudlr";
     s32 i;

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -14,8 +14,13 @@ OSTime sGraphPrevUpdateEndTime;
  */
 OSTime sGraphPrevTaskTimeStart;
 
+#if OOT_DEBUG
 FaultClient sGraphFaultClient;
+#endif
+
 CfbInfo sGraphCfbInfos[3];
+
+#if OOT_DEBUG
 FaultClient sGraphUcodeFaultClient;
 
 UCodeInfo D_8012D230[3] = {
@@ -30,7 +35,6 @@ UCodeInfo D_8012D248[3] = {
     { UCODE_S2DEX, gspS2DEX2d_fifoTextStart },
 };
 
-#if OOT_DEBUG
 void Graph_FaultClient(void) {
     void* nextFb = osViGetNextFramebuffer();
     void* newFb = (SysCfb_GetFbPtr(0) != nextFb) ? SysCfb_GetFbPtr(0) : SysCfb_GetFbPtr(1);

--- a/src/code/sched.c
+++ b/src/code/sched.c
@@ -45,14 +45,14 @@
 #define RDP_DONE_MSG 668
 #define NOTIFY_MSG 670 // original name: ENTRY_MSG
 
-vs32 sSchedDebugPrintfEnabled = false;
-
 OSTime sRSPGfxTimeStart;
 OSTime sRSPAudioTimeStart;
 OSTime sRSPOtherTimeStart;
 OSTime sRDPTimeStart;
 
 #if OOT_DEBUG
+vs32 sSchedDebugPrintfEnabled = false;
+
 #define SCHED_DEBUG_PRINTF        \
     if (sSchedDebugPrintfEnabled) \
     PRINTF

--- a/src/code/z_actor_dlftbls.c
+++ b/src/code/z_actor_dlftbls.c
@@ -41,19 +41,18 @@
 
 #else
 
-#define DEFINE_ACTOR(name, _1, allocType, nameString) \
-    { (uintptr_t)_ovl_##name##SegmentRomStart,        \
-      (uintptr_t)_ovl_##name##SegmentRomEnd,          \
-      _ovl_##name##SegmentStart,                      \
-      _ovl_##name##SegmentEnd,                        \
-      NULL,                                           \
-      &name##_InitVars,                               \
-      NULL,                                           \
-      allocType,                                      \
+#define DEFINE_ACTOR(name, _1, allocType, _3)  \
+    { (uintptr_t)_ovl_##name##SegmentRomStart, \
+      (uintptr_t)_ovl_##name##SegmentRomEnd,   \
+      _ovl_##name##SegmentStart,               \
+      _ovl_##name##SegmentEnd,                 \
+      NULL,                                    \
+      &name##_InitVars,                        \
+      NULL,                                    \
+      allocType,                               \
       0 },
 
-#define DEFINE_ACTOR_INTERNAL(name, _1, allocType, nameString) \
-    { 0, 0, NULL, NULL, NULL, &name##_InitVars, NULL, allocType, 0 },
+#define DEFINE_ACTOR_INTERNAL(name, _1, allocType, _3) { 0, 0, NULL, NULL, NULL, &name##_InitVars, NULL, allocType, 0 },
 
 #endif
 

--- a/src/code/z_actor_dlftbls.c
+++ b/src/code/z_actor_dlftbls.c
@@ -23,6 +23,8 @@
 #undef DEFINE_ACTOR_UNSET
 
 // Actor Overlay Table definition
+#if OOT_DEBUG
+
 #define DEFINE_ACTOR(name, _1, allocType, nameString) \
     { (uintptr_t)_ovl_##name##SegmentRomStart,        \
       (uintptr_t)_ovl_##name##SegmentRomEnd,          \
@@ -36,6 +38,24 @@
 
 #define DEFINE_ACTOR_INTERNAL(name, _1, allocType, nameString) \
     { 0, 0, NULL, NULL, NULL, &name##_InitVars, nameString, allocType, 0 },
+
+#else
+
+#define DEFINE_ACTOR(name, _1, allocType, nameString) \
+    { (uintptr_t)_ovl_##name##SegmentRomStart,        \
+      (uintptr_t)_ovl_##name##SegmentRomEnd,          \
+      _ovl_##name##SegmentStart,                      \
+      _ovl_##name##SegmentEnd,                        \
+      NULL,                                           \
+      &name##_InitVars,                               \
+      NULL,                                           \
+      allocType,                                      \
+      0 },
+
+#define DEFINE_ACTOR_INTERNAL(name, _1, allocType, nameString) \
+    { 0, 0, NULL, NULL, NULL, &name##_InitVars, NULL, allocType, 0 },
+
+#endif
 
 #define DEFINE_ACTOR_UNSET(_0) { 0 },
 

--- a/src/code/z_actor_dlftbls.c
+++ b/src/code/z_actor_dlftbls.c
@@ -41,6 +41,7 @@
 
 #else
 
+// Actor name is set to NULL in retail builds
 #define DEFINE_ACTOR(name, _1, allocType, _3)  \
     { (uintptr_t)_ovl_##name##SegmentRomStart, \
       (uintptr_t)_ovl_##name##SegmentRomEnd,   \

--- a/src/code/z_debug.c
+++ b/src/code/z_debug.c
@@ -29,6 +29,7 @@ Color_RGBA8 sDebugCamTextColors[] = {
     { 128, 255, 32, 128 },  // DEBUG_CAM_TEXT_GREEN
 };
 
+#if OOT_DEBUG
 InputCombo sRegGroupInputCombos[REG_GROUPS] = {
     { BTN_L, BTN_CUP },        //  REG
     { BTN_L, BTN_CLEFT },      // SREG
@@ -93,6 +94,7 @@ char sRegGroupChars[REG_GROUPS] = {
     'k', // kREG
     'b', // bREG
 };
+#endif
 
 void Regs_Init(void) {
     s32 i;

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -10,9 +10,16 @@ TransitionTile sTransitionTile;
 s32 gTransitionTileState;
 VisMono sPlayVisMono;
 Color_RGBA8_u32 gVisMonoColor;
+
+#if OOT_DEBUG
 FaultClient D_801614B8;
+#endif
+
 s16 sTransitionFillTimer;
+
+#if OOT_DEBUG
 u64 sDebugCutsceneScriptBuf[0xA00];
+#endif
 
 void Play_SpawnScene(PlayState* this, s32 sceneId, s32 spawn);
 
@@ -451,7 +458,8 @@ void Play_Init(GameState* thisx) {
     AnimationContext_Update(this, &this->animationCtx);
     gSaveContext.respawnFlag = 0;
 
-    if (OOT_DEBUG && R_USE_DEBUG_CUTSCENE) {
+#if OOT_DEBUG
+    if (R_USE_DEBUG_CUTSCENE) {
         gDebugCutsceneScript = sDebugCutsceneScriptBuf;
         PRINTF("\nkawauso_data=[%x]", gDebugCutsceneScript);
 
@@ -459,6 +467,7 @@ void Play_Init(GameState* thisx) {
         // Presumably the ROM was larger at a previous point in development when this debug feature was used.
         DmaMgr_DmaRomToRam(0x03FEB000, gDebugCutsceneScript, sizeof(sDebugCutsceneScriptBuf));
     }
+#endif
 }
 
 void Play_Update(PlayState* this) {

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -17,10 +17,6 @@ FaultClient D_801614B8;
 
 s16 sTransitionFillTimer;
 
-#if OOT_DEBUG
-u64 sDebugCutsceneScriptBuf[0xA00];
-#endif
-
 void Play_SpawnScene(PlayState* this, s32 sceneId, s32 spawn);
 
 // This macro prints the number "1" with a file and line number if R_ENABLE_PLAY_LOGS is enabled.
@@ -460,6 +456,8 @@ void Play_Init(GameState* thisx) {
 
 #if OOT_DEBUG
     if (R_USE_DEBUG_CUTSCENE) {
+        static u64 sDebugCutsceneScriptBuf[0xA00];
+
         gDebugCutsceneScript = sDebugCutsceneScriptBuf;
         PRINTF("\nkawauso_data=[%x]", gDebugCutsceneScript);
 


### PR DESCRIPTION
Notable changes:

* Realigned padding after sFaultDrawer so that it fits in NON_MATCHING mode
* Disabled terminal colors in debug builds (for __osMalloc.c rodata)
* Removed actor names from the actor table
* For src/audio/data.c, either `D_801333EC` or `D_801333EC` could be removed so I arbitrarily chose one