### PR TITLE
Add "disasm sym_info.py" script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ toml
 mapfile-parser>=2.3.5,<3.0.0
 pyelftools==0.30
 rabbitizer>=1.0.0,<2.0.0
-spimdisasm>=1.21.0,<2.0.0
+spimdisasm>=1.28.1,<2.0.0

--- a/tools/disasm/disasm.py
+++ b/tools/disasm/disasm.py
@@ -85,6 +85,11 @@ def main():
 
     args = parser.parse_args()
 
+    if spimdisasm.__version_info__ < (1, 28, 1):
+        print(f"Error: spimdisasm>=1.28.1 is required (you have {spimdisasm.__version__})")
+        print("Hint: run `make setup` to update the venv.")
+        exit(1)
+
     context = spimdisasm.common.Context()
     context.parseArgs(args)
     context.changeGlobalSegmentRanges(0x00000000, 0x01000000, 0x8000000, 0x81000000)

--- a/tools/disasm/disasm.py
+++ b/tools/disasm/disasm.py
@@ -117,9 +117,12 @@ def main():
     print()
     print("Analyzing done.")
 
-    print("Writing disassembled sections...")
     output_dir: Path = args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    context.saveContextToFile(output_dir / "context.csv")
+
+    print("Writing disassembled sections...")
     for i, file_splits in enumerate(all_file_splits):
         f = i / len(all_file_splits)
         spimdisasm.common.Utils.printQuietless(

--- a/tools/disasm/sym_info.py
+++ b/tools/disasm/sym_info.py
@@ -205,7 +205,7 @@ def main():
                     if not is_first_fs_sym:
                         print(f"{indent}...")
                 print(
-                    f"{indent}{sym.name} 0x{sym.value:X} ROM:{sym.vrom}"
+                    f"{indent}{sym.name} 0x{sym.value:X} ROM:0x{sym.vrom:X}"
                     + (f" ({sym.type})" if sym.type else "")
                     + (f" (sz=0x{sym.size:X})" if sym.size else "")
                 )

--- a/tools/disasm/sym_info.py
+++ b/tools/disasm/sym_info.py
@@ -73,10 +73,17 @@ def main():
     args = parser.parse_args()
 
     sym_or_vma = args.sym_or_vma
-    try:
-        target_sym_name = None
-        target_vma = int(sym_or_vma, 16)
-    except ValueError:
+    if "_" in sym_or_vma:
+        # special case to avoid parsing e.g. `D_80123456` as hexadecimal 0xD80123456
+        sym_or_vma_is_sym = True
+    else:
+        try:
+            target_sym_name = None
+            target_vma = int(sym_or_vma, 16)
+            sym_or_vma_is_sym = False
+        except ValueError:
+            sym_or_vma_is_sym = True
+    if sym_or_vma_is_sym:
         target_sym_name = sym_or_vma
         target_vma = None
 
@@ -128,7 +135,10 @@ def main():
     if target_vma is None:
         parser.error(f"No symbol '{target_sym_name}'")
     else:
-        print(f"{target_sym_name} = 0x{target_vma:08X}")
+        if target_sym_name is not None:
+            print(f"{target_sym_name} = 0x{target_vma:08X}")
+
+    del target_sym_name
 
     filesections = list[FileSection]()
 

--- a/tools/disasm/sym_info.py
+++ b/tools/disasm/sym_info.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 Dragorn421
+# SPDX-License-Identifier: CC0-1.0
+
+import argparse
+import csv
+import dataclasses
+from typing import Optional
+
+
+@dataclasses.dataclass
+class Sym:
+    name: str
+    value: int
+    type: Optional[str]
+    size: Optional[int]
+    vrom: int
+
+
+@dataclasses.dataclass
+class FileSection:
+    file: str
+    section: str
+    syms: list[Sym]
+    vma_start: int
+
+
+LABELS_TYPES = {
+    "@branchlabel",
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Print informations on a symbol/address"
+        " (and possibly surrounding symbols)"
+        " from the spimdisasm disassembly context saved in"
+        " expected/build/VERSION/context.csv"
+    )
+    parser.add_argument("sym_or_vma")
+    default_version = "ntsc-1.2"
+    parser.add_argument(
+        "--version",
+        "-v",
+        default=default_version,
+        help=f"oot version (default: {default_version})",
+    )
+    parser.add_argument(
+        "--around",
+        "-n",
+        type=int,
+        default=0,
+        help="how many symbols to show around the target (at least)",
+    )
+    parser.add_argument(
+        "--range",
+        "-r",
+        type=lambda v: int(v, 0),
+        default=0,
+        help="show symbols within this range from the target (at least)",
+    )
+    parser.add_argument(
+        "--file",
+        "-f",
+        action="store_true",
+        help="show symbols within the file section of the target (at least)",
+    )
+    parser.add_argument(
+        "--labels",
+        "-l",
+        action="store_true",
+        help="also show label symbols",
+    )
+    args = parser.parse_args()
+
+    sym_or_vma = args.sym_or_vma
+    try:
+        target_sym_name = None
+        target_vma = int(sym_or_vma, 16)
+    except ValueError:
+        target_sym_name = sym_or_vma
+        target_vma = None
+
+    syms_by_section_by_file = dict[str, dict[str, list[Sym]]]()
+
+    with open(f"expected/build/{args.version}/context.csv") as f:
+        for e in csv.DictReader(f):
+            if e["category"] != "symbol":
+                continue
+            sym_name = e["getName"]
+            sym_value = e["address"]
+            sym_type = e["getType"]
+            sym_size = e["getSize"]
+            sym_vrom = e["getVrom"]
+            sym_section = e["sectionType"]
+            sym_file = e["parentFileName"]
+
+            if sym_file == "None":
+                sym_file = None
+
+            if not sym_section or not sym_file:
+                continue
+
+            sym_value_int = int(sym_value, 0)
+            sym_size_int = int(sym_size, 0) if sym_size else None
+            sym_vrom_int = int(sym_vrom, 0)
+
+            syms_by_section_by_file.setdefault(sym_file, dict()).setdefault(
+                sym_section, list()
+            ).append(
+                Sym(
+                    sym_name,
+                    sym_value_int,
+                    sym_type if sym_type else None,
+                    sym_size_int,
+                    sym_vrom_int,
+                )
+            )
+
+            if sym_name == target_sym_name:
+                target_vma = sym_value_int
+
+    if target_vma is None:
+        parser.error(f"No symbol '{target_sym_name}'")
+    else:
+        print(f"{target_sym_name} = 0x{target_vma:08X}")
+
+    filesections = list[FileSection]()
+
+    for file, syms_by_section in syms_by_section_by_file.items():
+        for section, syms in syms_by_section.items():
+            syms.sort(key=lambda sym: sym.value)
+            vma_start = syms[0].value
+            filesections.append(FileSection(file, section, syms, vma_start))
+
+    filesections.sort(key=lambda fs: fs.vma_start)
+
+    def get_first_print_sym():
+        prev_syms = list[Sym]()
+        for fs in filesections:
+            for sym in fs.syms:
+                if not args.labels and sym.type in LABELS_TYPES:
+                    continue
+                if target_vma < sym.value:
+                    return prev_syms[0]
+                prev_syms.append(sym)
+                while (
+                    len(prev_syms) - 1 > args.around
+                    and prev_syms[0].value < target_vma - args.range
+                ):
+                    prev_syms.pop(0)
+
+    first_print_sym = get_first_print_sym()
+
+    def get_last_print_sym():
+        min_skip_count = args.around
+        for fs in filesections:
+            for sym in fs.syms:
+                if not args.labels and sym.type in LABELS_TYPES:
+                    continue
+                if target_vma <= sym.value:
+                    min_skip_count -= 1
+                    if min_skip_count < 0 and sym.value >= args.range + target_vma:
+                        return sym
+
+    last_print_sym = get_last_print_sym()
+
+    is_near_target = False
+
+    indent = " " * 4
+
+    for i_fs, fs in enumerate(filesections):
+        fs_printed = False
+        is_first_fs_sym = True
+        fs_printed_end_ellipsis = False
+        for sym in fs.syms:
+            if not args.labels and sym.type in LABELS_TYPES:
+                continue
+
+            if sym == first_print_sym:
+                is_near_target = True
+
+            print_sym = is_near_target or (
+                args.file
+                and (
+                    fs.vma_start
+                    <= target_vma
+                    < (
+                        filesections[i_fs + 1].vma_start
+                        if i_fs + 1 < len(filesections)
+                        else 0x1_0000_0000
+                    )
+                )
+            )
+            if not print_sym and fs_printed:
+                if not fs_printed_end_ellipsis:
+                    print(f"{indent}...")
+                    fs_printed_end_ellipsis = True
+            if print_sym:
+                if not fs_printed:
+                    print(fs.file, fs.section)
+                    fs_printed = True
+                    if not is_first_fs_sym:
+                        print(f"{indent}...")
+                print(
+                    f"{indent}{sym.name} 0x{sym.value:X} ROM:{sym.vrom}"
+                    + (f" ({sym.type})" if sym.type else "")
+                    + (f" (sz=0x{sym.size:X})" if sym.size else "")
+                )
+            is_first_fs_sym = False
+
+            if sym == last_print_sym:
+                is_near_target = False
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/disasm/sym_info.py
+++ b/tools/disasm/sym_info.py
@@ -5,6 +5,7 @@
 import argparse
 import csv
 import dataclasses
+from pathlib import Path
 from typing import Optional
 
 
@@ -81,7 +82,13 @@ def main():
 
     syms_by_section_by_file = dict[str, dict[str, list[Sym]]]()
 
-    with open(f"expected/build/{args.version}/context.csv") as f:
+    context_csv_p = Path(f"expected/build/{args.version}/context.csv")
+    if not context_csv_p.exists():
+        print(f"Context file does not exist: {context_csv_p}")
+        print(f"Hint: run `make VERSION={args.version} disasm`")
+        exit(1)
+
+    with context_csv_p.open() as f:
         for e in csv.DictReader(f):
             if e["category"] != "symbol":
                 continue

--- a/tools/disasm/sym_info.py
+++ b/tools/disasm/sym_info.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2024 Dragorn421
+# SPDX-FileCopyrightText: © 2024 ZeldaRET
 # SPDX-License-Identifier: CC0-1.0
 
 import argparse
@@ -25,9 +25,7 @@ class FileSection:
     vma_start: int
 
 
-LABELS_TYPES = {
-    "@branchlabel",
-}
+LABELS_TYPES = {"@branchlabel", "@jumptablelabel"}
 
 
 def main():
@@ -57,19 +55,19 @@ def main():
         "-r",
         type=lambda v: int(v, 0),
         default=0,
-        help="show symbols within this range from the target (at least)",
+        help="show symbols within this range around the target (at least)",
     )
     parser.add_argument(
         "--file",
         "-f",
         action="store_true",
-        help="show symbols within the file section of the target (at least)",
+        help="show symbols within the same file and section as the target (at least)",
     )
     parser.add_argument(
         "--labels",
         "-l",
         action="store_true",
-        help="also show label symbols",
+        help="also show branch and jump table labels symbols",
     )
     args = parser.parse_args()
 
