### PR TITLE
Some GCC flags improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ endif
 ASFLAGS := -march=vr4300 -32 -no-pad-sections -Iinclude
 
 ifeq ($(COMPILER),gcc)
-  CFLAGS += -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -mdivide-breaks -fno-zero-initialized-in-bss -fno-toplevel-reorder -ffreestanding -fno-common -fno-merge-constants -mno-explicit-relocs -mno-split-addresses $(CHECK_WARNINGS) -funsigned-char
+  CFLAGS += -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -mdivide-breaks -fno-PIC -fno-common -ffreestanding -fbuiltin -fno-builtin-sinf -fno-builtin-cosf $(CHECK_WARNINGS) -funsigned-char
   MIPS_VERSION := -mips3
 else
   # Suppress warnings for wrong number of macro arguments (to fake variadic
@@ -314,8 +314,11 @@ $(BUILD_DIR)/src/overlays/%.o: CC := $(PYTHON) tools/asm_processor/build.py $(CC
 
 $(BUILD_DIR)/assets/%.o: CC := $(PYTHON) tools/asm_processor/build.py $(CC) -- $(AS) $(ASFLAGS) --
 else
+# The / is intentionally left out to capture other directories starting with "assets"
+$(BUILD_DIR)/assets%.o: CFLAGS += -fno-zero-initialized-in-bss -fno-toplevel-reorder
+$(BUILD_DIR)/src/%.o: CFLAGS += -fexec-charset=euc-jp
 $(BUILD_DIR)/src/libultra/libc/ll.o: OPTFLAGS := -Ofast
-$(BUILD_DIR)/src/%.o: CC := $(CC) -fexec-charset=euc-jp
+$(BUILD_DIR)/src/overlays/%.o: CFLAGS += -fno-merge-constants -mno-explicit-relocs -mno-split-addresses
 endif
 
 #### Main Targets ###

--- a/Makefile
+++ b/Makefile
@@ -314,8 +314,8 @@ $(BUILD_DIR)/src/overlays/%.o: CC := $(PYTHON) tools/asm_processor/build.py $(CC
 
 $(BUILD_DIR)/assets/%.o: CC := $(PYTHON) tools/asm_processor/build.py $(CC) -- $(AS) $(ASFLAGS) --
 else
-# The / is intentionally left out to capture other directories starting with "assets"
-$(BUILD_DIR)/assets%.o: CFLAGS += -fno-zero-initialized-in-bss -fno-toplevel-reorder
+# Note that if adding additional assets directories for modding reasons these flags must also be used there
+$(BUILD_DIR)/assets/%.o: CFLAGS += -fno-zero-initialized-in-bss -fno-toplevel-reorder
 $(BUILD_DIR)/src/%.o: CFLAGS += -fexec-charset=euc-jp
 $(BUILD_DIR)/src/libultra/libc/ll.o: OPTFLAGS := -Ofast
 $(BUILD_DIR)/src/overlays/%.o: CFLAGS += -fno-merge-constants -mno-explicit-relocs -mno-split-addresses

--- a/include/ultra64/libc.h
+++ b/include/ultra64/libc.h
@@ -5,8 +5,14 @@
 
 void osSyncPrintf(const char* fmt, ...);
 
+#ifdef __GNUC__
+void bzero(void* __s, unsigned int __n);
+int bcmp(const void* __sl, const void* __s2, unsigned int __n);
+void bcopy(const void* __src, void* __dest, unsigned int __n);
+#else
 void bzero(void* __s, int __n);
 int bcmp(const void* __sl, const void* __s2, int __n);
 void bcopy(const void* __src, void* __dest, int __n);
+#endif
 
 #endif

--- a/src/gcc_fix/missing_gcc_functions.c
+++ b/src/gcc_fix/missing_gcc_functions.c
@@ -11,8 +11,8 @@
 // environment and there is no way to tell it otherwise.
 
 int memcmp(const void* s1, const void* s2, size_t n) {
-    const u8* m1 = (const u8*)s1;
-    const u8* m2 = (const u8*)s2;
+    const u8* m1 = s1;
+    const u8* m2 = s2;
     size_t i;
 
     for (i = 0; i < n; i++) {
@@ -27,7 +27,7 @@ int memcmp(const void* s1, const void* s2, size_t n) {
 }
 
 void* memset(void* str, int c, size_t n) {
-    u8* m = (u8*)str;
+    u8* m = str;
     size_t i;
 
     for (i = 0; i < n; i++) {

--- a/src/gcc_fix/missing_gcc_functions.c
+++ b/src/gcc_fix/missing_gcc_functions.c
@@ -10,10 +10,10 @@
 // Self-hosted libc memory functions, gcc assumes these exist even in a freestanding
 // environment and there is no way to tell it otherwise.
 
-int memcmp(void* s1, const void* s2, size_t n) {
-    u8* m1 = (u8*)s1;
-    u8* m2 = (u8*)s2;
-    u32 i;
+int memcmp(const void* s1, const void* s2, size_t n) {
+    const u8* m1 = (const u8*)s1;
+    const u8* m2 = (const u8*)s2;
+    size_t i;
 
     for (i = 0; i < n; i++) {
         if (m1[i] < m2[i]) {
@@ -26,15 +26,36 @@ int memcmp(void* s1, const void* s2, size_t n) {
     return 0;
 }
 
-void* memset(void* str, s32 c, size_t n) {
-    u8* m1 = (u8*)str;
-    u32 i;
+void* memset(void* str, int c, size_t n) {
+    u8* m = (u8*)str;
+    size_t i;
 
     for (i = 0; i < n; i++) {
-        m1[i] = c;
+        m[i] = c;
     }
 
     return str;
+}
+
+void* memmove(void* dest, const void* src, size_t len) {
+    u8* d = dest;
+    const u8* s = src;
+
+    if (d == s) {
+        return dest;
+    }
+    if (d < s) {
+        while (len--) {
+            *d++ = *s++;
+        }
+    } else {
+        d += len - 1;
+        s += len - 1;
+        while (len--) {
+            *d-- = *s--;
+        }
+    }
+    return dest;
 }
 
 // Conversions involving 64-bit integer types required by the O32 MIPS ABI.


### PR DESCRIPTION
Thanks to the prior alignment/UB changes these changes are now stable

* Move `-fno-toplevel-reorder -fno-zero-initialized-in-bss` to assets only
* Add `-fno-PIC` since some gcc versions use `-fPIC` as default (notably newer versions of mips-linux-gnu-)
* Enable builtin functions on gcc, with appropriate changes to missing_gcc_functions.c and ultra64/libc.h
* Move `-fno-merge-constants -mno-explicit-relocs -mno-split-addresses` to overlays only as they are only needed there for reloc reasons
