### PR TITLE
Remove global.h from z_fishing

### DIFF
--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -1,6 +1,7 @@
 #ifndef Z64ACTOR_H
 #define Z64ACTOR_H
 
+#include "color.h"
 #include "z64dma.h"
 #include "z64animation.h"
 #include "z64math.h"
@@ -14,18 +15,14 @@
 #define MASS_HEAVY 0xFE // Can only be pushed by OC colliders from actors with IMMOVABLE or HEAVY mass.
 
 struct Actor;
-struct PlayState;
+struct CollisionPoly;
 struct Lights;
+struct PlayState;
 
 typedef void (*ActorFunc)(struct Actor*, struct PlayState*);
 typedef void (*ActorShadowFunc)(struct Actor*, struct Lights*, struct PlayState*);
 typedef u16 (*NpcGetTextIdFunc)(struct PlayState*, struct Actor*);
 typedef s16 (*NpcUpdateTalkStateFunc)(struct PlayState*, struct Actor*);
-
-typedef struct {
-    Vec3f pos;
-    Vec3s rot;
-} PosRot; // size = 0x14
 
 typedef struct {
     /* 0x00 */ s16 id;
@@ -270,8 +267,8 @@ typedef struct Actor {
     /* 0x068 */ f32 speed; // Context dependent speed value. Can be used for XZ or XYZ depending on which move function is used
     /* 0x06C */ f32 gravity; // Acceleration due to gravity. Value is added to Y velocity every frame
     /* 0x070 */ f32 minVelocityY; // Sets the lower bounds cap for velocity along the Y axis. Only relevant when moved with gravity.
-    /* 0x074 */ CollisionPoly* wallPoly; // Wall polygon the actor is touching
-    /* 0x078 */ CollisionPoly* floorPoly; // Floor polygon directly below the actor
+    /* 0x074 */ struct CollisionPoly* wallPoly; // Wall polygon the actor is touching
+    /* 0x078 */ struct CollisionPoly* floorPoly; // Floor polygon directly below the actor
     /* 0x07C */ u8 wallBgId; // Bg ID of the wall polygon the actor is touching
     /* 0x07D */ u8 floorBgId; // Bg ID of the floor polygon directly below the actor
     /* 0x07E */ s16 wallYaw; // Y rotation of the wall polygon the actor is touching

--- a/include/z64bgcheck.h
+++ b/include/z64bgcheck.h
@@ -49,7 +49,7 @@ typedef struct {
 // flags for flags_vIB
 #define COLPOLY_IS_FLOOR_CONVEYOR (1 << 0)
 
-typedef struct {
+typedef struct CollisionPoly {
     /* 0x00 */ u16 type;
     union {
         u16 vtxData[3];

--- a/include/z64camera.h
+++ b/include/z64camera.h
@@ -130,6 +130,9 @@
 // Use a camera pivot setting that allows camera rotation (CAM_SET_PIVOT_SHOP_BROWSING for shop specifically)
 #define VIEWPOINT_PIVOT (BGCAM_INDEX_TOGGLE_PIVOT + 1)
 
+struct Actor;
+struct CollisionPoly;
+
 typedef enum {
     /* 0x00 */ CAM_SET_NONE,
     /* 0x01 */ CAM_SET_NORMAL0,
@@ -336,7 +339,7 @@ typedef enum {
 
 typedef struct {
     /* 0x00 */ Vec3f collisionClosePoint;
-    /* 0x0C */ CollisionPoly* atEyePoly;
+    /* 0x0C */ struct CollisionPoly* atEyePoly;
     /* 0x10 */ f32 swingUpdateRate;
     /* 0x14 */ s16 unk_14;
     /* 0x16 */ s16 unk_16;
@@ -676,7 +679,7 @@ typedef struct {
     /* 0x00 */ f32 initialEyeToAtDist;
     /* 0x04 */ f32 roll;
     /* 0x08 */ f32 yPosOffset;
-    /* 0x0C */ Actor* target;
+    /* 0x0C */ struct Actor* target;
     /* 0x10 */ f32 unk_10;
     /* 0x14 */ s16 unk_14; // unused
     /* 0x16 */ s16 initialEyeToAtYaw;
@@ -757,7 +760,7 @@ typedef struct {
     /* 0x00 */ f32 unk_00;
     /* 0x04 */ f32 unk_04;
     /* 0x08 */ f32 unk_08;
-    /* 0x0C */ Actor* unk_0C;
+    /* 0x0C */ struct Actor* unk_0C;
     /* 0x10 */ s16 unk_10;
     /* 0x12 */ s16 unk_12;
     /* 0x14 */ s16 unk_14;
@@ -806,7 +809,7 @@ typedef struct {
     /* 0x00 */ f32 eyeToAtTargetR;
     /* 0x08 */ f32 eyeToAtTargetYaw;
     /* 0x04 */ f32 eyeToAtTargetPitch;
-    /* 0x0C */ Actor* target;
+    /* 0x0C */ struct Actor* target;
     /* 0x10 */ Vec3f atTarget;
     /* 0x1C */ s16 animTimer;
 } KeepOn3ReadWriteData; // size = 0x20
@@ -1548,7 +1551,7 @@ typedef union {
 typedef struct {
     /* 0x00 */ Vec3f pos;
     /* 0x0C */ Vec3f norm;
-    /* 0x18 */ CollisionPoly* poly;
+    /* 0x18 */ struct CollisionPoly* poly;
     /* 0x1C */ VecGeo geoNorm;
     /* 0x24 */ s32 bgId;
 } CamColChk; // size = 0x28

--- a/include/z64cutscene.h
+++ b/include/z64cutscene.h
@@ -2,6 +2,7 @@
 #define Z64CUTSCENE_H
 
 #include "ultra64.h"
+#include "z64math.h"
 
 typedef union CutsceneData {
     s32 i;

--- a/include/z64math.h
+++ b/include/z64math.h
@@ -38,6 +38,11 @@ typedef struct {
 } Spheref; // size = 0x10
 
 typedef struct {
+    /* 0x00 */ Vec3f pos;
+    /* 0x0C */ Vec3s rot;
+} PosRot; // size = 0x14
+
+typedef struct {
     Vec3f normal;
     f32 originDist;
 } Plane; // size = 0x10

--- a/src/code/sys_math3d.c
+++ b/src/code/sys_math3d.c
@@ -7,7 +7,7 @@
 
 // For retail BSS ordering, the block number of cbf in Math3D_CylVsCylOverlapCenterDist
 // must be 0.
-#pragma increment_block_number 111
+#pragma increment_block_number 108
 
 s32 Math3D_LineVsLineClosestTwoPoints(Vec3f* lineAPointA, Vec3f* lineAPointB, Vec3f* lineBPointA, Vec3f* lineBPointB,
                                       Vec3f* lineAClosestToB, Vec3f* lineBClosestToA);

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -8,10 +8,11 @@
 
 #include "overlays/actors/ovl_En_Kanban/z_en_kanban.h"
 #include "assets/objects/object_fish/object_fish.h"
+#include "ichain.h"
 #include "terminal.h"
 
 // For retail BSS ordering, the block number of sStreamSfxProjectedPos must be 0.
-#pragma increment_block_number 183
+#pragma increment_block_number 182
 
 #define FLAGS ACTOR_FLAG_4
 

--- a/src/overlays/actors/ovl_Fishing/z_fishing.h
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.h
@@ -2,7 +2,8 @@
 #define Z_FISHING_H
 
 #include "ultra64.h"
-#include "global.h"
+#include "z64actor.h"
+#include "z64light.h"
 
 struct Fishing;
 


### PR DESCRIPTION
z_fishing.c is probably has the most fragile BSS right now so hopefully this will help. I moved PosRot to `include/z64math.h` like MM and added a couple missing `#include`s in the new headers but stopped myself before it got out of hand.