### PR TITLE
Add point lighting gbi features

### DIFF
--- a/include/ultra64/gbi.h
+++ b/include/ultra64/gbi.h
@@ -12,6 +12,10 @@
 
 #ifndef F3DEX_GBI
  #define F3DEX_GBI_2
+
+ /* F3DEX2 with Point Lighting */
+ /* TODO this should have version defines, gamecube versions have point light ucode but n64 versions don't */
+ #define F3DEX_GBI_PL
 #endif
 
 #ifdef    F3DEX_GBI_2
@@ -290,6 +294,9 @@
 #define G_TEXTURE_GEN           0x00040000
 #define G_TEXTURE_GEN_LINEAR    0x00080000
 #define G_LOD                   0x00100000  /* NOT IMPLEMENTED */
+#ifdef F3DEX_GBI_PL
+# define G_LIGHTING_POSITIONAL  0x00400000
+#endif
 #if (defined(F3DEX_GBI) || defined(F3DLP_GBI))
 # define G_CLIPPING             0x00800000
 #else
@@ -297,13 +304,16 @@
 #endif
 
 #ifdef _LANGUAGE_ASSEMBLY
-#define G_FOG_H                 (G_FOG/0x10000)
-#define G_LIGHTING_H            (G_LIGHTING/0x10000)
-#define G_TEXTURE_GEN_H         (G_TEXTURE_GEN/0x10000)
-#define G_TEXTURE_GEN_LINEAR_H  (G_TEXTURE_GEN_LINEAR/0x10000)
-#define G_LOD_H                 (G_LOD/0x10000) /* NOT IMPLEMENTED */
+# define G_FOG_H                    (G_FOG/0x10000)
+# define G_LIGHTING_H               (G_LIGHTING/0x10000)
+# define G_TEXTURE_GEN_H            (G_TEXTURE_GEN/0x10000)
+# define G_TEXTURE_GEN_LINEAR_H     (G_TEXTURE_GEN_LINEAR/0x10000)
+# define G_LOD_H                    (G_LOD/0x10000) /* NOT IMPLEMENTED */
+# ifdef F3DEX_GBI_PL
+#  define G_LIGHTING_POSITIONAL_H   (G_LIGHTING_POSITIONAL/0x10000)
+# endif
 # if (defined(F3DEX_GBI) || defined(F3DLP_GBI))
-#  define G_CLIPPING_H          (G_CLIPPING/0x10000)
+#  define G_CLIPPING_H              (G_CLIPPING/0x10000)
 # endif
 #endif
 
@@ -1309,6 +1319,17 @@ typedef struct {
     char          pad3;
 } Light_t;
 
+#ifdef F3DEX_GBI_PL
+typedef struct {
+    unsigned char col[3];   /* point light value (rgba) */
+    unsigned char kc;       /* constant attenuation (> 0 indicates point light) */
+    unsigned char colc[3];  /* copy of point light value (rgba) */
+    unsigned char kl;       /* linear attenuation */
+    short         pos[3];   /* world-space position of light */
+    unsigned char kq;       /* quadratic attenuation */
+} PointLight_t;
+#endif
+
 typedef struct {
     unsigned char col[3];   /* ambient light value (rgba) */
     char          pad1;
@@ -1325,7 +1346,10 @@ typedef struct {
 } Hilite_t;
 
 typedef union {
-    Light_t l;
+    Light_t         l;
+#ifdef F3DEX_GBI_PL
+    PointLight_t    p;
+#endif
     long long int force_structure_alignment[2];
 } Light;
 
@@ -1388,259 +1412,255 @@ typedef union {
     long int force_structure_alignment;
 } Hilite;
 
-#define gdSPDefLights0(ar, ag, ab)  \
-    {                               \
-        {{                          \
-            { ar, ag, ab }, 0,      \
-            { ar, ag, ab }, 0,      \
-        }},                         \
-        {                           \
-            {{                      \
-                { 0, 0, 0 }, 0,     \
-                { 0, 0, 0 }, 0,     \
-                { 0, 0, 0 }, 0,     \
-            }}                      \
-        }                           \
-    }
+#define gDefAmbient(r, g, b)    \
+    {{                          \
+        { (r), (g), (b) }, 0,   \
+        { (r), (g), (b) }, 0,   \
+    }}
 
-#define gdSPDefLights1(ar, ag, ab,              \
-                       r1, g1, b1, x1, y1, z1)  \
-    {                                           \
-        {{                                      \
-            { ar, ag, ab }, 0,                  \
-            { ar, ag, ab }, 0,                  \
-        }},                                     \
-        {                                       \
-            {{                                  \
-                { r1, g1, b1 }, 0,              \
-                { r1, g1, b1 }, 0,              \
-                { x1, y1, z1 }, 0,              \
-            }}                                  \
-        }                                       \
-    }
+#define gDefLight(r, g, b, x, y, z) \
+    {{                              \
+        { (r), (g), (b) }, 0,       \
+        { (r), (g), (b) }, 0,       \
+        { (x), (y), (z) }, 0,       \
+    }}
 
