### PR TITLE
Add DEG_TO_BINANG2/RAD_TO_BINANG2 to match ntsc-1.2 z_en_gs.c, z_en_mm.c, z_en_toryo.c

### DIFF
--- a/include/z64math.h
+++ b/include/z64math.h
@@ -123,6 +123,17 @@ typedef VecSphGeo VecGeo;
 #define BINANG_TO_RAD_ALT(binang) (((f32)(binang) / (f32)0x8000) * M_PI)
 #define BINANG_TO_RAD_ALT2(binang) (((f32)(binang) * M_PI) / 0x8000)
 
+// Angle conversion macros required for matching. These were probably the original macros used, but
+// we prefer DEG_TO_BINANG/RAD_TO_BINANG where possible to avoid possible undefined behavior with input
+// values outside of [-180, 180) degrees or [-PI, PI) radians.
+#if PLATFORM_N64
+#define DEG_TO_BINANG2(degrees) (f32)((degrees) * (0x8000 / 180.0f))
+#define RAD_TO_BINANG2(radians) (f32)((radians) * (0x8000 / M_PI))
+#else
+#define DEG_TO_BINANG2(degrees) (s32)((degrees) * (0x8000 / 180.0f))
+#define RAD_TO_BINANG2(radians) (s32)((radians) * (0x8000 / M_PI))
+#endif
+
 // Angle conversion macros (Camera)
 // these two angle conversion macros are slightly inaccurate
 #define CAM_DEG_TO_BINANG(degrees) (s16)TRUNCF_BINANG((degrees) * 182.04167f + .5f)

