### PR TITLE
Add "do {} while (0);" to CLOSE_DISPS

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -187,9 +187,11 @@ extern struct GraphicsContext* __gfxCtx;
         (void)__gfxCtx;                \
         Graph_OpenDisps(dispRefs, gfxCtx, file, line)
 
-#define CLOSE_DISPS(gfxCtx, file, line)                 \
-        Graph_CloseDisps(dispRefs, gfxCtx, file, line); \
-    }                                                   \
+#define CLOSE_DISPS(gfxCtx, file, line)                     \
+        do {                                                \
+            Graph_CloseDisps(dispRefs, gfxCtx, file, line); \
+        } while (0);                                        \
+    }                                                       \
     (void)0
 
 #define GRAPH_ALLOC(gfxCtx, size) Graph_Alloc(gfxCtx, size)
@@ -221,7 +223,7 @@ extern struct GraphicsContext* __gfxCtx;
         s32 __dispPad
 
 #define CLOSE_DISPS(gfxCtx, file, line) \
-    (void)0;                            \
+        do {} while (0);                \
     }                                   \
     (void)0
 

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -197,8 +197,6 @@ void GameState_Draw(GameState* gameState, GraphicsContext* gfxCtx) {
     Gfx_Close(polyOpaP, newDList);
     POLY_OPA_DISP = newDList;
 
-    if (1) {}
-
     CLOSE_DISPS(gfxCtx, "../game.c", 800);
 
     Debug_DrawText(gfxCtx);
@@ -237,8 +235,6 @@ void func_800C49F4(GraphicsContext* gfxCtx) {
     gSPEndDisplayList(newDlist++);
     Gfx_Close(polyOpaP, newDlist);
     POLY_OPA_DISP = newDlist;
-
-    if (1) {}
 
     CLOSE_DISPS(gfxCtx, "../game.c", 865);
 }

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -246,8 +246,6 @@ void Graph_TaskSet00(GraphicsContext* gfxCtx) {
 
         task->yield_data_ptr = gGfxSPTaskYieldBuffer;
 
-        if (1) {}
-
         task->yield_data_size = sizeof(gGfxSPTaskYieldBuffer);
 
         scTask->next = NULL;

--- a/src/code/z_debug.c
+++ b/src/code/z_debug.c
@@ -308,8 +308,6 @@ void Debug_DrawText(GraphicsContext* gfxCtx) {
     Gfx_Close(opaStart, gfx);
     POLY_OPA_DISP = gfx;
 
-    if (1) {}
-
     CLOSE_DISPS(gfxCtx, "../z_debug.c", 664);
 
     GfxPrint_Destroy(&printer);

--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -2222,7 +2222,6 @@ void CutsceneHandler_RunScript(PlayState* play, CutsceneContext* csCtx) {
             Gfx_Close(prevDisplayList, displayList);
             POLY_OPA_DISP = displayList;
 
-            if (1) {}
             CLOSE_DISPS(play->state.gfxCtx, "../z_demo.c", 4108);
         }
 #endif

--- a/src/code/z_draw.c
+++ b/src/code/z_draw.c
@@ -768,8 +768,6 @@ void GetItem_DrawSmallRupee(PlayState* play, s16 drawId) {
 
     Matrix_Scale(0.7f, 0.7f, 0.7f, MTXMODE_APPLY);
 
-    if (1) {}
-
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_draw.c", 1140), G_MTX_MODELVIEW | G_MTX_LOAD);
     gSPDisplayList(POLY_OPA_DISP++, sDrawItemTable[drawId].dlists[1]);

--- a/src/code/z_eff_blure.c
+++ b/src/code/z_eff_blure.c
@@ -452,8 +452,6 @@ void EffectBlure_DrawElemNoInterpolation(EffectBlure* this, EffectBlureElement* 
         vtx[2].v.cn[2] = sp7C.b;
         vtx[2].v.cn[3] = sp7C.a;
 
-        if (1) {} // Necessary to match
-
         sp60.x = sp84.x;
         sp60.y = sp84.y;
         sp60.z = sp84.z;

--- a/src/code/z_eff_ss_dead.c
+++ b/src/code/z_eff_ss_dead.c
@@ -23,8 +23,6 @@ void func_80026230(PlayState* play, Color_RGBA8* color, s16 arg2, s16 arg3) {
 
     POLY_OPA_DISP = displayListHead;
 
-    if (1) {} // Necessary to match
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_eff_ss_dead.c", 129);
 }
 
@@ -43,8 +41,6 @@ void func_80026400(PlayState* play, Color_RGBA8* color, s16 arg2, s16 arg3) {
         gSPFogPosition(displayListHead++, 0, (s16)(2800.0f * ABS(cos)) + 1700);
 
         POLY_OPA_DISP = displayListHead;
-
-        if (1) {} // Necessary to match
 
         CLOSE_DISPS(play->state.gfxCtx, "../z_eff_ss_dead.c", 153);
     }
@@ -83,8 +79,6 @@ void func_80026690(PlayState* play, Color_RGBA8* color, s16 arg2, s16 arg3) {
     gSPFogPosition(displayListHead++, 0, (s16)(absCos * 3000.0f) + 1500);
 
     POLY_XLU_DISP = displayListHead;
-
-    if (1) {} // Necessary to match
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_eff_ss_dead.c", 194);
 }

--- a/src/code/z_fcurve_data_skelanime.c
+++ b/src/code/z_fcurve_data_skelanime.c
@@ -162,8 +162,6 @@ void SkelCurve_DrawLimb(PlayState* play, s32 limbIndex, SkelCurve* skelCurve, Ov
 
     OPEN_DISPS(play->state.gfxCtx, "../z_fcurve_data_skelanime.c", 279);
 
-    if (1) {}
-
     Matrix_Push();
 
     if ((overrideLimbDraw == NULL) ||

--- a/src/code/z_kankyo.c
+++ b/src/code/z_kankyo.c
@@ -984,7 +984,6 @@ void Environment_Update(PlayState* play, EnvironmentContext* envCtx, LightContex
             gSPEndDisplayList(displayList++);
             Gfx_Close(prevDisplayList, displayList);
             POLY_OPA_DISP = displayList;
-            if (1) {}
             CLOSE_DISPS(play->state.gfxCtx, "../z_kankyo.c", 1690);
         }
 #endif

--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -3868,7 +3868,6 @@ void Message_Draw(PlayState* play) {
         Gfx_Close(polyOpaP, plusOne);
         POLY_OPA_DISP = plusOne;
     }
-    if (1) {}
 #endif
 
     plusOne = Gfx_Open(polyOpaP = POLY_OPA_DISP);

--- a/src/code/z_scene_table.c
+++ b/src/code/z_scene_table.c
@@ -415,8 +415,6 @@ void Scene_DrawConfigWaterTemple(PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx, "../z_scene_table.c", 5535);
 
-    if (1) {} // Necessary to match
-
     spB0 = (play->roomCtx.unk_74[1] >> 8) & 0xFF;
     spAC = play->roomCtx.unk_74[1] & 0xFF;
     gameplayFrames = play->gameplayFrames;
@@ -709,8 +707,6 @@ void Scene_DrawConfigLakesideLaboratory(PlayState* play) {
                                 32, 32));
     gSPSegment(POLY_XLU_DISP++, 0x09, Gfx_TexScroll(play->state.gfxCtx, 0, 255 - (gameplayFrames * 10) % 256, 32, 64));
 
-    if (1) {}
-
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
 
@@ -747,8 +743,6 @@ void* sGTGEntranceTextures[] = {
 
 void Scene_DrawConfigGerudoTrainingGround(PlayState* play) {
     u32 gameplayFrames;
-
-    if (0) {} // Necessary to match
 
     OPEN_DISPS(play->state.gfxCtx, "../z_scene_table.c", 6290);
 
@@ -914,8 +908,6 @@ void* sForestTempleEntranceTextures[] = {
 void Scene_DrawConfigForestTemple(PlayState* play) {
     u32 gameplayFrames;
 
-    if (0) {} // Necessary to match
-
     OPEN_DISPS(play->state.gfxCtx, "../z_scene_table.c", 6640);
 
     gameplayFrames = play->gameplayFrames;
@@ -1041,8 +1033,6 @@ void Scene_DrawConfigZorasRiver(PlayState* play) {
                Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, 127 - gameplayFrames % 128,
                                 (gameplayFrames * 1) % 128, 32, 32, 1, gameplayFrames % 128, (gameplayFrames * 1) % 128,
                                 32, 32));
-
-    if (1) {}
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
@@ -1176,8 +1166,6 @@ void Scene_DrawConfigZorasFountain(PlayState* play) {
     gSPSegment(POLY_XLU_DISP++, 0x0A,
                Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, 0, (gameplayFrames * 1) % 128, 32, 32, 1, 0,
                                 (gameplayFrames * 1) % 128, 32, 32));
-
-    if (1) {}
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
@@ -1552,8 +1540,6 @@ void Scene_DrawConfigInsideGanonsCastle(PlayState* play) {
 
     gameplayFrames = play->gameplayFrames;
 
-    if (1) {}
-
     gSPSegment(POLY_XLU_DISP++, 0x08,
                Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, 127 - gameplayFrames % 128,
                                 (gameplayFrames * 1) % 512, 32, 128, 1, gameplayFrames % 128,
@@ -1659,7 +1645,8 @@ void (*sSceneDrawConfigs[SDC_MAX])(PlayState*) = {
 };
 
 void Scene_Draw(PlayState* play) {
-    if ((R_HREG_MODE == HREG_MODE_SCENE_CONFIG) && OOT_DEBUG) {
+#if OOT_DEBUG
+    if (R_HREG_MODE == HREG_MODE_SCENE_CONFIG) {
         if (R_SCENE_CONFIG_INIT != HREG_MODE_SCENE_CONFIG) {
             R_SCENE_CONFIG_INIT = HREG_MODE_SCENE_CONFIG;
             R_SCENE_CONFIG_DRAW_DEFAULT_DLIST = 1;
@@ -1694,4 +1681,7 @@ void Scene_Draw(PlayState* play) {
     } else {
         sSceneDrawConfigs[play->sceneDrawConfig](play);
     }
+#else
+    sSceneDrawConfigs[play->sceneDrawConfig](play);
+#endif
 }

--- a/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
@@ -326,8 +326,6 @@ void BgHakaGate_DrawFlame(BgHakaGate* this, PlayState* play) {
         Matrix_RotateY(BINANG_TO_RAD(Camera_GetCamDirYaw(GET_ACTIVE_CAM(play))), MTXMODE_APPLY);
         scale = this->vFlameScale * 0.00001f;
 
-        if (1) {}
-
         Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
         gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_bg_haka_gate.c", 744),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);

--- a/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Tubo/z_bg_haka_tubo.c
@@ -228,7 +228,6 @@ void BgHakaTubo_DrawFlameCircle(BgHakaTubo* this, PlayState* play) {
                      MTXMODE_NEW);
     Matrix_RotateY(BINANG_TO_RAD(this->dyna.actor.shape.rot.y), MTXMODE_APPLY);
     Matrix_Scale(0.07f, 0.04f, 0.07f, MTXMODE_APPLY);
-    if (1) {}
     gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, 0, 170, 255, 255);
     gDPSetEnvColor(POLY_XLU_DISP++, 0, 0, 255, 255);
     gSPSegment(POLY_XLU_DISP++, 0x08,

--- a/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Bigmirror/z_bg_jya_bigmirror.c
@@ -225,7 +225,6 @@ void BgJyaBigmirror_DrawLightBeam(Actor* thisx, PlayState* play) {
     gSPDisplayList(POLY_XLU_DISP++, gBigMirror1DL);
 
     if (lift != NULL) {
-        if (1) {}
         Matrix_SetTranslateRotateYXZ(lift->world.pos.x, lift->world.pos.y, lift->world.pos.z, &D_80893F4C);
         Matrix_Scale(0.1f, 0.1f, 0.1f, MTXMODE_APPLY);
         gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_bg_jya_bigmirror.c", 467),

--- a/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
@@ -522,7 +522,6 @@ void BgMizuBwall_Draw(Actor* thisx, PlayState* play2) {
     u32 frames;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_bg_mizu_bwall.c", 1095);
-    if (1) {}
     frames = play->gameplayFrames;
 
     Gfx_SetupDL_25Opa(play->state.gfxCtx);

--- a/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Movebg/z_bg_mizu_movebg.c
@@ -382,8 +382,6 @@ void BgMizuMovebg_Draw(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     u32 frames;
 
-    if (1) {}
-
     OPEN_DISPS(play->state.gfxCtx, "../z_bg_mizu_movebg.c", 754);
 
     frames = play->gameplayFrames;

--- a/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
+++ b/src/overlays/actors/ovl_Bg_Spot03_Taki/z_bg_spot03_taki.c
@@ -147,8 +147,6 @@ void BgSpot03Taki_Draw(Actor* thisx, PlayState* play) {
 
     gSPDisplayList(POLY_XLU_DISP++, object_spot03_object_DL_001580);
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_bg_spot03_taki.c", 358);
 
     this->bufferIndex = this->bufferIndex == 0;

--- a/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.c
+++ b/src/overlays/actors/ovl_Bg_Spot16_Doughnut/z_bg_spot16_doughnut.c
@@ -125,8 +125,6 @@ void BgSpot16Doughnut_Draw(Actor* thisx, PlayState* play) {
 
     Gfx_SetupDL_25Xlu(play->state.gfxCtx);
 
-    if (1) {}
-
     gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_bg_spot16_doughnut.c", 213),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     if (this->fireFlag & 1) {

--- a/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.c
+++ b/src/overlays/actors/ovl_Bg_Spot17_Bakudankabe/z_bg_spot17_bakudankabe.c
@@ -123,9 +123,9 @@ void BgSpot17Bakudankabe_Update(Actor* thisx, PlayState* play) {
 }
 
 void BgSpot17Bakudankabe_Draw(Actor* thisx, PlayState* play) {
-    s32 pad;
-    s8 r = coss(play->gameplayFrames * 1500) >> 8;
-    s8 g = coss(play->gameplayFrames * 1500) >> 8;
+    PlayState* play2 = (PlayState*)play;
+    s8 r = coss(play2->gameplayFrames * 1500) >> 8;
+    s8 g = coss(play2->gameplayFrames * 1500) >> 8;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_bg_spot17_bakudankabe.c", 269);
 

--- a/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.c
+++ b/src/overlays/actors/ovl_Bg_Spot17_Funen/z_bg_spot17_funen.c
@@ -67,7 +67,5 @@ void func_808B7478(Actor* thisx, PlayState* play) {
                                 1, 0, (0 - play->gameplayFrames) & 0x7F, 0x20, 0x20));
     gSPDisplayList(POLY_XLU_DISP++, gCraterSmokeConeDL);
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_bg_spot17_funen.c", 176);
 }

--- a/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
@@ -418,8 +418,6 @@ void BgYdanSp_Draw(Actor* thisx, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx, "../z_bg_ydan_sp.c", 781);
 
-    if (1) {}
-
     Gfx_SetupDL_25Xlu(play->state.gfxCtx);
     if (thisx->params == WEB_WALL) {
         gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_bg_ydan_sp.c", 787),

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -3519,8 +3519,6 @@ void BossGanon_DrawBigMagicCharge(BossGanon* this, PlayState* play) {
             Matrix_Pop();
         }
 
-        if (1) {}
-
         CLOSE_DISPS(gfxCtx, "../z_boss_ganon.c", 7721);
     }
 }
@@ -4176,8 +4174,6 @@ void BossGanon_LightBall_Draw(Actor* thisx, PlayState* play) {
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, gGanondorfSquareDL);
     }
-
-    if (1) {}
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganon.c", 9911);
 }

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -2486,7 +2486,6 @@ void func_80904340(BossGanon2* this, PlayState* play) {
     }
 
     Matrix_Pop();
-    if (1) {}
     CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5255);
 }
 
@@ -2639,8 +2638,6 @@ void func_80904D88(BossGanon2* this, PlayState* play) {
             gSPDisplayList(POLY_XLU_DISP++, gGanonLightOrbModelDL);
         }
     }
-
-    if (1) {}
 
     CLOSE_DISPS(gameState->gfxCtx, "../z_boss_ganon2.c", 5622);
 }

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -1520,7 +1520,6 @@ void BossGanondrof_Draw(Actor* thisx, PlayState* play) {
                       BossGanondrof_PostLimbDraw, this);
     PRINTF("DRAW 22\n");
     POLY_OPA_DISP = Play_SetFog(play, POLY_OPA_DISP);
-    if (1) {}
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_ganondrof.c", 3814);
     PRINTF("DRAW END %d\n", this->actor.params);
 }

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -2753,7 +2753,6 @@ void BossMo_DrawTent(Actor* thisx, PlayState* play) {
     if (this->drawActor) {
         BossMo_DrawTentacle(this, play);
     }
-    if (1) {}
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_mo.c", 7023);
 }
 

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -3299,8 +3299,6 @@ void func_80941BC0(BossTw* this, PlayState* play) {
     gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gTwinrovaEffectHaloDL));
     Matrix_Pop();
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_tw.c", 6461);
 }
 
@@ -3564,8 +3562,6 @@ void BossTw_Draw(Actor* thisx, PlayState* play2) {
             func_80942C70(&this->actor, play);
         }
     }
-
-    if (1) {}
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_tw.c", 7123);
 }

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -3149,8 +3149,6 @@ void BossVa_BariPostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s*
         gSPDisplayList(POLY_XLU_DISP++, *dList);
     }
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_boss_va.c", 4517);
 }
 

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -764,11 +764,11 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
     static u32 D_8098CF94;
     static Vec3f D_8098CF98;
 
+    PlayState* play2 = (PlayState*)play;
     s16 i;
     f32 temp_f22;
     DemoKankyo* this = (DemoKankyo*)thisx;
-    Gfx* disp;
-    Player* player = GET_PLAYER(play);
+    Player* player = GET_PLAYER(play2);
     Vec3f camPos;
     f32 translateX;
     f32 translateY;
@@ -800,7 +800,7 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
                                       &this->unk_150[i].unk_1C) != 0) {
                         this->unk_150[i].unk_22++;
                     }
-                    if (play->sceneId == SCENE_TEMPLE_OF_TIME && play->csCtx.curFrame == 25) {
+                    if (play2->sceneId == SCENE_TEMPLE_OF_TIME && play2->csCtx.curFrame == 25) {
                         this->unk_150[i].unk_22++;
                     }
                 } else {
@@ -810,7 +810,7 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
                                       &this->unk_150[i].unk_1C) != 0) {
                         this->unk_150[i].unk_22++;
                     }
-                    if (D_8098CF84 < play->csCtx.curFrame && this->actor.params == DEMOKANKYO_WARP_OUT) {
+                    if (D_8098CF84 < play2->csCtx.curFrame && this->actor.params == DEMOKANKYO_WARP_OUT) {
                         this->unk_150[i].unk_22++;
                     }
                 }
@@ -820,11 +820,11 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
             case 2:
                 if (this->actor.params == DEMOKANKYO_WARP_OUT) {
                     if (i == 0) {
-                        Environment_WarpSongLeave(play);
+                        Environment_WarpSongLeave(play2);
                         this->unk_150[i].unk_22++;
                     }
-                } else if (i + 1 == this->sparkleCounter && play->csCtx.state == CS_STATE_IDLE) {
-                    Interface_SetSubTimerToFinalSecond(play);
+                } else if (i + 1 == this->sparkleCounter && play2->csCtx.state == CS_STATE_IDLE) {
+                    Interface_SetSubTimerToFinalSecond(play2);
                     Actor_Kill(&this->actor);
                 }
                 break;
@@ -862,7 +862,6 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
         translateZ = this->unk_150[i].unk_C.z + this->unk_150[i].unk_0.z;
 
         if (this->unk_150[i].unk_22 < 2) {
-            disp = (Gfx*)(uintptr_t)gEffFlash1DL; // necessary to match but probably fake
             if (linkAge != LINK_AGE_ADULT) {
                 Matrix_Translate(translateX, translateY, translateZ, MTXMODE_NEW);
             } else {
@@ -873,9 +872,9 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
                          this->unk_150[i].unk_18 * (0.018f * temp_f22), MTXMODE_APPLY);
             gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, 255, 255, 255, 255);
             if (this->actor.params == DEMOKANKYO_WARP_OUT) {
-                gDPSetEnvColor(POLY_XLU_DISP++, sWarpSparkleEnvColors[play->msgCtx.lastPlayedSong].r,
-                               sWarpSparkleEnvColors[play->msgCtx.lastPlayedSong].g,
-                               sWarpSparkleEnvColors[play->msgCtx.lastPlayedSong].b, 255);
+                gDPSetEnvColor(POLY_XLU_DISP++, sWarpSparkleEnvColors[play2->msgCtx.lastPlayedSong].r,
+                               sWarpSparkleEnvColors[play2->msgCtx.lastPlayedSong].g,
+                               sWarpSparkleEnvColors[play2->msgCtx.lastPlayedSong].b, 255);
             } else {
                 s8 respawnData = gSaveContext.respawn[RESPAWN_MODE_RETURN].data;
 
@@ -883,11 +882,11 @@ void DemoKankyo_DrawWarpSparkles(Actor* thisx, PlayState* play) {
                                sWarpSparkleEnvColors[respawnData].g, sWarpSparkleEnvColors[respawnData].b, 255);
             }
             Gfx_SetupDL_25Xlu(play->state.gfxCtx);
-            Matrix_Mult(&play->billboardMtxF, MTXMODE_APPLY);
+            Matrix_Mult(&play2->billboardMtxF, MTXMODE_APPLY);
             Matrix_RotateZ(DEG_TO_RAD(this->unk_150[i].unk_24), MTXMODE_APPLY);
             gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_demo_kankyo.c", 2011),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gSPDisplayList(POLY_XLU_DISP++, disp);
+            gSPDisplayList(POLY_XLU_DISP++, gEffFlash1DL);
             this->unk_150[i].unk_24 += 0x190;
         }
     }

--- a/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
+++ b/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
@@ -117,7 +117,5 @@ void DemoShd_Draw(Actor* thisx, PlayState* play) {
         gSPDisplayList(POLY_XLU_DISP++, D_809934B8);
     }
 
-    if (1) {} // Necessary to match
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_demo_shd.c", 762);
 }

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -974,7 +974,6 @@ void DoorShutter_Draw(Actor* thisx, PlayState* play) {
     DoorShutter* this = (DoorShutter*)thisx;
 
     if (1) {}
-    if (1) {}
 
     //! @bug This actor is not fully initialized until the required object dependency is loaded.
     //! In most cases, the check for objectSlot to equal requiredObjectSlot prevents the actor

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -837,7 +837,6 @@ s32 EnBigokuta_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec
             gDPPipeSync(POLY_OPA_DISP++);
 
             gDPSetEnvColor(POLY_OPA_DISP++, temp_f0, temp_f0, temp_f0, 255);
-            if (1) {}
             CLOSE_DISPS(play->state.gfxCtx, "../z_en_bigokuta.c", 1945);
         }
     } else if (limbIndex == 10) {
@@ -849,7 +848,6 @@ s32 EnBigokuta_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec
         }
         gDPPipeSync(POLY_OPA_DISP++);
         gDPSetEnvColor(POLY_OPA_DISP++, intensity, intensity, intensity, intensity);
