### PR TITLE
[ntsc-1.2] Match KaleidoScope_DrawEquipment and KaleidoScope_DrawItemSelect

### DIFF
--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -120,22 +120,22 @@ void KaleidoScope_ProcessPlayerPreRender(PlayState* play);
 void KaleidoScope_DrawEquipment(PlayState* play) {
     static s16 sEquipTimer = 0;
     PauseContext* pauseCtx = &play->pauseCtx;
+    InterfaceContext* interfaceCtx = &play->interfaceCtx;
     Input* input = &play->state.input[0];
     u16 i;
     u16 j;
     u16 k;
     u16 bit;
+    u16 rowStart;
     u16 temp;
     u16 point;
-    u16 rowStart;
-    u16 pad;
     s16 cursorMoveResult;
-    u16 cursorItem;
     u16 cursorSlot;
-    s16 cursorPoint;
+    u16 cursorItem;
     s16 cursorX;
     s16 cursorY;
-    volatile s16 oldCursorPoint;
+    s16 oldCursorPoint;
+    s16 cursorPoint;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_kaleido_equipment.c", 219);
 
@@ -170,7 +170,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
             cursorY = pauseCtx->cursorY[PAUSE_EQUIP];
 
             cursorMoveResult = 0;
-            while (cursorMoveResult == 0) {
+            do {
                 if (pauseCtx->stickAdjX < -30) {
                     if (pauseCtx->cursorX[PAUSE_EQUIP] != 0) {
                         pauseCtx->cursorX[PAUSE_EQUIP]--;
@@ -254,15 +254,13 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                 } else {
                     cursorMoveResult = 4;
                 }
-            }
+            } while (cursorMoveResult == 0);
 
             cursorPoint = pauseCtx->cursorPoint[PAUSE_EQUIP];
             cursorY = pauseCtx->cursorY[PAUSE_EQUIP];
 
-            if (cursorMoveResult) {}
-
             cursorMoveResult = 0;
-            while (cursorMoveResult == 0) {
+            do {
                 if (pauseCtx->stickAdjY > 30) {
                     if (pauseCtx->cursorY[PAUSE_EQUIP] != 0) {
                         pauseCtx->cursorY[PAUSE_EQUIP]--;
@@ -306,7 +304,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
                 } else {
                     cursorMoveResult = 4;
                 }
-            }
+            } while (cursorMoveResult == 0);
         } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
             if (pauseCtx->stickAdjX > 30) {
                 pauseCtx->nameDisplayTimer = 0;
@@ -340,19 +338,15 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
 
                     cursorY = cursorY + 1;
                     cursorPoint = cursorPoint + 4;
-                    if (cursorY < 4) {
-                        continue;
+                    if (cursorY >= 4) {
+                        cursorY = 0;
+                        cursorPoint = cursorX + 1;
+                        cursorX = cursorPoint;
+                        if (cursorX >= 4) {
+                            KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
+                            break;
+                        }
                     }
-
-                    cursorY = 0;
-                    cursorPoint = cursorX + 1;
-                    cursorX = cursorPoint;
-                    if (cursorX < 4) {
-                        continue;
-                    }
-
-                    KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
-                    break;
                 }
             }
         } else {
@@ -381,19 +375,15 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
 
                     cursorY = cursorY + 1;
                     cursorPoint = cursorPoint + 4;
-                    if (cursorY < 4) {
-                        continue;
+                    if (cursorY >= 4) {
+                        cursorY = 0;
+                        cursorPoint = cursorX - 1;
+                        cursorX = cursorPoint;
+                        if (cursorX < 0) {
+                            KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
+                            break;
+                        }
                     }
-
-                    cursorY = 0;
-                    cursorPoint = cursorX - 1;
-                    cursorX = cursorPoint;
-                    if (cursorX >= 0) {
-                        continue;
-                    }
-
-                    KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
-                    break;
                 }
             }
         }
@@ -599,7 +589,7 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
     gSPSegment(POLY_OPA_DISP++, 0x08, pauseCtx->iconItemSegment);
     gSPSegment(POLY_OPA_DISP++, 0x09, pauseCtx->iconItem24Segment);
     gSPSegment(POLY_OPA_DISP++, 0x0A, pauseCtx->nameSegment);
-    gSPSegment(POLY_OPA_DISP++, 0x0B, play->interfaceCtx.mapSegment);
+    gSPSegment(POLY_OPA_DISP++, 0x0B, interfaceCtx->mapSegment);
     gSPSegment(POLY_OPA_DISP++, 0x0C, pauseCtx->iconItemAltSegment);
 
     Gfx_SetupDL_42Opa(play->state.gfxCtx);

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -92,7 +92,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
     s16 cursorX;
     s16 cursorY;
     s16 oldCursorPoint;
