### PR TITLE
Change linker script so gGameOverTimer can be in z_game_over.c

### DIFF
--- a/spec
+++ b/spec
@@ -599,8 +599,12 @@ beginseg
     include "$(BUILD_DIR)/src/code/fmodf.o"
     include "$(BUILD_DIR)/src/code/__osMemset.o"
     include "$(BUILD_DIR)/src/code/__osMemmove.o"
-    include_data_with_rodata "$(BUILD_DIR)/src/code/z_message_PAL.o"
-    include "$(BUILD_DIR)/src/code/z_game_over.o"
+    // For some reason, the data sections of these files are placed here near the
+    // rodata sections of the other files
+    include_data_only_with_rodata "$(BUILD_DIR)/src/code/z_message_PAL.o"
+    include_data_only_with_rodata "$(BUILD_DIR)/src/code/z_game_over.o"
+    include_no_data "$(BUILD_DIR)/src/code/z_message_PAL.o"
+    include_no_data "$(BUILD_DIR)/src/code/z_game_over.o"
     include "$(BUILD_DIR)/src/code/z_construct.o"
     include "$(BUILD_DIR)/data/audio_tables.rodata.o"
     include "$(BUILD_DIR)/data/rsp.text.o"

--- a/spec
+++ b/spec
@@ -601,8 +601,8 @@ beginseg
     include "$(BUILD_DIR)/src/code/__osMemmove.o"
     // For some reason, the data sections of these files are placed here near the
     // rodata sections of the other files
-    include_data_only_with_rodata "$(BUILD_DIR)/src/code/z_message_PAL.o"
-    include_data_only_with_rodata "$(BUILD_DIR)/src/code/z_game_over.o"
+    include_data_only_within_rodata "$(BUILD_DIR)/src/code/z_message_PAL.o"
+    include_data_only_within_rodata "$(BUILD_DIR)/src/code/z_game_over.o"
     include_no_data "$(BUILD_DIR)/src/code/z_message_PAL.o"
     include_no_data "$(BUILD_DIR)/src/code/z_game_over.o"
     include "$(BUILD_DIR)/src/code/z_construct.o"

--- a/src/code/z_game_over.c
+++ b/src/code/z_game_over.c
@@ -13,7 +13,7 @@ void GameOver_FadeInLights(PlayState* play) {
     }
 }
 
