### PR TITLE
Fixup permuter_settings

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -114,7 +114,7 @@
 // argument errors instead.
 // Note some tools define __sgi but preprocess with a modern cpp implementation,
 // ensure that these do not use the IDO workaround to avoid errors.
-#define IDO_PRINTF_WORKAROUND (__sgi && !__GNUC__ && !PERMUTER && !M2CTX)
+#define IDO_PRINTF_WORKAROUND (__sgi && !__GNUC__ && !M2CTX)
 
 #if OOT_DEBUG
 #define PRINTF osSyncPrintf

--- a/tools/permuter_settings.toml
+++ b/tools/permuter_settings.toml
@@ -10,7 +10,6 @@ OPEN_DISPS = "void"
 CLOSE_DISPS = "void"
 GRAPH_ALLOC = "void*"
 LOG_UTILS_CHECK_NULL_POINTER = "void"
-PRINTF = "void"
 WORK_DISP = "void*"
 POLY_OPA_DISP = "void*"
 POLY_XLU_DISP = "void*"
@@ -19,6 +18,14 @@ OVERLAY_DISP = "void*"
 ABS = "int"
 SQ = "int"
 CLAMP = "int"
+
+# If changing to not preserve these, add a check for the permuter to IDO_PRINTF_WORKAROUND,
+# so that modern CPP (used by the permuter import) does not error on the IDO-specific hack.
+# For example:
+# #define IDO_PRINTF_WORKAROUND (__sgi && !__GNUC__ && !PERMUTER && !M2CTX)
+PRINTF = "void"
+SCHED_DEBUG_PRINTF = "void"
+ACTOR_DEBUG_PRINTF = "void"
 
 [decompme.compilers]
 "tools/ido_recomp/linux/7.1/cc" = "ido7.1"

--- a/tools/permuter_settings.toml
+++ b/tools/permuter_settings.toml
@@ -1,3 +1,6 @@
+build_system = "make"
+compiler_type = "ido"  # adjusts default weights for permuting
+
 [preserve_macros]
 "g[DS]P.*" = "void"
 "gDma.*" = "void"
@@ -28,9 +31,5 @@ SCHED_DEBUG_PRINTF = "void"
 ACTOR_DEBUG_PRINTF = "void"
 
 [decompme.compilers]
-"tools/ido_recomp/linux/7.1/cc" = "ido7.1"
-"tools/ido_recomp/macos/7.1/cc" = "ido7.1"
-"tools/ido_recomp/windows/7.1/cc" = "ido7.1"
-"tools/ido_recomp/linux/5.3/cc" = "ido5.3"
-"tools/ido_recomp/macos/5.3/cc" = "ido5.3"
-"tools/ido_recomp/windows/5.3/cc" = "ido5.3"
+"tools/ido_recomp/*/7.1/cc" = "ido7.1"
+"tools/ido_recomp/*/5.3/cc" = "ido5.3"


### PR DESCRIPTION
- Fix: make `IDO_PRINTF_WORKAROUND` not consider PERMUTER since the permuter preserves the PRINTF macros for IDO to process
- Misc fixup of permuter_settings.toml