### PR TITLE
Use Romfile in place of vromStart and vromEnd in structs

### DIFF
--- a/include/tables/object_table.h
+++ b/include/tables/object_table.h
@@ -5,7 +5,7 @@
  *    - Argument 1: Name of the object segment in spec
  *    - Argument 2: Enum value for this object
  *
- * DEFINE_OBJECT_UNSET and DEFINE_OBJECT_NULL are needed to define empty entries from the original game
+ * DEFINE_OBJECT_UNSET and DEFINE_OBJECT_EMPTY are needed to define empty entries from the original game
  */
 /* 0x0000 */ DEFINE_OBJECT_UNSET(OBJECT_INVALID) // Object ID 0 isn't usable and should remain unset
 /* 0x0001 */ DEFINE_OBJECT(gameplay_keep, OBJECT_GAMEPLAY_KEEP)
@@ -234,7 +234,7 @@
 /* 0x00E0 */ DEFINE_OBJECT(object_ma1, OBJECT_MA1)
 /* 0x00E1 */ DEFINE_OBJECT(object_ganon, OBJECT_GANON)
 /* 0x00E2 */ DEFINE_OBJECT(object_sst, OBJECT_SST)
-/* 0x00E3 */ DEFINE_OBJECT_NULL(object_ny, OBJECT_NY_UNUSED) // unused duplicate with size 0
+/* 0x00E3 */ DEFINE_OBJECT_EMPTY(object_ny, OBJECT_NY_UNUSED) // unused duplicate with size 0
 /* 0x00E4 */ DEFINE_OBJECT_UNSET(OBJECT_UNSET_E4)
 /* 0x00E5 */ DEFINE_OBJECT(object_ny, OBJECT_NY)
 /* 0x00E6 */ DEFINE_OBJECT(object_fr, OBJECT_FR)
@@ -257,7 +257,7 @@
 /* 0x00F7 */ DEFINE_OBJECT(object_gi_grass, OBJECT_GI_GRASS)
 /* 0x00F8 */ DEFINE_OBJECT(object_gi_longsword, OBJECT_GI_LONGSWORD)
 /* 0x00F9 */ DEFINE_OBJECT(object_spot01_objects, OBJECT_SPOT01_OBJECTS)
-/* 0x00FA */ DEFINE_OBJECT_NULL(object_md, OBJECT_MD_UNUSED) // unused duplicate with size 0
+/* 0x00FA */ DEFINE_OBJECT_EMPTY(object_md, OBJECT_MD_UNUSED) // unused duplicate with size 0
 /* 0x00FB */ DEFINE_OBJECT(object_md, OBJECT_MD)
 /* 0x00FC */ DEFINE_OBJECT(object_km1, OBJECT_KM1)
 /* 0x00FD */ DEFINE_OBJECT(object_kw1, OBJECT_KW1)

