### PR TITLE
Identify some unaccounted and blob asset data

### DIFF
--- a/assets/xml/objects/object_am.xml
+++ b/assets/xml/objects/object_am.xml
@@ -5,5 +5,6 @@
         <Animation Name="gArmosHopAnim" Offset="0x238"/>
         <Animation Name="gArmosDamagedAnim" Offset="0x5B3C"/>
         <Collision Name="gArmosCol" Offset="0x118"/>
+        <DList Name="gArmosUnusedDL" Offset="0x7A8"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_ani.xml
+++ b/assets/xml/objects/object_ani.xml
@@ -51,6 +51,8 @@
         <Texture Name="gRoofManEarTex" OutName="roof_man_ear" Format="ci8" Width="16" Height="16" Offset="0x01318" TlutOffset="0x1088"/>
         <Texture Name="gRoofManHairTex" OutName="roof_man_hair" Format="ci8" Width="16" Height="16" Offset="0x01418" TlutOffset="0x1088"/>
 
+        <!-- Kakariko Roof Man Unused Textures -->
+        <Texture Name="gRoofManUnusedTex" OutName="roof_man_unused" Format="ci8" Width="16" Height="16" Offset="0x308" TlutOffset="0x00108"/>
 
         <!-- Kakariko Roof Man Eye Textures -->
         <Texture Name="gRoofManEyeOpenTex" OutName="roof_man_eye_open" Format="rgba16" Width="32" Height="32" Offset="0x408"/>

--- a/assets/xml/objects/object_box.xml
+++ b/assets/xml/objects/object_box.xml
@@ -5,7 +5,9 @@
         <CurveAnimation Name="gTreasureChestCurveAnim_4F70" SkelOffset="0x5EB8" Offset="0x4F70"/>
         <Animation Name="gTreasureChestAnim_000128" Offset="0x128"/>
         <Animation Name="gTreasureChestAnim_00024C" Offset="0x24C"/>
+        <Blob Name="object_box_zeroes_Blob_00025C" Size="0xF4" Offset="0x025C"/>
         <Animation Name="gTreasureChestAnim_00043C" Offset="0x43C"/>
+        <Blob Name="object_box_zeroes_Blob_00044C" Size="0x64" Offset="0x044C"/>
 
         <DList Name="gTreasureChestChestFrontDL" Offset="0x6F0"/>
         <Texture Name="gTreasureChestFrontTex" OutName="chest_front" Format="rgba16" Width="32" Height="64" Offset="0x1798"/>
@@ -19,11 +21,7 @@
         <DList Name="gTreasureChestBossKeyChestSideAndTopDL" Offset="0x1678"/>
         <Texture Name="gTreasureChestBossKeySideAndTopTex" OutName="boss_key_side_and_top" Format="rgba16" Width="32" Height="32" Offset="0x2F98"/>
 
-        <Skeleton Name="gTreasureChestSkel" Type="Normal" LimbType="Standard" Offset="0x47D8"/>
+        <Skeleton Name="gTreasureChestSkel" Type="Flex" LimbType="Standard" Offset="0x47D8"/>
         <Collision Name="gTreasureChestCol" Offset="0x5FC8"/>
-
-        <!--Large Unaccounted-->
-        <Blob Name="gBoxBlob_00025C" Size="0xF4" Offset="0x025C"/>
-        <Blob Name="gBoxBlob_00044C" Size="0x64" Offset="0x044C"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_bv.xml
+++ b/assets/xml/objects/object_bv.xml
@@ -7,7 +7,7 @@
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16098"/>
         <Skeleton Name="gBarinadeZapperSkel" Type="Flex" LimbType="Standard" Offset="0x185A0"/>
         <Skeleton Name="gBarinadeStumpSkel" Type="Flex" LimbType="Standard" Offset="0x17470"/>
-        <Skeleton Name="gBarinadeBariSkel" Type="Normal" LimbType="Standard" Offset="0x3A70"/>
+        <Skeleton Name="gBarinadeBariSkel" Type="Flex" LimbType="Standard" Offset="0x3A70"/>
         <Skeleton Name="gBarinadeCutSupportSkel" Type="Flex" LimbType="Standard" Offset="0x16BC8"/>
 
         <Animation Name="gBarinadeBodyAnim" Offset="0x3D84"/> <!-- Body anim 1-->

--- a/assets/xml/objects/object_bv_pal.xml
+++ b/assets/xml/objects/object_bv_pal.xml
@@ -7,7 +7,7 @@
         <Skeleton Name="gBarinadeSupportSkel" Type="Flex" LimbType="Standard" Offset="0x17498"/>
         <Skeleton Name="gBarinadeZapperSkel" Type="Flex" LimbType="Standard" Offset="0x199A0"/>
         <Skeleton Name="gBarinadeStumpSkel" Type="Flex" LimbType="Standard" Offset="0x18870"/>
-        <Skeleton Name="gBarinadeBariSkel" Type="Normal" LimbType="Standard" Offset="0x4E70"/>
+        <Skeleton Name="gBarinadeBariSkel" Type="Flex" LimbType="Standard" Offset="0x4E70"/>
         <Skeleton Name="gBarinadeCutSupportSkel" Type="Flex" LimbType="Standard" Offset="0x17FC8"/>
 
         <Animation Name="gBarinadeBodyAnim" Offset="0x5184"/> <!-- Body anim 1-->

--- a/assets/xml/objects/object_door_killer.xml
+++ b/assets/xml/objects/object_door_killer.xml
@@ -12,6 +12,6 @@
         <DList Name="object_door_killer_DL_001550" Offset="0x1550"/>
         <DList Name="object_door_killer_DL_0017B8" Offset="0x17B8"/>
         <DList Name="object_door_killer_DL_001A58" Offset="0x1A58"/>
-        <Skeleton Name="object_door_killer_Skel_001BC8" Type="Flex" LimbType="Standard" Offset="0x1BC8"/>
+        <Skeleton Name="object_door_killer_Skel_001BC8" Type="Flex" LimbType="LOD" Offset="0x1BC8"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_gi_medal.xml
+++ b/assets/xml/objects/object_gi_medal.xml
@@ -2,7 +2,7 @@
     <File Name="object_gi_medal" Segment="6">
         <DList Name="gGiForestMedallionFaceDL" Offset="0x0CB0"/>
         <DList Name="gGiMedallionDL" Offset="0x0E18"/>
-        <Array Name="gGiFireMedallionUnusedVtx" Count="143" Offset="0x11B0">
+        <Array Name="gGiFireMedallionUnusedVtx" Count="148" Offset="0x11B0">
             <Vtx/>
         </Array>
         <DList Name="gGiFireMedallionFaceDL" Offset="0x1AF0"/>

--- a/assets/xml/objects/object_gi_medal.xml
+++ b/assets/xml/objects/object_gi_medal.xml
@@ -2,10 +2,25 @@
     <File Name="object_gi_medal" Segment="6">
         <DList Name="gGiForestMedallionFaceDL" Offset="0x0CB0"/>
         <DList Name="gGiMedallionDL" Offset="0x0E18"/>
+        <Array Name="gGiFireMedallionUnusedVtx" Count="143" Offset="0x11B0">
+            <Vtx/>
+        </Array>
         <DList Name="gGiFireMedallionFaceDL" Offset="0x1AF0"/>
+        <Array Name="gGiWaterMedallionUnusedVtx" Count="143" Offset="0x1F40">
+            <Vtx/>
+        </Array>
         <DList Name="gGiWaterMedallionFaceDL" Offset="0x2830"/>
+        <Array Name="gGiSpiritMedallionUnusedVtx" Count="143" Offset="0x2D20">
+            <Vtx/>
+        </Array>
         <DList Name="gGiSpiritMedallionFaceDL" Offset="0x3610"/>
+        <Array Name="gGiShadowMedallionUnusedVtx" Count="143" Offset="0x3A40">
+            <Vtx/>
+        </Array>
         <DList Name="gGiShadowMedallionFaceDL" Offset="0x4330"/>
+        <Array Name="gGiLightMedallionUnusedVtx" Count="143" Offset="0x4930">
+            <Vtx/>
+        </Array>
         <DList Name="gGiLightMedallionFaceDL" Offset="0x5220"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_hintnuts.xml
+++ b/assets/xml/objects/object_hintnuts.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="object_hintnuts" Segment="6">
         <!-- Deku scrub skeleton -->
-        <Skeleton Name="gHintNutsSkel" Type="Normal" LimbType="Standard" Offset="0x23B8"/>
+        <Skeleton Name="gHintNutsSkel" Type="Flex" LimbType="Standard" Offset="0x23B8"/>
 
         <!-- Deku Scrub animations -->
         <Animation Name="gHintNutsSpitAnim" Offset="0x168"/>

--- a/assets/xml/objects/object_hni.xml
+++ b/assets/xml/objects/object_hni.xml
@@ -16,7 +16,7 @@
         <Texture Name="gHorseIngoManeTex" OutName="horse_ingo_mane" Format="i8" Width="16" Height="16" Offset="0x740"/>
         <Texture Name="gHorseIngoNostrilsTex" OutName="horse_ingo_nostrils" Format="rgba16" Width="16" Height="16" Offset="0x440"/>
         <Texture Name="gHorseIngoNoseTex" OutName="horse_ingo_nose" Format="i8" Width="8" Height="8" Offset="0x400"/>
-        <Texture Name="gHorseIngoForeheadTex" OutName="horse_ingo_forehead" Format="i8" Width="8" Height="8" Offset="0x840"/>
+        <Texture Name="gHorseIngoForeheadTex" OutName="horse_ingo_forehead" Format="i8" Width="16" Height="8" Offset="0x840"/>
         <Limb Name="gHorseIngoHeadLimb" LimbType="Skin" Offset="0x4748"/>
 
         <!-- Body -->

