### PR TITLE
Fix extract_assets.py -s modification check

### DIFF
--- a/extract_assets.py
+++ b/extract_assets.py
@@ -149,9 +149,9 @@ def main():
 
         initializeWorker(versionConfig, mainAbort, args.unaccounted, extractedAssetsTracker, manager)
         # Always extract if -s is used.
-        fullPath = assetConfig.xml_path
-        if fullPath in extractedAssetsTracker:
-            del extractedAssetsTracker[fullPath]
+        xml_path_str = str(assetConfig.xml_path)
+        if xml_path_str in extractedAssetsTracker:
+            del extractedAssetsTracker[xml_path_str]
         ExtractFunc(assetConfig)
     else:
         class CannotMultiprocessError(Exception):


### PR DESCRIPTION
Previously, the `-s` flag like in `./extract_assets.py -v gc-us -s overlays/ovl_En_Jsjutan` would ignore file modification timestamps and always rebuild, but this got broken by #1967 due to some type confusion (`fullPath` was a `Path` but the keys of `extractedAssetsTracker` are `str`s).