### PR TITLE
Match retail demo actors

### DIFF
--- a/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
+++ b/src/overlays/actors/ovl_Demo_6K/z_demo_6k.c
@@ -775,8 +775,6 @@ void func_80968FB0(Actor* thisx, PlayState* play) {
     f32 scaleFactor;
     s32 pad;
 
-    if (1) {}
-
     OPEN_DISPS(play->state.gfxCtx, "../z_demo_6k.c", 1386);
 
     Gfx_SetupDL_25Xlu(play->state.gfxCtx);
@@ -787,6 +785,7 @@ void func_80968FB0(Actor* thisx, PlayState* play) {
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPSegment(POLY_XLU_DISP++, 0x08, displayList);
     gDPPipeSync(displayList++);
+    if (displayList) {}
     gDPSetPrimColor(displayList++, 0, 0x80, 255, 255, 255, this->unk_293);
     gDPSetRenderMode(displayList++, G_RM_PASS, G_RM_ZB_CLD_SURF2);
     gSPEndDisplayList(displayList++);

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
@@ -104,8 +104,11 @@ void DemoDu_UpdateBgCheckInfo(DemoDu* this, PlayState* play) {
 
 CsCmdActorCue* DemoDu_GetCue(PlayState* play, s32 cueChannel) {
     if (play->csCtx.state != CS_STATE_IDLE) {
-        return play->csCtx.actorCues[cueChannel];
+        CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
+
+        return cue;
     }
+
     return NULL;
 }
 

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
@@ -68,6 +68,7 @@ void DemoDu_SetMouthTexIndex(DemoDu* this, s16 mouthTexIndex) {
     this->mouthTexIndex = mouthTexIndex;
 }
 
+#if OOT_DEBUG
 // Resets all the values used in this cutscene.
 void DemoDu_CsAfterGanon_Reset(DemoDu* this) {
     this->updateIndex = CS_CHAMBERAFTERGANON_SUBSCENE(0);
@@ -93,6 +94,7 @@ void DemoDu_CsAfterGanon_CheckIfShouldReset(DemoDu* this, PlayState* play) {
         D_8096CE94 = true;
     }
 }
+#endif
 
 s32 DemoDu_UpdateSkelAnime(DemoDu* this) {
     return SkelAnime_Update(&this->skelAnime);
@@ -777,7 +779,9 @@ void DemoDu_CsAfterGanon_BackTo01(DemoDu* this, PlayState* play) {
 
 void DemoDu_UpdateCs_AG_00(DemoDu* this, PlayState* play) {
     DemoDu_CsAfterGanon_AdvanceTo01(this, play);
+#if OOT_DEBUG
     DemoDu_CsAfterGanon_CheckIfShouldReset(this, play);
+#endif
 }
 
 void DemoDu_UpdateCs_AG_01(DemoDu* this, PlayState* play) {
@@ -785,7 +789,9 @@ void DemoDu_UpdateCs_AG_01(DemoDu* this, PlayState* play) {
     DemoDu_UpdateSkelAnime(this);
     DemoDu_UpdateEyes(this);
     DemoDu_CsAfterGanon_AdvanceTo02(this, play);
+#if OOT_DEBUG
     DemoDu_CsAfterGanon_CheckIfShouldReset(this, play);
+#endif
 }
 
 void DemoDu_UpdateCs_AG_02(DemoDu* this, PlayState* play) {
@@ -793,7 +799,9 @@ void DemoDu_UpdateCs_AG_02(DemoDu* this, PlayState* play) {
     DemoDu_UpdateSkelAnime(this);
     DemoDu_UpdateEyes(this);
     DemoDu_CsAfterGanon_BackTo01(this, play);
+#if OOT_DEBUG
     DemoDu_CsAfterGanon_CheckIfShouldReset(this, play);
+#endif
 }
 
 // Similar to DemoDu_Draw_01, but this uses POLY_XLU_DISP. Also uses this->shadowAlpha for setting the env color.

--- a/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
+++ b/src/overlays/actors/ovl_Demo_Ec/z_demo_ec.c
@@ -334,10 +334,12 @@ void DemoEc_UseAnimationObject(DemoEc* this, PlayState* play) {
 
 CsCmdActorCue* DemoEc_GetCue(PlayState* play, s32 cueChannel) {
     if (play->csCtx.state != CS_STATE_IDLE) {
-        return play->csCtx.actorCues[cueChannel];
-    } else {
-        return NULL;
+        CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
+
+        return cue;
     }
+
+    return NULL;
 }
 
 void DemoEc_SetStartPosRotFromCue(DemoEc* this, PlayState* play, s32 cueChannel) {

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -24,7 +24,7 @@ void DemoEffect_DrawGodLgt(Actor* thisx, PlayState* play);
 void DemoEffect_DrawLightRing(Actor* thisx, PlayState* play2);
 void DemoEffect_DrawTriforceSpot(Actor* thisx, PlayState* play);
 void DemoEffect_DrawGetItem(Actor* thisx, PlayState* play);
-void DemoEffect_DrawLightEffect(Actor* thisx, PlayState* play);
+void DemoEffect_DrawLightEffect(Actor* thisx, PlayState* play2);
 void DemoEffect_DrawTimeWarp(Actor* thisx, PlayState* play);
 void DemoEffect_DrawJewel(Actor* thisx, PlayState* play2);
 
@@ -1806,42 +1806,43 @@ void DemoEffect_DrawGodLgt(Actor* thisx, PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx, "../z_demo_effect.c", 2829);
 }
 
-void DemoEffect_DrawLightEffect(Actor* thisx, PlayState* play) {
+void DemoEffect_DrawLightEffect(Actor* thisx, PlayState* play2) {
     DemoEffect* this = (DemoEffect*)thisx;
-    u8* alpha;
-    Gfx* disp;
+    PlayState* play = (PlayState*)play2;
+    u8* alpha = &this->light.alpha;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_demo_effect.c", 2842);
 
-    if (!DemoEffect_CheckForCue(this, play, 1)) {
+    if (1) {}
 
-        if (this->light.flicker == 0) {
-            this->light.flicker = 1;
-        } else {
-            disp = (Gfx*)(uintptr_t)gEffFlash1DL; // necessary to match but probably fake
-            alpha = &this->light.alpha;
-            Gfx_SetupDL_25Xlu(play->state.gfxCtx);
-            gDPSetPrimColor(POLY_XLU_DISP++, 0, 128, this->primXluColor[0], this->primXluColor[1],
-                            this->primXluColor[2], *alpha);
-            gDPSetEnvColor(POLY_XLU_DISP++, this->envXluColor[0], this->envXluColor[1], this->envXluColor[2], 255);
-            Matrix_Scale(((this->light.scaleFlag & 1) * 0.05f) + 1.0f, ((this->light.scaleFlag & 1) * 0.05f) + 1.0f,
-                         ((this->light.scaleFlag & 1) * 0.05f) + 1.0f, MTXMODE_APPLY);
-            Matrix_Push();
-            Matrix_Mult(&play->billboardMtxF, MTXMODE_APPLY);
-            Matrix_RotateZ(DEG_TO_RAD(this->light.rotation), MTXMODE_APPLY);
-            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_demo_effect.c", 2866),
-                      G_MTX_MODELVIEW | G_MTX_LOAD | G_MTX_NOPUSH);
-            if (disp) {};
-            gSPDisplayList(POLY_XLU_DISP++, disp);
-            Matrix_Pop();
-            Matrix_Mult(&play->billboardMtxF, MTXMODE_APPLY);
-            Matrix_RotateZ(DEG_TO_RAD(-(f32)this->light.rotation), MTXMODE_APPLY);
-            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_demo_effect.c", 2874),
-                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gSPDisplayList(POLY_XLU_DISP++, disp);
-        }
+    if (DemoEffect_CheckForCue(this, play, 1)) {
+        goto close_disps;
     }
 
+    if (this->light.flicker == 0) {
+        this->light.flicker = 1;
+    } else {
+        Gfx_SetupDL_25Xlu(play->state.gfxCtx);
+        gDPSetPrimColor(POLY_XLU_DISP++, 0, 128, this->primXluColor[0], this->primXluColor[1], this->primXluColor[2],
+                        *alpha);
+        gDPSetEnvColor(POLY_XLU_DISP++, this->envXluColor[0], this->envXluColor[1], this->envXluColor[2], 255);
+        Matrix_Scale(((this->light.scaleFlag & 1) * 0.05f) + 1.0f, ((this->light.scaleFlag & 1) * 0.05f) + 1.0f,
+                     ((this->light.scaleFlag & 1) * 0.05f) + 1.0f, MTXMODE_APPLY);
+        Matrix_Push();
+        Matrix_Mult(&play->billboardMtxF, MTXMODE_APPLY);
+        Matrix_RotateZ(DEG_TO_RAD(this->light.rotation), MTXMODE_APPLY);
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_demo_effect.c", 2866),
+                  G_MTX_MODELVIEW | G_MTX_LOAD | G_MTX_NOPUSH);
+        gSPDisplayList(POLY_XLU_DISP++, gEffFlash1DL);
+        Matrix_Pop();
+        Matrix_Mult(&play->billboardMtxF, MTXMODE_APPLY);
+        Matrix_RotateZ(DEG_TO_RAD(-(f32)this->light.rotation), MTXMODE_APPLY);
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_demo_effect.c", 2874),
+                  G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPDisplayList(POLY_XLU_DISP++, gEffFlash1DL);
+    }
+
+close_disps:
     CLOSE_DISPS(play->state.gfxCtx, "../z_demo_effect.c", 2881);
 }
 
@@ -2004,8 +2005,8 @@ s32 DemoEffect_OverrideLimbDrawTimeWarp(PlayState* play, SkelCurve* skelCurve, s
 }
 
 void DemoEffect_DrawTimeWarp(Actor* thisx, PlayState* play) {
-    DemoEffect* this = (DemoEffect*)thisx;
     GraphicsContext* gfxCtx = play->state.gfxCtx;
+    DemoEffect* this = (DemoEffect*)thisx;
     u8 effectType = (this->actor.params & 0x00FF);
 
     if (effectType == DEMO_EFFECT_TIMEWARP_TIMEBLOCK_LARGE || effectType == DEMO_EFFECT_TIMEWARP_TIMEBLOCK_SMALL ||

--- a/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.c
+++ b/src/overlays/actors/ovl_Demo_Ext/z_demo_ext.c
@@ -52,7 +52,9 @@ void DemoExt_PlayVortexSFX(DemoExt* this) {
 
 CsCmdActorCue* DemoExt_GetCue(PlayState* play, s32 cueChannel) {
     if (play->csCtx.state != CS_STATE_IDLE) {
-        return play->csCtx.actorCues[cueChannel];
+        CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
+
+        return cue;
     }
 
     return NULL;

--- a/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.c
+++ b/src/overlays/actors/ovl_Demo_Geff/z_demo_geff.c
@@ -165,7 +165,9 @@ void func_809782A0(DemoGeff* this, PlayState* play) {
 void func_80978308(DemoGeff* this, PlayState* play) {
     func_809781FC(this, play);
     func_809782A0(this, play);
+#if OOT_DEBUG
     func_80978030(this, play);
+#endif
 }
 
 void func_80978344(DemoGeff* this, PlayState* play) {

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
@@ -263,7 +263,7 @@ s32 DemoGj_InitSetIndices(DemoGj* this, PlayState* play, s32 updateMode, s32 dra
 }
 
 void DemoGj_DrawCommon(DemoGj* this, PlayState* play, Gfx* displayList) {
-    if (kREG(0) == 0) {
+    if (!OOT_DEBUG || kREG(0) == 0) {
         GraphicsContext* gfxCtx = play->state.gfxCtx;
 
         OPEN_DISPS(gfxCtx, "../z_demo_gj.c", 1163);
@@ -454,7 +454,7 @@ s32 DemoGj_IsGanondorfFloatingInAir(DemoGj* this, PlayState* play) {
 
 void DemoGj_SetupMovement(DemoGj* this, PlayState* play) {
     Actor* actor = &this->dyna.actor;
-    Player* player;
+    s32 pad;
     Vec3f* pos = &actor->world.pos;
     Vec3s* unk_172;
     f32 xDistance;
@@ -544,7 +544,8 @@ void DemoGj_SetupMovement(DemoGj* this, PlayState* play) {
         }
 
         if (xDistance == 0.0f && zDistance == 0.0f) {
-            player = GET_PLAYER(play);
+            Player* player = GET_PLAYER(play);
+
             xDistance = player->actor.world.pos.x - pos->x;
             zDistance = player->actor.world.pos.z - pos->z;
 
@@ -974,8 +975,10 @@ void DemoGj_InitDestructableRubble1(DemoGj* this, PlayState* play) {
     DemoGj_InitCylinder(this, play, &this->cylinders[2], &sCylinderInit1);
 }
 
+#if OOT_DEBUG
 void DemoGj_DoNothing1(DemoGj* this, PlayState* play) {
 }
+#endif
 
 /*
  * Moves the ColliderCylinder's relative to the actor's position.
@@ -1092,7 +1095,9 @@ void DemoGj_Update15(DemoGj* this, PlayState* play) {
 // func_8097B370
 void DemoGj_Update18(DemoGj* this, PlayState* play) {
     func_8097B22C(this, play);
+#if OOT_DEBUG
     DemoGj_DoNothing1(this, play);
+#endif
 }
 
 void DemoGj_DrawDestructableRubble1(DemoGj* this, PlayState* play) {
@@ -1107,8 +1112,10 @@ void DemoGj_InitDestructableRubble2(DemoGj* this, PlayState* play) {
     DemoGj_InitCylinder(this, play, &this->cylinders[2], &sCylinderInit2);
 }
 
+#if OOT_DEBUG
 void DemoGj_DoNothing2(DemoGj* this, PlayState* play) {
 }
+#endif
 
 // Moves the ColliderCylinder's relative to the actor's position.
 void func_8097B450(DemoGj* this, PlayState* play) {
@@ -1223,7 +1230,9 @@ void DemoGj_Update16(DemoGj* this, PlayState* play) {
 // func_8097B894
 void DemoGj_Update19(DemoGj* this, PlayState* play) {
     func_8097B750(this, play);
+#if OOT_DEBUG
     DemoGj_DoNothing2(this, play);
+#endif
 }
 
 void DemoGj_DemoGj_InitDestructableRubble2(DemoGj* this, PlayState* play) {
@@ -1236,8 +1245,10 @@ void DemoGj_InitDestructableRubbleTall(DemoGj* this, PlayState* play) {
     DemoGj_InitCylinder(this, play, &this->cylinders[0], &sCylinderInit3);
 }
 
+#if OOT_DEBUG
 void DemoGj_DoNothing3(DemoGj* this, PlayState* play) {
 }
+#endif
 
 void DemoGj_DirectedDoubleExplosion(DemoGj* this, PlayState* play, Vec3f* direction) {
     Vec3f pos;
@@ -1308,7 +1319,9 @@ void DemoGj_Update17(DemoGj* this, PlayState* play) {
 // func_8097BBA8
 void DemoGj_Update20(DemoGj* this, PlayState* play) {
     func_8097BA48(this, play);
+#if OOT_DEBUG
     DemoGj_DoNothing3(this, play);
+#endif
 }
 
 void DemoGj_DemoGj_InitDestructableRubbleTall(DemoGj* this, PlayState* play) {

--- a/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
+++ b/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
@@ -209,9 +209,12 @@ s32 func_8097CDB0(DemoGo* this, PlayState* play, u16 cueId) {
     CutsceneContext* csCtx = &play->csCtx;
     s32 cueChannel = DemoGo_GetCueChannel(this);
 
-    if ((csCtx->state != CS_STATE_IDLE) && (csCtx->actorCues[cueChannel] != NULL) &&
-        (csCtx->actorCues[cueChannel]->id == cueId)) {
-        return true;
+    if (csCtx->state != CS_STATE_IDLE) {
+        CsCmdActorCue* cue = csCtx->actorCues[cueChannel];
+
+        if (cue != NULL && cue->id == cueId) {
+            return true;
+        }
     }
 
     return false;
@@ -341,13 +344,13 @@ void func_8097D29C(DemoGo* this, PlayState* play) {
     s16 eyeTexIdx = this->unk_190;
     SkelAnime* skelAnime = &this->skelAnime;
     void* eyeTexture = sEyeTextures[eyeTexIdx];
-    void* mouthTexture = gGoronCsMouthSmileTex;
+    s32 pad2;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_demo_go.c", 732);
 
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(eyeTexture));
-    gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(mouthTexture));
+    gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(gGoronCsMouthSmileTex));
 
     SkelAnime_DrawFlexOpa(play, skelAnime->skeleton, skelAnime->jointTable, skelAnime->dListCount, NULL, NULL, this);
 

--- a/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.c
+++ b/src/overlays/actors/ovl_Demo_Gt/z_demo_gt.c
@@ -265,7 +265,6 @@ void func_8097E454(PlayState* play, Vec3f* spawnerPos, Vec3f* velocity, Vec3f* a
     s16 phi_s0;
     s16 dustScaleStep = 15.0f * scale;
     f32 dustScale = 300.0f * scale;
-    Vec3f pos;
 
     if ((!FrameAdvance_IsEnabled(play)) && (arg7 > 0) && (arg6 > 0)) {
         frames = (ABS((s32)play->gameplayFrames) % arg7);
@@ -273,6 +272,7 @@ void func_8097E454(PlayState* play, Vec3f* spawnerPos, Vec3f* velocity, Vec3f* a
         increment = 0x10000 / arg6;
 
         for (i = frames; i < arg6; i += arg7) {
+            Vec3f pos;
 
             pos.x = (Math_SinS(phi_s0) * arg4) + spawnerPos->x;
             pos.y = spawnerPos->y;
@@ -437,7 +437,7 @@ void func_8097ED64(DemoGt* this, PlayState* play, s32 cueChannel) {
 }
 
 u8 DemoGt_IsCutsceneLayer(void) {
-    if (kREG(2) != 0) {
+    if (OOT_DEBUG && kREG(2) != 0) {
         return true;
     } else if (!IS_CUTSCENE_LAYER) {
         return false;
@@ -503,7 +503,7 @@ void func_8097EF40(DemoGt* this, PlayState* play) {
     Vec3f* pos = &this->dyna.actor.world.pos;
     s32 pad;
 
-    if ((kREG(1) == 20) || (csCurFrame == 220)) {
+    if ((OOT_DEBUG && kREG(1) == 20) || (csCurFrame == 220)) {
         dustPos.x = pos->x + 256.0f;
         dustPos.y = pos->y + 679.0f;
         dustPos.z = pos->z + 82.0f;
@@ -526,7 +526,12 @@ void func_8097F0AC(DemoGt* this, PlayState* play) {
     u16 csCurFrame = play->csCtx.curFrame;
     s32 pad2;
 
-    if ((csCurFrame == 140) || (kREG(1) == 19)) {
+#if OOT_DEBUG
+    if (csCurFrame == 140 || kREG(1) == 19)
+#else
+    if (csCurFrame == 140)
+#endif
+    {
         sp38.x = this->dyna.actor.world.pos.x + 260.0f;
         sp38.y = this->dyna.actor.world.pos.y + 340.0f;
         sp38.z = this->dyna.actor.world.pos.z + 45.0f;
@@ -562,7 +567,6 @@ void func_8097F280(DemoGt* this, PlayState* play) {
     s32* unk178 = this->unk_178;
     s32* unk188 = this->unk_188;
     s32* unk198 = this->unk_198;
-    f32 temp_f0;
 
     if (play->csCtx.curFrame < 160) {
         unk178[0] = 100;
@@ -576,7 +580,7 @@ void func_8097F280(DemoGt* this, PlayState* play) {
         unk198[0]++;
         unk198[1]--;
     } else if (play->csCtx.curFrame < 170) {
-        temp_f0 = Environment_LerpWeightAccelDecel(170, 160, play->csCtx.curFrame, 0, 0);
+        f32 temp_f0 = Environment_LerpWeightAccelDecel(170, 160, play->csCtx.curFrame, 0, 0);
 
         unk178[0] = (temp_f0 * -63.0f) + 163.0f;
         unk178[1] = (temp_f0 * -155.0f) + 255.0f;
@@ -700,13 +704,14 @@ void func_8097F960(DemoGt* this, PlayState* play) {
 }
 
 void func_8097F96C(DemoGt* this, PlayState* play) {
-    static Actor* cloudRing = NULL;
     s32 pad[4];
     Vec3f pos;
     Actor* actor;
     u16 csCurFrame = play->csCtx.curFrame;
 
-    if (((csCurFrame > 1059) && (csCurFrame < 1062)) || kREG(1) == 17) {
+    if (((csCurFrame > 1059) && (csCurFrame < 1062)) || (OOT_DEBUG && kREG(1) == 17)) {
+        static Actor* cloudRing = NULL;
+
         pos.x = this->dyna.actor.world.pos.x;
         pos.y = this->dyna.actor.world.pos.y + 612.0f;
         pos.z = this->dyna.actor.world.pos.z;
@@ -730,7 +735,7 @@ void func_8097FA1C(DemoGt* this, PlayState* play) {
     Vec3f velOffset = { -12.0f, -17.0, 5.0 };
     s32 pad1[3];
 
-    if (((csCurFrame > 502) && !(csCurFrame >= 581)) || (kREG(1) == 5)) {
+    if (((csCurFrame > 502) && !(csCurFrame >= 581)) || (OOT_DEBUG && kREG(1) == 5)) {
         dustPos.x = pos->x + 300.0f;
         dustPos.y = pos->y + 360.0f;
         dustPos.z = pos->z - 377.0f;
@@ -739,19 +744,20 @@ void func_8097FA1C(DemoGt* this, PlayState* play) {
 }
 
 void func_8097FAFC(DemoGt* this, PlayState* play) {
-    static Vec3f velocity = { 0.0f, 1.0f, 0.0f };
-    static Vec3f accel = { 0.0f, 0.0f, 0.0f };
-    static f32 arg4 = 280.0f;
-    static f32 scale = 8.0f;
-    static s32 arg6 = 11;
-    static s32 arg7 = 1;
-    static s16 life = 3;
     s32 pad[2];
     u16 csCurFrame = play->csCtx.curFrame;
     Vec3f pos;
     f32 new_var = -200.0;
 
-    if (((csCurFrame > 582) && (csCurFrame < 683)) || (kREG(1) == 6)) {
+    if (((csCurFrame > 582) && (csCurFrame < 683)) || (OOT_DEBUG && kREG(1) == 6)) {
+        static Vec3f velocity = { 0.0f, 1.0f, 0.0f };
+        static Vec3f accel = { 0.0f, 0.0f, 0.0f };
+        static f32 arg4 = 280.0f;
+        static f32 scale = 8.0f;
+        static s32 arg6 = 11;
+        static s32 arg7 = 1;
+        static s16 life = 3;
+
         pos = this->dyna.actor.world.pos;
         pos.y += 680.0f;
 
@@ -773,7 +779,7 @@ void func_8097FC1C(DemoGt* this, PlayState* play) {
     Vec3f velOffset = { 5.0f, -16.0f, -16.0f };
     s32 pad1[3];
 
-    if (csCurFrame > 682 || kREG(1) == 7) {
+    if (csCurFrame > 682 || (OOT_DEBUG && kREG(1) == 7)) {
         dustPos.x = pos->x + 260.0f;
         dustPos.y = pos->y + 360.0f;
         dustPos.z = pos->z + 260.0f;
@@ -786,7 +792,12 @@ void func_8097FCE4(DemoGt* this, PlayState* play) {
     Vec3f vec;
     u16 csCurFrame = play->csCtx.curFrame;
 
-    if (csCurFrame == 503 || kREG(1) == 4) {
+#if OOT_DEBUG
+    if (csCurFrame == 503 || kREG(1) == 4)
+#else
+    if (csCurFrame == 503)
+#endif
+    {
         vec.x = this->dyna.actor.world.pos.x + 300.0f;
         vec.y = this->dyna.actor.world.pos.y + 560.0f;
         vec.z = this->dyna.actor.world.pos.z - 377.0f;
@@ -881,12 +892,13 @@ void func_80980178(DemoGt* this, PlayState* play) {
 }
 
 void func_80980184(DemoGt* this, PlayState* play) {
-    static Actor* cloudRing = NULL;
     s32 pad[4];
     Vec3f pos;
     Actor* actor;
 
     if ((play->csCtx.curFrame > 1027) && (play->csCtx.curFrame < 1031)) {
+        static Actor* cloudRing = NULL;
+
         pos.x = this->dyna.actor.world.pos.x;
         pos.y = this->dyna.actor.world.pos.y + 247.0f;
         pos.z = this->dyna.actor.world.pos.z;
@@ -903,12 +915,13 @@ void func_80980184(DemoGt* this, PlayState* play) {
 }
 
 void func_80980218(DemoGt* this, PlayState* play) {
-    static Actor* cloudRing = NULL;
     s32 pad[4];
     Vec3f pos;
     Actor* actor;
 
     if ((play->csCtx.curFrame > 997) && (play->csCtx.curFrame < 1001)) {
+        static Actor* cloudRing = NULL;
+
         pos.x = this->dyna.actor.home.pos.x;
         pos.y = this->dyna.actor.home.pos.y + 38.0f;
         pos.z = this->dyna.actor.home.pos.z;
@@ -964,7 +977,7 @@ void func_80980430(DemoGt* this, PlayState* play) {
     Vec3f velOffset = { 5.0f, -3.0f, 0.0f };
     s32 pad1[3];
 
-    if (csCurFrame > 709 || kREG(1) == 8) {
+    if (csCurFrame > 709 || (OOT_DEBUG && kREG(1) == 8)) {
         dustPos.x = pos->x + 760.0f;
         dustPos.y = pos->y - 40.0f;
         dustPos.z = pos->z - 240.0f;
@@ -980,7 +993,7 @@ void func_80980504(DemoGt* this, PlayState* play) {
     Vec3f velOffset = { 5.0f, -16.0f, -16.0f };
     s32 pad1[3];
 
-    if ((csCurFrame > 704) || kREG(1) == 9) {
+    if ((csCurFrame > 704) || (OOT_DEBUG && kREG(1) == 9)) {
         dustPos.x = pos->x + 830.0f;
         dustPos.y = pos->y + 60.0f;
         dustPos.z = pos->z + 390.0f;
@@ -996,7 +1009,7 @@ void func_809805D8(DemoGt* this, PlayState* play) {
     Vec3f velOffset = { 15.0f, -26.0, 0.0f };
     s32 pad1[3];
 
-    if (((csCurFrame > 739) && (csCurFrame < 781)) || kREG(1) == 11) {
+    if (((csCurFrame > 739) && (csCurFrame < 781)) || (OOT_DEBUG && kREG(1) == 11)) {
         dustPos.x = homePos->x + 550.0f;
         dustPos.y = homePos->y - 110.0f;
         dustPos.z = homePos->z + 50.0f;
@@ -1012,7 +1025,7 @@ void func_809806B8(DemoGt* this, PlayState* play) {
     Vec3f velOffset = { 5.0f, -16.0f, -16.0f };
     s32 pad1[3];
 
-    if ((csCurFrame > 964) || (kREG(1) == 12)) {
+    if ((csCurFrame > 964) || (OOT_DEBUG && kREG(1) == 12)) {
         dustPos.x = pos->x + 460.0f;
         dustPos.y = pos->y + 60.0f;
         dustPos.z = pos->z + 760.0f;
@@ -1028,7 +1041,7 @@ void func_8098078C(DemoGt* this, PlayState* play) {
     Vec3f velOffset = { 5.0f, -16.0f, -16.0f };
     s32 pad1[3];
 
-    if ((csCurFrame > 939) || (kREG(1) == 14)) {
+    if ((csCurFrame > 939) || (OOT_DEBUG && kREG(1) == 14)) {
         dustPos.x = pos->x + 360.0f;
         dustPos.y = pos->y + 70.0f;
         dustPos.z = pos->z - 640.0f;
@@ -1042,7 +1055,7 @@ void func_8098085C(DemoGt* this, PlayState* play) {
     u16 csCurFrame = play->csCtx.curFrame;
     Vec3f* pos = &this->dyna.actor.world.pos;
 
-    if ((csCurFrame == 58) || (kREG(1) == 1)) {
+    if ((csCurFrame == 58) || (OOT_DEBUG && kREG(1) == 1)) {
         sp28.x = pos->x + 900.0f;
         sp28.y = pos->y - 50.0f;
         sp28.z = pos->z + 93.0f;
@@ -1068,7 +1081,7 @@ void func_809809C0(DemoGt* this, PlayState* play2) {
     Vec3f sp54;
     s16 pad[3];
 
-    if (((csCurFrame > 469) && (csCurFrame < 481)) || (kREG(1) == 3)) {
+    if (((csCurFrame > 469) && (csCurFrame < 481)) || (OOT_DEBUG && kREG(1) == 3)) {
         Vec3f sp40 = { 20.0f, 6.0f, 0.0f };
         Vec3f sp34 = { 0.0f, 0.0f, 0.0f };
         s16 pad2[3];
@@ -1088,7 +1101,7 @@ void func_80980AD4(DemoGt* this, PlayState* play) {
     Vec3f pos;
     u16 csCurFrame = play->csCtx.curFrame;
 
-    if ((csCurFrame == 477) || (kREG(2) == 1)) {
+    if ((csCurFrame == 477) || (OOT_DEBUG && kREG(2) == 1)) {
         pos.x = this->dyna.actor.world.pos.x + 790.0f;
         pos.y = this->dyna.actor.world.pos.y + 60.0f;
         pos.z = this->dyna.actor.world.pos.z + 23.0f;
@@ -1103,7 +1116,7 @@ void func_80980B68(DemoGt* this, PlayState* play) {
     Vec3f pos;
     u16 csCurFrame = play->csCtx.curFrame;
 
-    if ((csCurFrame == 317) || (kREG(3) == 1)) {
+    if ((csCurFrame == 317) || (OOT_DEBUG && kREG(3) == 1)) {
         pos.x = this->dyna.actor.world.pos.x + 980.0f;
         pos.y = this->dyna.actor.world.pos.y + 410.0f;
         pos.z = this->dyna.actor.world.pos.z - 177.0f;
@@ -1117,7 +1130,7 @@ void func_80980BFC(DemoGt* this, PlayState* play) {
     Vec3f pos;
     u16 csCurFrame = play->csCtx.curFrame;
 
-    if ((csCurFrame == 740) || (kREG(4) == 1)) {
+    if ((csCurFrame == 740) || (OOT_DEBUG && kREG(4) == 1)) {
         pos.x = this->dyna.actor.world.pos.x + 790.0f;
         pos.y = this->dyna.actor.world.pos.y + 60.0f;
         pos.z = this->dyna.actor.world.pos.z + 23.0f;
@@ -1322,7 +1335,7 @@ void func_80981458(DemoGt* this, PlayState* play) {
     Vec3f dustPos;
     u16 csCurFrame = play->csCtx.curFrame;
 
-    if (((csCurFrame > 855) && (csCurFrame < 891)) || (kREG(1) == 13)) {
+    if (((csCurFrame > 855) && (csCurFrame < 891)) || (OOT_DEBUG && kREG(1) == 13)) {
         Vec3f velOffset = { 0.0f, -30.0f, 0.0f };
         s32 pad1[3];
 

--- a/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
+++ b/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
@@ -259,8 +259,8 @@ void DemoIk_Type1Action2(DemoIk* this, PlayState* play) {
 }
 
 void DemoIk_Type1PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx) {
-    DemoIk* this = (DemoIk*)thisx;
     GraphicsContext* gfxCtx = play->state.gfxCtx;
+    DemoIk* this = (DemoIk*)thisx;
 
     OPEN_DISPS(gfxCtx, "../z_demo_ik_inArmer.c", 385);
     if (limbIndex == 1) {

--- a/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
+++ b/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
@@ -36,8 +36,11 @@ s32 DemoIk_UpdateSkelAnime(DemoIk* this) {
 
 CsCmdActorCue* DemoIk_GetCue(PlayState* play, s32 cueChannel) {
     if (play->csCtx.state != CS_STATE_IDLE) {
-        return play->csCtx.actorCues[cueChannel];
+        CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
+
+        return cue;
     }
+
     return NULL;
 }
 

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -118,6 +118,7 @@ void func_80984BE0(DemoIm* this) {
     }
 }
 
+#if OOT_DEBUG
 void func_80984C68(DemoIm* this) {
     this->action = 7;
     this->drawConfig = 0;
@@ -143,6 +144,7 @@ void func_80984C8C(DemoIm* this, PlayState* play) {
         }
     }
 }
+#endif
 
 void DemoIm_InitCollider(Actor* thisx, PlayState* play) {
     DemoIm* this = (DemoIm*)thisx;
@@ -497,7 +499,9 @@ void func_80985B34(DemoIm* this, PlayState* play) {
 
 void func_80985C10(DemoIm* this, PlayState* play) {
     func_80985948(this, play);
+#if OOT_DEBUG
     func_80984C8C(this, play);
+#endif
 }
 
 void func_80985C40(DemoIm* this, PlayState* play) {
@@ -505,7 +509,9 @@ void func_80985C40(DemoIm* this, PlayState* play) {
     DemoIm_UpdateSkelAnime(this);
     func_80984BE0(this);
     func_809859E0(this, play);
+#if OOT_DEBUG
     func_80984C8C(this, play);
+#endif
 }
 
 void func_80985C94(DemoIm* this, PlayState* play) {
@@ -513,7 +519,9 @@ void func_80985C94(DemoIm* this, PlayState* play) {
     DemoIm_UpdateSkelAnime(this);
     func_80984BE0(this);
     func_80985B34(this, play);
+#if OOT_DEBUG
     func_80984C8C(this, play);
+#endif
 }
 
 void DemoIm_DrawTranslucent(DemoIm* this, PlayState* play) {
@@ -899,6 +907,8 @@ void func_80986BF8(DemoIm* this, PlayState* play) {
 
 void func_80986C30(DemoIm* this, PlayState* play) {
     if (func_80986A5C(this, play)) {
+        s32 pad;
+
         play->csCtx.script = SEGMENTED_TO_VIRTUAL(gZeldasCourtyardLullabyCs);
         gSaveContext.cutsceneTrigger = 1;
         SET_EVENTCHKINF(EVENTCHKINF_59);
@@ -924,10 +934,15 @@ void func_80986CFC(DemoIm* this, PlayState* play) {
 }
 
 void func_80986D40(DemoIm* this, PlayState* play) {
+#if OOT_DEBUG
     if (gSaveContext.sceneLayer == 6) {
         this->action = 19;
         this->drawConfig = 1;
-    } else if (GET_EVENTCHKINF(EVENTCHKINF_80)) {
+        return;
+    }
+#endif
+
+    if (GET_EVENTCHKINF(EVENTCHKINF_80)) {
         Actor_Kill(&this->actor);
     } else if (!GET_EVENTCHKINF(EVENTCHKINF_59)) {
         this->action = 23;

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -277,7 +277,6 @@ void DemoKankyo_Destroy(Actor* thisx, PlayState* play) {
 
 void DemoKankyo_SetupType(DemoKankyo* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
-    f32 temp;
 
     if (this->actor.objectSlot == this->requiredObjectSlot) {
         switch (this->actor.params) {
@@ -302,12 +301,14 @@ void DemoKankyo_SetupType(DemoKankyo* this, PlayState* play) {
                 play->envCtx.screenFillColor[2] = 0xFF;
                 play->envCtx.fillScreen = false;
                 if (this->warpTimer < 21 && this->warpTimer >= 15) {
-                    temp = (this->warpTimer - 15.0f) / 5.0f;
+                    f32 temp = (this->warpTimer - 15.0f) / 5.0f;
+
                     play->envCtx.fillScreen = true;
                     play->envCtx.screenFillColor[3] = 255 - 255 * temp;
                 }
                 if (this->warpTimer < 15 && this->warpTimer >= 4) {
-                    temp = (this->warpTimer - 4.0f) / 10.0f;
+                    f32 temp = (this->warpTimer - 4.0f) / 10.0f;
+
                     play->envCtx.fillScreen = true;
                     play->envCtx.screenFillColor[3] = 255 * temp;
                 }

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
@@ -127,6 +127,7 @@ void DemoSa_SetMouthIndex(DemoSa* this, s16 mouthIndex) {
     this->mouthIndex = mouthIndex;
 }
 
+#if OOT_DEBUG
 void func_8098E530(DemoSa* this) {
     this->action = 7;
     this->drawConfig = 0;
@@ -150,6 +151,7 @@ void func_8098E554(DemoSa* this, PlayState* play) {
         *something = 1;
     }
 }
+#endif
 
 void func_8098E5C8(DemoSa* this, PlayState* play) {
     Actor_UpdateBgCheckInfo(play, &this->actor, 75.0f, 30.0f, 30.0f, UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2);
@@ -441,7 +443,9 @@ void func_8098F050(DemoSa* this, PlayState* play) {
 
 void func_8098F0E8(DemoSa* this, PlayState* play) {
     func_8098EEA8(this, play);
+#if OOT_DEBUG
     func_8098E554(this, play);
+#endif
 }
 
 void func_8098F118(DemoSa* this, PlayState* play) {
@@ -449,7 +453,9 @@ void func_8098F118(DemoSa* this, PlayState* play) {
     DemoSa_UpdateSkelAnime(this);
     func_8098E480(this);
     func_8098EEFC(this, play);
+#if OOT_DEBUG
     func_8098E554(this, play);
+#endif
 }
 
 void func_8098F16C(DemoSa* this, PlayState* play) {
@@ -457,7 +463,9 @@ void func_8098F16C(DemoSa* this, PlayState* play) {
     DemoSa_UpdateSkelAnime(this);
     func_8098EDB0(this);
     func_8098F050(this, play);
+#if OOT_DEBUG
     func_8098E554(this, play);
+#endif
 }
 
 void DemoSa_DrawXlu(DemoSa* this, PlayState* play) {

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
@@ -161,7 +161,9 @@ s32 DemoSa_UpdateSkelAnime(DemoSa* this) {
 
 CsCmdActorCue* DemoSa_GetCue(PlayState* play, s32 cueChannel) {
     if (play->csCtx.state != CS_STATE_IDLE) {
-        return play->csCtx.actorCues[cueChannel];
+        CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
+
+        return cue;
     }
 
     return NULL;

--- a/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
+++ b/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
@@ -58,12 +58,10 @@ void func_80991298(DemoShd* this, PlayState* play) {
     }
 
     if (play->csCtx.state != CS_STATE_IDLE) {
-        CsCmdActorCue* cue = play->csCtx.actorCues[0];
-
-        if (cue != NULL) {
-            if (cue->id == 2) {
+        if (play->csCtx.actorCues[0] != NULL) {
+            if (play->csCtx.actorCues[0]->id == 2) {
                 if (!(this->unk_14C & 1)) {
-                    this->unk_14E = cue->startPos.x;
+                    this->unk_14E = play->csCtx.actorCues[0]->startPos.x;
                 }
                 this->unk_14C |= 1;
             } else {
@@ -73,12 +71,10 @@ void func_80991298(DemoShd* this, PlayState* play) {
     }
 
     if (play->csCtx.state != CS_STATE_IDLE) {
-        CsCmdActorCue* cue = play->csCtx.actorCues[1];
-
-        if (cue != NULL) {
-            if (cue->id == 2) {
+        if (play->csCtx.actorCues[1] != NULL) {
+            if (play->csCtx.actorCues[1]->id == 2) {
                 if (!(this->unk_14C & 2)) {
-                    this->unk_14E = cue->startPos.x;
+                    this->unk_14E = play->csCtx.actorCues[1]->startPos.x;
                 }
                 this->unk_14C |= 2;
             } else {
@@ -101,8 +97,6 @@ void DemoShd_Draw(Actor* thisx, PlayState* play) {
     s32 pad;
     u32 unk_14E = this->unk_14E;
 
-    if (1) {} // Necessary to match, can be anywhere in the function
-
     OPEN_DISPS(play->state.gfxCtx, "../z_demo_shd.c", 726);
 
     Gfx_SetupDL_25Xlu(play->state.gfxCtx);
@@ -122,6 +116,8 @@ void DemoShd_Draw(Actor* thisx, PlayState* play) {
                                         256, 1, 0, 255 - ((unk_14E * 5) & 255), 32, 32));
         gSPDisplayList(POLY_XLU_DISP++, D_809934B8);
     }
+
+    if (1) {} // Necessary to match
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_demo_shd.c", 762);
 }

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -1120,10 +1120,12 @@ s32 EnIk_UpdateSkelAnime(EnIk* this) {
 
 CsCmdActorCue* EnIk_GetCue(PlayState* play, s32 cueChannel) {
     if (play->csCtx.state != CS_STATE_IDLE) {
-        return play->csCtx.actorCues[cueChannel];
-    } else {
-        return NULL;
+        CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
+
+        return cue;
     }
+
+    return NULL;
 }
 
 void EnIk_SetStartPosRotFromCue(EnIk* this, PlayState* play, s32 cueChannel) {

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -231,7 +231,9 @@ s32 EnNb_UpdateSkelAnime(EnNb* this) {
 
 CsCmdActorCue* EnNb_GetCue(PlayState* play, s32 cueChannel) {
     if (play->csCtx.state != CS_STATE_IDLE) {
-        return play->csCtx.actorCues[cueChannel];
+        CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
+
+        return cue;
     }
 
     return NULL;

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -175,8 +175,11 @@ s32 EnRu2_UpdateSkelAnime(EnRu2* this) {
 
 CsCmdActorCue* EnRu2_GetCue(PlayState* play, s32 cueChannel) {
     if (play->csCtx.state != CS_STATE_IDLE) {
-        return play->csCtx.actorCues[cueChannel];
+        CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
+
+        return cue;
     }
+
     return NULL;
 }
 

--- a/src/overlays/actors/ovl_En_Zl2/z_en_zl2.c
+++ b/src/overlays/actors/ovl_En_Zl2/z_en_zl2.c
@@ -212,8 +212,11 @@ s32 EnZl2_UpdateSkelAnime(EnZl2* this) {
 
 CsCmdActorCue* EnZl2_GetCue(PlayState* play, s32 cueChannel) {
     if (play->csCtx.state != CS_STATE_IDLE) {
-        return play->csCtx.actorCues[cueChannel];
+        CsCmdActorCue* cue = play->csCtx.actorCues[cueChannel];
+
+        return cue;
     }
+
     return NULL;
 }
 


### PR DESCRIPTION
I'm really unsure what to do about `z_demo_gt.c`. I tried making a more generic macro but there's one case that doesn't fit so it seemed weird:
```
if ((OOT_DEBUG && kREG(1) == 20) || (csCurFrame == 220))
```
i.e. the `kREG` comes first rather than after `csCurFrame == 200`. Hopefully someone has a better idea.

There's also a `goto` match in `DemoEffect_DrawLightEffect` which I really wasn't able to remove with scoping, and early return doesn't seem to be an option here.