### PR TITLE
Create FILENAME_ macros for NTSC filename encoding

### DIFF
--- a/include/z64message.h
+++ b/include/z64message.h
@@ -35,7 +35,7 @@ typedef enum {
 #define FILENAME_SPACE                      0xDF
 // 0xE0: unknown
 #define FILENAME_QUESTION_MARK              0xE1
-#define FILENAME_EXCLAMATION_POINT          0xE2
+#define FILENAME_EXCLAMATION_MARK           0xE2
 #define FILENAME_COLON                      0xE3
 #define FILENAME_DASH                       0xE4
 #define FILENAME_LEFT_PARENTHESES           0xE5

--- a/include/z64message.h
+++ b/include/z64message.h
@@ -28,7 +28,7 @@ typedef enum {
 // the character 'A'.
 #if OOT_NTSC
 #define FILENAME_DIGIT(c)                   ((c) - '0')
-// 0x0A - 0x59: hirigana
+// 0x0A - 0x59: hiragana
 // 0x5A - 0xAA: katakana
 #define FILENAME_UPPERCASE(c)               ((c) - 'A' + 0xAB)
 #define FILENAME_LOWERCASE(c)               ((c) - 'a' + 0xC5)

--- a/include/z64message.h
+++ b/include/z64message.h
@@ -28,11 +28,23 @@ typedef enum {
 // the character 'A'.
 #if OOT_NTSC
 #define FILENAME_DIGIT(c)                   ((c) - '0')
+// 0x0A - 0x59: hirigana
+// 0x5A - 0xAA: katakana
 #define FILENAME_UPPERCASE(c)               ((c) - 'A' + 0xAB)
 #define FILENAME_LOWERCASE(c)               ((c) - 'a' + 0xC5)
 #define FILENAME_SPACE                      0xDF
+// 0xE0: unknown
+#define FILENAME_QUESTION_MARK              0xE1
+#define FILENAME_EXCLAMATION_POINT          0xE2
+#define FILENAME_COLON                      0xE3
 #define FILENAME_DASH                       0xE4
+#define FILENAME_LEFT_PARENTHESES           0xE5
+#define FILENAME_RIGHT_PARENTHESES          0xE6
+#define FILENAME_DAKUTEN                    0xE7
+#define FILENAME_HANDAKUTEN                 0xE8
+#define FILENAME_COMMA                      0xE9
 #define FILENAME_PERIOD                     0xEA
+#define FILENAME_SLASH                      0xEB
 #else
 #define FILENAME_DIGIT(c)                   ((c) - '0')
 #define FILENAME_UPPERCASE(c)               ((c) - 'A' + 0x0A)

--- a/include/z64message.h
+++ b/include/z64message.h
@@ -23,6 +23,25 @@ typedef enum {
 // TODO get these properties from the textures themselves
 #define MESSAGE_TEXTURE_STATIC_TEX_SIZE 0x900
 
+// Macros for generating characters in the filename encoding (specified by message 0xFFFC
+// and loaded by Font_LoadOrderedFont). For example, FILENAME_UPPERCASE('A') will encode
+// the character 'A'.
+#if OOT_NTSC
+#define FILENAME_DIGIT(c)                   ((c) - '0')
+#define FILENAME_UPPERCASE(c)               ((c) - 'A' + 0xAB)
+#define FILENAME_LOWERCASE(c)               ((c) - 'a' + 0xC5)
+#define FILENAME_SPACE                      0xDF
+#define FILENAME_DASH                       0xE4
+#define FILENAME_PERIOD                     0xEA
+#else
+#define FILENAME_DIGIT(c)                   ((c) - '0')
+#define FILENAME_UPPERCASE(c)               ((c) - 'A' + 0x0A)
+#define FILENAME_LOWERCASE(c)               ((c) - 'a' + 0x24)
+#define FILENAME_SPACE                      0x3E
+#define FILENAME_DASH                       0x3F
+#define FILENAME_PERIOD                     0x40
+#endif
+
 typedef enum {
     /* 0x00 */ MSGMODE_NONE,
     /* 0x01 */ MSGMODE_TEXT_START,

--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -1303,7 +1303,7 @@ void Message_Decode(PlayState* play) {
             // Substitute the player name control character for the file's player name.
             for (playerNameLen = ARRAY_COUNT(gSaveContext.save.info.playerData.playerName); playerNameLen > 0;
                  playerNameLen--) {
-                if (gSaveContext.save.info.playerData.playerName[playerNameLen - 1] != 0x3E) {
+                if (gSaveContext.save.info.playerData.playerName[playerNameLen - 1] != FILENAME_SPACE) {
                     break;
                 }
             }
@@ -1311,21 +1311,21 @@ void Message_Decode(PlayState* play) {
             PRINTF("\n名前 ＝ ");
             for (i = 0; i < playerNameLen; i++) {
                 curChar2 = gSaveContext.save.info.playerData.playerName[i];
-                if (curChar2 == 0x3E) {
+                if (curChar2 == FILENAME_SPACE) {
                     curChar2 = ' ';
-                } else if (curChar2 == 0x40) {
+                } else if (curChar2 == FILENAME_PERIOD) {
                     curChar2 = '.';
-                } else if (curChar2 == 0x3F) {
+                } else if (curChar2 == FILENAME_DASH) {
                     curChar2 = '-';
-                } else if (curChar2 < 0xA) {
-                    curChar2 += 0;
+                } else if (curChar2 <= FILENAME_DIGIT('9')) {
+                    curChar2 -= FILENAME_DIGIT('0');
                     curChar2 += '0';
-                } else if (curChar2 < 0x24) {
-                    curChar2 += 0;
-                    curChar2 += '7';
-                } else if (curChar2 < 0x3E) {
-                    curChar2 += 0;
-                    curChar2 += '=';
+                } else if (curChar2 <= FILENAME_UPPERCASE('Z')) {
+                    curChar2 -= FILENAME_UPPERCASE('A');
+                    curChar2 += 'A';
+                } else if (curChar2 <= FILENAME_LOWERCASE('z')) {
+                    curChar2 -= FILENAME_LOWERCASE('a');
+                    curChar2 += 'a';
                 }
                 if (curChar2 != ' ') {
                     Font_LoadChar(font, curChar2 - ' ', charTexIdx);

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -27,23 +27,32 @@ u16 gSramSlotOffsets[] = {
 static char sZeldaMagic[] = { '\0', '\0', '\0', '\x98', '\x09', '\x10', '\x21', 'Z', 'E', 'L', 'D', 'A' };
 
 static SavePlayerData sNewSavePlayerData = {
-    { '\0', '\0', '\0', '\0', '\0', '\0' },             // newf
-    0,                                                  // deaths
-    { 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E }, // playerName
-    0,                                                  // n64ddFlag
-    0x30,                                               // healthCapacity
-    0x30,                                               // defense
-    0,                                                  // magicLevel
-    MAGIC_NORMAL_METER,                                 // magic
-    0,                                                  // rupees
-    0,                                                  // swordHealth
-    0,                                                  // naviTimer
-    false,                                              // isMagicAcquired
-    0,                                                  // unk_1F
-    false,                                              // isDoubleMagicAcquired
-    false,                                              // isDoubleDefenseAcquired
-    0,                                                  // bgsFlag
-    0,                                                  // ocarinaGameRoundNum
+    { '\0', '\0', '\0', '\0', '\0', '\0' }, // newf
+    0,                                      // deaths
+    {
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+    },                  // playerName
+    0,                  // n64ddFlag
+    0x30,               // healthCapacity
+    0x30,               // defense
+    0,                  // magicLevel
+    MAGIC_NORMAL_METER, // magic
+    0,                  // rupees
+    0,                  // swordHealth
+    0,                  // naviTimer
+    false,              // isMagicAcquired
+    0,                  // unk_1F
+    false,              // isDoubleMagicAcquired
+    false,              // isDoubleDefenseAcquired
+    0,                  // bgsFlag
+    0,                  // ocarinaGameRoundNum
     {
         { ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE }, // buttonItems
         { SLOT_NONE, SLOT_NONE, SLOT_NONE },            // cButtonSlots
@@ -155,23 +164,32 @@ void Sram_InitNewSave(void) {
 }
 
 static SavePlayerData sDebugSavePlayerData = {
-    { 'Z', 'E', 'L', 'D', 'A', 'Z' },                   // newf
-    0,                                                  // deaths
-    { 0x15, 0x12, 0x17, 0x14, 0x3E, 0x3E, 0x3E, 0x3E }, // playerName ( "LINK" )
-    0,                                                  // n64ddFlag
-    0xE0,                                               // healthCapacity
-    0xE0,                                               // health
-    0,                                                  // magicLevel
-    MAGIC_NORMAL_METER,                                 // magic
-    150,                                                // rupees
-    8,                                                  // swordHealth
-    0,                                                  // naviTimer
-    true,                                               // isMagicAcquired
-    0,                                                  // unk_1F
-    false,                                              // isDoubleMagicAcquired
-    false,                                              // isDoubleDefenseAcquired
-    0,                                                  // bgsFlag
-    0,                                                  // ocarinaGameRoundNum
+    { 'Z', 'E', 'L', 'D', 'A', 'Z' }, // newf
+    0,                                // deaths
+    {
+        FILENAME_UPPERCASE('L'),
+        FILENAME_UPPERCASE('I'),
+        FILENAME_UPPERCASE('N'),
+        FILENAME_UPPERCASE('K'),
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+        FILENAME_SPACE,
+    },                  // playerName
+    0,                  // n64ddFlag
+    0xE0,               // healthCapacity
+    0xE0,               // health
+    0,                  // magicLevel
+    MAGIC_NORMAL_METER, // magic
+    150,                // rupees
+    8,                  // swordHealth
+    0,                  // naviTimer
+    true,               // isMagicAcquired
+    0,                  // unk_1F
+    false,              // isDoubleMagicAcquired
+    false,              // isDoubleDefenseAcquired
+    0,                  // bgsFlag
+    0,                  // ocarinaGameRoundNum
     {
         { ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE }, // buttonItems
         { SLOT_NONE, SLOT_NONE, SLOT_NONE },            // cButtonSlots

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -409,10 +409,14 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
     static s16 textFadeDirection = 0;
     static s16 textFadeTimer = 0;
     static u8 noControllerFontIndices[] = {
-        0x17, 0x18, 0x0C, 0x18, 0x17, 0x1D, 0x1B, 0x18, 0x15, 0x15, 0x0E, 0x1B,
+        FILENAME_UPPERCASE('N'), FILENAME_UPPERCASE('O'), FILENAME_UPPERCASE('C'), FILENAME_UPPERCASE('O'),
+        FILENAME_UPPERCASE('N'), FILENAME_UPPERCASE('T'), FILENAME_UPPERCASE('R'), FILENAME_UPPERCASE('O'),
+        FILENAME_UPPERCASE('L'), FILENAME_UPPERCASE('L'), FILENAME_UPPERCASE('E'), FILENAME_UPPERCASE('R'),
     };
     static u8 pressStartFontIndices[] = {
-        0x19, 0x1B, 0x0E, 0x1C, 0x1C, 0x1C, 0x1D, 0x0A, 0x1B, 0x1D,
+        FILENAME_UPPERCASE('P'), FILENAME_UPPERCASE('R'), FILENAME_UPPERCASE('E'), FILENAME_UPPERCASE('S'),
+        FILENAME_UPPERCASE('S'), FILENAME_UPPERCASE('S'), FILENAME_UPPERCASE('T'), FILENAME_UPPERCASE('A'),
+        FILENAME_UPPERCASE('R'), FILENAME_UPPERCASE('T'),
     };
     static void* effectMaskTextures[] = {
         gTitleEffectMask00Tex, gTitleEffectMask01Tex, gTitleEffectMask02Tex,

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -169,7 +169,10 @@ void FileSelect_FinishFadeIn(GameState* thisx) {
  * Update function for `CM_MAIN_MENU`
  */
 void FileSelect_UpdateMainMenu(GameState* thisx) {
-    static u8 emptyName[] = { 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E };
+    static u8 emptyName[] = {
+        FILENAME_SPACE, FILENAME_SPACE, FILENAME_SPACE, FILENAME_SPACE,
+        FILENAME_SPACE, FILENAME_SPACE, FILENAME_SPACE, FILENAME_SPACE,
+    };
     FileSelectState* this = (FileSelectState*)thisx;
     SramContext* sramCtx = &this->sramCtx;
     Input* input = &this->state.input[0];

--- a/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
@@ -373,12 +373,12 @@ void FileSelect_DrawNameEntry(GameState* thisx) {
             this->kbdY = 5;
             this->kbdX = 4;
         } else if (CHECK_BTN_ALL(input->press.button, BTN_B)) {
-            if ((this->newFileNameCharCount == 7) && (this->fileNames[this->buttonIndex][7] != 0x3E)) {
+            if ((this->newFileNameCharCount == 7) && (this->fileNames[this->buttonIndex][7] != FILENAME_SPACE)) {
                 for (i = this->newFileNameCharCount; i < 7; i++) {
                     this->fileNames[this->buttonIndex][i] = this->fileNames[this->buttonIndex][i + 1];
                 }
 
-                this->fileNames[this->buttonIndex][i] = 0x3E;
+                this->fileNames[this->buttonIndex][i] = FILENAME_SPACE;
                 Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_S, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
             } else {
@@ -392,7 +392,7 @@ void FileSelect_DrawNameEntry(GameState* thisx) {
                         this->fileNames[this->buttonIndex][i] = this->fileNames[this->buttonIndex][i + 1];
                     }
 
-                    this->fileNames[this->buttonIndex][i] = 0x3E;
+                    this->fileNames[this->buttonIndex][i] = FILENAME_SPACE;
                     Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_S, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                          &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                 }
@@ -419,12 +419,13 @@ void FileSelect_DrawNameEntry(GameState* thisx) {
                     }
                 } else if (CHECK_BTN_ALL(input->press.button, BTN_A) && (this->charPage != this->kbdButton)) {
                     if (this->kbdButton == FS_KBD_BTN_BACKSPACE) {
-                        if ((this->newFileNameCharCount == 7) && (this->fileNames[this->buttonIndex][7] != 0x3E)) {
+                        if ((this->newFileNameCharCount == 7) &&
+                            (this->fileNames[this->buttonIndex][7] != FILENAME_SPACE)) {
                             for (i = this->newFileNameCharCount; i < 7; i++) {
                                 this->fileNames[this->buttonIndex][i] = this->fileNames[this->buttonIndex][i + 1];
                             }
 
-                            this->fileNames[this->buttonIndex][i] = 0x3E;
+                            this->fileNames[this->buttonIndex][i] = FILENAME_SPACE;
                             Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_S, &gSfxDefaultPos, 4,
                                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
                                                  &gSfxDefaultReverb);
@@ -439,7 +440,7 @@ void FileSelect_DrawNameEntry(GameState* thisx) {
                                 this->fileNames[this->buttonIndex][i] = this->fileNames[this->buttonIndex][i + 1];
                             }
 
-                            this->fileNames[this->buttonIndex][i] = 0x3E;
+                            this->fileNames[this->buttonIndex][i] = FILENAME_SPACE;
                             Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_S, &gSfxDefaultPos, 4,
                                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
                                                  &gSfxDefaultReverb);
@@ -448,7 +449,7 @@ void FileSelect_DrawNameEntry(GameState* thisx) {
                         validName = false;
 
                         for (i = 0; i < 8; i++) {
-                            if (this->fileNames[this->buttonIndex][i] != 0x3E) {
+                            if (this->fileNames[this->buttonIndex][i] != FILENAME_SPACE) {
                                 validName = true;
                                 break;
                             }


### PR DESCRIPTION
NTSC uses a different filename encoding that includes Japanese characters (compare message 0xFFFC between NTSC and PAL). This affects everything that uses it, so I created some macros to help. As a bonus, the "NO CONTROLLER" and "PRESS START" texts are now more readable in the code