### PR TITLE
Force string.o to be in boot for gcc builds

### DIFF
--- a/spec
+++ b/spec
@@ -66,7 +66,7 @@ beginseg
 #endif
     include "$(BUILD_DIR)/src/libultra/os/unmaptlball.o"
     include "$(BUILD_DIR)/src/libultra/io/epidma.o"
-#if OOT_DEBUG
+#if OOT_DEBUG || COMPILER_GCC
     include "$(BUILD_DIR)/src/libultra/libc/string.o"
 #endif
     include "$(BUILD_DIR)/src/libultra/os/invalicache.o"
@@ -532,6 +532,8 @@ beginseg
     include "$(BUILD_DIR)/src/libultra/gu/lookathil.o"
 #if !OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/libc/xprintf.o"
+#endif
+#if !OOT_DEBUG && !COMPILER_GCC
     include "$(BUILD_DIR)/src/libultra/libc/string.o"
 #endif
     include "$(BUILD_DIR)/src/libultra/io/sp.o"


### PR DESCRIPTION
In retail builds, memcpy is linked in `code`, not `boot`, but GCC likes to call memcpy when copying structs so GCC builds will immediately crash in [__osInitialize_common](https://github.com/zeldaret/oot/blob/7e8b9144c2e08f65229696135980977e1f098d6c/src/libultra/os/initialize.c#L48)