### PR TITLE
Fix various data issues in gc-eu-mq

### DIFF
--- a/src/audio/general.c
+++ b/src/audio/general.c
@@ -123,7 +123,10 @@ u8 sAudioBaseFilter2 = 0;
 u8 sAudioExtraFilter2 = 0;
 Vec3f* sSariaBgmPtr = NULL;
 f32 D_80130650 = 2000.0f;
+
+#if OOT_DEBUG
 u8 sSeqModeInput = 0;
+#endif
 
 #define SEQ_FLAG_ENEMY (1 << 0) // Allows enemy bgm
 #define SEQ_FLAG_FANFARE (1 << 1)

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -159,7 +159,9 @@ void Graph_Destroy(GraphicsContext* gfxCtx) {
 }
 
 void Graph_TaskSet00(GraphicsContext* gfxCtx) {
+#if OOT_DEBUG
     static Gfx* sPrevTaskWorkBuffer = NULL;
+#endif
     static s32 sGraphCfbInfoIdx = 0;
 
     OSTime timeNow;

--- a/src/code/z_message_PAL.c
+++ b/src/code/z_message_PAL.c
@@ -3060,7 +3060,6 @@ void Message_Update(PlayState* play) {
         0x0015, 0x0016, 0x0017, 0x0003, 0x0000, 0x270B, 0x00C8, 0x012C, 0x012D, 0xFFDA, 0x0014, 0x0016, 0x0014, 0x0016,
     };
     static u8 D_80153D74 = 0;
-    static u16 D_80153D78 = 0;
     MessageContext* msgCtx = &play->msgCtx;
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
     Player* player = GET_PLAYER(play);
@@ -3073,6 +3072,8 @@ void Message_Update(PlayState* play) {
 
 #if OOT_DEBUG
     if (BREG(0) != 0) {
+        static u16 D_80153D78 = 0;
+
         if (CHECK_BTN_ALL(input->press.button, BTN_DDOWN) && CHECK_BTN_ALL(input->cur.button, BTN_L)) {
             PRINTF("msgno=%d\n", D_80153D78);
             Message_StartTextbox(play, R_MESSAGE_DEBUGGER_TEXTID, NULL);
@@ -3358,8 +3359,10 @@ void Message_SetTables(void) {
     sStaffMessageEntryTablePtr = sStaffMessageEntryTable;
 }
 
+#if OOT_DEBUG
 // Appears to be file padding
 UNK_TYPE D_80153D7C = 0x00000000;
+#endif
 
 // This should be part of z_game_over.c, but cannot be moved there as the entire
 // late_rodata section of this file is in the way

--- a/src/code/z_message_PAL.c
+++ b/src/code/z_message_PAL.c
@@ -3072,12 +3072,12 @@ void Message_Update(PlayState* play) {
 
 #if OOT_DEBUG
     if (BREG(0) != 0) {
-        static u16 D_80153D78 = 0;
+        static u16 sMessageDebuggerTextboxCount = 0;
 
         if (CHECK_BTN_ALL(input->press.button, BTN_DDOWN) && CHECK_BTN_ALL(input->cur.button, BTN_L)) {
-            PRINTF("msgno=%d\n", D_80153D78);
+            PRINTF("msgno=%d\n", sMessageDebuggerTextboxCount);
             Message_StartTextbox(play, R_MESSAGE_DEBUGGER_TEXTID, NULL);
-            D_80153D78 = (D_80153D78 + 1) % 10;
+            sMessageDebuggerTextboxCount = (sMessageDebuggerTextboxCount + 1) % 10;
         }
         if (R_MESSAGE_DEBUGGER_SELECT != 0) {
             while (R_MESSAGE_DEBUGGER_TEXTID != 0x8000) {

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -2,8 +2,11 @@
 #include "quake.h"
 #include "terminal.h"
 
+#if OOT_DEBUG
 void* gDebugCutsceneScript = NULL;
 UNK_TYPE D_8012D1F4 = 0; // unused
+#endif
+
 Input* D_8012D1F8 = NULL;
 
 TransitionTile sTransitionTile;


### PR DESCRIPTION
Found with check_ordering.py. Surely there's a more principled way to handle `gGameOverTimer` in z_message_PAL.c?