--- a/assets/xml/objects/object_ik.xml
+++ b/assets/xml/objects/object_ik.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_ik" Segment="6">
-        <Skeleton Name="object_ik_Skel_000380" Type="Normal" LimbType="Standard" Offset="0x380"/>
-        <Skeleton Name="object_ik_Skel_000660" Type="Normal" LimbType="Standard" Offset="0x660"/>
-        <Skeleton Name="object_ik_Skel_000C90" Type="Normal" LimbType="Standard" Offset="0xC90"/>
+        <Skeleton Name="object_ik_Skel_000380" Type="Flex" LimbType="Standard" Offset="0x380"/>
+        <Skeleton Name="object_ik_Skel_000660" Type="Flex" LimbType="Standard" Offset="0x660"/>
+        <Skeleton Name="object_ik_Skel_000C90" Type="Flex" LimbType="Standard" Offset="0xC90"/>
 
         <Skeleton Name="object_ik_Skel_000900" Type="Flex" LimbType="Standard" Offset="0x900"/>
         <Skeleton Name="object_ik_Skel_000F30" Type="Flex" LimbType="Standard" Offset="0xF30"/>
@@ -29,7 +29,10 @@
         <Animation Name="gIronKnuckleNabooruSummonAxeAnim" Offset="0xC114"/>
         <Animation Name="gIronKnuckleStandUpAnim" Offset="0xCD70"/>
         <Animation Name="object_ik_Anim_00DD50" Offset="0xDD50"/>
+        <Animation Name="gIronKnuckleUnused1Anim" Offset="0xE28C"/>
         <Animation Name="gIronKnuckleWalkAnim" Offset="0xED24"/>
+        <Animation Name="gIronKnuckleUnused2Anim" Offset="0xF620"/>
+        <Animation Name="gIronKnuckleUnused3Anim" Offset="0x1E820"/>
         <Animation Name="object_ik_Anim_01EB14" Offset="0x1EB14"/>
         <Animation Name="object_ik_Anim_01EE34" Offset="0x1EE34"/>
         <Animation Name="gIronKnuckleNabooruDeathAnim" Offset="0x203D8"/>

--- a/assets/xml/objects/object_kingdodongo.xml
+++ b/assets/xml/objects/object_kingdodongo.xml
@@ -101,7 +101,15 @@
         <Animation Name="object_kingdodongo_Anim_01CAE0" Offset="0x1B6E0"/>
         <Animation Name="object_kingdodongo_Anim_01D218" Offset="0x1BE18"/>
         <Animation Name="object_kingdodongo_Anim_01D934" Offset="0x1C534"/>
-        <DList Name="object_kingdodongo_DL_01D950" Offset="0x1C550"/><!--Blob Name="object_kingdodongo_Blob_01D9F0" Size="0x8000" Offset="0x1C5F0" /-->
+        <DList Name="object_kingdodongo_DL_01D950" Offset="0x1C550"/>
+        <Texture Name="object_kingdodongo_Tex_01D9F0" OutName="tex_0001D9F0" Format="ia8" Width="64" Height="64" Offset="0x1C5F0"/>
+        <Texture Name="object_kingdodongo_Tex_01E9F0" OutName="tex_0001E9F0" Format="ia8" Width="64" Height="64" Offset="0x1D5F0"/>
+        <Texture Name="object_kingdodongo_Tex_01F9F0" OutName="tex_0001F9F0" Format="ia8" Width="64" Height="64" Offset="0x1E5F0"/>
+        <Texture Name="object_kingdodongo_Tex_0209F0" OutName="tex_000209F0" Format="ia8" Width="64" Height="64" Offset="0x1F5F0"/>
+        <Texture Name="object_kingdodongo_Tex_0219F0" OutName="tex_000219F0" Format="ia8" Width="64" Height="64" Offset="0x205F0"/>
+        <Texture Name="object_kingdodongo_Tex_0229F0" OutName="tex_000229F0" Format="ia8" Width="64" Height="64" Offset="0x215F0"/>
+        <Texture Name="object_kingdodongo_Tex_0239F0" OutName="tex_000239F0" Format="ia8" Width="64" Height="64" Offset="0x225F0"/>
+        <Texture Name="object_kingdodongo_Tex_0249F0" OutName="tex_000249F0" Format="ia8" Width="64" Height="64" Offset="0x235F0"/>
         <DList Name="object_kingdodongo_DL_0259F0" Offset="0x245F0"/>
         <DList Name="object_kingdodongo_DL_025A90" Offset="0x24690"/>
         <Collision Name="object_kingdodongo_Col_025B64" Offset="0x24764"/>

--- a/assets/xml/objects/object_kingdodongo_pal.xml
+++ b/assets/xml/objects/object_kingdodongo_pal.xml
@@ -101,7 +101,15 @@
         <Animation Name="object_kingdodongo_Anim_01CAE0" Offset="0x1CAE0"/>
         <Animation Name="object_kingdodongo_Anim_01D218" Offset="0x1D218"/>
         <Animation Name="object_kingdodongo_Anim_01D934" Offset="0x1D934"/>
-        <DList Name="object_kingdodongo_DL_01D950" Offset="0x1D950"/><!--Blob Name="object_kingdodongo_Blob_01D9F0" Size="0x8000" Offset="0x1D9F0" /-->
+        <DList Name="object_kingdodongo_DL_01D950" Offset="0x1D950"/>
+        <Texture Name="object_kingdodongo_Tex_01D9F0" OutName="tex_0001D9F0" Format="ia8" Width="64" Height="64" Offset="0x1D9F0"/>
+        <Texture Name="object_kingdodongo_Tex_01E9F0" OutName="tex_0001E9F0" Format="ia8" Width="64" Height="64" Offset="0x1E9F0"/>
+        <Texture Name="object_kingdodongo_Tex_01F9F0" OutName="tex_0001F9F0" Format="ia8" Width="64" Height="64" Offset="0x1F9F0"/>
+        <Texture Name="object_kingdodongo_Tex_0209F0" OutName="tex_000209F0" Format="ia8" Width="64" Height="64" Offset="0x209F0"/>
+        <Texture Name="object_kingdodongo_Tex_0219F0" OutName="tex_000219F0" Format="ia8" Width="64" Height="64" Offset="0x219F0"/>
+        <Texture Name="object_kingdodongo_Tex_0229F0" OutName="tex_000229F0" Format="ia8" Width="64" Height="64" Offset="0x229F0"/>
+        <Texture Name="object_kingdodongo_Tex_0239F0" OutName="tex_000239F0" Format="ia8" Width="64" Height="64" Offset="0x239F0"/>
+        <Texture Name="object_kingdodongo_Tex_0249F0" OutName="tex_000249F0" Format="ia8" Width="64" Height="64" Offset="0x249F0"/>
         <DList Name="object_kingdodongo_DL_0259F0" Offset="0x259F0"/>
         <DList Name="object_kingdodongo_DL_025A90" Offset="0x25A90"/>
         <Collision Name="object_kingdodongo_Col_025B64" Offset="0x25B64"/>

--- a/assets/xml/objects/object_lightbox.xml
+++ b/assets/xml/objects/object_lightbox.xml
@@ -1,12 +1,11 @@
 <Root>
     <File Name="object_lightbox" Segment="6">
-        <Blob Name="object_lightbox_Blob_000000" Size="0x8" Offset="0x0"/>
-        <DList Name="object_lightbox_DL_000008" Offset="0x8"/>
-        <Blob Name="object_lightbox_Blob_0002A0" Size="0x130" Offset="0x2A0"/>
+        <DList Name="object_lightbox_DL_000000" Offset="0x0"/>
+        <Collision Name="object_lightbox_Col_0003A0" Offset="0x3A0"/>
         <DList Name="object_lightbox_DL_0003D0" Offset="0x3D0"/>
-        <Blob Name="object_lightbox_Blob_000670" Size="0x130" Offset="0x670"/>
+        <Collision Name="object_lightbox_Col_000770" Offset="0x770"/>
         <DList Name="object_lightbox_DL_0007A0" Offset="0x7A0"/>
-        <Blob Name="object_lightbox_Blob_000A40" Size="0x130" Offset="0xA40"/>
+        <Collision Name="object_lightbox_Col_000B40" Offset="0xB40"/>
         <DList Name="object_lightbox_DL_000B70" Offset="0xB70"/>
         <Texture Name="object_lightbox_Tex_000E10" OutName="tex_00000E10" Format="rgba16" Width="32" Height="32" Offset="0xE10"/>
         <Texture Name="object_lightbox_Tex_001610" OutName="tex_00001610" Format="rgba16" Width="32" Height="32" Offset="0x1610"/>

--- a/assets/xml/objects/object_link_child.xml
+++ b/assets/xml/objects/object_link_child.xml
@@ -123,6 +123,8 @@
         <Texture Name="gLinkChildNoseTex" OutName="nose" Format="ci8" Width="16" Height="16" Offset="0x5000" TlutOffset="0x5500"/>
         <Texture Name="gLinkChildUnusedHandTex" OutName="unused_hand" Format="ci8" Width="16" Height="16" Offset="0x5100" TlutOffset="0x5500"/>
         <Texture Name="gLinkChildEarTex" OutName="ear" Format="ci8" Width="16" Height="16" Offset="0x5200" TlutOffset="0x5500"/>
+        <Texture Name="gLinkChildUnused1Tex" OutName="unused_1" Format="ci8" Width="16" Height="16" Offset="0x5900" TlutOffset="0x5700"/>
+        <Texture Name="gLinkChildUnused2Tex" OutName="unused_2" Format="ci8" Width="32" Height="16" Offset="0x5A00" TlutOffset="0x5300"/>
         <Texture Name="gLinkChildLowerBootTex" OutName="lower_boot" Format="ci8" Width="16" Height="16" Offset="0x5C00" TlutOffset="0x5300"/>
         <Texture Name="gLinkChildUnusedBootTex" OutName="unused_boot" Format="ci8" Height="32" Width="24" Offset="0x5D00" TlutOffset="0x5300"/><!--Unused so hard to verify-->
         <Texture Name="gLinkChildBootTex" OutName="boot" Format="ci8" Width="32" Height="32" Offset="0x6000" TlutOffset="0x5300"/>
