### PR TITLE
Filename & line number args cleanup

### DIFF
--- a/include/fault.h
+++ b/include/fault.h
@@ -44,7 +44,7 @@ void Fault_Init(void);
 // Fatal Errors
 
 NORETURN void Fault_AddHungupAndCrashImpl(const char* exp1, const char* exp2);
-NORETURN void Fault_AddHungupAndCrash(const char* file, s32 line);
+NORETURN void Fault_AddHungupAndCrash(const char* file, int line);
 
 // Client Registration
 

--- a/include/functions.h
+++ b/include/functions.h
@@ -39,7 +39,7 @@ void isPrintfInit(void);
 void rmonPrintf(const char* fmt, ...);
 #if OOT_DEBUG
 void* is_proutSyncPrintf(void* arg, const char* str, size_t count);
-NORETURN void func_80002384(const char* exp, const char* file, u32 line);
+NORETURN void func_80002384(const char* exp, const char* file, int line);
 #endif
 OSPiHandle* osDriveRomInit(void);
 void Mio0_Decompress(u8* src, u8* dst);
@@ -51,11 +51,11 @@ u32 StackCheck_CheckAll(void);
 u32 StackCheck_Check(StackEntry* entry);
 #if OOT_DEBUG
 void LogUtils_LogHexDump(void* ptr, s32 size0);
-void LogUtils_CheckNullPointer(const char* exp, void* ptr, const char* file, s32 line);
-void LogUtils_CheckValidPointer(const char* exp, void* ptr, const char* file, s32 line);
-void LogUtils_LogThreadId(const char* name, s32 line);
+void LogUtils_CheckNullPointer(const char* exp, void* ptr, const char* file, int line);
+void LogUtils_CheckValidPointer(const char* exp, void* ptr, const char* file, int line);
+void LogUtils_LogThreadId(const char* name, int line);
 #endif
-void LogUtils_HungupThread(const char* name, s32 line);
+void LogUtils_HungupThread(const char* name, int line);
 void LogUtils_ResetHungup(void);
 void __osPiCreateAccessQueue(void);
 void __osPiGetAccess(void);
@@ -913,10 +913,10 @@ void ZeldaArena_Cleanup(void);
 u8 ZeldaArena_IsInitialized(void);
 #if OOT_DEBUG
 void ZeldaArena_CheckPointer(void* ptr, u32 size, const char* name, const char* action);
-void* ZeldaArena_MallocDebug(u32 size, const char* file, s32 line);
-void* ZeldaArena_MallocRDebug(u32 size, const char* file, s32 line);
-void* ZeldaArena_ReallocDebug(void* ptr, u32 newSize, const char* file, s32 line);
-void ZeldaArena_FreeDebug(void* ptr, const char* file, s32 line);
+void* ZeldaArena_MallocDebug(u32 size, const char* file, int line);
+void* ZeldaArena_MallocRDebug(u32 size, const char* file, int line);
+void* ZeldaArena_ReallocDebug(void* ptr, u32 newSize, const char* file, int line);
+void ZeldaArena_FreeDebug(void* ptr, const char* file, int line);
 void ZeldaArena_Display(void);
 #endif
 void MapMark_Init(PlayState* play);
@@ -1316,8 +1316,8 @@ void GameState_Destroy(GameState* gameState);
 GameStateFunc GameState_GetInit(GameState* gameState);
 u32 GameState_IsRunning(GameState* gameState);
 #if OOT_DEBUG
-void* GameState_Alloc(GameState* gameState, size_t size, char* file, s32 line);
-void* GameAlloc_MallocDebug(GameAlloc* this, u32 size, const char* file, s32 line);
+void* GameState_Alloc(GameState* gameState, size_t size, const char* file, int line);
+void* GameAlloc_MallocDebug(GameAlloc* this, u32 size, const char* file, int line);
 #endif
 void* GameAlloc_Malloc(GameAlloc* this, u32 size);
 void GameAlloc_Free(GameAlloc* this, void* data);
