### PR TITLE
Add all N64 version defines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,8 @@ VENV := .venv
 MAKE = make
 CPPFLAGS += -P -xc -fno-dollars-in-identifiers
 
-# Converts e.g. ntsc-1.0 to OOT_NTSC_1_0
-VERSION_MACRO := OOT_$(shell echo $(VERSION) | tr a-z-. A-Z__)
+# Converts e.g. ntsc-1.0 to NTSC_1_0
+VERSION_MACRO := $(shell echo $(VERSION) | tr a-z-. A-Z__)
 CPP_DEFINES += -DOOT_VERSION=$(VERSION_MACRO)
 CPP_DEFINES += -DOOT_REGION=REGION_$(REGION)
 

--- a/docs/c_cpp_properties.json
+++ b/docs/c_cpp_properties.json
@@ -15,7 +15,7 @@
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_NTSC_1_2",
+                "OOT_VERSION=NTSC_1_2",
                 "OOT_REGION=REGION_JP",
                 "PLATFORM_N64=1",
                 "PLATFORM_GC=0",
@@ -42,7 +42,7 @@
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_GC_JP",
+                "OOT_VERSION=GC_JP",
                 "OOT_REGION=REGION_JP",
                 "PLATFORM_N64=0",
                 "PLATFORM_GC=1",
@@ -71,7 +71,7 @@
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_GC_JP_MQ",
+                "OOT_VERSION=GC_JP_MQ",
                 "OOT_REGION=REGION_JP",
                 "PLATFORM_N64=0",
                 "PLATFORM_GC=1",
@@ -100,7 +100,7 @@
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_GC_US",
+                "OOT_VERSION=GC_US",
                 "OOT_REGION=REGION_US",
                 "PLATFORM_N64=0",
                 "PLATFORM_GC=1",
@@ -129,7 +129,7 @@
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_GC_US_MQ",
+                "OOT_VERSION=GC_US_MQ",
                 "OOT_REGION=REGION_US",
                 "PLATFORM_N64=0",
                 "PLATFORM_GC=1",
@@ -158,7 +158,7 @@
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_GC_EU_MQ_DBG",
+                "OOT_VERSION=GC_EU_MQ_DBG",
                 "OOT_REGION=REGION_EU",
                 "PLATFORM_N64=0",
                 "PLATFORM_GC=1",
@@ -187,7 +187,7 @@
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_GC_EU",
+                "OOT_VERSION=GC_EU",
                 "OOT_REGION=REGION_EU",
                 "PLATFORM_N64=0",
                 "PLATFORM_GC=1",
@@ -216,7 +216,7 @@
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_GC_EU_MQ",
+                "OOT_VERSION=GC_EU_MQ",
                 "OOT_REGION=REGION_EU",
                 "PLATFORM_N64=0",
                 "PLATFORM_GC=1",
