### PR TITLE
[ntsc-1.2] Match padmgr.c, sys_cfb.c, rcp_utils.c

### DIFF
--- a/src/code/padmgr.c
+++ b/src/code/padmgr.c
@@ -395,7 +395,7 @@ void PadMgr_HandleRetrace(PadMgr* padMgr) {
                 } else {
                     LOG_HEX("this->pad_status[i].type", padMgr->padStatus[i].type, "../padmgr.c", 458);
                     PRINTF(T("知らない種類のコントローラが接続されています\n",
-                            "An unknown type of controller is connected\n"));
+                             "An unknown type of controller is connected\n"));
                 }
             }
         }

--- a/src/code/padmgr.c
+++ b/src/code/padmgr.c
@@ -237,7 +237,7 @@ void PadMgr_RumbleStop(PadMgr* padMgr) {
         if (osMotorInit(serialEventQueue, &padMgr->rumblePfs[i], i) == 0) {
             // If there is a rumble pak attached to this controller, stop it
 
-            if (FAULT_MSG_ID == 0 && padMgr->rumbleOnTimer != 0) {
+            if (!FAULT_MSG_ID && padMgr->rumbleOnTimer != 0) {
                 PADMGR_LOG(i, T("振動パック 停止", "Stop rumble pak"));
             }
             osMotorStop(&padMgr->rumblePfs[i]);
@@ -348,8 +348,6 @@ void PadMgr_UpdateInputs(PadMgr* padMgr) {
 
 void PadMgr_HandleRetrace(PadMgr* padMgr) {
     OSMesgQueue* serialEventQueue = PadMgr_AcquireSerialEventQueue(padMgr);
-    u32 mask;
-    s32 i;
 
     // Begin reading controller data
     osContStartReadData(serialEventQueue);
@@ -384,21 +382,25 @@ void PadMgr_HandleRetrace(PadMgr* padMgr) {
 
     PadMgr_ReleaseSerialEventQueue(padMgr, serialEventQueue);
 
-    // Update the state of connected controllers
-    mask = 0;
-    for (i = 0; i < MAXCONTROLLERS; i++) {
-        if (padMgr->padStatus[i].errno == 0) {
-            // Only standard N64 controllers are supported
-            if (padMgr->padStatus[i].type == CONT_TYPE_NORMAL) {
-                mask |= 1 << i;
-            } else {
-                LOG_HEX("this->pad_status[i].type", padMgr->padStatus[i].type, "../padmgr.c", 458);
-                PRINTF(T("知らない種類のコントローラが接続されています\n",
-                         "An unknown type of controller is connected\n"));
+    {
+        u32 mask = 0;
+        s32 i;
+
+        // Update the state of connected controllers
+        for (i = 0; i < MAXCONTROLLERS; i++) {
+            if (padMgr->padStatus[i].errno == 0) {
+                // Only standard N64 controllers are supported
+                if (padMgr->padStatus[i].type == CONT_TYPE_NORMAL) {
+                    mask |= 1 << i;
+                } else {
+                    LOG_HEX("this->pad_status[i].type", padMgr->padStatus[i].type, "../padmgr.c", 458);
+                    PRINTF(T("知らない種類のコントローラが接続されています\n",
+                            "An unknown type of controller is connected\n"));
+                }
             }
         }
+        padMgr->validCtrlrsMask = mask;
     }
-    padMgr->validCtrlrsMask = mask;
 
     if (FAULT_MSG_ID != 0) {
         // If fault is active, no rumble

--- a/src/code/rcp_utils.c
+++ b/src/code/rcp_utils.c
@@ -1,18 +1,26 @@
 #include "global.h"
 
+#if PLATFORM_N64 || OOT_DEBUG
+#define RCP_UTILS_PRINTF osSyncPrintf
+#elif IDO_PRINTF_WORKAROUND
+#define RCP_UTILS_PRINTF(args) (void)0
+#else
+#define RCP_UTILS_PRINTF(format, ...) (void)0
+#endif
+
 #define printSpStatus(x, name) \
     if (x & SP_STATUS_##name)  \
-    PRINTF(#name " ")
+    RCP_UTILS_PRINTF(#name " ")
 
 #define printDpStatus(x, name) \
     if (x & DPC_STATUS_##name) \
-    PRINTF(#name " ")
+    RCP_UTILS_PRINTF(#name " ")
 
 void RcpUtils_PrintRegisterStatus(void) {
     u32 spStatus = __osSpGetStatus();
     u32 dpStatus = osDpGetStatus();
 
-    PRINTF("osSpGetStatus=%08x: ", spStatus);
+    RCP_UTILS_PRINTF("osSpGetStatus=%08x: ", spStatus);
     printSpStatus(spStatus, HALT);
     printSpStatus(spStatus, BROKE);
     printSpStatus(spStatus, DMA_BUSY);
@@ -28,9 +36,9 @@ void RcpUtils_PrintRegisterStatus(void) {
     printSpStatus(spStatus, SIG5);
     printSpStatus(spStatus, SIG6);
     printSpStatus(spStatus, SIG7);
-    PRINTF("\n");
+    RCP_UTILS_PRINTF("\n");
 
-    PRINTF("osDpGetStatus=%08x:", dpStatus);
+    RCP_UTILS_PRINTF("osDpGetStatus=%08x:", dpStatus);
     printDpStatus(dpStatus, XBUS_DMEM_DMA);
     printDpStatus(dpStatus, FREEZE);
     printDpStatus(dpStatus, FLUSH);
@@ -42,7 +50,7 @@ void RcpUtils_PrintRegisterStatus(void) {
     printDpStatus(dpStatus, DMA_BUSY);
     printDpStatus(dpStatus, END_VALID);
     printDpStatus(dpStatus, START_VALID);
-    PRINTF("\n");
+    RCP_UTILS_PRINTF("\n");
 }
 
 void RcpUtils_Reset(void) {

--- a/src/code/sys_cfb.c
+++ b/src/code/sys_cfb.c
@@ -32,7 +32,11 @@ void SysCfb_Init(s32 n64dd) {
         PRINTF("RAM4M mode\n");
         sSysCfbEnd = 0x80400000;
     } else {
+#if PLATFORM_N64
+        LogUtils_HungupThread("../sys_cfb.c", 322);
+#else
         LogUtils_HungupThread("../sys_cfb.c", 354);
+#endif
     }
 
     screenSize = SCREEN_WIDTH * SCREEN_HEIGHT;


### PR DESCRIPTION
It seems like `FAULT_MSG_ID == 0` wasn't loading `FAULT_MSG_ID` even though it's volatile. Seems like a compiler bug?

For the second padmgr function, a fake label before `if (FAULT_MSG_ID != 0)` matches too but I thought using a scope was a bit better