### PR TITLE
Add make_options.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .idea/
 
 # Project-specific ignores
+.make_options.mk
 extracted/
 build/
 expected/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL = /bin/bash
 .SHELLFLAGS = -o pipefail -c
 
 # Build options can either be changed by modifying the makefile, or by building with 'make SETTING=value'
-# It is also possible to override default settings in a file called .make_options with 'SETTING=value'.
+# It is also possible to override default settings in a file called .make_options.mk with 'SETTING=value'.
 
 -include .make_options.mk
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SHELL = /bin/bash
 .SHELLFLAGS = -o pipefail -c
 
 # Build options can either be changed by modifying the makefile, or by building with 'make SETTING=value'
+# It is also possible to override default settings in a file called .make_options with 'SETTING=value'.
+
+-include .make_options.mk
 
 # If COMPARE is 1, check the output md5sum after building
 COMPARE := 1


### PR DESCRIPTION
This gives users the option to override default make options by creating a file called `.make_options.mk`, which is git ignored.
MM has had this for a while, and I think it would be useful here too.