### PR TITLE
[ntsc-1.2] Match z_game_over.c, PAL 1.1 fixes

### DIFF
--- a/src/code/z_game_over.c
+++ b/src/code/z_game_over.c
@@ -61,7 +61,12 @@ void GameOver_Update(PlayState* play) {
                 }
             }
 
+#if OOT_VERSION < PAL_1_1
+            gSaveContext.nayrusLoveTimer = 0;
+#else
             gSaveContext.nayrusLoveTimer = 2000;
+#endif
+
             gSaveContext.save.info.playerData.naviTimer = 0;
             gSaveContext.seqId = (u8)NA_BGM_DISABLED;
             gSaveContext.natureAmbienceId = NATURE_ID_DISABLED;

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -237,10 +237,10 @@ s32 EnGe3_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* p
         // Turn head
         case GELDB_LIMB_HEAD:
             rot->x += this->headRot.y;
-#if PLATFORM_GC
+#if OOT_VERSION >= PAL_1_1
             FALLTHROUGH;
-        // This is a hack to fix the color-changing clothes this Gerudo has on N64 versions
         default:
+            // This is a hack to fix the color-changing clothes this Gerudo has on before below PAL 1.1
             OPEN_DISPS(play->state.gfxCtx, "../z_en_ge3.c", 547);
             switch (limbIndex) {
                 case GELDB_LIMB_NECK:

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1577,7 +1577,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
                     this->actionFunc = EnGo2_CurledUp;
                 }
             } else {
-#if PLATFORM_GC
+#if OOT_VERSION >= PAL_1_1
                 CLEAR_INFTABLE(INFTABLE_10C);
 #endif
                 this->collider.dim.height = (D_80A4816C[PARAMS_GET_S(this->actor.params, 0, 5)].height * 0.6f);


### PR DESCRIPTION
The z_game_over.c change fixes the "Nayru's Love crash": https://www.youtube.com/watch?v=HLsbXliEHEI
I didn't comment on the bug though because I don't fully understand the details (something like other magic items check `gSaveContext.nayrusLoveTimer != 0` to decide when to activate but NL could still be active, and things get crashy because all magic items share the same memory space?)

I checked disassembly for z_en_go3 (rolling goron says wrong text if you stop him, reload the area, then talk to him) and z_en_ge3 (Gerudo's color-changing clothes) to confirm these were PAL 1.1 changes as well (thanks Fig for pointing these out)