@@ -175,11 +177,12 @@
         <Texture Name="gLinkChildBunnyHoodEarTex" OutName="bunny_hood_ear" Format="rgba16" Width="16" Height="32" Offset="0x2C028"/>
 
         <!--TLUTs-->
+        <Texture Name="gLinkChildBeltTLUT" OutName="belt_tlut" Format="rgba16" Width="16" Height="16" Offset="0x5300"/>
         <Texture Name="gLinkChildSkinTLUT" OutName="skin_tlut" Format="rgba16" Width="16" Height="16" Offset="0x5500"/>
+        <Texture Name="gLinkChildUnusedTLUT" OutName="unused_tlut" Format="rgba16" Width="16" Height="16" Offset="0x5700"/>
         <Texture Name="gLinkChildHandTLUT" OutName="hand_tlut" Format="rgba16" Width="17" Height="4" Offset="0x9E88"/>
         <Texture Name="gLinkChildSwordsTLUT" OutName="swords_tlut" Format="rgba16" Width="16" Height="16" Offset="0x9F10"/> <!--For both the kokiri sword sheath and master sword-->
         <Texture Name="gLinkChildSwordTLUT" OutName="sword_tlut" Format="rgba16" Width="27" Height="4" Offset="0xA118"/>
-        <Texture Name="gLinkChildBeltTLUT" OutName="belt_tlut" Format="rgba16" Width="16" Height="16" Offset="0x5300"/>
 
         <!--Eyes-->
         <Texture Name="gLinkChildEyesOpenTex" OutName="eyes_open" Format="ci8" Width="64" Height="32" Offset="0x0000" TlutOffset="0x5500"/>

--- a/assets/xml/objects/object_medal.xml
+++ b/assets/xml/objects/object_medal.xml
@@ -6,7 +6,7 @@
         <DList Name="object_medal_DL_001200" Offset="0x1200"/>
         <DList Name="object_medal_DL_0016E0" Offset="0x16E0"/>
         <DList Name="object_medal_DL_001BC0" Offset="0x1BC0"/>
-        <Blob Name="object_medal_Blob_001D40" Size="0x400" Offset="0x1D40"/>
+        <Texture Name="object_medal_Tex_001D40" OutName="tex_00001D40" Format="ia8" Width="32" Height="32" Offset="0x1D40"/>
         <Texture Name="object_medal_Tex_002140" OutName="tex_00002140" Format="rgba16" Width="32" Height="32" Offset="0x2140"/>
         <Texture Name="object_medal_Tex_002940" OutName="tex_00002940" Format="rgba16" Width="32" Height="32" Offset="0x2940"/>
         <Texture Name="object_medal_Tex_003140" OutName="tex_00003140" Format="rgba16" Width="32" Height="32" Offset="0x3140"/>

--- a/assets/xml/objects/object_oA3.xml
+++ b/assets/xml/objects/object_oA3.xml
@@ -1,7 +1,6 @@
 <Root>
     <File Name="object_oA3" Segment="6">
-        <Blob Name="object_oA3_Blob_00000000" Size="0x8" Offset="0x0"/>
-        <DList Name="object_oA3_DL_00000008" Offset="0x8"/>
+        <DList Name="object_oA3_DL_00000000" Offset="0x0"/>
         <Texture Name="object_oA3_Tex_000012F0" OutName="tex_000012F0" Format="rgba16" Width="32" Height="32" Offset="0x12F0"/>
         <Texture Name="object_oA3_Tex_00001AF0" OutName="tex_00001AF0" Format="rgba16" Width="16" Height="16" Offset="0x1AF0"/>
         <Texture Name="object_oA3_Tex_00001CF0" OutName="tex_00001CF0" Format="rgba16" Width="16" Height="16" Offset="0x1CF0"/>

--- a/assets/xml/objects/object_oE1.xml
+++ b/assets/xml/objects/object_oE1.xml
@@ -56,7 +56,8 @@
         <DList Name="object_oE1_DL_004738" Offset="0x4738"/>
         <Texture Name="object_oE1_TLUT_004808" OutName="tlut_00004808" Format="rgba16" Width="16" Height="16" Offset="0x4808"/>
         <Texture Name="object_oE1_Tex_004A08" OutName="tex_00004A08" Format="ci8" Width="32" Height="32" Offset="0x4A08" TlutOffset="0x4808"/>
-        <Blob Name="object_oE1_Blob_004E08" Size="0x800" Offset="0x4E08"/>
+        <Texture Name="object_oE1_Tex_004E08" OutName="tex_00004E08" Format="ci8" Width="32" Height="32" Offset="0x4E08" TlutOffset="0x4808"/>
+        <Texture Name="object_oE1_Tex_005208" OutName="tex_00005208" Format="ci8" Width="32" Height="32" Offset="0x5208" TlutOffset="0x4808"/>
         <Texture Name="object_oE1_TLUT_005608" OutName="tlut_00005608" Format="rgba16" Width="16" Height="16" Offset="0x5608"/>
         <Texture Name="object_oE1_Tex_005808" OutName="tex_00005808" Format="ci8" Width="8" Height="8" Offset="0x5808" TlutOffset="0x5608"/>
         <Texture Name="object_oE1_Tex_005848" OutName="tex_00005848" Format="ci8" Width="16" Height="16" Offset="0x5848" TlutOffset="0x5608"/>

--- a/assets/xml/objects/object_oE11.xml
+++ b/assets/xml/objects/object_oE11.xml
@@ -3,7 +3,8 @@
         <DList Name="object_oE11_DL_0009F0" Offset="0x9F0"/>
         <Texture Name="object_oE11_TLUT_000F70" OutName="tlut_00000F70" Format="rgba16" Width="16" Height="16" Offset="0xF70"/>
         <Texture Name="object_oE11_Tex_001170" OutName="tex_00001170" Format="ci8" Width="32" Height="32" Offset="0x1170" TlutOffset="0xF70"/>
-        <Blob Name="object_oE11_Blob_001570" Size="0x800" Offset="0x1570"/>
+        <Texture Name="object_oE11_Tex_001570" OutName="tex_00001570" Format="ci8" Width="32" Height="32" Offset="0x1570" TlutOffset="0xF70"/>
+        <Texture Name="object_oE11_Tex_001970" OutName="tex_00001970" Format="ci8" Width="32" Height="32" Offset="0x1970" TlutOffset="0xF70"/>
         <Texture Name="object_oE11_TLUT_001D70" OutName="tlut_00001D70" Format="rgba16" Width="16" Height="16" Offset="0x1D70"/>
         <Texture Name="object_oE11_Tex_001F70" OutName="tex_00001F70" Format="ci8" Width="8" Height="8" Offset="0x1F70" TlutOffset="0x1D70"/>
         <Texture Name="object_oE11_Tex_001FB0" OutName="tex_00001FB0" Format="ci8" Width="16" Height="16" Offset="0x1FB0" TlutOffset="0x1D70"/>

--- a/assets/xml/objects/object_oE12.xml
+++ b/assets/xml/objects/object_oE12.xml
@@ -3,7 +3,8 @@
         <DList Name="object_oE12_DL_001020" Offset="0x1020"/>
         <Texture Name="object_oE12_TLUT_001600" OutName="tlut_00001600" Format="rgba16" Width="16" Height="16" Offset="0x1600"/>
         <Texture Name="object_oE12_Tex_001800" OutName="tex_00001800" Format="ci8" Width="32" Height="32" Offset="0x1800" TlutOffset="0x1600"/>
-        <Blob Name="object_oE12_Blob_001C00" Size="0x800" Offset="0x1C00"/>
+        <Texture Name="object_oE12_Tex_001C00" OutName="tex_00001C00" Format="ci8" Width="32" Height="32" Offset="0x1C00" TlutOffset="0x1600"/>
+        <Texture Name="object_oE12_Tex_002000" OutName="tex_00002000" Format="ci8" Width="32" Height="32" Offset="0x2000" TlutOffset="0x1600"/>
         <Texture Name="object_oE12_Tex_002400" OutName="tex_00002400" Format="rgba16" Width="8" Height="8" Offset="0x2400"/>
         <Texture Name="object_oE12_Tex_002480" OutName="tex_00002480" Format="rgba16" Width="32" Height="16" Offset="0x2480"/>
         <Texture Name="object_oE12_Tex_002880" OutName="tex_00002880" Format="rgba16" Width="8" Height="16" Offset="0x2880"/>

--- a/assets/xml/objects/object_oE2.xml
+++ b/assets/xml/objects/object_oE2.xml
@@ -56,7 +56,8 @@
         <DList Name="object_oE2_DL_003AB0" Offset="0x3AB0"/>
         <Texture Name="object_oE2_TLUT_003C70" OutName="tlut_00003C70" Format="rgba16" Width="16" Height="16" Offset="0x3C70"/>
         <Texture Name="object_oE2_Tex_003E70" OutName="tex_00003E70" Format="ci8" Width="32" Height="32" Offset="0x3E70" TlutOffset="0x3C70"/>
-        <Blob Name="object_oE2_Blob_004270" Size="0x800" Offset="0x4270"/>
+        <Texture Name="object_oE2_Tex_004270" OutName="tex_00004270" Format="ci8" Width="32" Height="32" Offset="0x4270" TlutOffset="0x3C70"/>
+        <Texture Name="object_oE2_Tex_004670" OutName="tex_00004670" Format="ci8" Width="32" Height="32" Offset="0x4670" TlutOffset="0x3C70"/>
         <Texture Name="object_oE2_TLUT_004A70" OutName="tlut_00004A70" Format="rgba16" Width="16" Height="16" Offset="0x4A70"/>
         <Texture Name="object_oE2_Tex_004C70" OutName="tex_00004C70" Format="ci8" Width="32" Height="32" Offset="0x4C70" TlutOffset="0x4A70"/>
         <Texture Name="object_oE2_Tex_005070" OutName="tex_00005070" Format="ci8" Width="16" Height="16" Offset="0x5070" TlutOffset="0x4A70"/>