-    s16 moveCursorResult;
+    s16 cursorMoveResult;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_kaleido_item.c", 234);
 
@@ -105,7 +105,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 
     if ((pauseCtx->state == PAUSE_STATE_MAIN) && (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE) &&
         (pauseCtx->pageIndex == PAUSE_ITEM)) {
-        moveCursorResult = 0;
+        cursorMoveResult = 0;
         oldCursorPoint = pauseCtx->cursorPoint[PAUSE_ITEM];
 
         cursorItem = pauseCtx->cursorItem[PAUSE_ITEM];
@@ -118,10 +118,6 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                 pauseCtx->stickAdjX = 40;
             }
 
-#if !OOT_DEBUG
-            if (&gSaveContext) {}
-#endif
-
             if (ABS(pauseCtx->stickAdjX) > 30) {
                 cursorPoint = pauseCtx->cursorPoint[PAUSE_ITEM];
                 cursorX = pauseCtx->cursorX[PAUSE_ITEM];
@@ -129,13 +125,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 
                 PRINTF("now=%d  ccc=%d\n", cursorPoint, cursorItem);
 
-#if OOT_DEBUG
-                // Seems necessary to match
-                if (pauseCtx->cursorX[PAUSE_ITEM]) {}
-                if (gSaveContext.save.info.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]]) {}
-#endif
-
-                while (moveCursorResult == 0) {
+                do {
                     if (pauseCtx->stickAdjX < -30) {
                         if (pauseCtx->cursorX[PAUSE_ITEM] != 0) {
                             pauseCtx->cursorX[PAUSE_ITEM]--;
@@ -143,7 +133,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 
                             if (gSaveContext.save.info.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] !=
                                 ITEM_NONE) {
-                                moveCursorResult = 1;
+                                cursorMoveResult = 1;
                             }
                         } else {
                             pauseCtx->cursorX[PAUSE_ITEM] = cursorX;
@@ -166,7 +156,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 
                                 KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
 
-                                moveCursorResult = 2;
+                                cursorMoveResult = 2;
                             }
                         }
                     } else if (pauseCtx->stickAdjX > 30) {
@@ -176,7 +166,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 
                             if (gSaveContext.save.info.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] !=
                                 ITEM_NONE) {
-                                moveCursorResult = 1;
+                                cursorMoveResult = 1;
                             }
                         } else {
                             pauseCtx->cursorX[PAUSE_ITEM] = cursorX;
@@ -199,18 +189,18 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 
                                 KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
 
-                                moveCursorResult = 2;
+                                cursorMoveResult = 2;
                             }
                         }
                     }
-                }
+                } while (cursorMoveResult == 0);
 
-                if (moveCursorResult == 1) {
+                if (cursorMoveResult == 1) {
                     cursorItem = gSaveContext.save.info.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]];
                 }
 
                 PRINTF("【Ｘ cursor=%d(%) (cur_xpt=%d)(ok_fg=%d)(ccc=%d)(key_angle=%d)】  ",
-                       pauseCtx->cursorPoint[PAUSE_ITEM], pauseCtx->cursorX[PAUSE_ITEM], moveCursorResult, cursorItem,
+                       pauseCtx->cursorPoint[PAUSE_ITEM], pauseCtx->cursorX[PAUSE_ITEM], cursorMoveResult, cursorItem,
                        pauseCtx->cursorSpecialPos);
             }
         } else if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
@@ -227,25 +217,21 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                         pauseCtx->cursorPoint[PAUSE_ITEM] = cursorPoint;
                         pauseCtx->cursorX[PAUSE_ITEM] = cursorX;
                         pauseCtx->cursorY[PAUSE_ITEM] = cursorY;
-                        moveCursorResult = 1;
+                        cursorMoveResult = 1;
                         break;
                     }
 
                     cursorY = cursorY + 1;
                     cursorPoint = cursorPoint + 6;
-                    if (cursorY < 4) {
-                        continue;
+                    if (cursorY >= 4) {
+                        cursorY = 0;
+                        cursorPoint = cursorX + 1;
+                        cursorX = cursorPoint;
+                        if (cursorX >= 6) {
+                            KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
+                            break;
+                        }
                     }
-
-                    cursorY = 0;
-                    cursorPoint = cursorX + 1;
-                    cursorX = cursorPoint;
-                    if (cursorX < 6) {
-                        continue;
-                    }
-
-                    KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_RIGHT);
-                    break;
                 }
             }
         } else {
@@ -263,25 +249,21 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                         pauseCtx->cursorPoint[PAUSE_ITEM] = cursorPoint;
                         pauseCtx->cursorX[PAUSE_ITEM] = cursorX;
                         pauseCtx->cursorY[PAUSE_ITEM] = cursorY;
-                        moveCursorResult = 1;
+                        cursorMoveResult = 1;
                         break;
                     }
 
                     cursorY = cursorY + 1;
                     cursorPoint = cursorPoint + 6;
