### PR TITLE
[Doc] Docs for BgHaka gravestone actor (tiny)

### DIFF
--- a/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
+++ b/src/overlays/actors/ovl_Bg_Haka/z_bg_haka.c
@@ -14,11 +14,11 @@ void BgHaka_Destroy(Actor* thisx, PlayState* play);
 void BgHaka_Update(Actor* thisx, PlayState* play);
 void BgHaka_Draw(Actor* thisx, PlayState* play);
 
-void func_8087B758(BgHaka* this, Player* player);
-void func_8087B7E8(BgHaka* this, PlayState* play);
-void func_8087B938(BgHaka* this, PlayState* play);
-void func_8087BAAC(BgHaka* this, PlayState* play);
-void func_8087BAE4(BgHaka* this, PlayState* play);
+void BgHaka_CheckPlayerOnDirtPatch(BgHaka* this, Player* player);
+void BgHaka_IdleClosed(BgHaka* this, PlayState* play);
+void BgHaka_Pull(BgHaka* this, PlayState* play);
+void BgHaka_IdleOpened(BgHaka* this, PlayState* play);
+void BgHaka_IdleLockedClosed(BgHaka* this, PlayState* play);
 
 ActorProfile Bg_Haka_Profile = {
     /**/ ACTOR_BG_HAKA,
@@ -46,7 +46,7 @@ void BgHaka_Init(Actor* thisx, PlayState* play) {
     DynaPolyActor_Init(&this->dyna, 0);
     CollisionHeader_GetVirtual(&gGravestoneCol, &colHeader);
     this->dyna.bgId = DynaPoly_SetBgActor(play, &play->colCtx.dyna, &this->dyna.actor, colHeader);
-    this->actionFunc = func_8087B7E8;
+    this->actionFunc = BgHaka_IdleClosed;
 }
 
 void BgHaka_Destroy(Actor* thisx, PlayState* play) {
@@ -55,16 +55,16 @@ void BgHaka_Destroy(Actor* thisx, PlayState* play) {
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
 }
 
-void func_8087B758(BgHaka* this, Player* player) {
-    Vec3f sp1C;
+void BgHaka_CheckPlayerOnDirtPatch(BgHaka* this, Player* player) {
+    Vec3f playerRelativePos;
 
-    func_8002DBD0(&this->dyna.actor, &sp1C, &player->actor.world.pos);
-    if (fabsf(sp1C.x) < 34.6f && sp1C.z > -112.8f && sp1C.z < -36.0f) {
+    func_8002DBD0(&this->dyna.actor, &playerRelativePos, &player->actor.world.pos);
+    if (fabsf(playerRelativePos.x) < 34.6f && playerRelativePos.z > -112.8f && playerRelativePos.z < -36.0f) {
         player->stateFlags2 |= PLAYER_STATE2_FORCE_SAND_FLOOR_SOUND;
     }
 }
 
-void func_8087B7E8(BgHaka* this, PlayState* play) {
+void BgHaka_IdleClosed(BgHaka* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     if (this->dyna.unk_150 != 0.0f) {
@@ -73,8 +73,8 @@ void func_8087B7E8(BgHaka* this, PlayState* play) {
             player->stateFlags2 &= ~PLAYER_STATE2_4;
             if (!Play_InCsMode(play)) {
                 Message_StartTextbox(play, 0x5073, NULL);
-                this->dyna.actor.params = 100;
-                this->actionFunc = func_8087BAE4;
+                this->dyna.actor.params = 100; // Used as a cooldown for displaying Graveyard Boy's warning
+                this->actionFunc = BgHaka_IdleLockedClosed;
             }
         } else if (0.0f < this->dyna.unk_150 ||
                    (play->sceneId == SCENE_LAKE_HYLIA && !LINK_IS_ADULT && !Flags_GetSwitch(play, 0x23))) {
@@ -82,24 +82,25 @@ void func_8087B7E8(BgHaka* this, PlayState* play) {
             player->stateFlags2 &= ~PLAYER_STATE2_4;
         } else {
             this->dyna.actor.world.rot.y = this->dyna.actor.shape.rot.y + 0x8000;
-            this->actionFunc = func_8087B938;
+            this->actionFunc = BgHaka_Pull;
         }
     }
-    func_8087B758(this, player);
+    BgHaka_CheckPlayerOnDirtPatch(this, player);
 }
 
-void func_8087B938(BgHaka* this, PlayState* play) {
+void BgHaka_Pull(BgHaka* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
-    s32 sp38;
+    s32 reachedMaxPullDist;
 
     this->dyna.actor.speed += 0.05f;
     this->dyna.actor.speed = CLAMP_MAX(this->dyna.actor.speed, 1.5f);
-    sp38 = Math_StepToF(&this->dyna.actor.minVelocityY, 60.0f, this->dyna.actor.speed);
+    // minVelocityY is used to keep track of the distance pulled from home
+    reachedMaxPullDist = Math_StepToF(&this->dyna.actor.minVelocityY, 60.0f, this->dyna.actor.speed);
     this->dyna.actor.world.pos.x =
         Math_SinS(this->dyna.actor.world.rot.y) * this->dyna.actor.minVelocityY + this->dyna.actor.home.pos.x;
     this->dyna.actor.world.pos.z =
         Math_CosS(this->dyna.actor.world.rot.y) * this->dyna.actor.minVelocityY + this->dyna.actor.home.pos.z;
-    if (sp38 != 0) {
+    if (reachedMaxPullDist) {
         this->dyna.unk_150 = 0.0f;
         player->stateFlags2 &= ~PLAYER_STATE2_4;
         if (this->dyna.actor.params == 1) {
@@ -108,12 +109,12 @@ void func_8087B938(BgHaka* this, PlayState* play) {
             Actor_Spawn(&play->actorCtx, play, ACTOR_EN_POH, this->dyna.actor.home.pos.x, this->dyna.actor.home.pos.y,
                         this->dyna.actor.home.pos.z, 0, this->dyna.actor.shape.rot.y, 0, 1);
         }
-        this->actionFunc = func_8087BAAC;
+        this->actionFunc = BgHaka_IdleOpened;
     }
     func_8002F974(&this->dyna.actor, NA_SE_EV_ROCK_SLIDE - SFX_FLAG);
 }
 
-void func_8087BAAC(BgHaka* this, PlayState* play) {
+void BgHaka_IdleOpened(BgHaka* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     if (this->dyna.unk_150 != 0.0f) {
@@ -122,7 +123,7 @@ void func_8087BAAC(BgHaka* this, PlayState* play) {
     }
 }
 
-void func_8087BAE4(BgHaka* this, PlayState* play) {
+void BgHaka_IdleLockedClosed(BgHaka* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 pad;
 
@@ -134,9 +135,9 @@ void func_8087BAE4(BgHaka* this, PlayState* play) {
         player->stateFlags2 &= ~PLAYER_STATE2_4;
     }
     if (this->dyna.actor.params == 0) {
-        this->actionFunc = func_8087B7E8;
+        this->actionFunc = BgHaka_IdleClosed;
     }
-    func_8087B758(this, player);
+    BgHaka_CheckPlayerOnDirtPatch(this, player);
 }
 
 void BgHaka_Update(Actor* thisx, PlayState* play) {


### PR DESCRIPTION
This actor's author was very stingy, re-using generic fields in interesting ways rather than adding anything to the actor struct.

some notes:
- `func_8002DBD0` is effectively `Actor_WorldPosToLocal`, transforming a world position into a local position relative to the actor & its facing angle. Would be happy to rename this, but didn't want to include a bunch of other actors here.
- `dyna.unk_150` is something like "playerPushedVelocity" or something. it's set by player when interacting with a push/pull actor, and is how player signals to these actors that he's actively pushing/pulling them. maybe someone wants to do all the unks in `DynaPolyActor` struct at once, dunno, but didn't name it for the same reason as above ^