-        if (1) {}
         CLOSE_DISPS(play->state.gfxCtx, "../z_en_bigokuta.c", 1972);
     } else if (limbIndex == 17 && this->actionFunc == func_809BE26C) {
         if (this->unk_198 < 5) {

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -359,10 +359,6 @@ void EnBom_Draw(Actor* thisx, PlayState* play) {
     s32 pad;
     EnBom* this = (EnBom*)thisx;
 
-#if OOT_DEBUG
-    if (1) {}
-#endif
-
     OPEN_DISPS(play->state.gfxCtx, "../z_en_bom.c", 913);
 
     if (thisx->params == BOMB_BODY) {

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -508,7 +508,5 @@ void EnBombf_Draw(Actor* thisx, PlayState* play) {
         Collider_UpdateSpheres(0, &this->explosionCollider);
     }
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_bombf.c", 1063);
 }

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -272,7 +272,5 @@ void EnBoom_Draw(Actor* thisx, PlayState* play) {
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, gBoomerangRefDL);
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_boom.c", 604);
 }

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -425,8 +425,6 @@ void EnBubble_Draw(Actor* thisx, PlayState* play) {
         gSPDisplayList(POLY_XLU_DISP++, gBubbleDL);
     }
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_bubble.c", 1226);
 
     if (this->actionFunc != EnBubble_Disappear) {

--- a/src/overlays/actors/ovl_En_Bw/z_en_bw.c
+++ b/src/overlays/actors/ovl_En_Bw/z_en_bw.c
@@ -907,7 +907,5 @@ void EnBw_Draw(Actor* thisx, PlayState* play2) {
         }
     }
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_bw.c", 1521);
 }

--- a/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
+++ b/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
@@ -607,8 +607,6 @@ void EnDaiku_Draw(Actor* thisx, PlayState* play) {
     SkelAnime_DrawFlexOpa(play, this->skelAnime.skeleton, this->skelAnime.jointTable, this->skelAnime.dListCount,
                           EnDaiku_OverrideLimbDraw, EnDaiku_PostLimbDraw, this);
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_daiku.c", 1255);
 }
 

--- a/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
+++ b/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
@@ -562,7 +562,5 @@ void EnDaikuKakariko_Draw(Actor* thisx, PlayState* play) {
     SkelAnime_DrawFlexOpa(play, this->skelAnime.skeleton, this->skelAnime.jointTable, this->skelAnime.dListCount,
                           EnDaikuKakariko_OverrideLimbDraw, EnDaikuKakariko_PostLimbDraw, thisx);
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_daiku_kakariko.c", 1151);
 }

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
@@ -1278,7 +1278,6 @@ void EnDekubaba_Draw(Actor* thisx, PlayState* play) {
     EnDekubaba* this = (EnDekubaba*)thisx;
     f32 scale;
 
-    if (1) {}
     OPEN_DISPS(play->state.gfxCtx, "../z_en_dekubaba.c", 2752);
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
 

--- a/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.c
+++ b/src/overlays/actors/ovl_En_Fd_Fire/z_en_fd_fire.c
@@ -255,7 +255,6 @@ void EnFdFire_Draw(Actor* thisx, PlayState* play) {
     sp80 = Math_Vec3f_DistXZ(&scale, &this->actor.velocity) / 1.5f;
     if (1) {}
     if (1) {}
-    if (1) {}
     Matrix_RotateY(BINANG_TO_RAD((s16)(Camera_GetCamDirYaw(GET_ACTIVE_CAM(play)) + 0x8000)), MTXMODE_APPLY);
     Matrix_RotateZ(DEG_TO_RAD((sp88 * -10.0f) * sp80), MTXMODE_APPLY);
     scale.x = scale.y = scale.z = this->scale * 0.001f;

--- a/src/overlays/actors/ovl_En_Fz/z_en_fz.c
+++ b/src/overlays/actors/ovl_En_Fz/z_en_fz.c
@@ -722,8 +722,6 @@ void EnFz_Draw(Actor* thisx, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_fz.c", 1167);
 
-    if (1) {}
-
     if (this->actor.colChkInfo.health == 0) {
         index = 2;
     }

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -1567,7 +1567,6 @@ void EnGeldB_Draw(Actor* thisx, PlayState* play) {
     EnGeldB* this = (EnGeldB*)thisx;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_geldB.c", 2672);
-    if (1) {}
 
     if ((this->spinAttackState >= 2) && SkelAnime_Update(&this->skelAnime)) {
         if (this->spinAttackState == 2) {

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -1141,8 +1141,6 @@ s32 EnHy_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
         rot->z += Math_CosS(this->unk_23C[limbIndex]) * 200.0f;
     }
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_hy.c", 2228);
 
     return false;

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -558,8 +558,6 @@ void EnMm_Draw(Actor* thisx, PlayState* play) {
         }
     }
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_mm.c", 1141);
 }
 

--- a/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
+++ b/src/overlays/actors/ovl_En_Po_Field/z_en_po_field.c
@@ -796,8 +796,6 @@ void EnPoField_DrawFlame(EnPoField* this, PlayState* play) {
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, gEffFire1DL);
 
-        if (1) {}
-
         CLOSE_DISPS(play->state.gfxCtx, "../z_en_po_field.c", 1712);
     }
 }
@@ -999,8 +997,6 @@ void EnPoField_DrawSoul(Actor* thisx, PlayState* play) {
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, gPoeFieldSoulDL);
     }
-
-    if (1) {}
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_po_field.c", 2149);
     EnPoField_DrawFlame(this, play);

--- a/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
+++ b/src/overlays/actors/ovl_En_Po_Relay/z_en_po_relay.c
@@ -385,7 +385,6 @@ void EnPoRelay_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* 
         gDPPipeSync(POLY_OPA_DISP++);
         gDPSetEnvColor(POLY_OPA_DISP++, this->lightColor.r, this->lightColor.g, this->lightColor.b, 128);
         gSPDisplayList(POLY_OPA_DISP++, gDampeLanternDL);
-        if (1) {}
         CLOSE_DISPS(play->state.gfxCtx, "../z_en_po_relay.c", 901);
         Matrix_MultVec3f(&D_80AD8D48, &vec);
         Lights_PointNoGlowSetInfo(&this->lightInfo, vec.x, vec.y, vec.z, this->lightColor.r, this->lightColor.g,

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -994,7 +994,5 @@ void EnRd_Draw(Actor* thisx, PlayState* play) {
         func_80033C30(&thisPos, &sShadowScale, this->alpha, play);
     }
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_rd.c", 1735);
 }

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -901,20 +901,18 @@ void EnRr_Draw(Actor* thisx, PlayState* play) {
         s32 offIndex;
 
         this->actor.colorFilterTimer++;
-        if ((effectTimer & 1) != 0) {
-            return;
-        }
+        if ((effectTimer & 1) == 0) {
+            segIndex = 4 - (effectTimer >> 2);
+            offIndex = (effectTimer >> 1) & 3;
 
-        segIndex = 4 - (effectTimer >> 2);
-        offIndex = (effectTimer >> 1) & 3;
-
-        effectPos.x = this->effectPos[segIndex].x + sEffectOffsets[offIndex].x + Rand_CenteredFloat(10.0f);
-        effectPos.y = this->effectPos[segIndex].y + sEffectOffsets[offIndex].y + Rand_CenteredFloat(10.0f);
-        effectPos.z = this->effectPos[segIndex].z + sEffectOffsets[offIndex].z + Rand_CenteredFloat(10.0f);
-        if (this->actor.colorFilterParams & 0x4000) {
-            EffectSsEnFire_SpawnVec3f(play, &this->actor, &effectPos, 100, 0, 0, -1);
-        } else {
-            EffectSsEnIce_SpawnFlyingVec3f(play, &this->actor, &effectPos, 150, 150, 150, 250, 235, 245, 255, 3.0f);
+            effectPos.x = this->effectPos[segIndex].x + sEffectOffsets[offIndex].x + Rand_CenteredFloat(10.0f);
+            effectPos.y = this->effectPos[segIndex].y + sEffectOffsets[offIndex].y + Rand_CenteredFloat(10.0f);
+            effectPos.z = this->effectPos[segIndex].z + sEffectOffsets[offIndex].z + Rand_CenteredFloat(10.0f);
+            if (this->actor.colorFilterParams & 0x4000) {
+                EffectSsEnFire_SpawnVec3f(play, &this->actor, &effectPos, 100, 0, 0, -1);
+            } else {
+                EffectSsEnIce_SpawnFlyingVec3f(play, &this->actor, &effectPos, 150, 150, 150, 250, 235, 245, 255, 3.0f);
+            }
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.c
+++ b/src/overlays/actors/ovl_En_Siofuki/z_en_siofuki.c
@@ -294,8 +294,6 @@ void EnSiofuki_Draw(Actor* thisx, PlayState* play) {
                Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, x, y, 64, 64, 1, x, y, 64, 64));
     gSPDisplayList(POLY_XLU_DISP++, object_siofuki_DL_000B70);
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_siofuki.c", 674);
 
     if (this->sfxFlags & 1) {

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -609,8 +609,6 @@ void EnWallmas_DrawXlu(EnWallmas* this, PlayState* play) {
     gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_en_wallmas.c", 1421), G_MTX_LOAD);
     gSPDisplayList(POLY_XLU_DISP++, gCircleShadowDL);
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_wallmas.c", 1426);
 }
 

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -4555,8 +4555,6 @@ void Fishing_DrawPondProps(PlayState* play) {
 
     Matrix_Pop();
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_fishing.c", 7805);
 }
 

--- a/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
+++ b/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
@@ -283,8 +283,6 @@ void ObjSyokudai_Draw(Actor* thisx, PlayState* play) {
         }
         flameScale *= 0.0027f;
 
-        if (1) {}
-
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
 
         gSPSegment(POLY_XLU_DISP++, 0x08,

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -693,7 +693,6 @@ void ObjectKankyo_DrawSnow(Actor* thisx, PlayState* play2) {
             }
 
             if (1) {}
-            if (1) {}
             Matrix_Translate(this->effects[i].base.x + this->effects[i].pos.x,
                              this->effects[i].base.y + this->effects[i].pos.y,
                              this->effects[i].base.z + this->effects[i].pos.z, MTXMODE_NEW);
@@ -859,8 +858,6 @@ void ObjectKankyo_DrawSunGraveSpark(Actor* thisx, PlayState* play2) {
             gDPSetEnvColor(POLY_XLU_DISP++, (u8)(155 * this->effects[0].amplitude) + 100,
                            (u8)(255 * this->effects[0].amplitude), 255 - (u8)(255 * this->effects[0].amplitude),
                            this->effects[0].alpha);
-
-            if (1) {}
 
             Matrix_Mult(&play->billboardMtxF, MTXMODE_APPLY);
             gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_object_kankyo.c", 1416), G_MTX_LOAD);

--- a/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
@@ -124,7 +124,5 @@ void OceffWipe_Draw(Actor* thisx, PlayState* play) {
                                                      32, 1, 0 - scroll, scroll * (-2), 32, 32));
     gSPDisplayList(POLY_XLU_DISP++, sFrustumDL);
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_oceff_wipe.c", 398);
 }

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -11610,8 +11610,6 @@ void Player_DrawGameplay(PlayState* play, Player* this, s32 lod, Gfx* cullDList,
         }
     }
 
-    if (1) {}
-
     CLOSE_DISPS(play->state.gfxCtx, "../z_player.c", 19328);
 }
 

--- a/src/overlays/effects/ovl_Effect_Ss_Bomb2/z_eff_ss_bomb2.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Bomb2/z_eff_ss_bomb2.c
@@ -94,8 +94,6 @@ void EffectSsBomb2_DrawFade(PlayState* play, u32 index, EffectSs* this) {
     }
 
     if (1) {}
-    if (1) {}
-
     CLOSE_DISPS(gfxCtx, "../z_eff_ss_bomb2.c", 345);
 }
 
@@ -160,8 +158,6 @@ void EffectSsBomb2_DrawLayered(PlayState* play, u32 index, EffectSs* this) {
     }
 
     if (1) {}
-    if (1) {}
-
     CLOSE_DISPS(gfxCtx, "../z_eff_ss_bomb2.c", 456);
 }
 

