### PR TITLE
Decompile N64 anti-piracy checks in overlays

### DIFF
--- a/include/cic6105.h
+++ b/include/cic6105.h
@@ -1,0 +1,8 @@
+#ifndef CIC6105_H
+#define CIC6105_H
+
+#include "ultra64.h"
+
+extern u32 B_80008EE0;
+
+#endif

--- a/include/variables.h
+++ b/include/variables.h
@@ -9,6 +9,7 @@ extern Mtx D_01000000;
 extern u32 osTvType;
 extern u32 osRomBase;
 extern u32 osResetType;
+extern u32 osCicId;
 extern u32 osMemSize;
 extern u8 osAppNMIBuffer[0x40];
 

--- a/spec
+++ b/spec
@@ -20,6 +20,9 @@ beginseg
     include "$(BUILD_DIR)/src/boot/z_std_dma.o"
     include "$(BUILD_DIR)/src/boot/yaz0.o"
     include "$(BUILD_DIR)/src/boot/z_locale.o"
+#if PLATFORM_N64
+    include "$(BUILD_DIR)/src/boot/cic6105.o"
+#endif
 #if OOT_DEBUG
     include "$(BUILD_DIR)/src/boot/assert.o"
 #endif

--- a/src/boot/cic6105.c
+++ b/src/boot/cic6105.c
@@ -1,1 +1,3 @@
+#include "cic6105.h"
 
+u32 B_80008EE0;

