### PR TITLE
Update `mapfile_parser`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ pycparser
 toml
 
 # tools
-mapfile-parser>=1.2.1,<2.0.0
+mapfile-parser>=2.3.5,<3.0.0
 rabbitizer>=1.0.0,<2.0.0
 spimdisasm>=1.21.0,<2.0.0


### PR DESCRIPTION
Updates `mapfile_parser` to version 2.X.

The most note worthy thing this version has is the mapfile parsing was rewritten in Rust, making it a lot faster than the old pure-python version.

Even if this is a new major version of the lib, none of interface directly used by the scripts changed, so this is a drop-in replacement for this repo.