-s16 gGameOverTimer = 0;
+s16 sGameOverTimer = 0;
 
 void GameOver_Update(PlayState* play) {
     GameOverContext* gameOverCtx = &play->gameOverCtx;
@@ -73,7 +73,7 @@ void GameOver_Update(PlayState* play) {
                 gSaveContext.hudVisibilityModeTimer = 0; // false, HUD_VISIBILITY_NO_CHANGE
 
             Environment_InitGameOverLights(play);
-            gGameOverTimer = 20;
+            sGameOverTimer = 20;
 
             if (1) {}
             rumbleStrength = R_GAME_OVER_RUMBLE_STRENGTH;
@@ -91,9 +91,9 @@ void GameOver_Update(PlayState* play) {
             break;
 
         case GAMEOVER_DEATH_DELAY_MENU:
-            gGameOverTimer--;
+            sGameOverTimer--;
 
-            if (gGameOverTimer == 0) {
+            if (sGameOverTimer == 0) {
                 play->pauseCtx.state = PAUSE_STATE_8;
                 gameOverCtx->state++;
                 Rumble_Reset();
@@ -102,13 +102,13 @@ void GameOver_Update(PlayState* play) {
 
         case GAMEOVER_REVIVE_START:
             gameOverCtx->state++;
-            gGameOverTimer = 0;
+            sGameOverTimer = 0;
             Environment_InitGameOverLights(play);
             Letterbox_SetSizeTarget(32);
             return;
 
         case GAMEOVER_REVIVE_RUMBLE:
-            gGameOverTimer = 50;
+            sGameOverTimer = 50;
             gameOverCtx->state++;
 
             if (1) {}
@@ -122,28 +122,28 @@ void GameOver_Update(PlayState* play) {
             break;
 
         case GAMEOVER_REVIVE_WAIT_GROUND:
-            gGameOverTimer--;
+            sGameOverTimer--;
 
-            if (gGameOverTimer == 0) {
-                gGameOverTimer = 64;
+            if (sGameOverTimer == 0) {
+                sGameOverTimer = 64;
                 gameOverCtx->state++;
             }
             break;
 
         case GAMEOVER_REVIVE_WAIT_FAIRY:
-            gGameOverTimer--;
+            sGameOverTimer--;
 
-            if (gGameOverTimer == 0) {
-                gGameOverTimer = 50;
+            if (sGameOverTimer == 0) {
+                sGameOverTimer = 50;
                 gameOverCtx->state++;
             }
             break;
 
         case GAMEOVER_REVIVE_FADE_OUT:
             Environment_FadeOutGameOverLights(play);
-            gGameOverTimer--;
+            sGameOverTimer--;
 
-            if (gGameOverTimer == 0) {
+            if (sGameOverTimer == 0) {
                 gameOverCtx->state = GAMEOVER_INACTIVE;
             }
             break;

--- a/src/code/z_game_over.c
+++ b/src/code/z_game_over.c
@@ -13,8 +13,7 @@ void GameOver_FadeInLights(PlayState* play) {
     }
 }
 
-// This variable cannot be moved into this file as all of z_message_PAL rodata is in the way
-extern s16 gGameOverTimer;
+s16 gGameOverTimer = 0;
 
 void GameOver_Update(PlayState* play) {
     GameOverContext* gameOverCtx = &play->gameOverCtx;

--- a/src/code/z_message_PAL.c
+++ b/src/code/z_message_PAL.c
@@ -3358,12 +3358,3 @@ void Message_SetTables(void) {
     sFraMessageEntryTablePtr = sFraMessageEntryTable;
     sStaffMessageEntryTablePtr = sStaffMessageEntryTable;
 }
-
-#if OOT_DEBUG
-// Appears to be file padding
-UNK_TYPE D_80153D7C = 0x00000000;
-#endif
-
-// This should be part of z_game_over.c, but cannot be moved there as the entire
-// late_rodata section of this file is in the way
-s16 gGameOverTimer = 0;

--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -42,10 +42,6 @@ static void write_ld_script(FILE *fout)
 
         // initialized data (.text, .data, .rodata, .sdata)
 
-        // Increment the start of the section
-        //if (seg->fields & (1 << STMT_increment))
-            //fprintf(fout, "    . += 0x%08X;\n", seg->increment);
-
         fprintf(fout, "    _%sSegmentRomStartTemp = _RomSize;\n"
                   "    _%sSegmentRomStart = _%sSegmentRomStartTemp;\n"
                   "    ..%s ", seg->name, seg->name, seg->name, seg->name);
@@ -68,10 +64,13 @@ static void write_ld_script(FILE *fout)
 
         for (j = 0; j < seg->includesCount; j++)
         {
-            fprintf(fout, "            %s (.text)\n", seg->includes[j].fpath);
-            if (seg->includes[j].linkerPadding != 0)
-                fprintf(fout, "            . += 0x%X;\n", seg->includes[j].linkerPadding);
-            fprintf(fout, "        . = ALIGN(0x10);\n");
+            if (!seg->includes[j].dataOnlyWithRodata)
+            {
+                fprintf(fout, "            %s (.text)\n", seg->includes[j].fpath);
+                if (seg->includes[j].linkerPadding != 0)
+                    fprintf(fout, "            . += 0x%X;\n", seg->includes[j].linkerPadding);
+                fprintf(fout, "        . = ALIGN(0x10);\n");
+            }
         }
 
         fprintf(fout, "        _%sSegmentTextEnd = .;\n", seg->name);
@@ -82,20 +81,11 @@ static void write_ld_script(FILE *fout)
 
         for (j = 0; j < seg->includesCount; j++)
         {
-            if (!seg->includes[j].dataWithRodata)
+            if (!seg->includes[j].dataOnlyWithRodata && !seg->includes[j].noData)
                 fprintf(fout, "            %s (.data)\n"
                               "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
         }
 
-        /*
-         for (j = 0; j < seg->includesCount; j++)
-            fprintf(fout, "            %s (.rodata)\n", seg->includes[j].fpath);
-
-          for (j = 0; j < seg->includesCount; j++)
-            fprintf(fout, "            %s (.sdata)\n", seg->includes[j].fpath);
-        */
-
-        //fprintf(fout, "        . = ALIGN(0x10);\n");
         fprintf(fout, "        _%sSegmentDataEnd = .;\n", seg->name);
 
         fprintf(fout, "    _%sSegmentDataSize = ABSOLUTE( _%sSegmentDataEnd - _%sSegmentDataStart );\n", seg->name, seg->name, seg->name);
@@ -104,7 +94,7 @@ static void write_ld_script(FILE *fout)
 
         for (j = 0; j < seg->includesCount; j++)
         {
-            if (seg->includes[j].dataWithRodata)
+            if (seg->includes[j].dataOnlyWithRodata)
                 fprintf(fout, "            %s (.data)\n"
                               "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
@@ -116,11 +106,12 @@ static void write_ld_script(FILE *fout)
             // the beginning of the entire rodata area in order to remain consistent.
             // Inconsistencies will lead to various .rodata reloc crashes as a result of
             // either missing relocs or wrong relocs.
-            fprintf(fout, "            %s (.rodata)\n"
-                          "            %s (.rodata.str*)\n"
-                          "            %s (.rodata.cst*)\n"
-                          "        . = ALIGN(0x10);\n",
-                    seg->includes[j].fpath, seg->includes[j].fpath, seg->includes[j].fpath);
+            if (!seg->includes[j].dataOnlyWithRodata)
+                fprintf(fout, "            %s (.rodata)\n"
+                            "            %s (.rodata.str*)\n"
+                            "            %s (.rodata.cst*)\n"
+                            "        . = ALIGN(0x10);\n",
+                        seg->includes[j].fpath, seg->includes[j].fpath, seg->includes[j].fpath);
         }
 
         fprintf(fout, "        _%sSegmentRoDataEnd = .;\n", seg->name);
@@ -130,15 +121,17 @@ static void write_ld_script(FILE *fout)
         fprintf(fout, "        _%sSegmentSDataStart = .;\n", seg->name);
 
         for (j = 0; j < seg->includesCount; j++)
-            fprintf(fout, "            %s (.sdata)\n"
-                          "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
+            if (!seg->includes[j].dataOnlyWithRodata)
+                fprintf(fout, "            %s (.sdata)\n"
+                            "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
         fprintf(fout, "        _%sSegmentSDataEnd = .;\n", seg->name);
 
         fprintf(fout, "        _%sSegmentOvlStart = .;\n", seg->name);
 
         for (j = 0; j < seg->includesCount; j++)
-            fprintf(fout, "            %s (.ovl)\n", seg->includes[j].fpath);
+            if (!seg->includes[j].dataOnlyWithRodata)
+                fprintf(fout, "            %s (.ovl)\n", seg->includes[j].fpath);
 
         fprintf(fout, "        _%sSegmentOvlEnd = .;\n", seg->name);
 
@@ -166,20 +159,24 @@ static void write_ld_script(FILE *fout)
                       seg->name, seg->name, seg->name, seg->name);
 
         for (j = 0; j < seg->includesCount; j++)
-            fprintf(fout, "            %s (.sbss)\n"
-                          "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
+            if (!seg->includes[j].dataOnlyWithRodata)
+                fprintf(fout, "            %s (.sbss)\n"
+                            "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
         for (j = 0; j < seg->includesCount; j++)
-            fprintf(fout, "            %s (.scommon)\n"
-                          "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
+            if (!seg->includes[j].dataOnlyWithRodata)
+                fprintf(fout, "            %s (.scommon)\n"
+                            "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
         for (j = 0; j < seg->includesCount; j++)
-            fprintf(fout, "            %s (.bss)\n"
-                          "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
+            if (!seg->includes[j].dataOnlyWithRodata)
+                fprintf(fout, "            %s (.bss)\n"
+                            "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
         for (j = 0; j < seg->includesCount; j++)
-            fprintf(fout, "            %s (COMMON)\n"
-                          "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
+            if (!seg->includes[j].dataOnlyWithRodata)
+                fprintf(fout, "            %s (COMMON)\n"
+                            "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
         fprintf(fout, "        . = ALIGN(0x10);\n"
                       "        _%sSegmentBssEnd = .;\n"
@@ -187,25 +184,6 @@ static void write_ld_script(FILE *fout)
                       "    }\n"
                       "    _%sSegmentBssSize = ABSOLUTE( _%sSegmentBssEnd - _%sSegmentBssStart );\n\n",
                       seg->name, seg->name, seg->name, seg->name, seg->name);
-
-        // Increment the end of the segment
-        //if (seg->fields & (1 << STMT_increment))
-            //fprintf(fout, "    . += 0x%08X;\n", seg->increment);
-
-        //fprintf(fout, "    ..%s.ovl ADDR(..%s) + SIZEOF(..%s) :\n"
-        //    /*"    ..%s.bss :\n"*/
-        //    "    {\n",
-        //    seg->name, seg->name, seg->name);
-        //fprintf(fout, "        _%sSegmentOvlStart = .;\n", seg->name);
-
-        //for (j = 0; j < seg->includesCount; j++)
-        //    fprintf(fout, "            %s (.ovl)\n", seg->includes[j].fpath);
-
-        ////fprintf(fout, "        . = ALIGN(0x10);\n");
-
-        //fprintf(fout, "        _%sSegmentOvlEnd = .;\n", seg->name);
-
-        //fprintf(fout, "\n    }\n");
     }
 
     fputs("    _RomEnd = _RomSize;\n\n", fout);

--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -64,7 +64,7 @@ static void write_ld_script(FILE *fout)
 
         for (j = 0; j < seg->includesCount; j++)
         {
-            if (!seg->includes[j].dataOnlyWithRodata)
+            if (!seg->includes[j].dataOnlyWithinRodata)
             {
                 fprintf(fout, "            %s (.text)\n", seg->includes[j].fpath);
                 if (seg->includes[j].linkerPadding != 0)
@@ -81,7 +81,7 @@ static void write_ld_script(FILE *fout)
 
         for (j = 0; j < seg->includesCount; j++)
         {
-            if (!seg->includes[j].dataOnlyWithRodata && !seg->includes[j].noData)
+            if (!seg->includes[j].dataOnlyWithinRodata && !seg->includes[j].noData)
                 fprintf(fout, "            %s (.data)\n"
                               "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
         }
@@ -94,7 +94,7 @@ static void write_ld_script(FILE *fout)
 
         for (j = 0; j < seg->includesCount; j++)
         {
-            if (seg->includes[j].dataOnlyWithRodata)
+            if (seg->includes[j].dataOnlyWithinRodata)
                 fprintf(fout, "            %s (.data)\n"
                               "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
@@ -106,7 +106,7 @@ static void write_ld_script(FILE *fout)
             // the beginning of the entire rodata area in order to remain consistent.
             // Inconsistencies will lead to various .rodata reloc crashes as a result of
             // either missing relocs or wrong relocs.
-            if (!seg->includes[j].dataOnlyWithRodata)
+            if (!seg->includes[j].dataOnlyWithinRodata)
                 fprintf(fout, "            %s (.rodata)\n"
                             "            %s (.rodata.str*)\n"
                             "            %s (.rodata.cst*)\n"
@@ -121,7 +121,7 @@ static void write_ld_script(FILE *fout)
         fprintf(fout, "        _%sSegmentSDataStart = .;\n", seg->name);
 
         for (j = 0; j < seg->includesCount; j++)
-            if (!seg->includes[j].dataOnlyWithRodata)
+            if (!seg->includes[j].dataOnlyWithinRodata)
                 fprintf(fout, "            %s (.sdata)\n"
                             "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
@@ -130,7 +130,7 @@ static void write_ld_script(FILE *fout)
         fprintf(fout, "        _%sSegmentOvlStart = .;\n", seg->name);
 
         for (j = 0; j < seg->includesCount; j++)
-            if (!seg->includes[j].dataOnlyWithRodata)
+            if (!seg->includes[j].dataOnlyWithinRodata)
                 fprintf(fout, "            %s (.ovl)\n", seg->includes[j].fpath);
 
         fprintf(fout, "        _%sSegmentOvlEnd = .;\n", seg->name);
@@ -159,22 +159,22 @@ static void write_ld_script(FILE *fout)
                       seg->name, seg->name, seg->name, seg->name);
 
         for (j = 0; j < seg->includesCount; j++)
-            if (!seg->includes[j].dataOnlyWithRodata)
+            if (!seg->includes[j].dataOnlyWithinRodata)
                 fprintf(fout, "            %s (.sbss)\n"
                             "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
         for (j = 0; j < seg->includesCount; j++)
-            if (!seg->includes[j].dataOnlyWithRodata)
+            if (!seg->includes[j].dataOnlyWithinRodata)
                 fprintf(fout, "            %s (.scommon)\n"
                             "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
         for (j = 0; j < seg->includesCount; j++)
-            if (!seg->includes[j].dataOnlyWithRodata)
+            if (!seg->includes[j].dataOnlyWithinRodata)
                 fprintf(fout, "            %s (.bss)\n"
                             "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 
         for (j = 0; j < seg->includesCount; j++)
-            if (!seg->includes[j].dataOnlyWithRodata)
+            if (!seg->includes[j].dataOnlyWithinRodata)
                 fprintf(fout, "            %s (COMMON)\n"
                             "        . = ALIGN(0x10);\n", seg->includes[j].fpath);
 

--- a/tools/spec.c
+++ b/tools/spec.c
@@ -136,7 +136,7 @@ static const char *const stmtNames[] =
     [STMT_entry]     = "entry",
     [STMT_flags]     = "flags",
     [STMT_include]   = "include",
-    [STMT_include_data_only_with_rodata] = "include_data_only_with_rodata",
+    [STMT_include_data_only_within_rodata] = "include_data_only_within_rodata",
     [STMT_include_no_data] = "include_no_data",
     [STMT_name]      = "name",
     [STMT_number]    = "number",
@@ -159,7 +159,7 @@ STMTId get_stmt_id_by_stmt_name(const char *stmtName, int lineNum) {
 
 bool parse_segment_statement(struct Segment *currSeg, STMTId stmt, char* args, int lineNum) {
     // ensure no duplicates (except for 'include' or 'pad_text')
-    if (stmt != STMT_include && stmt != STMT_include_data_only_with_rodata &&
+    if (stmt != STMT_include && stmt != STMT_include_data_only_within_rodata &&
         stmt != STMT_include_no_data && stmt != STMT_pad_text &&
         (currSeg->fields & (1 << stmt)))
         util_fatal_error("line %i: duplicate '%s' statement", lineNum, stmtNames[stmt]);
@@ -213,7 +213,7 @@ bool parse_segment_statement(struct Segment *currSeg, STMTId stmt, char* args, i
             util_fatal_error("line %i: alignment is not a power of two", lineNum);
         break;
     case STMT_include:
-    case STMT_include_data_only_with_rodata:
+    case STMT_include_data_only_within_rodata:
     case STMT_include_no_data:
         currSeg->includesCount++;
         currSeg->includes = realloc(currSeg->includes, currSeg->includesCount * sizeof(*currSeg->includes));
@@ -222,7 +222,7 @@ bool parse_segment_statement(struct Segment *currSeg, STMTId stmt, char* args, i
             util_fatal_error("line %i: invalid filename", lineNum);
 
         currSeg->includes[currSeg->includesCount - 1].linkerPadding = 0;
-        currSeg->includes[currSeg->includesCount - 1].dataOnlyWithRodata = (stmt == STMT_include_data_only_with_rodata);
+        currSeg->includes[currSeg->includesCount - 1].dataOnlyWithinRodata = (stmt == STMT_include_data_only_within_rodata);
         currSeg->includes[currSeg->includesCount - 1].noData = (stmt == STMT_include_no_data);
         break;
     case STMT_increment:

--- a/tools/spec.c
+++ b/tools/spec.c
@@ -136,7 +136,8 @@ static const char *const stmtNames[] =
     [STMT_entry]     = "entry",
     [STMT_flags]     = "flags",
     [STMT_include]   = "include",
-    [STMT_include_data_with_rodata] = "include_data_with_rodata",
+    [STMT_include_data_only_with_rodata] = "include_data_only_with_rodata",
+    [STMT_include_no_data] = "include_no_data",
     [STMT_name]      = "name",
     [STMT_number]    = "number",
     [STMT_romalign]  = "romalign",
@@ -158,7 +159,8 @@ STMTId get_stmt_id_by_stmt_name(const char *stmtName, int lineNum) {
 
 bool parse_segment_statement(struct Segment *currSeg, STMTId stmt, char* args, int lineNum) {
     // ensure no duplicates (except for 'include' or 'pad_text')
-    if (stmt != STMT_include && stmt != STMT_include_data_with_rodata && stmt != STMT_pad_text &&
+    if (stmt != STMT_include && stmt != STMT_include_data_only_with_rodata &&
+        stmt != STMT_include_no_data && stmt != STMT_pad_text &&
         (currSeg->fields & (1 << stmt)))
         util_fatal_error("line %i: duplicate '%s' statement", lineNum, stmtNames[stmt]);
 
@@ -211,7 +213,8 @@ bool parse_segment_statement(struct Segment *currSeg, STMTId stmt, char* args, i
             util_fatal_error("line %i: alignment is not a power of two", lineNum);
         break;
     case STMT_include:
-    case STMT_include_data_with_rodata:
+    case STMT_include_data_only_with_rodata:
+    case STMT_include_no_data:
         currSeg->includesCount++;
         currSeg->includes = realloc(currSeg->includes, currSeg->includesCount * sizeof(*currSeg->includes));
 
@@ -219,7 +222,8 @@ bool parse_segment_statement(struct Segment *currSeg, STMTId stmt, char* args, i
             util_fatal_error("line %i: invalid filename", lineNum);
 
         currSeg->includes[currSeg->includesCount - 1].linkerPadding = 0;
-        currSeg->includes[currSeg->includesCount - 1].dataWithRodata = (stmt == STMT_include_data_with_rodata);
+        currSeg->includes[currSeg->includesCount - 1].dataOnlyWithRodata = (stmt == STMT_include_data_only_with_rodata);
+        currSeg->includes[currSeg->includesCount - 1].noData = (stmt == STMT_include_no_data);
         break;
     case STMT_increment:
         if (!parse_number(args, &currSeg->increment))

--- a/tools/spec.h
+++ b/tools/spec.h
@@ -14,7 +14,7 @@ typedef enum {
     STMT_entry,
     STMT_flags,
     STMT_include,
-    STMT_include_data_only_with_rodata,
+    STMT_include_data_only_within_rodata,
     STMT_include_no_data,
     STMT_name,
     STMT_number,
@@ -35,7 +35,7 @@ enum {
 struct Include {
     char* fpath;
     int linkerPadding;
-    bool dataOnlyWithRodata;
+    bool dataOnlyWithinRodata;
     bool noData;
 };
 

--- a/tools/spec.h
+++ b/tools/spec.h
@@ -14,7 +14,8 @@ typedef enum {
     STMT_entry,
     STMT_flags,
     STMT_include,
-    STMT_include_data_with_rodata,
+    STMT_include_data_only_with_rodata,
+    STMT_include_no_data,
     STMT_name,
     STMT_number,
     STMT_romalign,
@@ -34,7 +35,8 @@ enum {
 struct Include {
     char* fpath;
     int linkerPadding;
-    uint8_t dataWithRodata;
+    bool dataOnlyWithRodata;
+    bool noData;
 };
 
 typedef struct Segment {


### PR DESCRIPTION
Currently, `gGameOverTimer` is placed in `z_message_PAL.c`, which is wrong, and annoying because we have to manually adjust the padding for other versions. This introduces `include_data_only_within_rodata` and `include_no_data` spec directives to deal with it instead.

Additionally, I removed some ancient commented-out code in mkldscript.c because I didn't want to deal with it.