### PR TITLE
Rename FaultDrawer_ functions to Fault_

### DIFF
--- a/include/fault.h
+++ b/include/fault.h
@@ -79,6 +79,7 @@ void Fault_DrawText(s32 x, s32 y, const char* fmt, ...);
 
 #elif FAULT_VERSION == FAULT_GC
 
+void Fault_InitDrawer(void);
 void Fault_SetForeColor(u16 color);
 void Fault_SetBackColor(u16 color);
 void Fault_SetFontColor(u16 color);

--- a/include/fault.h
+++ b/include/fault.h
@@ -67,29 +67,23 @@ void Fault_SetFrameBuffer(void* fb, u16 w, u16 h);
 
 void Fault_WaitForInput(void);
 
-#if FAULT_VERSION == FAULT_N64
-
-// Not implemented. Silently noop-ing is fine, these are not essential for functionality.
-#define FaultDrawer_SetFontColor(color) (void)0
-#define FaultDrawer_SetCharPad(padW, padH) (void)0
-
 void Fault_SetCursor(s32 x, s32 y);
 s32 Fault_Printf(const char* fmt, ...);
 void Fault_DrawText(s32 x, s32 y, const char* fmt, ...);
-#define FaultDrawer_SetCursor Fault_SetCursor
-#define FaultDrawer_Printf Fault_Printf
-#define FaultDrawer_DrawText Fault_DrawText
+
+#if FAULT_VERSION == FAULT_N64
+
+// Not implemented. Silently noop-ing is fine, these are not essential for functionality.
+#define Fault_SetFontColor(color) (void)0
+#define Fault_SetCharPad(padW, padH) (void)0
 
 #elif FAULT_VERSION == FAULT_GC
 
-void FaultDrawer_SetForeColor(u16 color);
-void FaultDrawer_SetBackColor(u16 color);
-void FaultDrawer_SetFontColor(u16 color);
-void FaultDrawer_SetCharPad(s8 padW, s8 padH);
-void FaultDrawer_SetCursor(s32 x, s32 y);
-s32 FaultDrawer_VPrintf(const char* fmt, va_list args);
-s32 FaultDrawer_Printf(const char* fmt, ...);
-void FaultDrawer_DrawText(s32 x, s32 y, const char* fmt, ...);
+void Fault_SetForeColor(u16 color);
+void Fault_SetBackColor(u16 color);
+void Fault_SetFontColor(u16 color);
+void Fault_SetCharPad(s8 padW, s8 padH);
+s32 Fault_VPrintf(const char* fmt, va_list args);
 
 #endif
 

