### PR TITLE
Restore terminal colors in retail, except in __osMalloc.c

### DIFF
--- a/include/terminal.h
+++ b/include/terminal.h
@@ -28,23 +28,11 @@
 #define VT_SGR(n) VT_ESC VT_CSI n "m"
 
 // Add more macros if necessary
-#if OOT_DEBUG
-
 #define VT_COL(back, fore) VT_SGR(VT_COLOR(BACKGROUND, back) ";" VT_COLOR(FOREGROUND, fore))
 #define VT_FGCOL(color) VT_SGR(VT_COLOR(FOREGROUND, color))
 #define VT_BGCOL(color) VT_SGR(VT_COLOR(BACKGROUND, color))
 #define VT_RST VT_SGR("")
 #define VT_CLS VT_ED(2)
-
-#else
-
-#define VT_COL(back, fore) ""
-#define VT_FGCOL(color) ""
-#define VT_BGCOL(color) ""
-#define VT_RST ""
-#define VT_CLS ""
-
-#endif
 
 // ASCII BEL character, plays an alert tone
 #define BEL '\a'

--- a/src/code/__osMalloc.c
+++ b/src/code/__osMalloc.c
@@ -852,7 +852,11 @@ u32 __osCheckArena(Arena* arena) {
     while (iter != NULL) {
         if (iter && iter->magic == NODE_MAGIC) {
             // "Oops!! (%08x %08x)"
+#if OOT_DEBUG
             osSyncPrintf(VT_COL(RED, WHITE) "おおっと！！ (%08x %08x)\n" VT_RST, iter, iter->magic);
+#else
+            osSyncPrintf("おおっと！！ (%08x %08x)\n", iter, iter->magic);
+#endif
             error = 1;
             break;
         }


### PR DESCRIPTION
In #1741 I attempted to match retail __osMalloc.c .rodata by disabling terminal colors in retail. Turns out this was probably not the right move, because they still show up in fault.c and fault_drawer.c. So, I've reverted that and ifdef'd out the string in __osMalloc.c instead.