### PR TITLE
Update fado

### DIFF
--- a/tools/fado/.gitrepo
+++ b/tools/fado/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:EllipticEllipsis/fado.git
 	branch = master
-	commit = 8d896ee97d565508755584803c409fc33bb0c953
-	parent = 9f09505d34619883748a7dab05071883281c14fd
+	commit = 7fad57f834a86b6a752292996f99f08771f29df4
+	parent = 17d683780d3878159959a87a9c4a2683d8781ef2
 	method = merge
-	cmdver = 0.4.5
+	cmdver = 0.4.6

--- a/tools/fado/Makefile
+++ b/tools/fado/Makefile
@@ -57,7 +57,7 @@ clean:
 	$(RM) -r build $(ELF)
 
 format:
-	clang-format-11 -i $(C_FILES) $(H_FILES) lib/fairy/*
+	clang-format-14 -i $(C_FILES) $(H_FILES) lib/fairy/*
 
 .PHONY: all clean format
 

--- a/tools/fado/include/mips_elf.h
+++ b/tools/fado/include/mips_elf.h
@@ -476,9 +476,9 @@ typedef struct {
 /* Relocation table entry with addend (in section of type SHT_RELA).  */
 
 typedef struct {
-    Elf32_Addr  r_offset;   /* Address */
-    Elf32_Word  r_info;     /* Relocation type and symbol index */
-    Elf32_Sword r_addend;   /* Addend */
+    Elf32_Addr r_offset;  /* Address */
+    Elf32_Word r_info;    /* Relocation type and symbol index */
+    Elf32_Sword r_addend; /* Addend */
 } Elf32_Rela;
 
 /* How to extract and insert information held in the r_info field.  */

--- a/tools/fado/lib/fairy/fairy_print.c
+++ b/tools/fado/lib/fairy/fairy_print.c
@@ -368,7 +368,7 @@ void Fairy_PrintSectionSizes(FairySecHeader* sectionTable, FILE* inputFile, size
         }
     }
     /* Can use symbols here too */
-    puts(".section .ovl");
+    puts(".section .ovl, \"a\"");
     printf("# OverlayInfo\n");
     printf(".word 0x%08X # .text size\n", textSize);
     printf(".word 0x%08X # .data size\n", dataSize);

--- a/tools/fado/src/fado.c
+++ b/tools/fado/src/fado.c
@@ -17,16 +17,6 @@
 
 /* String-finding-related functions */
 
-bool Fado_CheckInProgBitsSections(Elf32_Section section, vc_vector* progBitsSections) {
-    Elf32_Section* i;
-    VC_FOREACH(i, progBitsSections) {
-        if (*i == section) {
-            return true;
-        }
-    }
-    return false;
-}
-
 /**
  * For each input file, construct a vector of pointers to the starts of the strings defined in that file.
  */
@@ -41,8 +31,7 @@ void Fado_ConstructStringVectors(vc_vector** stringVectors, FairyFileInfo* fileI
 
         /* Build a vector of pointers to defined symbols' names */
         for (currentSym = 0; currentSym < fileInfo[currentFile].symtabInfo.sectionEntryCount; currentSym++) {
-            if ((symtab[currentSym].st_shndx != STN_UNDEF) &&
-                Fado_CheckInProgBitsSections(symtab[currentSym].st_shndx, fileInfo[currentFile].progBitsSections)) {
+            if (symtab[currentSym].st_shndx != STN_UNDEF) {
                 /* Have to pass a double pointer so it copies the pointer instead of the start of the string */
                 char* stringPtr = &fileInfo[currentFile].strtab[symtab[currentSym].st_name];
                 assert(vc_vector_push_back(stringVectors[currentFile], &stringPtr));
@@ -251,7 +240,7 @@ void Fado_Relocs(FILE* outputFile, int inputFilesCount, FILE** inputFiles, const
 
     {
         /* Write header */
-        fprintf(outputFile, ".section .ovl\n");
+        fprintf(outputFile, ".section .ovl, \"a\"\n");
         fprintf(outputFile, "# %sOverlayInfo\n", ovlName);
         fprintf(outputFile, ".word _%sSegmentTextSize\n", ovlName);
         fprintf(outputFile, ".word _%sSegmentDataSize\n", ovlName);

--- a/tools/fado/src/version.inc
+++ b/tools/fado/src/version.inc
@@ -1,5 +1,5 @@
 /* Copyright (C) 2021 Elliptic Ellipsis */
 /* SPDX-License-Identifier: AGPL-3.0-only */
-const char versionNumber[] = "1.3.1";
+const char versionNumber[] = "1.3.2";
 const char credits[] = "Written by Elliptic Ellipsis\nwith additions from AngheloAlf and Tharo";
 const char repo[] = "https://github.com/EllipticEllipsis/fado/";


### PR DESCRIPTION
fado is the zelda64 relocs generation tool, for z64 overlays relocs

Recent updates fix a bug with relocs relative to another file's bss section, and set correct flags for the .ovl section (which doesn't matter with our current linker script but otherwise breaks stuff)