-#define gdSPDefLights2(ar, ag, ab,              \
-                       r1, g1, b1, x1, y1, z1,  \
-                       r2, g2, b2, x2, y2, z2)  \
-    {                                           \
-        {{                                      \
-            { ar, ag, ab }, 0,                  \
-            { ar, ag, ab }, 0,                  \
-        }},                                     \
-        {                                       \
-            {{                                  \
-                { r1, g1, b1 }, 0,              \
-                { r1, g1, b1 }, 0,              \
-                { x1, y1, z1 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r2, g2, b2 }, 0,              \
-                { r2, g2, b2 }, 0,              \
-                { x2, y2, z2 }, 0,              \
-            }}                                  \
-        }                                       \
-    }
+#define gdSPDefLights0(ar, ag, ab)                  \
+        {                                           \
+            gDefAmbient(ar, ag, ab),                \
+            {                                       \
+                gDefLight(0, 0, 0, 0, 0, 0),        \
+            }                                       \
+        }
 
-#define gdSPDefLights3(ar, ag, ab,              \
-                       r1, g1, b1, x1, y1, z1,  \
-                       r2, g2, b2, x2, y2, z2,  \
-                       r3, g3, b3, x3, y3, z3)  \
-    {                                           \
-        {{                                      \
-            { ar, ag, ab }, 0,                  \
-            { ar, ag, ab }, 0,                  \
-        }},                                     \
-        {                                       \
-            {{                                  \
-                { r1, g1, b1 }, 0,              \
-                { r1, g1, b1 }, 0,              \
-                { x1, y1, z1 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r2, g2, b2 }, 0,              \
-                { r2, g2, b2 }, 0,              \
-                { x2, y2, z2 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r3, g3, b3 }, 0,              \
-                { r3, g3, b3 }, 0,              \
-                { x3, y3, z3 }, 0,              \
-            }}                                  \
-        }                                       \
-    }
+#define gdSPDefLights1(ar, ag, ab,                  \
+                       r1, g1, b1, x1, y1, z1)      \
+        {                                           \
+            gDefAmbient(ar, ag, ab),                \
+            {                                       \
+                gDefLight(r1, g1, b1, x1, y1, z1),  \
+            }                                       \
+        }
 
