### PR TITLE
[ntsc-1.2] Match boot_main.c, logutils.c, z_locale.c (text)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,7 @@ $(shell mkdir -p $(foreach dir, \
 endif
 
 ifeq ($(COMPILER),ido)
+$(BUILD_DIR)/src/boot/logutils.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/boot/stackcheck.o: OPTFLAGS := -O2
 
 $(BUILD_DIR)/src/code/__osMalloc.o: OPTFLAGS := -O2
@@ -408,7 +409,6 @@ $(BUILD_DIR)/src/code/jpegutils.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/jpegdecoder.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/load.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/loadfragment2.o: OPTFLAGS := -O2
-$(BUILD_DIR)/src/code/logutils.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/mtxuty-cvt.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/padsetup.o: OPTFLAGS := -O2
 $(BUILD_DIR)/src/code/padutils.o: OPTFLAGS := -O2

--- a/include/cic6105.h
+++ b/include/cic6105.h
@@ -5,4 +5,6 @@
 
 extern u32 B_80008EE0;
 
+void func_80001720(void);
+
 #endif

--- a/include/functions.h
+++ b/include/functions.h
@@ -4,7 +4,6 @@
 #include "z64.h"
 #include "macros.h"
 
-void cleararena(void);
 void bootproc(void);
 void Main_ThreadEntry(void* arg);
 void Idle_ThreadEntry(void* arg);
@@ -47,6 +46,9 @@ s32 osSendMesg(OSMesgQueue* mq, OSMesg msg, s32 flag);
 void osStopThread(OSThread* thread);
 void osViExtendVStart(u32 value);
 s32 osRecvMesg(OSMesgQueue* mq, OSMesg* msg, s32 flag);
+#if PLATFORM_N64
+void osInitialize(void);
+#endif
 void __osInitialize_common(void);
 void __osInitialize_autodetect(void);
 void __osEnqueueAndYield(OSThread**);

--- a/include/functions.h
+++ b/include/functions.h
@@ -48,6 +48,12 @@ void osViExtendVStart(u32 value);
 s32 osRecvMesg(OSMesgQueue* mq, OSMesg* msg, s32 flag);
 #if PLATFORM_N64
 void osInitialize(void);
+#else
+#define osInitialize()           \
+{                                \
+    __osInitialize_common();     \
+    __osInitialize_autodetect(); \
+}
 #endif
 void __osInitialize_common(void);
 void __osInitialize_autodetect(void);

--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -18,13 +18,9 @@ void bootproc(void) {
     osMemSize = osGetMemSize();
 #if PLATFORM_N64
     func_80001720();
+#endif
     bootclear();
     osInitialize();
-#else
-    bootclear();
-    __osInitialize_common();
-    __osInitialize_autodetect();
-#endif
 
     gCartHandle = osCartRomInit();
     osDriveRomInit();

--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "boot.h"
+#include "cic6105.h"
 
 StackEntry sBootThreadInfo;
 OSThread sIdleThread;
@@ -15,9 +16,15 @@ void bootproc(void) {
     StackCheck_Init(&sBootThreadInfo, sBootThreadStack, STACK_TOP(sBootThreadStack), 0, -1, "boot");
 
     osMemSize = osGetMemSize();
+#if PLATFORM_N64
+    func_80001720();
+    bootclear();
+    osInitialize();
+#else
     bootclear();
     __osInitialize_common();
     __osInitialize_autodetect();
+#endif
 
     gCartHandle = osCartRomInit();
     osDriveRomInit();

--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -1,6 +1,8 @@
 #include "global.h"
 #include "boot.h"
+#if PLATFORM_N64
 #include "cic6105.h"
+#endif
 
 StackEntry sBootThreadInfo;
 OSThread sIdleThread;

--- a/src/boot/logutils.c
+++ b/src/boot/logutils.c
@@ -1,16 +1,18 @@
 #include "global.h"
 #include "terminal.h"
 
-#if OOT_DEBUG
+#if PLATFORM_N64 || OOT_DEBUG
 f32 LogUtils_CheckFloatRange(const char* exp, int line, const char* valueName, f32 value, const char* minName, f32 min,
                              const char* maxName, f32 max) {
     if (value < min || max < value) {
-        PRINTF("%s %d: range error %s(%f) < %s(%f) < %s(%f)\n", exp, line, minName, min, valueName, value, maxName,
-               max);
+        osSyncPrintf("%s %d: range error %s(%f) < %s(%f) < %s(%f)\n", exp, line, minName, min, valueName, value,
+                     maxName, max);
     }
     return value;
 }
+#endif
 
+#if OOT_DEBUG
 s32 LogUtils_CheckIntRange(const char* exp, int line, const char* valueName, s32 value, const char* minName, s32 min,
                            const char* maxName, s32 max) {
     if (value < min || max < value) {
@@ -105,11 +107,15 @@ void LogUtils_LogThreadId(const char* name, int line) {
 void LogUtils_HungupThread(const char* name, int line) {
     OSId threadId = osGetThreadId(NULL);
 
-    PRINTF("*** HungUp in thread %d, [%s:%d] ***\n", threadId, name, line);
+#if PLATFORM_N64 || OOT_DEBUG
+    osSyncPrintf("*** HungUp in thread %d, [%s:%d] ***\n", threadId, name, line);
+#endif
     Fault_AddHungupAndCrash(name, line);
 }
 
 void LogUtils_ResetHungup(void) {
-    PRINTF("*** Reset ***\n");
+#if PLATFORM_N64 || OOT_DEBUG
+    osSyncPrintf("*** Reset ***\n");
+#endif
     Fault_AddHungupAndCrash("Reset", 0);
 }

--- a/src/boot/z_locale.c
+++ b/src/boot/z_locale.c
@@ -6,10 +6,25 @@ s32 gCurrentRegion = 0;
 LocaleCartInfo sCartInfo;
 
 void Locale_Init(void) {
+#if PLATFORM_N64
+    ALIGNED(4) u8 regionInfo[4];
+    u8 countryCode;
+
+    osEPiReadIo(gCartHandle, 0x3C, (u32*)regionInfo);
+#else
+    u8 countryCode;
+
     osEPiReadIo(gCartHandle, 0x38, &sCartInfo.mediaFormat);
     osEPiReadIo(gCartHandle, 0x3C, &sCartInfo.regionInfo);
+#endif
 
-    switch (sCartInfo.countryCode) {
+#if PLATFORM_N64
+    countryCode = regionInfo[2];
+#else
+    countryCode = sCartInfo.countryCode;
+#endif
+
+    switch (countryCode) {
         case 'J': // "NTSC-J (Japan)"
             gCurrentRegion = REGION_JP;
             break;
@@ -22,7 +37,11 @@ void Locale_Init(void) {
         default:
             PRINTF(VT_COL(RED, WHITE));
             PRINTF("z_locale_init: 日本用かアメリカ用か判別できません\n");
+#if PLATFORM_N64
+            LogUtils_HungupThread("../z_locale.c", 101);
+#else
             LogUtils_HungupThread("../z_locale.c", 118);
+#endif
             PRINTF(VT_RST);
             break;
     }

--- a/src/boot/z_locale.c
+++ b/src/boot/z_locale.c
@@ -3,7 +3,6 @@
 #include "terminal.h"
 
 s32 gCurrentRegion = 0;
-LocaleCartInfo sCartInfo;
 
 void Locale_Init(void) {
 #if PLATFORM_N64
@@ -14,6 +13,7 @@ void Locale_Init(void) {
 
     countryCode = regionInfo[2];
 #else
+    static LocaleCartInfo sCartInfo;
     u8 countryCode;
 
     osEPiReadIo(gCartHandle, 0x38, &sCartInfo.mediaFormat);

--- a/src/boot/z_locale.c
+++ b/src/boot/z_locale.c
@@ -11,16 +11,14 @@ void Locale_Init(void) {
     u8 countryCode;
 
     osEPiReadIo(gCartHandle, 0x3C, (u32*)regionInfo);
+
+    countryCode = regionInfo[2];
 #else
     u8 countryCode;
 
     osEPiReadIo(gCartHandle, 0x38, &sCartInfo.mediaFormat);
     osEPiReadIo(gCartHandle, 0x3C, &sCartInfo.regionInfo);
-#endif
 
-#if PLATFORM_N64
-    countryCode = regionInfo[2];
-#else
     countryCode = sCartInfo.countryCode;
 #endif
 

--- a/tools/disasm/ntsc-1.2/functions.txt
+++ b/tools/disasm/ntsc-1.2/functions.txt
@@ -1,5 +1,5 @@
 entrypoint = 0x80000400; // type:func
-cleararena = 0x80000460; // type:func
+bootclear = 0x80000460; // type:func
 bootproc = 0x80000498; // type:func
 Main_ThreadEntry = 0x800005A0; // type:func
 Idle_ThreadEntry = 0x8000063C; // type:func
@@ -27,7 +27,7 @@ func_800015E8_unknown = 0x800015E8; // type:func
 func_8000161C_unknown = 0x8000161C; // type:func
 func_80001640_unknown = 0x80001640; // type:func
 func_80001714_unknown = 0x80001714; // type:func
-func_80001720_unknown = 0x80001720; // type:func
+func_80001720 = 0x80001720; // type:func
 osSyncPrintfUnused = 0x80001750; // type:func
 osSyncPrintf = 0x8000176C; // type:func
 rmonPrintf = 0x80001788; // type:func

--- a/undefined_syms.txt
+++ b/undefined_syms.txt
@@ -9,3 +9,11 @@ D_0F000000 = 0x0F000000;
 
 // z_bg_mjin
 D_06000000 = 0x06000000;
+
+#if PLATFORM_N64
+
+// boot_main.c
+func_80001720 = 0x80001720;
+osInitialize = 0x80003230;
+
+#endif


### PR DESCRIPTION
Thanks to Anghelo for finding -g3 had to be removed for `LogUtils_CheckFloatRange` to match