### PR TITLE
Sync gbi.h with MM, move ucode defines to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,13 +156,13 @@ ifeq ($(COMPILER),gcc)
   OPTFLAGS := -Os -ffast-math -fno-unsafe-math-optimizations
 endif
 
-# TODO PL should be disabled for non-gamecube
-UCODE_DEFS := -DF3DEX_GBI_2 -DF3DEX_GBI_PL
+# TODO PL and DOWHILE should be disabled for non-gamecube
+GBI_DEFINES := -DF3DEX_GBI_2 -DF3DEX_GBI_PL -DGBI_DOWHILE
 ifeq ($(DEBUG),1)
-  UCODE_DEFS += -DGBI_DEBUG
+  GBI_DEFINES += -DGBI_DEBUG
 endif
 
-CFLAGS += $(UCODE_DEFS)
+CFLAGS += $(GBI_DEFINES)
 
 ASFLAGS := -march=vr4300 -32 -no-pad-sections -Iinclude
 
@@ -180,7 +180,7 @@ endif
 ifeq ($(COMPILER),ido)
   # Have CC_CHECK pretend to be a MIPS compiler
   MIPS_BUILTIN_DEFS := -D_MIPS_ISA_MIPS2=2 -D_MIPS_ISA=_MIPS_ISA_MIPS2 -D_ABIO32=1 -D_MIPS_SIM=_ABIO32 -D_MIPS_SZINT=32 -D_MIPS_SZLONG=32 -D_MIPS_SZPTR=32
-  CC_CHECK  = gcc -fno-builtin -fsyntax-only -funsigned-char -std=gnu90 -D_LANGUAGE_C $(CPP_DEFINES) $(MIPS_BUILTIN_DEFS) $(UCODE_DEFS) $(INC) $(CHECK_WARNINGS)
+  CC_CHECK  = gcc -fno-builtin -fsyntax-only -funsigned-char -std=gnu90 -D_LANGUAGE_C $(CPP_DEFINES) $(MIPS_BUILTIN_DEFS) $(GBI_DEFINES) $(INC) $(CHECK_WARNINGS)
   ifeq ($(shell getconf LONG_BIT), 32)
     # Work around memory allocation bug in QEMU
     export QEMU_GUEST_BASE := 1
@@ -309,7 +309,7 @@ $(BUILD_DIR)/src/libultra/libc/%.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/libultra/rmon/%.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/libultra/gu/%.o: OPTFLAGS := -O2
 
-$(BUILD_DIR)/assets/misc/z_select_static/%.o: UCODE_DEFS := -DF3DEX_GBI
+$(BUILD_DIR)/assets/misc/z_select_static/%.o: GBI_DEFINES := -DF3DEX_GBI
 
 $(BUILD_DIR)/src/libultra/gu/%.o: CC := $(CC_OLD)
 $(BUILD_DIR)/src/libultra/io/%.o: CC := $(CC_OLD)

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,14 @@ ifeq ($(COMPILER),gcc)
   OPTFLAGS := -Os -ffast-math -fno-unsafe-math-optimizations
 endif
 
+# TODO PL should be disabled for non-gamecube
+UCODE_DEFS := -DF3DEX_GBI_2 -DF3DEX_GBI_PL
+ifeq ($(DEBUG),1)
+  UCODE_DEFS += -DGBI_DEBUG
+endif
+
+CFLAGS += $(UCODE_DEFS)
+
 ASFLAGS := -march=vr4300 -32 -no-pad-sections -Iinclude
 
 ifeq ($(COMPILER),gcc)
@@ -172,7 +180,7 @@ endif
 ifeq ($(COMPILER),ido)
   # Have CC_CHECK pretend to be a MIPS compiler
   MIPS_BUILTIN_DEFS := -D_MIPS_ISA_MIPS2=2 -D_MIPS_ISA=_MIPS_ISA_MIPS2 -D_ABIO32=1 -D_MIPS_SIM=_ABIO32 -D_MIPS_SZINT=32 -D_MIPS_SZLONG=32 -D_MIPS_SZPTR=32
-  CC_CHECK  = gcc -fno-builtin -fsyntax-only -funsigned-char -std=gnu90 -D_LANGUAGE_C $(CPP_DEFINES) $(MIPS_BUILTIN_DEFS) $(INC) $(CHECK_WARNINGS)
+  CC_CHECK  = gcc -fno-builtin -fsyntax-only -funsigned-char -std=gnu90 -D_LANGUAGE_C $(CPP_DEFINES) $(MIPS_BUILTIN_DEFS) $(UCODE_DEFS) $(INC) $(CHECK_WARNINGS)
   ifeq ($(shell getconf LONG_BIT), 32)
     # Work around memory allocation bug in QEMU
     export QEMU_GUEST_BASE := 1