-#define gdSPDefLights4(ar, ag, ab,              \
-                       r1, g1, b1, x1, y1, z1,  \
-                       r2, g2, b2, x2, y2, z2,  \
-                       r3, g3, b3, x3, y3, z3,  \
-                       r4, g4, b4, x4, y4, z4)  \
-    {                                           \
-        {{                                      \
-            { ar, ag, ab }, 0,                  \
-            { ar, ag, ab }, 0,                  \
-        }},                                     \
-        {                                       \
-            {{                                  \
-                { r1, g1, b1 }, 0,              \
-                { r1, g1, b1 }, 0,              \
-                { x1, y1, z1 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r2, g2, b2 }, 0,              \
-                { r2, g2, b2 }, 0,              \
-                { x2, y2, z2 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r3, g3, b3 }, 0,              \
-                { r3, g3, b3 }, 0,              \
-                { x3, y3, z3 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r4, g4, b4 }, 0,              \
-                { r4, g4, b4 }, 0,              \
-                { x4, y4, z4 }, 0,              \
-            }}                                  \
-        }                                       \
-    }
+#define gdSPDefLights2(ar, ag, ab,                  \
+                       r1, g1, b1, x1, y1, z1,      \
+                       r2, g2, b2, x2, y2, z2)      \
+        {                                           \
+            gDefAmbient(ar, ag, ab),                \
+            {                                       \
+                gDefLight(r1, g1, b1, x1, y1, z1),  \
+                gDefLight(r2, g2, b2, x2, y2, z2),  \
+            }                                       \
+        }
 
-#define gdSPDefLights5(ar, ag, ab,              \
-                       r1, g1, b1, x1, y1, z1,  \
-                       r2, g2, b2, x2, y2, z2,  \
-                       r3, g3, b3, x3, y3, z3,  \
-                       r4, g4, b4, x4, y4, z4,  \
-                       r5, g5, b5, x5, y5, z5)  \
-    {                                           \
-        {{                                      \
-            { ar, ag, ab }, 0,                  \
-            { ar, ag, ab }, 0,                  \
-        }},                                     \
-        {                                       \
-            {{                                  \
-                { r1, g1, b1 }, 0,              \
-                { r1, g1, b1 }, 0,              \
-                { x1, y1, z1 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r2, g2, b2 }, 0,              \
-                { r2, g2, b2 }, 0,              \
-                { x2, y2, z2 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r3, g3, b3 }, 0,              \
-                { r3, g3, b3 }, 0,              \
-                { x3, y3, z3 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r4, g4, b4 }, 0,              \
-                { r4, g4, b4 }, 0,              \
-                { x4, y4, z4 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r5, g5, b5 }, 0,              \
-                { r5, g5, b5 }, 0,              \
-                { x5, y5, z5 }, 0,              \
-            }}                                  \
-        }                                       \
-    }
+#define gdSPDefLights3(ar, ag, ab,                  \
+                       r1, g1, b1, x1, y1, z1,      \
+                       r2, g2, b2, x2, y2, z2)      \
+                       r3, g3, b3, x3, y3, z3)      \
+        {                                           \
+            gDefAmbient(ar, ag, ab),                \
+            {                                       \
+                gDefLight(r1, g1, b1, x1, y1, z1),  \
+                gDefLight(r2, g2, b2, x2, y2, z2),  \
+                gDefLight(r3, g3, b3, x3, y3, z3),  \
+            }                                       \
+        }
 