@@ -182,14 +180,11 @@ def main():
 
             print_sym = is_near_target or (
                 args.file
+                and fs.vma_start <= target_vma
                 and (
-                    fs.vma_start
-                    <= target_vma
-                    < (
-                        filesections[i_fs + 1].vma_start
-                        if i_fs + 1 < len(filesections)
-                        else 0x1_0000_0000
-                    )
+                    target_vma < filesections[i_fs + 1].vma_start
+                    if i_fs + 1 < len(filesections)
+                    else True
                 )
             )
             if not print_sym and fs_printed:


### PR DESCRIPTION
This is useful for investigating the expected memory layout

~~**Bleeding edge spimdisasm is currently required** in order for the csv written by `saveContextToFile` to have file names info set~~
**requires spimdisasm >= 1.28.1** (just `make setup` and the venv will update it)

<details>

<summary>Some examples of running the script:</summary>


<details>

<summary>help</summary>

```
$ ./tools/disasm/sym_info.py --help
usage: sym_info.py [-h] [--version VERSION] [--around AROUND] [--range RANGE] [--file]
                   [--labels]
                   sym_or_vma

Print informations on a symbol/address (and possibly surrounding symbols) from the
spimdisasm disassembly context saved in expected/build/VERSION/context.csv

positional arguments:
  sym_or_vma

options:
  -h, --help            show this help message and exit
  --version VERSION, -v VERSION
                        oot version (default: ntsc-1.2)
  --around AROUND, -n AROUND
                        how many symbols to show around the target (at least)
  --range RANGE, -r RANGE
                        show symbols within this range from the target (at least)
  --file, -f            show symbols within the file section of the target (at least)
  --labels, -l          also show label symbols
```