@@ -1333,8 +1333,8 @@ void Graph_ThreadEntry(void*);
 void* Graph_Alloc(GraphicsContext* gfxCtx, size_t size);
 void* Graph_Alloc2(GraphicsContext* gfxCtx, size_t size);
 #if OOT_DEBUG
-void Graph_OpenDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, s32 line);
-void Graph_CloseDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, s32 line);
+void Graph_OpenDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, int line);
+void Graph_CloseDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, int line);
 #endif
 Gfx* Gfx_Open(Gfx* gfx);
 Gfx* Gfx_Close(Gfx* gfx, Gfx* dst);
@@ -1437,8 +1437,8 @@ void Matrix_TranslateRotateZYX(Vec3f* translation, Vec3s* rotation);
 void Matrix_SetTranslateRotateYXZ(f32 translateX, f32 translateY, f32 translateZ, Vec3s* rot);
 Mtx* Matrix_MtxFToMtx(MtxF* src, Mtx* dest);
 #if OOT_DEBUG
-Mtx* Matrix_ToMtx(Mtx* dest, char* file, s32 line);
-Mtx* Matrix_NewMtx(GraphicsContext* gfxCtx, char* file, s32 line);
+Mtx* Matrix_ToMtx(Mtx* dest, const char* file, int line);
+Mtx* Matrix_NewMtx(GraphicsContext* gfxCtx, const char* file, int line);
 #else
 Mtx* Matrix_ToMtx(Mtx* dest);
 Mtx* Matrix_NewMtx(GraphicsContext* gfxCtx);
@@ -1453,7 +1453,7 @@ void Matrix_MtxFToYXZRotS(MtxF* mf, Vec3s* rotDest, s32 flag);
 void Matrix_MtxFToZYXRotS(MtxF* mf, Vec3s* rotDest, s32 flag);
 void Matrix_RotateAxis(f32 angle, Vec3f* axis, u8 mode);
 #if OOT_DEBUG
-MtxF* Matrix_CheckFloats(MtxF* mf, char* file, s32 line);
+MtxF* Matrix_CheckFloats(MtxF* mf, const char* file, int line);
 #endif
 void Matrix_SetTranslateScaleMtx2(Mtx* mtx, f32 scaleX, f32 scaleY, f32 scaleZ, f32 translateX, f32 translateY,
                                   f32 translateZ);
@@ -1476,10 +1476,10 @@ void DebugArena_Cleanup(void);
 u8 DebugArena_IsInitialized(void);
 #if OOT_DEBUG
 void DebugArena_CheckPointer(void* ptr, u32 size, const char* name, const char* action);
-void* DebugArena_MallocDebug(u32 size, const char* file, s32 line);
-void* DebugArena_MallocRDebug(u32 size, const char* file, s32 line);
-void* DebugArena_ReallocDebug(void* ptr, u32 newSize, const char* file, s32 line);
-void DebugArena_FreeDebug(void* ptr, const char* file, s32 line);
+void* DebugArena_MallocDebug(u32 size, const char* file, int line);
+void* DebugArena_MallocRDebug(u32 size, const char* file, int line);
+void* DebugArena_ReallocDebug(void* ptr, u32 newSize, const char* file, int line);
+void DebugArena_FreeDebug(void* ptr, const char* file, int line);
 void DebugArena_Display(void);
 #endif
 void UCodeDisas_Init(UCodeDisas*);
@@ -1774,10 +1774,10 @@ void SystemArena_Init(void* start, u32 size);
 void SystemArena_Cleanup(void);
 u8 SystemArena_IsInitialized(void);
 #if OOT_DEBUG
-void* SystemArena_MallocDebug(u32 size, const char* file, s32 line);
-void* SystemArena_MallocRDebug(u32 size, const char* file, s32 line);
-void* SystemArena_ReallocDebug(void* ptr, u32 newSize, const char* file, s32 line);
-void SystemArena_FreeDebug(void* ptr, const char* file, s32 line);
+void* SystemArena_MallocDebug(u32 size, const char* file, int line);
+void* SystemArena_MallocRDebug(u32 size, const char* file, int line);
+void* SystemArena_ReallocDebug(void* ptr, u32 newSize, const char* file, int line);
+void SystemArena_FreeDebug(void* ptr, const char* file, int line);
 void SystemArena_Display(void);
 #endif
 u32 Rand_Next(void);
