### PR TITLE
Handle messages with different box types/positions between JPN/NES

### DIFF
--- a/tools/msgdis.py
+++ b/tools/msgdis.py
@@ -230,7 +230,7 @@ def read_sfx_ids():
     return sfx_ids
 
 def unique_or_none(lst : List[T]) -> Optional[T]:
-    if len(lst) == 0:
+    if not lst:
         return None
     elem = lst[0]
     for e in lst[1:]:

--- a/tools/msgdis.py
+++ b/tools/msgdis.py
@@ -746,9 +746,6 @@ class MessageEntry:
                 assert self.data[1] is not None
                 out += self.define_message("DEFINE_MESSAGE_JPN", self.data[0].box_type, self.data[0].box_pos, [self.data[0], None, None, None])
                 out += self.define_message("DEFINE_MESSAGE_NES", self.data[1].box_type, self.data[1].box_pos, [None, self.data[1], None, None])
-        elif all(selection):
-            # Valid for all languages
-            out += self.define_message("DEFINE_MESSAGE", self.data[0].box_type, self.data[0].box_pos, self.data)
         elif selection == (True,False,True,True):
             # JPN only
             out += self.define_message("DEFINE_MESSAGE_JPN", self.data[0].box_type, self.data[0].box_pos, self.data)

--- a/tools/msgdis.py
+++ b/tools/msgdis.py
@@ -744,6 +744,8 @@ class MessageEntry:
                 # so emit both DEFINE_MESSAGE_JPN and DEFINE_MESSAGE_NES
                 assert self.data[0] is not None
                 assert self.data[1] is not None
+                assert self.data[2] is None
+                assert self.data[3] is None
                 out += self.define_message("DEFINE_MESSAGE_JPN", self.data[0].box_type, self.data[0].box_pos, [self.data[0], None, None, None])
                 out += self.define_message("DEFINE_MESSAGE_NES", self.data[1].box_type, self.data[1].box_pos, [None, self.data[1], None, None])
         elif selection == (True,False,True,True):


### PR DESCRIPTION
The unused NTSC messages 0x00F8, 0x016E, 0x016F, and 0x706A have different attributes between the JP and English messages. These are now handled by writing both `DEFINE_MESSAGE_JPN` and `DEFINE_MESSAGE_NES`, for example
```
DEFINE_MESSAGE_JPN(0x706A, TEXTBOX_TYPE_BLACK, TEXTBOX_POS_VARIABLE,
MSG(
"７０６Ａ"
)
,
MSG(/* MISSING */)
,
MSG(/* MISSING */)
,
MSG(/* MISSING */)
)
DEFINE_MESSAGE_NES(0x706A, TEXTBOX_TYPE_BLUE, TEXTBOX_POS_VARIABLE,
MSG(/* MISSING */)
,
MSG(
"706a"
)
,
MSG(/* MISSING */)
,
MSG(/* MISSING */)
)
```