--- a/assets/xml/objects/object_oE3.xml
+++ b/assets/xml/objects/object_oE3.xml
@@ -56,13 +56,14 @@
         <DList Name="object_oE3_DL_004D70" Offset="0x4D70"/>
         <Texture Name="object_oE3_TLUT_004F20" OutName="tlut_00004F20" Format="rgba16" Width="16" Height="16" Offset="0x4F20"/>
         <Texture Name="object_oE3_Tex_005120" OutName="tex_00005120" Format="ci8" Width="32" Height="32" Offset="0x5120" TlutOffset="0x4F20"/>
-        <Blob Name="object_oE3_Blob_005520" Size="0x800" Offset="0x5520"/>
+        <Texture Name="object_oE3_Tex_005520" OutName="tex_00005520" Format="ci8" Width="32" Height="32" Offset="0x5520" TlutOffset="0x4F20"/>
+        <Texture Name="object_oE3_Tex_005920" OutName="tex_00005920" Format="ci8" Width="32" Height="32" Offset="0x5920" TlutOffset="0x4F20"/>
         <Texture Name="object_oE3_TLUT_005D20" OutName="tlut_00005D20" Format="rgba16" Width="16" Height="16" Offset="0x5D20"/>
         <Texture Name="object_oE3_Tex_005F20" OutName="tex_00005F20" Format="ci8" Width="8" Height="8" Offset="0x5F20" TlutOffset="0x5D20"/>
-        <Blob Name="object_oE3_Blob_005F60" Size="0x200" Offset="0x5F60"/>
+        <Texture Name="object_oE3_Tex_005F60" OutName="tex_00005F60" Format="ci8" Width="32" Height="16" Offset="0x5F60" TlutOffset="0x5D20"/>
         <Texture Name="object_oE3_Tex_006160" OutName="tex_00006160" Format="ci8" Width="16" Height="16" Offset="0x6160" TlutOffset="0x5D20"/>
         <Texture Name="object_oE3_Tex_006260" OutName="tex_00006260" Format="ci8" Width="16" Height="16" Offset="0x6260" TlutOffset="0x5D20"/>
-        <Blob Name="object_oE3_Blob_006360" Size="0x200" Offset="0x6360"/>
+        <Texture Name="object_oE3_Tex_006360" OutName="tex_00006360" Format="ci8" Width="32" Height="16" Offset="0x6360" TlutOffset="0x5D20"/>
         <Texture Name="object_oE3_Tex_006560" OutName="tex_00006560" Format="rgba16" Width="8" Height="16" Offset="0x6560"/>
         <Texture Name="object_oE3_Tex_006660" OutName="tex_00006660" Format="rgba16" Width="32" Height="32" Offset="0x6660"/>
         <Texture Name="object_oE3_Tex_006E60" OutName="tex_00006E60" Format="i4" Width="16" Height="8" Offset="0x6E60"/>

--- a/assets/xml/objects/object_oE5.xml
+++ b/assets/xml/objects/object_oE5.xml
@@ -52,9 +52,9 @@
         <Texture Name="object_oE5_Tex_003A40" OutName="tex_00003A40" Format="ci8" Width="32" Height="32" Offset="0x3A40"  TlutOffset="0x3440"/>
         <Texture Name="object_oE5_Tex_003E40" OutName="tex_00003E40" Format="ci8" Width="32" Height="32" Offset="0x3E40"  TlutOffset="0x3440"/>
         <Texture Name="object_oE5_TLUT_004240" OutName="tlut_00004240" Format="rgba16" Width="16" Height="16" Offset="0x4240"/>
-        <Texture Name="object_oE5_Tex_004440" OutName="tex_00004440" Format="ci8" Width="8" Height="8" Offset="0x4440"  TlutOffset="0x4240"/>
-        <Texture Name="object_oE5_Tex_004480" OutName="tex_00004480" Format="ci8" Width="16" Height="16" Offset="0x4480"  TlutOffset="0x4240"/>
-        <Texture Name="object_oE5_Tex_004580" OutName="tex_00004580" Format="ci8" Width="16" Height="16" Offset="0x4580"  TlutOffset="0x4240"/>
+        <Texture Name="object_oE5_Tex_004440" OutName="tex_00004440" Format="ci8" Width="8" Height="8" Offset="0x4440" TlutOffset="0x4240"/>
+        <Texture Name="object_oE5_Tex_004480" OutName="tex_00004480" Format="ci8" Width="16" Height="16" Offset="0x4480" TlutOffset="0x4240"/>
+        <Texture Name="object_oE5_Tex_004580" OutName="tex_00004580" Format="ci8" Width="16" Height="16" Offset="0x4580" TlutOffset="0x4240"/>
         <Texture Name="object_oE5_Tex_004680" OutName="tex_00004680" Format="rgba16" Width="32" Height="16" Offset="0x4680"/>
         <Texture Name="object_oE5_Tex_004A80" OutName="tex_00004A80" Format="rgba16" Width="8" Height="16" Offset="0x4A80"/>
         <Texture Name="object_oE5_Tex_004B80" OutName="tex_00004B80" Format="i4" Width="16" Height="8" Offset="0x4B80"/>

--- a/assets/xml/objects/object_oE6.xml
+++ b/assets/xml/objects/object_oE6.xml
@@ -3,7 +3,8 @@
         <DList Name="object_oE6_DL_000AE0" Offset="0xAE0"/>
         <Texture Name="object_oE6_TLUT_000FD0" OutName="tlut_00000FD0" Format="rgba16" Width="16" Height="16" Offset="0xFD0"/>
         <Texture Name="object_oE6_Tex_0011D0" OutName="tex_000011D0" Format="ci8" Width="32" Height="32" Offset="0x11D0" TlutOffset="0xFD0"/>
-        <Blob Name="object_oE6_Blob_0015D0" Size="0x800" Offset="0x15D0"/>
+        <Texture Name="object_oE6_Tex_0015D0" OutName="tex_000015D0" Format="ci8" Width="32" Height="32" Offset="0x15D0" TlutOffset="0xFD0"/>
+        <Texture Name="object_oE6_Tex_0019D0" OutName="tex_000019D0" Format="ci8" Width="32" Height="32" Offset="0x19D0" TlutOffset="0xFD0"/>
         <Texture Name="object_oE6_TLUT_001DD0" OutName="tlut_00001DD0" Format="rgba16" Width="16" Height="16" Offset="0x1DD0"/>
         <Texture Name="object_oE6_Tex_001FD0" OutName="tex_00001FD0" Format="ci8" Width="8" Height="8" Offset="0x1FD0" TlutOffset="0x1DD0"/>
         <Texture Name="object_oE6_Tex_002010" OutName="tex_00002010" Format="ci8" Width="16" Height="16" Offset="0x2010" TlutOffset="0x1DD0"/>

--- a/assets/xml/objects/object_oE7.xml
+++ b/assets/xml/objects/object_oE7.xml
@@ -7,7 +7,8 @@
         <Texture Name="object_oE7_Tex_001158" OutName="tex_00001158" Format="ci8" Width="16" Height="16" Offset="0x1158" TlutOffset="0xB18"/>
         <Texture Name="object_oE7_TLUT_001258" OutName="tlut_00001258" Format="rgba16" Width="16" Height="16" Offset="0x1258"/>
         <Texture Name="object_oE7_Tex_001458" OutName="tex_00001458" Format="ci8" Width="32" Height="32" Offset="0x1458" TlutOffset="0x1258"/>
-        <Blob Name="object_oE7_Blob_001858" Size="0x800" Offset="0x1858"/>
+        <Texture Name="object_oE7_Tex_001858" OutName="tex_00001858" Format="ci8" Width="32" Height="32" Offset="0x1858" TlutOffset="0x1258"/>
+        <Texture Name="object_oE7_Tex_001C58" OutName="tex_00001C58" Format="ci8" Width="32" Height="32" Offset="0x1C58" TlutOffset="0x1258"/>
         <Texture Name="object_oE7_Tex_002058" OutName="tex_00002058" Format="rgba16" Width="32" Height="32" Offset="0x2058"/>
         <Texture Name="object_oE7_Tex_002858" OutName="tex_00002858" Format="rgba16" Width="16" Height="16" Offset="0x2858"/>
     </File>

--- a/assets/xml/objects/object_oE8.xml
+++ b/assets/xml/objects/object_oE8.xml
@@ -3,7 +3,8 @@
         <DList Name="object_oE8_DL_000CA0" Offset="0xCA0"/>
         <Texture Name="object_oE8_TLUT_001248" OutName="tlut_00001248" Format="rgba16" Width="16" Height="16" Offset="0x1248"/>
         <Texture Name="object_oE8_Tex_001448" OutName="tex_00001448" Format="ci8" Width="32" Height="32" Offset="0x1448" TlutOffset="0x1248"/>
-        <Blob Name="object_oE8_Blob_001848" Size="0x800" Offset="0x1848"/>
+        <Texture Name="object_oE8_Tex_001848" OutName="tex_00001848" Format="ci8" Width="32" Height="32" Offset="0x1848" TlutOffset="0x1248"/>
+        <Texture Name="object_oE8_Tex_001C48" OutName="tex_00001C48" Format="ci8" Width="32" Height="32" Offset="0x1C48" TlutOffset="0x1248"/>
         <Texture Name="object_oE8_TLUT_002048" OutName="tlut_00002048" Format="rgba16" Width="16" Height="16" Offset="0x2048"/>
         <Texture Name="object_oE8_Tex_002248" OutName="tex_00002248" Format="ci8" Width="8" Height="8" Offset="0x2248" TlutOffset="0x2048"/>
         <Texture Name="object_oE8_Tex_002288" OutName="tex_00002288" Format="ci8" Width="16" Height="16" Offset="0x2288" TlutOffset="0x2048"/>