-#define gdSPDefLights6(ar, ag, ab,              \
-                       r1, g1, b1, x1, y1, z1,  \
-                       r2, g2, b2, x2, y2, z2,  \
-                       r3, g3, b3, x3, y3, z3,  \
-                       r4, g4, b4, x4, y4, z4,  \
-                       r5, g5, b5, x5, y5, z5,  \
-                       r6, g6, b6, x6, y6, z6)  \
-    {                                           \
-        {{                                      \
-            { ar, ag, ab }, 0,                  \
-            { ar, ag, ab }, 0,                  \
-        }},                                     \
-        {                                       \
-            {{                                  \
-                { r1, g1, b1 }, 0,              \
-                { x1, y1, z1 }, 0,              \
-                { r1, g1, b1 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r2, g2, b2 }, 0,              \
-                { r2, g2, b2 }, 0,              \
-                { x2, y2, z2 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r3, g3, b3 }, 0,              \
-                { r3, g3, b3 }, 0,              \
-                { x3, y3, z3 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r4, g4, b4 }, 0,              \
-                { r4, g4, b4 }, 0,              \
-                { x4, y4, z4 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r5, g5, b5 }, 0,              \
-                { r5, g5, b5 }, 0,              \
-                { x5, y5, z5 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r6, g6, b6 }, 0,              \
-                { r6, g6, b6 }, 0,              \
-                { x6, y6, z6 }, 0,              \
-            }}                                  \
-        }                                       \
-    }
+#define gdSPDefLights4(ar, ag, ab,                  \
+                       r1, g1, b1, x1, y1, z1,      \
+                       r2, g2, b2, x2, y2, z2,      \
+                       r3, g3, b3, x3, y3, z3,      \
+                       r4, g4, b4, x4, y4, z4)      \
+        {                                           \
+            gDefAmbient(ar, ag, ab),                \
+            {                                       \
+                gDefLight(r1, g1, b1, x1, y1, z1),  \
+                gDefLight(r2, g2, b2, x2, y2, z2),  \
+                gDefLight(r3, g3, b3, x3, y3, z3),  \
+                gDefLight(r4, g4, b4, x4, y4, z4),  \
+            }                                       \
+        }
 
-#define gdSPDefLights7(ar, ag, ab,              \
-                       r1, g1, b1, x1, y1, z1,  \
-                       r2, g2, b2, x2, y2, z2,  \
-                       r3, g3, b3, x3, y3, z3,  \
-                       r4, g4, b4, x4, y4, z4,  \
-                       r5, g5, b5, x5, y5, z5,  \
-                       r6, g6, b6, x6, y6, z6,  \
-                       r7, g7, b7, x7, y7, z7)  \
-    {                                           \
-        {{                                      \
-            { ar, ag, ab}, 0,                   \
-            { ar, ag, ab}, 0,                   \
-        }},                                     \
-        {                                       \
-            {{                                  \
-                { r1, g1, b1 }, 0,              \
-                { r1, g1, b1 }, 0,              \
-                { x1, y1, z1 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r2, g2, b2 }, 0,              \
-                { r2, g2, b2 }, 0,              \
-                { x2, y2, z2 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r3, g3, b3 }, 0,              \
-                { r3, g3, b3 }, 0,              \
-                { x3, y3, z3 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r4, g4, b4 }, 0,              \
-                { r4, g4, b4 }, 0,              \
-                { x4, y4, z4 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r5, g5, b5 }, 0,              \
-                { r5, g5, b5 }, 0,              \
-                { x5, y5, z5 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r6, g6, b6 }, 0,              \
-                { r6, g6, b6 }, 0,              \
-                { x6, y6, z6 }, 0,              \
-            }},                                 \
-            {{                                  \
-                { r7, g7, b7 }, 0,              \
-                { r7, g7, b7 }, 0,              \
-                { x7, y7, z7 }, 0,              \
-            }}                                  \
-        }                                       \
-    }
+#define gdSPDefLights5(ar, ag, ab,                  \
+                       r1, g1, b1, x1, y1, z1,      \
+                       r2, g2, b2, x2, y2, z2,      \
+                       r3, g3, b3, x3, y3, z3,      \
+                       r4, g4, b4, x4, y4, z4)      \
+                       r5, g5, b5, x5, y5, z5)      \
+        {                                           \
+            gDefAmbient(ar, ag, ab),                \
+            {                                       \
+                gDefLight(r1, g1, b1, x1, y1, z1),  \
+                gDefLight(r2, g2, b2, x2, y2, z2),  \
+                gDefLight(r3, g3, b3, x3, y3, z3),  \
+                gDefLight(r4, g4, b4, x4, y4, z4),  \
+                gDefLight(r5, g5, b5, x5, y5, z5),  \
+            }                                       \
+        }
 
