### PR TITLE
Fix extract_assets.py error message

### DIFF
--- a/extract_assets.py
+++ b/extract_assets.py
@@ -53,7 +53,7 @@ def ExtractFile(assetConfig: version_config.AssetConfig, outputPath: Path, outpu
     if exitValue != 0:
         globalAbort.set()
         print("\n")
-        print("Error when extracting from file " + xmlPath, file=os.sys.stderr)
+        print(f"Error when extracting from file {xmlPath}", file=os.sys.stderr)
         print("Aborting...", file=os.sys.stderr)
         print("\n")
 


### PR DESCRIPTION
More type errors (xmlPath is a `Path` which can't be used with `+`)