### PR TITLE
Mostly match retail bosses, part 1

### DIFF
--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -105,27 +105,29 @@ void func_808C12C4(u8* arg1, s16 arg2) {
     func_808C1278(SEGMENTED_TO_VIRTUAL(object_kingdodongo_Tex_016E10), arg1, arg2);
 }
 
-void func_808C1554(void* arg0, void* floorTex, s32 arg2, f32 arg3) {
-    u16* temp_s3 = SEGMENTED_TO_VIRTUAL(arg0);
-    u16* temp_s1 = SEGMENTED_TO_VIRTUAL(floorTex);
+void func_808C1554(u16* arg0, u16* floorTex, s32 arg2, f32 arg3) {
+    s32 pad[2];
     s16 i;
     s16 i2;
     u16 sp54[2048];
     s16 temp;
-    s16 temp2;
+
+    arg0 = SEGMENTED_TO_VIRTUAL(arg0);
+    floorTex = SEGMENTED_TO_VIRTUAL(floorTex);
 
     for (i = 0; i < 2048; i += 32) {
         temp = sinf((((i / 32) + (s16)((arg2 * 50.0f) / 100.0f)) & 0x1F) * (M_PI / 16)) * arg3;
         for (i2 = 0; i2 < 32; i2++) {
-            sp54[i + ((temp + i2) & 0x1F)] = temp_s1[i + i2];
+            sp54[i + ((temp + i2) & 0x1F)] = floorTex[i + i2];
         }
     }
     for (i = 0; i < 32; i++) {
         temp = sinf(((i + (s16)((arg2 * 80.0f) / 100.0f)) & 0x1F) * (M_PI / 16)) * arg3;
         temp *= 32;
         for (i2 = 0; i2 < 2048; i2 += 32) {
-            temp2 = (temp + i2) & 0x7FF;
-            temp_s3[i + temp2] = sp54[i + i2];
+            s16 temp2 = (temp + i2) & 0x7FF;
+
+            arg0[i + temp2] = sp54[i + i2];
         }
     }
 }
@@ -179,9 +181,6 @@ s32 BossDodongo_AteExplosive(BossDodongo* this, PlayState* play) {
 void BossDodongo_Init(Actor* thisx, PlayState* play) {
     BossDodongo* this = (BossDodongo*)thisx;
     s16 i;
-    u16* temp_s1_3;
-    u16* temp_s2;
-    u32 temp_v0;
 
     play->specialEffects = this->effects;
     Actor_ProcessInitChain(&this->actor, sInitChain);
@@ -202,8 +201,9 @@ void BossDodongo_Init(Actor* thisx, PlayState* play) {
     Collider_SetJntSph(play, &this->collider, &this->actor, &sJntSphInit, this->items);
 
     if (Flags_GetClear(play, play->roomCtx.curRoom.num)) { // KD is dead
-        temp_s1_3 = SEGMENTED_TO_VIRTUAL(gDodongosCavernBossLavaFloorTex);
-        temp_s2 = SEGMENTED_TO_VIRTUAL(sLavaFloorRockTex);
+        u16* temp_s1_3 = SEGMENTED_TO_VIRTUAL(gDodongosCavernBossLavaFloorTex);
+        u16* temp_s2 = SEGMENTED_TO_VIRTUAL(sLavaFloorRockTex);
+        u32 temp_v0;
 
         Actor_Kill(&this->actor);
         Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_DOOR_WARP1, -890.0f, -1523.76f, -3304.0f, 0, 0, 0,
@@ -488,8 +488,7 @@ void BossDodongo_SetupRoll(BossDodongo* this) {
 }
 
 void BossDodongo_SetupBlowFire(BossDodongo* this) {
-    this->actor.speed = 0.0f;
-    this->unk_1E4 = 0.0f;
+    this->actor.speed = this->unk_1E4 = 0.0f;
     Animation_Change(&this->skelAnime, &object_kingdodongo_Anim_0061D4, 1.0f, 0.0f,
                      Animation_GetLastFrame(&object_kingdodongo_Anim_0061D4), ANIMMODE_ONCE, 0.0f);
     this->actionFunc = BossDodongo_BlowFire;
@@ -913,8 +912,8 @@ void BossDodongo_Update(Actor* thisx, PlayState* play2) {
         Math_SmoothStepToF(&this->colorFilterMax, 1099.0f, 1, 10.0f, 0.0);
     } else {
         Math_SmoothStepToF(&this->colorFilterR, play->lightCtx.fogColor[0], 1, 5.0f, 0.0);
-        Math_SmoothStepToF(&this->colorFilterG, play->lightCtx.fogColor[1], 1.0f, 5.0f, 0.0);
-        Math_SmoothStepToF(&this->colorFilterB, play->lightCtx.fogColor[2], 1.0f, 5.0f, 0.0);
+        Math_SmoothStepToF(&this->colorFilterG, play->lightCtx.fogColor[1], 1, 5.0f, 0.0);
+        Math_SmoothStepToF(&this->colorFilterB, play->lightCtx.fogColor[2], 1, 5.0f, 0.0);
         Math_SmoothStepToF(&this->colorFilterMin, play->lightCtx.fogNear, 1.0, 5.0f, 0.0);
         Math_SmoothStepToF(&this->colorFilterMax, 1000.0f, 1, 5.0f, 0.0);
     }
@@ -992,16 +991,17 @@ void BossDodongo_Update(Actor* thisx, PlayState* play2) {
             }
         }
 
-        func_808C1554(gDodongosCavernBossLavaFloorTex, sLavaFloorLavaTex, this->unk_19E, this->unk_224);
+        func_808C1554((u16*)gDodongosCavernBossLavaFloorTex, (u16*)sLavaFloorLavaTex, this->unk_19E, this->unk_224);
     }
 
     if (this->unk_1C6 != 0) {
         u16* ptr1 = SEGMENTED_TO_VIRTUAL(sLavaFloorLavaTex);
         u16* ptr2 = SEGMENTED_TO_VIRTUAL(sLavaFloorRockTex);
         s16 i2;
+        s16 new_var;
 
         for (i2 = 0; i2 < 20; i2++) {
-            s16 new_var = this->unk_1C2 & 0x7FF;
+            new_var = this->unk_1C2 & 0x7FF;
 
             ptr1[new_var] = ptr2[new_var];
             this->unk_1C2 += 37;
@@ -1272,8 +1272,7 @@ void BossDodongo_UpdateDamage(BossDodongo* this, PlayState* play) {
 }
 
 void BossDodongo_SetupDeathCutscene(BossDodongo* this) {
-    this->actor.speed = 0.0f;
-    this->unk_1E4 = 0.0f;
+    this->actor.speed = this->unk_1E4 = 0.0f;
     Animation_Change(&this->skelAnime, &object_kingdodongo_Anim_002D0C, 1.0f, 0.0f,
                      Animation_GetLastFrame(&object_kingdodongo_Anim_002D0C), ANIMMODE_ONCE, -5.0f);
     this->actionFunc = BossDodongo_DeathCutscene;

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -258,7 +258,6 @@ static Vec3f sCeilingTargets[] = {
 
 void BossFd_Fly(BossFd* this, PlayState* play) {
     u8 sp1CF = false;
-    u8 temp_rand;
     s16 i1;
     s16 i2;
     s16 i3;
@@ -272,7 +271,6 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
     f32 temp_y;
     f32 temp_x;
     f32 temp_z;
-    f32 temp;
 
     SkelAnime_Update(&this->skelAnimeHead);
     SkelAnime_Update(&this->skelAnimeRightArm);
@@ -476,13 +474,13 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
                     this->subCamAtVel.y = 85.56f;
                     this->subCamAtVel.z = 25.0f;
                 } else {
-                    // the following `temp` stuff is probably fake but is required to match
+                    // the following `temp_z` stuff is probably fake but is required to match
                     // it's optimized to 1.0f because sp1CF is false at this point, but the 0.1f ends up in rodata
-                    temp = 0.1f;
+                    temp_z = 0.1f;
                     if (!sp1CF) {
-                        temp = 1.0f;
+                        temp_z = 1.0f;
                     }
-                    Math_ApproachF(&this->subCamShake, 2.0f, temp, 0.1 * 0.08f);
+                    Math_ApproachF(&this->subCamShake, 2.0f, temp_z, 0.1 * 0.08f);
                     this->subCamAtYOffset = Math_CosS(this->work[BFD_MOVE_TIMER] * 0x8000) * this->subCamShake;
                 }
                 if (this->timers[3] == 160) {
@@ -561,6 +559,8 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
                     this->timers[0] = 0;
                     this->timers[1] = 100;
                 } else {
+                    u8 temp_rand;
+
                     if (this->introState != BFD_CS_NONE) {
                         this->holeIndex = 6;
                     } else {
@@ -919,12 +919,6 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
 
     if (!this->work[BFD_STOP_FLAG]) {
         s16 i4;
-        Vec3f spE0[3];
-        Vec3f spBC[3];
-        f32 phi_f20;
-        f32 padB4;
-        f32 padB0;
-        f32 padAC;
 
         Math_ApproachS(&this->actor.world.rot.y, angleToTarget, 0xA, this->fwork[BFD_TURN_RATE]);
 
@@ -993,6 +987,8 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
         }
 
         if (!sp1CF) {
+            Vec3f spE0[3];
+            Vec3f spBC[3];
             spE0[0].x = spE0[0].y = Math_SinS(this->work[BFD_MOVE_TIMER] * 1500.0f) * 3000.0f;
             spE0[1].x = Math_SinS(this->work[BFD_MOVE_TIMER] * 2000.0f) * 4000.0f;
             spE0[1].y = Math_SinS(this->work[BFD_MOVE_TIMER] * 2200.0f) * 4000.0f;
@@ -1012,7 +1008,11 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
             }
         } else {
             for (i2 = 0; i2 < 3; i2++) {
-                phi_f20 = 0.0f;
+                f32 phi_f20 = 0.0f;
+                f32 padB4;
+                f32 padB0;
+                f32 padAC;
+
                 Math_ApproachZeroF(&this->rightArmRot[i2].y, 0.1f, 100.0f);
                 Math_ApproachZeroF(&this->leftArmRot[i2].y, 0.1f, 100.0f);
                 if (i2 == 0) {
@@ -1027,14 +1027,16 @@ void BossFd_Fly(BossFd* this, PlayState* play) {
 
 void BossFd_Wait(BossFd* this, PlayState* play) {
     if (this->handoffSignal == FD2_SIGNAL_FLY) { // Set by BossFd2
-        u8 temp_rand;
-
         this->handoffSignal = FD2_SIGNAL_NONE;
         BossFd_SetupFly(this, play);
-        do {
-            temp_rand = Rand_ZeroFloat(8.9f);
-        } while (temp_rand == this->holeIndex);
-        this->holeIndex = temp_rand;
+        {
+            u8 temp_rand;
+
+            do {
+                temp_rand = Rand_ZeroFloat(8.9f);
+            } while (temp_rand == this->holeIndex);
+            this->holeIndex = temp_rand;
+        }
         if (1) {} // Needed for matching
         this->targetPosition.x = sHoleLocations[this->holeIndex].x;
         this->targetPosition.y = sHoleLocations[this->holeIndex].y - 200.0f;
@@ -1071,7 +1073,6 @@ void BossFd_Effects(BossFd* this, PlayState* play) {
     s16 eyeStates[] = { EYE_OPEN, EYE_HALF, EYE_CLOSED, EYE_CLOSED, EYE_HALF };
     f32 temp_x;
     f32 temp_z;
-    s16 i;
 
     if (1) {} // Needed for match
 
@@ -1088,6 +1089,8 @@ void BossFd_Effects(BossFd* this, PlayState* play) {
         play->envCtx.prevLightSetting = 0;
         Math_ApproachF(&play->envCtx.lightBlend, 1.0f, 1.0f, 0.05f);
     } else if (this->fogMode == 2) {
+        s16 pad;
+
         this->fogMode--;
         play->envCtx.lightSettingOverride = 0;
         Math_ApproachF(&play->envCtx.lightBlend, 0.55f + 0.05f * Math_SinS(this->work[BFD_VAR_TIMER] * 0x3E00), 1.0f,
@@ -1096,6 +1099,8 @@ void BossFd_Effects(BossFd* this, PlayState* play) {
         play->envCtx.lightSetting = 3;
         play->envCtx.prevLightSetting = 0;
     } else if (this->fogMode == 10) {
+        s16 pad;
+
         this->fogMode = 1;
         play->envCtx.lightSettingOverride = 0;
         Math_ApproachF(&play->envCtx.lightBlend, 0.21f + 0.07f * Math_SinS(this->work[BFD_VAR_TIMER] * 0xC00), 1.0f,
@@ -1150,7 +1155,7 @@ void BossFd_Effects(BossFd* this, PlayState* play) {
         Vec3f spawnVel1;
         Vec3f spawnAccel1;
         Vec3f spawnPos1;
-        s32 pad;
+        s16 i;
 
         Audio_PlaySfxGeneral(NA_SE_EN_VALVAISA_APPEAR - SFX_FLAG, &this->actor.projectedPos, 4,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
@@ -1220,6 +1225,7 @@ void BossFd_Effects(BossFd* this, PlayState* play) {
         breathOpacity = (this->fireBreathTimer >= 6) ? 255 : this->fireBreathTimer * 50;
     }
     if (breathOpacity != 0) {
+        s16 i;
         f32 spawnAngleX;
         f32 spawnAngleY;
         Vec3f spawnSpeed2 = { 0.0f, 0.0f, 0.0f };
@@ -1299,12 +1305,8 @@ void BossFd_CollisionCheck(BossFd* this, PlayState* play) {
 }
 
 void BossFd_Update(Actor* thisx, PlayState* play) {
-    s32 pad;
-    BossFd* this = (BossFd*)thisx;
-    f32 headGlow;
-    f32 rManeGlow;
-    f32 lManeGlow;
     s16 i;
+    BossFd* this = (BossFd*)thisx;
 
     PRINTF("FD MOVE START \n");
     this->work[BFD_VAR_TIMER]++;
@@ -1339,47 +1341,55 @@ void BossFd_Update(Actor* thisx, PlayState* play) {
     this->fwork[BFD_TEX2_SCROLL_X] += 3.0f;
     this->fwork[BFD_TEX2_SCROLL_Y] -= 2.0f;
 
-    Math_ApproachF(&this->fwork[BFD_BODY_TEX2_ALPHA], (this->work[BFD_VAR_TIMER] & 0x10) ? 30.0f : 158.0f, 1.0f, 8.0f);
-    if (this->skinSegments == 0) {
-        this->fwork[BFD_HEAD_TEX2_ALPHA] = this->fwork[BFD_BODY_TEX2_ALPHA];
-    } else {
-        headGlow = (this->work[BFD_VAR_TIMER] & 4) ? 0.0f : 255.0f;
-        Math_ApproachF(&this->fwork[BFD_HEAD_TEX2_ALPHA], headGlow, 1.0f, 64.0f);
-    }
+    if (1) {
+        f32 headGlow;
+        f32 rManeGlow;
+        f32 lManeGlow;
+        s32 pad;
 
-    headGlow = (this->work[BFD_VAR_TIMER] & 8) ? 128.0f : 255.0f;
-    rManeGlow = ((this->work[BFD_VAR_TIMER] + 3) & 8) ? 128.0f : 255.0f;
-    lManeGlow = ((this->work[BFD_VAR_TIMER] + 6) & 8) ? 128.0f : 255.0f;
+        Math_ApproachF(&this->fwork[BFD_BODY_TEX2_ALPHA], (this->work[BFD_VAR_TIMER] & 0x10) ? 30.0f : 158.0f, 1.0f,
+                       8.0f);
+        if (this->skinSegments == 0) {
+            this->fwork[BFD_HEAD_TEX2_ALPHA] = this->fwork[BFD_BODY_TEX2_ALPHA];
+        } else {
+            headGlow = (this->work[BFD_VAR_TIMER] & 4) ? 0.0f : 255.0f;
+            Math_ApproachF(&this->fwork[BFD_HEAD_TEX2_ALPHA], headGlow, 1.0f, 64.0f);
+        }
 
-    Math_ApproachF(&this->fwork[BFD_MANE_COLOR_CENTER], headGlow, 1.0f, 16.0f);
-    Math_ApproachF(&this->fwork[BFD_MANE_COLOR_RIGHT], rManeGlow, 1.0f, 16.0f);
-    Math_ApproachF(&this->fwork[BFD_MANE_COLOR_LEFT], lManeGlow, 1.0f, 16.0f);
+        headGlow = (this->work[BFD_VAR_TIMER] & 8) ? 128.0f : 255.0f;
+        rManeGlow = ((this->work[BFD_VAR_TIMER] + 3) & 8) ? 128.0f : 255.0f;
+        lManeGlow = ((this->work[BFD_VAR_TIMER] + 6) & 8) ? 128.0f : 255.0f;
 
-    if (this->work[BFD_ROCK_TIMER] != 0) {
-        this->work[BFD_ROCK_TIMER]--;
-        if ((this->work[BFD_ROCK_TIMER] % 16) == 0) {
-            EnVbBall* bossFdRock = (EnVbBall*)Actor_SpawnAsChild(
-                &play->actorCtx, &this->actor, play, ACTOR_EN_VB_BALL, this->actor.world.pos.x, 1000.0f,
-                this->actor.world.pos.z, 0, 0, (s16)Rand_ZeroFloat(50.0f) + 130, 100);
+        Math_ApproachF(&this->fwork[BFD_MANE_COLOR_CENTER], headGlow, 1.0f, 16.0f);
+        Math_ApproachF(&this->fwork[BFD_MANE_COLOR_RIGHT], rManeGlow, 1.0f, 16.0f);
+        Math_ApproachF(&this->fwork[BFD_MANE_COLOR_LEFT], lManeGlow, 1.0f, 16.0f);
 
-            if (bossFdRock != NULL) {
-                for (i = 0; i < 10; i++) {
-                    Vec3f debrisVel = { 0.0f, 0.0f, 0.0f };
-                    Vec3f debrisAccel = { 0.0f, -1.0f, 0.0f };
-                    Vec3f debrisPos;
+        if (this->work[BFD_ROCK_TIMER] != 0) {
+            this->work[BFD_ROCK_TIMER]--;
+            if ((this->work[BFD_ROCK_TIMER] % 16) == 0) {
+                EnVbBall* bossFdRock = (EnVbBall*)Actor_SpawnAsChild(
+                    &play->actorCtx, &this->actor, play, ACTOR_EN_VB_BALL, this->actor.world.pos.x, 1000.0f,
+                    this->actor.world.pos.z, 0, 0, (s16)Rand_ZeroFloat(50.0f) + 130, 100);
 
-                    debrisPos.x = Rand_CenteredFloat(300.0f) + bossFdRock->actor.world.pos.x;
-                    debrisPos.y = Rand_CenteredFloat(300.0f) + bossFdRock->actor.world.pos.y;
-                    debrisPos.z = Rand_CenteredFloat(300.0f) + bossFdRock->actor.world.pos.z;
+                if (bossFdRock != NULL) {
+                    for (i = 0; i < 10; i++) {
+                        Vec3f debrisVel = { 0.0f, 0.0f, 0.0f };
+                        Vec3f debrisAccel = { 0.0f, -1.0f, 0.0f };
+                        Vec3f debrisPos;
 
-                    BossFd_SpawnDebris(this->effects, &debrisPos, &debrisVel, &debrisAccel,
-                                       (s16)Rand_ZeroFloat(15.0f) + 20);
+                        debrisPos.x = Rand_CenteredFloat(300.0f) + bossFdRock->actor.world.pos.x;
+                        debrisPos.y = Rand_CenteredFloat(300.0f) + bossFdRock->actor.world.pos.y;
+                        debrisPos.z = Rand_CenteredFloat(300.0f) + bossFdRock->actor.world.pos.z;
+
+                        BossFd_SpawnDebris(this->effects, &debrisPos, &debrisVel, &debrisAccel,
+                                           (s16)Rand_ZeroFloat(15.0f) + 20);
+                    }
                 }
             }
         }
     }
 
-    if (1) { // Needed for matching, and also to define new variables
+    if (1) {
         Vec3f emberVel = { 0.0f, 0.0f, 0.0f };
         Vec3f emberAccel = { 0.0f, 0.0f, 0.0f };
         Vec3f emberPos;
@@ -1432,7 +1442,7 @@ void BossFd_UpdateEffects(BossFd* this, PlayState* play) {
     Color_RGB8 colors[4] = { { 255, 128, 0 }, { 255, 0, 0 }, { 255, 255, 0 }, { 255, 0, 0 } };
     Vec3f diff;
     s16 i1;
-    s16 i2;
+    s16 cInd;
 
     for (i1 = 0; i1 < BOSSFD_EFFECT_COUNT; i1++, effect++) {
         if (effect->type != BFD_FX_NONE) {
@@ -1446,7 +1456,7 @@ void BossFd_UpdateEffects(BossFd* this, PlayState* play) {
             effect->velocity.y += effect->accel.y;
             effect->velocity.z += effect->accel.z;
             if (effect->type == BFD_FX_EMBER) {
-                s16 cInd = effect->timer1 % 4;
+                cInd = effect->timer1 % 4;
 
                 effect->color.r = colors[cInd].r;
                 effect->color.g = colors[cInd].g;
@@ -1477,6 +1487,8 @@ void BossFd_UpdateEffects(BossFd* this, PlayState* play) {
                     this->timers[3] = 50;
                     func_8002F6D4(play, NULL, 5.0f, effect->kbAngle, 0.0f, 0x30);
                     if (!player->bodyIsBurning) {
+                        s16 i2;
+
                         for (i2 = 0; i2 < PLAYER_BODYPART_MAX; i2++) {
                             player->bodyFlameTimers[i2] = Rand_S16Offset(0, 200);
                         }

--- a/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
+++ b/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2.c
@@ -224,11 +224,10 @@ void BossFd2_SetupEmerge(BossFd2* this, PlayState* play) {
 }
 
 void BossFd2_Emerge(BossFd2* this, PlayState* play) {
-    s8 health;
+    s16 holeTime;
     BossFd* bossFd = (BossFd*)this->actor.parent;
     Player* player = GET_PLAYER(play);
     s16 i;
-    s16 holeTime;
 
     PRINTF("UP 1    mode %d\n", this->work[FD2_ACTION_STATE]);
     SkelAnime_Update(&this->skelAnime);
@@ -239,6 +238,8 @@ void BossFd2_Emerge(BossFd2* this, PlayState* play) {
             PRINTF("PL time %x \n", player);
             PRINTF("MT time %x \n", bossFd);
             if ((this->timers[0] == 0) && (player->actor.world.pos.y > 70.0f)) {
+                s8 health;
+
                 PRINTF("UP 1.6 \n");
                 bossFd->faceExposed = 0;
                 bossFd->holePosition.x = this->actor.world.pos.x;
@@ -645,7 +646,6 @@ void BossFd2_Death(BossFd2* this, PlayState* play) {
     f32 pad3;
     f32 pad2;
     f32 pad1;
-    f32 cameraShake;
     SkelAnime* skelAnime = &this->skelAnime;
 
     SkelAnime_Update(skelAnime);
@@ -766,6 +766,8 @@ void BossFd2_Death(BossFd2* this, PlayState* play) {
             this->subCamEyeNext.y = 140.0f;
             Math_ApproachF(&this->subCamEyeNext.z, 220.0f, 0.5f, 1.15f);
             if (bossFd->work[BFD_CAM_SHAKE_TIMER] != 0) {
+                f32 cameraShake;
+
                 bossFd->work[BFD_CAM_SHAKE_TIMER]--;
                 cameraShake = bossFd->work[BFD_CAM_SHAKE_TIMER] / 0.5f;
                 if (cameraShake >= 20.0f) {

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -184,6 +184,8 @@ void BossGanonEff_SpawnLightRay(PlayState* play, Vec3f* pos, Vec3f* velocity, Ve
 
     for (i = 0; i < 150; i++, eff++) {
         if (eff->type == GDF_EFF_NONE) {
+            s32 pad;
+
             eff->type = GDF_EFF_LIGHT_RAY;
             eff->pos = *pos;
             eff->velocity = *velocity;
@@ -1222,9 +1224,6 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
     Vec3f sp98;
     Vec3f sp8C;
     Vec3f sp80;
-    Vec3f sp74;
-    Camera* mainCam;
-    Vec3f sp64;
 
     gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.slots[this->animObjectSlot].segment);
 
@@ -1570,7 +1569,8 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
                 }
 
                 if (this->csTimer == 190) {
-                    sp74 = this->actor.world.pos;
+                    Vec3f sp74 = this->actor.world.pos;
+
                     sp74.y = 4102.0f;
                     BossGanonEff_SpawnDustDark(play, &sp74, 0.2f, 0.7f);
                 }
@@ -1782,7 +1782,7 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
             this->csCamAt.z = (sZelda->actor.world.pos.z - 25.0f) + 80.0f;
 
             if (this->csTimer > 50) {
-                mainCam = Play_GetCamera(play, CAM_ID_MAIN);
+                Camera* mainCam = Play_GetCamera(play, CAM_ID_MAIN);
 
                 mainCam->eye = this->csCamEye;
                 mainCam->eyeNext = this->csCamEye;
@@ -1807,6 +1807,8 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
     }
 
     if (this->csCamIndex != 0) {
+        Vec3f sp64;
+
         if (moveCam) {
             Math_ApproachF(&this->csCamEye.x, this->csCamTargetEye.x, this->csCamMovementScale,
                            this->csCamEyeMaxStep.x * this->csCamMaxStepScale);
@@ -1830,10 +1832,10 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, PlayState* play) {
 
 void BossGanon_SetupPoundFloor(BossGanon* this, PlayState* play) {
     this->unk_1C2 = 0;
-    this->timers[0] = 40;
-    this->actionFunc = BossGanon_PoundFloor;
     this->actor.velocity.x = 0.0f;
     this->actor.velocity.y = 0.0f;
+    this->timers[0] = 40;
+    this->actionFunc = BossGanon_PoundFloor;
     this->fwork[GDF_CENTER_POS] = 100.0f;
 }
 
@@ -1844,8 +1846,6 @@ void BossGanon_PoundFloor(BossGanon* this, PlayState* play) {
     f32 targetPosZ;
     Vec3f sp6C;
     Vec3f sp60;
-    Vec3f sp54;
-    Vec3f sp48;
 
     SkelAnime_Update(&this->skelAnime);
 
@@ -1951,13 +1951,15 @@ void BossGanon_PoundFloor(BossGanon* this, PlayState* play) {
     }
 
     if ((this->unk_19C == 35) || (this->unk_19C == 30) || (this->unk_19C == 25)) {
-        sp54 = this->actor.world.pos;
+        Vec3f sp54 = this->actor.world.pos;
+
         sp54.y = 0.0f;
         BossGanonEff_SpawnDustLight(play, &sp54, 0, 3.0f, this->unk_19C - 25);
     }
 
     if (this->unk_19C == 35) {
-        sp48 = this->actor.world.pos;
+        Vec3f sp48 = this->actor.world.pos;
+
         sp48.y = 0.0f;
         BossGanonEff_SpawnShockwave(play, &sp48, 0, 3.0f);
     }
@@ -1965,9 +1967,9 @@ void BossGanon_PoundFloor(BossGanon* this, PlayState* play) {
 
 void BossGanon_SetupChargeBigMagic(BossGanon* this, PlayState* play) {
     this->unk_1C2 = 0;
-    this->timers[0] = 30;
     this->actor.velocity.x = 0.0f;
     this->actor.velocity.y = 0.0f;
+    this->timers[0] = 30;
     this->fwork[GDF_CENTER_POS] = 100.0f;
     this->unk_1AA = Rand_ZeroFloat(20000.0f);
     this->unk_1AC = 0;
@@ -3332,8 +3334,8 @@ f32 BossGanon_RandZeroOne(void) {
     return fabsf(randFloat);
 }
 
-void BossGanon_DrawShock(BossGanon* this, PlayState* play) {
-    s32 pad;
+void BossGanon_DrawShock(BossGanon* this, PlayState* play2) {
+    PlayState* play = (PlayState*)play2;
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     s16 i;
 
@@ -3346,12 +3348,12 @@ void BossGanon_DrawShock(BossGanon* this, PlayState* play) {
         gSPDisplayList(POLY_XLU_DISP++, gGanondorfLightBallMaterialDL);
 
         if (this->unk_2E8 != 0) {
-            Player* player = GET_PLAYER(play);
+            Player* player = GET_PLAYER(play2);
 
             for (i = 0; i < PLAYER_BODYPART_MAX; i++) {
                 Matrix_Translate(player->bodyPartsPos[i].x, player->bodyPartsPos[i].y, player->bodyPartsPos[i].z,
                                  MTXMODE_NEW);
-                Matrix_ReplaceRotation(&play->billboardMtxF);
+                Matrix_ReplaceRotation(&play2->billboardMtxF);
                 Matrix_Scale(this->unk_49C[i], this->unk_49C[i], this->unk_49C[i], MTXMODE_APPLY);
                 Matrix_RotateZ(Rand_CenteredFloat(M_PI), MTXMODE_APPLY);
                 gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gfxCtx, "../z_boss_ganon.c", 7384),
@@ -3361,7 +3363,7 @@ void BossGanon_DrawShock(BossGanon* this, PlayState* play) {
         } else {
             for (i = 1; i < 15; i++) {
                 Matrix_Translate(this->unk_2EC[i].x, this->unk_2EC[i].y, this->unk_2EC[i].z, MTXMODE_NEW);
-                Matrix_ReplaceRotation(&play->billboardMtxF);
+                Matrix_ReplaceRotation(&play2->billboardMtxF);
                 Matrix_Scale(this->unk_49C[i], this->unk_49C[i], this->unk_49C[i], MTXMODE_APPLY);
 
                 if (!this->shockGlow) {
@@ -3388,8 +3390,8 @@ void BossGanon_DrawShock(BossGanon* this, PlayState* play) {
     CLOSE_DISPS(gfxCtx, "../z_boss_ganon.c", 7465);
 }
 
-void BossGanon_DrawHandLightBall(BossGanon* this, PlayState* play) {
-    s32 pad;
+void BossGanon_DrawHandLightBall(BossGanon* this, PlayState* play2) {
+    PlayState* play = (PlayState*)play2;
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     s32 alpha;
 
@@ -3428,8 +3430,8 @@ void BossGanon_DrawHandLightBall(BossGanon* this, PlayState* play) {
     }
 }
 
-void BossGanon_DrawBigMagicCharge(BossGanon* this, PlayState* play) {
-    s32 pad;
+void BossGanon_DrawBigMagicCharge(BossGanon* this, PlayState* play2) {
+    PlayState* play = (PlayState*)play2;
     f32 yRot;
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     s16 i;
@@ -3508,6 +3510,8 @@ void BossGanon_DrawBigMagicCharge(BossGanon* this, PlayState* play) {
 
             Matrix_Pop();
         }
+
+        if (1) {}
 
         CLOSE_DISPS(gfxCtx, "../z_boss_ganon.c", 7721);
     }
@@ -3836,6 +3840,8 @@ s32 BossGanon_CheckFallingPlatforms(BossGanon* this, PlayState* play, Vec3f* che
             f32 zDiff = platform->dyna.actor.world.pos.z - checkPos->z;
 
             if ((fabsf(xDiff) < 60.0f) && (yDiff < 20.0f) && (yDiff > -20.0f) && (fabsf(zDiff) < 60.0f)) {
+                s32 pad;
+
                 platform->isFalling = true;
                 platform->visibleSides = OTYUKA_SIDE_ALL;
 
@@ -3972,6 +3978,7 @@ void BossGanon_LightBall_Update(Actor* thisx, PlayState* play2) {
                                 this->unk_1C2 = 1;
                             } else {
                                 this->unk_1C2 = 3;
+                                break;
                             }
                         }
                     }
@@ -4162,6 +4169,8 @@ void BossGanon_LightBall_Draw(Actor* thisx, PlayState* play) {
         gSPDisplayList(POLY_XLU_DISP++, gGanondorfSquareDL);
     }
 
+    if (1) {}
+
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon.c", 9911);
 }
 
@@ -4170,14 +4179,6 @@ void func_808E1EB4(Actor* thisx, PlayState* play2) {
     BossGanon* this = (BossGanon*)thisx;
     PlayState* play = play2;
     BossGanon* dorf = (BossGanon*)this->actor.parent;
-    f32 xDiff;
-    f32 yDiff;
-    f32 zDiff;
-    f32 xzDist;
-    s16 xRotTarget;
-    s16 yRotTarget;
-    Vec3f vel;
-    Vec3f accel;
 
     this->unk_1A2++;
     dorf->envLightMode = 1;
@@ -4207,6 +4208,15 @@ void func_808E1EB4(Actor* thisx, PlayState* play2) {
             this->unk_1C2 = 1;
         }
     } else if (this->unk_1C2 == 1) {
+        f32 xDiff;
+        f32 yDiff;
+        f32 zDiff;
+        f32 xzDist;
+        s16 xRotTarget;
+        s16 yRotTarget;
+        Vec3f vel;
+        Vec3f accel;
+
         xDiff = dorf->unk_1FC.x - this->actor.world.pos.x;
         yDiff = dorf->unk_1FC.y - this->actor.world.pos.y;
         zDiff = dorf->unk_1FC.z - this->actor.world.pos.z;
@@ -4305,8 +4315,6 @@ void func_808E2544(Actor* thisx, PlayState* play) {
     BossGanon* dorf = (BossGanon*)this->actor.parent;
     s32 pad;
     Player* player = GET_PLAYER(play);
-    ColliderElement* acHitElem;
-    Vec3f sp60;
 
     this->unk_1A2++;
     Actor_SetScale(&this->actor, 0.01f);
@@ -4415,7 +4423,7 @@ void func_808E2544(Actor* thisx, PlayState* play) {
             }
 
             if (this->collider.base.acFlags & AC_HIT) {
-                acHitElem = this->collider.elem.acHitElem;
+                ColliderElement* acHitElem = this->collider.elem.acHitElem;
 
                 this->collider.base.acFlags &= ~AC_HIT;
 
@@ -4524,6 +4532,8 @@ void func_808E2544(Actor* thisx, PlayState* play) {
     }
 
     if (numEffects) {
+        Vec3f sp60;
+
         SfxSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, 80, NA_SE_EN_FANTOM_THUNDER);
 
         for (i = 0; i < numEffects; i++) {
@@ -4676,6 +4686,8 @@ void BossGanon_UpdateEffects(PlayState* play) {
 
                 Math_ApproachF(&eff->unk_38, eff->unk_40, 1.0f, (eff->unk_40 / 15.0f) * 4.0f);
             } else if (eff->type == GDF_EFF_SHOCK) {
+                s32 pad4;
+
                 if (eff->unk_2E == GDF_SHOCK_DORF_YELLOW) {
                     bodyPart = (s16)Rand_ZeroFloat(13.9f) + 1;
 

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -3334,26 +3334,26 @@ f32 BossGanon_RandZeroOne(void) {
     return fabsf(randFloat);
 }
 
-void BossGanon_DrawShock(BossGanon* this, PlayState* play2) {
-    PlayState* play = (PlayState*)play2;
-    GraphicsContext* gfxCtx = play->state.gfxCtx;
+void BossGanon_DrawShock(BossGanon* this, PlayState* play) {
+    GameState* gameState = &play->state;
+    GraphicsContext* gfxCtx = gameState->gfxCtx;
     s16 i;
 
     OPEN_DISPS(gfxCtx, "../z_boss_ganon.c", 7350);
 
     if ((this->unk_2E8 != 0) || (this->unk_2E6 != 0)) {
-        Gfx_SetupDL_25Xlu(play->state.gfxCtx);
+        Gfx_SetupDL_25Xlu(gameState->gfxCtx);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 255, 255);
         gDPSetEnvColor(POLY_XLU_DISP++, 255, 255, 0, 0);
         gSPDisplayList(POLY_XLU_DISP++, gGanondorfLightBallMaterialDL);
 
         if (this->unk_2E8 != 0) {
-            Player* player = GET_PLAYER(play2);
+            Player* player = GET_PLAYER(play);
 
             for (i = 0; i < PLAYER_BODYPART_MAX; i++) {
                 Matrix_Translate(player->bodyPartsPos[i].x, player->bodyPartsPos[i].y, player->bodyPartsPos[i].z,
                                  MTXMODE_NEW);
-                Matrix_ReplaceRotation(&play2->billboardMtxF);
+                Matrix_ReplaceRotation(&play->billboardMtxF);
                 Matrix_Scale(this->unk_49C[i], this->unk_49C[i], this->unk_49C[i], MTXMODE_APPLY);
                 Matrix_RotateZ(Rand_CenteredFloat(M_PI), MTXMODE_APPLY);
                 gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gfxCtx, "../z_boss_ganon.c", 7384),
@@ -3363,7 +3363,7 @@ void BossGanon_DrawShock(BossGanon* this, PlayState* play2) {
         } else {
             for (i = 1; i < 15; i++) {
                 Matrix_Translate(this->unk_2EC[i].x, this->unk_2EC[i].y, this->unk_2EC[i].z, MTXMODE_NEW);
-                Matrix_ReplaceRotation(&play2->billboardMtxF);
+                Matrix_ReplaceRotation(&play->billboardMtxF);
                 Matrix_Scale(this->unk_49C[i], this->unk_49C[i], this->unk_49C[i], MTXMODE_APPLY);
 
                 if (!this->shockGlow) {
@@ -3375,7 +3375,7 @@ void BossGanon_DrawShock(BossGanon* this, PlayState* play2) {
 
                 if (this->shockGlow) {
                     gSPSegment(POLY_XLU_DISP++, 0x08,
-                               Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, 0, 0, 32, 64, 1, 0,
+                               Gfx_TwoTexScroll(gameState->gfxCtx, G_TX_RENDERTILE, 0, 0, 32, 64, 1, 0,
                                                 (this->unk_1A2 + i) * -15, 32, 64));
                     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 200, 255, 170, 255);
                     gDPSetEnvColor(POLY_XLU_DISP++, 255, 255, 0, 128);
@@ -3390,15 +3390,15 @@ void BossGanon_DrawShock(BossGanon* this, PlayState* play2) {
     CLOSE_DISPS(gfxCtx, "../z_boss_ganon.c", 7465);
 }
 
-void BossGanon_DrawHandLightBall(BossGanon* this, PlayState* play2) {
-    PlayState* play = (PlayState*)play2;
-    GraphicsContext* gfxCtx = play->state.gfxCtx;
+void BossGanon_DrawHandLightBall(BossGanon* this, PlayState* play) {
+    GameState* gameState = &play->state;
+    GraphicsContext* gfxCtx = gameState->gfxCtx;
     s32 alpha;
 
     OPEN_DISPS(gfxCtx, "../z_boss_ganon.c", 7476);
 
     if (this->handLightBallScale > 0.0f) {
-        Gfx_SetupDL_25Xlu(play->state.gfxCtx);
+        Gfx_SetupDL_25Xlu(gameState->gfxCtx);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 255, 255);
 
         if ((this->unk_1A2 % 2) != 0) {
@@ -3422,7 +3422,7 @@ void BossGanon_DrawHandLightBall(BossGanon* this, PlayState* play2) {
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 155, alpha);
         Matrix_Translate(this->unk_260.x, 0.0f, this->unk_260.z, MTXMODE_NEW);
         Matrix_Scale(this->handLightBallScale * 0.75f, 1.0f, this->handLightBallScale * 0.75f, MTXMODE_APPLY);
-        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon.c", 7531),
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon.c", 7531),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, gGanondorfLightCoreDL);
 
@@ -3430,22 +3430,22 @@ void BossGanon_DrawHandLightBall(BossGanon* this, PlayState* play2) {
     }
 }
 
-void BossGanon_DrawBigMagicCharge(BossGanon* this, PlayState* play2) {
-    PlayState* play = (PlayState*)play2;
+void BossGanon_DrawBigMagicCharge(BossGanon* this, PlayState* play) {
+    GameState* gameState = &play->state;
     f32 yRot;
-    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    GraphicsContext* gfxCtx = gameState->gfxCtx;
     s16 i;
 
     OPEN_DISPS(gfxCtx, "../z_boss_ganon.c", 7548);
 
     if (this->unk_284 > 0.0f) {
-        Gfx_SetupDL_25Xlu(play->state.gfxCtx);
+        Gfx_SetupDL_25Xlu(gameState->gfxCtx);
 
         // light flecks
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 170, (s8)this->unk_290);
         gDPSetEnvColor(POLY_XLU_DISP++, 200, 255, 0, 128);
         gSPSegment(POLY_XLU_DISP++, 0x08,
-                   Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, this->unk_1A2 * -2, 0, 0x40, 0x40, 1, 0,
+                   Gfx_TwoTexScroll(gameState->gfxCtx, G_TX_RENDERTILE, this->unk_1A2 * -2, 0, 0x40, 0x40, 1, 0,
                                     this->unk_1A2 * 0xA, 0x40, 0x40));
         Matrix_Translate(this->unk_278.x, this->unk_278.y, this->unk_278.z, MTXMODE_NEW);
         Matrix_ReplaceRotation(&play->billboardMtxF);
@@ -3462,14 +3462,14 @@ void BossGanon_DrawBigMagicCharge(BossGanon* this, PlayState* play2) {
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 0, 100, (s8)this->unk_288);
         gSPSegment(POLY_XLU_DISP++, 0x09,
-                   Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, 0, 0, 0x20, 0x20, 1, 0, this->unk_1A2 * -4,
+                   Gfx_TwoTexScroll(gameState->gfxCtx, G_TX_RENDERTILE, 0, 0, 0x20, 0x20, 1, 0, this->unk_1A2 * -4,
                                     0x20, 0x20));
         gSPDisplayList(POLY_XLU_DISP++, gGanondorfBigMagicBGCircleDL);
 
         // yellow background dot
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 150, 170, 0, (s8)this->unk_288);
         gSPSegment(POLY_XLU_DISP++, 0x0A,
-                   Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, 0, 0, 0x20, 0x20, 1, this->unk_1A2 * 2,
+                   Gfx_TwoTexScroll(gameState->gfxCtx, G_TX_RENDERTILE, 0, 0, 0x20, 0x20, 1, this->unk_1A2 * 2,
                                     this->unk_1A2 * -0x14, 0x40, 0x40));
         gSPDisplayList(POLY_XLU_DISP++, gGanondorfDotDL);
 
@@ -3518,10 +3518,10 @@ void BossGanon_DrawBigMagicCharge(BossGanon* this, PlayState* play2) {
 }
 
 void BossGanon_DrawTriforce(BossGanon* this, PlayState* play) {
-    s32 pad;
+    GameState* gameState = &play->state;
 
     if (this->fwork[GDF_TRIFORCE_PRIM_A] > 0.0f) {
-        OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon.c", 7732);
+        OPEN_DISPS(gameState->gfxCtx, "../z_boss_ganon.c", 7732);
 
         Matrix_Push();
 
@@ -3559,26 +3559,26 @@ void BossGanon_DrawTriforce(BossGanon* this, PlayState* play) {
         }
 
         Matrix_Scale(this->fwork[GDF_TRIFORCE_SCALE], this->fwork[GDF_TRIFORCE_SCALE], 1.0f, MTXMODE_APPLY);
-        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon.c", 7779),
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon.c", 7779),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gGanondorfTriforceDL));
 
         Matrix_Pop();
 
-        CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon.c", 7782);
+        CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon.c", 7782);
     }
 }
 
 void BossGanon_DrawDarkVortex(BossGanon* this, PlayState* play) {
-    s32 pad;
+    GameState* gameState = &play->state;
 
     if (this->fwork[GDF_VORTEX_ALPHA] > 0.0f) {
-        OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon.c", 7792);
+        OPEN_DISPS(gameState->gfxCtx, "../z_boss_ganon.c", 7792);
 
         Matrix_Push();
         gDPPipeSync(POLY_XLU_DISP++);
         gSPSegment(POLY_XLU_DISP++, 0x08,
-                   Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, this->unk_1A2 * -8, 0, 0x20, 0x40, 1,
+                   Gfx_TwoTexScroll(gameState->gfxCtx, G_TX_RENDERTILE, this->unk_1A2 * -8, 0, 0x20, 0x40, 1,
                                     this->unk_1A2 * -4, this->unk_1A2 * -8, 0x20, 0x20));
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 100, 0, 200, (s8)this->fwork[GDF_VORTEX_ALPHA]);
         gDPSetEnvColor(POLY_XLU_DISP++, 130, 0, 0, 128);
@@ -3594,13 +3594,13 @@ void BossGanon_DrawDarkVortex(BossGanon* this, PlayState* play) {
 
         Matrix_Scale(this->fwork[GDF_VORTEX_SCALE], this->fwork[GDF_VORTEX_SCALE], this->fwork[GDF_VORTEX_SCALE],
                      MTXMODE_APPLY);
-        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon.c", 7841),
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon.c", 7841),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gGanondorfVortexDL));
 
         Matrix_Pop();
 
-        CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon.c", 7844);
+        CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon.c", 7844);
     }
 }
 
@@ -3750,13 +3750,13 @@ void BossGanon_GenShadowTexture(u8* tex, BossGanon* this, PlayState* play) {
 }
 
 void BossGanon_DrawShadowTexture(void* tex, BossGanon* this, PlayState* play) {
-    s32 pad;
+    GameState* gameState = &play->state;
     f32 zOffset;
-    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    GraphicsContext* gfxCtx = gameState->gfxCtx;
 
     OPEN_DISPS(gfxCtx, "../z_boss_ganon.c", 8372);
 
-    Gfx_SetupDL_25Opa(play->state.gfxCtx);
+    Gfx_SetupDL_25Opa(gameState->gfxCtx);
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 0, 0, 0, 50);
     gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
 
@@ -3768,7 +3768,7 @@ void BossGanon_DrawShadowTexture(void* tex, BossGanon* this, PlayState* play) {
     }
 
     Matrix_Scale(0.95000005f, 1.0f, 0.95000005f, MTXMODE_APPLY);
-    gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon.c", 8396),
+    gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon.c", 8396),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, gGanondorfShadowSetupDL);
     gDPLoadTextureBlock(POLY_OPA_DISP++, tex, G_IM_FMT_I, G_IM_SIZ_8b, 64, 64, 0, G_TX_NOMIRROR | G_TX_CLAMP,

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -97,14 +97,14 @@ void func_808FD210(PlayState* play, Vec3f* arg1) {
 
     effects[0].type = 1;
     effects[0].position = *arg1;
-    effects[0].unk_2E = 0;
-    effects[0].unk_01 = 0;
     effects[0].velocity.x = 25.0f;
     effects[0].velocity.y = 15.0f;
     effects[0].velocity.z = 0.0f;
     effects[0].accel.x = 0.0f;
     effects[0].accel.y = -1.0f;
     effects[0].accel.z = 0.0f;
+    effects[0].unk_2E = 0;
+    effects[0].unk_01 = 0;
 }
 
 void func_808FD27C(PlayState* play, Vec3f* position, Vec3f* velocity, f32 scale) {
@@ -751,16 +751,16 @@ void func_808FD5F4(BossGanon2* this, PlayState* play) {
                 this->subCamEye.x = effects[0].position.x + 70.0f;
                 this->subCamEye.y = effects[0].position.y - 30.0f;
                 this->subCamEye.z = effects[0].position.z + 70.0f;
+                if ((this->unk_398 & 3) == 0) {
+                    Sfx_PlaySfxCentered(NA_SE_IT_SWORD_SWING);
+                }
+                if (this->unk_398 == 25) {
+                    Player_SetCsActionWithHaltedActors(play, &this->actor, PLAYER_CSACTION_87);
+                    this->unk_39C = 25;
+                    this->unk_398 = 0;
+                }
+                break;
             }
-            if ((this->unk_398 & 3) == 0) {
-                Sfx_PlaySfxCentered(NA_SE_IT_SWORD_SWING);
-            }
-            if (this->unk_398 == 25) {
-                Player_SetCsActionWithHaltedActors(play, &this->actor, PLAYER_CSACTION_87);
-                this->unk_39C = 25;
-                this->unk_398 = 0;
-            }
-            break;
         case 25:
             SkelAnime_Update(&this->skelAnime);
             this->subCamEye.x = (player->actor.world.pos.x - 40.0f) + 80.0f;
@@ -895,7 +895,7 @@ void func_808FD5F4(BossGanon2* this, PlayState* play) {
     if (this->subCamId != SUB_CAM_ID_DONE) {
         // fake, tricks the compiler into putting some pointers on the stack
         if (zero) {
-            PRINTF(NULL, 0, 0);
+            osSyncPrintf(NULL, 0, 0);
         }
         this->subCamAt.y += this->unk_41C;
         Play_SetCameraAtEyeUp(play, this->subCamId, &this->subCamAt, &this->subCamEye, &this->subCamUp);
@@ -1283,9 +1283,6 @@ void func_80900890(BossGanon2* this, PlayState* play) {
     Player* player;
     Camera* mainCam2;
     Camera* mainCam3;
-    s32 pad;
-    f32 temp_f12;
-    f32 temp_f2;
 
     mainCam1 = Play_GetCamera(play, CAM_ID_MAIN);
     player = GET_PLAYER(play);
@@ -1341,6 +1338,8 @@ void func_80900890(BossGanon2* this, PlayState* play) {
                 Message_StartTextbox(play, 0x70D7, NULL);
             }
             if ((this->unk_1A2[1] < 30) && (Message_GetState(&play->msgCtx) == TEXT_STATE_NONE)) {
+                s32 pad;
+
                 mainCam2 = Play_GetCamera(play, CAM_ID_MAIN);
                 mainCam2->eye = this->subCamEye;
                 mainCam2->eyeNext = this->subCamEye;
@@ -1403,8 +1402,8 @@ void func_80900890(BossGanon2* this, PlayState* play) {
             }
 
             if ((this->unk_1A2[0] == 0) || (this->unk_334 != 0)) {
-                temp_f2 = -200.0f - player->actor.world.pos.x;
-                temp_f12 = -200.0f - player->actor.world.pos.z;
+                f32 temp_f2 = -200.0f - player->actor.world.pos.x;
+                f32 temp_f12 = -200.0f - player->actor.world.pos.z;
 
                 if (sqrtf(SQ(temp_f2) + SQ(temp_f12)) <= 784.0f) {
                     Animation_MorphToPlayOnce(&this->skelAnime, &gGanonGetUpAnim, 0.0f);
@@ -1466,10 +1465,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
     Player* player;
     f32 temp_f14;
     f32 temp_f12;
-    Camera* mainCam;
     s16 temp_a0_2;
-    f32 phi_f0;
-    s32 phi_a1;
 
     player = GET_PLAYER(play);
     this->unk_398++;
@@ -1619,7 +1615,8 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
             this->subCamAt.y = player->actor.world.pos.y + 40.0f;
             this->subCamAt.z = player->actor.world.pos.z;
             if (this->unk_398 == 166) {
-                mainCam = Play_GetCamera(play, CAM_ID_MAIN);
+                Camera* mainCam = Play_GetCamera(play, CAM_ID_MAIN);
+
                 mainCam->eye = this->subCamEye;
                 mainCam->eyeNext = this->subCamEye;
                 mainCam->at = this->subCamAt;
@@ -1676,6 +1673,9 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
                 this->subCamAt.y = 1117.0f;
                 this->subCamAt.z = -11.0f;
             } else {
+                f32 phi_f0;
+                s32 phi_a1;
+
                 if (this->unk_398 < 30) {
                     phi_a1 = 0;
                 } else if (this->unk_398 < 43) {
@@ -1862,6 +1862,8 @@ void func_80902348(BossGanon2* this, PlayState* play) {
     }
 
     if (this->unk_324 > 0.0f) {
+        s16 pad;
+
         player = GET_PLAYER(play);
         temp_f2 = -200.0f - player->actor.world.pos.x;
         temp_f12 = -200.0f - player->actor.world.pos.z;
@@ -1962,12 +1964,6 @@ void BossGanon2_Update(Actor* thisx, PlayState* play) {
     BossGanon2* this = (BossGanon2*)thisx;
     s32 pad;
     s16 i;
-    f32 phi_f2;
-    u16 i2;
-    Vec3f sp58;
-    Vec3f sp4C;
-    f32 angle;
-    f32 sp44;
 
     if ((this->unk_337 == 0) || (this->unk_337 == 2)) {
         BossGanon2_SetObjectSegment(this, play, OBJECT_GANON_ANIME3, false);
@@ -2051,6 +2047,8 @@ void BossGanon2_Update(Actor* thisx, PlayState* play) {
     }
 
     for (i = 0; i < ARRAY_COUNT(this->unk_348); i++) {
+        f32 phi_f2;
+
         if (i == 0) {
             phi_f2 = 0.2f;
         } else if (i == 1) {
@@ -2175,6 +2173,12 @@ void BossGanon2_Update(Actor* thisx, PlayState* play) {
         this->unk_339 = 0;
     }
     if (D_80906D78 != 0) {
+        u16 i2;
+        Vec3f sp58;
+        Vec3f sp4C;
+        f32 angle;
+        f32 sp44;
+
         D_80906D78 = 0;
 
         for (i2 = 0; i2 < 100; i2++) {
@@ -2438,10 +2442,10 @@ void func_80904108(BossGanon2* this, PlayState* play) {
 
 void func_80904340(BossGanon2* this, PlayState* play) {
     s16 i;
-    f32 rand;
-    f32 angle;
+    s32 pad;
     f32 sin;
     f32 cos;
+    f32 rand;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5196);
     Matrix_Push();
@@ -2461,16 +2465,14 @@ void func_80904340(BossGanon2* this, PlayState* play) {
         gDPPipeSync(POLY_XLU_DISP++);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 255, this->unk_328);
         BossGanon2_InitRand(this->unk_340 + 1, 0x71AC - this->unk_340, 0x263A);
-        rand = BossGanon2_RandZeroOne();
-        if (1) {}
+        rand = BossGanon2_RandZeroOne() * M_PI;
 
         for (i = 0; i < 5; i++) {
-            angle = (i * (2 * M_PI / 5)) + (rand * M_PI);
-            sin = 5000.0f * sinf(angle);
-            cos = 5000.0f * cosf(angle);
+            sin = 5000.0f * sinf((i * (2 * M_PI / 5)) + rand);
+            cos = 5000.0f * cosf((i * (2 * M_PI / 5)) + rand);
             Matrix_Translate(-200.0f + sin, 4786.0f, -200.0f + cos, MTXMODE_NEW);
             Matrix_Scale(this->unk_32C, this->unk_32C, this->unk_32C, MTXMODE_APPLY);
-            Matrix_RotateY(angle, MTXMODE_APPLY);
+            Matrix_RotateY((i * (2 * M_PI / 5)) + rand, MTXMODE_APPLY);
             Matrix_RotateZ((BossGanon2_RandZeroOne() - 0.5f) * 100.0f * 0.01f, MTXMODE_APPLY);
 
             if (BossGanon2_RandZeroOne() < 0.5f) {
@@ -2484,6 +2486,7 @@ void func_80904340(BossGanon2* this, PlayState* play) {
     }
 
     Matrix_Pop();
+    if (1) {}
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5255);
 }
 
@@ -2609,8 +2612,8 @@ void BossGanon2_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s*
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5566);
 }
 
-void func_80904D88(BossGanon2* this, PlayState* play) {
-    s32 pad;
+void func_80904D88(BossGanon2* this, PlayState* play2) {
+    PlayState* play = (PlayState*)play2;
     s16 i;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5575);
@@ -2628,7 +2631,7 @@ void func_80904D88(BossGanon2* this, PlayState* play) {
 
         for (i = 0; i < 15; i++) {
             Matrix_Translate(this->unk_234[i].x, this->unk_234[i].y, this->unk_234[i].z, MTXMODE_NEW);
-            Matrix_ReplaceRotation(&play->billboardMtxF);
+            Matrix_ReplaceRotation(&play2->billboardMtxF);
             Matrix_Scale(this->unk_30C, this->unk_30C, this->unk_30C, MTXMODE_APPLY);
             Matrix_RotateZ(Rand_CenteredFloat(M_PI), MTXMODE_APPLY);
             gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5618),
@@ -2637,11 +2640,13 @@ void func_80904D88(BossGanon2* this, PlayState* play) {
         }
     }
 
+    if (1) {}
+
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5622);
 }
 
-void func_80904FC8(BossGanon2* this, PlayState* play) {
-    s32 pad;
+void func_80904FC8(BossGanon2* this, PlayState* play2) {
+    PlayState* play = (PlayState*)play2;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5632);
 
@@ -2667,14 +2672,15 @@ void func_80904FC8(BossGanon2* this, PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5667);
 }
 
-void func_8090523C(BossGanon2* this, PlayState* play) {
-    Player* player;
+void func_8090523C(BossGanon2* this, PlayState* play2) {
     f32 phi_f20;
+    PlayState* play = (PlayState*)play2;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5675);
 
     if (this->unk_38C > 0.0f) {
         s8 i;
+        Player* player;
 
         player = GET_PLAYER(play);
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
@@ -2692,7 +2698,7 @@ void func_8090523C(BossGanon2* this, PlayState* play) {
                 phi_f20 = 1.0f - ((i - 7) * 0.2333333f); // 7 / 30
             }
 
-            Matrix_ReplaceRotation(&play->billboardMtxF);
+            Matrix_ReplaceRotation(&play2->billboardMtxF);
             Matrix_Scale(200.0f * phi_f20, 200.0f * phi_f20, 1.0f, MTXMODE_APPLY);
             Matrix_RotateZ(Rand_ZeroFloat(2.0f * M_PI), MTXMODE_APPLY);
             gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5721),
@@ -2829,14 +2835,15 @@ void BossGanon2_Draw(Actor* thisx, PlayState* play) {
 }
 
 void BossGanon2_UpdateEffects(BossGanon2* this, PlayState* play) {
-    s32 pad[5];
+    s32 pad[4];
     Player* player = GET_PLAYER(play);
     BossGanon2Effect* effect = play->specialEffects;
-    Vec3f sp78;
     s16 i;
 
     for (i = 0; i < BOSS_GANON2_EFFECT_COUNT; i++, effect++) {
         if (effect->type != 0) {
+            Vec3f sp78;
+
             effect->position.x += effect->velocity.x;
             effect->position.y += effect->velocity.y;
             effect->position.z += effect->velocity.z;
@@ -2845,6 +2852,8 @@ void BossGanon2_UpdateEffects(BossGanon2* this, PlayState* play) {
             effect->velocity.y += effect->accel.y;
             effect->velocity.z += effect->accel.z;
             if (effect->type == 1) {
+                s32 pad2;
+
                 if (effect->unk_2E == 0) {
                     effect->unk_38.z += 1.0f;
                     effect->unk_38.y = (2.0f * M_PI) / 5.0f;
@@ -2908,6 +2917,7 @@ void BossGanon2_DrawEffects(PlayState* play) {
             Vec3f spA0;
             f32 temp_f0;
             f32 angle;
+            s32 pad;
 
             Gfx_SetupDL_25Xlu(play->state.gfxCtx);
             spA0.x = play->envCtx.dirLight1.params.dir.x;
@@ -3058,8 +3068,8 @@ void BossGanon2_GenShadowTexture(void* shadowTexture, BossGanon2* this, PlayStat
 
 void BossGanon2_DrawShadowTexture(void* shadowTexture, BossGanon2* this, PlayState* play) {
     s32 pad;
-    GraphicsContext* gfxCtx = play->state.gfxCtx;
     s16 alpha;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
 
     OPEN_DISPS(gfxCtx, "../z_boss_ganon2.c", 6430);
 

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -2417,37 +2417,37 @@ void func_80903F38(BossGanon2* this, PlayState* play) {
 }
 
 void func_80904108(BossGanon2* this, PlayState* play) {
-    s32 pad;
+    GameState* gameState = &play->state;
 
     if (this->unk_324 > 0.0f) {
-        OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5131);
+        OPEN_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5131);
 
         Matrix_Push();
         gDPPipeSync(POLY_XLU_DISP++);
         gSPSegment(POLY_XLU_DISP++, 0x08,
-                   Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, (s32)play->gameplayFrames, 0, 32, 64, 1,
+                   Gfx_TwoTexScroll(gameState->gfxCtx, G_TX_RENDERTILE, (s32)play->gameplayFrames, 0, 32, 64, 1,
                                     -play->gameplayFrames * 2, -play->gameplayFrames * 8, 32, 32));
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 200, 0, (s8)this->unk_324);
         gDPSetEnvColor(POLY_XLU_DISP++, 255, 0, 0, 128);
         Matrix_Translate(-200.0f, 1086.0f, -200.0f, MTXMODE_NEW);
         Matrix_Scale(0.098000005f, 0.1f, 0.098000005f, MTXMODE_APPLY);
-        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5183),
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon2.c", 5183),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gGanonFireRingDL));
         Matrix_Pop();
 
-        CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5186);
+        CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5186);
     }
 }
 
 void func_80904340(BossGanon2* this, PlayState* play) {
+    GameState* gameState = &play->state;
     s16 i;
-    s32 pad;
     f32 sin;
     f32 cos;
     f32 rand;
 
-    OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5196);
+    OPEN_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5196);
     Matrix_Push();
 
     if ((this->unk_330 != 0) || (this->unk_328 != 0)) {
@@ -2479,7 +2479,7 @@ void func_80904340(BossGanon2* this, PlayState* play) {
                 Matrix_RotateY(M_PI, MTXMODE_APPLY);
             }
 
-            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5250),
+            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon2.c", 5250),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gGanonLightningDL));
         }
@@ -2487,14 +2487,14 @@ void func_80904340(BossGanon2* this, PlayState* play) {
 
     Matrix_Pop();
     if (1) {}
-    CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5255);
+    CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5255);
 }
 
 void func_8090464C(BossGanon2* this, PlayState* play) {
-    s32 pad;
+    GameState* gameState = &play->state;
 
     if (this->unk_1B4 > 0.0f) {
-        OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5264);
+        OPEN_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5264);
 
         Matrix_Push();
         gDPPipeSync(POLY_XLU_DISP++);
@@ -2504,12 +2504,12 @@ void func_8090464C(BossGanon2* this, PlayState* play) {
         Matrix_ReplaceRotation(&play->billboardMtxF);
         Matrix_RotateZ(-0.2f, MTXMODE_APPLY);
         Matrix_Scale(0.6f, 0.6f, 1.0f, MTXMODE_APPLY);
-        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5290),
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon2.c", 5290),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gGanonTriforceDL));
         Matrix_Pop();
 
-        CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5293);
+        CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5293);
     }
 }
 
@@ -2612,14 +2612,14 @@ void BossGanon2_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s*
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5566);
 }
 
-void func_80904D88(BossGanon2* this, PlayState* play2) {
-    PlayState* play = (PlayState*)play2;
+void func_80904D88(BossGanon2* this, PlayState* play) {
+    GameState* gameState = &play->state;
     s16 i;
 
-    OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5575);
+    OPEN_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5575);
 
     if (this->unk_30C > 0.0f) {
-        Gfx_SetupDL_25Xlu(play->state.gfxCtx);
+        Gfx_SetupDL_25Xlu(gameState->gfxCtx);
         if (this->unk_380 > 0.0f) {
             gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 170, 255);
             gDPSetEnvColor(POLY_XLU_DISP++, 255, 200, 0, 0);
@@ -2631,10 +2631,10 @@ void func_80904D88(BossGanon2* this, PlayState* play2) {
 
         for (i = 0; i < 15; i++) {
             Matrix_Translate(this->unk_234[i].x, this->unk_234[i].y, this->unk_234[i].z, MTXMODE_NEW);
-            Matrix_ReplaceRotation(&play2->billboardMtxF);
+            Matrix_ReplaceRotation(&play->billboardMtxF);
             Matrix_Scale(this->unk_30C, this->unk_30C, this->unk_30C, MTXMODE_APPLY);
             Matrix_RotateZ(Rand_CenteredFloat(M_PI), MTXMODE_APPLY);
-            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5618),
+            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon2.c", 5618),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_XLU_DISP++, gGanonLightOrbModelDL);
         }
@@ -2642,16 +2642,16 @@ void func_80904D88(BossGanon2* this, PlayState* play2) {
 
     if (1) {}
 
-    CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5622);
+    CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5622);
 }
 
-void func_80904FC8(BossGanon2* this, PlayState* play2) {
-    PlayState* play = (PlayState*)play2;
+void func_80904FC8(BossGanon2* this, PlayState* play) {
+    GameState* gameState = &play->state;
 
-    OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5632);
+    OPEN_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5632);
 
     if (this->unk_384 > 0.0f) {
-        Gfx_SetupDL_25Xlu(play->state.gfxCtx);
+        Gfx_SetupDL_25Xlu(gameState->gfxCtx);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 255, 200);
         gDPSetEnvColor(POLY_XLU_DISP++, 255, 200, 0, 0);
         gSPDisplayList(POLY_XLU_DISP++, gGanonLightOrbMaterialDL);
@@ -2660,30 +2660,30 @@ void func_80904FC8(BossGanon2* this, PlayState* play2) {
         Matrix_ReplaceRotation(&play->billboardMtxF);
         Matrix_Scale(this->unk_384, this->unk_384, this->unk_384, MTXMODE_APPLY);
         Matrix_RotateZ(this->unk_388, MTXMODE_APPLY);
-        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5661),
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon2.c", 5661),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gGanonLightOrbModelDL));
         Matrix_RotateZ(this->unk_388 * -2.0f, MTXMODE_APPLY);
-        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5664),
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon2.c", 5664),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gGanonLightOrbModelDL));
     }
 
-    CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5667);
+    CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5667);
 }
 
-void func_8090523C(BossGanon2* this, PlayState* play2) {
+void func_8090523C(BossGanon2* this, PlayState* play) {
+    GameState* gameState = &play->state;
     f32 phi_f20;
-    PlayState* play = (PlayState*)play2;
 
-    OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5675);
+    OPEN_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5675);
 
     if (this->unk_38C > 0.0f) {
         s8 i;
         Player* player;
 
         player = GET_PLAYER(play);
-        Gfx_SetupDL_25Xlu(play->state.gfxCtx);
+        Gfx_SetupDL_25Xlu(gameState->gfxCtx);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 255, (s16)this->unk_38C);
         gDPSetEnvColor(POLY_XLU_DISP++, 0, 255, 255, 0);
         gSPDisplayList(POLY_XLU_DISP++, gGanonLightOrbMaterialDL);
@@ -2698,16 +2698,16 @@ void func_8090523C(BossGanon2* this, PlayState* play2) {
                 phi_f20 = 1.0f - ((i - 7) * 0.2333333f); // 7 / 30
             }
 
-            Matrix_ReplaceRotation(&play2->billboardMtxF);
+            Matrix_ReplaceRotation(&play->billboardMtxF);
             Matrix_Scale(200.0f * phi_f20, 200.0f * phi_f20, 1.0f, MTXMODE_APPLY);
             Matrix_RotateZ(Rand_ZeroFloat(2.0f * M_PI), MTXMODE_APPLY);
-            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5721),
+            gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon2.c", 5721),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gGanonLightOrbModelDL));
         }
     }
 
-    CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5725);
+    CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5725);
 }
 
 void BossGanon2_PostLimbDraw2(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx) {
@@ -2731,15 +2731,15 @@ void BossGanon2_PostLimbDraw2(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s
 }
 
 void func_80905674(BossGanon2* this, PlayState* play) {
-    s32 pad;
+    GameState* gameState = &play->state;
 
     if (this->unk_380 > 0.0f) {
-        OPEN_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5772);
+        OPEN_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5772);
 
         Matrix_Push();
         gDPPipeSync(POLY_XLU_DISP++);
         gSPSegment(POLY_XLU_DISP++, 0x08,
-                   Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, this->unk_19C * -8, 0, 32, 64, 1,
+                   Gfx_TwoTexScroll(gameState->gfxCtx, G_TX_RENDERTILE, this->unk_19C * -8, 0, 32, 64, 1,
                                     this->unk_19C * -4, this->unk_19C * -8, 32, 32));
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 170, (s16)this->unk_37C);
         gDPSetEnvColor(POLY_XLU_DISP++, 255, 200, 0, 128);
@@ -2748,12 +2748,12 @@ void func_80905674(BossGanon2* this, PlayState* play) {
         Matrix_RotateY(-M_PI / 4.0f, MTXMODE_APPLY);
         Matrix_Scale(0.040000003f, 0.040000003f, this->unk_380, MTXMODE_APPLY);
         Matrix_RotateX(M_PI / 2.0f, MTXMODE_APPLY);
-        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 5814),
+        gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon2.c", 5814),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gGanonZeldaMagicDL));
         Matrix_Pop();
 
-        CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon2.c", 5817);
+        CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5817);
     }
 }
 
@@ -3067,13 +3067,13 @@ void BossGanon2_GenShadowTexture(void* shadowTexture, BossGanon2* this, PlayStat
 }
 
 void BossGanon2_DrawShadowTexture(void* shadowTexture, BossGanon2* this, PlayState* play) {
-    s32 pad;
+    GameState* gameState = &play->state;
     s16 alpha;
-    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    GraphicsContext* gfxCtx = gameState->gfxCtx;
 
     OPEN_DISPS(gfxCtx, "../z_boss_ganon2.c", 6430);
 
-    Gfx_SetupDL_25Opa(play->state.gfxCtx);
+    Gfx_SetupDL_25Opa(gameState->gfxCtx);
 
     if ((play->envCtx.lightSetting == 1) || (play->envCtx.lightSetting == 2)) {
         alpha = (s16)(play->envCtx.lightBlend * 180.0f) + 30;
@@ -3085,7 +3085,7 @@ void BossGanon2_DrawShadowTexture(void* shadowTexture, BossGanon2* this, PlaySta
     gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
     Matrix_Translate(this->actor.world.pos.x, this->actor.floorHeight, this->actor.world.pos.z - 20.0f, MTXMODE_NEW);
     Matrix_Scale(1.65f, 1.0f, 1.65f, MTXMODE_APPLY);
-    gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_boss_ganon2.c", 6457),
+    gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(gameState->gfxCtx, "../z_boss_ganon2.c", 6457),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, gGanonShadowMaterialDL);
     gDPLoadTextureBlock(POLY_OPA_DISP++, shadowTexture, G_IM_FMT_I, G_IM_SIZ_8b, 64, 64, 0, G_TX_NOMIRROR | G_TX_CLAMP,


### PR DESCRIPTION
The sequel to part 2. I wasn't able to solve BossFd_DrawBody or BossFd2_UpdateMane so I made scratches for those.

Highlights:
* Using both `play` and `play2` seemed to work more than once. I guess that fits with the theory that one of them is a `PlayState*` and the other is a `GameState*`.
* There's a weird `break;` in BossGanon_CheckFallingPlatforms that doesn't really fit, but the only other matches I could find were fake labels
* The .rodata hacks in `BossFd_Fly` used a variable `temp` that I had to remove, so I grabbed a random variable to use but it makes even less sense now