-                    if (cursorY < 4) {
-                        continue;
+                    if (cursorY >= 4) {
+                        cursorY = 0;
+                        cursorPoint = cursorX - 1;
+                        cursorX = cursorPoint;
+                        if (cursorX < 0) {
+                            KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
+                            break;
+                        }
                     }
-
-                    cursorY = 0;
-                    cursorPoint = cursorX - 1;
-                    cursorX = cursorPoint;
-                    if (cursorX >= 0) {
-                        continue;
-                    }
-
-                    KaleidoScope_MoveCursorToSpecialPos(play, PAUSE_CURSOR_PAGE_LEFT);
-                    break;
                 }
             }
         }
@@ -289,11 +271,11 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
         if (pauseCtx->cursorSpecialPos == 0) {
             if (cursorItem != PAUSE_ITEM_NONE) {
                 if (ABS(pauseCtx->stickAdjY) > 30) {
-                    moveCursorResult = 0;
+                    cursorMoveResult = 0;
 
                     cursorPoint = pauseCtx->cursorPoint[PAUSE_ITEM];
                     cursorY = pauseCtx->cursorY[PAUSE_ITEM];
-                    while (moveCursorResult == 0) {
+                    do {
                         if (pauseCtx->stickAdjY > 30) {
                             if (pauseCtx->cursorY[PAUSE_ITEM] != 0) {
                                 pauseCtx->cursorY[PAUSE_ITEM]--;
@@ -301,13 +283,13 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 
                                 if (gSaveContext.save.info.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] !=
                                     ITEM_NONE) {
-                                    moveCursorResult = 1;
+                                    cursorMoveResult = 1;
                                 }
                             } else {
                                 pauseCtx->cursorY[PAUSE_ITEM] = cursorY;
                                 pauseCtx->cursorPoint[PAUSE_ITEM] = cursorPoint;
 
-                                moveCursorResult = 2;
+                                cursorMoveResult = 2;
                             }
                         } else if (pauseCtx->stickAdjY < -30) {
                             if (pauseCtx->cursorY[PAUSE_ITEM] < 3) {
@@ -316,20 +298,20 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 
                                 if (gSaveContext.save.info.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]] !=
                                     ITEM_NONE) {
-                                    moveCursorResult = 1;
+                                    cursorMoveResult = 1;
                                 }
                             } else {
                                 pauseCtx->cursorY[PAUSE_ITEM] = cursorY;
                                 pauseCtx->cursorPoint[PAUSE_ITEM] = cursorPoint;
 
-                                moveCursorResult = 2;
+                                cursorMoveResult = 2;
                             }
                         }
-                    }
+                    } while (cursorMoveResult == 0);
 
                     cursorPoint = PAUSE_ITEM;
                     PRINTF("【Ｙ cursor=%d(%) (cur_ypt=%d)(ok_fg=%d)(ccc=%d)】  ", pauseCtx->cursorPoint[cursorPoint],
-                           pauseCtx->cursorY[PAUSE_ITEM], moveCursorResult, cursorItem);
+                           pauseCtx->cursorY[PAUSE_ITEM], cursorMoveResult, cursorItem);
                 }
             }
 
@@ -337,9 +319,9 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
 
             pauseCtx->cursorColorSet = 4;
 
-            if (moveCursorResult == 1) {
+            if (cursorMoveResult == 1) {
                 cursorItem = gSaveContext.save.info.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]];
-            } else if (moveCursorResult != 2) {
+            } else if (cursorMoveResult != 2) {
                 cursorItem = gSaveContext.save.info.inventory.items[pauseCtx->cursorPoint[PAUSE_ITEM]];
             }
 
@@ -418,6 +400,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         }
     } else if ((pauseCtx->mainState == PAUSE_MAIN_STATE_3) && (pauseCtx->pageIndex == PAUSE_ITEM)) {
+        //! @bug cursorSlot is uninitialized
         KaleidoScope_SetCursorVtx(pauseCtx, cursorSlot * 4, pauseCtx->itemVtx);
         pauseCtx->cursorColorSet = 4;
     }


### PR DESCRIPTION
Permuter found the `interfaceCtx` match. For `KaleidoScope_DrawItemSelect`, I noticed via the uopt debugger that reducing the number of graph nodes would fix two different regalloc problems, so I tried to refactor things to remove useless branches even if they would be optimized away anyway. This turn out to fix a bunch of fake matches (empty ifs and `volatile`s) in both functions.