--- a/assets/xml/objects/object_oE9.xml
+++ b/assets/xml/objects/object_oE9.xml
@@ -3,7 +3,8 @@
         <DList Name="object_oE9_DL_000800" Offset="0x800"/>
         <Texture Name="object_oE9_TLUT_000C90" OutName="tlut_00000C90" Format="rgba16" Width="16" Height="16" Offset="0xC90"/>
         <Texture Name="object_oE9_Tex_000E90" OutName="tex_00000E90" Format="ci8" Width="32" Height="32" Offset="0xE90" TlutOffset="0xC90"/>
-        <Blob Name="object_oE9_Blob_001290" Size="0x800" Offset="0x1290"/>
+        <Texture Name="object_oE9_Tex_001290" OutName="tex_00001290" Format="ci8" Width="32" Height="32" Offset="0x1290" TlutOffset="0xC90"/>
+        <Texture Name="object_oE9_Tex_001690" OutName="tex_00001690" Format="ci8" Width="32" Height="32" Offset="0x1690" TlutOffset="0xC90"/>
         <Texture Name="object_oE9_TLUT_001A90" OutName="tlut_00001A90" Format="rgba16" Width="16" Height="16" Offset="0x1A90"/>
         <Texture Name="object_oE9_Tex_001C90" OutName="tex_00001C90" Format="ci8" Width="8" Height="8" Offset="0x1C90" TlutOffset="0x1A90"/>
         <Texture Name="object_oE9_Tex_001CD0" OutName="tex_00001CD0" Format="ci8" Width="16" Height="16" Offset="0x1CD0" TlutOffset="0x1A90"/>

--- a/assets/xml/objects/object_ossan.xml
+++ b/assets/xml/objects/object_ossan.xml
@@ -1,6 +1,9 @@
 <Root>
     <File Name="object_ossan" Segment="6">
         <Animation Name="gObjectOssanAnim_000338" Offset="0x338"/>
+        <Array Name="gObjectOssanUnusedVtx" Count="156" Offset="0x350">
+            <Vtx/>
+        </Array>
         <Texture Name="gOssanEyesTLUT" OutName="ossan_eyes_tlut" Format="rgba16" Width="63" Height="4" Offset="0x4530"/>
         <Texture Name="gOssanTLUT" OutName="ossan_tlut" Format="rgba16" Width="168" Height="1" Offset="0x4728"/>
         <Texture Name="gOssanEyeOpenTex" OutName="eye_open" Format="ci8" Width="32" Height="32" Offset="0x4878" TlutOffset="0x4530"/>

--- a/assets/xml/objects/object_ossan.xml
+++ b/assets/xml/objects/object_ossan.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="object_ossan" Segment="6">
         <Animation Name="gObjectOssanAnim_000338" Offset="0x338"/>
-        <Array Name="gObjectOssanUnusedVtx" Count="156" Offset="0x350">
+        <Array Name="gObjectOssanUnusedVtx" Count="97" Offset="0x350">
             <Vtx/>
         </Array>
         <Texture Name="gOssanEyesTLUT" OutName="ossan_eyes_tlut" Format="rgba16" Width="63" Height="4" Offset="0x4530"/>

--- a/assets/xml/objects/object_rl.xml
+++ b/assets/xml/objects/object_rl.xml
@@ -12,8 +12,6 @@
         <DList Name="object_rl_DL_002F20" Offset="0x2F20"/>
         <DList Name="object_rl_DL_003058" Offset="0x3058"/>
         <Texture Name="object_rl_TLUT_0032A0" OutName="tlut_000032A0" Format="rgba16" Width="160" Height="1" Offset="0x32A0"/>
-        <!--Blob Name="object_rl_Blob_0034A0" Size="0x80" Offset="0x34A0" /-->
-
         <Texture Name="object_rl_Tex_003520" OutName="tex_00003520" Format="ci8" Width="16" Height="16" Offset="0x3520" TlutOffset="0x32A0"/>
         <Texture Name="object_rl_Tex_003620" OutName="tex_00003620" Format="ci8" Width="32" Height="16" Offset="0x3620" TlutOffset="0x32A0"/>
         <Texture Name="object_rl_Tex_003820" OutName="tex_00003820" Format="ci8" Width="16" Height="16" Offset="0x3820" TlutOffset="0x32A0"/>
@@ -22,13 +20,12 @@
         <Texture Name="object_rl_Tex_003B60" OutName="tex_00003B60" Format="ci8" Width="32" Height="16" Offset="0x3B60" TlutOffset="0x32A0"/>
         <Texture Name="object_rl_Tex_003D60" OutName="tex_00003D60" Format="ci8" Width="8" Height="8" Offset="0x3D60" TlutOffset="0x32A0"/>
         <Texture Name="object_rl_Tex_003DA0" OutName="tex_00003DA0" Format="ci8" Width="16" Height="16" Offset="0x3DA0" TlutOffset="0x32A0"/>
-
         <DList Name="object_rl_DL_005220" Offset="0x5220"/>
         <Texture Name="object_rl_TLUT_006318" OutName="tlut_00006318" Format="rgba16" Width="16" Height="16" Offset="0x6318"/>
         <Texture Name="object_rl_Tex_006518" OutName="tex_00006518" Format="ci8" Width="16" Height="16" Offset="0x6518" TlutOffset="0x6318"/>
         <Texture Name="object_rl_Tex_006618" OutName="tex_00006618" Format="ci8" Width="8" Height="8" Offset="0x6618" TlutOffset="0x6318"/>
         <Texture Name="object_rl_Tex_006658" OutName="tex_00006658" Format="ci8" Width="16" Height="16" Offset="0x6658" TlutOffset="0x6318"/>
-        <Blob Name="object_rl_Blob_006758" Size="0x40" Offset="0x6758"/>
+        <Texture Name="object_rl_Tex_006758" OutName="tex_00006758" Format="ci8" Width="8" Height="8" Offset="0x6758" TlutOffset="0x6318"/>
         <Texture Name="object_rl_Tex_006798" OutName="tex_00006798" Format="ci8" Width="32" Height="32" Offset="0x6798" TlutOffset="0x6318"/>
         <Texture Name="object_rl_Tex_006B98" OutName="tex_00006B98" Format="ci8" Width="32" Height="32" Offset="0x6B98" TlutOffset="0x6318"/>
         <Texture Name="object_rl_Tex_006F98" OutName="tex_00006F98" Format="ci8" Width="16" Height="32" Offset="0x6F98" TlutOffset="0x6318"/>

--- a/assets/xml/objects/object_sa.xml
+++ b/assets/xml/objects/object_sa.xml
@@ -66,7 +66,7 @@
         <DList Name="gSariaLeftShinDL" Offset="0xAC20"/>
         <DList Name="gSariaLeftFootDL" Offset="0xAEE0"/>
 
-        <Texture Name="gSariaClothesTLUT" OutName="clothes_tlut" Format="rgba16" Width="18" Height="6" Offset="0x21F0"/>
+        <Texture Name="gSariaClothesTLUT" OutName="clothes_tlut" Format="rgba16" Width="16" Height="16" Offset="0x21F0"/>
         <Texture Name="gSariaMouthTLUT" OutName="mouth_tlut" Format="rgba16" Width="29" Height="8" Offset="0x2CF8"/>
         <Texture Name="gSariaEyeTLUT" OutName="eye_tlut" Format="rgba16" Width="63" Height="4" Offset="0x2B00"/>
         <Texture Name="gSariaSkinTLUT" OutName="skin_tlut" Format="rgba16" Width="8" Height="9" Offset="0x2A70"/>

--- a/assets/xml/objects/object_sb.xml
+++ b/assets/xml/objects/object_sb.xml
@@ -4,8 +4,9 @@
         <Animation Name="object_sb_Anim_0000B4" Offset="0xB4"/>
         <Animation Name="object_sb_Anim_000124" Offset="0x124"/>
         <Animation Name="object_sb_Anim_000194" Offset="0x194"/>
-        <Blob Name="object_sb_Blob_0001A4" Size="0x49C" Offset="0x1A4"/>
-        <Blob Name="object_sb_Blob_000840" Size="0x3C0" Offset="0x840"/>
+        <Array Name="object_sb_Vtx_0001B0" Count="189" Offset="0x1B0">
+            <Vtx/>
+        </Array>
         <DList Name="object_sb_DL_000D80" Offset="0xD80"/>
         <DList Name="object_sb_DL_000E70" Offset="0xE70"/>
         <Texture Name="object_sb_Tex_001020" OutName="tex_00001020" Format="rgba16" Width="32" Height="32" Offset="0x1020"/>

--- a/assets/xml/objects/object_skb.xml
+++ b/assets/xml/objects/object_skb.xml
@@ -55,10 +55,15 @@
         <Texture Name="gStalchildEyeTex" OutName="stalchild_eye" Format="rgba16" Width="8" Height="8" Offset="0x2120"/>
 
         <!-- Stalchild animations -->
-        <Animation Name="gStalchildUncurlingAnim" Offset="0x1854"/>
-        <Animation Name="gStalchildDyingAnim" Offset="0x9DC"/>
-        <Animation Name="gStalchildDamagedAnim" Offset="0xD98"/>
-        <Animation Name="gStalchildWalkingAnim" Offset="0x47E0"/>
         <Animation Name="gStalchildAttackingAnim" Offset="0x460"/>
+        <Blob Name="object_skb_zeroes_Blob_470" Size="0x20" Offset="0x470"/>
+        <Animation Name="gStalchildDyingAnim" Offset="0x9DC"/>
+        <Blob Name="object_skb_zeroes_Blob_9EC" Size="0x24" Offset="0x9EC"/>
+        <Animation Name="gStalchildDamagedAnim" Offset="0xD98"/>
+        <Blob Name="object_skb_zeroes_Blob_DA8" Size="0x18" Offset="0xDA8"/>
+        <Animation Name="gStalchildUncurlingAnim" Offset="0x1854"/>
+        <Blob Name="object_skb_zeroes_Blob_1864" Size="0x3C" Offset="0x1864"/>
+        <Animation Name="gStalchildWalkingAnim" Offset="0x47E0"/>
+        <Blob Name="object_skb_zeroes_Blob_47F0" Size="0x20" Offset="0x47F0"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_skj.xml
+++ b/assets/xml/objects/object_skj.xml
@@ -41,27 +41,25 @@
         <DList Name="gSkullKidRightArmDL" Offset="0x4810"/>
 
         <Animation Name="gSkullKidBackflipAnim" Offset="0x051C"/>