@@ -301,7 +309,7 @@ $(BUILD_DIR)/src/libultra/libc/%.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/libultra/rmon/%.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/libultra/gu/%.o: OPTFLAGS := -O2
 
-$(BUILD_DIR)/assets/misc/z_select_static/%.o: CFLAGS += -DF3DEX_GBI
+$(BUILD_DIR)/assets/misc/z_select_static/%.o: UCODE_DEFS := -DF3DEX_GBI
 
 $(BUILD_DIR)/src/libultra/gu/%.o: CC := $(CC_OLD)
 $(BUILD_DIR)/src/libultra/io/%.o: CC := $(CC_OLD)

--- a/include/ultra64/gbi.h
+++ b/include/ultra64/gbi.h
@@ -3,12 +3,16 @@
 #ifndef ULTRA64_GBI_H
 #define ULTRA64_GBI_H
 
+#ifdef GBI_DOWHILE
+/* Private macro to wrap other macros in do {...} while (0) */
+#define _DW(macro) do { macro } while (0)
+#else
+#define _DW(macro) { macro } (void)0
+#endif
+
 /* To enable Fast3DEX grucode support, define F3DEX_GBI. */
 
 /* Types */
-
-/* Private macro to wrap other macros in do {...} while (0) */
-#define _DW(macro) do {macro} while (0)
 
 #ifdef    F3DEX_GBI_2
 # ifndef  F3DEX_GBI

--- a/include/ultra64/gbi.h
+++ b/include/ultra64/gbi.h
@@ -10,14 +10,6 @@
 /* Private macro to wrap other macros in do {...} while (0) */
 #define _DW(macro) do {macro} while (0)
 
-#ifndef F3DEX_GBI
- #define F3DEX_GBI_2
-
- /* F3DEX2 with Point Lighting */
- /* TODO this should have version defines, gamecube versions have point light ucode but n64 versions don't */
- #define F3DEX_GBI_PL
-#endif
-
 #ifdef    F3DEX_GBI_2
 # ifndef  F3DEX_GBI
 #  define F3DEX_GBI
@@ -2015,7 +2007,9 @@ typedef union {
     Gquad           quad;
 #endif
     Gline3D         line;
+#if (defined(F3DLP_GBI) || defined(F3DEX_GBI))
     Gcull           cull;
+#endif
     Gmovewd         movewd;
     Gmovemem        movemem;
     Gpopmtx         popmtx;
@@ -3454,6 +3448,15 @@ _DW({                                               \
 #define gsDPSetAlphaDither(mode)        \
     gsSPSetOtherMode(    G_SETOTHERMODE_H, G_MDSFT_ALPHADITHER, 2, mode)
 #endif
+
+/*
+ * Majora's Mask Extension, sets both RGB and Alpha dither modes in the same
+ * macro. `mode` should use both G_CD_* and G_AD_* constants.
+ */
+#define gDPSetDither(pkt, mode) \
+    gSPSetOtherMode(pkt, G_SETOTHERMODE_H, G_MDSFT_ALPHADITHER, 4, mode)
+#define gsDPSetDither(mode)     \
+    gsSPSetOtherMode(    G_SETOTHERMODE_H, G_MDSFT_ALPHADITHER, 4, mode)
 
 /* 'blendmask' is not supported anymore.
  * The bits are reserved for future use.
@@ -5143,7 +5146,7 @@ _DW({                                                   \
 #define gDPNoOpTag(pkt, tag)    gDPParam(pkt,   G_NOOP, tag)
 #define gsDPNoOpTag(tag)        gsDPParam(      G_NOOP, tag)
 
-#if OOT_DEBUG
+#ifdef GBI_DEBUG
 
 #define gDPNoOpHere(pkt, file, line)        gDma1p(pkt, G_NOOP, file, line, 1)
 #define gDPNoOpString(pkt, data, n)         gDma1p(pkt, G_NOOP, data, n, 2)
@@ -5169,7 +5172,7 @@ _DW({                                                   \
 #define gDPNoOpCloseDisp(pkt, file, line)
 #define gDPNoOpTag3(pkt, type, data, n)
 
-#endif /* OOT_DEBUG */
+#endif /* GBI_DEBUG */
 
 #endif
 


### PR DESCRIPTION
This syncs the contents of gbi.h with MM, once https://github.com/zeldaret/mm/pull/1650 is merged. It also moves the gbi defines out of the header and into the makefile; the original unmodified gbi.h expected users to set the defines in the compile command.

I've also removed the usage of `OOT_DEBUG` since that doesn't really work for MM. I've replaced it with `GBI_DEBUG` to be a game-agnostic way of toggling the gbi debug macros.
