### PR TITLE
Document en_ba damage bug

### DIFF
--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.c
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.c
@@ -235,6 +235,7 @@ void EnBa_SwingAtPlayer(EnBa* this, PlayState* play) {
     s16 phi_fp;
 
     Math_SmoothStepToF(&this->actor.world.pos.y, this->actor.home.pos.y + 60.0f, 1.0f, 10.0f, 0.0f);
+
     if ((this->actor.xzDistToPlayer <= 175.0f) || (this->unk_31A != 0)) {
         if (this->unk_318 == 20) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_HAND_UP);
@@ -300,16 +301,22 @@ void EnBa_SwingAtPlayer(EnBa* this, PlayState* play) {
         }
         this->unk_2A8[13].x = this->unk_2A8[12].x;
         this->unk_2A8[13].y = this->unk_2A8[12].y;
+
+        //! @bug This code being located here gives multiple opportunities for the current action to change
+        //! before damage handling can be done.
+        //! By, for example, taking damage on the same frame the collider contacts Player, a different action 
+        //! will run and `AT_HIT` will remain set. Then when returning back to this action, Player 
+        //! will get knocked back instantly, even though there was no apparent collision.
+        //! Handling `AT_HIT` directly in Update, where it can run every frame, would help catch these edge cases.
         if (this->collider.base.atFlags & AT_HIT) {
             this->collider.base.atFlags &= ~AT_HIT;
             if (this->collider.base.at == &player->actor) {
                 func_8002F71C(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             }
         }
+
         CollisionCheck_SetAT(play, &play->colChkCtx, &this->collider.base);
-        return;
-    }
-    if ((this->actor.xzDistToPlayer > 175.0f) || (player->stateFlags1 & PLAYER_STATE1_26)) {
+    } else if ((this->actor.xzDistToPlayer > 175.0f) || (player->stateFlags1 & PLAYER_STATE1_26)) {
         EnBa_SetupIdle(this);
     } else {
         EnBa_SetupSwingAtPlayer(this);

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.c
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.c
@@ -304,8 +304,8 @@ void EnBa_SwingAtPlayer(EnBa* this, PlayState* play) {
 
         //! @bug This code being located here gives multiple opportunities for the current action to change
         //! before damage handling can be done.
-        //! By, for example, taking damage on the same frame the collider contacts Player, a different action 
-        //! will run and `AT_HIT` will remain set. Then when returning back to this action, Player 
+        //! By, for example, taking damage on the same frame the collider contacts Player, a different action
+        //! will run and `AT_HIT` will remain set. Then when returning back to this action, Player
         //! will get knocked back instantly, even though there was no apparent collision.
         //! Handling `AT_HIT` directly in Update, where it can run every frame, would help catch these edge cases.
         if (this->collider.base.atFlags & AT_HIT) {


### PR DESCRIPTION
This bug was found in the speedrunning community today. The bug comment hopefully explains it well.
Here is a video demonstration: https://youtu.be/7lu-mA-6X3k
