### PR TITLE
[ntsc-1.2] Partially match z_en_mag

### DIFF
--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -484,10 +484,7 @@ void func_80AEEA48_unknown(Gfx** gfxP, s16 arg1, s16 arg2, u32 arg3) {
 
         gDPPipeSync(gfx++);
         gDPSetCycleType(gfx++, G_CYC_1CYCLE);
-        // G_RM_XLU_SURF ?
-        gDPSetRenderMode(gfx++, GBL_c1(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_MEM, G_BL_1MA),
-                         GBL_c2(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_MEM, G_BL_1MA) | IM_RD | CVG_DST_FULL | ZMODE_OPA |
-                             FORCE_BL);
+        gDPSetRenderMode(gfx++, G_RM_XLU_SURF, G_RM_XLU_SURF2);
         gDPSetCombineLERP(gfx++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE,
                           ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
         gDPSetPrimColor(gfx++, 0x00, 0x00, 255, 255, 255, arg3);
@@ -588,7 +585,7 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
     if ((s16)this->mainAlpha != 0) {
         EnMag_DrawImageRGBA32(&gfx, 160 + LOGO_X_SHIFT, 100, (u8*)gTitleZeldaShieldLogoTex, 160, 160);
 #if PLATFORM_N64
-        func_80AEEA48_unknown(&gfx, 0xA0, 0x64, (u32)this->mainAlpha);
+        func_80AEEA48_unknown(&gfx, 160, 100, (u32)this->mainAlpha);
 #endif
     }
 

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -6,6 +6,9 @@
 
 #include "z_en_mag.h"
 #include "assets/objects/object_mag/object_mag.h"
+#if PLATFORM_N64
+#include "n64dd.h"
+#endif
 #include "versions.h"
 
 #define FLAGS (ACTOR_FLAG_4 | ACTOR_FLAG_5)
@@ -255,8 +258,13 @@ void EnMag_Update(Actor* thisx, PlayState* play) {
 
     if (this->globalState == MAG_STATE_FADE_IN) {
         if (this->effectFadeInState == 0) {
+#if PLATFORM_N64
+            this->effectPrimLodFrac += 0.8f;
+            this->effectAlpha += 6.375f;
+#else
             this->effectAlpha += 6.375f;
             this->effectPrimLodFrac += 0.8f;
+#endif
 
             this->effectPrimColor[0] += 6.375f;
             this->effectPrimColor[1] += 3.875f;
@@ -280,6 +288,9 @@ void EnMag_Update(Actor* thisx, PlayState* play) {
                 this->effectFadeInState = 1;
             }
         } else if (this->effectFadeInState == 1) {
+#if PLATFORM_N64
+            this->effectPrimLodFrac += 2.4f;
+#endif
 #if !OOT_MQ
             this->effectPrimColor[2] += -2.125f;
             this->effectEnvColor[1] += -3.875f;
@@ -287,8 +298,9 @@ void EnMag_Update(Actor* thisx, PlayState* play) {
             this->effectPrimColor[0] += -2.125f;
             this->effectEnvColor[0] += -1.375f;
 #endif
-
+#if !PLATFORM_N64
             this->effectPrimLodFrac += 2.4f;
+#endif
 
             this->effectFadeInTimer--;
 
@@ -459,6 +471,41 @@ void EnMag_DrawImageRGBA32(Gfx** gfxP, s16 centerX, s16 centerY, u8* source, u32
     *gfxP = gfx;
 }
 
+#if PLATFORM_N64
+// TODO n64dd functions
+s32 func_801C79BC_unknown(void);
+
+// TODO does not match, some regalloc diffs. https://decomp.me/scratch/H8OK5
+void func_80AEEA48_unknown(Gfx** gfxP, s16 arg1, s16 arg2, u32 arg3) {
+    if ((B_80121AE2 != 0) && (func_801C79BC_unknown() != 0)) {
+        Gfx* gfx = *gfxP;
+        s32 temp_a3;
+        s32 temp_t0;
+
+        gDPPipeSync(gfx++);
+        gDPSetCycleType(gfx++, G_CYC_1CYCLE);
+        // G_RM_XLU_SURF ?
+        gDPSetRenderMode(gfx++, GBL_c1(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_MEM, G_BL_1MA),
+                         GBL_c2(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_MEM, G_BL_1MA) | IM_RD | CVG_DST_FULL | ZMODE_OPA |
+                             FORCE_BL);
+        gDPSetCombineLERP(gfx++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE,
+                          ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+        gDPSetPrimColor(gfx++, 0x00, 0x00, 255, 255, 255, arg3);
+        gDPSetEnvColor(gfx++, 48, 36, 146, 255);
+        gDPLoadTextureBlock(gfx++, gTitleDiskTex, G_IM_FMT_IA, G_IM_SIZ_8b, 48, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                            G_TX_NOMIRROR | G_TX_WRAP, 0, 0, 0, 0);
+        temp_a3 = arg1 + 0x40;
+        temp_t0 = arg2 + 5;
+        gSPTextureRectangle(gfx++, temp_a3 << 2, temp_t0 << 2, (temp_a3 << 2) + 0xC0, (temp_t0 << 2) + 0x40,
+                            G_TX_RENDERTILE, 0, 0, (1 << 10), (1 << 10));
+        gDPPipeSync(gfx++);
+        gDPSetCycleType(gfx++, G_CYC_2CYCLE);
+
+        *gfxP = gfx;
+    }
+}
+#endif
+
 void EnMag_DrawCharTexture(Gfx** gfxP, u8* texture, s32 rectLeft, s32 rectTop) {
     Gfx* gfx = *gfxP;
 
@@ -540,6 +587,9 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
 
     if ((s16)this->mainAlpha != 0) {
         EnMag_DrawImageRGBA32(&gfx, 160 + LOGO_X_SHIFT, 100, (u8*)gTitleZeldaShieldLogoTex, 160, 160);
+#if PLATFORM_N64
+        func_80AEEA48_unknown(&gfx, 0xA0, 0x64, (u32)this->mainAlpha);
+#endif
     }
 
     Gfx_SetupDL_39Ptr(&gfx);
@@ -641,7 +691,7 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
 
     if ((s16)this->copyrightAlpha != 0) {
 #if PLATFORM_N64
-        gDPLoadTextureBlock(gfx++, gTitleCopyright1998Tex, G_IM_FMT_IA, G_IM_SIZ_8b, 160, 16, 0,
+        gDPLoadTextureBlock(gfx++, gTitleCopyright1998Tex, G_IM_FMT_IA, G_IM_SIZ_8b, 128, 16, 0,
                             G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
                             G_TX_NOLOD, G_TX_NOLOD);
 #elif OOT_VERSION < OOT_GC_US
@@ -664,7 +714,11 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
                             G_TX_NOLOD, G_TX_NOLOD);
 #endif
 
+#if PLATFORM_N64
+        gSPTextureRectangle(gfx++, 94 << 2, 198 << 2, 222 << 2, 214 << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+#else
         gSPTextureRectangle(gfx++, 78 << 2, 198 << 2, 238 << 2, 214 << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+#endif
     }
 
     if (gSaveContext.fileNum == 0xFEDC) {

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -475,12 +475,11 @@ void EnMag_DrawImageRGBA32(Gfx** gfxP, s16 centerX, s16 centerY, u8* source, u32
 // TODO n64dd functions
 s32 func_801C79BC_unknown(void);
 
-// TODO does not match, some regalloc diffs. https://decomp.me/scratch/H8OK5
 void func_80AEEA48_unknown(Gfx** gfxP, s16 arg1, s16 arg2, u32 arg3) {
     if ((B_80121AE2 != 0) && (func_801C79BC_unknown() != 0)) {
         Gfx* gfx = *gfxP;
-        s32 temp_a3;
-        s32 temp_t0;
+        s32 temp_a3 = (arg1 + 0x40) << 2;
+        s32 temp_t0 = (arg2 + 5) << 2;
 
         gDPPipeSync(gfx++);
         gDPSetCycleType(gfx++, G_CYC_1CYCLE);
@@ -491,10 +490,8 @@ void func_80AEEA48_unknown(Gfx** gfxP, s16 arg1, s16 arg2, u32 arg3) {
         gDPSetEnvColor(gfx++, 48, 36, 146, 255);
         gDPLoadTextureBlock(gfx++, gTitleDiskTex, G_IM_FMT_IA, G_IM_SIZ_8b, 48, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
                             G_TX_NOMIRROR | G_TX_WRAP, 0, 0, 0, 0);
-        temp_a3 = arg1 + 0x40;
-        temp_t0 = arg2 + 5;
-        gSPTextureRectangle(gfx++, temp_a3 << 2, temp_t0 << 2, (temp_a3 << 2) + 0xC0, (temp_t0 << 2) + 0x40,
-                            G_TX_RENDERTILE, 0, 0, (1 << 10), (1 << 10));
+        gSPTextureRectangle(gfx++, temp_a3, temp_t0, temp_a3 + (48 << 2), temp_t0 + (16 << 2), G_TX_RENDERTILE, 0, 0,
+                            (1 << 10), (1 << 10));
         gDPPipeSync(gfx++);
         gDPSetCycleType(gfx++, G_CYC_2CYCLE);
 

--- a/undefined_syms.txt
+++ b/undefined_syms.txt
@@ -26,4 +26,7 @@ func_801C8510_unknown = 0x801C8510;
 D_801DA410 = 0x801DA410;
 D_801E8090 = 0x801E8090;
 
+// z_en_mag.c
+func_801C79BC_unknown = 0x801C79BC;
+
 #endif


### PR DESCRIPTION
- ~~`func_80AEEA48_unknown` has some slight regalloc diffs: https://decomp.me/scratch/H8OK5~~ (matched by cadmic!)
- ~~I didn't attempt~~ `EnMag_DrawImageRGBA32`: https://decomp.me/scratch/rrBaz (look at the forks)
- others are matching
