### PR TITLE
Automatically find end of staff message table

### DIFF
--- a/baseroms/gc-eu-mq-dbg/config.yml
+++ b/baseroms/gc-eu-mq-dbg/config.yml
@@ -5,4 +5,3 @@ variables:
   sGerMessageEntryTable: 0x8014F548
   sFraMessageEntryTable: 0x80151658
   sStaffMessageEntryTable: 0x80153768
-  sNesMessageEntryTablePtr: 0x801538F0

--- a/baseroms/gc-eu-mq/config.yml
+++ b/baseroms/gc-eu-mq/config.yml
@@ -5,4 +5,3 @@ variables:
   sGerMessageEntryTable: 0x8010BA18
   sFraMessageEntryTable: 0x8010DB28
   sStaffMessageEntryTable: 0x8010FC38
-  sNesMessageEntryTablePtr: 0x8010FDC0

--- a/baseroms/gc-eu/config.yml
+++ b/baseroms/gc-eu/config.yml
@@ -5,4 +5,3 @@ variables:
   sGerMessageEntryTable: 0x8010BA38
   sFraMessageEntryTable: 0x8010DB48
   sStaffMessageEntryTable: 0x8010FC58
-  sNesMessageEntryTablePtr: 0x8010FDE0

--- a/tools/msgdis.py
+++ b/tools/msgdis.py
@@ -23,10 +23,16 @@ def as_word_list(b):
         return None
     return [i[0] for i in struct.iter_unpack(">I", b)]
 
-def as_message_table_entry(b):
-    if len(b) % 8 != 0:
-        return None
-    return [(e[0], e[1]>>0x4&0xF, e[1]&0xF, e[2]) for e in [i for i in struct.iter_unpack(">HBxI", b)]]
+def read_message_table(b, offset):
+    table = []
+    while True:
+        e = struct.unpack(">HBxI", b[offset:offset+8])
+        entry = (e[0], e[1]>>0x4&0xF, e[1]&0xF, e[2])
+        table.append(entry)
+        offset += 8
+        if entry[0] == 0xFFFF:
+            break
+    return table
 
 def segmented_to_physical(address):
     return address & ~0x07000000
@@ -268,7 +274,6 @@ nes_message_entry_table_addr = None
 ger_message_entry_table_addr = None
 fra_message_entry_table_addr = None
 staff_message_entry_table_addr = None
-staff_message_entry_table_addr_end = None
 
 nes_message_entry_table = []
 ger_message_entry_table = []
@@ -290,7 +295,7 @@ def read_tables():
     with open(f"extracted/{version}/baserom/code","rb") as infile:
         baserom = infile.read()
 
-    nes_message_entry_table = as_message_table_entry(baserom[nes_message_entry_table_addr:ger_message_entry_table_addr])
+    nes_message_entry_table = read_message_table(baserom, nes_message_entry_table_addr)
 
     ids = [entry[0] for entry in nes_message_entry_table if entry[0] != 0xFFFC]
     ger_message_entry_table = list(zip(ids,as_word_list(baserom[ger_message_entry_table_addr:  fra_message_entry_table_addr])))
@@ -302,7 +307,7 @@ def read_tables():
         else:
             combined_message_entry_table.append((*entry, None, None))
 
-    staff_message_entry_table = as_message_table_entry(baserom[staff_message_entry_table_addr:staff_message_entry_table_addr_end])
+    staff_message_entry_table = read_message_table(baserom, staff_message_entry_table_addr)
 
 # ===================================================
 #   Run
@@ -423,7 +428,6 @@ def main():
     global ger_message_entry_table_addr
     global fra_message_entry_table_addr
     global staff_message_entry_table_addr
-    global staff_message_entry_table_addr_end
 
     parser = argparse.ArgumentParser(
         description="Extract text from the baserom into .h files"
@@ -447,7 +451,6 @@ def main():
     ger_message_entry_table_addr = config.variables["sGerMessageEntryTable"] - code_vram
     fra_message_entry_table_addr = config.variables["sFraMessageEntryTable"] - code_vram
     staff_message_entry_table_addr = config.variables["sStaffMessageEntryTable"] - code_vram
-    staff_message_entry_table_addr_end = config.variables["sNesMessageEntryTablePtr"] - code_vram
 
     extract_all_text(args.text_out, args.staff_text_out)
 


### PR DESCRIPTION
by using message 0xFFFF instead of `sNesMessageEntryTablePtr`. It's one less variable we have to worry about for other versions (and besides the following variable should be called `sJpnMessageEntryTablePtr` not `sNesMessageEntryTablePtr` for NTSC anyway)