### PR TITLE
Make distclean delete build artifacts for all versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,8 +349,10 @@ assetclean:
 	$(RM) -r $(BUILD_DIR)/assets
 	$(RM) -r .extracted-assets.json
 
-distclean: clean assetclean
-	$(RM) -r $(BASEROM_SEGMENTS_DIR)
+distclean: assetclean
+	$(RM) -r baseroms/*/segments
+	$(RM) -r extracted/
+	$(RM) -r build/
 	$(MAKE) -C tools distclean
 
 venv:


### PR DESCRIPTION
Right now it's somewhat surprising that `make distclean` only cleans gc-eu-mq-dbg, instead of bringing the whole repo back to a fresh state. I left the dependency on `assetclean` because that's not fully multiversion yet, but in the future I think that `assetclean` should only delete `expected/$(VERSION)` and this dependency won't be necessary.

I didn't delete expected/ even though that's where gc-eu-mq disassembly goes, because it might be annoying to delete people's matching builds for gc-eu-mq-dbg too, and I'm not sure if there's a clean way to differentiate them.