+        <Blob Name="object_skj_zeroes_Blob_52C" Size="0x24" Offset="0x52C"/>
         <Animation Name="gSkullKidShootNeedleAnim" Offset="0x07A4"/>
         <Animation Name="gSkullKidPlayFluteAnim" Offset="0x0E10"/>
+        <Blob Name="object_skj_zeroes_Blob_E20" Size="0x30" Offset="0xE20"/>
         <Animation Name="gSkullKidDieAnim" Offset="0x6A98"/>
+        <Blob Name="object_skj_zeroes_Blob_EAA8" Size="0x48" Offset="0x6AA8"/>
         <Animation Name="gSkullKidHitAnim" Offset="0x6D84"/>
+        <Blob Name="object_skj_zeroes_Blob_ED94" Size="0x1C" Offset="0x6D94"/>
         <Animation Name="gSkullKidLandAnim" Offset="0x7128"/>
+        <Blob Name="object_skj_zeroes_Blob_7138" Size="0x18" Offset="0x7138"/>
         <Animation Name="gSkullKidLookLeftAndRightAnim" Offset="0x8174"/>
+        <Blob Name="object_skj_zeroes_Blob_8184" Size="0x6C" Offset="0x8184"/>
         <Animation Name="gSkullKidFightingStanceAnim" Offset="0x8374"/>
+        <Blob Name="object_skj_zeroes_Blob_8BAC" Size="0x54" Offset="0x8BAC"/>
         <Animation Name="gSkullKidWaitAnim" Offset="0x8B9C"/>
         <Animation Name="gSkullKidWalkToPlayerAnim" Offset="0x8E14"/>
 
         <Texture Name="gSkullKidSkullMaskTex" OutName="skull_mask" Format="rgba16" Width="16" Height="16" Offset="0xF08"/>
         <Texture Name="gSkullKidSkullMaskTeethTex" OutName="skull_mask_teeth" Format="rgba16" Width="8" Height="8" Offset="0x1108"/>
         <Texture Name="gSkullKidSkullMaskNoseTex" OutName="skull_mask_nose" Format="rgba16" Width="8" Height="8" Offset="0x1188"/>
-
-        <!--Unaccounted blocks larger than the padding of a file-->
-        <Blob Name="gSKJunaccounted_52C" Size="0x24" Offset="0x52C"/>
-        <Blob Name="gSKJunaccounted_E20" Size="0x30" Offset="0xE20"/>
-        <Blob Name="gSKJunaccounted_EAA8" Size="0x48" Offset="0x6AA8"/>
-        <Blob Name="gSKJunaccounted_ED94" Size="0x1C" Offset="0x6D94"/>
-        <Blob Name="gSKJunaccounted_7138" Size="0x18" Offset="0x7138"/>
-        <Blob Name="gSKJunaccounted_8184" Size="0x6C" Offset="0x8184"/>
-        <Blob Name="gSKJunaccounted_8BAC" Size="0x54" Offset="0x8BAC"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_spot02_objects.xml
+++ b/assets/xml/objects/object_spot02_objects.xml
@@ -3,7 +3,6 @@
         <Texture Name="object_spot02_objects_Tex_000000" OutName="tex_00000000" Format="i8" Width="32" Height="64" Offset="0x0"/>
         <Texture Name="object_spot02_objects_Tex_000800" OutName="tex_00000800" Format="i8" Width="32" Height="64" Offset="0x800"/>
         <DList Name="object_spot02_objects_DL_0013F0" Offset="0x13F0"/>
-        <Blob Name="object_spot02_objects_Blob_0015D8" Size="0x0008" Offset="0x15D8"/>
         <DList Name="object_spot02_objects_DL_009620" Offset="0x9620"/>
         <DList Name="object_spot02_objects_DL_0126F0" Offset="0x126F0"/>
         <DList Name="object_spot02_objects_DL_0127C0" Offset="0x127C0"/>

--- a/assets/xml/objects/object_st.xml
+++ b/assets/xml/objects/object_st.xml
@@ -22,7 +22,9 @@
         <Texture Name="object_st_Tex_0024D0" OutName="tex_000024D0" Format="rgba16" Width="16" Height="8" Offset="0x24D0"/>
         <Texture Name="object_st_Tex_0025D0" OutName="tex_000025D0" Format="i4" Width="16" Height="16" Offset="0x25D0"/>
         <Texture Name="object_st_Tex_002650" OutName="tex_00002650" Format="rgba16" Width="8" Height="8" Offset="0x2650"/>
-        <Blob Name="object_st_Blob_003C50" Size="0x360" Offset="0x3C50"/>
+        <Array Name="object_st_Vtx_0026D0" Count="398" Offset="0x26D0">
+            <Vtx/>
+        </Array>
         <DList Name="object_st_DL_003FB0" Offset="0x3FB0"/>
         <DList Name="object_st_DL_0043D8" Offset="0x43D8"/>
         <DList Name="object_st_DL_0045C0" Offset="0x45C0"/>

--- a/assets/xml/objects/object_ta.xml
+++ b/assets/xml/objects/object_ta.xml
@@ -66,7 +66,6 @@
         <Texture Name="gTalonNecklaceStringUpperTex" OutName="necklace_string_upper" Format="ci8" Width="16" Height="32" Offset="0xADB8" TlutOffset="0xA638"/>
         <Texture Name="gTalonBowserTex" OutName="bowser" Format="rgba16" Width="16" Height="32" Offset="0xAFB8"/>
         <Texture Name="gTalonNecklaceLowerStringsTex" OutName="necklace_string_lower" Format="rgba16" Width="8" Height="16" Offset="0xB3B8"/>
-
-        <Blob Name="object_ta_Blob_00B4B8" Size="0x200" Offset="0xB4B8"/>
+        <Texture Name="gTalonUnusedTex" OutName="unused" Format="rgba16" Width="16" Height="16" Offset="0xB4B8"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_tk.xml
+++ b/assets/xml/objects/object_tk.xml
@@ -8,7 +8,8 @@
         <Texture Name="gDampeEyeOpenTex" OutName="dampe_eye_open" Format="rgba16" Width="32" Height="32" Offset="0x3B40"/>
         <Texture Name="gDampeEyeHalfTex" OutName="dampe_eye_half_open" Format="rgba16" Width="32" Height="32" Offset="0x4340"/>
         <Texture Name="gDampeEyeClosedTex" OutName="dampe_eye_closed" Format="rgba16" Width="32" Height="32" Offset="0x4B40"/>
-        <Texture Name="gDampeUnkTex" OutName="dampe_unk" Format="ci8" Width="16" Height="16" Offset="0x5540" TlutOffset="0x3780"/>
+        <Texture Name="gDampeUnused1Tex" OutName="dampe_unused_1" Format="ci8" Width="16" Height="16" Offset="0x5540" TlutOffset="0x3780"/>
+        <Texture Name="gDampeUnused2Tex" OutName="dampe_unused_2" Format="ci8" Width="8" Height="16" Offset="0x5640" TlutOffset="0x3780"/>
         <DList Name="gDampeShovelDL" Offset="0xACE0"/>
         <DList Name="gDampeLanternDL" Offset="0xB838"/>
         <DList Name="gDampeHaloDL" Offset="0xBBA0"/>

--- a/assets/xml/objects/object_toki_objects.xml
+++ b/assets/xml/objects/object_toki_objects.xml
@@ -12,7 +12,8 @@
         <Texture Name="object_toki_objects_Tex_003DC0" OutName="tex_003DC0" Format="rgba16" Width="32" Height="32" Offset="0x3DC0"/>
         <Texture Name="object_toki_objects_Tex_0045C0" OutName="tex_0045C0" Format="i4" Width="64" Height="128" Offset="0x45C0"/>
         <Texture Name="object_toki_objects_Tex_0055C0" OutName="tex_0055C0" Format="rgba16" Width="32" Height="64" Offset="0x55C0"/>
-        <Blob Name="object_toki_objects_Blob_0065C0" Size="0xA00" Offset="0x65C0"/>
+        <Texture Name="object_toki_objects_Tex_0065C0" OutName="tex_0065C0" Format="rgba16" Width="16" Height="16" Offset="0x65C0"/>
+        <Texture Name="object_toki_objects_Tex_0067C0" OutName="tex_0067C0" Format="rgba16" Width="32" Height="32" Offset="0x67C0"/>
         <Texture Name="object_toki_objects_Tex_006FC0" OutName="tex_006FC0" Format="rgba16" Width="16" Height="16" Offset="0x6FC0"/>
         <DList Name="object_toki_objects_DL_007440" Offset="0x7440"/> <!-- Door of Time left -->
         <DList Name="object_toki_objects_DL_007578" Offset="0x7578"/> <!-- Door of Time right -->

--- a/assets/xml/objects/object_tr.xml
+++ b/assets/xml/objects/object_tr.xml
@@ -9,7 +9,9 @@
         <Animation Name="gKotakeKoumeFlyAnim" Offset="0x49C8"/>
         <Animation Name="gKotakeKoumeStandingBroomOverRightShoulderUnusedAnim" Offset="0x5308"/> <!-- Very similar to gKotakeKoumeStandingBroomOverRightShoulderAnim but not quite a duplicate -->
 