@@ -245,7 +245,7 @@
             ],
             "defines": [
                 "_LANGUAGE_C",
-                "OOT_VERSION=OOT_GC_JP_CE",
+                "OOT_VERSION=GC_JP_CE",
                 "OOT_REGION=REGION_JP",
                 "PLATFORM_N64=0",
                 "PLATFORM_GC=1",

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -60,7 +60,7 @@ A more complete `c_cpp_properties.json` with configurations for all supported ve
             "defines": [
                 "_LANGUAGE_C", // For gbi.h
                 // Version-specific
-                "OOT_VERSION=OOT_GC_EU_MQ_DBG",
+                "OOT_VERSION=GC_EU_MQ_DBG",
                 "OOT_REGION=REGION_EU",
                 "PLATFORM_N64=0",
                 "PLATFORM_GC=1",

--- a/include/versions.h
+++ b/include/versions.h
@@ -2,18 +2,18 @@
 #define VERSIONS_H
 
 // OOT versions in build order
-#define NTSC_1_0 1
-#define NTSC_1_1 2
-#define PAL_1_0 3
-#define NTSC_1_2 4
-#define PAL_1_1 5
-#define GC_JP 6
-#define GC_JP_MQ 7
-#define GC_US 8
-#define GC_US_MQ 9
-#define GC_EU_MQ_DBG 10
-#define GC_EU 11
-#define GC_EU_MQ 12
-#define GC_JP_CE 13
+#define NTSC_1_0       1
+#define NTSC_1_1       2
+#define PAL_1_0        3
+#define NTSC_1_2       4
+#define PAL_1_1        5
+#define GC_JP          6
+#define GC_JP_MQ       7
+#define GC_US          8
+#define GC_US_MQ       9
+#define GC_EU_MQ_DBG  10
+#define GC_EU         11
+#define GC_EU_MQ      12
+#define GC_JP_CE      13
 
 #endif

--- a/include/versions.h
+++ b/include/versions.h
@@ -2,14 +2,18 @@
 #define VERSIONS_H
 
 // OOT versions in build order
-#define OOT_NTSC_1_2 1
-#define OOT_GC_JP 2
-#define OOT_GC_JP_MQ 3
-#define OOT_GC_US 4
-#define OOT_GC_US_MQ 5
-#define OOT_GC_EU_MQ_DBG 6
-#define OOT_GC_EU 7
-#define OOT_GC_EU_MQ 8
-#define OOT_GC_JP_CE 9
+#define OOT_NTSC_1_0 1
+#define OOT_NTSC_1_1 2
+#define OOT_PAL_1_0 3
+#define OOT_NTSC_1_2 4
+#define OOT_PAL_1_1 5
+#define OOT_GC_JP 6
+#define OOT_GC_JP_MQ 7
+#define OOT_GC_US 8
+#define OOT_GC_US_MQ 9
+#define OOT_GC_EU_MQ_DBG 10
+#define OOT_GC_EU 11
+#define OOT_GC_EU_MQ 12
+#define OOT_GC_JP_CE 13
 
 #endif

--- a/include/versions.h
+++ b/include/versions.h
@@ -2,18 +2,18 @@
 #define VERSIONS_H
 
 // OOT versions in build order
-#define OOT_NTSC_1_0 1
-#define OOT_NTSC_1_1 2
-#define OOT_PAL_1_0 3
-#define OOT_NTSC_1_2 4
-#define OOT_PAL_1_1 5
-#define OOT_GC_JP 6
-#define OOT_GC_JP_MQ 7
-#define OOT_GC_US 8
-#define OOT_GC_US_MQ 9
-#define OOT_GC_EU_MQ_DBG 10
-#define OOT_GC_EU 11
-#define OOT_GC_EU_MQ 12
-#define OOT_GC_JP_CE 13
+#define NTSC_1_0 1
+#define NTSC_1_1 2
+#define PAL_1_0 3
+#define NTSC_1_2 4
+#define PAL_1_1 5
+#define GC_JP 6
+#define GC_JP_MQ 7
+#define GC_US 8
+#define GC_US_MQ 9
+#define GC_EU_MQ_DBG 10
+#define GC_EU 11
+#define GC_EU_MQ 12
+#define GC_JP_CE 13
 
 #endif

--- a/src/boot/build.c
+++ b/src/boot/build.c
@@ -6,23 +6,23 @@ const char gBuildTeam[] = "zelda@srd44";
 const char gBuildTeam[] = "zelda@srd022j";
 #endif
 
-#if OOT_VERSION == OOT_NTSC_1_2
+#if OOT_VERSION == NTSC_1_2
 const char gBuildDate[] = "98-11-12 18:17:03";
-#elif OOT_VERSION == OOT_GC_JP
+#elif OOT_VERSION == GC_JP
 const char gBuildDate[] = "02-10-29 23:49:53";
-#elif OOT_VERSION == OOT_GC_JP_MQ
+#elif OOT_VERSION == GC_JP_MQ
 const char gBuildDate[] = "02-10-30 00:15:15";
-#elif OOT_VERSION == OOT_GC_US
+#elif OOT_VERSION == GC_US
 const char gBuildDate[] = "02-12-19 13:28:09";
-#elif OOT_VERSION == OOT_GC_US_MQ
+#elif OOT_VERSION == GC_US_MQ
 const char gBuildDate[] = "02-12-19 14:05:42";
-#elif OOT_VERSION == OOT_GC_EU_MQ_DBG
+#elif OOT_VERSION == GC_EU_MQ_DBG
 const char gBuildDate[] = "03-02-21 00:16:31";
-#elif OOT_VERSION == OOT_GC_EU
+#elif OOT_VERSION == GC_EU
 const char gBuildDate[] = "03-02-21 20:12:23";
-#elif OOT_VERSION == OOT_GC_EU_MQ
+#elif OOT_VERSION == GC_EU_MQ
 const char gBuildDate[] = "03-02-21 20:37:19";
-#elif OOT_VERSION == OOT_GC_JP_CE
+#elif OOT_VERSION == GC_JP_CE
 const char gBuildDate[] = "03-10-08 21:53:00";
 #else
 #error "Unsupported OOT_VERSION"

--- a/src/code/z_common_data.c
+++ b/src/code/z_common_data.c
@@ -23,16 +23,16 @@ void SaveContext_Init(void) {
     gSaveContext.dogIsLost = true;
     gSaveContext.nextTransitionType = TRANS_NEXT_TYPE_DEFAULT;
     gSaveContext.prevHudVisibilityMode = HUD_VISIBILITY_ALL;
-#if OOT_NTSC && OOT_VERSION < OOT_GC_US
+#if OOT_NTSC && OOT_VERSION < GC_US
     if (gCurrentRegion == REGION_JP) {
         gSaveContext.language = LANGUAGE_JPN;
     }
     if (gCurrentRegion == REGION_US) {
         gSaveContext.language = LANGUAGE_ENG;
     }
-#elif OOT_VERSION == OOT_GC_US || OOT_VERSION == OOT_GC_US_MQ
+#elif OOT_VERSION == GC_US || OOT_VERSION == GC_US_MQ
     gSaveContext.language = LANGUAGE_ENG;
-#elif OOT_VERSION == OOT_GC_JP_CE
+#elif OOT_VERSION == GC_JP_CE
     gSaveContext.language = LANGUAGE_JPN;
 #endif
 }

--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -3853,7 +3853,7 @@ void Message_DrawDebugText(PlayState* play, Gfx** p) {
 void Message_Draw(PlayState* play) {
     Gfx* plusOne;
     Gfx* polyOpaP;
-#if OOT_VERSION < OOT_GC_US
+#if OOT_VERSION < GC_US
     s32 pad;
 #endif
 #if OOT_DEBUG
@@ -3905,7 +3905,7 @@ void Message_Update(PlayState* play) {
         0x0400, 0x0400, 0x0200, 0x0000, 0x1038, 0x0008, 0x200A, 0x088B, 0x0007, 0x0009, 0x000A, 0x107E, 0x2008, 0x2007,
         0x0015, 0x0016, 0x0017, 0x0003, 0x0000, 0x270B, 0x00C8, 0x012C, 0x012D, 0xFFDA, 0x0014, 0x0016, 0x0014, 0x0016,
     };
-#if OOT_VERSION < OOT_GC_US
+#if OOT_VERSION < GC_US
     static s32 sUnknown = 0;
 #endif
     static u8 D_80153D74 = 0;
@@ -3918,7 +3918,7 @@ void Message_Update(PlayState* play) {
     s16 averageY;
     s16 playerFocusScreenPosY;
     s16 actorFocusScreenPosY;
-#if OOT_VERSION < OOT_GC_US
+#if OOT_VERSION < GC_US
     s32 pad[2];
 #endif
 

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -171,9 +171,9 @@ void Play_SetupTransition(PlayState* this, s32 transitionType) {
                 break;
 
             default:
-#if OOT_VERSION < OOT_GC_EU_MQ_DBG
+#if OOT_VERSION < GC_EU_MQ_DBG
                 HUNGUP_AND_CRASH("../z_play.c", 2287);
-#elif OOT_VERSION < OOT_GC_JP_CE
+#elif OOT_VERSION < GC_JP_CE
                 HUNGUP_AND_CRASH("../z_play.c", 2290);
 #else
                 HUNGUP_AND_CRASH("../z_play.c", 2293);

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -32,7 +32,7 @@ ActorProfile En_Mag_Profile = {
 
 static s16 sDelayTimer = 0;
 
-#if OOT_VERSION < OOT_GC_US
+#if OOT_VERSION < GC_US
 void EnMag_ResetSram(void) {
     static u8 buffer[0x2000];
 
@@ -141,7 +141,7 @@ void EnMag_Init(Actor* thisx, PlayState* play) {
 void EnMag_Destroy(Actor* thisx, PlayState* play) {
 }
 
-#if OOT_VERSION < OOT_GC_US
+#if OOT_VERSION < GC_US
 void EnMag_CheckSramResetCode(PlayState* play, EnMag* this) {
     static s32 sSramResetCode[] = {
         BTN_DUP, BTN_DDOWN,  BTN_DLEFT, BTN_DRIGHT, BTN_START, BTN_B, BTN_CDOWN,
@@ -189,7 +189,7 @@ void EnMag_Update(Actor* thisx, PlayState* play) {
     s32 pad[2];
     EnMag* this = (EnMag*)thisx;
 
-#if OOT_VERSION < OOT_GC_US
+#if OOT_VERSION < GC_US
     EnMag_CheckSramResetCode(play, this);
 #endif
 
@@ -626,9 +626,9 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
 #if OOT_MQ
         gDPPipeSync(gfx++);
         gDPSetPrimColor(gfx++, 0, 0, 255, 255, 255, (s16)this->subAlpha);
-#if OOT_VERSION == OOT_GC_JP_MQ
+#if OOT_VERSION == GC_JP_MQ
         EnMag_DrawImageRGBA32(&gfx, 235, 149, (u8*)gTitleUraLogoTex, 40, 40);
-#elif OOT_VERSION == OOT_GC_US_MQ
+#elif OOT_VERSION == GC_US_MQ
         if (gSaveContext.language == LANGUAGE_JPN) {
             EnMag_DrawImageRGBA32(&gfx, 235, 149, (u8*)gTitleUraLogoTex, 40, 40);
         } else {
@@ -688,7 +688,7 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
         gDPLoadTextureBlock(gfx++, gTitleCopyright1998Tex, G_IM_FMT_IA, G_IM_SIZ_8b, 128, 16, 0,
                             G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
                             G_TX_NOLOD, G_TX_NOLOD);
-#elif OOT_VERSION < OOT_GC_US
+#elif OOT_VERSION < GC_US
         gDPLoadTextureBlock(gfx++, gTitleCopyright19982002Tex, G_IM_FMT_IA, G_IM_SIZ_8b, 160, 16, 0,
                             G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
                             G_TX_NOLOD, G_TX_NOLOD);

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -809,7 +809,7 @@ static s16 sQuestItemGreen[] = { 255, 255, 255, 255, 60, 100, 130, 50, 200 };
 static s16 sQuestItemBlue[] = { 255, 255, 255, 0, 0, 255, 0, 255, 0 };
 static s16 sQuestItemFlags[] = { 0x0012, 0x0013, 0x0014, 0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005 };
 
-#if OOT_NTSC && OOT_VERSION < OOT_GC_JP_CE
+#if OOT_NTSC && OOT_VERSION < GC_JP_CE
 static void* sSaveXTextures[] = { gFileSelSaveXJPNTex, gFileSelSaveXENGTex };
 #endif
 

--- a/src/overlays/gamestates/ovl_title/z_title.c
+++ b/src/overlays/gamestates/ovl_title/z_title.c
@@ -226,7 +226,7 @@ void ConsoleLogo_Init(GameState* thisx) {
     this->state.destroy = ConsoleLogo_Destroy;
     this->exit = false;
 
-#if OOT_VERSION < OOT_GC_US
+#if OOT_VERSION < GC_US
     if (!(gPadMgr.validCtrlrsMask & 1)) {
         gSaveContext.fileNum = 0xFEDC;
     } else {


### PR DESCRIPTION
We're going to need these soon anyway, and it's nice to have now for documentation purposes (i.e. changes we know were between NTSC 1.2 and PAL 1.1).

I also removed the `OOT_` prefix because I think it's ugly and doesn't add anything here. Lmk if I should split this into another PR though