### PR TITLE
Update c_cpp_properties.json for VSCode

### DIFF
--- a/docs/c_cpp_properties.json
+++ b/docs/c_cpp_properties.json
@@ -1,6 +1,91 @@
 {
     "configurations": [
         {
+            "name": "oot-ntsc-1.2",
+            "compilerArgs": [
+                "-m32"
+            ],
+            "includePath": [
+                "include",
+                "include/libc",
+                "src",
+                "build/ntsc-1.2",
+                ".",
+                "extracted/ntsc-1.2"
+            ],
+            "defines": [
+                "_LANGUAGE_C",
+                "OOT_VERSION=OOT_NTSC_1_2",
+                "OOT_REGION=REGION_JP",
+                "PLATFORM_N64=1",
+                "PLATFORM_GC=0",
+                "OOT_NTSC=1",
+                "OOT_MQ=0",
+                "OOT_DEBUG=0",
+                "NDEBUG",
+                "F3DEX_GBI_2"
+            ],
+            "cStandard": "gnu89"
+        },
+        {
+            "name": "oot-gc-jp",
+            "compilerArgs": [
+                "-m32"
+            ],
+            "includePath": [
+                "include",
+                "include/libc",
+                "src",
+                "build/gc-jp",
+                ".",
+                "extracted/gc-jp"
+            ],
+            "defines": [
+                "_LANGUAGE_C",
+                "OOT_VERSION=OOT_GC_JP",
+                "OOT_REGION=REGION_JP",
+                "PLATFORM_N64=0",
+                "PLATFORM_GC=1",
+                "OOT_NTSC=1",
+                "OOT_MQ=0",
+                "OOT_DEBUG=0",
+                "NDEBUG",
+                "F3DEX_GBI_2",
+                "F3DEX_GBI_PL",
+                "GBI_DOWHILE"
+            ],
+            "cStandard": "gnu89"
+        },
+        {
+            "name": "oot-gc-jp-mq",
+            "compilerArgs": [
+                "-m32"
+            ],
+            "includePath": [
+                "include",
+                "include/libc",
+                "src",
+                "build/gc-jp-mq",
+                ".",
+                "extracted/gc-jp-mq"
+            ],
+            "defines": [
+                "_LANGUAGE_C",
+                "OOT_VERSION=OOT_GC_JP_MQ",
+                "OOT_REGION=REGION_JP",
+                "PLATFORM_N64=0",
+                "PLATFORM_GC=1",
+                "OOT_NTSC=1",
+                "OOT_MQ=1",
+                "OOT_DEBUG=0",
+                "NDEBUG",
+                "F3DEX_GBI_2",
+                "F3DEX_GBI_PL",
+                "GBI_DOWHILE"
+            ],
+            "cStandard": "gnu89"
+        },
+        {
             "name": "oot-gc-us",
             "compilerArgs": [
                 "-m32"
@@ -17,6 +102,8 @@
                 "_LANGUAGE_C",
                 "OOT_VERSION=OOT_GC_US",
                 "OOT_REGION=REGION_US",
+                "PLATFORM_N64=0",
+                "PLATFORM_GC=1",
                 "OOT_NTSC=1",
                 "OOT_MQ=0",
                 "OOT_DEBUG=0",
@@ -24,6 +111,64 @@
                 "F3DEX_GBI_2",
                 "F3DEX_GBI_PL",
                 "GBI_DOWHILE"
+            ],
+            "cStandard": "gnu89"
+        },
+        {
+            "name": "oot-gc-us-mq",
+            "compilerArgs": [
+                "-m32"
+            ],
+            "includePath": [
+                "include",
+                "include/libc",
+                "src",
+                "build/gc-us-mq",
+                ".",
+                "extracted/gc-us-mq"
+            ],
+            "defines": [
+                "_LANGUAGE_C",
+                "OOT_VERSION=OOT_GC_US_MQ",
+                "OOT_REGION=REGION_US",
+                "PLATFORM_N64=0",
+                "PLATFORM_GC=1",
+                "OOT_NTSC=1",
+                "OOT_MQ=1",
+                "OOT_DEBUG=0",
+                "NDEBUG",
+                "F3DEX_GBI_2",
+                "F3DEX_GBI_PL",
+                "GBI_DOWHILE"
+            ],
+            "cStandard": "gnu89"
+        },
+        {
+            "name": "oot-gc-eu-mq-dbg",
+            "compilerArgs": [
+                "-m32"
+            ],
+            "includePath": [
+                "include",
+                "include/libc",
+                "src",
+                "build/gc-eu-mq-dbg",
+                ".",
+                "extracted/gc-eu-mq-dbg"
+            ],
+            "defines": [
+                "_LANGUAGE_C",
+                "OOT_VERSION=OOT_GC_EU_MQ_DBG",
+                "OOT_REGION=REGION_EU",
+                "PLATFORM_N64=0",
+                "PLATFORM_GC=1",
+                "OOT_PAL=1",
+                "OOT_MQ=1",
+                "OOT_DEBUG=1",
+                "F3DEX_GBI_2",
+                "F3DEX_GBI_PL",
+                "GBI_DOWHILE",
+                "GBI_DEBUG"
             ],
             "cStandard": "gnu89"
         },
@@ -44,6 +189,8 @@
                 "_LANGUAGE_C",
                 "OOT_VERSION=OOT_GC_EU",
                 "OOT_REGION=REGION_EU",
+                "PLATFORM_N64=0",
+                "PLATFORM_GC=1",
                 "OOT_PAL=1",
                 "OOT_MQ=0",
                 "OOT_DEBUG=0",
@@ -71,6 +218,8 @@
                 "_LANGUAGE_C",
                 "OOT_VERSION=OOT_GC_EU_MQ",
                 "OOT_REGION=REGION_EU",
+                "PLATFORM_N64=0",
+                "PLATFORM_GC=1",
                 "OOT_PAL=1",
                 "OOT_MQ=1",
                 "OOT_DEBUG=0",
@@ -82,7 +231,7 @@
             "cStandard": "gnu89"
         },
         {
-            "name": "oot-gc-eu-mq-dbg",
+            "name": "oot-gc-jp-ce",
             "compilerArgs": [
                 "-m32"
             ],
@@ -90,24 +239,26 @@
                 "include",
                 "include/libc",
                 "src",
-                "build/gc-eu-mq-dbg",
+                "build/gc-jp-ce",
                 ".",
-                "extracted/gc-eu-mq-dbg"
+                "extracted/gc-jp-ce"
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_GC_EU_MQ_DBG",
-                "OOT_REGION=REGION_EU",
-                "OOT_PAL=1",
-                "OOT_MQ=1",
-                "OOT_DEBUG=1",
+                "OOT_VERSION=OOT_GC_JP_CE",
+                "OOT_REGION=REGION_JP",
+                "PLATFORM_N64=0",
+                "PLATFORM_GC=1",
+                "OOT_NTSC=1",
+                "OOT_MQ=0",
+                "OOT_DEBUG=0",
+                "NDEBUG",
                 "F3DEX_GBI_2",
                 "F3DEX_GBI_PL",
-                "GBI_DOWHILE",
-                "GBI_DEBUG"
+                "GBI_DOWHILE"
             ],
             "cStandard": "gnu89"
-        }
+        },
     ],
     "version": 4
 }

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -46,11 +46,9 @@ A more complete `c_cpp_properties.json` with configurations for all supported ve
     "configurations": [
         {
             "name": "oot-gc-eu-mq-dbg",
-            "compilerPath": "${default}", // Needs to not be "" for -m32 to work
             "compilerArgs": [
                 "-m32" // Removes integer truncation warnings with gbi macros
             ],
-            "intelliSenseMode": "${default}", // Shouldn't matter
             "includePath": [ // Matches makefile's includes
                 "include",
                 "include/libc",
@@ -64,6 +62,8 @@ A more complete `c_cpp_properties.json` with configurations for all supported ve
                 // Version-specific
                 "OOT_VERSION=OOT_GC_EU_MQ_DBG",
                 "OOT_REGION=REGION_EU",
+                "PLATFORM_N64=0",
+                "PLATFORM_GC=1",
                 "OOT_PAL=1",
                 "OOT_MQ=1",
                 "OOT_DEBUG=1",
@@ -73,7 +73,6 @@ A more complete `c_cpp_properties.json` with configurations for all supported ve
                 "GBI_DEBUG"
             ],
             "cStandard": "gnu89", // C89 + some GNU extensions from C99 like C++ comments
-            "cppStandard": "${default}" // Only ZAPD uses C++, so doesn't really matter
         }
     ],
     "version": 4