-        <Blob Name="object_tr_Blob_0062E0" Size="0x60" Offset="0x62E0"/>
+        <Array Name="gKotakeVtx" Count="288" Offset="0x5320">
+            <Vtx/>
+        </Array>
 
         <DList Name="gKotakePelvisDL" Offset="0x6520"/>
         <DList Name="gKotakeTorsoDL" Offset="0x66A0"/>
@@ -97,7 +99,9 @@
 
         <Animation Name="gKotakeKoumeTPoseAnim" Offset="0xC60C"/>
 
-        <Blob Name="object_tr_Blob_00D5E0" Size="0x60" Offset="0xD5E0"/>
+        <Array Name="gKoumeVtx" Count="288" Offset="0xC620">
+            <Vtx/>
+        </Array>
 
         <DList Name="gKoumePelvisDL" Offset="0xD820"/>
         <DList Name="gKoumeTorsoDL" Offset="0xD9A0"/>

--- a/assets/xml/objects/object_tw.xml
+++ b/assets/xml/objects/object_tw.xml
@@ -106,9 +106,11 @@
         <DList Name="gTwinrovaKotakeFireBroomHeadDL" Offset="0x14070"/>
         <DList Name="gTwinrovaKotakeFireBroomHeadOuterDL" Offset="0x14158"/>
 
-        <Blob Name="object_tw_Blob_015200" Size="0x60" Offset="0x15200"/>
-
         <!-- Kotake DLs -->
+        <Array Name="gTwinrovaKotakeVtx" Count="288" Offset="0x14240">
+            <Vtx/>
+        </Array>
+
         <DList Name="gTwinrovaKotakeLeftBraidEndDL" Offset="0x15440"/>
         <DList Name="gTwinrovaKotakeLeftBraidStartDL" Offset="0x15538"/>
         <DList Name="gTwinrovaKotakeRightBraidEndDL" Offset="0x15648"/>
@@ -130,9 +132,11 @@
         <Texture Name="gTwinrovaBraidEndTex" OutName="twinrova_braid_end" Format="rgba16" Width="8" Height="8" Offset="0x16650"/>
         <Texture Name="gTwinrovaLeftFootTex" OutName="twinrova_left_foot" Format="rgba16" Width="4" Height="8" Offset="0x166D0"/>
 
-        <Blob Name="object_tw_Blob_0176D0" Size="0x60" Offset="0x176D0"/>
-
         <!-- Koume DLs -->
+        <Array Name="gTwinrovaKoumeVtx" Count="288" Offset="0x16710">
+            <Vtx/>
+        </Array>
+
         <DList Name="gTwinrovaKoumeLeftBraidEndDL" Offset="0x17910"/>
         <DList Name="gTwinrovaKoumeLeftBraidStartDL" Offset="0x17A08"/>
         <DList Name="gTwinrovaKoumeRightBraidEndDL" Offset="0x17B18"/>

--- a/assets/xml/objects/object_wf.xml
+++ b/assets/xml/objects/object_wf.xml
@@ -122,6 +122,7 @@
         <Animation Name="gWolfosSidesteppingAnim" Offset="0x98C8"/>
         <Blob Name="object_wf_zeroes_Blob_0098D8" Size="0x18" Offset="0x98D8"/>
         <Animation Name="gWolfosDamagedAnim" Offset="0x9B20"/>
+        <Blob Name="object_wf_zeroes_Blob_009B30" Size="0x10" Offset="0x9B30"/>
         <Animation Name="gWolfosWaitingAnim" Offset="0xA4AC"/>
         <Blob Name="object_wf_zeroes_Blob_00A4BC" Size="0x44" Offset="0xA4BC"/>
     </File>

--- a/assets/xml/objects/object_wood02.xml
+++ b/assets/xml/objects/object_wood02.xml
@@ -20,7 +20,7 @@
         <Texture Name="object_wood02_Tex_006F90" OutName="tex_00006F90" Format="ia8" Width="32" Height="64" Offset="0x6F90"/>
         <DList Name="object_wood02_DL_0078D0" Offset="0x78D0"/>
         <DList Name="object_wood02_DL_007968" Offset="0x7968"/>
-        <Blob Name="object_wood02_Blob_007A00" Size="0xA0" Offset="0x7A00"/>
+        <Collision Name="object_wood02_Col_007A70" Offset="0x7A70"/>
         <DList Name="object_wood02_DL_007AD0" Offset="0x7AD0"/>
         <DList Name="object_wood02_DL_007CA0" Offset="0x7CA0"/>
         <DList Name="object_wood02_DL_007D38" Offset="0x7D38"/>

--- a/assets/xml/scenes/indoors/tokinoma.xml
+++ b/assets/xml/scenes/indoors/tokinoma.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="tokinoma_scene" Segment="2">
+        <Cutscene Name="gTempleOfTimeUnusedCs" Offset="0x280"/>
         <Cutscene Name="gTempleOfTimeFirstAdultCs" Offset="0x46F0"/>
         <Cutscene Name="gTempleOfTimePreludeCs" Offset="0x6D20"/>
         <Cutscene Name="gTempleOfTimeIntroCs" Offset="0xCE00"/>
@@ -12,7 +13,6 @@
         <Cutscene Name="gTempleOfTimeSongOfTimeCs" Offset="0x61C0"/>
         <Cutscene Name="gTempleOfTimeSheikRevealStartCs" Offset="0x84E0"/>
         <Cutscene Name="gTempleOfTimeDoorOpeningUnusedCs" Offset="0x3330"/>
-
         <Scene Name="tokinoma_scene" Offset="0x0"/>
     </File>
     <File Name="tokinoma_room_0" Segment="3">

--- a/assets/xml/scenes/indoors/tokinoma_pal_n64.xml
+++ b/assets/xml/scenes/indoors/tokinoma_pal_n64.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="tokinoma_scene" Segment="2">
+        <Cutscene Name="gTempleOfTimeUnusedCs" Offset="0x280"/>
         <Cutscene Name="gTempleOfTimeFirstAdultCs" Offset="0x4700"/>
         <Cutscene Name="gTempleOfTimePreludeCs" Offset="0x6D34"/>
         <Cutscene Name="gTempleOfTimeIntroCs" Offset="0xCE20"/>

--- a/assets/xml/scenes/overworld/spot20.xml
+++ b/assets/xml/scenes/overworld/spot20.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="spot20_scene" Segment="2">
+        <Cutscene Name="gLonLonRanchUnusedCs" Offset="0x320"/>
         <Cutscene Name="gLonLonRanchIntroCs" Offset="0x5B70"/>
         <Cutscene Name="gLonLonRanchRaceIntroCs" Offset="0x2980"/>
         <Cutscene Name="gLonLonRanchEponasSongCs" Offset="0x2B40"/>

--- a/assets/xml/scenes/overworld/spot20_pal.xml
+++ b/assets/xml/scenes/overworld/spot20_pal.xml
@@ -1,5 +1,6 @@
 <Root>
     <File Name="spot20_scene" Segment="2">
