### PR TITLE
Small cleanup of cleararena (bootclear)

### DIFF
--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -8,7 +8,7 @@ StackEntry sIdleThreadInfo;
 STACK(sBootThreadStack, BOOT_STACK_SIZE);
 
 void cleararena(void) {
-    bzero(_dmadataSegmentStart, osMemSize - OS_K0_TO_PHYSICAL(_dmadataSegmentStart));
+    bzero(_bootSegmentEnd, osMemSize - OS_K0_TO_PHYSICAL(_bootSegmentEnd));
 }
 
 void bootproc(void) {

--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -7,7 +7,7 @@ STACK(sIdleThreadStack, 0x400);
 StackEntry sIdleThreadInfo;
 STACK(sBootThreadStack, BOOT_STACK_SIZE);
 
-void cleararena(void) {
+void bootclear(void) {
     bzero(_bootSegmentEnd, osMemSize - OS_K0_TO_PHYSICAL(_bootSegmentEnd));
 }
 
@@ -15,7 +15,7 @@ void bootproc(void) {
     StackCheck_Init(&sBootThreadInfo, sBootThreadStack, STACK_TOP(sBootThreadStack), 0, -1, "boot");
 
     osMemSize = osGetMemSize();
-    cleararena();
+    bootclear();
     __osInitialize_common();
     __osInitialize_autodetect();
 


### PR DESCRIPTION
As mentioned in discord, this seems more accurate to use the end of the boot segment, instead of the start of dmadata. Also renamed it to bootclear to match `AF`. I'm not opposed to renaming to something else (or renaming bootproc if we want).