@@ -1799,10 +1799,10 @@ void* __osRealloc(Arena* arena, void* ptr, u32 newSize);
 void ArenaImpl_GetSizes(Arena* arena, u32* outMaxFree, u32* outFree, u32* outAlloc);
 u32 __osCheckArena(Arena* arena);
 #if OOT_DEBUG
-void* __osMallocDebug(Arena* arena, u32 size, const char* file, s32 line);
-void* __osMallocRDebug(Arena* arena, u32 size, const char* file, s32 line);
-void __osFreeDebug(Arena* arena, void* ptr, const char* file, s32 line);
-void* __osReallocDebug(Arena* arena, void* ptr, u32 newSize, const char* file, s32 line);
+void* __osMallocDebug(Arena* arena, u32 size, const char* file, int line);
+void* __osMallocRDebug(Arena* arena, u32 size, const char* file, int line);
+void __osFreeDebug(Arena* arena, void* ptr, const char* file, int line);
+void* __osReallocDebug(Arena* arena, void* ptr, u32 newSize, const char* file, int line);
 void __osDisplayArena(Arena* arena);
 #endif
 s32 PrintUtils_VPrintf(PrintCallback* pfn, const char* fmt, va_list args);

--- a/include/z64.h
+++ b/include/z64.h
@@ -717,7 +717,7 @@ typedef struct ArenaNode {
     /* 0x0C */ struct ArenaNode* prev;
 #if OOT_DEBUG // TODO: This debug info is also present in N64 retail builds
     /* 0x10 */ const char* filename;
-    /* 0x14 */ s32 line;
+    /* 0x14 */ int line;
     /* 0x18 */ OSId threadId;
     /* 0x1C */ Arena* arena;
     /* 0x20 */ OSTime time;

--- a/include/z64dma.h
+++ b/include/z64dma.h
@@ -9,7 +9,7 @@ typedef struct {
     /* 0x04 */ void*        dramAddr; // DRAM address (destination)
     /* 0x08 */ size_t       size;     // File Transfer size
     /* 0x0C */ const char*  filename; // Filename for debugging
-    /* 0x10 */ s32          line;     // Line for debugging
+    /* 0x10 */ int          line;     // Line number for debugging
     /* 0x14 */ s32          unk_14;
     /* 0x18 */ OSMesgQueue* notifyQueue; // Message queue for the notification message
     /* 0x1C */ OSMesg       notifyMsg;   // Completion notification message
@@ -48,8 +48,8 @@ s32 DmaMgr_RequestAsync(DmaRequest* req, void* ram, uintptr_t vrom, size_t size,
 s32 DmaMgr_RequestSync(void* ram, uintptr_t vrom, size_t size);
 #if OOT_DEBUG
 s32 DmaMgr_RequestAsyncDebug(DmaRequest* req, void* ram, uintptr_t vrom, size_t size, u32 unk5, OSMesgQueue* queue,
-                             OSMesg msg, const char* file, s32 line);
-s32 DmaMgr_RequestSyncDebug(void* ram, uintptr_t vrom, size_t size, const char* file, s32 line);
+                             OSMesg msg, const char* file, int line);
+s32 DmaMgr_RequestSyncDebug(void* ram, uintptr_t vrom, size_t size, const char* file, int line);
 #endif
 
 // Special-purpose DMA Requests

--- a/src/boot/is_debug.c
+++ b/src/boot/is_debug.c
@@ -95,7 +95,7 @@ void* is_proutSyncPrintf(void* arg, const char* str, size_t count) {
     return (void*)1;
 }
 
-NORETURN void func_80002384(const char* exp, const char* file, u32 line) {
+NORETURN void func_80002384(const char* exp, const char* file, int line) {
     osSyncPrintf("File:%s Line:%d  %s \n", file, line, exp);
     while (true) {
         ;

--- a/src/boot/logutils.c
+++ b/src/boot/logutils.c
@@ -2,7 +2,7 @@
 #include "terminal.h"
 
 #if OOT_DEBUG
-f32 LogUtils_CheckFloatRange(const char* exp, s32 line, const char* valueName, f32 value, const char* minName, f32 min,
+f32 LogUtils_CheckFloatRange(const char* exp, int line, const char* valueName, f32 value, const char* minName, f32 min,
                              const char* maxName, f32 max) {
     if (value < min || max < value) {
         PRINTF("%s %d: range error %s(%f) < %s(%f) < %s(%f)\n", exp, line, minName, min, valueName, value, maxName,
@@ -11,7 +11,7 @@ f32 LogUtils_CheckFloatRange(const char* exp, s32 line, const char* valueName, f
     return value;
 }
 
-s32 LogUtils_CheckIntRange(const char* exp, s32 line, const char* valueName, s32 value, const char* minName, s32 min,
+s32 LogUtils_CheckIntRange(const char* exp, int line, const char* valueName, s32 value, const char* minName, s32 min,
                            const char* maxName, s32 max) {
     if (value < min || max < value) {
         PRINTF("%s %d: range error %s(%d) < %s(%d) < %s(%d)\n", exp, line, minName, min, valueName, value, maxName,
@@ -73,11 +73,11 @@ void LogUtils_LogHexDump(void* ptr, s32 size0) {
     }
 }
 
-void LogUtils_LogPointer(s32 value, u32 max, void* ptr, const char* name, const char* file, s32 line) {
+void LogUtils_LogPointer(s32 value, u32 max, void* ptr, const char* name, const char* file, int line) {
     PRINTF(VT_COL(RED, WHITE) "%s %d %s[%d] max=%u ptr=%08x\n" VT_RST, file, line, name, value, max, ptr);
 }
 
-void LogUtils_CheckBoundary(const char* name, s32 value, s32 unk, const char* file, s32 line) {
+void LogUtils_CheckBoundary(const char* name, s32 value, s32 unk, const char* file, int line) {
     u32 mask = (unk - 1);
 
     if (value & mask) {
@@ -85,24 +85,24 @@ void LogUtils_CheckBoundary(const char* name, s32 value, s32 unk, const char* fi
     }
 }
 
-void LogUtils_CheckNullPointer(const char* exp, void* ptr, const char* file, s32 line) {
+void LogUtils_CheckNullPointer(const char* exp, void* ptr, const char* file, int line) {
     if (ptr == NULL) {
         PRINTF(VT_COL(RED, WHITE) "%s %d:%s は はヌルポインタです\n" VT_RST, file, line, exp);
     }
 }
 
-void LogUtils_CheckValidPointer(const char* exp, void* ptr, const char* file, s32 line) {
+void LogUtils_CheckValidPointer(const char* exp, void* ptr, const char* file, int line) {
     if (ptr == NULL || (u32)ptr < 0x80000000 || (0x80000000 + osMemSize) <= (u32)ptr) {
         PRINTF(VT_COL(RED, WHITE) "%s %d:ポインタ %s(%08x) が異常です\n" VT_RST, file, line, exp, ptr);
     }
 }
 
-void LogUtils_LogThreadId(const char* name, s32 line) {
+void LogUtils_LogThreadId(const char* name, int line) {
     PRINTF("<%d %s %d>", osGetThreadId(NULL), name, line);
 }
 #endif
 
-void LogUtils_HungupThread(const char* name, s32 line) {
+void LogUtils_HungupThread(const char* name, int line) {
     OSId threadId = osGetThreadId(NULL);
 
     PRINTF("*** HungUp in thread %d, [%s:%d] ***\n", threadId, name, line);

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -598,7 +598,7 @@ void DmaMgr_Init(void) {
  * @see DmaMgr_RequestAsync
  */
 s32 DmaMgr_RequestAsyncDebug(DmaRequest* req, void* ram, uintptr_t vrom, size_t size, u32 unk5, OSMesgQueue* queue,
-                             OSMesg msg, const char* file, s32 line) {
+                             OSMesg msg, const char* file, int line) {
     req->filename = file;
     req->line = line;
     return DmaMgr_RequestAsync(req, ram, vrom, size, unk5, queue, msg);
@@ -609,7 +609,7 @@ s32 DmaMgr_RequestAsyncDebug(DmaRequest* req, void* ram, uintptr_t vrom, size_t 
  *
  * @see DmaMgr_RequestSync
  */
-s32 DmaMgr_RequestSyncDebug(void* ram, uintptr_t vrom, size_t size, const char* file, s32 line) {
+s32 DmaMgr_RequestSyncDebug(void* ram, uintptr_t vrom, size_t size, const char* file, int line) {
     DmaRequest req;
     s32 ret;
     OSMesgQueue queue;

--- a/src/code/__osMalloc.c
+++ b/src/code/__osMalloc.c
@@ -100,7 +100,7 @@ void ArenaImpl_UnsetCheckFreeBlock(Arena* arena) {
     arena->flag &= ~CHECK_FREE_BLOCK_FLAG;
 }
 
-void ArenaImpl_SetDebugInfo(ArenaNode* node, const char* file, s32 line, Arena* arena) {
+void ArenaImpl_SetDebugInfo(ArenaNode* node, const char* file, int line, Arena* arena) {
     node->filename = file;
     node->line = line;
     node->threadId = osGetThreadId(NULL);
@@ -254,7 +254,7 @@ void __osMalloc_FreeBlockTest(Arena* arena, ArenaNode* node) {
     }
 }
 
-void* __osMalloc_NoLockDebug(Arena* arena, u32 size, const char* file, s32 line) {
+void* __osMalloc_NoLockDebug(Arena* arena, u32 size, const char* file, int line) {
     ArenaNode* iter;
     u32 blockSize;
     ArenaNode* newNode;
@@ -299,7 +299,7 @@ void* __osMalloc_NoLockDebug(Arena* arena, u32 size, const char* file, s32 line)
     return alloc;
 }
 
-void* __osMallocDebug(Arena* arena, u32 size, const char* file, s32 line) {
+void* __osMallocDebug(Arena* arena, u32 size, const char* file, int line) {
     void* alloc;
 
     ArenaImpl_Lock(arena);
@@ -309,7 +309,7 @@ void* __osMallocDebug(Arena* arena, u32 size, const char* file, s32 line) {
     return alloc;
 }
 
-void* __osMallocRDebug(Arena* arena, u32 size, const char* file, s32 line) {
+void* __osMallocRDebug(Arena* arena, u32 size, const char* file, int line) {
     ArenaNode* iter;
     ArenaNode* newNode;
     u32 blockSize;
@@ -528,7 +528,7 @@ void __osFree(Arena* arena, void* ptr) {
 }
 
 #if OOT_DEBUG
-void __osFree_NoLockDebug(Arena* arena, void* ptr, const char* file, s32 line) {
+void __osFree_NoLockDebug(Arena* arena, void* ptr, const char* file, int line) {
     ArenaNode* node;
     ArenaNode* next;
     ArenaNode* prev;
@@ -586,7 +586,7 @@ void __osFree_NoLockDebug(Arena* arena, void* ptr, const char* file, s32 line) {
     }
 }
 
-void __osFreeDebug(Arena* arena, void* ptr, const char* file, s32 line) {
+void __osFreeDebug(Arena* arena, void* ptr, const char* file, int line) {
     ArenaImpl_Lock(arena);
     __osFree_NoLockDebug(arena, ptr, file, line);
     ArenaImpl_Unlock(arena);
@@ -695,7 +695,7 @@ void* __osRealloc(Arena* arena, void* ptr, u32 newSize) {
 }
 
 #if OOT_DEBUG
-void* __osReallocDebug(Arena* arena, void* ptr, u32 newSize, const char* file, s32 line) {
+void* __osReallocDebug(Arena* arena, void* ptr, u32 newSize, const char* file, int line) {
     return __osRealloc(arena, ptr, newSize);
 }
 #endif

--- a/src/code/debug_malloc.c
+++ b/src/code/debug_malloc.c
@@ -36,7 +36,7 @@ void* DebugArena_Malloc(u32 size) {
 }
 
 #if OOT_DEBUG
-void* DebugArena_MallocDebug(u32 size, const char* file, s32 line) {
+void* DebugArena_MallocDebug(u32 size, const char* file, int line) {
     void* ptr = __osMallocDebug(&sDebugArena, size, file, line);
 
     DEBUG_ARENA_CHECK_POINTER(ptr, size, "debug_malloc_DEBUG", "確保"); // "Secure"
@@ -52,7 +52,7 @@ void* DebugArena_MallocR(u32 size) {
 }
 
 #if OOT_DEBUG
-void* DebugArena_MallocRDebug(u32 size, const char* file, s32 line) {
+void* DebugArena_MallocRDebug(u32 size, const char* file, int line) {
     void* ptr = __osMallocRDebug(&sDebugArena, size, file, line);
 
     DEBUG_ARENA_CHECK_POINTER(ptr, size, "debug_malloc_r_DEBUG", "確保"); // "Secure"
@@ -67,7 +67,7 @@ void* DebugArena_Realloc(void* ptr, u32 newSize) {
 }
 
 #if OOT_DEBUG
-void* DebugArena_ReallocDebug(void* ptr, u32 newSize, const char* file, s32 line) {
+void* DebugArena_ReallocDebug(void* ptr, u32 newSize, const char* file, int line) {
     ptr = __osReallocDebug(&sDebugArena, ptr, newSize, file, line);
     DEBUG_ARENA_CHECK_POINTER(ptr, newSize, "debug_realloc_DEBUG", "再確保"); // "Re-securing"
     return ptr;
@@ -79,7 +79,7 @@ void DebugArena_Free(void* ptr) {
 }
 
 #if OOT_DEBUG
-void DebugArena_FreeDebug(void* ptr, const char* file, s32 line) {
+void DebugArena_FreeDebug(void* ptr, const char* file, int line) {
     __osFreeDebug(&sDebugArena, ptr, file, line);
 }
 #endif

--- a/src/code/fault.c
+++ b/src/code/fault.c
@@ -1322,7 +1322,7 @@ NORETURN void Fault_AddHungupAndCrashImpl(const char* exp1, const char* exp2) {
  * Like `Fault_AddHungupAndCrashImpl`, however provides a fixed message containing
  * filename and line number
  */
-NORETURN void Fault_AddHungupAndCrash(const char* file, s32 line) {
+NORETURN void Fault_AddHungupAndCrash(const char* file, int line) {
     char msg[256];
 
     sprintf(msg, "HungUp %s:%d", file, line);

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -408,7 +408,7 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
     gameState->destroy = NULL;
     gameState->running = 1;
     startTime = osGetTime();
-    gameState->size = gameState->init = 0;
+    gameState->size = (u32)(gameState->init = NULL);
 
     {
         s32 requiredScopeTemp;
@@ -494,7 +494,7 @@ u32 GameState_IsRunning(GameState* gameState) {
 }
 
 #if OOT_DEBUG
-void* GameState_Alloc(GameState* gameState, size_t size, char* file, s32 line) {
+void* GameState_Alloc(GameState* gameState, size_t size, const char* file, int line) {
     void* ret;
 
     if (THA_IsCrash(&gameState->tha)) {

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -408,6 +408,9 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
     gameState->destroy = NULL;
     gameState->running = 1;
     startTime = osGetTime();
+
+    // Thse assignments must be written this way for matching and to avoid a warning due to casting a pointer to an
+    // integer without a cast. This assigns init = NULL and size = 0.
     gameState->size = (u32)(gameState->init = NULL);
 
     {

--- a/src/code/gamealloc.c
+++ b/src/code/gamealloc.c
@@ -13,7 +13,7 @@ void GameAlloc_Log(GameAlloc* this) {
 }
 
 #if OOT_DEBUG
-void* GameAlloc_MallocDebug(GameAlloc* this, u32 size, const char* file, s32 line) {
+void* GameAlloc_MallocDebug(GameAlloc* this, u32 size, const char* file, int line) {
     GameAllocEntry* ptr = SystemArena_MallocDebug(size + sizeof(GameAllocEntry), file, line);
 
     if (ptr != NULL) {

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -501,7 +501,7 @@ void* Graph_Alloc2(GraphicsContext* gfxCtx, size_t size) {
 }
 
 #if OOT_DEBUG
-void Graph_OpenDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, s32 line) {
+void Graph_OpenDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, int line) {
     if (R_HREG_MODE == HREG_MODE_UCODE_DISAS && R_UCODE_DISAS_LOG_MODE != 4) {
         dispRefs[0] = gfxCtx->polyOpa.p;
         dispRefs[1] = gfxCtx->polyXlu.p;
@@ -513,7 +513,7 @@ void Graph_OpenDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, 
     }
 }
 
-void Graph_CloseDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, s32 line) {
+void Graph_CloseDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, int line) {
     if (R_HREG_MODE == HREG_MODE_UCODE_DISAS && R_UCODE_DISAS_LOG_MODE != 4) {
         if (dispRefs[0] + 1 == gfxCtx->polyOpa.p) {
             gfxCtx->polyOpa.p = dispRefs[0];

--- a/src/code/sys_matrix.c
+++ b/src/code/sys_matrix.c
@@ -605,11 +605,11 @@ Mtx* Matrix_MtxFToMtx(MtxF* src, Mtx* dest) {
 
 #if OOT_DEBUG
 
-Mtx* Matrix_ToMtx(Mtx* dest, char* file, s32 line) {
+Mtx* Matrix_ToMtx(Mtx* dest, const char* file, int line) {
     return Matrix_MtxFToMtx(MATRIX_CHECK_FLOATS(sCurrentMatrix, file, line), dest);
 }
 
-Mtx* Matrix_NewMtx(GraphicsContext* gfxCtx, char* file, s32 line) {
+Mtx* Matrix_NewMtx(GraphicsContext* gfxCtx, const char* file, int line) {
     return Matrix_ToMtx(GRAPH_ALLOC(gfxCtx, sizeof(Mtx)), file, line);
 }
 
@@ -970,7 +970,7 @@ void Matrix_RotateAxis(f32 angle, Vec3f* axis, u8 mode) {
 }
 
 #if OOT_DEBUG
-MtxF* Matrix_CheckFloats(MtxF* mf, char* file, s32 line) {
+MtxF* Matrix_CheckFloats(MtxF* mf, const char* file, int line) {
     s32 i, j;
 
     for (i = 0; i < 4; i++) {

--- a/src/code/system_malloc.c
+++ b/src/code/system_malloc.c
@@ -36,7 +36,7 @@ void* SystemArena_Malloc(u32 size) {
 }
 
 #if OOT_DEBUG
-void* SystemArena_MallocDebug(u32 size, const char* file, s32 line) {
+void* SystemArena_MallocDebug(u32 size, const char* file, int line) {
     void* ptr = __osMallocDebug(&gSystemArena, size, file, line);
 
     SYSTEM_ARENA_CHECK_POINTER(ptr, size, "malloc_DEBUG", "確保"); // "Secure"
@@ -52,7 +52,7 @@ void* SystemArena_MallocR(u32 size) {
 }
 
 #if OOT_DEBUG
-void* SystemArena_MallocRDebug(u32 size, const char* file, s32 line) {
+void* SystemArena_MallocRDebug(u32 size, const char* file, int line) {
     void* ptr = __osMallocRDebug(&gSystemArena, size, file, line);
 
     SYSTEM_ARENA_CHECK_POINTER(ptr, size, "malloc_r_DEBUG", "確保"); // "Secure"
@@ -67,7 +67,7 @@ void* SystemArena_Realloc(void* ptr, u32 newSize) {
 }
 
 #if OOT_DEBUG
-void* SystemArena_ReallocDebug(void* ptr, u32 newSize, const char* file, s32 line) {
+void* SystemArena_ReallocDebug(void* ptr, u32 newSize, const char* file, int line) {
     ptr = __osReallocDebug(&gSystemArena, ptr, newSize, file, line);
     SYSTEM_ARENA_CHECK_POINTER(ptr, newSize, "realloc_DEBUG", "再確保"); // "Re-securing"
     return ptr;
@@ -79,7 +79,7 @@ void SystemArena_Free(void* ptr) {
 }
 
 #if OOT_DEBUG
-void SystemArena_FreeDebug(void* ptr, const char* file, s32 line) {
+void SystemArena_FreeDebug(void* ptr, const char* file, int line) {
     __osFreeDebug(&gSystemArena, ptr, file, line);
 }
 #endif

--- a/src/code/z_bgcheck.c
+++ b/src/code/z_bgcheck.c
@@ -83,7 +83,7 @@ u16 sSurfaceMaterialToSfxOffset[SURFACE_MATERIAL_MAX] = {
 /**
  * original name: T_BGCheck_PosErrorCheck
  */
-s32 BgCheck_PosErrorCheck(Vec3f* pos, char* file, s32 line) {
+s32 BgCheck_PosErrorCheck(Vec3f* pos, const char* file, int line) {
     if (pos->x >= BGCHECK_XYZ_ABSMAX || pos->x <= -BGCHECK_XYZ_ABSMAX || pos->y >= BGCHECK_XYZ_ABSMAX ||
         pos->y <= -BGCHECK_XYZ_ABSMAX || pos->z >= BGCHECK_XYZ_ABSMAX || pos->z <= -BGCHECK_XYZ_ABSMAX) {
         PRINTF(VT_FGCOL(RED));

--- a/src/code/z_malloc.c
+++ b/src/code/z_malloc.c
@@ -35,7 +35,7 @@ void* ZeldaArena_Malloc(u32 size) {
 }
 
 #if OOT_DEBUG
-void* ZeldaArena_MallocDebug(u32 size, const char* file, s32 line) {
+void* ZeldaArena_MallocDebug(u32 size, const char* file, int line) {
     void* ptr = __osMallocDebug(&sZeldaArena, size, file, line);
 
     ZELDA_ARENA_CHECK_POINTER(ptr, size, "zelda_malloc_DEBUG", "確保"); // "Secure"
@@ -51,7 +51,7 @@ void* ZeldaArena_MallocR(u32 size) {
 }
 
 #if OOT_DEBUG
-void* ZeldaArena_MallocRDebug(u32 size, const char* file, s32 line) {
+void* ZeldaArena_MallocRDebug(u32 size, const char* file, int line) {
     void* ptr = __osMallocRDebug(&sZeldaArena, size, file, line);
 
     ZELDA_ARENA_CHECK_POINTER(ptr, size, "zelda_malloc_r_DEBUG", "確保"); // "Secure"
@@ -66,7 +66,7 @@ void* ZeldaArena_Realloc(void* ptr, u32 newSize) {
 }
 
 #if OOT_DEBUG
-void* ZeldaArena_ReallocDebug(void* ptr, u32 newSize, const char* file, s32 line) {
+void* ZeldaArena_ReallocDebug(void* ptr, u32 newSize, const char* file, int line) {
     ptr = __osReallocDebug(&sZeldaArena, ptr, newSize, file, line);
     ZELDA_ARENA_CHECK_POINTER(ptr, newSize, "zelda_realloc_DEBUG", "再確保"); // "Re-securing"
     return ptr;
@@ -78,7 +78,7 @@ void ZeldaArena_Free(void* ptr) {
 }
 
 #if OOT_DEBUG
-void ZeldaArena_FreeDebug(void* ptr, const char* file, s32 line) {
+void ZeldaArena_FreeDebug(void* ptr, const char* file, int line) {
     __osFreeDebug(&sZeldaArena, ptr, file, line);
 }
 #endif


### PR DESCRIPTION
* Use int for line number args over s32/u32
* Add missing const qualifiers from filename args
* Fix gcc warning in game.c

Line numbers are printed with the format `%d` so they shouldn't really be of long type. It could be argued that a lot of s32/u32 are also printed with `%d` and we can't do a lot about this in general, but line numbers are a nice subset of args where we can do something about it.