+        <Cutscene Name="gLonLonRanchUnusedCs" Offset="0x320"/>
         <Cutscene Name="gLonLonRanchIntroCs" Offset="0x5BD0"/>
         <Cutscene Name="gLonLonRanchRaceIntroCs" Offset="0x2980"/>
         <Cutscene Name="gLonLonRanchEponasSongCs" Offset="0x2B40"/>

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -612,7 +612,7 @@ void BossVa_Init(Actor* thisx, PlayState* play2) {
             break;
         default:
             this->actor.flags |= ACTOR_FLAG_SFX_FOR_PLAYER_BODY_HIT;
-            SkelAnime_Init(play, &this->skelAnime, &gBarinadeBariSkel, &gBarinadeBariAnim, NULL, NULL, 0);
+            SkelAnime_Init(play, &this->skelAnime, &gBarinadeBariSkel.sh, &gBarinadeBariAnim, NULL, NULL, 0);
             this->actor.shape.yOffset = 400.0f;
             break;
         case BOSSVA_DOOR:

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -613,7 +613,8 @@ void BossVa_Init(Actor* thisx, PlayState* play2) {
         default:
             this->actor.flags |= ACTOR_FLAG_SFX_FOR_PLAYER_BODY_HIT;
             //! @bug Flex skeleton is used as normal skeleton
-            SkelAnime_Init(play, &this->skelAnime, &gBarinadeBariSkel.sh, &gBarinadeBariAnim, NULL, NULL, 0);
+            SkelAnime_Init(play, &this->skelAnime, (SkeletonHeader*)&gBarinadeBariSkel, &gBarinadeBariAnim, NULL, NULL,
+                           0);
             this->actor.shape.yOffset = 400.0f;
             break;
         case BOSSVA_DOOR:

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -612,6 +612,7 @@ void BossVa_Init(Actor* thisx, PlayState* play2) {
             break;
         default:
             this->actor.flags |= ACTOR_FLAG_SFX_FOR_PLAYER_BODY_HIT;
+            //! @bug Flex skeleton is used as normal skeleton
             SkelAnime_Init(play, &this->skelAnime, &gBarinadeBariSkel.sh, &gBarinadeBariAnim, NULL, NULL, 0);
             this->actor.shape.yOffset = 400.0f;
             break;

--- a/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
+++ b/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
@@ -165,17 +165,17 @@ void DemoIk_Type1Init(DemoIk* this, PlayState* play) {
 
     switch (this->actor.params) {
         case 0:
-            skeleton = &object_ik_Skel_000C90;
+            skeleton = &object_ik_Skel_000C90.sh;
             animation = &object_ik_Anim_000C6C;
             phi_f0 = 30.0f;
             break;
         case 1:
-            skeleton = &object_ik_Skel_000660;
+            skeleton = &object_ik_Skel_000660.sh;
             animation = &object_ik_Anim_000634;
             phi_f0 = 10.0f;
             break;
         default:
-            skeleton = &object_ik_Skel_000380;
+            skeleton = &object_ik_Skel_000380.sh;
             animation = &object_ik_Anim_00035C;
             phi_f0 = 20.0f;
             // No break is required for matching

--- a/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
+++ b/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
@@ -182,7 +182,7 @@ void DemoIk_Type1Init(DemoIk* this, PlayState* play) {
     }
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, phi_f0);
     //! @bug Flex skeleton is used as normal skeleton
-    SkelAnime_Init(play, &this->skelAnime, skeleton.sh, NULL, this->jointTable, this->morphTable, 2);
+    SkelAnime_Init(play, &this->skelAnime, (SkeletonHeader*)skeleton, NULL, this->jointTable, this->morphTable, 2);
     Animation_Change(&this->skelAnime, animation, 1.0f, 0.0f, Animation_GetLastFrame(animation), ANIMMODE_ONCE, 0.0f);
 }
 

--- a/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
+++ b/src/overlays/actors/ovl_Demo_Ik/z_demo_ik.c
@@ -159,29 +159,30 @@ void DemoIk_MoveToStartPos(DemoIk* this, PlayState* play, s32 cueChannel) {
 
 void DemoIk_Type1Init(DemoIk* this, PlayState* play) {
     s32 pad[3];
-    SkeletonHeader* skeleton;
+    FlexSkeletonHeader* skeleton;
     AnimationHeader* animation;
     f32 phi_f0;
 
     switch (this->actor.params) {
         case 0:
-            skeleton = &object_ik_Skel_000C90.sh;
+            skeleton = &object_ik_Skel_000C90;
             animation = &object_ik_Anim_000C6C;
             phi_f0 = 30.0f;
             break;
         case 1:
-            skeleton = &object_ik_Skel_000660.sh;
+            skeleton = &object_ik_Skel_000660;
             animation = &object_ik_Anim_000634;
             phi_f0 = 10.0f;
             break;
         default:
-            skeleton = &object_ik_Skel_000380.sh;
+            skeleton = &object_ik_Skel_000380;
             animation = &object_ik_Anim_00035C;
             phi_f0 = 20.0f;
             // No break is required for matching
     }
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, phi_f0);
-    SkelAnime_Init(play, &this->skelAnime, skeleton, NULL, this->jointTable, this->morphTable, 2);
+    //! @bug Flex skeleton is used as normal skeleton
+    SkelAnime_Init(play, &this->skelAnime, skeleton.sh, NULL, this->jointTable, this->morphTable, 2);
     Animation_Change(&this->skelAnime, animation, 1.0f, 0.0f, Animation_GetLastFrame(animation), ANIMMODE_ONCE, 0.0f);
 }
 

--- a/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -172,7 +172,8 @@ void EnBox_Init(Actor* thisx, PlayState* play2) {
     this->dyna.actor.home.rot.z = this->dyna.actor.world.rot.z = this->dyna.actor.shape.rot.z = 0;
 
     //! @bug Flex skeleton is used as normal skeleton
-    SkelAnime_Init(play, &this->skelanime, &gTreasureChestSkel.sh, anim, this->jointTable, this->morphTable, 5);
+    SkelAnime_Init(play, &this->skelanime, (SkeletonHeader*)&gTreasureChestSkel, anim, this->jointTable,
+                   this->morphTable, 5);
     Animation_Change(&this->skelanime, anim, 1.5f, animFrameStart, endFrame, ANIMMODE_ONCE, 0.0f);
 
     switch (this->type) {

--- a/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -171,7 +171,7 @@ void EnBox_Init(Actor* thisx, PlayState* play2) {
     this->dyna.actor.world.rot.y += 0x8000;
     this->dyna.actor.home.rot.z = this->dyna.actor.world.rot.z = this->dyna.actor.shape.rot.z = 0;
 
-    SkelAnime_Init(play, &this->skelanime, &gTreasureChestSkel, anim, this->jointTable, this->morphTable, 5);
+    SkelAnime_Init(play, &this->skelanime, &gTreasureChestSkel.sh, anim, this->jointTable, this->morphTable, 5);
     Animation_Change(&this->skelanime, anim, 1.5f, animFrameStart, endFrame, ANIMMODE_ONCE, 0.0f);
 
     switch (this->type) {

--- a/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -171,6 +171,7 @@ void EnBox_Init(Actor* thisx, PlayState* play2) {
     this->dyna.actor.world.rot.y += 0x8000;
     this->dyna.actor.home.rot.z = this->dyna.actor.world.rot.z = this->dyna.actor.shape.rot.z = 0;
 
+    //! @bug Flex skeleton is used as normal skeleton
     SkelAnime_Init(play, &this->skelanime, &gTreasureChestSkel.sh, anim, this->jointTable, this->morphTable, 5);
     Animation_Change(&this->skelanime, anim, 1.5f, animFrameStart, endFrame, ANIMMODE_ONCE, 0.0f);
 

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -197,8 +197,8 @@ void EnDntNomal_WaitForObject(EnDntNomal* this, PlayState* play) {
         Actor_SetScale(&this->actor, 0.01f);
         if (this->type == ENDNTNOMAL_TARGET) {
             //! @bug Flex skeleton is used as normal skeleton
-            SkelAnime_Init(play, &this->skelAnime, &gHintNutsSkel.sh, &gHintNutsBurrowAnim, this->jointTable,
-                           this->morphTable, 10);
+            SkelAnime_Init(play, &this->skelAnime, (SkeletonHeader*)&gHintNutsSkel, &gHintNutsBurrowAnim,
+                           this->jointTable, this->morphTable, 10);
             this->actor.draw = EnDntNomal_DrawTargetScrub;
         } else {
             SkelAnime_Init(play, &this->skelAnime, &gDntStageSkel, &gDntStageHideAnim, this->jointTable,

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -196,6 +196,7 @@ void EnDntNomal_WaitForObject(EnDntNomal* this, PlayState* play) {
         this->actor.gravity = -2.0f;
         Actor_SetScale(&this->actor, 0.01f);
         if (this->type == ENDNTNOMAL_TARGET) {
+            //! @bug Flex skeleton is used as normal skeleton
             SkelAnime_Init(play, &this->skelAnime, &gHintNutsSkel.sh, &gHintNutsBurrowAnim, this->jointTable,
                            this->morphTable, 10);
             this->actor.draw = EnDntNomal_DrawTargetScrub;

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -196,7 +196,7 @@ void EnDntNomal_WaitForObject(EnDntNomal* this, PlayState* play) {
         this->actor.gravity = -2.0f;
         Actor_SetScale(&this->actor, 0.01f);
         if (this->type == ENDNTNOMAL_TARGET) {
-            SkelAnime_Init(play, &this->skelAnime, &gHintNutsSkel, &gHintNutsBurrowAnim, this->jointTable,
+            SkelAnime_Init(play, &this->skelAnime, &gHintNutsSkel.sh, &gHintNutsBurrowAnim, this->jointTable,
                            this->morphTable, 10);
             this->actor.draw = EnDntNomal_DrawTargetScrub;
         } else {

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
@@ -79,7 +79,7 @@ void EnHintnuts_Init(Actor* thisx, PlayState* play) {
     } else {
         ActorShape_Init(&this->actor.shape, 0x0, ActorShadow_DrawCircle, 35.0f);
         //! @bug Flex skeleton is used as normal skeleton
-        SkelAnime_Init(play, &this->skelAnime, &gHintNutsSkel.sh, &gHintNutsStandAnim, this->jointTable,
+        SkelAnime_Init(play, &this->skelAnime, (SkeletonHeader*)&gHintNutsSkel, &gHintNutsStandAnim, this->jointTable,
                        this->morphTable, 10);
         Collider_InitCylinder(play, &this->collider);
         Collider_SetCylinder(play, &this->collider, &this->actor, &sCylinderInit);

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
@@ -78,8 +78,8 @@ void EnHintnuts_Init(Actor* thisx, PlayState* play) {
         this->actor.flags &= ~(ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE);
     } else {
         ActorShape_Init(&this->actor.shape, 0x0, ActorShadow_DrawCircle, 35.0f);
-        SkelAnime_Init(play, &this->skelAnime, &gHintNutsSkel, &gHintNutsStandAnim, this->jointTable, this->morphTable,
-                       10);
+        SkelAnime_Init(play, &this->skelAnime, &gHintNutsSkel.sh, &gHintNutsStandAnim, this->jointTable,
+                       this->morphTable, 10);
         Collider_InitCylinder(play, &this->collider);
         Collider_SetCylinder(play, &this->collider, &this->actor, &sCylinderInit);
         CollisionCheck_SetInfo(&this->actor.colChkInfo, NULL, &sColChkInfoInit);

--- a/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
+++ b/src/overlays/actors/ovl_En_Hintnuts/z_en_hintnuts.c
@@ -78,6 +78,7 @@ void EnHintnuts_Init(Actor* thisx, PlayState* play) {
         this->actor.flags &= ~(ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE);
     } else {
         ActorShape_Init(&this->actor.shape, 0x0, ActorShadow_DrawCircle, 35.0f);
+        //! @bug Flex skeleton is used as normal skeleton
         SkelAnime_Init(play, &this->skelAnime, &gHintNutsSkel.sh, &gHintNutsStandAnim, this->jointTable,
                        this->morphTable, 10);
         Collider_InitCylinder(play, &this->collider);


### PR DESCRIPTION
I tried to go through all "unaccounted" or "blob" assets (except for room files). I kept track of things with a [spreadsheet](https://docs.google.com/spreadsheets/d/1MUiilOuJclbtaEZtT-ExAwuHltkyLKR3uPyLlWuGH4c/edit?usp=sharing) (notes with question marks are things I didn't solve in this PR).

Common problems:
* Very commonly there's an extra 8 bytes of palette data after palettes loaded with `gsDPLoadTLUT_pal256`. I left these as-is for now.
* ZAPD only discovers Vtxs that are used instead of marking the entire array. I explicitly wrote these vertex arrays but maybe this isn't necessary if extraction is smarter in the future.
* A few animations have blocks of 0s after them which isn't explained by file padding. I marked these as Blobs since that's what most of them were already.
* Some textures (mostly indexed ones) I didn't want to figure out so I left them as Blobs.