### PR DESCRIPTION
Add newly supported versions and `PLATFORM_` macros.

Generated by the following script and data (anghelo look it's a csv!!!)

<details>

`gen_c_cpp_properties_json.csv`
```csv
version      ,version_upper ,region ,platform ,is_pal ,is_mq ,is_debug
ntsc-1.2     ,NTSC_1_2      ,JP     ,N64      ,     0 ,    0 ,       0
gc-jp        ,GC_JP         ,JP     ,GC       ,     0 ,    0 ,       0
gc-jp-mq     ,GC_JP_MQ      ,JP     ,GC       ,     0 ,    1 ,       0
gc-us        ,GC_US         ,US     ,GC       ,     0 ,    0 ,       0
gc-us-mq     ,GC_US_MQ      ,US     ,GC       ,     0 ,    1 ,       0
gc-eu-mq-dbg ,GC_EU_MQ_DBG  ,EU     ,GC       ,     1 ,    1 ,       1
gc-eu        ,GC_EU         ,EU     ,GC       ,     1 ,    0 ,       0
gc-eu-mq     ,GC_EU_MQ      ,EU     ,GC       ,     1 ,    1 ,       0
gc-jp-ce     ,GC_JP_CE      ,JP     ,GC       ,     0 ,    0 ,       0
```

`gen_c_cpp_properties_json.py`
```py
# SPDX-FileCopyrightText: 2024 Dragorn421
# SPDX-License-Identifier: CC0-1.0

import csv
from pathlib import Path
from typing import Literal


def gen_version_config(
    version: str,
    version_upper: str,
    region: Literal["JP", "US", "EU"],
    platform: Literal["N64", "GC"],
    is_pal: bool,
    is_mq: bool,
    is_debug: bool,
):
    defines = []
    defines += [
        "_LANGUAGE_C",
        f"OOT_VERSION=OOT_{version_upper}",
        f"OOT_REGION=REGION_{region}",
        f"PLATFORM_N64={1 if platform == 'N64' else 0}",
        f"PLATFORM_GC={1 if platform == 'GC' else 0}",
        "OOT_PAL=1" if is_pal else "OOT_NTSC=1",
        f"OOT_MQ={1 if is_mq else 0}",
        f"OOT_DEBUG={1 if is_debug else 0}",
    ]
    if not is_debug:
        defines += ["NDEBUG"]

    defines += ["F3DEX_GBI_2"]
    if platform == "GC":
        defines += [
            "F3DEX_GBI_PL",
            "GBI_DOWHILE",
        ]
    if is_debug:
        defines += ["GBI_DEBUG"]

    assert all('"' not in d for d in defines)
    return (
        "{"
        f"""
    "name": "oot-{version}",
    "compilerArgs": [
        "-m32"
    ],
    "includePath": [
        "include",
        "include/libc",
        "src",
        "build/{version}",
        ".",
        "extracted/{version}"
    ],
    "defines": ["""
        + ",".join(f'\n        "{d}"' for d in defines)
        + """
    ],
    "cStandard": "gnu89"
},
"""
    )


def add_indent(text: str, indent: str):
    return "".join(indent + l for l in text.splitlines(keepends=True))


version_configs = []

with Path(__file__).with_suffix(".csv").open() as f:
    for r in csv.DictReader(f):
        ver_cfg = gen_version_config(
            **{
                k.strip(): (bool(int(v.strip())) if k.startswith("is_") else v.strip())
                for k, v in r.items()
            }
        )
        version_configs.append(ver_cfg)
Path("docs/c_cpp_properties.json").write_text(
    """\
{
    "configurations": [
"""
    + "".join(add_indent(ver_cfg, "        ") for ver_cfg in version_configs)
    + """\
    ],
    "version": 4
}
"""
)
```

</details>