+#define gdSPDefLights6(ar, ag, ab,                  \
+                       r1, g1, b1, x1, y1, z1,      \
+                       r2, g2, b2, x2, y2, z2,      \
+                       r3, g3, b3, x3, y3, z3,      \
+                       r4, g4, b4, x4, y4, z4,      \
+                       r5, g5, b5, x5, y5, z5,      \
+                       r6, g6, b6, x6, y6, z6)      \
+        {                                           \
+            gDefAmbient(ar, ag, ab),                \
+            {                                       \
+                gDefLight(r1, g1, b1, x1, y1, z1),  \
+                gDefLight(r2, g2, b2, x2, y2, z2),  \
+                gDefLight(r3, g3, b3, x3, y3, z3),  \
+                gDefLight(r4, g4, b4, x4, y4, z4),  \
+                gDefLight(r5, g5, b5, x5, y5, z5),  \
+                gDefLight(r6, g6, b6, x6, y6, z6),  \
+            }                                       \
+        }
+
+#define gdSPDefLights7(ar, ag, ab,                  \
+                       r1, g1, b1, x1, y1, z1,      \
+                       r2, g2, b2, x2, y2, z2,      \
+                       r3, g3, b3, x3, y3, z3,      \
+                       r4, g4, b4, x4, y4, z4,      \
+                       r5, g5, b5, x5, y5, z5,      \
+                       r6, g6, b6, x6, y6, z6)      \
+                       r7, g7, b7, x7, y7, z7)      \
+        {                                           \
+            gDefAmbient(ar, ag, ab),                \
+            {                                       \
+                gDefLight(r1, g1, b1, x1, y1, z1),  \
+                gDefLight(r2, g2, b2, x2, y2, z2),  \
+                gDefLight(r3, g3, b3, x3, y3, z3),  \
+                gDefLight(r4, g4, b4, x4, y4, z4),  \
+                gDefLight(r5, g5, b5, x5, y5, z5),  \
+                gDefLight(r6, g6, b6, x6, y6, z6),  \
+                gDefLight(r7, g7, b7, x7, y7, z7),  \
+            }                                       \
+        }
+
+#ifdef F3DEX_GBI_PL
+
+#define gDefPointLight(r, g, b, x, y, z, kc, kl, kq)    \
+    {{                                                  \
+        { (r1), (g1), (b1) }, (kc),                     \
+        { (r1), (g1), (b1) }, (kl),                     \
+        { (x1), (y1), (z1) }, (kq),                     \
+    }}
+
+#define gdSPDefPointLights0(ar, ag, ab)                     \
+        {                                                   \
+            gDefAmbient(ar, ag, ab),                        \
+            {                                               \
+                gDefPointLight(0, 0, 0, 0, 0, 0, 0, 0, 0),  \
+            }                                               \
+        }
+
+#define gdSPDefPointLights1(ar, ag, ab,                             \
+                            r1, g1, b1, x1, y1, z1, c1, l1, q1)     \
+        {                                                           \
+            gDefAmbient(ar, ag, ab),                                \
+            {                                                       \
+                gDefPointLight(r1, g1, b1, x1, y1, z1, c1, l1, q1), \
+            }                                                       \
+        }
+
+#define gdSPDefPointLights2(ar, ag, ab,                             \
+                            r1, g1, b1, x1, y1, z1, c1, l1, q1,     \
+                            r2, g2, b2, x2, y2, z2, c2, l2, q2)     \
+        {                                                           \
+            gDefAmbient(ar, ag, ab),                                \
+            {                                                       \
+                gDefPointLight(r1, g1, b1, x1, y1, z1, c1, l1, q1), \
+                gDefPointLight(r2, g2, b2, x2, y2, z2, c2, l2, q2), \
+            }                                                       \
+        }
+
+#define gdSPDefPointLights3(ar, ag, ab,                             \
+                            r1, g1, b1, x1, y1, z1, c1, l1, q1,     \
+                            r2, g2, b2, x2, y2, z2, c2, l2, q2)     \
+                            r3, g3, b3, x3, y3, z3, c3, l3, q3)     \
+        {                                                           \
+            gDefAmbient(ar, ag, ab),                                \
+            {                                                       \
+                gDefPointLight(r1, g1, b1, x1, y1, z1, c1, l1, q1), \
+                gDefPointLight(r2, g2, b2, x2, y2, z2, c2, l2, q2), \
+                gDefPointLight(r3, g3, b3, x3, y3, z3, c3, l3, q3), \
+            }                                                       \
+        }
+
+#define gdSPDefPointLights4(ar, ag, ab,                             \
+                            r1, g1, b1, x1, y1, z1, c1, l1, q1,     \
+                            r2, g2, b2, x2, y2, z2, c2, l2, q2,     \
+                            r3, g3, b3, x3, y3, z3, c3, l3, q3,     \
+                            r4, g4, b4, x4, y4, z4, c4, l4, q4)     \
+        {                                                           \
+            gDefAmbient(ar, ag, ab),                                \
+            {                                                       \
+                gDefPointLight(r1, g1, b1, x1, y1, z1, c1, l1, q1), \
+                gDefPointLight(r2, g2, b2, x2, y2, z2, c2, l2, q2), \
+                gDefPointLight(r3, g3, b3, x3, y3, z3, c3, l3, q3), \
+                gDefPointLight(r4, g4, b4, x4, y4, z4, c4, l4, q4), \
+            }                                                       \
+        }
+
+#define gdSPDefPointLights5(ar, ag, ab,                             \
+                            r1, g1, b1, x1, y1, z1, c1, l1, q1,     \
+                            r2, g2, b2, x2, y2, z2, c2, l2, q2,     \
+                            r3, g3, b3, x3, y3, z3, c3, l3, q3,     \
+                            r4, g4, b4, x4, y4, z4, c4, l4, q4)     \
+                            r5, g5, b5, x5, y5, z5, c5, l5, q5)     \
+        {                                                           \
+            gDefAmbient(ar, ag, ab),                                \
+            {                                                       \
+                gDefPointLight(r1, g1, b1, x1, y1, z1, c1, l1, q1), \
+                gDefPointLight(r2, g2, b2, x2, y2, z2, c2, l2, q2), \
+                gDefPointLight(r3, g3, b3, x3, y3, z3, c3, l3, q3), \
+                gDefPointLight(r4, g4, b4, x4, y4, z4, c4, l4, q4), \
+                gDefPointLight(r5, g5, b5, x5, y5, z5, c5, l5, q5), \
+            }                                                       \
+        }
+
+#define gdSPDefPointLights6(ar, ag, ab,                             \
+                            r1, g1, b1, x1, y1, z1, c1, l1, q1,     \
+                            r2, g2, b2, x2, y2, z2, c2, l2, q2,     \
+                            r3, g3, b3, x3, y3, z3, c3, l3, q3,     \
+                            r4, g4, b4, x4, y4, z4, c4, l4, q4)     \
+                            r5, g5, b5, x5, y5, z5, c5, l5, q5)     \
+                            r6, g6, b6, x6, y6, z6, c6, l6, q6)     \
+        {                                                           \
+            gDefAmbient(ar, ag, ab),                                \
+            {                                                       \
+                gDefPointLight(r1, g1, b1, x1, y1, z1, c1, l1, q1), \
+                gDefPointLight(r2, g2, b2, x2, y2, z2, c2, l2, q2), \
+                gDefPointLight(r3, g3, b3, x3, y3, z3, c3, l3, q3), \
+                gDefPointLight(r4, g4, b4, x4, y4, z4, c4, l4, q4), \
+                gDefPointLight(r5, g5, b5, x5, y5, z5, c5, l5, q5), \
+                gDefPointLight(r6, g6, b6, x6, y6, z6, c6, l6, q6), \
+            }                                                       \
+        }
+
+#define gdSPDefPointLights7(ar, ag, ab,                             \
+                            r1, g1, b1, x1, y1, z1, c1, l1, q1,     \
+                            r2, g2, b2, x2, y2, z2, c2, l2, q2,     \
+                            r3, g3, b3, x3, y3, z3, c3, l3, q3,     \
+                            r4, g4, b4, x4, y4, z4, c4, l4, q4,     \
+                            r5, g5, b5, x5, y5, z5, c5, l5, q5,     \
+                            r6, g6, b6, x6, y6, z6, c6, l6, q6)     \
+                            r7, g7, b7, x7, y7, z7, c7, l7, q7)     \
+        {                                                           \
+            gDefAmbient(ar, ag, ab),                                \
+            {                                                       \
+                gDefPointLight(r1, g1, b1, x1, y1, z1, c1, l1, q1), \
+                gDefPointLight(r2, g2, b2, x2, y2, z2, c2, l2, q2), \
+                gDefPointLight(r3, g3, b3, x3, y3, z3, c3, l3, q3), \
+                gDefPointLight(r4, g4, b4, x4, y4, z4, c4, l4, q4), \
+                gDefPointLight(r5, g5, b5, x5, y5, z5, c5, l5, q5), \
+                gDefPointLight(r6, g6, b6, x6, y6, z6, c6, l6, q6), \
+                gDefPointLight(r7, g7, b7, x7, y7, z7, c7, l7, q7), \
+            }                                                       \
+        }
+
+#endif
 
 #define gdSPDefLookAt(rightx, righty, rightz, upx, upy, upz)    \
     {{                                                          \

--- a/src/code/sys_math3d.c
+++ b/src/code/sys_math3d.c
@@ -7,7 +7,7 @@
 
 // For retail BSS ordering, the block number of cbf in Math3D_CylVsCylOverlapCenterDist
 // must be 0.
-#pragma increment_block_number 114
+#pragma increment_block_number 111
 
 s32 Math3D_LineVsLineClosestTwoPoints(Vec3f* lineAPointA, Vec3f* lineAPointB, Vec3f* lineBPointA, Vec3f* lineBPointB,
                                       Vec3f* lineAClosestToB, Vec3f* lineBClosestToA);

--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -115,6 +115,8 @@ void* sUnusedEntranceCsList[] = {
     gDekuTreeIntroCs, gJabuJabuIntroCs, gDcOpeningCs, gMinuetCs, gIceCavernSerenadeCs, gTowerBarrierCs,
 };
 
+#pragma increment_block_number 254
+
 // Stores the frame the relevant cam data was last applied on
 u16 gCamAtSplinePointsAppliedFrame;
 u16 gCamEyePointAppliedFrame;

--- a/src/code/z_kankyo.c
+++ b/src/code/z_kankyo.c
@@ -7,7 +7,7 @@
 // For retail BSS ordering, the block number of sLensFlareUnused must be lower
 // than the extern variables declared in the header (e.g. gLightningStrike)
 // while the block number of sNGameOverLightNode must be higher.
-#pragma increment_block_number 80
+#pragma increment_block_number 78
 
 typedef enum {
     /* 0x00 */ LIGHTNING_BOLT_START,

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -11,7 +11,7 @@
 #include "terminal.h"
 
 // For retail BSS ordering, the block number of sStreamSfxProjectedPos must be 0.
-#pragma increment_block_number 193
+#pragma increment_block_number 190
 
 #define FLAGS ACTOR_FLAG_4
 


### PR DESCRIPTION
This PR adds point lighting macros and structures to `gbi.h`. While OoT does not use point lighting, gamecube versions use a microcode version that supports them, so it seems appropriate to expose the means to use it. This will mirror MM's gbi implementation once https://github.com/zeldaret/mm/pull/1647 is in.

The hope is to standardize the point lighting gbi implementation for modding purposes, as currently a few subtly incompatible gbi implementations exist.
