### PR TITLE
CC_CHECK: Add -Werror=implicit-function-declaration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ INC := -Iinclude -Iinclude/libc -Isrc -I$(BUILD_DIR) -I. -I$(EXTRACTED_DIR)
 
 # Check code syntax with host compiler
 CHECK_WARNINGS := -Wall -Wextra -Wno-format-security -Wno-unknown-pragmas -Wno-unused-parameter -Wno-unused-variable -Wno-missing-braces
+CHECK_WARNINGS += -Werror=implicit-function-declaration
 
 # The `cpp` command behaves differently on macOS (it behaves as if
 # `-traditional-cpp` was passed) so we use `gcc -E` instead.


### PR DESCRIPTION
Promote the CC_CHECK gcc warning implicit-function-declaration to an error

This prevents calling functions without having a visible prototype for them.

This is good practice in general (it's an error by default with gcc when using > C99, but we pass -std=gnu90 for CC_CHECK), and it also helps with splitting headers in case a function is moved to a header, but a file using said function doesn't include that header. A simple warning would be flooded away, and figuring out why the build possibly doesn't match is harder than just if the build error'ed in the first place.