### PR TITLE
Revert "Replace ‾ with - in z_bg_gnd_iceblock.c for encoding into EUC-JP (#1937)"

### DIFF
--- a/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
+++ b/src/overlays/actors/ovl_Bg_Gnd_Iceblock/z_bg_gnd_iceblock.c
@@ -84,7 +84,7 @@ void BgGndIceblock_Destroy(Actor* thisx, PlayState* play) {
  * | 3     h8    15    19 |
  * | 4      9 11 XX   *20*|
  * |*5*    XX 12      *21*|
- *  ----------------------
+ *  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
  * XX are rocks
  * ** are pits
  * h is the hole.


### PR DESCRIPTION
This didn't really fix anything (there are more places where `‾` appears in the source) and we won't have to worry about different `iconv` implementations after #1927 since it moves the reencoding to Python