### PR TITLE
Remove 0xFF padding from uncompressed ROMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The only build currently supported is Master Quest (Debug), but other versions a
 
 It builds the following ROM:
 
-* oot-gc-eu-mq-dbg.z64 `md5: f0b7f35375f9cc8ca1b2d59d78e35405`
+* oot-gc-eu-mq-dbg.z64 `md5: 75e344f41c26ec2ec5ad92caa9e25629`
 
 **Note: This repository does not include any of the assets necessary to build the ROM. A prior copy of the game is required to extract the needed assets.**
 

--- a/baseroms/gc-eu-mq-dbg/checksum.md5
+++ b/baseroms/gc-eu-mq-dbg/checksum.md5
@@ -1,1 +1,1 @@
-f0b7f35375f9cc8ca1b2d59d78e35405  build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.z64
+75e344f41c26ec2ec5ad92caa9e25629  build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.z64

--- a/baseroms/gc-eu-mq/checksum.md5
+++ b/baseroms/gc-eu-mq/checksum.md5
@@ -1,1 +1,1 @@
-1a438f4235f8038856971c14a798122a  build/gc-eu-mq/oot-gc-eu-mq.z64
+4920520254b9aab86de57b42ab477dbb  build/gc-eu-mq/oot-gc-eu-mq.z64

--- a/tools/decompress_baserom.py
+++ b/tools/decompress_baserom.py
@@ -128,7 +128,8 @@ def byte_swap(file_content: bytearray) -> bytearray:
 
 def per_version_fixes(file_content: bytearray, version: str) -> bytearray:
     if version == "gc-eu-mq-dbg":
-        # Strip the overdump
+        # Strip the overdump, which consists of an area of 0xFF bytes that may
+        # be erased memory and ROM data from an unrelated game
         print("Stripping overdump...")
         file_content = file_content[0:0x035CF000]
 

--- a/tools/decompress_baserom.py
+++ b/tools/decompress_baserom.py
@@ -128,8 +128,8 @@ def byte_swap(file_content: bytearray) -> bytearray:
 
 def per_version_fixes(file_content: bytearray, version: str) -> bytearray:
     if version == "gc-eu-mq-dbg":
-        # Strip the overdump, which consists of an area of 0xFF bytes that may
-        # be erased memory and ROM data from an unrelated game
+        # Strip the overdump, which consists of an area of 0xFF bytes (which may
+        # be erased flash memory) and ROM data from an unrelated game
         print("Stripping overdump...")
         file_content = file_content[0:0x035CF000]
 

--- a/tools/decompress_baserom.py
+++ b/tools/decompress_baserom.py
@@ -88,9 +88,10 @@ def decompress_rom(
         dma_entry.to_bin(entry_data)
         decompressed.write(entry_data)
     # pad to size
-    padding_end = round_up(dma_entries[-1].vrom_end, 14)
-    decompressed.seek(padding_end - 1)
-    decompressed.write(bytearray([0]))
+    padding_start = dma_entries[-1].vrom_end
+    padding_end = round_up(padding_start, 12)
+    decompressed.seek(padding_start)
+    decompressed.write(b"\x00" * (padding_end - padding_start))
     # re-calculate crc
     return bytearray(update_crc(decompressed).getbuffer())
 
@@ -129,20 +130,11 @@ def per_version_fixes(file_content: bytearray, version: str) -> bytearray:
     if version == "gc-eu-mq-dbg":
         # Strip the overdump
         print("Stripping overdump...")
-        file_content = file_content[0:0x3600000]
+        file_content = file_content[0:0x035CF000]
 
         # Patch the header
         print("Patching header...")
         file_content[0x3E] = 0x50
-    return file_content
-
-
-def pad_rom(file_content: bytearray, dma_entries: list[dmadata.DmaEntry]) -> bytearray:
-    padding_start = round_up(dma_entries[-1].vrom_end, 12)
-    padding_end = round_up(dma_entries[-1].vrom_end, 14)
-    print(f"Padding from {padding_start:X} to {padding_end:X}...")
-    for i in range(padding_start, padding_end):
-        file_content[i] = 0xFF
     return file_content
 
 
@@ -227,8 +219,6 @@ def main():
             file_content, dmadata_start, dma_entries, is_zlib_compressed
         )
 
-    file_content = pad_rom(file_content, dma_entries)
-
     # Check to see if the ROM is a "vanilla" ROM
     str_hash = get_str_hash(file_content)
     if str_hash != correct_str_hash:
@@ -237,7 +227,7 @@ def main():
         )
 
         if version == "gc-eu-mq-dbg":
-            if str_hash == "32fe2770c0f9b1a9cd2a4d449348c1cb":
+            if str_hash == "9fede30e3239558cf3993f12b7ed7458":
                 print(
                     "The provided baserom is a rom which has been edited with ZeldaEdit and is not suitable for use with decomp. Find a new one."
                 )


### PR DESCRIPTION
Recall that the Debug ROM dump looks like this:
* The ROM begins at offset 0x00000000
* The last DMA segment file in the ROM ends at offset 0x035CE040
* The dump is filled with 0x00 up to offset 0x035CF000
* Then, the dump is filled 0xFF up to offset 0x03600000 (54 MiB)
* Then, the dump contains Pokemon Stadium 2 data(?) that has been partially overwritten.

Handling these 0xFFs makes the build process slightly more complicated so it's nice to get rid of it. In fact, right now decompress_baserom.py pads with 0xFF up to 0x4000 while elf2rom pads up to 0x100000, which causes problems for gc-eu-mq. I suspect that the 0xFFs are not actually part of the padded ROM, but are erased data from the development cartridge, since Flash or EEPROM memory has a default state of all 1s after being erased.

After this change, both decompress_baserom.py and elf2rom will pad ROMs with 0s up to the next 0x1000-byte boundary with no further padding (elf2rom via `_RomSize` in the linker script). Compressed ROMs are still the same as before, where they are filled with the 0x00,0x01,...,0xFE,0xFF pattern up to a multiple of 8 MiB.