--- a/src/overlays/effects/ovl_Effect_Ss_G_Spk/z_eff_ss_g_spk.c
+++ b/src/overlays/effects/ovl_Effect_Ss_G_Spk/z_eff_ss_g_spk.c
@@ -101,8 +101,6 @@ void EffectSsGSpk_Draw(PlayState* play, u32 index, EffectSs* this) {
     }
 
     if (1) {}
-    if (1) {}
-
     CLOSE_DISPS(gfxCtx, "../z_eff_ss_g_spk.c", 255);
 }
 


### PR DESCRIPTION
Turns out many N64 draw functions are sensitive to this due to the graphics macro changes, so hopefully this will match many ntsc-1.2 functions all at once.

Finding the right macro for debug required a bit of trial and error. I think I tried all of
```c
if (1) {}
Graph_CloseDisps(dispRefs, gfxCtx, file, line);
```
```c
Graph_CloseDisps(dispRefs, gfxCtx, file, line);
if (1) {}
```
```c
if (1) {}
Graph_CloseDisps(dispRefs, gfxCtx, file, line);
if (1) {}
```
```c
if (1) {
    Graph_CloseDisps(dispRefs, gfxCtx, file, line);
}
```
but they all didn't match in some places (in small functions too, so I thought it was unlikely that they could be matched by other means).