### PR TITLE
Match ``z_fbdemo.c`` and ``z_fbdemo_fade.c`` for NTSC-1.2

### DIFF
--- a/src/code/z_fbdemo.c
+++ b/src/code/z_fbdemo.c
@@ -90,14 +90,8 @@ void TransitionTile_InitGraphics(TransitionTile* this) {
     for (row = 0; row < this->rows; row++) {
         gSPVertex(gfx++, SEGMENT_ADDR(0xA, (u32)row * (this->cols + 1) * sizeof(Vtx)), 2 * (this->cols + 1), 0);
 
-#if PLATFORM_N64
         col2 = 0;
         colTex = 0;
-#else
-        colTex = 0;
-        col2 = 0;
-#endif
-
         col = 0;
         while (col < this->cols) {
             gDPPipeSync(gfx++);

--- a/src/code/z_fbdemo.c
+++ b/src/code/z_fbdemo.c
@@ -90,8 +90,14 @@ void TransitionTile_InitGraphics(TransitionTile* this) {
     for (row = 0; row < this->rows; row++) {
         gSPVertex(gfx++, SEGMENT_ADDR(0xA, (u32)row * (this->cols + 1) * sizeof(Vtx)), 2 * (this->cols + 1), 0);
 
+#if PLATFORM_N64
+        col2 = 0;
+        colTex = 0;
+#else
         colTex = 0;
         col2 = 0;
+#endif
+
         col = 0;
         while (col < this->cols) {
             gDPPipeSync(gfx++);

--- a/src/code/z_fbdemo_fade.c
+++ b/src/code/z_fbdemo_fade.c
@@ -96,12 +96,18 @@ void TransitionFade_Update(void* thisx, s32 updateRate) {
     }
 }
 
+#if PLATFORM_N64
+#define ALPHA_NOT_ZERO color->a != 0
+#else
+#define ALPHA_NOT_ZERO color->a > 0
+#endif
+
 void TransitionFade_Draw(void* thisx, Gfx** gfxP) {
     TransitionFade* this = (TransitionFade*)thisx;
     Gfx* gfx;
     Color_RGBA8_u32* color = &this->color;
 
-    if (color->a > 0) {
+    if (ALPHA_NOT_ZERO) {
         gfx = *gfxP;
         gSPDisplayList(gfx++, sTransFadeSetupDL);
         gDPSetPrimColor(gfx++, 0, 0, color->r, color->g, color->b, color->a);

--- a/src/code/z_fbdemo_fade.c
+++ b/src/code/z_fbdemo_fade.c
@@ -96,18 +96,17 @@ void TransitionFade_Update(void* thisx, s32 updateRate) {
     }
 }
 
-#if PLATFORM_N64
-#define ALPHA_NOT_ZERO color->a != 0
-#else
-#define ALPHA_NOT_ZERO color->a > 0
-#endif
-
 void TransitionFade_Draw(void* thisx, Gfx** gfxP) {
     TransitionFade* this = (TransitionFade*)thisx;
     Gfx* gfx;
     Color_RGBA8_u32* color = &this->color;
 
-    if (ALPHA_NOT_ZERO) {
+#if PLATFORM_N64
+    if (color->a != 0)
+#else
+    if (color->a > 0)
+#endif
+    {
         gfx = *gfxP;
         gSPDisplayList(gfx++, sTransFadeSetupDL);
         gDPSetPrimColor(gfx++, 0, 0, color->r, color->g, color->b, color->a);


### PR DESCRIPTION
hopefully the ``z_fbdemo.c`` change works in the other GC versions (I only tested ``gc-eu-mq-dbg`` and it *works on my machine™*)