--- a/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Gate/z_bg_haka_gate.c
@@ -194,7 +194,7 @@ void BgHakaGate_StatueTurn(BgHakaGate* this, PlayState* play) {
     this->vTurnRateDeg10 = CLAMP_MAX(this->vTurnRateDeg10, 5);
     turnFinished = Math_StepToS(&this->vTurnAngleDeg10, 600, this->vTurnRateDeg10);
     turnAngle = this->vTurnAngleDeg10 * this->vTurnDirection;
-    this->dyna.actor.shape.rot.y = (this->vRotYDeg10 + turnAngle) * 0.1f * (0x10000 / 360.0f);
+    this->dyna.actor.shape.rot.y = DEG_TO_BINANG((this->vRotYDeg10 + turnAngle) * 0.1f);
     if ((player->stateFlags2 & PLAYER_STATE2_4) && (sStatueDistToPlayer > 0.0f)) {
         player->actor.world.pos.x =
             this->dyna.actor.home.pos.x +

--- a/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Kaitenkabe/z_bg_mori_kaitenkabe.c
@@ -138,7 +138,7 @@ void BgMoriKaitenkabe_Rotate(BgMoriKaitenkabe* this, PlayState* play) {
         thisx->world.rot.y = thisx->shape.rot.y = thisx->home.rot.y;
         Sfx_PlaySfxCentered2(NA_SE_EV_STONEDOOR_STOP);
     } else {
-        rotY = this->rotYdeg * (0x10000 / 360.0f);
+        rotY = DEG_TO_BINANG(this->rotYdeg);
         thisx->world.rot.y = thisx->shape.rot.y = thisx->home.rot.y + rotY;
         Sfx_PlaySfxCentered2(NA_SE_EV_WALL_SLIDE - SFX_FLAG);
     }

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -234,7 +234,7 @@ void EnFd_SpawnChildFire(EnFd* this, PlayState* play, s16 fireCnt, s16 color) {
     s32 i;
 
     for (i = 0; i < fireCnt; i++) {
-        s16 angle = (s16)DEG_TO_BINANG((i * 360.0f) / fireCnt) + this->actor.yawTowardsPlayer;
+        s16 angle = DEG_TO_BINANG((i * 360.0f) / fireCnt) + this->actor.yawTowardsPlayer;
         Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_EN_FD_FIRE, this->actor.world.pos.x,
                            this->actor.world.pos.y, this->actor.world.pos.z, 0, angle, 0, (color << 0xF) | i);
     }

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -234,7 +234,7 @@ void EnFd_SpawnChildFire(EnFd* this, PlayState* play, s16 fireCnt, s16 color) {
     s32 i;
 
     for (i = 0; i < fireCnt; i++) {
-        s16 angle = (s16)((((i * 360.0f) / fireCnt) * (0x10000 / 360.0f))) + this->actor.yawTowardsPlayer;
+        s16 angle = (s16)DEG_TO_BINANG((i * 360.0f) / fireCnt) + this->actor.yawTowardsPlayer;
         Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_EN_FD_FIRE, this->actor.world.pos.x,
                            this->actor.world.pos.y, this->actor.world.pos.z, 0, angle, 0, (color << 0xF) | i);
     }

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.c
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.c
@@ -240,7 +240,7 @@ void func_80A4EA08(EnGs* this, PlayState* play) {
         this->unk_200 = 0;
         this->unk_19F = 1;
     } else if (this->unk_19F == 1) {
-        this->unk_1A0[0].z = (((this->unk_200 % 8) / 8.0f) * 360.0f) * (0x10000 / 360.0f);
+        this->unk_1A0[0].z = DEG_TO_BINANG(((this->unk_200 % 8) / 8.0f) * 360.0f);
         this->unk_1A0[1].z = -this->unk_1A0[0].z;
         if (func_80A4E754(this, play, &this->unk_1E8, &this->unk_1EC, &this->unk_200, 0.8f, 0.005f, 0.001f, 7, 0) ==
             0.0f) {
@@ -408,14 +408,14 @@ void func_80A4F13C(EnGs* this, PlayState* play) {
     if (this->unk_19F == 1) {
         Math_SmoothStepToF(&this->unk_1F0, this->unk_1F4, 1.0f, 0.1f, 0.001f);
         tmpf1 = Math_SmoothStepToF(&this->unk_1E8, this->unk_1EC, 1.0f, this->unk_1F0, 0.001f);
-        this->unk_1A0[0].y += (s32)(this->unk_1E8 * (0x10000 / 360.0f));
+        this->unk_1A0[0].y += DEG_TO_BINANG2(this->unk_1E8);
         if (tmpf1 == 0.0f) {
             this->unk_200 = 0;
             this->unk_19F = 2;
         }
     }
     if (this->unk_19F == 2) {
-        this->unk_1A0[0].y += (s32)(this->unk_1E8 * (0x10000 / 360.0f));
+        this->unk_1A0[0].y += DEG_TO_BINANG2(this->unk_1E8);
         if (this->unk_200++ > 40) {
             this->unk_1E8 = this->unk_1B4[0].y - 1.0f;
             this->unk_1EC = 1.5f;
@@ -426,7 +426,7 @@ void func_80A4F13C(EnGs* this, PlayState* play) {
         }
     }
     if (this->unk_19F == 3) {
-        this->unk_1A0[0].y += 0x4000;
+        this->unk_1A0[0].y += DEG_TO_BINANG2(90.0f);
         tmpf1 = Math_SmoothStepToF(&this->unk_1E8, this->unk_1EC, 0.8f, 0.2f, 0.001f);
         Math_SmoothStepToF(&this->unk_1F0, this->unk_1F4, 0.8f, 0.2f, 0.001f);
         this->unk_1B4[0].x = this->unk_1F0 + 1.0f;
@@ -438,7 +438,7 @@ void func_80A4F13C(EnGs* this, PlayState* play) {
         }
     }
     if (this->unk_19F == 4) {
-        tmpf1 = Math_SmoothStepToF(&this->unk_1E8, this->unk_1EC, 0.8f, 16384.0f, 3640.0f);
+        tmpf1 = Math_SmoothStepToF(&this->unk_1E8, this->unk_1EC, 0.8f, DEG_TO_BINANG2(90.0f), 3640.0f);
         this->unk_1A0[0].y += (s16)this->unk_1E8;
         if (tmpf1 == 0.0f) {
 
@@ -458,7 +458,7 @@ void func_80A4F13C(EnGs* this, PlayState* play) {
             tmp -= 0xFFFF;
         }
         this->unk_1E8 = tmp;
-        tmpf1 = Math_SmoothStepToF(&this->unk_1E8, this->unk_1EC, 0.8f, 3640.0f, 0.001f);
+        tmpf1 = Math_SmoothStepToF(&this->unk_1E8, this->unk_1EC, 0.8f, DEG_TO_BINANG2(20.0f), 0.001f);
         this->unk_1A0[0].y = this->unk_1E8;
         if (tmpf1 == 0.0f) {
             this->unk_1E8 = this->unk_1B4[0].y - 1.0f;

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -334,7 +334,7 @@ s32 func_80AADEF0(EnMm* this, PlayState* play) {
     xDiff = waypointPos.x - this->actor.world.pos.x;
     zDiff = waypointPos.z - this->actor.world.pos.z;
 
-    this->yawToWaypoint = (s32)(Math_FAtan2F(xDiff, zDiff) * (0x8000 / M_PI));
+    this->yawToWaypoint = RAD_TO_BINANG2(Math_FAtan2F(xDiff, zDiff));
     this->distToWaypoint = sqrtf(SQ(xDiff) + SQ(zDiff));
 
     while ((this->distToWaypoint <= 10.44f) && (this->unk_1E8 != 0)) {
@@ -379,7 +379,7 @@ s32 func_80AADEF0(EnMm* this, PlayState* play) {
         xDiff = waypointPos.x - this->actor.world.pos.x;
         zDiff = waypointPos.z - this->actor.world.pos.z;
 
-        this->yawToWaypoint = (s32)(Math_FAtan2F(xDiff, zDiff) * (0x8000 / M_PI));
+        this->yawToWaypoint = RAD_TO_BINANG2(Math_FAtan2F(xDiff, zDiff));
         this->distToWaypoint = sqrtf(SQ(xDiff) + SQ(zDiff));
     }
 

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -367,7 +367,7 @@ void EnToryo_Update(Actor* thisx, PlayState* play) {
         }
 
         rot = thisx->yawTowardsPlayer - thisx->shape.rot.y;
-        if ((rot < 14563.0f) && (rot > -14563.0f)) {
+        if ((rot < DEG_TO_BINANG2(80.0f)) && (rot > DEG_TO_BINANG2(-80.0f))) {
             Npc_TrackPoint(thisx, &this->interactInfo, 0, NPC_TRACKING_HEAD_AND_TORSO);
         } else {
             Npc_TrackPoint(thisx, &this->interactInfo, 0, NPC_TRACKING_NONE);

--- a/src/overlays/actors/ovl_En_Vali/z_en_vali.c
+++ b/src/overlays/actors/ovl_En_Vali/z_en_vali.c
@@ -347,7 +347,7 @@ void EnVali_FloatIdle(EnVali* this, PlayState* play) {
 
     curFrame = ((curFrame > 40) ? (80 - curFrame) : curFrame);
 
-    this->actor.shape.rot.y += (s16)((curFrame + 4) * 0.4f * (0x10000 / 360.0f));
+    this->actor.shape.rot.y += DEG_TO_BINANG((curFrame + 4) * 0.4f);
     if (this->actor.xzDistToPlayer > 250.0f) {
         EnVali_SetupReturnToLurk(this);
     }


### PR DESCRIPTION
It seems like the original DEG_TO_BINANG/RAD_TO_BINANG macros returned an f32 on N64 versions and an s32 on GC versions. In most places this doesn't matter because the result is immediately converted to an s16 anyway. But in these 3 actors it matters and causes slight behavior changes between the N64 and GC versions.

The current DEG_TO_BINANG/RAD_TO_BINANG macros (which always convert to s16) are still useful because they can protect against surprising behavior on GCC with bad input values, and perhaps they make it clear that the f32/s32 change does not result in a real difference between N64 and GC versions. So, I've left them as-is wherever possible, and cleaned up a couple other places that `DEG_TO_BINANG` could be used.