### PR TITLE
AVOID_UB for out-of-bounds access in AudioLoad_Init

### DIFF
--- a/src/audio/lib/load.c
+++ b/src/audio/lib/load.c
@@ -1133,9 +1133,19 @@ void AudioLoad_Init(void* heap, u32 heapSize) {
         s32 i;
         u8* audioContextPtr = (u8*)&gAudioCtx;
 
+#ifndef AVOID_UB
+        //! @bug This clearing loop sets one extra byte to 0 following gAudioCtx.
+        //! In practice this is harmless as it would set the most significant byte in gAudioCustomUpdateFunction to 0,
+        //! which was just reset to NULL above.
         for (i = sizeof(gAudioCtx); i >= 0; i--) {
             *audioContextPtr++ = 0;
         }
+#else
+        // Avoid out-of-bounds variable access
+        for (i = sizeof(gAudioCtx); i > 0; i--) {
+            *audioContextPtr++ = 0;
+        }
+#endif
     }
 
     // 1000 is a conversion from seconds to milliseconds


### PR DESCRIPTION
This is (potentially) no longer harmless if using a compiler that is allowed to reorder global variables