### PR TITLE
Replace ‾ with - in z_bg_gnd_iceblock.c for encoding into EUC-JP

### DIFF
--- a/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
@@ -84,7 +84,7 @@ void BgGndIceblock_Destroy(Actor* thisx, PlayState* play) {
  * | 3     h8    15    19 |
  * | 4      9 11 XX   *20*|
  * |*5*    XX 12      *21*|
- *  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+ *  ----------------------
  * XX are rocks
  * ** are pits
  * h is the hole.


### PR DESCRIPTION
`‾` can't be encoded into EUC-JP, and apparently some iconv implementations will replace it with something else (e.g. `~`) while others will error.

See https://discord.com/channels/688807550715560050/688851337085190255/1224062773718417621