### PR TITLE
Add clangd files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@ __pycache__/
 .pyc
 .DS_Store
 
-# Text editor remnants
+# IDE files
 .vscode/
 .vs/
 .idea/
+.cache/
+compile_commands.json
 
 # Project-specific ignores
 .make_options.mk


### PR DESCRIPTION
I've recently become fed up with intellisense's slowness enough that I'm trying out clangd instead. I may also contribute how to use clangd to docs/ eventually if I don't find major flaws
Doesn't hurt to gitignore the relevant folder and file in the meantime