### PR TITLE
Detect shifted .bss sections in check_ordering.py

### DIFF
--- a/tools/check_ordering.py
+++ b/tools/check_ordering.py
@@ -94,7 +94,7 @@ def read_s16(f: BinaryIO, offset: int) -> int:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Report data/bss reorderings between the baserom and the current build "
+        description="Report bss reorderings between the baserom and the current build "
         "by parsing relocations from the built object files and comparing their final values "
         "between the baserom and the current build. "
         "Assumes that the only differences are due to ordering and that the text sections of the "
@@ -111,6 +111,11 @@ def main():
         "--segment",
         type=str,
         help="ROM segment to check, e.g. 'boot', 'code', or 'ovl_player_actor' (default: all)",
+    )
+    parser.add_argument(
+        "--all-sections",
+        action="store_true",
+        help="Check ordering for all section types, not just .bss",
     )
 
     args = parser.parse_args()
@@ -188,6 +193,9 @@ def main():
     # Go through sections and report differences
     for mapfile_segment in source_code_segments:
         for file in mapfile_segment:
+            if not args.all_sections and not file.sectionType == ".bss":
+                continue
+
             pointers_in_section = [
                 p
                 for p in pointers


### PR DESCRIPTION
Sometimes, a bss reordering can cause the bss section size to change due to padding and alignment. Currently this causes `tools/check_ordering.py` to spew output for every bss section afterwards since the addresses have all shifted. Now, we try to detect if the bss section would match if it was shifted by a constant.

I also changed it to only check .bss sections by default once again, since the output for other sections is not that useful and can be confusing. I added an `--all-sections` flag if you really want to check everything.