### PR TITLE
Add -DF3DEX_GBI_2 to format.py flags

### DIFF
--- a/format.py
+++ b/format.py
@@ -31,7 +31,7 @@ APPLY_OPTS = "--format --style=file"
 # Compiler options used with Clang-Tidy
 # Normal warnings are disabled with -Wno-everything to focus only on tidying
 INCLUDES = "-Iinclude -Isrc -Ibuild/gc-eu-mq-dbg -I."
-DEFINES = "-D_LANGUAGE_C -DNON_MATCHING"
+DEFINES = "-D_LANGUAGE_C -DNON_MATCHING -DF3DEX_GBI_2"
 COMPILER_OPTS = f"-fno-builtin -std=gnu90 -m32 -Wno-everything {INCLUDES} {DEFINES}"
 
 


### PR DESCRIPTION
For whatever reason, without this clang-format likes to screw up `src/code/ucode_disas.c` and make it no longer match. I've noticed this for a while but didn't look into it before now. Is it just me? For some reason the CI machines don't have this issue.

The bad formatting:
```diff
--- a/src/code/ucode_disas.c
+++ b/src/code/ucode_disas.c
@@ -804,7 +804,7 @@ void UCodeDisas_Disassemble(UCodeDisas* this, Gfx* ptr) {
                     case UCODE_UNK: {
                         switch (cmd) {
                             case G_MTX: {
-                                Gdma2 gmtx = ptr->dma2;
+                                Gdma gmtx = ptr->dma;
                                 u32 params;
                                 MtxF mtxF;
                                 s32 j = 0;
@@ -908,17 +908,17 @@ void UCodeDisas_Disassemble(UCodeDisas* this, Gfx* ptr) {
                             } break;

                             case G_TRI2: {
-                                Gtri2 tri2 = ptr->tri2;
+                                Gtri tri2 = ptr->tri;
                                 u32 v0, v1, v2;
                                 u32 v3, v4, v5;

-                                v0 = tri2.tri1.v[0] / 2;
-                                v1 = tri2.tri1.v[1] / 2;
-                                v2 = tri2.tri1.v[2] / 2;
+                                v0 = tri2.tri.v[0] / 2;
+                                v1 = tri2.tri.v[1] / 2;
+                                v2 = tri2.tri.v[2] / 2;

-                                v3 = tri2.tri2.v[0] / 2;
-                                v4 = tri2.tri2.v[1] / 2;
-                                v5 = tri2.tri2.v[2] / 2;
+                                v3 = tri2.tri.v[0] / 2;
+                                v4 = tri2.tri.v[1] / 2;
+                                v5 = tri2.tri.v[2] / 2;

                                 DISAS_LOG("gsSP2Triangles(%d, %d, %d, 0, %d, %d, %d, 0),", v0, v1, v2, v3, v4, v5);
```