--- a/include/z64.h
+++ b/include/z64.h
@@ -557,8 +557,7 @@ typedef struct {
 
 typedef struct {
     /* 0x00 */ void*     loadedRamAddr;
-    /* 0x04 */ uintptr_t vromStart; // if applicable
-    /* 0x08 */ uintptr_t vromEnd;   // if applicable
+    /* 0x04 */ RomFile   file;      // if applicable
     /* 0x0C */ void*     vramStart; // if applicable
     /* 0x10 */ void*     vramEnd;   // if applicable
     /* 0x14 */ void*     unk_14;

--- a/include/z64.h
+++ b/include/z64.h
@@ -194,8 +194,7 @@ typedef struct {
 
 typedef struct {
     /* 0x00 */ void* loadedRamAddr;
-    /* 0x04 */ uintptr_t vromStart;
-    /* 0x08 */ uintptr_t vromEnd;
+    /* 0x04 */ RomFile file;
     /* 0x0C */ void* vramStart;
     /* 0x10 */ void* vramEnd;
     /* 0x14 */ u32 offset; // loadedRamAddr - vramStart

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -89,8 +89,7 @@ typedef struct {
 #define ACTOROVL_ALLOC_PERSISTENT (1 << 1)
 
 typedef struct {
-    /* 0x00 */ uintptr_t vromStart;
-    /* 0x04 */ uintptr_t vromEnd;
+    /* 0x00 */ RomFile file;
     /* 0x08 */ void* vramStart;
     /* 0x0C */ void* vramEnd;
     /* 0x10 */ void* loadedRamAddr; // original name: "allocp"

--- a/include/z64dma.h
+++ b/include/z64dma.h
@@ -32,7 +32,7 @@ typedef struct {
 #define ROM_FILE_EMPTY(name) \
     { (uintptr_t)_##name##SegmentRomStart, (uintptr_t)_##name##SegmentRomStart }
 #define ROM_FILE_UNSET \
-    { 0 }
+    { 0, 0 }
 
 extern DmaEntry gDmaDataTable[];
 

--- a/include/z64dma.h
+++ b/include/z64dma.h
@@ -5,6 +5,18 @@
 #include "alignment.h"
 
 typedef struct {
+    /* 0x00 */ uintptr_t vromStart;
+    /* 0x04 */ uintptr_t vromEnd;
+} RomFile; // size = 0x8
+
+#define ROM_FILE(name) \
+    { (uintptr_t)_##name##SegmentRomStart, (uintptr_t)_##name##SegmentRomEnd }
+#define ROM_FILE_EMPTY(name) \
+    { (uintptr_t)_##name##SegmentRomStart, (uintptr_t)_##name##SegmentRomStart }
+#define ROM_FILE_UNSET \
+    { 0, 0 }
+
+typedef struct {
     /* 0x00 */ uintptr_t    vromAddr; // VROM address (source)
     /* 0x04 */ void*        dramAddr; // DRAM address (destination)
     /* 0x08 */ size_t       size;     // File Transfer size
@@ -16,23 +28,10 @@ typedef struct {
 } DmaRequest; // size = 0x20
 
 typedef struct {
-    /* 0x00 */ uintptr_t vromStart;
-    /* 0x04 */ uintptr_t vromEnd;
+    /* 0x00 */ RomFile file;
     /* 0x08 */ uintptr_t romStart;
     /* 0x0C */ uintptr_t romEnd;
 } DmaEntry;
-
-typedef struct {
-    /* 0x00 */ uintptr_t vromStart;
-    /* 0x04 */ uintptr_t vromEnd;
-} RomFile; // size = 0x8
-
-#define ROM_FILE(name) \
-    { (uintptr_t)_##name##SegmentRomStart, (uintptr_t)_##name##SegmentRomEnd }
-#define ROM_FILE_EMPTY(name) \
-    { (uintptr_t)_##name##SegmentRomStart, (uintptr_t)_##name##SegmentRomStart }
-#define ROM_FILE_UNSET \
-    { 0, 0 }
 
 extern DmaEntry gDmaDataTable[];
 

--- a/include/z64effect.h
+++ b/include/z64effect.h
@@ -202,8 +202,7 @@ typedef struct {
 } EffectSsInit; // size = 0x08
 
 typedef struct {
-    /* 0x00 */ uintptr_t vromStart;
-    /* 0x04 */ uintptr_t vromEnd;
+    /* 0x00 */ RomFile file;
     /* 0x08 */ void* vramStart;
     /* 0x0C */ void* vramEnd;
     /* 0x10 */ void* loadedRamAddr;

--- a/include/z64object.h
+++ b/include/z64object.h
@@ -23,7 +23,7 @@ typedef struct {
 } ObjectContext; // size = 0x518
 
 #define DEFINE_OBJECT(_0, enum) enum,
-#define DEFINE_OBJECT_NULL(_0, enum) enum,
+#define DEFINE_OBJECT_EMPTY(_0, enum) enum,
 #define DEFINE_OBJECT_UNSET(enum) enum,
 
 typedef enum {
@@ -32,7 +32,7 @@ typedef enum {
 } ObjectId;
 
 #undef DEFINE_OBJECT
-#undef DEFINE_OBJECT_NULL
+#undef DEFINE_OBJECT_EMPTY
 #undef DEFINE_OBJECT_UNSET
 
 #endif

--- a/src/code/object_table.c
+++ b/src/code/object_table.c
@@ -6,24 +6,24 @@ u32 gObjectTableSize = ARRAY_COUNT(gObjectTable);
 
 // Object linker symbol declarations (used in the table below)
 #define DEFINE_OBJECT(name, _1) DECLARE_ROM_SEGMENT(name)
-#define DEFINE_OBJECT_NULL(_0, _1)
+#define DEFINE_OBJECT_EMPTY(_0, _1)
 #define DEFINE_OBJECT_UNSET(_0)
 
 #include "tables/object_table.h"
 
 #undef DEFINE_OBJECT
-#undef DEFINE_OBJECT_NULL
+#undef DEFINE_OBJECT_EMPTY
 #undef DEFINE_OBJECT_UNSET
 
 // Object Table definition
 #define DEFINE_OBJECT(name, _1) ROM_FILE(name),
-#define DEFINE_OBJECT_NULL(name, _1) ROM_FILE_EMPTY(name),
-#define DEFINE_OBJECT_UNSET(_0) { 0 },
+#define DEFINE_OBJECT_EMPTY(name, _1) ROM_FILE_EMPTY(name),
+#define DEFINE_OBJECT_UNSET(_0) ROM_FILE_UNSET,
 
 RomFile gObjectTable[] = {
 #include "tables/object_table.h"
 };
 
 #undef DEFINE_OBJECT
-#undef DEFINE_OBJECT_NULL
+#undef DEFINE_OBJECT_EMPTY
 #undef DEFINE_OBJECT_UNSET

--- a/src/code/z_DLF.c
+++ b/src/code/z_DLF.c
@@ -10,7 +10,7 @@ void Overlay_LoadGameState(GameStateOverlay* overlayEntry) {
     if (overlayEntry->vramStart == NULL) {
         overlayEntry->unk_28 = 0;
     } else {
-        overlayEntry->loadedRamAddr = Overlay_AllocateAndLoad(overlayEntry->vromStart, overlayEntry->vromEnd,
+        overlayEntry->loadedRamAddr = Overlay_AllocateAndLoad(overlayEntry->file.vromStart, overlayEntry->file.vromEnd,
                                                               overlayEntry->vramStart, overlayEntry->vramEnd);
 
         if (overlayEntry->loadedRamAddr == NULL) {

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2877,8 +2877,8 @@ Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 pos
                 return NULL;
             }
 
-            Overlay_Load(overlayEntry->vromStart, overlayEntry->vromEnd, overlayEntry->vramStart, overlayEntry->vramEnd,
-                         overlayEntry->loadedRamAddr);
+            Overlay_Load(overlayEntry->file.vromStart, overlayEntry->file.vromEnd, overlayEntry->vramStart,
+                         overlayEntry->vramEnd, overlayEntry->loadedRamAddr);
 
             PRINTF(VT_FGCOL(GREEN));
             PRINTF("OVL(a):Seg:%08x-%08x Ram:%08x-%08x Off:%08x %s\n", overlayEntry->vramStart, overlayEntry->vramEnd,

--- a/src/code/z_actor_dlftbls.c
+++ b/src/code/z_actor_dlftbls.c
@@ -40,7 +40,10 @@
         ROM_FILE_UNSET, NULL, NULL, NULL, &name##_InitVars, nameString, allocType, 0, \
     },
 
-#define DEFINE_ACTOR_UNSET(_0) { 0 },
+#define DEFINE_ACTOR_UNSET(_0)                              \
+    {                                                       \
+        ROM_FILE_UNSET, NULL, NULL, NULL, NULL, '\0', 0, 0, \
+    },
 
 ActorOverlay gActorOverlayTable[] = {
 #include "tables/actor_table.h"

--- a/src/code/z_actor_dlftbls.c
+++ b/src/code/z_actor_dlftbls.c
@@ -24,18 +24,21 @@
 
 // Actor Overlay Table definition
 #define DEFINE_ACTOR(name, _1, allocType, nameString) \
-    { (uintptr_t)_ovl_##name##SegmentRomStart,        \
-      (uintptr_t)_ovl_##name##SegmentRomEnd,          \
-      _ovl_##name##SegmentStart,                      \
-      _ovl_##name##SegmentEnd,                        \
-      NULL,                                           \
-      &name##_InitVars,                               \
-      nameString,                                     \
-      allocType,                                      \
-      0 },
+    {                                                 \
+        ROM_FILE(ovl_##name),                         \
+        _ovl_##name##SegmentStart,                    \
+        _ovl_##name##SegmentEnd,                      \
+        NULL,                                         \
+        &name##_InitVars,                             \
+        nameString,                                   \
+        allocType,                                    \
+        0,                                            \
+    },
 
-#define DEFINE_ACTOR_INTERNAL(name, _1, allocType, nameString) \
-    { 0, 0, NULL, NULL, NULL, &name##_InitVars, nameString, allocType, 0 },
+#define DEFINE_ACTOR_INTERNAL(name, _1, allocType, nameString)                        \
+    {                                                                                 \
+        ROM_FILE_UNSET, NULL, NULL, NULL, &name##_InitVars, nameString, allocType, 0, \
+    },
 
 #define DEFINE_ACTOR_UNSET(_0) { 0 },
 
@@ -60,7 +63,7 @@ void ActorOverlayTable_LogPrint(void) {
     PRINTF("RomStart RomEnd   SegStart SegEnd   allocp   profile  segname\n");
 
     for (i = 0, overlayEntry = &gActorOverlayTable[0]; i < (u32)gMaxActorId; i++, overlayEntry++) {
-        PRINTF("%08x %08x %08x %08x %08x %08x %s\n", overlayEntry->vromStart, overlayEntry->vromEnd,
+        PRINTF("%08x %08x %08x %08x %08x %08x %s\n", overlayEntry->file.vromStart, overlayEntry->file.vromEnd,
                overlayEntry->vramStart, overlayEntry->vramEnd, overlayEntry->loadedRamAddr, &overlayEntry->initInfo->id,
                overlayEntry->name != NULL ? overlayEntry->name : "?");
     }

--- a/src/code/z_effect_soft_sprite.c
+++ b/src/code/z_effect_soft_sprite.c
@@ -12,7 +12,8 @@ void EffectSs_InitInfo(PlayState* play, s32 tableSize) {
     for (i = 0; i < ARRAY_COUNT(gEffectSsOverlayTable); i++) {
         overlay = &gEffectSsOverlayTable[i];
         PRINTF("effect index %3d:size=%6dbyte romsize=%6dbyte\n", i,
-               (uintptr_t)overlay->vramEnd - (uintptr_t)overlay->vramStart, overlay->vromEnd - overlay->vromStart);
+               (uintptr_t)overlay->vramEnd - (uintptr_t)overlay->vramStart,
+               overlay->file.vromEnd - overlay->file.vromStart);
     }
 #endif
 
@@ -205,13 +206,13 @@ void EffectSs_Spawn(PlayState* play, s32 type, s32 priority, void* initParams) {
                 return;
             }
 
-            Overlay_Load(overlayEntry->vromStart, overlayEntry->vromEnd, overlayEntry->vramStart, overlayEntry->vramEnd,
-                         overlayEntry->loadedRamAddr);
+            Overlay_Load(overlayEntry->file.vromStart, overlayEntry->file.vromEnd, overlayEntry->vramStart,
+                         overlayEntry->vramEnd, overlayEntry->loadedRamAddr);
 
             PRINTF(VT_FGCOL(GREEN));
-            PRINTF("EFFECT SS OVL:SegRom %08x %08x, Seg %08x %08x, RamStart %08x, type: %d\n", overlayEntry->vromStart,
-                   overlayEntry->vromEnd, overlayEntry->vramStart, overlayEntry->vramEnd, overlayEntry->loadedRamAddr,
-                   type);
+            PRINTF("EFFECT SS OVL:SegRom %08x %08x, Seg %08x %08x, RamStart %08x, type: %d\n",
+                   overlayEntry->file.vromStart, overlayEntry->file.vromEnd, overlayEntry->vramStart,
+                   overlayEntry->vramEnd, overlayEntry->loadedRamAddr, type);
             PRINTF(VT_RST);
         }
 

--- a/src/code/z_effect_soft_sprite_dlftbls.c
+++ b/src/code/z_effect_soft_sprite_dlftbls.c
@@ -19,18 +19,15 @@
 #undef DEFINE_EFFECT_SS_UNSET
 
 // Effect SS Overlay Table definition
-#define DEFINE_EFFECT_SS(name, _1)               \
-    {                                            \
-        (uintptr_t)_ovl_##name##SegmentRomStart, \
-        (uintptr_t)_ovl_##name##SegmentRomEnd,   \
-        _ovl_##name##SegmentStart,               \
-        _ovl_##name##SegmentEnd,                 \
-        NULL,                                    \
-        &name##_InitVars,                        \
-        1,                                       \
+#define DEFINE_EFFECT_SS(name, _1)                                                                           \
+    {                                                                                                        \
+        ROM_FILE(ovl_##name), _ovl_##name##SegmentStart, _ovl_##name##SegmentEnd, NULL, &name##_InitVars, 1, \
     },
 
-#define DEFINE_EFFECT_SS_UNSET(_0) { 0 },
+#define DEFINE_EFFECT_SS_UNSET(_0)                 \
+    {                                              \
+        ROM_FILE_UNSET, NULL, NULL, NULL, NULL, 0, \
+    },
 
 EffectSsOverlay gEffectSsOverlayTable[] = {
 #include "tables/effect_ss_table.h"

--- a/src/code/z_game_dlftbls.c
+++ b/src/code/z_game_dlftbls.c
@@ -10,22 +10,26 @@
 #undef DEFINE_GAMESTATE_INTERNAL
 
 // Gamestate Overlay Table definition
-#define DEFINE_GAMESTATE_INTERNAL(typeName, enumName) \
-    { NULL, 0, 0, NULL, NULL, NULL, typeName##_Init, typeName##_Destroy, NULL, NULL, 0, sizeof(typeName##State) },
+#define DEFINE_GAMESTATE_INTERNAL(typeName, enumName)                                                     \
+    {                                                                                                     \
+        NULL, ROM_FILE_UNSET,          NULL, NULL, NULL, typeName##_Init, typeName##_Destroy, NULL, NULL, \
+        0,    sizeof(typeName##State),                                                                    \
+    },
 
 #define DEFINE_GAMESTATE(typeName, enumName, name) \
-    { NULL,                                        \
-      (uintptr_t)_ovl_##name##SegmentRomStart,     \
-      (uintptr_t)_ovl_##name##SegmentRomEnd,       \
-      _ovl_##name##SegmentStart,                   \
-      _ovl_##name##SegmentEnd,                     \
-      NULL,                                        \
-      typeName##_Init,                             \
-      typeName##_Destroy,                          \
-      NULL,                                        \
-      NULL,                                        \
-      0,                                           \
-      sizeof(typeName##State) },
+    {                                              \
+        NULL,                                      \
+        ROM_FILE(ovl_##name),                      \
+        _ovl_##name##SegmentStart,                 \
+        _ovl_##name##SegmentEnd,                   \
+        NULL,                                      \
+        typeName##_Init,                           \
+        typeName##_Destroy,                        \
+        NULL,                                      \
+        NULL,                                      \
+        0,                                         \
+        sizeof(typeName##State),                   \
+    },
 
 GameStateOverlay gGameStateOverlayTable[] = {
 #include "tables/gamestate_table.h"

--- a/src/code/z_kaleido_manager.c
+++ b/src/code/z_kaleido_manager.c
@@ -1,11 +1,8 @@
 #include "global.h"
 #include "terminal.h"
 
-#define KALEIDO_OVERLAY(name, nameString)                                                     \
-    {                                                                                         \
-        NULL, (uintptr_t)_ovl_##name##SegmentRomStart, (uintptr_t)_ovl_##name##SegmentRomEnd, \
-            _ovl_##name##SegmentStart, _ovl_##name##SegmentEnd, 0, nameString,                \
-    }
+#define KALEIDO_OVERLAY(name, nameString) \
+    { NULL, ROM_FILE(ovl_##name), _ovl_##name##SegmentStart, _ovl_##name##SegmentEnd, 0, nameString, }
 
 KaleidoMgrOverlay gKaleidoMgrOverlayTable[] = {
     KALEIDO_OVERLAY(kaleido_scope, "kaleido_scope"),
@@ -20,7 +17,7 @@ void KaleidoManager_LoadOvl(KaleidoMgrOverlay* ovl) {
     LOG_UTILS_CHECK_NULL_POINTER("KaleidoArea_allocp", sKaleidoAreaPtr, "../z_kaleido_manager.c", 99);
 
     ovl->loadedRamAddr = sKaleidoAreaPtr;
-    Overlay_Load(ovl->vromStart, ovl->vromEnd, ovl->vramStart, ovl->vramEnd, ovl->loadedRamAddr);
+    Overlay_Load(ovl->file.vromStart, ovl->file.vromEnd, ovl->vramStart, ovl->vramEnd, ovl->loadedRamAddr);
 
     PRINTF(VT_FGCOL(GREEN));
     PRINTF("OVL(k):Seg:%08x-%08x Ram:%08x-%08x Off:%08x %s\n", ovl->vramStart, ovl->vramEnd, ovl->loadedRamAddr,

--- a/src/code/z_map_mark.c
+++ b/src/code/z_map_mark.c
@@ -16,8 +16,7 @@ typedef struct {
 
 typedef struct {
     /* 0x00 */ void* loadedRamAddr; // original name: "allocp"
-    /* 0x04 */ uintptr_t vromStart;
-    /* 0x08 */ uintptr_t vromEnd;
+    /* 0x04 */ RomFile file;
     /* 0x0C */ void* vramStart;
     /* 0x10 */ void* vramEnd;
     /* 0x14 */ void* vramTable;
@@ -43,12 +42,7 @@ static MapMarkInfo sMapMarkInfoTable[] = {
 };
 
 static MapMarkDataOverlay sMapMarkDataOvl = {
-    NULL,
-    (uintptr_t)_ovl_map_mark_dataSegmentRomStart,
-    (uintptr_t)_ovl_map_mark_dataSegmentRomEnd,
-    _ovl_map_mark_dataSegmentStart,
-    _ovl_map_mark_dataSegmentEnd,
-    gMapMarkDataTable,
+    NULL, ROM_FILE(ovl_map_mark_data), _ovl_map_mark_dataSegmentStart, _ovl_map_mark_dataSegmentEnd, gMapMarkDataTable,
 };
 
 static MapMarkData** sLoadedMarkDataTable;
@@ -60,7 +54,8 @@ void MapMark_Init(PlayState* play) {
     overlay->loadedRamAddr = GAME_STATE_ALLOC(&play->state, overlaySize, "../z_map_mark.c", 235);
     LOG_UTILS_CHECK_NULL_POINTER("dlftbl->allocp", overlay->loadedRamAddr, "../z_map_mark.c", 236);
 
-    Overlay_Load(overlay->vromStart, overlay->vromEnd, overlay->vramStart, overlay->vramEnd, overlay->loadedRamAddr);
+    Overlay_Load(overlay->file.vromStart, overlay->file.vromEnd, overlay->vramStart, overlay->vramEnd,
+                 overlay->loadedRamAddr);
 
     sLoadedMarkDataTable = gMapMarkDataTable;
     sLoadedMarkDataTable =

--- a/src/dmadata/dmadata.c
+++ b/src/dmadata/dmadata.c
@@ -10,8 +10,12 @@
 #undef DEFINE_DMA_ENTRY
 
 // dmadata Table definition
-#define DEFINE_DMA_ENTRY(name, _1) \
-    { (uintptr_t)_##name##SegmentRomStart, (uintptr_t)_##name##SegmentRomEnd, (uintptr_t)_##name##SegmentRomStart, 0 },
+#define DEFINE_DMA_ENTRY(name, _1)           \
+    {                                        \
+        ROM_FILE(name),                      \
+        (uintptr_t)_##name##SegmentRomStart, \
+        0,                                   \
+    },
 
 DmaEntry gDmaDataTable[] = {
 #include "tables/dmadata_table.h"


### PR DESCRIPTION
I had casually brought this up in mm-decomp. I liked the way it turned out so thought I would PR it to see what other people's thoughts are.