### PR TITLE
Promote the warnings `implicit-int`, `int-conversion`, `incompatible-pointer-types` to errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ INC := -Iinclude -Iinclude/libc -Isrc -I$(BUILD_DIR) -I. -I$(EXTRACTED_DIR)
 
 # Check code syntax with host compiler
 CHECK_WARNINGS := -Wall -Wextra -Wno-format-security -Wno-unknown-pragmas -Wno-unused-parameter -Wno-unused-variable -Wno-missing-braces
-CHECK_WARNINGS += -Werror=implicit-function-declaration
+CHECK_WARNINGS += -Werror=implicit-int -Werror=implicit-function-declaration -Werror=int-conversion -Werror=incompatible-pointer-types
 
 # The `cpp` command behaves differently on macOS (it behaves as if
 # `-traditional-cpp` was passed) so we use `gcc -E` instead.


### PR DESCRIPTION
Promotes 3 warnings to errors
- `implicit-int` is when a type is left unspecified and defaults to `int`.
- `int-conversion` is when a pointer is converted to an int without an explicit cast.
- `incompatible-pointer-types` is when a pointer of an incompatible type is used in e.g. a function call, without an explicit cast.

GCC 14 recently promoted these to errors by default (see https://gcc.gnu.org/gcc-14/porting_to.html), this change backports this to earlier GCC versions for the purpose of warnings checking on IDO (`CC_CHECK`) and building with GCC.
There's no case where we or any users of the codebase would want to leave these warnings un-addressed, promoting these to errors enforces this and ensures they aren't lost amidst other warnings that are harder or impossible for us to address.