</details>

<details>

<summary>look up a single symbol by name</summary>

```
$ ./tools/disasm/sym_info.py EnDaiku_Update
EnDaiku_Update = 0x80A8DE90
src/overlays/actors/ovl_En_Daiku/z_en_daiku .text
    ...
    EnDaiku_Update 0x80A8DE90 ROM:4480 (@function) (sz=0x118)
    ...
```

the ellipsis means there are symbols before and after in the file

</details>

<details>

<summary>look up symbol(s) by address</summary>

```
$ ./tools/disasm/sym_info.py 0x80A8DE94
None = 0x80A8DE94
src/overlays/actors/ovl_En_Daiku/z_en_daiku .text
    ...
    EnDaiku_Update 0x80A8DE90 ROM:4480 (@function) (sz=0x118)
    EnDaiku_Draw 0x80A8DFA8 ROM:4760 (@function) (sz=0x128)
    ...
```

</details>

<details>

<summary>look up symbols within 0x300 bytes (after or before) of 0x80A8E000</summary>

```
$ ./tools/disasm/sym_info.py 0x80A8E000 --range 0x300
None = 0x80A8E000
src/overlays/actors/ovl_En_Daiku/z_en_daiku .text
    ...
    EnDaiku_Update 0x80A8DE90 ROM:4480 (@function) (sz=0x118)
    EnDaiku_Draw 0x80A8DFA8 ROM:4760 (@function) (sz=0x128)
    EnDaiku_OverrideLimbDraw 0x80A8E0D0 ROM:5056 (@function) (sz=0x84)
    EnDaiku_PostLimbDraw 0x80A8E154 ROM:5188 (@function) (sz=0x7C)
src/overlays/actors/ovl_En_Daiku/z_en_daiku .data
    D_80A8E1D0_unknown 0x80A8E1D0 ROM:5312 (sz=0x4)
    D_80A8E1F0_unknown 0x80A8E1F0 ROM:5344 (sz=0x4)
    D_80A8E21C_unknown 0x80A8E21C ROM:5388 (sz=0x4)
    D_80A8E228_unknown 0x80A8E228 ROM:5400 (sz=0x4)
    D_80A8E248_unknown 0x80A8E248 ROM:5432 (sz=0x4)
    D_80A8E298_unknown 0x80A8E298 ROM:5512 (sz=0x4)
    D_80A8E2A4_unknown 0x80A8E2A4 ROM:5524 (sz=0x4)
    D_80A8E2D8_unknown 0x80A8E2D8 ROM:5576 (sz=0x4)
    D_80A8E2E4_unknown 0x80A8E2E4 ROM:5588 (sz=0x4)
    D_STR_80A8E2F4_unknown 0x80A8E2F4 ROM:5604 (sz=0x4)
src/overlays/actors/ovl_En_Daiku/z_en_daiku .rodata
    RO_FLT_80A8E300_unknown 0x80A8E300 ROM:5616 (f32) (sz=0x4)
    ...
```

