### PR TITLE
Use recomp instead of qemu-irix in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,20 +30,7 @@ pipeline {
                 sh 'make -j setup'
             }
         }
-        stage('Build gc-eu-mq-dbg (qemu-irix)') {
-            when {
-                branch 'main'
-            }
-            steps {
-                sh 'make -j ORIG_COMPILER=1'
-            }
-        }
         stage('Build gc-eu-mq-dbg') {
-            when {
-                not {
-                    branch 'main'
-                }
-            }
             steps {
                 sh 'make -j RUN_CC_CHECK=0'
             }
@@ -54,20 +41,7 @@ pipeline {
                 sh 'make -j setup VERSION=gc-eu-mq'
             }
         }
-        stage('Build gc-eu-mq (qemu-irix)') {
-            when {
-                branch 'main'
-            }
-            steps {
-                sh 'make -j VERSION=gc-eu-mq ORIG_COMPILER=1'
-            }
-        }
         stage('Build gc-eu-mq') {
-            when {
-                not {
-                    branch 'main'
-                }
-            }
             steps {
                 sh 'make -j VERSION=gc-eu-mq RUN_CC_CHECK=0'
             }


### PR DESCRIPTION
qemu-irix currently does not implement syssgi(24), the syscall for pathconf(), without which the effective max path length is 70 with -g3 (else a heap buffer will overrun and the compiler may segfault or worse). Also it's kind of nice that `main` runs the same checks as PRs.

The Makefile still has support for qemu-irix which is still useful for the debug ROM or if qemu-irix gets fixed.