### PR TITLE
Add NO_SQRTF_INTRINSIC for z_rumble.c and audio/general.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,10 @@ $(BUILD_DIR)/src/code/fault_drawer.o: CFLAGS += -trapuv
 $(BUILD_DIR)/src/code/fault_drawer.o: OPTFLAGS := -O2 -g3
 $(BUILD_DIR)/src/code/ucode_disas.o: OPTFLAGS := -O2 -g3
 
+ifeq ($(PLATFORM),N64)
+$(BUILD_DIR)/src/code/z_rumble.o: CFLAGS += -DNO_SQRTF_INTRINSIC
+endif
+
 ifeq ($(DEBUG),1)
 $(BUILD_DIR)/src/libc/%.o: OPTFLAGS := -g
 else
@@ -435,6 +439,10 @@ $(BUILD_DIR)/src/audio/%.o: OPTFLAGS := -O2
 
 # Use signed chars instead of unsigned for this audio file (needed to match AudioDebug_ScrPrt)
 $(BUILD_DIR)/src/audio/general.o: CFLAGS += -signed
+
+ifeq ($(PLATFORM),N64)
+$(BUILD_DIR)/src/audio/general.o: CFLAGS += -DNO_SQRTF_INTRINSIC
+endif
 
 # Put string literals in .data for some audio files (needed to match these files with literals)
 $(BUILD_DIR)/src/audio/sfx.o: CFLAGS += -use_readwrite_const

--- a/include/libc/math.h
+++ b/include/libc/math.h
@@ -42,7 +42,9 @@ f32 fabsf(f32 f);
 #endif
 
 f32 sqrtf(f32 f);
-#ifdef __sgi
+// IDO has a sqrtf intrinsic, but in N64 versions it's not used for some files.
+// For these files we define NO_SQRTF_INTRINSIC to use the sqrtf function instead.
+#if defined(__sgi) && !defined(NO_SQRTF_INTRINSIC)
 #pragma intrinsic(sqrtf)
 #endif
 


### PR DESCRIPTION
For whatever reason, these files (and libultra files) call the sqrtf function instead of of using the intrinsic in N64 versions. We could handle this by declaring two versions of sqrtf in two different headers, but I think using a CPP define is more explicit.