--- a/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
+++ b/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
@@ -72,8 +72,11 @@ s32 func_808C0CC8(BgZg* this) {
 
 void func_808C0CD4(BgZg* this, PlayState* play) {
 #if PLATFORM_N64
-    // Anti-piracy check, bars will not open if the check fails
-    if (IO_READ(0x800002E8) != 0xC86E2000) {
+    // Anti-piracy check, bars will not open if the check fails.
+    // The address 0x000002E8 is near the start of RDRAM, and is written when IPL3 copies itself to
+    // RDRAM after RDRAM has been initialized. Specifically, this is an instruction from some
+    // embedded RSP code at offset 0x7F8 into IPL3 (0xC86E2000 disassembles to `lqv $v14[0], ($3)`).
+    if (IO_READ(0x000002E8) != 0xC86E2000) {
         return;
     }
 #endif

--- a/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
+++ b/src/overlays/actors/ovl_Bg_Zg/z_bg_zg.c
@@ -71,6 +71,13 @@ s32 func_808C0CC8(BgZg* this) {
 }
 
 void func_808C0CD4(BgZg* this, PlayState* play) {
+#if PLATFORM_N64
+    // Anti-piracy check, bars will not open if the check fails
+    if (IO_READ(0x800002E8) != 0xC86E2000) {
+        return;
+    }
+#endif
+
     if (func_808C0C98(this, play) != 0) {
         this->action = 1;
         func_808C0C50(this);

--- a/src/overlays/actors/ovl_En_Zl2/z_en_zl2.c
+++ b/src/overlays/actors/ovl_En_Zl2/z_en_zl2.c
@@ -447,17 +447,25 @@ void func_80B4F230(EnZl2* this, s16 arg1, s32 arg2) {
 s32 func_80B4F45C(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx, Gfx** gfx) {
     s32 pad;
     EnZl2* this = (EnZl2*)thisx;
-    Mtx* sp74;
-    MtxF sp34;
-    Vec3s sp2C;
-    s16 pad2;
-    s16* unk_1DC = this->unk_1DC;
 
     if (limbIndex == 14) {
-        sp74 = GRAPH_ALLOC(play->state.gfxCtx, sizeof(Mtx) * 7);
+        Mtx* sp74 = GRAPH_ALLOC(play->state.gfxCtx, sizeof(Mtx) * 7);
+        MtxF sp34;
+        Vec3s sp2C;
+        s16 pad2;
+        s16* unk_1DC = this->unk_1DC;
+
         gSPSegment((*gfx)++, 0x0C, sp74);
 
         Matrix_Push();
+
+#if PLATFORM_N64
+        // Anti-piracy check, Zelda's hair is misshapen if the check fails
+        if (osCicId != 6105) {
+            Matrix_Scale(2.0f, 0.5f, 2.0f, MTXMODE_APPLY);
+        }
+#endif
+
         Matrix_Translate(pos->x, pos->y, pos->z, MTXMODE_APPLY);
         Matrix_RotateZYX(rot->x, rot->y, rot->z, MTXMODE_APPLY);
         Matrix_Push();

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -10,8 +10,11 @@
 #include "assets/objects/object_fish/object_fish.h"
 #include "ichain.h"
 #include "terminal.h"
+#if PLATFORM_N64
+#include "cic6105.h"
+#endif
 
-#pragma increment_block_number "gc-eu:205 gc-eu-mq:205 gc-jp:207 gc-jp-ce:207 gc-jp-mq:207 gc-us:207 gc-us-mq:207"
+#pragma increment_block_number "gc-eu:204 gc-eu-mq:204 gc-jp:206 gc-jp-ce:206 gc-jp-mq:206 gc-us:206 gc-us-mq:206"
 
 #define FLAGS ACTOR_FLAG_4
 
@@ -852,7 +855,14 @@ void Fishing_Init(Actor* thisx, PlayState* play2) {
     if (thisx->params < EN_FISH_PARAM) {
         FishingGroupFish* fish;
 
+#if PLATFORM_N64
+        // Anti-piracy check, if the check fails the line can't be reeled in if
+        // a fish is caught and the fish will always let go after 50 frames.
+        sReelLock = !(B_80008EE0 == 0xAD090010);
+#else
         sReelLock = 0;
+#endif
+
         sFishingMain = this;
         Collider_InitJntSph(play, &sFishingMain->collider);
         Collider_SetJntSph(play, &sFishingMain->collider, thisx, &sJntSphInit, sFishingMain->colliderElements);

--- a/tools/disasm/ntsc-1.2/files_boot.csv
+++ b/tools/disasm/ntsc-1.2/files_boot.csv
@@ -127,6 +127,7 @@ offset,vram,.bss
 7F00,80008360,src/boot/z_std_dma
 8670,80008AD0,src/boot/yaz0
 8A80,80008EE0,src/boot/z_locale
+8A90,80008EF0,src/boot/cic6105
 8AA0,80008F00,src/libultra/io/driverominit
 8B20,80008F80,src/libultra/io/piacs
 8B40,80008FA0,src/libultra/os/initialize

--- a/tools/disasm/ntsc-1.2/files_boot.csv
+++ b/tools/disasm/ntsc-1.2/files_boot.csv
@@ -126,8 +126,7 @@ offset,vram,.bss
 72F0,80007750,src/boot/idle
 7F00,80008360,src/boot/z_std_dma
 8670,80008AD0,src/boot/yaz0
-8A80,80008EE0,src/boot/z_locale
-8A90,80008EF0,src/boot/cic6105
+8A80,80008EE0,src/boot/cic6105
 8AA0,80008F00,src/libultra/io/driverominit
 8B20,80008F80,src/libultra/io/piacs
 8B40,80008FA0,src/libultra/os/initialize


### PR DESCRIPTION
All 3 checks seemingly use a different mechanism (for extra security?):
* In z_bg_zg.c, it checks if the value at RAM address 0x800002E8 is set to 0xC86E2000. I'm not really sure what sets this address, maybe IPL3? If the check fails, the default action func for the bars in Ganon's Tower escape does nothing, so they will not open when their switch flags are set.
* In z_en_zl2.c, it checks that the value of the IPL variable `osCicId` is 6105. If the check fails, Zelda gets a new hairdo due to an extra `Matrix_Scale` before drawing the hair (I assume).
* In z_fishing.c, it checks if some BSS variable in cic610c.c is set to the value 0xAD090010. If the check fails, `sReelLock` is set to 1 which means the line can't be reeled in if a fish is caught, and caught fish will always let go after 50 frames.