### PR TITLE
Clean up gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .idea/
 
 # Project-specific ignores
+extracted/
 build/
 expected/
 docs/doxygen/
@@ -23,13 +24,7 @@ ctx.c
 tools/*dSYM/
 graphs/
 
-# Assets
-.extracted-assets.json
-extracted/
-
-# Docs
-!docs/tutorial/
-
 # Per-user configuration
-# Use `git config core.excludesFile path/to/my_gitignore_file`
-# if you want to use your own gitignore rules without modifying this file.
+# If you want to use your own gitignore rules without modifying this file:
+# - use `git config core.excludesFile path/to/my_gitignore_file`
+# - or edit `.git/info/exclude`

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ docs/doxygen/
 
 # Tools
 .venv/
-tools/disasm/output/*
 ctx.c
 tools/*dSYM/
 graphs/

--- a/.gitignore
+++ b/.gitignore
@@ -7,49 +7,23 @@ __pycache__/
 .vscode/
 .vs/
 .idea/
-CMakeLists.txt
-cmake-build-debug
-venv/
-.venv/
 
 # Project-specific ignores
 build/
 expected/
-notes/
-baserom/
-baseroms/*/segments/
 docs/doxygen/
-*.elf
-*.sra
 *.z64
 *.n64
 *.v64
-*.map
-*.dump
-out.txt
-*.ram
 
-# Tool artifacts
-tools/mipspro7.2_compiler/
-tools/overlayhelpers/batchdisasm/output/*
-tools/overlayhelpers/batchdisasm/output2/*
-tools/overlayhelpers/batchdisasm/mipsdisasm/*
+# Tools
+.venv/
 tools/disasm/output/*
-tools/asmsplitter/asm/*
-tools/asmsplitter/c/*
 ctx.c
 tools/*dSYM/
 graphs/
 
 # Assets
-*.png
-*.jpg
-*.mdli
-*.anmi
-*.obj
-*.mtl
-*.fbx
-!*_custom*
 .extracted-assets.json
 extracted/
 
@@ -57,4 +31,5 @@ extracted/
 !docs/tutorial/
 
 # Per-user configuration
-.python-version
+# Use `git config core.excludesFile path/to/my_gitignore_file`
+# if you want to use your own gitignore rules without modifying this file.


### PR DESCRIPTION
Remove ancient things from gitignore and gitignoring extracted assets files (now gitignored as part of extracted/)

Here's a one liner to remove all "old files":
`rm -rf .extracted-assets.json *.elf *.z64 *.n64 *.v64 baseroms/gc-eu-mq-dbg/segments/ baseroms/gc-eu-mq/segments/ ; find assets \( -name '*.png' -o -name '*.jpg' \) -delete`
