### PR TITLE
Add T macro for translated debug strings

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -17,6 +17,13 @@
 #define BAD_RETURN(type) void
 #endif
 
+/**
+ * The T macro holds translations in English for original debug strings written in Japanese.
+ * The translated strings match the original debug strings, they are only direct translations.
+ * For example, any original name is left as is rather than being replaced with the name in the codebase.
+ */
+#define T(jp, en) jp
+
 #define ARRAY_COUNT(arr) (s32)(sizeof(arr) / sizeof(arr[0]))
 #define ARRAY_COUNTU(arr) (u32)(sizeof(arr) / sizeof(arr[0]))
 

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -244,8 +244,7 @@ NORETURN void DmaMgr_Error(DmaRequest* req, const char* filename, const char* er
 
     PRINTF("%c", BEL);
     PRINTF(VT_FGCOL(RED));
-    // "DMA Fatal Error"
-    PRINTF("DMA致命的エラー(%s)\nROM:%X RAM:%X SIZE:%X %s\n",
+    PRINTF(T("DMA致命的エラー(%s)\nROM:%X RAM:%X SIZE:%X %s\n", "DMA Fatal Error (%s)\nROM:%X RAM:%X SIZE:%X %s\n"),
            errorDesc != NULL ? errorDesc : (errorName != NULL ? errorName : "???"), vrom, ram, size,
            filename != NULL ? filename : "???");
 
@@ -433,8 +432,7 @@ void DmaMgr_ThreadEntry(void* arg) {
     OSMesg msg;
     DmaRequest* req;
 
-    // "DMA manager thread execution start"
-    PRINTF("ＤＭＡマネージャスレッド実行開始\n");
+    PRINTF(T("ＤＭＡマネージャスレッド実行開始\n", "DMA manager thread execution start\n"));
 
     while (true) {
         // Wait for DMA Requests to arrive from other threads
@@ -460,8 +458,7 @@ void DmaMgr_ThreadEntry(void* arg) {
         }
     }
 
-    // "DMA manager thread execution end"
-    PRINTF("ＤＭＡマネージャスレッド実行終了\n");
+    PRINTF(T("ＤＭＡマネージャスレッド実行終了\n", "DMA manager thread execution end\n"));
 }
 
 /**
@@ -503,8 +500,8 @@ s32 DmaMgr_RequestAsync(DmaRequest* req, void* ram, uintptr_t vrom, size_t size,
         sDmaMgrQueueFullLogged++;
         PRINTF("%c", BEL);
         PRINTF(VT_FGCOL(RED));
-        // "dmaEntryMsgQ is full. Reconsider your queue size."
-        PRINTF("dmaEntryMsgQが一杯です。キューサイズの再検討をおすすめします。");
+        PRINTF(T("dmaEntryMsgQが一杯です。キューサイズの再検討をおすすめします。",
+                 "dmaEntryMsgQ is full. Reconsider your queue size."));
         LOG_NUM("(sizeof(dmaEntryMsgBufs) / sizeof(dmaEntryMsgBufs[0]))", ARRAY_COUNT(sDmaMgrMsgBuf), "../z_std_dma.c",
                 952);
         PRINTF(VT_RST);

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -112,8 +112,8 @@ s32 DmaMgr_DmaRomToRam(uintptr_t rom, void* ram, size_t size) {
         ioMsg.size = buffSize;
 
         if (gDmaMgrVerbose == 10) {
-            PRINTF("%10lld ノーマルＤＭＡ %08x %08x %08x (%d)\n", OS_CYCLES_TO_USEC(osGetTime()), ioMsg.dramAddr,
-                   ioMsg.devAddr, ioMsg.size, MQ_GET_COUNT(&gPiMgrCmdQueue));
+            PRINTF("%10lld " T("ノーマルＤＭＡ", "Normal DMA") " %08x %08x %08x (%d)\n", OS_CYCLES_TO_USEC(osGetTime()),
+                   ioMsg.dramAddr, ioMsg.devAddr, ioMsg.size, MQ_GET_COUNT(&gPiMgrCmdQueue));
         }
 
         ret = osEPiStartDma(gCartHandle, &ioMsg, OS_READ);
@@ -122,12 +122,14 @@ s32 DmaMgr_DmaRomToRam(uintptr_t rom, void* ram, size_t size) {
         }
 
         if (gDmaMgrVerbose == 10) {
-            PRINTF("%10lld ノーマルＤＭＡ START (%d)\n", OS_CYCLES_TO_USEC(osGetTime()), MQ_GET_COUNT(&gPiMgrCmdQueue));
+            PRINTF("%10lld " T("ノーマルＤＭＡ", "Normal DMA") " START (%d)\n", OS_CYCLES_TO_USEC(osGetTime()),
+                   MQ_GET_COUNT(&gPiMgrCmdQueue));
         }
 
         osRecvMesg(&queue, NULL, OS_MESG_BLOCK);
         if (gDmaMgrVerbose == 10) {
-            PRINTF("%10lld ノーマルＤＭＡ END (%d)\n", OS_CYCLES_TO_USEC(osGetTime()), MQ_GET_COUNT(&gPiMgrCmdQueue));
+            PRINTF("%10lld " T("ノーマルＤＭＡ", "Normal DMA") " END (%d)\n", OS_CYCLES_TO_USEC(osGetTime()),
+                   MQ_GET_COUNT(&gPiMgrCmdQueue));
         }
 
         size -= buffSize;
@@ -146,8 +148,8 @@ s32 DmaMgr_DmaRomToRam(uintptr_t rom, void* ram, size_t size) {
     ioMsg.size = size;
 
     if (gDmaMgrVerbose == 10) {
-        PRINTF("%10lld ノーマルＤＭＡ %08x %08x %08x (%d)\n", OS_CYCLES_TO_USEC(osGetTime()), ioMsg.dramAddr,
-               ioMsg.devAddr, ioMsg.size, MQ_GET_COUNT(&gPiMgrCmdQueue));
+        PRINTF("%10lld " T("ノーマルＤＭＡ", "Normal DMA") " %08x %08x %08x (%d)\n", OS_CYCLES_TO_USEC(osGetTime()),
+               ioMsg.dramAddr, ioMsg.devAddr, ioMsg.size, MQ_GET_COUNT(&gPiMgrCmdQueue));
     }
 
     ret = osEPiStartDma(gCartHandle, &ioMsg, OS_READ);
@@ -157,7 +159,8 @@ s32 DmaMgr_DmaRomToRam(uintptr_t rom, void* ram, size_t size) {
 
     osRecvMesg(&queue, NULL, OS_MESG_BLOCK);
     if (gDmaMgrVerbose == 10) {
-        PRINTF("%10lld ノーマルＤＭＡ END (%d)\n", OS_CYCLES_TO_USEC(osGetTime()), MQ_GET_COUNT(&gPiMgrCmdQueue));
+        PRINTF("%10lld " T("ノーマルＤＭＡ", "Normal DMA") " END (%d)\n", OS_CYCLES_TO_USEC(osGetTime()),
+               MQ_GET_COUNT(&gPiMgrCmdQueue));
     }
 
 end:
@@ -185,8 +188,8 @@ s32 DmaMgr_AudioDmaHandler(OSPiHandle* pihandle, OSIoMesg* mb, s32 direction) {
     ASSERT(mb != NULL, "mb != NULL", "../z_std_dma.c", 532);
 
     if (gDmaMgrVerbose == 10) {
-        PRINTF("%10lld サウンドＤＭＡ %08x %08x %08x (%d)\n", OS_CYCLES_TO_USEC(osGetTime()), mb->dramAddr, mb->devAddr,
-               mb->size, MQ_GET_COUNT(&gPiMgrCmdQueue));
+        PRINTF("%10lld " T("サウンドＤＭＡ", "Sound DMA") " %08x %08x %08x (%d)\n", OS_CYCLES_TO_USEC(osGetTime()),
+               mb->dramAddr, mb->devAddr, mb->size, MQ_GET_COUNT(&gPiMgrCmdQueue));
     }
 
     ret = osEPiStartDma(pihandle, mb, direction);
@@ -244,7 +247,7 @@ NORETURN void DmaMgr_Error(DmaRequest* req, const char* filename, const char* er
 
     PRINTF("%c", BEL);
     PRINTF(VT_FGCOL(RED));
-    PRINTF(T("DMA致命的エラー(%s)\nROM:%X RAM:%X SIZE:%X %s\n", "DMA Fatal Error (%s)\nROM:%X RAM:%X SIZE:%X %s\n"),
+    PRINTF(T("DMA致命的エラー(%s)\n", "DMA Fatal Error (%s)\n") "ROM:%X RAM:%X SIZE:%X %s\n",
            errorDesc != NULL ? errorDesc : (errorName != NULL ? errorName : "???"), vrom, ram, size,
            filename != NULL ? filename : "???");
 
@@ -359,9 +362,10 @@ void DmaMgr_ProcessRequest(DmaRequest* req) {
                 if (iter->file.vromEnd < vrom + size) {
                     // Error, vrom + size ends up in a different file than it started in
 
-                    // "DMA transfers cannot cross segment boundaries"
                     DMA_ERROR(req, filename, "Segment Alignment Error",
-                              "セグメント境界をまたがってＤＭＡ転送することはできません", "../z_std_dma.c", 726);
+                              T("セグメント境界をまたがってＤＭＡ転送することはできません",
+                                "DMA transfers cannot cross segment boundaries"),
+                              "../z_std_dma.c", 726);
                 }
 
                 DmaMgr_DmaRomToRam(iter->romStart + (vrom - iter->file.vromStart), ram, size);
@@ -379,17 +383,19 @@ void DmaMgr_ProcessRequest(DmaRequest* req) {
                 if (vrom != iter->file.vromStart) {
                     // Error, requested vrom is not the start of a file
 
-                    // "DMA transfer cannot be performed from the middle of a compressed segment"
                     DMA_ERROR(req, filename, "Can't Transfer Segment",
-                              "圧縮されたセグメントの途中からはＤＭＡ転送することはできません", "../z_std_dma.c", 746);
+                              T("圧縮されたセグメントの途中からはＤＭＡ転送することはできません",
+                                "DMA transfer cannot be performed from the middle of a compressed segment"),
+                              "../z_std_dma.c", 746);
                 }
 
                 if (size != iter->file.vromEnd - iter->file.vromStart) {
                     // Error, only part of the file was requested
 
-                    // "It is not possible to DMA only part of a compressed segment"
                     DMA_ERROR(req, filename, "Can't Transfer Segment",
-                              "圧縮されたセグメントの一部だけをＤＭＡ転送することはできません", "../z_std_dma.c", 752);
+                              T("圧縮されたセグメントの一部だけをＤＭＡ転送することはできません",
+                                "It is not possible to DMA only part of a compressed segment"),
+                              "../z_std_dma.c", 752);
                 }
 
                 // Reduce the thread priority and decompress the file, the decompression routine handles the DMA
@@ -414,15 +420,15 @@ void DmaMgr_ProcessRequest(DmaRequest* req) {
         if (sDmaMgrIsRomCompressed) {
             // Error, rom is compressed so DMA may only be requested within the filesystem bounds
 
-            // "Corresponding data does not exist"
-            DMA_ERROR(req, NULL, "DATA DON'T EXIST", "該当するデータが存在しません", "../z_std_dma.c", 771);
+            DMA_ERROR(req, NULL, "DATA DON'T EXIST",
+                      T("該当するデータが存在しません", "Corresponding data does not exist"), "../z_std_dma.c", 771);
             return;
         } else {
             // ROM is uncompressed, allow arbitrary DMA even if the region is not marked in the filesystem
             DmaMgr_DmaRomToRam(vrom, ram, size);
 
             if (0) {
-                PRINTF("No Press ROM:%08X RAM:%08X SIZE:%08X (非公式)\n", vrom, ram, size);
+                PRINTF("No Press ROM:%08X RAM:%08X SIZE:%08X (" T("非公式", "informal") ")\n", vrom, ram, size);
             }
         }
     }
@@ -443,7 +449,7 @@ void DmaMgr_ThreadEntry(void* arg) {
         }
 
         if (0) {
-            PRINTF("ＤＭＡ登録受付 dmap=%08x\n", req);
+            PRINTF(T("ＤＭＡ登録受付", "DMA registration acceptance") " dmap=%08x\n", req);
         }
 
         // Process the DMA request
@@ -484,7 +490,8 @@ s32 DmaMgr_RequestAsync(DmaRequest* req, void* ram, uintptr_t vrom, size_t size,
         // The line numbers for `DMA_ERROR` are only used in retail builds, but this usage was removed so
         // its line number is unknown.
         //! @bug `req` is passed to `DMA_ERROR` without rom, ram and size being set
-        DMA_ERROR(req, NULL, "ILLIGAL DMA-FUNCTION CALL", "パラメータ異常です", "../z_std_dma.c", 0);
+        DMA_ERROR(req, NULL, "ILLIGAL DMA-FUNCTION CALL", T("パラメータ異常です", "Parameter error"), "../z_std_dma.c",
+                  0);
     }
 #endif
 

--- a/src/code/__osMalloc.c
+++ b/src/code/__osMalloc.c
@@ -745,9 +745,9 @@ void __osDisplayArena(Arena* arena) {
     freeSize = 0;
     allocatedSize = 0;
 
-    osSyncPrintf("アリーナの内容 (0x%08x)\n", arena); // "Arena contents (0x%08x)"
-    // "Memory node range status size [time s ms us ns: TID: src: line]"
-    osSyncPrintf("メモリブロック範囲 status サイズ  [時刻  s ms us ns: TID:src:行]\n");
+    osSyncPrintf(T("アリーナの内容 (0x%08x)\n", "Arena contents (0x%08x)\n"), arena);
+    osSyncPrintf(T("メモリブロック範囲 status サイズ  [時刻  s ms us ns: TID:src:行]\n",
+                   "Memory node range status size [time s ms us ns: TID:src:line]\n"));
 
     iter = arena->head;
     while (iter != NULL) {
@@ -755,8 +755,7 @@ void __osDisplayArena(Arena* arena) {
             next = iter->next;
             osSyncPrintf("%08x-%08x%c %s %08x", iter, ((u32)iter + sizeof(ArenaNode) + iter->size),
                          (next == NULL) ? '$' : (iter != next->prev ? '!' : ' '),
-                         iter->isFree ? "空き" : "確保", //? "Free" : "Secure"
-                         iter->size);
+                         iter->isFree ? T("空き", "Free") : T("確保", "Secure"), iter->size);
 
             if (!iter->isFree) {
                 osSyncPrintf(" [%016llu:%2d:%s:%d]", OS_CYCLES_TO_NSEC(iter->time), iter->threadId,
@@ -780,12 +779,10 @@ void __osDisplayArena(Arena* arena) {
         iter = next;
     }
 
-    // "Total reserved node size 0x%08x bytes"
-    osSyncPrintf("確保ブロックサイズの合計 0x%08x バイト\n", allocatedSize);
-    // "Total free node size 0x%08x bytes"
-    osSyncPrintf("空きブロックサイズの合計 0x%08x バイト\n", freeSize);
-    // "Maximum free node size 0x%08x bytes"
-    osSyncPrintf("最大空きブロックサイズ   0x%08x バイト\n", maxFree);
+    osSyncPrintf(T("確保ブロックサイズの合計 0x%08x バイト\n", "Total reserved node size 0x%08x bytes\n"),
+                 allocatedSize);
+    osSyncPrintf(T("空きブロックサイズの合計 0x%08x バイト\n", "Total free node size 0x%08x bytes\n"), freeSize);
+    osSyncPrintf(T("最大空きブロックサイズ   0x%08x バイト\n", "Maximum free node size 0x%08x bytes\n"), maxFree);
 
     ArenaImpl_Unlock(arena);
 }
@@ -846,16 +843,17 @@ u32 __osCheckArena(Arena* arena) {
     u32 error = 0;
 
     ArenaImpl_Lock(arena);
-    // "Checking the contents of the arena. . ． (%08x)"
-    osSyncPrintf("アリーナの内容をチェックしています．．． (%08x)\n", arena);
+    osSyncPrintf(
+        T("アリーナの内容をチェックしています．．． (%08x)\n", "Checking the contents of the arena... (%08x)\n"),
+        arena);
     iter = arena->head;
     while (iter != NULL) {
         if (iter && iter->magic == NODE_MAGIC) {
-            // "Oops!! (%08x %08x)"
 #if OOT_DEBUG
-            osSyncPrintf(VT_COL(RED, WHITE) "おおっと！！ (%08x %08x)\n" VT_RST, iter, iter->magic);
+            osSyncPrintf(VT_COL(RED, WHITE) T("おおっと！！ (%08x %08x)\n", "Oops!! (%08x %08x)\n") VT_RST, iter,
+                         iter->magic);
 #else
-            osSyncPrintf("おおっと！！ (%08x %08x)\n", iter, iter->magic);
+            osSyncPrintf(T("おおっと！！ (%08x %08x)\n", "Oops!! (%08x %08x)\n"), iter, iter->magic);
 #endif
             error = 1;
             break;
@@ -863,7 +861,7 @@ u32 __osCheckArena(Arena* arena) {
         iter = NODE_GET_NEXT(iter);
     }
     if (error == 0) {
-        osSyncPrintf("アリーナはまだ、いけそうです\n"); // "The arena is still going well"
+        osSyncPrintf(T("アリーナはまだ、いけそうです\n", "The arena is still going well\n"));
     }
     ArenaImpl_Unlock(arena);
 

--- a/src/code/audio_thread_manager.c
+++ b/src/code/audio_thread_manager.c
@@ -81,8 +81,8 @@ void AudioMgr_HandleRetrace(AudioMgr* audioMgr) {
  * @see Audio_PreNMI
  */
 void AudioMgr_HandlePreNMI(AudioMgr* audioMgr) {
-    // "Audio manager received OS_SC_PRE_NMI_MSG"
-    PRINTF("オーディオマネージャが OS_SC_PRE_NMI_MSG を受け取りました\n");
+    PRINTF(
+        T("オーディオマネージャが OS_SC_PRE_NMI_MSG を受け取りました\n", "Audio manager received OS_SC_PRE_NMI_MSG\n"));
     Audio_PreNMI();
 }
 
@@ -91,8 +91,7 @@ void AudioMgr_ThreadEntry(void* arg) {
     IrqMgrClient irqClient;
     s16* msg = NULL;
 
-    // "Start running audio manager thread"
-    PRINTF("オーディオマネージャスレッド実行開始\n");
+    PRINTF(T("オーディオマネージャスレッド実行開始\n", "Start running audio manager thread\n"));
 
     // Initialize audio driver
     Audio_Init();

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -378,7 +378,7 @@ void GameState_Realloc(GameState* gameState, size_t size) {
         size = systemMaxFree - 0x10;
     }
 
-    PRINTF(T("ハイラル再確保 サイズ＝%u バイト\n", "Hyral reallocate size = %u bytes\n"), size);
+    PRINTF(T("ハイラル再確保 サイズ＝%u バイト\n", "Hyrule reallocate size = %u bytes\n"), size);
 
     gameArena = GAME_ALLOC_MALLOC(alloc, size, "../game.c", 1033);
     if (gameArena != NULL) {
@@ -386,7 +386,7 @@ void GameState_Realloc(GameState* gameState, size_t size) {
         PRINTF(T("ハイラル再確保成功\n", "Successful reacquisition of Hyrule\n"));
     } else {
         THA_Init(&gameState->tha, NULL, 0);
-        PRINTF(T("ハイラル再確保失敗\n", "Failure to secure Hyral\n"));
+        PRINTF(T("ハイラル再確保失敗\n", "Failure to secure Hyrule\n"));
 
 #if OOT_DEBUG
         SystemArena_Display();
@@ -502,7 +502,7 @@ void* GameState_Alloc(GameState* gameState, size_t size, const char* file, int l
         ret = NULL;
     } else if ((u32)THA_GetRemaining(&gameState->tha) < size) {
         PRINTF(T("滅亡寸前のハイラルには %d バイトの余力もない（滅亡まであと %d バイト）\n",
-                 "Hyral on the verge of extinction does not have %d bytes left (%d bytes until extinction)\n"),
+                 "Hyrule on the verge of extinction does not have %d bytes left (%d bytes until extinction)\n"),
                size, THA_GetRemaining(&gameState->tha));
         ret = NULL;
     } else {

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -187,8 +187,9 @@ void GameState_Draw(GameState* gameState, GraphicsContext* gfxCtx) {
         s32 pad;
         DebugArena_Display();
         SystemArena_Display();
-        // "%08x bytes left until the death of Hyrule (game_alloc)"
-        PRINTF("ハイラル滅亡まであと %08x バイト(game_alloc)\n", THA_GetRemaining(&gameState->tha));
+        PRINTF(T("ハイラル滅亡まであと %08x バイト(game_alloc)\n",
+                 "%08x bytes left until Hyrule is destroyed (game_alloc)\n"),
+               THA_GetRemaining(&gameState->tha));
 #endif
         R_ENABLE_ARENA_DBG = 0;
     }
@@ -341,15 +342,15 @@ void GameState_Update(GameState* gameState) {
 void GameState_InitArena(GameState* gameState, size_t size) {
     void* arena;
 
-    PRINTF("ハイラル確保 サイズ＝%u バイト\n", size); // "Hyrule reserved size = %u bytes"
+    PRINTF(T("ハイラル確保 サイズ＝%u バイト\n", "Hyrule reserved size = %u bytes\n"), size);
     arena = GAME_ALLOC_MALLOC(&gameState->alloc, size, "../game.c", 992);
 
     if (arena != NULL) {
         THA_Init(&gameState->tha, arena, size);
-        PRINTF("ハイラル確保成功\n"); // "Successful Hyral"
+        PRINTF(T("ハイラル確保成功\n", "Hyrule successfully secured\n"));
     } else {
         THA_Init(&gameState->tha, NULL, 0);
-        PRINTF("ハイラル確保失敗\n"); // "Failure to secure Hyrule"
+        PRINTF(T("ハイラル確保失敗\n", "Failure to secure Hyrule\n"));
         HUNGUP_AND_CRASH("../game.c", 999);
     }
 }
@@ -364,28 +365,28 @@ void GameState_Realloc(GameState* gameState, size_t size) {
 
     THA_Destroy(&gameState->tha);
     GameAlloc_Free(alloc, thaStart);
-    PRINTF("ハイラル一時解放!!\n"); // "Hyrule temporarily released!!"
+    PRINTF(T("ハイラル一時解放!!\n", "Hyrule temporarily released!!\n"));
     SystemArena_GetSizes(&systemMaxFree, &systemFree, &systemAlloc);
     if ((systemMaxFree - 0x10) < size) {
         PRINTF("%c", BEL);
         PRINTF(VT_FGCOL(RED));
 
-        // "Not enough memory. Change the hyral size to the largest possible value"
-        PRINTF("メモリが足りません。ハイラルサイズを可能な最大値に変更します\n");
+        PRINTF(T("メモリが足りません。ハイラルサイズを可能な最大値に変更します\n",
+                 "Not enough memory. Change Hyrule size to maximum possible value\n"));
         PRINTF("(hyral=%08x max=%08x free=%08x alloc=%08x)\n", size, systemMaxFree, systemFree, systemAlloc);
         PRINTF(VT_RST);
         size = systemMaxFree - 0x10;
     }
 
-    PRINTF("ハイラル再確保 サイズ＝%u バイト\n", size); // "Hyral reallocate size = %u bytes"
+    PRINTF(T("ハイラル再確保 サイズ＝%u バイト\n", "Hyral reallocate size = %u bytes\n"), size);
 
     gameArena = GAME_ALLOC_MALLOC(alloc, size, "../game.c", 1033);
     if (gameArena != NULL) {
         THA_Init(&gameState->tha, gameArena, size);
-        PRINTF("ハイラル再確保成功\n"); // "Successful reacquisition of Hyrule"
+        PRINTF(T("ハイラル再確保成功\n", "Successful reacquisition of Hyrule\n"));
     } else {
         THA_Init(&gameState->tha, NULL, 0);
-        PRINTF("ハイラル再確保失敗\n"); // "Failure to secure Hyral"
+        PRINTF(T("ハイラル再確保失敗\n", "Failure to secure Hyral\n"));
 
 #if OOT_DEBUG
         SystemArena_Display();
@@ -398,7 +399,7 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
     OSTime startTime;
     OSTime endTime;
 
-    PRINTF("game コンストラクタ開始\n"); // "game constructor start"
+    PRINTF(T("game コンストラクタ開始\n", "game constructor start\n"));
     gameState->gfxCtx = gfxCtx;
     gameState->frames = 0;
     gameState->main = NULL;
@@ -413,23 +414,22 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
     {
         s32 requiredScopeTemp;
         endTime = osGetTime();
-        // "game_set_next_game_null processing time %d us"
-        PRINTF("game_set_next_game_null 処理時間 %d us\n", OS_CYCLES_TO_USEC(endTime - startTime));
+        PRINTF(T("game_set_next_game_null 処理時間 %d us\n", "game_set_next_game_null processing time %d us\n"),
+               OS_CYCLES_TO_USEC(endTime - startTime));
         startTime = endTime;
         GameAlloc_Init(&gameState->alloc);
     }
 
     endTime = osGetTime();
-    // "gamealloc_init processing time %d us"
-    PRINTF("gamealloc_init 処理時間 %d us\n", OS_CYCLES_TO_USEC(endTime - startTime));
+    PRINTF(T("gamealloc_init 処理時間 %d us\n", "gamealloc_init processing time %d us\n"),
+           OS_CYCLES_TO_USEC(endTime - startTime));
     startTime = endTime;
     GameState_InitArena(gameState, 0x100000);
 
     R_UPDATE_RATE = 3;
     init(gameState);
     endTime = osGetTime();
-    // "init processing time %d us"
-    PRINTF("init 処理時間 %d us\n", OS_CYCLES_TO_USEC(endTime - startTime));
+    PRINTF(T("init 処理時間 %d us\n", "init processing time %d us\n"), OS_CYCLES_TO_USEC(endTime - startTime));
 
     startTime = endTime;
     LOG_UTILS_CHECK_NULL_POINTER("this->cleanup", gameState->destroy, "../game.c", 1088);
@@ -443,18 +443,18 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
     Rumble_Init();
     osSendMesg(&gameState->gfxCtx->queue, NULL, OS_MESG_BLOCK);
     endTime = osGetTime();
-    // "Other initialization processing time %d us"
-    PRINTF("その他初期化 処理時間 %d us\n", OS_CYCLES_TO_USEC(endTime - startTime));
+    PRINTF(T("その他初期化 処理時間 %d us\n", "Other initialization processing time %d us\n"),
+           OS_CYCLES_TO_USEC(endTime - startTime));
 
 #if OOT_DEBUG
     Fault_AddClient(&sGameFaultClient, GameState_FaultPrint, NULL, NULL);
 #endif
 
-    PRINTF("game コンストラクタ終了\n"); // "game constructor end"
+    PRINTF(T("game コンストラクタ終了\n", "game constructor end\n"));
 }
 
 void GameState_Destroy(GameState* gameState) {
-    PRINTF("game デストラクタ開始\n"); // "game destructor start"
+    PRINTF(T("game デストラクタ開始\n", "game destructor start\n"));
     AudioMgr_StopAllSfx();
     Audio_Update();
     osRecvMesg(&gameState->gfxCtx->queue, NULL, OS_MESG_BLOCK);
@@ -478,7 +478,7 @@ void GameState_Destroy(GameState* gameState) {
     Fault_RemoveClient(&sGameFaultClient);
 #endif
 
-    PRINTF("game デストラクタ終了\n"); // "game destructor end"
+    PRINTF(T("game デストラクタ終了\n", "game destructor end\n"));
 }
 
 GameStateFunc GameState_GetInit(GameState* gameState) {
@@ -501,14 +501,14 @@ void* GameState_Alloc(GameState* gameState, size_t size, const char* file, int l
         PRINTF("ハイラルは滅亡している\n");
         ret = NULL;
     } else if ((u32)THA_GetRemaining(&gameState->tha) < size) {
-        // "Hyral on the verge of extinction does not have %d bytes left (%d bytes until extinction)"
-        PRINTF("滅亡寸前のハイラルには %d バイトの余力もない（滅亡まであと %d バイト）\n", size,
-               THA_GetRemaining(&gameState->tha));
+        PRINTF(T("滅亡寸前のハイラルには %d バイトの余力もない（滅亡まであと %d バイト）\n",
+                 "Hyral on the verge of extinction does not have %d bytes left (%d bytes until extinction)\n"),
+               size, THA_GetRemaining(&gameState->tha));
         ret = NULL;
     } else {
         ret = THA_AllocTailAlign16(&gameState->tha, size);
         if (THA_IsCrash(&gameState->tha)) {
-            PRINTF("ハイラルは滅亡してしまった\n"); // "Hyrule has been destroyed"
+            PRINTF(T("ハイラルは滅亡してしまった\n", "Hyrule has been destroyed\n"));
             ret = NULL;
         }
     }

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -184,7 +184,7 @@ void Graph_TaskSet00(GraphicsContext* gfxCtx) {
         if (msg == (OSMesg)666) {
 #if OOT_DEBUG
             PRINTF(VT_FGCOL(RED));
-            PRINTF("RCPが帰ってきませんでした。"); // "RCP did not return."
+            PRINTF(T("RCPが帰ってきませんでした。", "RCP did not return."));
             PRINTF(VT_RST);
 
             LogUtils_LogHexDump((void*)PHYS_TO_K1(SP_BASE_REG), 0x20);
@@ -364,8 +364,8 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
         if (pool->headMagic != GFXPOOL_HEAD_MAGIC) {
             //! @bug (?) : "problem = true;" may be missing
             PRINTF("%c", BEL);
-            // "Dynamic area head is destroyed"
-            PRINTF(VT_COL(RED, WHITE) "ダイナミック領域先頭が破壊されています\n" VT_RST);
+            PRINTF(VT_COL(RED, WHITE) T("ダイナミック領域先頭が破壊されています\n", "Dynamic area head is destroyed\n")
+                       VT_RST);
 #if PLATFORM_N64
             Fault_AddHungupAndCrash("../graph.c", 951);
 #else
@@ -375,8 +375,8 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
         if (pool->tailMagic != GFXPOOL_TAIL_MAGIC) {
             problem = true;
             PRINTF("%c", BEL);
-            // "Dynamic region tail is destroyed"
-            PRINTF(VT_COL(RED, WHITE) "ダイナミック領域末尾が破壊されています\n" VT_RST);
+            PRINTF(VT_COL(RED, WHITE)
+                       T("ダイナミック領域末尾が破壊されています\n", "Dynamic region tail is destroyed\n") VT_RST);
 #if PLATFORM_N64
             Fault_AddHungupAndCrash("../graph.c", 957);
 #else
@@ -388,20 +388,20 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
     if (THGA_IsCrash(&gfxCtx->polyOpa)) {
         problem = true;
         PRINTF("%c", BEL);
-        // "Zelda 0 is dead"
-        PRINTF(VT_COL(RED, WHITE) "ゼルダ0は死んでしまった(graph_alloc is empty)\n" VT_RST);
+        PRINTF(VT_COL(RED, WHITE) T("ゼルダ0は死んでしまった(graph_alloc is empty)\n",
+                                    "Zelda 0 is dead (graph_alloc is empty)\n") VT_RST);
     }
     if (THGA_IsCrash(&gfxCtx->polyXlu)) {
         problem = true;
         PRINTF("%c", BEL);
-        // "Zelda 1 is dead"
-        PRINTF(VT_COL(RED, WHITE) "ゼルダ1は死んでしまった(graph_alloc is empty)\n" VT_RST);
+        PRINTF(VT_COL(RED, WHITE) T("ゼルダ1は死んでしまった(graph_alloc is empty)\n",
+                                    "Zelda 1 is dead (graph_alloc is empty)\n") VT_RST);
     }
     if (THGA_IsCrash(&gfxCtx->overlay)) {
         problem = true;
         PRINTF("%c", BEL);
-        // "Zelda 4 is dead"
-        PRINTF(VT_COL(RED, WHITE) "ゼルダ4は死んでしまった(graph_alloc is empty)\n" VT_RST);
+        PRINTF(VT_COL(RED, WHITE) T("ゼルダ4は死んでしまった(graph_alloc is empty)\n",
+                                    "Zelda 4 is dead (graph_alloc is empty)\n") VT_RST);
     }
 
     if (!problem) {
@@ -438,8 +438,8 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
     }
 
     if (gIsCtrlr2Valid && PreNmiBuff_IsResetting(gAppNmiBufferPtr) && !gameState->inPreNMIState) {
-        // "To reset mode"
-        PRINTF(VT_COL(YELLOW, BLACK) "PRE-NMIによりリセットモードに移行します\n" VT_RST);
+        PRINTF(VT_COL(YELLOW, BLACK) T("PRE-NMIによりリセットモードに移行します\n",
+                                       "PRE-NMI causes the system to transition to reset mode\n") VT_RST);
         SET_NEXT_GAMESTATE(gameState, PreNMI_Init, PreNMIState);
         gameState->running = false;
     }
@@ -453,7 +453,7 @@ void Graph_ThreadEntry(void* arg0) {
     GameStateOverlay* nextOvl = &gGameStateOverlayTable[GAMESTATE_SETUP];
     GameStateOverlay* ovl;
 
-    PRINTF("グラフィックスレッド実行開始\n"); // "Start graphic thread execution"
+    PRINTF(T("グラフィックスレッド実行開始\n", "Start graphic thread execution\n"));
     Graph_Init(&gfxCtx);
 
     while (nextOvl != NULL) {
@@ -461,7 +461,7 @@ void Graph_ThreadEntry(void* arg0) {
         Overlay_LoadGameState(ovl);
 
         size = ovl->instanceSize;
-        PRINTF("クラスサイズ＝%dバイト\n", size); // "Class size = %d bytes"
+        PRINTF(T("クラスサイズ＝%dバイト\n", "Class size = %d bytes\n"), size);
 
         gameState = SYSTEM_ARENA_MALLOC(size, "../graph.c", 1196);
 
@@ -469,7 +469,7 @@ void Graph_ThreadEntry(void* arg0) {
 #if OOT_DEBUG
             char faultMsg[0x50];
 
-            PRINTF("確保失敗\n"); // "Failure to secure"
+            PRINTF(T("確保失敗\n", "Failure to secure\n"));
 
             sprintf(faultMsg, "CLASS SIZE= %d bytes", size);
             Fault_AddHungupAndCrashImpl("GAME CLASS MALLOC FAILED", faultMsg);
@@ -492,7 +492,7 @@ void Graph_ThreadEntry(void* arg0) {
         Overlay_FreeGameState(ovl);
     }
     Graph_Destroy(&gfxCtx);
-    PRINTF("グラフィックスレッド実行終了\n"); // "End of graphic thread execution"
+    PRINTF(T("グラフィックスレッド実行終了\n", "End of graphic thread execution\n"));
 }
 
 void* Graph_Alloc(GraphicsContext* gfxCtx, size_t size) {

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -32,9 +32,9 @@ OSMesg sSerialMsgBuf[1];
 #if OOT_DEBUG
 void Main_LogSystemHeap(void) {
     PRINTF(VT_FGCOL(GREEN));
-    // "System heap size% 08x (% dKB) Start address% 08x"
-    PRINTF("システムヒープサイズ %08x(%dKB) 開始アドレス %08x\n", gSystemHeapSize, gSystemHeapSize / 1024,
-           _buffersSegmentEnd);
+    PRINTF(
+        T("システムヒープサイズ %08x(%dKB) 開始アドレス %08x\n", "System heap size %08x (%dKB) Start address %08x\n"),
+        gSystemHeapSize, gSystemHeapSize / 1024, _buffersSegmentEnd);
     PRINTF(VT_RST);
 }
 #endif
@@ -46,7 +46,7 @@ void Main(void* arg) {
     uintptr_t systemHeapStart;
     uintptr_t fb;
 
-    PRINTF("mainproc 実行開始\n"); // "Start running"
+    PRINTF(T("mainproc 実行開始\n", "mainproc Start running\n"));
     gScreenWidth = SCREEN_WIDTH;
     gScreenHeight = SCREEN_HEIGHT;
     gAppNmiBufferPtr = (PreNmiBuff*)osAppNMIBuffer;
@@ -56,8 +56,8 @@ void Main(void* arg) {
     systemHeapStart = (uintptr_t)_buffersSegmentEnd;
     fb = (uintptr_t)SysCfb_GetFbPtr(0);
     gSystemHeapSize = fb - systemHeapStart;
-    // "System heap initalization"
-    PRINTF("システムヒープ初期化 %08x-%08x %08x\n", systemHeapStart, fb, gSystemHeapSize);
+    PRINTF(T("システムヒープ初期化 %08x-%08x %08x\n", "System heap initalization %08x-%08x %08x\n"), systemHeapStart,
+           fb, gSystemHeapSize);
     SystemHeap_Init((void*)systemHeapStart, gSystemHeapSize); // initializes the system heap
 
 #if OOT_DEBUG
@@ -93,7 +93,7 @@ void Main(void* arg) {
     StackCheck_Init(&sIrqMgrStackInfo, sIrqMgrStack, STACK_TOP(sIrqMgrStack), 0, 0x100, "irqmgr");
     IrqMgr_Init(&gIrqMgr, STACK_TOP(sIrqMgrStack), THREAD_PRI_IRQMGR, 1);
 
-    PRINTF("タスクスケジューラの初期化\n"); // "Initialize the task scheduler"
+    PRINTF(T("タスクスケジューラの初期化\n", "Initialize the task scheduler\n"));
     StackCheck_Init(&sSchedStackInfo, sSchedStack, STACK_TOP(sSchedStack), 0, 0x100, "sched");
     Sched_Init(&gScheduler, STACK_TOP(sSchedStack), THREAD_PRI_SCHED, gViConfigModeType, 1, &gIrqMgr);
 
@@ -120,13 +120,13 @@ void Main(void* arg) {
             break;
         }
         if (*msg == OS_SC_PRE_NMI_MSG) {
-            PRINTF("main.c: リセットされたみたいだよ\n"); // "Looks like it's been reset"
+            PRINTF(T("main.c: リセットされたみたいだよ\n", "main.c: Looks like it's been reset\n"));
             PreNmiBuff_SetReset(gAppNmiBufferPtr);
         }
     }
 
-    PRINTF("mainproc 後始末\n"); // "Cleanup"
+    PRINTF(T("mainproc 後始末\n", "mainproc Cleanup\n"));
     osDestroyThread(&sGraphThread);
     RcpUtils_Reset();
-    PRINTF("mainproc 実行終了\n"); // "End of execution"
+    PRINTF(T("mainproc 実行終了\n", "mainproc End of execution\n"));
 }

--- a/src/code/padmgr.c
+++ b/src/code/padmgr.c
@@ -31,13 +31,12 @@
 #include "global.h"
 #include "terminal.h"
 
-#define PADMGR_LOG(controllerNum, msg)                              \
-    if (OOT_DEBUG) {                                                \
-        PRINTF(VT_FGCOL(YELLOW));                                   \
-        /* padmgr: Controller %d: %s */                             \
-        PRINTF("padmgr: %dコン: %s\n", (controllerNum) + 1, (msg)); \
-        PRINTF(VT_RST);                                             \
-    }                                                               \
+#define PADMGR_LOG(controllerNum, msg)                                                                \
+    if (OOT_DEBUG) {                                                                                  \
+        PRINTF(VT_FGCOL(YELLOW));                                                                     \
+        PRINTF(T("padmgr: %dコン: %s\n", "padmgr: Controller %d: %s\n"), (controllerNum) + 1, (msg)); \
+        PRINTF(VT_RST);                                                                               \
+    }                                                                                                 \
     (void)0
 
 #define LOG_SEVERITY_NOLOG 0
@@ -73,17 +72,18 @@ OSMesgQueue* PadMgr_AcquireSerialEventQueue(PadMgr* padMgr) {
 #endif
 
     if (gPadMgrLogSeverity >= LOG_SEVERITY_VERBOSE) {
-        // "serialMsgQ Waiting for lock"
-        PRINTF("%2d %d serialMsgQロック待ち         %08x %08x          %08x\n", osGetThreadId(NULL),
-               MQ_GET_COUNT(&padMgr->serialLockQueue), padMgr, &padMgr->serialLockQueue, &serialEventQueue);
+        PRINTF(T("%2d %d serialMsgQロック待ち         %08x %08x          %08x\n",
+                 "%2d %d serialMsgQ Waiting for lock         %08x %08x          %08x\n"),
+               osGetThreadId(NULL), MQ_GET_COUNT(&padMgr->serialLockQueue), padMgr, &padMgr->serialLockQueue,
+               &serialEventQueue);
     }
 
     osRecvMesg(&padMgr->serialLockQueue, (OSMesg*)&serialEventQueue, OS_MESG_BLOCK);
 
     if (gPadMgrLogSeverity >= LOG_SEVERITY_VERBOSE) {
-        // "serialMsgQ Locked"
-        PRINTF("%2d %d serialMsgQをロックしました                     %08x\n", osGetThreadId(NULL),
-               MQ_GET_COUNT(&padMgr->serialLockQueue), serialEventQueue);
+        PRINTF(T("%2d %d serialMsgQをロックしました                     %08x\n",
+                 "%2d %d serialMsgQ Locked                     %08x\n"),
+               osGetThreadId(NULL), MQ_GET_COUNT(&padMgr->serialLockQueue), serialEventQueue);
     }
 
     return serialEventQueue;
@@ -98,17 +98,17 @@ OSMesgQueue* PadMgr_AcquireSerialEventQueue(PadMgr* padMgr) {
  */
 void PadMgr_ReleaseSerialEventQueue(PadMgr* padMgr, OSMesgQueue* serialEventQueue) {
     if (gPadMgrLogSeverity >= LOG_SEVERITY_VERBOSE) {
-        // "serialMsgQ Unlock"
-        PRINTF("%2d %d serialMsgQロック解除します   %08x %08x %08x\n", osGetThreadId(NULL),
-               MQ_GET_COUNT(&padMgr->serialLockQueue), padMgr, &padMgr->serialLockQueue, serialEventQueue);
+        PRINTF(T("%2d %d serialMsgQロック解除します   %08x %08x %08x\n", "%2d %d serialMsgQ Unlock   %08x %08x %08x\n"),
+               osGetThreadId(NULL), MQ_GET_COUNT(&padMgr->serialLockQueue), padMgr, &padMgr->serialLockQueue,
+               serialEventQueue);
     }
 
     osSendMesg(&padMgr->serialLockQueue, (OSMesg)serialEventQueue, OS_MESG_BLOCK);
 
     if (gPadMgrLogSeverity >= LOG_SEVERITY_VERBOSE) {
-        // "serialMsgQ Unlocked"
-        PRINTF("%2d %d serialMsgQロック解除しました %08x %08x %08x\n", osGetThreadId(NULL),
-               MQ_GET_COUNT(&padMgr->serialLockQueue), padMgr, &padMgr->serialLockQueue, serialEventQueue);
+        PRINTF(T("%2d %d serialMsgQロック解除しました %08x %08x %08x\n", "%2d %d serialMsgQ Unlocked %08x %08x %08x\n"),
+               osGetThreadId(NULL), MQ_GET_COUNT(&padMgr->serialLockQueue), padMgr, &padMgr->serialLockQueue,
+               serialEventQueue);
     }
 }
 
@@ -401,8 +401,8 @@ void PadMgr_HandleRetrace(PadMgr* padMgr) {
                 mask |= 1 << i;
             } else {
                 LOG_HEX("this->pad_status[i].type", padMgr->padStatus[i].type, "../padmgr.c", 458);
-                // "An unknown type of controller is connected"
-                PRINTF("知らない種類のコントローラが接続されています\n");
+                PRINTF(T("知らない種類のコントローラが接続されています\n",
+                         "An unknown type of controller is connected\n"));
             }
         }
     }
@@ -476,13 +476,13 @@ void PadMgr_ThreadEntry(PadMgr* padMgr) {
     s16* msg = NULL;
     s32 exit;
 
-    PRINTF("コントローラスレッド実行開始\n"); // "Controller thread execution start"
+    PRINTF(T("コントローラスレッド実行開始\n", "Controller thread execution start"));
 
     exit = false;
     while (!exit) {
         if (gPadMgrLogSeverity >= LOG_SEVERITY_VERBOSE && MQ_IS_EMPTY(&padMgr->interruptQueue)) {
-            // "Waiting for controller thread event"
-            PRINTF("コントローラスレッドイベント待ち %lld\n", OS_CYCLES_TO_USEC(osGetTime()));
+            PRINTF(T("コントローラスレッドイベント待ち %lld\n", "Waiting for controller thread event %lld\n"),
+                   OS_CYCLES_TO_USEC(osGetTime()));
         }
 
         osRecvMesg(&padMgr->interruptQueue, (OSMesg*)&msg, OS_MESG_BLOCK);
@@ -511,11 +511,11 @@ void PadMgr_ThreadEntry(PadMgr* padMgr) {
 
     IrqMgr_RemoveClient(padMgr->irqMgr, &padMgr->irqClient);
 
-    PRINTF("コントローラスレッド実行終了\n"); // "Controller thread execution end"
+    PRINTF(T("コントローラスレッド実行終了\n", "Controller thread execution end\n"));
 }
 
 void PadMgr_Init(PadMgr* padMgr, OSMesgQueue* serialEventQueue, IrqMgr* irqMgr, OSId id, OSPri priority, void* stack) {
-    PRINTF("パッドマネージャ作成 padmgr_Create()\n"); // "Pad Manager creation"
+    PRINTF(T("パッドマネージャ作成 padmgr_Create()\n", "Pad Manager creation padmgr_Create()\n"));
 
     bzero(padMgr, sizeof(PadMgr));
     padMgr->irqMgr = irqMgr;

--- a/src/code/sys_cfb.c
+++ b/src/code/sys_cfb.c
@@ -8,19 +8,18 @@ void SysCfb_Init(s32 n64dd) {
     uintptr_t tmpFbEnd;
 
     if (osMemSize >= 0x800000) {
-        // "8MB or more memory is installed"
-        PRINTF("８Ｍバイト以上のメモリが搭載されています\n");
+        PRINTF(T("８Ｍバイト以上のメモリが搭載されています\n", "8MB or more memory is installed\n"));
         tmpFbEnd = 0x8044BE80;
         if (n64dd == 1) {
-            PRINTF("RAM 8M mode (N64DD対応)\n"); // "RAM 8M mode (N64DD compatible)"
+            PRINTF(T("RAM 8M mode (N64DD対応)\n", "RAM 8M mode (N64DD compatible)\n"));
 #if OOT_DEBUG
             sSysCfbEnd = 0x805FB000;
 #else
             sSysCfbEnd = 0x80600000;
 #endif
         } else {
-            // "The margin for this version is %dK bytes"
-            PRINTF("このバージョンのマージンは %dK バイトです\n", (0x4BC00 / 1024));
+            PRINTF(T("このバージョンのマージンは %dK バイトです\n", "The margin for this version is %dK bytes\n"),
+                   (0x4BC00 / 1024));
 #if OOT_DEBUG
             sSysCfbEnd = tmpFbEnd;
 #else
@@ -39,12 +38,12 @@ void SysCfb_Init(s32 n64dd) {
 
     if (1) {}
 
-    // "The final address used by the system is %08x"
-    PRINTF("システムが使用する最終アドレスは %08x です\n", sSysCfbEnd);
+    PRINTF(T("システムが使用する最終アドレスは %08x です\n", "The final address used by the system is %08x\n"),
+           sSysCfbEnd);
     sSysCfbFbPtr[0] = sSysCfbEnd - (screenSize * 4);
     sSysCfbFbPtr[1] = sSysCfbEnd - (screenSize * 2);
-    // "Frame buffer addresses are %08x and %08x"
-    PRINTF("フレームバッファのアドレスは %08x と %08x です\n", sSysCfbFbPtr[0], sSysCfbFbPtr[1]);
+    PRINTF(T("フレームバッファのアドレスは %08x と %08x です\n", "Frame buffer addresses are %08x and %08x\n"),
+           sSysCfbFbPtr[0], sSysCfbFbPtr[1]);
 }
 
 void SysCfb_Reset(void) {

--- a/src/code/system_malloc.c
+++ b/src/code/system_malloc.c
@@ -12,14 +12,12 @@ s32 gSystemArenaLogSeverity = LOG_SEVERITY_NOLOG;
 void SystemArena_CheckPointer(void* ptr, u32 size, const char* name, const char* action) {
     if (ptr == NULL) {
         if (gSystemArenaLogSeverity >= LOG_SEVERITY_ERROR) {
-            // "%s: %u bytes %s failed\n"
-            PRINTF("%s: %u バイトの%sに失敗しました\n", name, size, action);
+            PRINTF(T("%s: %u バイトの%sに失敗しました\n", "%s: %u bytes %s failed\n"), name, size, action);
             __osDisplayArena(&gSystemArena);
             return;
         }
     } else if (gSystemArenaLogSeverity >= LOG_SEVERITY_VERBOSE) {
-        // "%s: %u bytes %s succeeded\n"
-        PRINTF("%s: %u バイトの%sに成功しました\n", name, size, action);
+        PRINTF(T("%s: %u バイトの%sに成功しました\n", "%s: %u bytes %s succeeded\n"), name, size, action);
     }
 }
 
@@ -99,7 +97,7 @@ void* SystemArena_Calloc(u32 num, u32 size) {
 
 #if OOT_DEBUG
 void SystemArena_Display(void) {
-    PRINTF("システムヒープ表示\n"); // "System heap display"
+    PRINTF(T("システムヒープ表示\n", "System heap display\n"));
     __osDisplayArena(&gSystemArena);
 }
 #endif

--- a/src/code/title_setup.c
+++ b/src/code/title_setup.c
@@ -1,7 +1,7 @@
 #include "global.h"
 
 void Setup_InitImpl(SetupState* this) {
-    PRINTF("ゼルダ共通データ初期化\n"); // "Zelda common data initalization"
+    PRINTF(T("ゼルダ共通データ初期化\n", "Zelda common data initalization\n"));
     SaveContext_Init();
     this->state.running = false;
     SET_NEXT_GAMESTATE(&this->state, ConsoleLogo_Init, ConsoleLogoState);

--- a/src/code/z_DLF.c
+++ b/src/code/z_DLF.c
@@ -3,7 +3,7 @@
 
 void Overlay_LoadGameState(GameStateOverlay* overlayEntry) {
     if (overlayEntry->loadedRamAddr != NULL) {
-        PRINTF("既にリンクされています\n"); // "Already linked"
+        PRINTF(T("既にリンクされています\n", "Already linked\n"));
         return;
     }
 
@@ -14,7 +14,7 @@ void Overlay_LoadGameState(GameStateOverlay* overlayEntry) {
                                                               overlayEntry->vramStart, overlayEntry->vramEnd);
 
         if (overlayEntry->loadedRamAddr == NULL) {
-            PRINTF("ロードに失敗しました\n"); // "Loading failed"
+            PRINTF(T("ロードに失敗しました\n", "Loading failed\n"));
             return;
         }
 

--- a/src/code/z_construct.c
+++ b/src/code/z_construct.c
@@ -32,8 +32,7 @@ void Interface_Init(PlayState* play) {
 
     parameterSize = (uintptr_t)_parameter_staticSegmentRomEnd - (uintptr_t)_parameter_staticSegmentRomStart;
 
-    // "Permanent PARAMETER Segment = %x"
-    PRINTF("常駐ＰＡＲＡＭＥＴＥＲセグメント=%x\n", parameterSize);
+    PRINTF(T("常駐ＰＡＲＡＭＥＴＥＲセグメント=%x\n", "Permanent PARAMETER Segment = %x\n"), parameterSize);
 
     interfaceCtx->parameterSegment = GAME_STATE_ALLOC(&play->state, parameterSize, "../z_construct.c", 159);
 
@@ -45,7 +44,7 @@ void Interface_Init(PlayState* play) {
 
     interfaceCtx->doActionSegment = GAME_STATE_ALLOC(&play->state, 3 * DO_ACTION_TEX_SIZE, "../z_construct.c", 166);
 
-    PRINTF("ＤＯアクション テクスチャ初期=%x\n", 3 * DO_ACTION_TEX_SIZE); // "DO Action Texture Initialization"
+    PRINTF(T("ＤＯアクション テクスチャ初期=%x\n", "DO Action Texture Initialization = %x\n"), 3 * DO_ACTION_TEX_SIZE);
     PRINTF("parameter->do_actionSegment=%x\n", interfaceCtx->doActionSegment);
 
     ASSERT(interfaceCtx->doActionSegment != NULL, "parameter->do_actionSegment != NULL", "../z_construct.c", 169);
@@ -91,8 +90,8 @@ void Interface_Init(PlayState* play) {
 
     interfaceCtx->iconItemSegment = GAME_STATE_ALLOC(&play->state, ICON_ITEM_SEGMENT_SIZE, "../z_construct.c", 190);
 
-    // "Icon Item Texture Initialization = %x"
-    PRINTF("アイコンアイテム テクスチャ初期=%x\n", ICON_ITEM_SEGMENT_SIZE);
+    PRINTF(T("アイコンアイテム テクスチャ初期=%x\n", "Icon Item Texture Initialization = %x\n"),
+           ICON_ITEM_SEGMENT_SIZE);
     PRINTF("parameter->icon_itemSegment=%x\n", interfaceCtx->iconItemSegment);
 
     ASSERT(interfaceCtx->iconItemSegment != NULL, "parameter->icon_itemSegment != NULL", "../z_construct.c", 193);
@@ -165,11 +164,12 @@ void Interface_Init(PlayState* play) {
 
     if ((gSaveContext.timerState >= TIMER_STATE_UP_INIT) && (gSaveContext.timerState <= TIMER_STATE_UP_FREEZE)) {
         gSaveContext.timerState = TIMER_STATE_OFF;
-        // "Timer Stop!!!!!!!!!!!!!!!!!!!!!!"
-        PRINTF("タイマー停止！！！！！！！！！！！！！！！！！！！！！  = %d\n", gSaveContext.timerState);
+        PRINTF(T("タイマー停止！！！！！！！！！！！！！！！！！！！！！  = %d\n",
+                 "Timer Stop!!!!!!!!!!!!!!!!!!!!!  = %d\n"),
+               gSaveContext.timerState);
     }
 
-    PRINTF("ＰＡＲＡＭＥＴＥＲ領域＝%x\n", parameterSize + 0x5300); // "Parameter Area = %x"
+    PRINTF(T("ＰＡＲＡＭＥＴＥＲ領域＝%x\n", "Parameter Area = %x\n"), parameterSize + 0x5300);
 
     Health_InitMeter(play);
     Map_Init(play);
@@ -215,7 +215,7 @@ void Message_Init(PlayState* play) {
 
     PRINTF("message->fukidashiSegment=%x\n", msgCtx->textboxSegment);
 
-    PRINTF("吹き出しgame_alloc=%x\n", TEXTBOX_SEGMENT_SIZE); // "Textbox game_alloc=%x"
+    PRINTF(T("吹き出しgame_alloc=%x\n", "Textbox game_alloc=%x\n"), TEXTBOX_SEGMENT_SIZE);
     ASSERT(msgCtx->textboxSegment != NULL, "message->fukidashiSegment != NULL", "../z_construct.c", 352);
 
     Font_LoadOrderedFont(&play->msgCtx.font);

--- a/src/code/z_kaleido_manager.c
+++ b/src/code/z_kaleido_manager.c
@@ -51,7 +51,8 @@ void KaleidoManager_Init(PlayState* play) {
     }
 
     PRINTF(VT_FGCOL(GREEN));
-    PRINTF("KaleidoArea の最大サイズは %d バイトを確保します\n", largestSize);
+    PRINTF(T("KaleidoArea の最大サイズは %d バイトを確保します\n", "The maximum size of KaleidoArea is %d bytes\n"),
+           largestSize);
     PRINTF(VT_RST);
 
     sKaleidoAreaPtr = GAME_STATE_ALLOC(&play->state, largestSize, "../z_kaleido_manager.c", 150);
@@ -91,7 +92,7 @@ void* KaleidoManager_GetRamAddr(void* vram) {
             //! @bug Probably missing iter++ here
         }
 
-        PRINTF("異常\n"); // "Abnormal"
+        PRINTF(T("異常\n", "Abnormal\n"));
         return NULL;
     }
 


### PR DESCRIPTION
As discussed on Discord ( https://discord.com/channels/688807550715560050/688851317593997489/1274103057008955494 ), and use it in a few files. Will open more PRs after if this is accepted to do the rest bits by bits

Things to watch out for: mostly respecting the original format string like the `%` directives and not forgetting line returns `\n`. occasionally move `VT` stuff out of `T()`


<details>

<summary>helper script to turn `// "translation"` comments into `T()`:

</summary>

```py
#!/usr/bin/env python3
# SPDX-FileCopyrightText: 2024 Dragorn421
# SPDX-License-Identifier: CC0-1.0

import argparse
import dataclasses
from pathlib import Path
from typing import Optional


@dataclasses.dataclass
class PrintCall:
    fmt: str
    args: list[str]
    comment: Optional[str]
    comment_is_above: Optional[bool]
    """comment can be above (True) or on the same line (False)"""


def c_comma_split(s: str):
    in_string = False
    escape_seq = False
    n_open_parens = 0
    part = ""
    for c in s:
        if in_string:
            if c == '"':
                if not escape_seq:
                    in_string = False
            part += c
            if c == "\\":
                escape_seq = not escape_seq
            else:
                escape_seq = False
        else:
            if c == ",":
                if n_open_parens == 0:
                    yield part
                    part = ""
                else:
                    part += c
            else:
                if c == '"':
                    in_string = True
                elif c == "(":
                    n_open_parens += 1
                elif c == ")":
                    n_open_parens -= 1
                    assert n_open_parens >= 0, s
                part += c
    yield part


def test_c_comma_split():
    for s, it in (
        ("", [""]),
        ("a", ["a"]),
        ("a,b", ["a", "b"]),
        ("a,b,c", ["a", "b", "c"]),
        ("(a,b),c", ["(a,b)", "c"]),
        ("a,(b,c)", ["a", "(b,c)"]),
        ("(a,b,c)", ["(a,b,c)"]),
        ('"a,b",c', ['"a,b"', "c"]),
        ('("a,b)",c),d', ['("a,b)",c)', "d"]),
    ):
        res = list(c_comma_split(s))
        assert res == it, (s, res, it)


def c_index(s: str, needle: str, start: int):
    assert needle != '"'
    in_string = False
    escape_seq = False
    for i, c in enumerate(s[start:], start):
        if in_string:
            if c == '"':
                if not escape_seq:
                    in_string = False
            if c == "\\":
                escape_seq = not escape_seq
            else:
                escape_seq = False
        else:
            if c == '"':
                in_string = True
            if c == needle:
                return i
    raise ValueError


def parse_src(src: str) -> list[str | PrintCall]:
    # PRINTF("abc %d\n", 1); // "abc"
    frags = []
    i = 0
    while (j := src.find("PRINTF", i)) != -1:
        start = j
        end = c_index(src, ";", j) + 1

        printf_call_str = src[start:end]
        assert printf_call_str.startswith("PRINTF("), printf_call_str
        assert printf_call_str.endswith(");"), printf_call_str
        printf_call_str = printf_call_str.removeprefix("PRINTF(").removesuffix(");")
        fmt, *args = c_comma_split(printf_call_str)

        assert "%%" not in fmt
        assert fmt.count("%") == len(args), printf_call_str

        comment = None
        comment_is_above = None

        k = src.index("\n", j)
        m = src.find("//", j, k)
        if m != -1:
            end = k
            comment = src[m + 2 : k]
            comment_is_above = False
        else:
            k = src.rindex("\n", 0, j)
            m = src.rindex("\n", 0, k)
            n = src.rfind("//", m, k)
            if n != -1:
                start = n
                comment = src[n + 2 : k]
                comment_is_above = True

        frags.append(src[i:start])
        frags.append(PrintCall(fmt, args, comment, comment_is_above))
        i = end
    frags.append(src[i:])
    return frags


def test_parse_src():

    for src, it in (
        (
            """foo
// "def"
PRINTF("abc");
bar
""",
            [
                "foo\n",
                PrintCall('"abc"', [], ' "def"', True),
                "\nbar\n",
            ],
        ),
        (
            """foo
PRINTF("abc"); // "def"
bar
""",
            [
                "foo\n",
                PrintCall('"abc"', [], ' "def"', False),
                "\nbar\n",
            ],
        ),
    ):
        res = parse_src(src)
        assert res == it, (src, res, it)


def test():
    test_c_comma_split()
    test_parse_src()


def process_file_for_T(file: Path):
    src = file.read_text()
    src_frags = parse_src(src)
    new_src_frags_str = []
    for sf in src_frags:
        if isinstance(sf, str):
            sf_str = sf
        else:
            fmt = sf.fmt
            comment_used_as_t = False
            if sf.comment:
                if sf.comment.strip().startswith('"') and sf.comment.strip().endswith(
                    '"'
                ):
                    comment_used_as_t = True
                    fmt = f"T({sf.fmt}, {sf.comment})"
            if sf.comment and not comment_used_as_t and sf.comment_is_above:
                new_src_frags_str.append(f"//{sf.comment}\n")
            sf_str = "PRINTF(" + ", ".join((fmt, *sf.args)) + ");"
            if sf.comment and not comment_used_as_t and not sf.comment_is_above:
                new_src_frags_str.append(f" //{sf.comment}")
        new_src_frags_str.append(sf_str)
    new_src = "".join(new_src_frags_str)
    file.write_text(new_src)


def process_all_files_for_T(*, pause):
    for dir_p, dirnames, filenames in Path("src").walk():
        for filename in filenames:
            if filename in (
                # bad arguments, see later
                "z_bgcheck.c",
                "z_onepointdemo.c",
                "z_message.c",
                "z_kankyo.c",
                "z_parameter.c",
                "z_map_mark.c",
                "idle.c",
                "z_door_warp1.c",
                "sfx.c",
                # PRINTF in a macro/comment, see later
                "z_actor.c",
                "code_800430A0.c",
                "sched.c",
                # bad format string, see later
                "z_kaleido_item.c",
                # bad arguments, but nothing to translate anyway
                "z_prenmi.c",
                "z_fishing.c",
                # PRINTF in a macro, but nothing to translate anyway
                "ucode_disas.c",
                "rcp_utils.c",
                # misc.
                "z_en_fr.h",  # "PRINTF" in a comment
            ):
                continue
            file = dir_p / filename
            print(file)
            process_file_for_T(file)
            if pause:
                input()


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("files", nargs="*", type=Path)
    parser.add_argument("--all-files", action="store_true")
    parser.add_argument("--pause", action="store_true")
    args = parser.parse_args()
    if args.all_files:
        process_all_files_for_T(pause=args.pause)
        print("all files processed")
    else:
        if not args.files:
            parser.error("No files to process")

        for file in args.files:
            print(file)
            process_file_for_T(file)
            if args.pause:
                input()
        print(len(args.files), "files processed")


if __name__ == "__main__":
    if 0:
        test()
    if 1:
        main()
```

</details>