### PR TITLE
Line up code segment for gc-eu-mq

### DIFF
--- a/spec
+++ b/spec
@@ -318,6 +318,7 @@ beginseg
     name "code"
     compress
     after "dmadata"
+    align 0x20
     include "$(BUILD_DIR)/src/code/z_en_a_keep.o"
     include "$(BUILD_DIR)/src/code/z_en_item00.o"
     include "$(BUILD_DIR)/src/code/z_eff_blure.o"
@@ -455,7 +456,7 @@ beginseg
 #if OOT_DEBUG
     include "$(BUILD_DIR)/src/code/ucode_disas.o"
 #endif
-    pad_text // audio library aligned to 32 bytes?
+    pad_text // on GameCube, NTSC 1.0 and "0.9" prerelease
     include "$(BUILD_DIR)/src/audio/lib/data.o"
     include "$(BUILD_DIR)/src/audio/lib/synthesis.o"
     include "$(BUILD_DIR)/src/audio/lib/heap.o"
@@ -467,6 +468,9 @@ beginseg
     include "$(BUILD_DIR)/src/audio/lib/effects.o"
     include "$(BUILD_DIR)/src/audio/lib/seqplayer.o"
     include "$(BUILD_DIR)/src/audio/general.o"
+#if !OOT_DEBUG
+    pad_text // on retail GameCube
+#endif
     include "$(BUILD_DIR)/src/audio/sfx_params.o"
     include "$(BUILD_DIR)/src/audio/sfx.o"
     include "$(BUILD_DIR)/src/audio/sequence.o"

--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -51,11 +51,13 @@ static void write_ld_script(FILE *fout)
                   "    ..%s ", seg->name, seg->name, seg->name, seg->name);
 
         if (seg->fields & (1 << STMT_after))
-            fprintf(fout, "_%sSegmentEnd ", seg->after);
+            fprintf(fout, "(_%sSegmentEnd + %i) & ~ %i ", seg->after, seg->align - 1, seg->align - 1);
         else if (seg->fields & (1 << STMT_number))
             fprintf(fout, "0x%02X000000 ", seg->number);
         else if (seg->fields & (1 << STMT_address))
             fprintf(fout, "0x%08X ", seg->address);
+        else
+            fprintf(fout, "ALIGN(0x%X) ", seg->align);
 
         // (AT(_RomSize) isn't necessary, but adds useful "load address" lines to the map file)
         fprintf(fout, ": AT(_RomSize)\n    {\n"
@@ -63,9 +65,6 @@ static void write_ld_script(FILE *fout)
                   "        . = ALIGN(0x10);\n"
                   "        _%sSegmentTextStart = .;\n",
                   seg->name, seg->name);
-
-        if (seg->fields & (1 << STMT_align))
-            fprintf(fout, "        . = ALIGN(0x%X);\n", seg->align);
 
         for (j = 0; j < seg->includesCount; j++)
         {
@@ -168,9 +167,6 @@ static void write_ld_script(FILE *fout)
                       "        . = ALIGN(0x10);\n"
                       "        _%sSegmentBssStart = .;\n",
                       seg->name, seg->name, seg->name, seg->name);
-
-        if (seg->fields & (1 << STMT_align))
-            fprintf(fout, "        . = ALIGN(0x%X);\n", seg->align);
 
         for (j = 0; j < seg->includesCount; j++)
             fprintf(fout, "            %s (.sbss)\n"


### PR DESCRIPTION
Fix the following gc-eu-mq padding/alignment problems, with help from the [zelda64_compare spreadsheet](https://docs.google.com/spreadsheets/d/17yPD3DqqH5lZeR7c_QmJfgxWgVyYkGgTLZoKcvLTwtw/edit#gid=204902945):
* The VRAM address of `code` was wrong; it should be 80010f00 but it was assigned address 80010ef0. This doesn't seem to be due to missing padding because the `boot` and `dmadata` segments have the right size. From the spreadsheet it looks like the `code` segment is 0x20-aligned on all versions, so I changed the implementation of the `align` directive to align the entire segment instead of individual sections and used that.
* There's 16 bytes of padding between the .text for audio/general.o and audio/sfx.o. It doesn't look like this is due to alignment and only exists in some versions, so I can't explain this. I added a `pad_text` in all retail builds for now and added a comment for later (same with the other `pad_text` before audio/lib/data.o).

I tested this with `tools/bss_reordering.py` (after hackily matching Camera_Battle1), since that seems to pretty reliably detect when things are shifted. For the curious, here are the non-overlay files with BSS ordering problems:
```
boot/idle.o
code/z_actor.o
code/z_camera.o
code/z_collision_check.o
code/z_common_data.o
code/z_demo.o
code/z_kankyo.o
code/z_kaleido_scope_call.o
code/z_play.o
code/main.o
code/speed_meter.o
code/sys_math3d.o
code/fault.o
```