note: --range can also be used with a symbol name (like all options)

</details>

<details>

<summary>look up a symbol by name and the 3 symbols before and after too</summary>

```
$ ./tools/disasm/sym_info.py EnDaiku_Draw --around 3
EnDaiku_Draw = 0x80A8DFA8
src/overlays/actors/ovl_En_Daiku/z_en_daiku .text
    ...
    EnDaiku_EscapeSuccess 0x80A8DB48 ROM:3640 (@function) (sz=0x13C)
    EnDaiku_EscapeRun 0x80A8DC84 ROM:3956 (@function) (sz=0x20C)
    EnDaiku_Update 0x80A8DE90 ROM:4480 (@function) (sz=0x118)
    EnDaiku_Draw 0x80A8DFA8 ROM:4760 (@function) (sz=0x128)
    EnDaiku_OverrideLimbDraw 0x80A8E0D0 ROM:5056 (@function) (sz=0x84)
    EnDaiku_PostLimbDraw 0x80A8E154 ROM:5188 (@function) (sz=0x7C)
src/overlays/actors/ovl_En_Daiku/z_en_daiku .data
    D_80A8E1D0_unknown 0x80A8E1D0 ROM:5312 (sz=0x4)
    ...
```

</details>

<details>

<summary>look up a symbol and also all symbols in its file-section</summary>

```
$ ./tools/disasm/sym_info.py bootproc -f
bootproc = 0x80000498
src/boot/boot_main .text
    bootclear 0x80000460 ROM:0 (@function) (sz=0x38)
    bootproc 0x80000498 ROM:56 (@function) (sz=0x108)
```

</details>

</details>