### PR TITLE
Mostly match retail bosses, part 2

### DIFF
--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -1293,8 +1293,8 @@ void BossGanondrof_Update(Actor* thisx, PlayState* play) {
     s32 pad2;
     s16 i;
     s32 pad;
-    BossGanondrof* this = (BossGanondrof*)thisx;
     EnfHG* horse;
+    BossGanondrof* this = (BossGanondrof*)thisx;
 
     PRINTF("MOVE START %d\n", this->actor.params);
     this->actor.flags &= ~ACTOR_FLAG_10;
@@ -1303,8 +1303,8 @@ void BossGanondrof_Update(Actor* thisx, PlayState* play) {
         Actor_Kill(&this->actor);
         return;
     }
-    this->work[GND_VARIANCE_TIMER]++;
     horse = (EnfHG*)this->actor.child;
+    this->work[GND_VARIANCE_TIMER]++;
     PRINTF("MOVE START EEEEEEEEEEEEEEEEEEEEEE%d\n", this->actor.params);
 
     this->actionFunc(this, play);
@@ -1520,6 +1520,7 @@ void BossGanondrof_Draw(Actor* thisx, PlayState* play) {
                       BossGanondrof_PostLimbDraw, this);
     PRINTF("DRAW 22\n");
     POLY_OPA_DISP = Play_SetFog(play, POLY_OPA_DISP);
+    if (1) {}
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganondrof.c", 3814);
     PRINTF("DRAW END %d\n", this->actor.params);
 }

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -672,7 +672,8 @@ void BossGoma_SetupEncounterState4(BossGoma* this, PlayState* play) {
 void BossGoma_Encounter(BossGoma* this, PlayState* play) {
     Camera* mainCam;
     Player* player = GET_PLAYER(play);
-    s32 pad[2];
+    f32 s;
+    s32 pad;
 
     Math_ApproachZeroF(&this->actor.speed, 0.5f, 2.0f);
 
@@ -761,7 +762,8 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
             }
 
             if (this->frameCount >= 228) {
-                mainCam = Play_GetCamera(play, CAM_ID_MAIN);
+                Camera* mainCam = Play_GetCamera(play, CAM_ID_MAIN);
+
                 mainCam->eye = this->subCamEye;
                 mainCam->eyeNext = this->subCamEye;
                 mainCam->at = this->subCamAt;
@@ -909,8 +911,7 @@ void BossGoma_Encounter(BossGoma* this, PlayState* play) {
             this->subCamAt.z = this->actor.world.pos.z;
 
             if (this->framesUntilNextAction != 0) {
-                f32 s = sinf(this->framesUntilNextAction * 3.1415f * 0.5f);
-
+                s = sinf(this->framesUntilNextAction * 3.1415f * 0.5f);
                 this->subCamAt.y = this->framesUntilNextAction * s * 0.7f + this->actor.world.pos.y;
             } else {
                 Math_ApproachF(&this->subCamAt.y, this->actor.focus.pos.y, 0.1f, 10.0f);
@@ -2047,9 +2048,8 @@ void BossGoma_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* r
     static Vec3f zero = { 0.0f, 0.0f, 0.0f };
     Vec3f childPos;
     Vec3s childRot;
-    EnGoma* babyGohma;
     BossGoma* this = (BossGoma*)thisx;
-    s32 pad;
+    s32 pad[2];
     MtxF mtx;
 
     if (limbIndex == BOSSGOMA_LIMB_TAIL4) { // tail end/last part
@@ -2073,6 +2073,8 @@ void BossGoma_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* r
     }
 
     if (this->deadLimbsState[limbIndex] == 1) {
+        EnGoma* babyGohma;
+
         this->deadLimbsState[limbIndex] = 2;
         Matrix_MultVec3f(&zero, &childPos);
         Matrix_Get(&mtx);

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -407,51 +407,14 @@ void BossMo_SetupTentacle(BossMo* this, PlayState* play) {
 }
 
 void BossMo_Tentacle(BossMo* this, PlayState* play) {
-    s16 tentXrot;
-    s16 sp1B4 = 0;
-    s32 buttons;
-    Player* player = GET_PLAYER(play);
-    s16 indS0;
     s16 indS1;
-    Camera* mainCam1;
-    Camera* mainCam2;
-    BossMo* otherTent = (BossMo*)this->otherTent;
-    f32 maxSwingRateX;
-    f32 maxSwingLagX;
-    f32 maxSwingSizeX;
-    f32 maxSwingRateZ;
-    f32 maxSwingLagZ;
-    f32 maxSwingSizeZ;
-    f32 swingRateAccel;
-    f32 swingSizeAccel;
-    s16 rippleCount;
-    s16 indT5;
-    Vec3f ripplePos;
-    f32 randAngle;
-    f32 randFloat;
+    s16 sp1B4 = 0;
+    Player* player = GET_PLAYER(play);
     f32 tempf1;
     f32 tempf2;
     f32 sin;
     f32 cos;
-    f32 temp;
-    f32 dx;
-    f32 dy;
-    f32 dz;
-    Vec3f sp138;
-    Vec3f sp12C;
-    Vec3f sp120;
-    s32 pad11C;
-    s32 pad118;
-    s32 pad114;
-    s32 pad110;
-    s32 pad10C;
-    s32 pad108;
-    Vec3f spFC;
-    Vec3f spF0;
-    f32 padEC;
-    Vec3f spE0;
-    Vec3f spD4;
-    Vec3f spC8;
+    BossMo* otherTent = (BossMo*)this->otherTent;
 
     if (this->work[MO_TENT_ACTION_STATE] <= MO_TENT_DEATH_3) {
         this->actor.world.pos.y = MO_WATER_LEVEL(play);
@@ -460,6 +423,15 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
         (this->work[MO_TENT_ACTION_STATE] >= MO_TENT_DEATH_START) ||
         (this->work[MO_TENT_ACTION_STATE] == MO_TENT_RETREAT) || (this->work[MO_TENT_ACTION_STATE] == MO_TENT_SWING) ||
         (this->work[MO_TENT_ACTION_STATE] == MO_TENT_SHAKE)) {
+        f32 maxSwingRateX;
+        f32 maxSwingLagX;
+        f32 maxSwingSizeX;
+        f32 maxSwingRateZ;
+        f32 maxSwingLagZ;
+        f32 maxSwingSizeZ;
+        f32 swingRateAccel;
+        f32 swingSizeAccel;
+
         if (this->work[MO_TENT_ACTION_STATE] == MO_TENT_READY) {
             if (sMorphaCore->csState != MO_BATTLE) {
                 maxSwingRateX = 2000.0f;
@@ -570,25 +542,33 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                     this->timers[0] = 60;
                 }
             }
-            if (this->timers[0] > 50) {
-                rippleCount = 1;
-            } else if (this->timers[0] > 40) {
-                rippleCount = 3;
-            } else if (this->timers[0] > 30) {
-                rippleCount = 5;
-            } else if (this->timers[0] > 20) {
-                rippleCount = 8;
-            } else {
-                rippleCount = 3;
-            }
-            for (indS1 = 0; indS1 < rippleCount; indS1++) {
-                randFloat = Rand_ZeroFloat(50.0f);
-                randAngle = Rand_ZeroFloat(0x10000);
-                ripplePos = this->actor.world.pos;
-                ripplePos.x += sinf(randAngle) * randFloat;
-                ripplePos.z += cosf(randAngle) * randFloat;
-                ripplePos.y = MO_WATER_LEVEL(play);
-                BossMo_SpawnRipple(play->specialEffects, &ripplePos, 40.0f, 110.0f, 80, 290, MO_FX_SMALL_RIPPLE);
+            if (1) {
+                s16 rippleCount;
+                Vec3f ripplePos;
+                f32 randAngle;
+                f32 randFloat;
+                s32 pad;
+
+                if (this->timers[0] > 50) {
+                    rippleCount = 1;
+                } else if (this->timers[0] > 40) {
+                    rippleCount = 3;
+                } else if (this->timers[0] > 30) {
+                    rippleCount = 5;
+                } else if (this->timers[0] > 20) {
+                    rippleCount = 8;
+                } else {
+                    rippleCount = 3;
+                }
+                for (indS1 = 0; indS1 < rippleCount; indS1++) {
+                    randFloat = Rand_ZeroFloat(50.0f);
+                    randAngle = Rand_ZeroFloat(0x10000);
+                    ripplePos = this->actor.world.pos;
+                    ripplePos.x += sinf(randAngle) * randFloat;
+                    ripplePos.z += cosf(randAngle) * randFloat;
+                    ripplePos.y = MO_WATER_LEVEL(play);
+                    BossMo_SpawnRipple(play->specialEffects, &ripplePos, 40.0f, 110.0f, 80, 290, MO_FX_SMALL_RIPPLE);
+                }
             }
             break;
         case MO_TENT_READY:
@@ -634,7 +614,8 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                     this->attackAngleMod = Rand_CenteredFloat(0x1000);
                 }
             } else {
-                tentXrot = this->tentRot[28].x;
+                s16 tentXrot = this->tentRot[28].x;
+
                 if ((this->timers[0] == 0) && (tentXrot >= 0) && (sp1B4 < 0)) {
                     this->work[MO_TENT_ACTION_STATE] = MO_TENT_ATTACK;
                     if (this == sMorphaTent1) {
@@ -661,9 +642,10 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
             Math_ApproachF(&this->tentMaxAngle, 0.5f, 1.0f, 0.01);
             Math_ApproachF(&this->tentSpeed, 160.0f, 1.0f, 50.0f);
             if ((this->timers[0] == 0) || (this->playerHitTimer != 0)) {
-                dx = this->tentPos[22].x - player->actor.world.pos.x;
-                dy = this->tentPos[22].y - player->actor.world.pos.y;
-                dz = this->tentPos[22].z - player->actor.world.pos.z;
+                f32 dx = this->tentPos[22].x - player->actor.world.pos.x;
+                f32 dy = this->tentPos[22].y - player->actor.world.pos.y;
+                f32 dz = this->tentPos[22].z - player->actor.world.pos.z;
+
                 if ((fabsf(dy) < 50.0f) && !HAS_LINK(otherTent) && (sqrtf(SQ(dx) + SQ(dy) + SQ(dz)) < 120.0f)) {
                     this->tentMaxAngle = .001f;
                     this->work[MO_TENT_ACTION_STATE] = MO_TENT_CURL;
@@ -765,7 +747,8 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 Math_ApproachS(&player->actor.shape.rot.y, this->grabPosRot.rot.y, 2, 0x7D0);
                 Math_ApproachS(&player->actor.shape.rot.z, this->grabPosRot.rot.z, 2, 0x7D0);
                 if (this->timers[0] == 0) {
-                    mainCam1 = Play_GetCamera(play, CAM_ID_MAIN);
+                    Camera* mainCam = Play_GetCamera(play, CAM_ID_MAIN);
+
                     this->work[MO_TENT_ACTION_STATE] = MO_TENT_SHAKE;
                     this->tentMaxAngle = .001f;
                     this->fwork[MO_TENT_SWING_RATE_X] = this->fwork[MO_TENT_SWING_RATE_Z] =
@@ -778,8 +761,8 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                     this->subCamId = Play_CreateSubCamera(play);
                     Play_ChangeCameraStatus(play, CAM_ID_MAIN, CAM_STAT_WAIT);
                     Play_ChangeCameraStatus(play, this->subCamId, CAM_STAT_ACTIVE);
-                    this->subCamEye = mainCam1->eye;
-                    this->subCamAt = mainCam1->at;
+                    this->subCamEye = mainCam->eye;
+                    this->subCamAt = mainCam->at;
                     this->subCamYaw = Math_FAtan2F(this->subCamEye.x - this->actor.world.pos.x,
                                                    this->subCamEye.z - this->actor.world.pos.z);
                     this->subCamYawRate = 0;
@@ -798,12 +781,14 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
             }
             Math_ApproachF(&this->waterLevelMod, -5.0f, 0.1f, 0.4f);
             sp1B4 = this->tentRot[15].x;
-            buttons = play->state.input[0].press.button;
-            if (CHECK_BTN_ALL(buttons, BTN_A) || CHECK_BTN_ALL(buttons, BTN_B)) {
+            if (CHECK_BTN_ALL(play->state.input[0].press.button, BTN_A) ||
+                CHECK_BTN_ALL(play->state.input[0].press.button, BTN_B)) {
                 this->mashCounter++;
             }
             for (indS1 = 0; indS1 < 41; indS1++) {
                 if (indS1 < 20) {
+                    f32 temp;
+
                     sin = Math_SinS(((s16)this->fwork[MO_TENT_SWING_LAG_X] * indS1) + this->xSwing);
                     tempf1 = this->fwork[MO_TENT_SWING_SIZE_X] * (indS1 * 0.025f * sin);
                     cos = Math_SinS(((s16)this->fwork[MO_TENT_SWING_LAG_Z] * indS1) + this->zSwing);
@@ -828,7 +813,8 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
             Math_ApproachF(&this->tentSpeed, 480.0f, 1.0f, 10.0f);
             Math_ApproachF(&this->tentPulse, 0.3f, 0.5f, 0.03f);
             if ((this->mashCounter >= 40) || (this->timers[0] == 0)) {
-                tentXrot = this->tentRot[15].x;
+                s16 tentXrot = this->tentRot[15].x;
+
                 if ((tentXrot < 0) && (sp1B4 >= 0)) {
                     this->work[MO_TENT_ACTION_STATE] = MO_TENT_RETREAT;
                     this->work[MO_TENT_INVINC_TIMER] = 50;
@@ -844,6 +830,9 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 }
             }
             if (this->subCamId != SUB_CAM_ID_DONE) {
+                Vec3f sp138;
+                Vec3f sp12C;
+
                 sp138.x = 0;
                 sp138.y = 100.0f;
                 sp138.z = 200.0f;
@@ -869,6 +858,12 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
             }
             Math_ApproachF(&this->tentRippleSize, 0.15f, 0.5f, 0.01);
             if (this->meltIndex < 41) {
+                Vec3f sp120;
+                s16 indS0;
+                s32 pad118;
+                s32 pad114;
+                s32 pad110;
+
                 for (indS0 = 0; indS0 < 10; indS0++) {
                     sp120 = this->tentPos[this->meltIndex];
                     sp120.x += Rand_CenteredFloat(30.0f);
@@ -895,10 +890,11 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 Math_ApproachF(&this->subCamAt.z, player->actor.world.pos.z, 0.5f, 50.0f);
                 Play_SetCameraAtEye(play, this->subCamId, &this->subCamAt, &this->subCamEye);
                 if (player->actor.world.pos.y <= 42.0f) {
-                    mainCam2 = Play_GetCamera(play, CAM_ID_MAIN);
-                    mainCam2->eye = this->subCamEye;
-                    mainCam2->eyeNext = this->subCamEye;
-                    mainCam2->at = this->subCamAt;
+                    Camera* mainCam = Play_GetCamera(play, CAM_ID_MAIN);
+
+                    mainCam->eye = this->subCamEye;
+                    mainCam->eyeNext = this->subCamEye;
+                    mainCam->at = this->subCamAt;
                     Play_ReturnToMainCam(play, this->subCamId, 0);
                     this->subCamId = SUB_CAM_ID_DONE;
                     Cutscene_StopManual(play, &play->csCtx);
@@ -917,11 +913,14 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
             Math_ApproachF(&this->tentMaxAngle, 0.5f, 1.0f, 0.01);
             Math_ApproachF(&this->tentSpeed, 320.0f, 1.0f, 50.0f);
             if (this->timers[0] == 0) {
+                s16 indS0;
+                Vec3f spFC;
+                Vec3f spF0;
+
                 this->actor.flags &= ~ACTOR_FLAG_0;
                 Math_ApproachF(&this->baseAlpha, 0.0, 1.0f, 5.0f);
                 for (indS1 = 0; indS1 < 40; indS1++) {
-                    indT5 = Rand_ZeroFloat(20.9f);
-                    indS0 = sTentSpawnIndex[indT5];
+                    indS0 = sTentSpawnIndex[(s16)Rand_ZeroFloat(20.9f)];
                     spFC.x = 0;
                     spFC.y = 0;
                     spFC.z = 0;
@@ -1067,6 +1066,8 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                 Math_ApproachF(&this->tentSpeed, 0.1f, 1.0f, 0.005f);
                 this->actor.velocity.y = 0.0;
             } else {
+                f32 padEC;
+
                 this->fwork[MO_TENT_MAX_STRETCH] = 0.2f;
                 this->fwork[MO_TENT_MAX_STRETCH] += Math_SinS(this->work[MO_TENT_MOVE_TIMER] * 0x2000) * 0.05f;
                 padEC = Math_CosS(this->work[MO_TENT_MOVE_TIMER] * 0x2000) * 0.0005f;
@@ -1081,6 +1082,10 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
                     this->timers[0] = 60;
                     Sfx_PlaySfxAtPos(&this->tentTipPos, NA_SE_EN_MOFER_CORE_JUMP);
                     for (indS1 = 0; indS1 < 300; indS1++) {
+                        Vec3f spE0;
+                        Vec3f spD4;
+                        Vec3f spC8;
+
                         spC8.x = 0.0;
                         spC8.y = 0.0;
                         spC8.z = indS1 * 0.03f;
@@ -1137,11 +1142,11 @@ void BossMo_Tentacle(BossMo* this, PlayState* play) {
 
 void BossMo_TentCollisionCheck(BossMo* this, PlayState* play) {
     s16 i1;
+    s16 i2;
+    ColliderElement* acHitElem;
 
     for (i1 = 0; i1 < ARRAY_COUNT(this->tentElements); i1++) {
         if (this->tentCollider.elements[i1].base.bumperFlags & BUMP_HIT) {
-            s16 i2;
-            ColliderElement* acHitElem;
 
             for (i2 = 0; i2 < 19; i2++) {
                 this->tentCollider.elements[i2].base.bumperFlags &= ~BUMP_HIT;
@@ -1352,13 +1357,14 @@ void BossMo_IntroCs(BossMo* this, PlayState* play) {
                 this->work[MO_TENT_ACTION_STATE] = MO_CORE_INTRO_REVEAL;
                 this->actor.flags &= ~ACTOR_FLAG_0;
                 sMorphaTent1->actor.flags |= ACTOR_FLAG_0;
-            } else {
-                sMorphaTent1->xSwing = 0xCEC;
-                sMorphaTent1->fwork[MO_TENT_SWING_RATE_X] = 0.0f;
-                sMorphaTent1->fwork[MO_TENT_SWING_LAG_X] = 1000.0f;
-                sMorphaTent1->fwork[MO_TENT_SWING_SIZE_X] = 2500.0f;
-                break;
+                goto intro_reveal;
             }
+            sMorphaTent1->xSwing = 0xCEC;
+            sMorphaTent1->fwork[MO_TENT_SWING_RATE_X] = 0.0f;
+            sMorphaTent1->fwork[MO_TENT_SWING_LAG_X] = 1000.0f;
+            sMorphaTent1->fwork[MO_TENT_SWING_SIZE_X] = 2500.0f;
+            break;
+        intro_reveal:
         case MO_INTRO_REVEAL:
             if (this->timers[2] >= 160) {
                 this->subCamEye.x = 150.0f;
@@ -1858,13 +1864,6 @@ void BossMo_Core(BossMo* this, PlayState* play) {
     s16 index; // not on stack
     f32 sp88;
     s32 pad84;
-    f32 sp80;
-    f32 sp7C;
-    Vec3f sp70;
-    Vec3f sp64;
-    f32 sp60;
-    f32 sp5C;
-    f32 sp58;
 
     this->waterTex1x += -1.0f;
     this->waterTex1y += -1.0f;
@@ -2028,6 +2027,11 @@ void BossMo_Core(BossMo* this, PlayState* play) {
         Math_ApproachF(&this->actor.world.pos.z, this->targetPos.z, 0.5f, this->actor.speed);
         Math_ApproachF(&this->actor.speed, 30.0f, 1.0f, 1.0f);
     } else {
+        f32 sp80;
+        f32 sp7C;
+        Vec3f sp70;
+        Vec3f sp64;
+
         switch (this->work[MO_TENT_ACTION_STATE]) {
             case MO_CORE_MOVE:
                 sp80 = Math_SinS(this->work[MO_TENT_VAR_TIMER] * 0x800) * 100.0f;
@@ -2165,6 +2169,9 @@ void BossMo_Core(BossMo* this, PlayState* play) {
         } else {
             this->timers[3] = 8;
             for (i = 0; i < 10; i++) {
+                f32 sp60;
+                f32 sp5C;
+
                 sp5C = Rand_ZeroFloat(3.14f);
                 sp60 = Rand_ZeroFloat(0.6f) + 1.6f;
                 effectVelocity.x = Math_SinS(((i * (f32)0x10000) / 10.0f) + sp5C) * sp60;
@@ -2187,6 +2194,8 @@ void BossMo_Core(BossMo* this, PlayState* play) {
     }
     if ((this->actor.world.pos.y < MO_WATER_LEVEL(play)) || (this->work[MO_TENT_ACTION_STATE] >= MO_CORE_ATTACK)) {
         for (i = 0; i < 3; i++) {
+            f32 sp58;
+
             effectAccel.x = effectAccel.z = 0.0f;
             effectVelocity.x = effectVelocity.y = effectVelocity.z = 0.0f;
             if (this->work[MO_TENT_ACTION_STATE] >= MO_CORE_ATTACK) {
@@ -2725,7 +2734,6 @@ void BossMo_DrawTent(Actor* thisx, PlayState* play) {
     u16 texCoordScale;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_boss_mo.c", 6958);
-    if (1) {}
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, (s8)(this->baseAlpha * 1.5f));
     gDPSetEnvColor(POLY_OPA_DISP++, 150, 150, 150, 0);
@@ -2743,6 +2751,7 @@ void BossMo_DrawTent(Actor* thisx, PlayState* play) {
     if (this->drawActor) {
         BossMo_DrawTentacle(this, play);
     }
+    if (1) {}
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_mo.c", 7023);
 }
 

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -363,10 +363,11 @@ void BossSst_HeadSetupIntro(BossSst* this, PlayState* play) {
     player->actor.world.pos.x = sRoomCenter.x;
     player->actor.world.pos.y = ROOM_CENTER_Y + 1000.0f;
     player->actor.world.pos.z = sRoomCenter.z;
-    player->speedXZ = player->actor.velocity.y = 0.0f;
+    player->speedXZ = 0.0f;
     player->actor.shape.rot.y = -0x8000;
     player->zTargetYaw = -0x8000;
     player->yaw = -0x8000;
+    player->actor.velocity.y = 0.0f;
     player->fallStartHeight = 0;
     player->stateFlags1 |= PLAYER_STATE1_5;
 
@@ -654,8 +655,10 @@ void BossSst_HeadNeutral(BossSst* this, PlayState* play) {
     }
 
     if (this->timer == 0) {
-        if ((GET_PLAYER(play)->actor.world.pos.y > -50.0f) &&
-            !(GET_PLAYER(play)->stateFlags1 & (PLAYER_STATE1_7 | PLAYER_STATE1_13 | PLAYER_STATE1_14))) {
+        Player* player = GET_PLAYER(play);
+
+        if ((player->actor.world.pos.y > -50.0f) &&
+            !(player->stateFlags1 & (PLAYER_STATE1_7 | PLAYER_STATE1_13 | PLAYER_STATE1_14))) {
             sHands[Rand_ZeroOne() <= 0.5f]->ready = true;
             BossSst_HeadSetupWait(this);
         } else {
@@ -825,9 +828,8 @@ void BossSst_HeadSetupStunned(BossSst* this) {
 }
 
 void BossSst_HeadStunned(BossSst* this, PlayState* play) {
-    f32 bounce;
-    s32 animFinish;
     f32 currentFrame;
+    s32 animFinish;
 
     Math_StepToF(&sHandOffsets[LEFT].z, 600.0f, 20.0f);
     Math_StepToF(&sHandOffsets[RIGHT].z, 600.0f, 20.0f);
@@ -837,7 +839,8 @@ void BossSst_HeadStunned(BossSst* this, PlayState* play) {
     animFinish = SkelAnime_Update(&this->skelAnime);
     currentFrame = this->skelAnime.curFrame;
     if (currentFrame <= 6.0f) {
-        bounce = (sinf((M_PI / 11) * currentFrame) * 100.0f) + (this->actor.home.pos.y - 180.0f);
+        f32 bounce = (sinf((M_PI / 11) * currentFrame) * 100.0f) + (this->actor.home.pos.y - 180.0f);
+
         if (this->actor.world.pos.y < bounce) {
             this->actor.world.pos.y = bounce;
         }
@@ -1565,7 +1568,6 @@ void BossSst_HandSetupSweep(BossSst* this) {
 
 void BossSst_HandSweep(BossSst* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
-    s16 newTargetYaw;
 
     SkelAnime_Update(&this->skelAnime);
     this->handAngSpeed += 0x60;
@@ -1575,6 +1577,8 @@ void BossSst_HandSweep(BossSst* this, PlayState* play) {
         this->colliderJntSph.base.ocFlags1 &= ~OC1_NO_PUSH;
         BossSst_HandSetupRetreat(this);
     } else if (this->colliderJntSph.base.atFlags & AT_HIT) {
+        s16 newTargetYaw;
+
         this->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
         this->ready = true;
         func_8002F71C(play, &this->actor, 5.0f, this->actor.shape.rot.y - (this->vParity * 0x3800), 0.0f);
@@ -2772,57 +2776,41 @@ void BossSst_DrawHand(Actor* thisx, PlayState* play) {
 s32 BossSst_OverrideHeadDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx,
                              Gfx** gfx) {
     BossSst* this = (BossSst*)thisx;
-    s32 shakeAmp;
-    s32 pad;
-    s32 timer12;
-    f32 shakeMod;
 
     if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_REACT_TO_LENS) && this->vVanish) {
         *dList = NULL;
     } else if (this->actionFunc == BossSst_HeadThrash) { // Animation modifications for death cutscene
-        shakeAmp = (this->timer / 10) + 1;
+        s32 shakeAmp = (this->timer / 10) + 1;
+
         if ((limbIndex == 3) || (limbIndex == 39) || (limbIndex == 42)) {
-
-            shakeMod = sinf(this->timer * (M_PI / 5));
-            rot->x += ((0x500 * Rand_ZeroOne() + 0xA00) / 0x10) * shakeAmp * shakeMod;
-
-            shakeMod = sinf((this->timer % 5) * (M_PI / 5));
-            rot->z -= ((0x800 * Rand_ZeroOne() + 0x1000) / 0x10) * shakeAmp * shakeMod + 0x1000;
+            rot->x += ((0x500 * Rand_ZeroOne() + 0xA00) / 0x10) * shakeAmp * sinf(this->timer * (M_PI / 5));
+            rot->z -=
+                ((0x800 * Rand_ZeroOne() + 0x1000) / 0x10) * shakeAmp * sinf((this->timer % 5) * (M_PI / 5)) + 0x1000;
 
             if (limbIndex == 3) {
-
-                shakeMod = sinf(this->timer * (M_PI / 5));
-                rot->y += ((0x500 * Rand_ZeroOne() + 0xA00) / 0x10) * shakeAmp * shakeMod;
+                rot->y += ((0x500 * Rand_ZeroOne() + 0xA00) / 0x10) * shakeAmp * sinf(this->timer * (M_PI / 5));
             }
         } else if ((limbIndex == 5) || (limbIndex == 6)) {
-
-            shakeMod = sinf((this->timer % 5) * (M_PI / 5));
-            rot->z -= ((0x280 * Rand_ZeroOne() + 0x500) / 0x10) * shakeAmp * shakeMod + 0x500;
+            rot->z -=
+                ((0x280 * Rand_ZeroOne() + 0x500) / 0x10) * shakeAmp * sinf((this->timer % 5) * (M_PI / 5)) + 0x500;
 
             if (limbIndex == 5) {
-
-                shakeMod = sinf(this->timer * (M_PI / 5));
-                rot->x += ((0x500 * Rand_ZeroOne() + 0xA00) / 0x10) * shakeAmp * shakeMod;
-
-                shakeMod = sinf(this->timer * (M_PI / 5));
-                rot->y += ((0x500 * Rand_ZeroOne() + 0xA00) / 0x10) * shakeAmp * shakeMod;
+                rot->x += ((0x500 * Rand_ZeroOne() + 0xA00) / 0x10) * shakeAmp * sinf(this->timer * (M_PI / 5));
+                rot->y += ((0x500 * Rand_ZeroOne() + 0xA00) / 0x10) * shakeAmp * sinf(this->timer * (M_PI / 5));
             }
         } else if (limbIndex == 2) {
-            shakeMod = sinf(this->timer * (M_PI / 5));
-            rot->x += ((0x200 * Rand_ZeroOne() + 0x400) / 0x10) * shakeAmp * shakeMod;
-
-            shakeMod = sinf(this->timer * (M_PI / 5));
-            rot->y += ((0x200 * Rand_ZeroOne() + 0x400) / 0x10) * shakeAmp * shakeMod;
-
-            shakeMod = sinf((this->timer % 5) * (M_PI / 5));
-            rot->z -= ((0x100 * Rand_ZeroOne() + 0x200) / 0x10) * shakeAmp * shakeMod + 0x200;
+            rot->x += ((0x200 * Rand_ZeroOne() + 0x400) / 0x10) * shakeAmp * sinf(this->timer * (M_PI / 5));
+            rot->y += ((0x200 * Rand_ZeroOne() + 0x400) / 0x10) * shakeAmp * sinf(this->timer * (M_PI / 5));
+            rot->z -=
+                ((0x100 * Rand_ZeroOne() + 0x200) / 0x10) * shakeAmp * sinf((this->timer % 5) * (M_PI / 5)) + 0x200;
         }
     } else if (this->actionFunc == BossSst_HeadDeath) {
+        s32 timer12;
+
         if (this->timer > 48) {
             timer12 = this->timer - 36;
         } else {
-            pad = ((this->timer > 6) ? 6 : this->timer);
-            timer12 = pad * 2;
+            timer12 = ((this->timer > 6) ? 6 : this->timer) * 2;
         }
 
         if ((limbIndex == 3) || (limbIndex == 39) || (limbIndex == 42)) {
@@ -2947,14 +2935,16 @@ void BossSst_SpawnHeadShadow(BossSst* this) {
     s32 i;
     f32 sn;
     f32 cs;
+    BossSstEffect* shadow;
+    Vec3f* offset;
 
     this->effectMode = BONGO_SHADOW;
     sn = Math_SinS(this->actor.shape.rot.y);
     cs = Math_CosS(this->actor.shape.rot.y);
 
     for (i = 0; i < 3; i++) {
-        BossSstEffect* shadow = &this->effects[i];
-        Vec3f* offset = &shadowOffset[i];
+        shadow = &this->effects[i];
+        offset = &shadowOffset[i];
 
         shadow->pos.x = this->actor.world.pos.x + (sn * offset->z) + (cs * offset->x);
         shadow->pos.y = 0.0f;
@@ -2983,12 +2973,13 @@ void BossSst_SpawnShockwave(BossSst* this) {
     s32 i;
     s32 scale = 120;
     s32 alpha = 250;
+    BossSstEffect* shockwave;
 
     Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_HAND_WAVE);
     this->effectMode = BONGO_SHOCKWAVE;
 
     for (i = 0; i < 3; i++) {
-        BossSstEffect* shockwave = &this->effects[i];
+        shockwave = &this->effects[i];
 
         Math_Vec3f_Copy(&shockwave->pos, &this->actor.world.pos);
         shockwave->move = (i + 9) * 2;
@@ -3049,6 +3040,7 @@ void BossSst_SpawnIceShard(BossSst* this) {
     s32 i;
     Vec3f spawnPos;
     f32 offXZ;
+    BossSstEffect* ice;
 
     this->effectMode = BONGO_ICE;
     offXZ = Math_CosS(this->actor.shape.rot.x) * 50.0f;
@@ -3057,7 +3049,7 @@ void BossSst_SpawnIceShard(BossSst* this) {
     spawnPos.z = Math_SinS(this->actor.shape.rot.y) * offXZ + this->actor.world.pos.z;
 
     for (i = 0; i < 18; i++) {
-        BossSstEffect* ice = &this->effects[i];
+        ice = &this->effects[i];
 
         Math_Vec3f_Copy(&ice->pos, &spawnPos);
         ice->status = 1;
@@ -3120,9 +3112,12 @@ void BossSst_UpdateEffects(Actor* thisx, PlayState* play) {
                 this->effectMode = BONGO_NULL;
             }
         } else if (this->effectMode == BONGO_SHOCKWAVE) {
+            BossSstEffect* effect2;
+            s32 scale;
+
             for (i = 0; i < 3; i++) {
-                BossSstEffect* effect2 = &this->effects[i];
-                s32 scale = effect2->move * 2;
+                effect2 = &this->effects[i];
+                scale = effect2->move * 2;
 
                 effect2->scale += CLAMP_MAX(scale, 20) + i;
                 if (effect2->move != 0) {

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -790,7 +790,6 @@ s32 BossTw_BeamHitPlayerCheck(BossTw* this, PlayState* play) {
     Vec3f offset;
     Vec3f beamDistFromPlayer;
     Player* player = GET_PLAYER(play);
-    s16 i;
 
     offset.x = player->actor.world.pos.x - this->beamOrigin.x;
     offset.y = player->actor.world.pos.y - this->beamOrigin.y;
@@ -812,6 +811,8 @@ s32 BossTw_BeamHitPlayerCheck(BossTw* this, PlayState* play) {
                     sFreezeState = 1;
                 }
             } else if (!player->bodyIsBurning) {
+                s16 i;
+
                 for (i = 0; i < PLAYER_BODYPART_MAX; i++) {
                     player->bodyFlameTimers[i] = Rand_S16Offset(0, 200);
                 }
@@ -3301,6 +3302,8 @@ void func_80941BC0(BossTw* this, PlayState* play) {
     gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gTwinrovaEffectHaloDL));
     Matrix_Pop();
 
+    if (1) {}
+
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_tw.c", 6461);
 }
 
@@ -3533,9 +3536,10 @@ void BossTw_Draw(Actor* thisx, PlayState* play2) {
     }
 
     if (this->actor.params == TW_KOTAKE) {
+        Vec3f diff;
+
         if (this->workf[UNK_F9] > 0.0f) {
             if (this->workf[UNK_F11] > 0.0f) {
-                Vec3f diff;
                 diff.x = this->groundBlastPos2.x - player->actor.world.pos.x;
                 diff.y = this->groundBlastPos2.y - player->actor.world.pos.y;
                 diff.z = this->groundBlastPos2.z - player->actor.world.pos.z;
@@ -3563,6 +3567,8 @@ void BossTw_Draw(Actor* thisx, PlayState* play2) {
             func_80942C70(&this->actor, play);
         }
     }
+
+    if (1) {}
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_tw.c", 7123);
 }
@@ -4077,7 +4083,7 @@ void BossTw_BlastFire(BossTw* this, PlayState* play) {
                 break;
             }
 
-            {
+            if (1) {
                 f32 sp4C = sGroundBlastType == 2 ? 3.0f : 1.0f;
 
                 Math_ApproachF(&sKoumePtr->workf[UNK_F9], 0.0f, 1.0f, 10.0f * sp4C);
@@ -4231,6 +4237,8 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
 
         case TW_ICE_BLAST_GROUND:
             if (this->timers[0] != 0) {
+                s32 pad;
+
                 if (this->timers[0] == 1) {
                     sEnvType = 0;
                 }
@@ -4242,7 +4250,6 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
                 Actor_PlaySfx(&this->actor, NA_SE_EV_ICE_FREEZE - SFX_FLAG);
 
                 if (this->timers[0] > (sTwinrovaPtr->actionFunc == BossTw_Wait ? 70 : 20)) {
-                    s32 pad;
                     Vec3f pos;
                     Vec3f velocity;
                     Vec3f accel;
@@ -4320,12 +4327,13 @@ void BossTw_BlastIce(BossTw* this, PlayState* play) {
 s32 BossTw_BlastShieldCheck(BossTw* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 ret = false;
-    ColliderElement* acHitElem;
 
     if (1) {}
 
     if (this->csState1 == 1) {
         if (this->collider.base.acFlags & AC_HIT) {
+            ColliderElement* acHitElem;
+
             this->collider.base.acFlags &= ~AC_HIT;
             this->collider.base.atFlags &= ~AT_HIT;
             acHitElem = this->collider.elem.acHitElem;
@@ -4565,17 +4573,6 @@ void BossTw_UpdateEffects(PlayState* play) {
     s16 j;
     s16 colorIdx;
     Vec3f off;
-    Vec3f spF4;
-    Vec3f spE8;
-    Vec3f spDC;
-    Vec3f spD0;
-    f32 phi_f22;
-    Vec3f spC0;
-    Vec3f spB4;
-    Vec3f spA8;
-    s16 spA6;
-    f32 phi_f0;
-    Actor* unk44;
 
     for (i = 0; i < BOSS_TW_EFFECT_COUNT; i++) {
         if (eff->type != TWEFF_NONE) {
@@ -4654,8 +4651,13 @@ void BossTw_UpdateEffects(PlayState* play) {
                 off.z = sTwinrovaPtr->actor.world.pos.z - eff->pos.z;
 
                 if (sTwinrovaPtr->actionFunc != BossTw_TwinrovaStun) {
+                    Vec3f spF4;
+                    Vec3f spE8;
+                    Vec3f spDC;
+
                     if ((SQ(off.x) + SQ(off.y) + SQ(off.z)) < SQ(60.0f)) {
                         for (j = 0; j < 50; j++) {
+
                             spF4.x = sTwinrovaPtr->actor.world.pos.x + Rand_CenteredFloat(35.0f);
                             spF4.y = sTwinrovaPtr->actor.world.pos.y + Rand_CenteredFloat(70.0f);
                             spF4.z = sTwinrovaPtr->actor.world.pos.z + Rand_CenteredFloat(35.0f);
@@ -4715,6 +4717,8 @@ void BossTw_UpdateEffects(PlayState* play) {
                     Math_ApproachF(&eff->workf[EFF_DIST], 1000.0f, 1.0f, 10.0f);
                     if (eff->work[EFF_UNKS1] >= 0x10) {
                         if ((eff->work[EFF_UNKS1] == 16) && (sp113 == 0)) {
+                            Vec3f spD0;
+
                             sp113 = 1;
                             spD0 = eff->pos;
                             if (eff->pos.y > 40.0f) {
@@ -4722,8 +4726,7 @@ void BossTw_UpdateEffects(PlayState* play) {
                             } else {
                                 spD0.y = -50.0f;
                             }
-                            sTwinrovaPtr->groundBlastPos.y = phi_f0 = BossTw_GetFloorY(&spD0);
-                            if (phi_f0 >= 0.0f) {
+                            if ((sTwinrovaPtr->groundBlastPos.y = BossTw_GetFloorY(&spD0)) >= 0.0f) {
                                 if (sTwinrovaPtr->groundBlastPos.y != 35.0f) {
                                     sTwinrovaPtr->groundBlastPos.x = eff->pos.x;
                                     sTwinrovaPtr->groundBlastPos.z = eff->pos.z;
@@ -4790,7 +4793,7 @@ void BossTw_UpdateEffects(PlayState* play) {
                 }
             } else if (eff->type == TWEFF_PLYR_FRZ) {
                 if (eff->work[EFF_ARGS] < eff->frame) {
-                    phi_f0 = 1.0f;
+                    f32 phi_f0 = 1.0f;
 
                     if (eff->target != NULL || sGroundBlastType == 1) {
                         phi_f0 *= 3.0f;
@@ -4834,7 +4837,11 @@ void BossTw_UpdateEffects(PlayState* play) {
                     }
 
                     if ((eff->workf[EFF_DIST] > 0.4f) && ((eff->frame & 7) == 0)) {
-                        spA6 = Rand_ZeroFloat(PLAYER_BODYPART_MAX - 0.1f);
+                        Vec3f spC0;
+                        Vec3f spB4;
+                        Vec3f spA8;
+                        s16 spA6 = Rand_ZeroFloat(PLAYER_BODYPART_MAX - 0.1f);
+                        f32 phi_f22;
 
                         if (eff->target == NULL) {
                             spC0.x = player->bodyPartsPos[spA6].x + Rand_CenteredFloat(5.0f);
@@ -4842,7 +4849,8 @@ void BossTw_UpdateEffects(PlayState* play) {
                             spC0.z = player->bodyPartsPos[spA6].z + Rand_CenteredFloat(5.0f);
                             phi_f22 = 10.0f;
                         } else {
-                            unk44 = eff->target;
+                            Actor* unk44 = eff->target;
+
                             spC0.x = unk44->world.pos.x + Rand_CenteredFloat(40.0f);
                             spC0.y = unk44->world.pos.y + Rand_CenteredFloat(40.0f);
                             spC0.z = unk44->world.pos.z + Rand_CenteredFloat(40.0f);
@@ -4899,10 +4907,11 @@ void BossTw_DrawEffects(PlayState* play) {
     s32 pad;
     Player* player = GET_PLAYER(play);
     s16 phi_s4;
-    BossTwEffect* currentEffect = play->specialEffects;
+    BossTwEffect* currentEffect;
     BossTwEffect* effectHead;
     GraphicsContext* gfxCtx = play->state.gfxCtx;
 
+    currentEffect = play->specialEffects;
     effectHead = currentEffect;
 
     OPEN_DISPS(gfxCtx, "../z_boss_tw.c", 9592);
@@ -5028,10 +5037,10 @@ void BossTw_DrawEffects(PlayState* play) {
     currentEffect = effectHead;
 
     for (i = 0; i < BOSS_TW_EFFECT_COUNT; i++) {
-        Actor* actor;
-        Vec3f off;
-
         if (currentEffect->type == TWEFF_PLYR_FRZ) {
+            Actor* actor;
+            Vec3f off;
+
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gTwinrovaIceSurroundingPlayerMaterialDL));
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 195, 225, 235, 255);
@@ -5204,7 +5213,7 @@ void BossTw_TwinrovaShootBlast(BossTw* this, PlayState* play) {
 
         sEnvType = twMagic->blastType + 1;
 
-        {
+        if (1) {
             Vec3f velocity = { 0.0f, 0.0f, 0.0f };
             Vec3f accel = { 0.0f, 0.0f, 0.0f };
 

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -4657,7 +4657,6 @@ void BossTw_UpdateEffects(PlayState* play) {
 
                     if ((SQ(off.x) + SQ(off.y) + SQ(off.z)) < SQ(60.0f)) {
                         for (j = 0; j < 50; j++) {
-
                             spF4.x = sTwinrovaPtr->actor.world.pos.x + Rand_CenteredFloat(35.0f);
                             spF4.y = sTwinrovaPtr->actor.world.pos.y + Rand_CenteredFloat(70.0f);
                             spF4.z = sTwinrovaPtr->actor.world.pos.z + Rand_CenteredFloat(35.0f);

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -1121,7 +1121,6 @@ void BossVa_SetupBodyPhase2(BossVa* this, PlayState* play) {
 
 void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
-    Vec3f sp48;
 
     if (this->actor.colorFilterTimer == 0) {
         sPhase2Timer++;
@@ -1166,7 +1165,8 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
     }
 
     if ((sPhase2Timer > 10) && !(sPhase2Timer & 7) && (this->actor.speed == 1.0f)) {
-        sp48 = this->actor.world.pos;
+        Vec3f sp48 = this->actor.world.pos;
+
         sp48.y += 310.0f + (this->actor.shape.yOffset * this->actor.scale.y);
         sp48.x += -10.0f;
         sp48.z += 220.0f;
@@ -1918,19 +1918,6 @@ void BossVa_ZapperAttack(BossVa* this, PlayState* play) {
     u32 sp88;
     Vec3f sp7C;
     s32 pad3;
-    f32 sp74;
-    s32 i;
-    s16 sp6E;
-    s16 sp6C;
-    f32 sp68;
-    f32 sp64;
-    f32 sp60;
-    f32 sp5C;
-    s16 sp5A;
-    s16 sp58;
-    s16 sp56;
-    s16 sp54;
-    f32 sp50;
 
     boomerang = BossVa_FindBoomerang(play);
 
@@ -1939,6 +1926,20 @@ void BossVa_ZapperAttack(BossVa* this, PlayState* play) {
         sp7C.y += 10.0f;
         sp8E = 0x3E80;
     } else {
+        f32 sp74;
+        s32 i;
+        s16 sp6E;
+        s16 sp6C;
+        f32 sp68;
+        f32 sp64;
+        f32 sp60;
+        f32 sp5C;
+        s16 sp5A;
+        s16 sp58;
+        s16 sp56;
+        s16 sp54;
+        f32 sp50;
+
         sp74 = R_UPDATE_RATE * 0.5f;
         sp8E = 0x4650;
 
@@ -3148,6 +3149,8 @@ void BossVa_BariPostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s*
         gSPDisplayList(POLY_XLU_DISP++, *dList);
     }
 
+    if (1) {}
+
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_va.c", 4517);
 }
 
@@ -3279,10 +3282,6 @@ void BossVa_UpdateEffects(PlayState* play) {
     s16 spB6;
     s16 i;
     f32 spB0;
-    f32 spAC;
-    s16 pitch;
-    BossVa* refActor2;
-    BossVa* refActor;
 
     for (i = 0; i < BOSS_VA_EFFECT_COUNT; i++, effect++) {
         if (effect->type == VA_NONE) {
@@ -3300,15 +3299,16 @@ void BossVa_UpdateEffects(PlayState* play) {
         effect->velocity.z += effect->accel.z;
 
         if ((effect->type == VA_LARGE_SPARK) || (effect->type == VA_SMALL_SPARK)) {
-            refActor = effect->parent;
+            BossVa* refActor = effect->parent;
 
             effect->rot.z += (s16)(Rand_ZeroOne() * 0x4E20) + 0x2000;
             effect->rot.y += (s16)(Rand_ZeroOne() * 0x2710) + 0x2000;
 
             if ((effect->mode == SPARK_TETHER) || (effect->mode == SPARK_UNUSED)) {
-                pitch = effect->rot.x - Math_Vec3f_Pitch(&refActor->actor.world.pos, &GET_BODY(refActor)->unk_1D8);
-                spAC = Math_SinS(refActor->actor.world.rot.y);
-                effect->pos.x = refActor->actor.world.pos.x - (effect->offset.x * spAC);
+                s16 pitch = effect->rot.x - Math_Vec3f_Pitch(&refActor->actor.world.pos, &GET_BODY(refActor)->unk_1D8);
+
+                spB0 = Math_SinS(refActor->actor.world.rot.y);
+                effect->pos.x = refActor->actor.world.pos.x - (effect->offset.x * spB0);
                 spB0 = Math_CosS(refActor->actor.world.rot.y);
                 effect->pos.z = refActor->actor.world.pos.z - (effect->offset.x * spB0);
                 spB0 = Math_CosS(-pitch);
@@ -3347,13 +3347,13 @@ void BossVa_UpdateEffects(PlayState* play) {
         }
 
         if (effect->type == VA_SPARK_BALL) {
-            refActor2 = effect->parent;
+            BossVa* refActor = effect->parent;
 
             effect->rot.z += (s16)(Rand_ZeroOne() * 0x2710) + 0x24A8;
-            effect->pos.x = effect->offset.x + refActor2->actor.world.pos.x;
+            effect->pos.x = effect->offset.x + refActor->actor.world.pos.x;
             effect->pos.y =
-                refActor2->actor.world.pos.y + 310.0f + (refActor2->actor.shape.yOffset * refActor2->actor.scale.y);
-            effect->pos.z = effect->offset.z + refActor2->actor.world.pos.z;
+                refActor->actor.world.pos.y + 310.0f + (refActor->actor.shape.yOffset * refActor->actor.scale.y);
+            effect->pos.z = effect->offset.z + refActor->actor.world.pos.z;
             effect->mode = (effect->mode + 1) & 7;
 
             if (effect->timer < 100) {
@@ -3378,9 +3378,9 @@ void BossVa_UpdateEffects(PlayState* play) {
 
         if (effect->type == VA_BLOOD) {
             if (effect->mode < BLOOD_SPOT) {
+                f32 floorY;
                 Vec3f checkPos;
                 CollisionPoly* groundPoly;
-                f32 floorY;
 
                 checkPos = effect->pos;
                 checkPos.y -= effect->velocity.y + 4.0f;
@@ -3415,9 +3415,9 @@ void BossVa_UpdateEffects(PlayState* play) {
 
         if (effect->type == VA_GORE) {
             if (effect->mode == GORE_PERMANENT) {
+                f32 floorY;
                 Vec3f checkPos;
                 CollisionPoly* groundPoly;
-                f32 floorY;
 
                 checkPos = effect->pos;
                 checkPos.y -= effect->velocity.y + 4.0f;
@@ -3452,9 +3452,8 @@ void BossVa_UpdateEffects(PlayState* play) {
         }
 
         if (effect->type == VA_TUMOR) {
+            BossVa* refActor = effect->parent;
             s16 yaw;
-
-            refActor = effect->parent;
 
             effect->rot.z += 0x157C;
             effect->envColor[3] = (s16)(Math_SinS(effect->rot.z) * 50.0f) + 80;
@@ -3982,7 +3981,7 @@ void BossVa_DrawDoor(PlayState* play, s16 scale) {
 
     Matrix_Get(&doorMtx);
 
-    for (i = 0; i < 8; i++, segAngle -= M_PI / 4) {
+    for (i = 0; i < 8; i++) {
         Matrix_Put(&doorMtx);
         Matrix_RotateZ(segAngle, MTXMODE_APPLY);
         Matrix_Translate(0.0f, doorPieceLength[i] * yScale, 0.0f, MTXMODE_APPLY);
@@ -3990,6 +3989,7 @@ void BossVa_DrawDoor(PlayState* play, s16 scale) {
         gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_va.c", 5621),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_OPA_DISP++, doorPieceDispList[i]);
+        segAngle -= M_PI / 4;
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_va.c", 5629);

--- a/tools/disasm/disasm.py
+++ b/tools/disasm/disasm.py
@@ -88,6 +88,7 @@ def main():
     context = spimdisasm.common.Context()
     context.parseArgs(args)
     context.changeGlobalSegmentRanges(0x00000000, 0x01000000, 0x8000000, 0x81000000)
+    context.addBannedSymbolRange(0x0000F000, 0x00010100)
     context.addBannedSymbolRange(0x10000000, 0x80000300)
     context.addBannedSymbolRange(0xA0000000, 0xFFFFFFFF)
 


### PR DESCRIPTION
Part 1 coming soon. I skipped BossMo_DrawCore (https://decomp.me/scratch/sLMBY)

Highlights:
* There's already some `if (1) { ... }` used some scoping, and I added some more but maybe that's not fake?
* `goto` match in `BossMo_IntroCs`, but I noticed a similar pattern is already used in `BossMo_Tentacle` and other bosses as well
* To squash some fake diffs, I banned pointers in disassembly in the range 0x0000F000 to 0x00010100 (not for any principled reason, but because all the pointers in that range currently are fake)