### PR TITLE
[ntsc-1.2] Fix some data / disassembly / undefined_syms

### DIFF
--- a/src/boot/cic6105.c
+++ b/src/boot/cic6105.c
@@ -2,10 +2,6 @@
 #include "cic6105.h"
 #include "fault.h"
 
-// TODO N64 fault.c functions
-void func_800AE1E0_unknown(s32, s32);
-void func_800AE258_unknown(const char*, ...);
-
 s32 func_80001714(void);
 
 extern u64 cic6105ucodeTextStart[];
@@ -32,19 +28,19 @@ void CIC6105_FaultClient(void) {
     s32 spStatus;
 
     spStatus = IO_READ(SP_STATUS_REG);
-    func_800AE1E0_unknown(48, 200);
+    Fault_SetCursor(48, 200);
     if (spStatus & SP_STATUS_SIG7) {
-        func_800AE258_unknown("OCARINA %08x %08x", B_80008EF8, B_80008EFC);
+        Fault_Printf("OCARINA %08x %08x", B_80008EF8, B_80008EFC);
     } else {
-        func_800AE258_unknown("LEGEND %08x %08x", B_80008EF8, B_80008EFC);
+        Fault_Printf("LEGEND %08x %08x", B_80008EF8, B_80008EFC);
     }
-    func_800AE1E0_unknown(40, 184);
-    func_800AE258_unknown("ROM_F");
-    func_800AE258_unknown(" [Creator:%s]", gBuildTeam);
-    func_800AE1E0_unknown(56, 192);
-    func_800AE258_unknown("[Date:%s]", gBuildDate);
-    func_800AE1E0_unknown(96, 32);
-    func_800AE258_unknown("I LOVE YOU %08x", func_80001714());
+    Fault_SetCursor(40, 184);
+    Fault_Printf("ROM_F");
+    Fault_Printf(" [Creator:%s]", gBuildTeam);
+    Fault_SetCursor(56, 192);
+    Fault_Printf("[Date:%s]", gBuildDate);
+    Fault_SetCursor(96, 32);
+    Fault_Printf("I LOVE YOU %08x", func_80001714());
 }
 
 void CIC6105_AddFaultClient(void) {

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -82,7 +82,7 @@ const char* sFpExceptionNames[] = {
 };
 
 u16 sFaultFontColor = GPACK_RGBA5551(255, 255, 255, 1);
-s32 D_800FF9C4[7] = {0}; // Unused (file padding?)
+s32 D_800FF9C4[7] = { 0 }; // Unused (file padding?)
 
 Input sFaultInputs[MAXCONTROLLERS];
 

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -82,6 +82,7 @@ const char* sFpExceptionNames[] = {
 };
 
 u16 sFaultFontColor = GPACK_RGBA5551(255, 255, 255, 1);
+s32 D_800FF9C4[7] = {0}; // Unused (file padding?)
 
 Input sFaultInputs[MAXCONTROLLERS];
 
@@ -95,7 +96,8 @@ vs32 sFaultExit;
 vs32 gFaultMsgId;
 vs32 sFaultDisplayEnable;
 OSThread* sFaultFaultedThread;
-s32 B_80122570[0x10];
+s32 B_80122570[16];
+s32 B_801225B0[8]; // Unused (file padding?)
 
 void Fault_SleepImpl(u32 ms) {
     Sleep_Msec(ms);

--- a/tools/disasm/ntsc-1.2/files_code.csv
+++ b/tools/disasm/ntsc-1.2/files_code.csv
@@ -276,7 +276,7 @@ EDD90,800FF470,src/code/sys_ucode
 EDDA0,800FF480,src/code/sys_rumble
 EDDB0,800FF490,src/code/irqmgr
 EDDD0,800FF4B0,src/code/code_n64dd_800AD4C0
-EE280,800FF960,src/code/fault_n64
+EDE80,800FF560,src/code/fault_n64
 EE300,800FF9E0,src/audio/lib/data
 F0710,80101DF0,src/audio/lib/synthesis
 F0740,80101E20,src/audio/lib/load
@@ -445,6 +445,7 @@ offset,vram,.bss
 110FB0,80122690,src/audio/general
 1111B0,80122890,src/audio/sfx
 1139C0,801250A0,src/audio/sequence
+1146E0,80125DC0,src/audio/data
 114780,80125E60,src/audio/session_config
 11AC90,8012C370,src/code/system_malloc
 11ACA0,8012C380,src/code/jpegdecoder

--- a/undefined_syms.txt
+++ b/undefined_syms.txt
@@ -18,8 +18,6 @@ osInitialize = 0x80003230;
 
 // cic6105.c
 cic6105ucodeTextStart = 0x80006720;
-func_800AE258_unknown = 0x800AE258;
-func_800AE1E0_unknown = 0x800AE1E0;
 
 // code_n64dd_800AD410.c
 osGetIntMask = 0x800CFBB0;


### PR DESCRIPTION
Fault splits were just wrong (sFaultDrawerFont in wrong file) and audio splits are due to #2085.

fault_n64.c bss size is technically still wrong but it should be right after bss ordering is fixed (currently `gFaultMsgId` reordered due to being declared extern in a header)