### PR TITLE
In fix_bss.py, always use BSS section start from map file

### DIFF
--- a/src/audio/data.c
+++ b/src/audio/data.c
@@ -69,3 +69,5 @@ u8 gSoundModeList[] = {
 u8 gAudioSpecId = 0;
 
 u8 D_80133418 = 0;
+
+u8 D_8016F0E0[0xA0]; // unused

--- a/src/audio/session_config.c
+++ b/src/audio/session_config.c
@@ -1,6 +1,5 @@
 #include "global.h"
 
-u8 D_8016F0E0[0xA0]; // unused
 AudioContext gAudioCtx;
 AudioCustomUpdateFunction gAudioCustomUpdateFunction;
 s32 D_801755D8[3]; // unused


### PR DESCRIPTION
Currently, when trying to detect if there is any bss reordering, fix_bss.py tries to be robust to bss shifting by using assuming the .bss section starts at the lowest address of any pointer into the section. Unfortunately, this can't detect cases where an unused variable is reordered to the front and the rest of the .bss section shifts (and this bug is hit in practice here: https://discord.com/channels/688807550715560050/688851337085190255/1276746017693241435)

Instead, we use the .bss section start from the map file instead here too. We can't do this for the baserom through so we still do the lowest address thing. This doesn't work for files where bss starts with unused data, which are src/audio/session_config.c and src/boot/z_locale.c. I "fixed" session_config.c by moving the unused bss variable to another file, and z_locale.c will never be a problem since it has 0 or 1 bss variables so we just skip it.