--- a/src/boot/cic6105.c
+++ b/src/boot/cic6105.c
@@ -28,19 +28,19 @@ void CIC6105_FaultClient(void) {
     s32 spStatus;
 
     spStatus = IO_READ(SP_STATUS_REG);
-    FaultDrawer_SetCursor(48, 200);
+    Fault_SetCursor(48, 200);
     if (spStatus & SP_STATUS_SIG7) {
-        FaultDrawer_Printf("OCARINA %08x %08x", B_80008EF8, B_80008EFC);
+        Fault_Printf("OCARINA %08x %08x", B_80008EF8, B_80008EFC);
     } else {
-        FaultDrawer_Printf("LEGEND %08x %08x", B_80008EF8, B_80008EFC);
+        Fault_Printf("LEGEND %08x %08x", B_80008EF8, B_80008EFC);
     }
-    FaultDrawer_SetCursor(40, 184);
-    FaultDrawer_Printf("ROM_F");
-    FaultDrawer_Printf(" [Creator:%s]", gBuildTeam);
-    FaultDrawer_SetCursor(56, 192);
-    FaultDrawer_Printf("[Date:%s]", gBuildDate);
-    FaultDrawer_SetCursor(96, 32);
-    FaultDrawer_Printf("I LOVE YOU %08x", func_80001714());
+    Fault_SetCursor(40, 184);
+    Fault_Printf("ROM_F");
+    Fault_Printf(" [Creator:%s]", gBuildTeam);
+    Fault_SetCursor(56, 192);
+    Fault_Printf("[Date:%s]", gBuildDate);
+    Fault_SetCursor(96, 32);
+    Fault_Printf("I LOVE YOU %08x", func_80001714());
 }
 
 void CIC6105_AddFaultClient(void) {

--- a/src/code/__osMalloc.c
+++ b/src/code/__osMalloc.c
@@ -805,9 +805,9 @@ void ArenaImpl_FaultClient(Arena* arena) {
     ArenaNode* iter;
     ArenaNode* next;
 
-    FaultDrawer_Printf("ARENA INFO (0x%08x)\n", arena);
+    Fault_Printf("ARENA INFO (0x%08x)\n", arena);
     if (!__osMallocIsInitialized(arena)) {
-        FaultDrawer_Printf("Arena is uninitalized\n", arena);
+        Fault_Printf("Arena is uninitalized\n", arena);
         return;
     }
 
@@ -815,16 +815,16 @@ void ArenaImpl_FaultClient(Arena* arena) {
     freeSize = 0;
     allocatedSize = 0;
 
-    FaultDrawer_Printf("Memory Block Region status size\n");
+    Fault_Printf("Memory Block Region status size\n");
 
     iter = arena->head;
     while (iter != NULL) {
         if (iter != NULL && iter->magic == NODE_MAGIC) {
             next = iter->next;
-            FaultDrawer_Printf("%08x-%08x%c %s %08x", iter, ((u32)iter + sizeof(ArenaNode) + iter->size),
-                               (!next) ? '$' : (iter != next->prev ? '!' : ' '), iter->isFree ? "F" : "A", iter->size);
+            Fault_Printf("%08x-%08x%c %s %08x", iter, ((u32)iter + sizeof(ArenaNode) + iter->size),
+                         (!next) ? '$' : (iter != next->prev ? '!' : ' '), iter->isFree ? "F" : "A", iter->size);
 
-            FaultDrawer_Printf("\n");
+            Fault_Printf("\n");
 
             if (iter->isFree) {
                 freeSize += iter->size;
@@ -835,17 +835,17 @@ void ArenaImpl_FaultClient(Arena* arena) {
                 allocatedSize += iter->size;
             }
         } else {
-            FaultDrawer_SetFontColor(0xF801);
-            FaultDrawer_Printf("%08x Block Invalid\n", iter);
+            Fault_SetFontColor(0xF801);
+            Fault_Printf("%08x Block Invalid\n", iter);
             next = NULL;
         }
         iter = next;
     }
 
-    FaultDrawer_SetFontColor(0x7F1);
-    FaultDrawer_Printf("Total Alloc Block Size  %08x\n", allocatedSize);
-    FaultDrawer_Printf("Total Free Block Size   %08x\n", freeSize);
-    FaultDrawer_Printf("Largest Free Block Size %08x\n", maxFree);
+    Fault_SetFontColor(0x7F1);
+    Fault_Printf("Total Alloc Block Size  %08x\n", allocatedSize);
+    Fault_Printf("Total Free Block Size   %08x\n", freeSize);
+    Fault_Printf("Largest Free Block Size %08x\n", maxFree);
 }
 
 u32 __osCheckArena(Arena* arena) {

--- a/src/code/code_n64dd_800AD4C0.c
+++ b/src/code/code_n64dd_800AD4C0.c
@@ -13,7 +13,7 @@ n64ddStruct_800FF4B0_pointers D_800FF4B0 = {
     NULL,
     Fault_RemoveClient,
     Fault_AddClient,
-    FaultDrawer_DrawText,
+    Fault_DrawText,
     Fault_WaitForInput,
     Fault_AddHungupAndCrashImpl,
     Fault_AddHungupAndCrash,

--- a/src/code/fault_gc.c
+++ b/src/code/fault_gc.c
@@ -1277,7 +1277,7 @@ void Fault_SetFrameBuffer(void* fb, u16 w, u16 h) {
 void Fault_Init(void) {
     sFaultInstance = &gFaultMgr;
     bzero(sFaultInstance, sizeof(FaultMgr));
-    Fault_Init();
+    Fault_InitDrawer();
     Fault_SetInputCallback(Fault_WaitForInput);
     sFaultInstance->exit = false;
     sFaultInstance->msgId = 0;

--- a/src/code/fault_gc.c
+++ b/src/code/fault_gc.c
@@ -55,12 +55,12 @@
 #pragma increment_block_number "gc-eu:64 gc-eu-mq:64 gc-eu-mq-dbg:222 gc-jp:64 gc-jp-ce:64 gc-jp-mq:64 gc-us:64" \
                                "gc-us-mq:64"
 
-void FaultDrawer_Init(void);
-void FaultDrawer_SetOsSyncPrintfEnabled(u32 enabled);
-void FaultDrawer_DrawRecImpl(s32 xStart, s32 yStart, s32 xEnd, s32 yEnd, u16 color);
-void FaultDrawer_FillScreen(void);
-void FaultDrawer_SetInputCallback(void (*callback)(void));
-void FaultDrawer_SetDrawerFB(void* fb, u16 w, u16 h);
+void Fault_Init(void);
+void Fault_SetOsSyncPrintfEnabled(u32 enabled);
+void Fault_DrawRecImpl(s32 xStart, s32 yStart, s32 xEnd, s32 yEnd, u16 color);
+void Fault_FillScreen(void);
+void Fault_SetInputCallback(void (*callback)(void));
+void Fault_SetDrawerFB(void* fb, u16 w, u16 h);
 
 const char* sExceptionNames[] = {
     "Interrupt",
@@ -421,11 +421,11 @@ u32 Fault_WaitForInputImpl(void) {
             }
 
             if (pressedBtn == BTN_DUP) {
-                FaultDrawer_SetOsSyncPrintfEnabled(true);
+                Fault_SetOsSyncPrintfEnabled(true);
             }
 
             if (pressedBtn == BTN_DDOWN) {
-                FaultDrawer_SetOsSyncPrintfEnabled(false);
+                Fault_SetOsSyncPrintfEnabled(false);
             }
         }
     }
@@ -438,21 +438,21 @@ void Fault_WaitForInput(void) {
 }
 
 void Fault_DrawRec(s32 x, s32 y, s32 w, s32 h, u16 color) {
-    FaultDrawer_DrawRecImpl(x, y, x + w - 1, y + h - 1, color);
+    Fault_DrawRecImpl(x, y, x + w - 1, y + h - 1, color);
 }
 
 void Fault_FillScreenBlack(void) {
-    FaultDrawer_SetForeColor(GPACK_RGBA5551(255, 255, 255, 1));
-    FaultDrawer_SetBackColor(GPACK_RGBA5551(0, 0, 0, 1));
-    FaultDrawer_FillScreen();
-    FaultDrawer_SetBackColor(GPACK_RGBA5551(0, 0, 0, 0));
+    Fault_SetForeColor(GPACK_RGBA5551(255, 255, 255, 1));
+    Fault_SetBackColor(GPACK_RGBA5551(0, 0, 0, 1));
+    Fault_FillScreen();
+    Fault_SetBackColor(GPACK_RGBA5551(0, 0, 0, 0));
 }
 
 void Fault_FillScreenRed(void) {
-    FaultDrawer_SetForeColor(GPACK_RGBA5551(255, 255, 255, 1));
-    FaultDrawer_SetBackColor(GPACK_RGBA5551(240, 0, 0, 1));
-    FaultDrawer_FillScreen();
-    FaultDrawer_SetBackColor(GPACK_RGBA5551(0, 0, 0, 0));
+    Fault_SetForeColor(GPACK_RGBA5551(255, 255, 255, 1));
+    Fault_SetBackColor(GPACK_RGBA5551(240, 0, 0, 1));
+    Fault_FillScreen();
+    Fault_SetBackColor(GPACK_RGBA5551(0, 0, 0, 0));
 }
 
 void Fault_DrawCornerRec(u16 color) {
@@ -464,10 +464,10 @@ void Fault_PrintFReg(s32 idx, f32* value) {
     s32 exp = ((raw & 0x7F800000) >> 23) - 127;
 
     if ((exp > -127 && exp <= 127) || raw == 0) {
-        FaultDrawer_Printf("F%02d:%14.7e ", idx, *value);
+        Fault_Printf("F%02d:%14.7e ", idx, *value);
     } else {
         // Print subnormal floats as their ieee-754 hex representation
-        FaultDrawer_Printf("F%02d:  %08x(16) ", idx, raw);
+        Fault_Printf("F%02d:  %08x(16) ", idx, raw);
     }
 }
 
@@ -486,18 +486,18 @@ void Fault_PrintFPCSR(u32 value) {
     s32 i;
     u32 flag = FPCSR_CE;
 
-    FaultDrawer_Printf("FPCSR:%08xH ", value);
+    Fault_Printf("FPCSR:%08xH ", value);
 
     // Go through each of the six causes and print the name of
     // the first cause that is set
     for (i = 0; i < ARRAY_COUNT(sFpExceptionNames); i++) {
         if (value & flag) {
-            FaultDrawer_Printf("(%s)", sFpExceptionNames[i]);
+            Fault_Printf("(%s)", sFpExceptionNames[i]);
             break;
         }
         flag >>= 1;
     }
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
 }
 
 void Fault_LogFPCSR(u32 value) {
@@ -525,55 +525,55 @@ void Fault_PrintThreadContext(OSThread* thread) {
         causeStrIdx = 17;
     }
 
-    FaultDrawer_FillScreen();
-    FaultDrawer_SetCharPad(-2, 4);
-    FaultDrawer_SetCursor(22, 20);
+    Fault_FillScreen();
+    Fault_SetCharPad(-2, 4);
+    Fault_SetCursor(22, 20);
 
     ctx = &thread->context;
-    FaultDrawer_Printf("THREAD:%d (%d:%s)\n", thread->id, causeStrIdx, sExceptionNames[causeStrIdx]);
-    FaultDrawer_SetCharPad(-1, 0);
+    Fault_Printf("THREAD:%d (%d:%s)\n", thread->id, causeStrIdx, sExceptionNames[causeStrIdx]);
+    Fault_SetCharPad(-1, 0);
 
-    FaultDrawer_Printf("PC:%08xH SR:%08xH VA:%08xH\n", (u32)ctx->pc, (u32)ctx->sr, (u32)ctx->badvaddr);
-    FaultDrawer_Printf("AT:%08xH V0:%08xH V1:%08xH\n", (u32)ctx->at, (u32)ctx->v0, (u32)ctx->v1);
-    FaultDrawer_Printf("A0:%08xH A1:%08xH A2:%08xH\n", (u32)ctx->a0, (u32)ctx->a1, (u32)ctx->a2);
-    FaultDrawer_Printf("A3:%08xH T0:%08xH T1:%08xH\n", (u32)ctx->a3, (u32)ctx->t0, (u32)ctx->t1);
-    FaultDrawer_Printf("T2:%08xH T3:%08xH T4:%08xH\n", (u32)ctx->t2, (u32)ctx->t3, (u32)ctx->t4);
-    FaultDrawer_Printf("T5:%08xH T6:%08xH T7:%08xH\n", (u32)ctx->t5, (u32)ctx->t6, (u32)ctx->t7);
-    FaultDrawer_Printf("S0:%08xH S1:%08xH S2:%08xH\n", (u32)ctx->s0, (u32)ctx->s1, (u32)ctx->s2);
-    FaultDrawer_Printf("S3:%08xH S4:%08xH S5:%08xH\n", (u32)ctx->s3, (u32)ctx->s4, (u32)ctx->s5);
-    FaultDrawer_Printf("S6:%08xH S7:%08xH T8:%08xH\n", (u32)ctx->s6, (u32)ctx->s7, (u32)ctx->t8);
-    FaultDrawer_Printf("T9:%08xH GP:%08xH SP:%08xH\n", (u32)ctx->t9, (u32)ctx->gp, (u32)ctx->sp);
-    FaultDrawer_Printf("S8:%08xH RA:%08xH LO:%08xH\n\n", (u32)ctx->s8, (u32)ctx->ra, (u32)ctx->lo);
+    Fault_Printf("PC:%08xH SR:%08xH VA:%08xH\n", (u32)ctx->pc, (u32)ctx->sr, (u32)ctx->badvaddr);
+    Fault_Printf("AT:%08xH V0:%08xH V1:%08xH\n", (u32)ctx->at, (u32)ctx->v0, (u32)ctx->v1);
+    Fault_Printf("A0:%08xH A1:%08xH A2:%08xH\n", (u32)ctx->a0, (u32)ctx->a1, (u32)ctx->a2);
+    Fault_Printf("A3:%08xH T0:%08xH T1:%08xH\n", (u32)ctx->a3, (u32)ctx->t0, (u32)ctx->t1);
+    Fault_Printf("T2:%08xH T3:%08xH T4:%08xH\n", (u32)ctx->t2, (u32)ctx->t3, (u32)ctx->t4);
+    Fault_Printf("T5:%08xH T6:%08xH T7:%08xH\n", (u32)ctx->t5, (u32)ctx->t6, (u32)ctx->t7);
+    Fault_Printf("S0:%08xH S1:%08xH S2:%08xH\n", (u32)ctx->s0, (u32)ctx->s1, (u32)ctx->s2);
+    Fault_Printf("S3:%08xH S4:%08xH S5:%08xH\n", (u32)ctx->s3, (u32)ctx->s4, (u32)ctx->s5);
+    Fault_Printf("S6:%08xH S7:%08xH T8:%08xH\n", (u32)ctx->s6, (u32)ctx->s7, (u32)ctx->t8);
+    Fault_Printf("T9:%08xH GP:%08xH SP:%08xH\n", (u32)ctx->t9, (u32)ctx->gp, (u32)ctx->sp);
+    Fault_Printf("S8:%08xH RA:%08xH LO:%08xH\n\n", (u32)ctx->s8, (u32)ctx->ra, (u32)ctx->lo);
 
     Fault_PrintFPCSR(ctx->fpcsr);
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
 
     Fault_PrintFReg(0, &ctx->fp0.f.f_even);
     Fault_PrintFReg(2, &ctx->fp2.f.f_even);
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
     Fault_PrintFReg(4, &ctx->fp4.f.f_even);
     Fault_PrintFReg(6, &ctx->fp6.f.f_even);
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
     Fault_PrintFReg(8, &ctx->fp8.f.f_even);
     Fault_PrintFReg(10, &ctx->fp10.f.f_even);
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
     Fault_PrintFReg(12, &ctx->fp12.f.f_even);
     Fault_PrintFReg(14, &ctx->fp14.f.f_even);
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
     Fault_PrintFReg(16, &ctx->fp16.f.f_even);
     Fault_PrintFReg(18, &ctx->fp18.f.f_even);
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
     Fault_PrintFReg(20, &ctx->fp20.f.f_even);
     Fault_PrintFReg(22, &ctx->fp22.f.f_even);
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
     Fault_PrintFReg(24, &ctx->fp24.f.f_even);
     Fault_PrintFReg(26, &ctx->fp26.f.f_even);
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
     Fault_PrintFReg(28, &ctx->fp28.f.f_even);
     Fault_PrintFReg(30, &ctx->fp30.f.f_even);
-    FaultDrawer_Printf("\n");
+    Fault_Printf("\n");
 
-    FaultDrawer_SetCharPad(0, 0);
+    Fault_SetCharPad(0, 0);
 }
 
 void Fault_LogThreadContext(OSThread* thread) {
@@ -687,8 +687,8 @@ void Fault_WaitForButtonCombo(void) {
     osSyncPrintf(VT_FGCOL(WHITE) "KeyWaitB'(ＬＲ左" VT_FGCOL(YELLOW) "右 +" VT_FGCOL(RED) "START" VT_FGCOL(
         WHITE) ")" VT_RST "\n");
 
-    FaultDrawer_SetForeColor(GPACK_RGBA5551(255, 255, 255, 1));
-    FaultDrawer_SetBackColor(GPACK_RGBA5551(0, 0, 0, 1));
+    Fault_SetForeColor(GPACK_RGBA5551(255, 255, 255, 1));
+    Fault_SetBackColor(GPACK_RGBA5551(0, 0, 0, 1));
 
     state = 0;
     s1 = 0;
@@ -838,21 +838,21 @@ void Fault_DrawMemDumpContents(const char* title, uintptr_t addr, u32 arg2) {
 
     // Reset screen
     Fault_FillScreenBlack();
-    FaultDrawer_SetCharPad(-2, 0);
+    Fault_SetCharPad(-2, 0);
 
-    FaultDrawer_DrawText(36, 18, "%s %08x", title != NULL ? title : "PrintDump", alignedAddr);
+    Fault_DrawText(36, 18, "%s %08x", title != NULL ? title : "PrintDump", alignedAddr);
 
     // Draw memory page contents
     if (alignedAddr >= K0BASE && alignedAddr < K2BASE) {
         for (y = 0; y < 22; y++) {
-            FaultDrawer_DrawText(24, 28 + y * 9, "%06x", writeAddr);
+            Fault_DrawText(24, 28 + y * 9, "%06x", writeAddr);
             for (x = 0; x < 4; x++) {
-                FaultDrawer_DrawText(82 + x * 52, 28 + y * 9, "%08x", *writeAddr++);
+                Fault_DrawText(82 + x * 52, 28 + y * 9, "%08x", *writeAddr++);
             }
         }
     }
 
-    FaultDrawer_SetCharPad(0, 0);
+    Fault_SetCharPad(0, 0);
 }
 
 /**
@@ -1075,15 +1075,15 @@ void Fault_DrawStackTrace(OSThread* thread, s32 x, s32 y, s32 height) {
     uintptr_t pc = thread->context.pc;
     uintptr_t addr;
 
-    FaultDrawer_DrawText(x, y, "SP       PC       (VPC)");
+    Fault_DrawText(x, y, "SP       PC       (VPC)");
 
     // Backtrace from the current function to the start of the thread
     for (line = 1; line < height && (ra != 0 || sp != 0) && pc != (uintptr_t)__osCleanupThread; line++) {
-        FaultDrawer_DrawText(x, y + line * 8, "%08x %08x", sp, pc);
+        Fault_DrawText(x, y + line * 8, "%08x %08x", sp, pc);
         // Convert relocated address to virtual address if applicable
         addr = Fault_ConvertAddress(pc);
         if (addr != 0) {
-            FaultDrawer_Printf(" -> %08x", addr);
+            Fault_Printf(" -> %08x", addr);
         }
         // Search one function for the previous function
         Fault_WalkStack(&sp, &pc, &ra);
@@ -1138,7 +1138,7 @@ void Fault_DisplayFrameBuffer(void) {
     }
 
     osViSwapBuffer(fb);
-    FaultDrawer_SetDrawerFB(fb, SCREEN_WIDTH, SCREEN_HEIGHT);
+    Fault_SetDrawerFB(fb, SCREEN_WIDTH, SCREEN_HEIGHT);
 }
 
 /**
@@ -1152,10 +1152,10 @@ void Fault_ProcessClients(void) {
     while (client != NULL) {
         if (client->callback != NULL) {
             Fault_FillScreenBlack();
-            FaultDrawer_SetCharPad(-2, 0);
-            FaultDrawer_Printf(FAULT_COLOR(DARK_GRAY) "CallBack (%d) %08x %08x %08x\n" FAULT_COLOR(WHITE), idx++,
-                               client, client->arg0, client->arg1);
-            FaultDrawer_SetCharPad(0, 0);
+            Fault_SetCharPad(-2, 0);
+            Fault_Printf(FAULT_COLOR(DARK_GRAY) "CallBack (%d) %08x %08x %08x\n" FAULT_COLOR(WHITE), idx++, client,
+                         client->arg0, client->arg1);
+            Fault_SetCharPad(0, 0);
             Fault_ProcessClient(client->callback, client->arg0, client->arg1);
             Fault_WaitForInput();
             Fault_DisplayFrameBuffer();
@@ -1235,8 +1235,8 @@ void Fault_ThreadEntry(void* arg) {
 
         // Set auto-scrolling and default colors
         sFaultInstance->autoScroll = true;
-        FaultDrawer_SetForeColor(GPACK_RGBA5551(255, 255, 255, 1));
-        FaultDrawer_SetBackColor(GPACK_RGBA5551(0, 0, 0, 0));
+        Fault_SetForeColor(GPACK_RGBA5551(255, 255, 255, 1));
+        Fault_SetBackColor(GPACK_RGBA5551(0, 0, 0, 0));
 
         // Draw pages
         do {
@@ -1246,7 +1246,7 @@ void Fault_ThreadEntry(void* arg) {
             Fault_WaitForInput();
             // Stack trace page
             Fault_FillScreenBlack();
-            FaultDrawer_DrawText(120, 16, "STACK TRACE");
+            Fault_DrawText(120, 16, "STACK TRACE");
             Fault_DrawStackTrace(faultedThread, 36, 24, 22);
             Fault_LogStackTrace(faultedThread, 50);
             Fault_WaitForInput();
@@ -1256,10 +1256,10 @@ void Fault_ThreadEntry(void* arg) {
             Fault_DrawMemDump(faultedThread->context.pc - 0x100, (uintptr_t)faultedThread->context.sp, 0, 0);
             // End page
             Fault_FillScreenRed();
-            FaultDrawer_DrawText(64, 80, "    CONGRATURATIONS!    ");
-            FaultDrawer_DrawText(64, 90, "All Pages are displayed.");
-            FaultDrawer_DrawText(64, 100, "       THANK YOU!       ");
-            FaultDrawer_DrawText(64, 110, " You are great debugger!");
+            Fault_DrawText(64, 80, "    CONGRATURATIONS!    ");
+            Fault_DrawText(64, 90, "All Pages are displayed.");
+            Fault_DrawText(64, 100, "       THANK YOU!       ");
+            Fault_DrawText(64, 110, " You are great debugger!");
             Fault_WaitForInput();
         } while (!sFaultInstance->exit);
 
@@ -1271,14 +1271,14 @@ void Fault_ThreadEntry(void* arg) {
 
 void Fault_SetFrameBuffer(void* fb, u16 w, u16 h) {
     sFaultInstance->fb = fb;
-    FaultDrawer_SetDrawerFB(fb, w, h);
+    Fault_SetDrawerFB(fb, w, h);
 }
 
 void Fault_Init(void) {
     sFaultInstance = &gFaultMgr;
     bzero(sFaultInstance, sizeof(FaultMgr));
-    FaultDrawer_Init();
-    FaultDrawer_SetInputCallback(Fault_WaitForInput);
+    Fault_Init();
+    Fault_SetInputCallback(Fault_WaitForInput);
     sFaultInstance->exit = false;
     sFaultInstance->msgId = 0;
     sFaultInstance->faultHandlerEnabled = false;
@@ -1302,9 +1302,9 @@ void Fault_HungupFaultClient(const char* exp1, const char* exp2) {
     osSyncPrintf("HungUp on Thread %d\n", osGetThreadId(NULL));
     osSyncPrintf("%s\n", exp1 != NULL ? exp1 : "(NULL)");
     osSyncPrintf("%s\n", exp2 != NULL ? exp2 : "(NULL)");
-    FaultDrawer_Printf("HungUp on Thread %d\n", osGetThreadId(NULL));
-    FaultDrawer_Printf("%s\n", exp1 != NULL ? exp1 : "(NULL)");
-    FaultDrawer_Printf("%s\n", exp2 != NULL ? exp2 : "(NULL)");
+    Fault_Printf("HungUp on Thread %d\n", osGetThreadId(NULL));
+    Fault_Printf("%s\n", exp1 != NULL ? exp1 : "(NULL)");
+    Fault_Printf("%s\n", exp2 != NULL ? exp2 : "(NULL)");
 }
 
 /**

--- a/src/code/fault_gc_drawer.c
+++ b/src/code/fault_gc_drawer.c
@@ -344,7 +344,7 @@ void Fault_WritebackFBDCache(void) {
     osWritebackDCache(sFaultDrawer.fb, sFaultDrawer.w * sFaultDrawer.h * sizeof(u16));
 }
 
-void Fault_Init(void) {
+void Fault_InitDrawer(void) {
     bcopy(&sFaultDrawerDefault, &sFaultDrawer, sizeof(FaultDrawer));
     sFaultDrawer.fb = (u16*)(PHYS_TO_K0(osMemSize) - sizeof(u16[SCREEN_HEIGHT][SCREEN_WIDTH]));
 }

--- a/src/code/fault_gc_drawer.c
+++ b/src/code/fault_gc_drawer.c
@@ -112,11 +112,11 @@ FaultDrawer sFaultDrawerDefault = {
 FaultDrawer sFaultDrawer;
 char D_8016B6C0[0x20];
 
-void FaultDrawer_SetOsSyncPrintfEnabled(u32 enabled) {
+void Fault_SetOsSyncPrintfEnabled(u32 enabled) {
     sFaultDrawer.osSyncPrintfEnabled = enabled;
 }
 
-void FaultDrawer_DrawRecImpl(s32 xStart, s32 yStart, s32 xEnd, s32 yEnd, u16 color) {
+void Fault_DrawRecImpl(s32 xStart, s32 yStart, s32 xEnd, s32 yEnd, u16 color) {
     u16* fb;
     s32 x, y;
     s32 xDiff = sFaultDrawer.w - xStart;
@@ -145,7 +145,7 @@ void FaultDrawer_DrawRecImpl(s32 xStart, s32 yStart, s32 xEnd, s32 yEnd, u16 col
     }
 }
 
-void FaultDrawer_DrawChar(char c) {
+void Fault_DrawChar(char c) {
     u16* fb;
     s32 x, y;
     const u32* dataPtr;
@@ -178,7 +178,7 @@ void FaultDrawer_DrawChar(char c) {
     }
 }
 
-s32 FaultDrawer_ColorToPrintColor(u16 color) {
+s32 Fault_ColorToPrintColor(u16 color) {
     s32 i;
 
     for (i = 0; i < ARRAY_COUNT(sFaultDrawer.printColors); i++) {
@@ -189,44 +189,44 @@ s32 FaultDrawer_ColorToPrintColor(u16 color) {
     return -1;
 }
 
-void FaultDrawer_UpdatePrintColor(void) {
+void Fault_UpdatePrintColor(void) {
     s32 idx;
 
     if (sFaultDrawer.osSyncPrintfEnabled) {
         osSyncPrintf(VT_RST);
 
-        idx = FaultDrawer_ColorToPrintColor(sFaultDrawer.foreColor);
+        idx = Fault_ColorToPrintColor(sFaultDrawer.foreColor);
         if (idx >= 0 && idx < ARRAY_COUNT(sFaultDrawer.printColors) - 2) {
             osSyncPrintf(VT_SGR("3%d"), idx);
         }
 
-        idx = FaultDrawer_ColorToPrintColor(sFaultDrawer.backColor);
+        idx = Fault_ColorToPrintColor(sFaultDrawer.backColor);
         if (idx >= 0 && idx < ARRAY_COUNT(sFaultDrawer.printColors) - 2) {
             osSyncPrintf(VT_SGR("4%d"), idx);
         }
     }
 }
 
-void FaultDrawer_SetForeColor(u16 color) {
+void Fault_SetForeColor(u16 color) {
     sFaultDrawer.foreColor = color;
-    FaultDrawer_UpdatePrintColor();
+    Fault_UpdatePrintColor();
 }
 
-void FaultDrawer_SetBackColor(u16 color) {
+void Fault_SetBackColor(u16 color) {
     sFaultDrawer.backColor = color;
-    FaultDrawer_UpdatePrintColor();
+    Fault_UpdatePrintColor();
 }
 
-void FaultDrawer_SetFontColor(u16 color) {
-    FaultDrawer_SetForeColor(color | 1); // force alpha to be set
+void Fault_SetFontColor(u16 color) {
+    Fault_SetForeColor(color | 1); // force alpha to be set
 }
 
-void FaultDrawer_SetCharPad(s8 padW, s8 padH) {
+void Fault_SetCharPad(s8 padW, s8 padH) {
     sFaultDrawer.charWPad = padW;
     sFaultDrawer.charHPad = padH;
 }
 
-void FaultDrawer_SetCursor(s32 x, s32 y) {
+void Fault_SetCursor(s32 x, s32 y) {
     if (sFaultDrawer.osSyncPrintfEnabled) {
         osSyncPrintf(VT_CUP("%d", "%d"), (y - sFaultDrawer.yStart) / (sFaultDrawer.charH + sFaultDrawer.charHPad),
                      (x - sFaultDrawer.xStart) / (sFaultDrawer.charW + sFaultDrawer.charWPad));
@@ -235,17 +235,17 @@ void FaultDrawer_SetCursor(s32 x, s32 y) {
     sFaultDrawer.cursorY = y;
 }
 
-void FaultDrawer_FillScreen(void) {
+void Fault_FillScreen(void) {
     if (sFaultDrawer.osSyncPrintfEnabled) {
         osSyncPrintf(VT_CLS);
     }
 
-    FaultDrawer_DrawRecImpl(sFaultDrawer.xStart, sFaultDrawer.yStart, sFaultDrawer.xEnd, sFaultDrawer.yEnd,
-                            sFaultDrawer.backColor | 1);
-    FaultDrawer_SetCursor(sFaultDrawer.xStart, sFaultDrawer.yStart);
+    Fault_DrawRecImpl(sFaultDrawer.xStart, sFaultDrawer.yStart, sFaultDrawer.xEnd, sFaultDrawer.yEnd,
+                      sFaultDrawer.backColor | 1);
+    Fault_SetCursor(sFaultDrawer.xStart, sFaultDrawer.yStart);
 }
 
-void* FaultDrawer_PrintCallback(void* arg, const char* str, size_t count) {
+void* Fault_PrintCallback(void* arg, const char* str, size_t count) {
     for (; count != 0; count--, str++) {
         s32 curXStart;
         s32 curXEnd;
@@ -253,7 +253,7 @@ void* FaultDrawer_PrintCallback(void* arg, const char* str, size_t count) {
         if (sFaultDrawer.escCode) {
             sFaultDrawer.escCode = false;
             if (*str > '0' && *str <= '9') {
-                FaultDrawer_SetForeColor(sFaultDrawer.printColors[*str - '0']);
+                Fault_SetForeColor(sFaultDrawer.printColors[*str - '0']);
             }
 
             curXStart = sFaultDrawer.cursorX;
@@ -279,7 +279,7 @@ void* FaultDrawer_PrintCallback(void* arg, const char* str, size_t count) {
                         osSyncPrintf("%c", *str);
                     }
 
-                    FaultDrawer_DrawChar(*str);
+                    Fault_DrawChar(*str);
                     sFaultDrawer.cursorX += sFaultDrawer.charW + sFaultDrawer.charWPad;
 
                     curXStart = sFaultDrawer.cursorX;
@@ -294,7 +294,7 @@ void* FaultDrawer_PrintCallback(void* arg, const char* str, size_t count) {
             if (sFaultDrawer.yEnd - sFaultDrawer.charH <= sFaultDrawer.cursorY) {
                 if (sFaultDrawer.inputCallback) {
                     sFaultDrawer.inputCallback();
-                    FaultDrawer_FillScreen();
+                    Fault_FillScreen();
                 }
                 sFaultDrawer.cursorY = sFaultDrawer.yStart;
             }
@@ -305,46 +305,46 @@ void* FaultDrawer_PrintCallback(void* arg, const char* str, size_t count) {
     return arg;
 }
 
-s32 FaultDrawer_VPrintf(const char* fmt, va_list args) {
-    return _Printf(FaultDrawer_PrintCallback, &sFaultDrawer, fmt, args);
+s32 Fault_VPrintf(const char* fmt, va_list args) {
+    return _Printf(Fault_PrintCallback, &sFaultDrawer, fmt, args);
 }
 
-s32 FaultDrawer_Printf(const char* fmt, ...) {
+s32 Fault_Printf(const char* fmt, ...) {
     s32 ret;
     va_list args;
     va_start(args, fmt);
 
-    ret = FaultDrawer_VPrintf(fmt, args);
+    ret = Fault_VPrintf(fmt, args);
 
     va_end(args);
     return ret;
 }
 
-void FaultDrawer_DrawText(s32 x, s32 y, const char* fmt, ...) {
+void Fault_DrawText(s32 x, s32 y, const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
 
-    FaultDrawer_SetCursor(x, y);
-    FaultDrawer_VPrintf(fmt, args);
+    Fault_SetCursor(x, y);
+    Fault_VPrintf(fmt, args);
 
     va_end(args);
 }
 
-void FaultDrawer_SetDrawerFB(void* fb, u16 w, u16 h) {
+void Fault_SetDrawerFB(void* fb, u16 w, u16 h) {
     sFaultDrawer.fb = fb;
     sFaultDrawer.w = w;
     sFaultDrawer.h = h;
 }
 
-void FaultDrawer_SetInputCallback(void (*callback)(void)) {
+void Fault_SetInputCallback(void (*callback)(void)) {
     sFaultDrawer.inputCallback = callback;
 }
 
-void FaultDrawer_WritebackFBDCache(void) {
+void Fault_WritebackFBDCache(void) {
     osWritebackDCache(sFaultDrawer.fb, sFaultDrawer.w * sFaultDrawer.h * sizeof(u16));
 }
 
-void FaultDrawer_Init(void) {
+void Fault_Init(void) {
     bcopy(&sFaultDrawerDefault, &sFaultDrawer, sizeof(FaultDrawer));
     sFaultDrawer.fb = (u16*)(PHYS_TO_K0(osMemSize) - sizeof(u16[SCREEN_HEIGHT][SCREEN_WIDTH]));
 }

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -21,10 +21,10 @@ void GameState_FaultPrint(void) {
     s32 i;
 
     PRINTF("last_button=%04x\n", sLastButtonPressed);
-    FaultDrawer_DrawText(120, 180, "%08x", sLastButtonPressed);
+    Fault_DrawText(120, 180, "%08x", sLastButtonPressed);
     for (i = 0; i < ARRAY_COUNT(sBtnChars); i++) {
         if (sLastButtonPressed & (1 << i)) {
-            FaultDrawer_DrawText((i * 8) + 120, 190, "%c", sBtnChars[i]);
+            Fault_DrawText((i * 8) + 120, 190, "%c", sBtnChars[i]);
         }
     }
 }

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2318,8 +2318,8 @@ void Actor_FaultPrint(Actor* actor, char* command) {
     char* name;
 
     if ((actor == NULL) || (actor->overlayEntry == NULL)) {
-        FaultDrawer_SetCursor(48, 24);
-        FaultDrawer_Printf("ACTOR NAME is NULL");
+        Fault_SetCursor(48, 24);
+        Fault_Printf("ACTOR NAME is NULL");
     }
 
 #if OOT_DEBUG
@@ -2335,8 +2335,8 @@ void Actor_FaultPrint(Actor* actor, char* command) {
         PRINTF("コメント:%s\n", command); // "Command:%s"
     }
 
-    FaultDrawer_SetCursor(48, 24);
-    FaultDrawer_Printf("ACTOR NAME %08x:%s", actor, name);
+    Fault_SetCursor(48, 24);
+    Fault_Printf("ACTOR NAME %08x:%s", actor, name);
 }
 
 void Actor_Draw(PlayState* play, Actor* actor) {

--- a/src/code/z_actor_dlftbls.c
+++ b/src/code/z_actor_dlftbls.c
@@ -100,17 +100,17 @@ void ActorOverlayTable_FaultPrint(void* arg0, void* arg1) {
     u32 overlaySize;
     s32 i;
 
-    FaultDrawer_SetCharPad(-2, 0);
+    Fault_SetCharPad(-2, 0);
 
-    FaultDrawer_Printf("actor_dlftbls %u\n", gMaxActorId);
-    FaultDrawer_Printf("No. RamStart- RamEnd cn  Name\n");
+    Fault_Printf("actor_dlftbls %u\n", gMaxActorId);
+    Fault_Printf("No. RamStart- RamEnd cn  Name\n");
 
     for (i = 0, overlayEntry = &gActorOverlayTable[0]; i < gMaxActorId; i++, overlayEntry++) {
         overlaySize = (uintptr_t)overlayEntry->vramEnd - (uintptr_t)overlayEntry->vramStart;
         if (overlayEntry->loadedRamAddr != NULL) {
-            FaultDrawer_Printf("%3d %08x-%08x %3d %s\n", i, overlayEntry->loadedRamAddr,
-                               (uintptr_t)overlayEntry->loadedRamAddr + overlaySize, overlayEntry->numLoaded,
-                               (OOT_DEBUG && overlayEntry->name != NULL) ? overlayEntry->name : "");
+            Fault_Printf("%3d %08x-%08x %3d %s\n", i, overlayEntry->loadedRamAddr,
+                         (uintptr_t)overlayEntry->loadedRamAddr + overlaySize, overlayEntry->numLoaded,
+                         (OOT_DEBUG && overlayEntry->name != NULL) ? overlayEntry->name : "");
         }
     }
 }


### PR DESCRIPTION
In N64, these functions are not split between "fault" and "fault_drawer", so this makes the similarities between the N64 and GC versions more clean. And even for GC versions, I think this change makes the Fault interface feel more unified anyway.

This doesn't work for `FaultDrawer_Init` since there's already a `Fault_Init`, so I renamed that to `Fault_InitDrawer` instead.