### PR TITLE
Jenkinsfile: `make -j` -> `make -j$(nproc)`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,8 +27,8 @@ pipeline {
         stage('Build ntsc-1.2, check disasm metadata') {
             steps {
                 sh 'ln -s /usr/local/etc/roms/oot-ntsc-1.2-us.z64 baseroms/ntsc-1.2/baserom.z64'
-                sh 'make -j setup VERSION=ntsc-1.2'
-                sh 'make -j VERSION=ntsc-1.2'
+                sh 'make -j$(nproc) setup VERSION=ntsc-1.2'
+                sh 'make -j$(nproc) VERSION=ntsc-1.2'
                 sh '.venv/bin/python3 tools/check_disasm_metadata_unksyms.py -v ntsc-1.2'
                 sh 'make clean assetclean VERSION=ntsc-1.2'
             }
@@ -39,64 +39,64 @@ pipeline {
         stage('Build gc-jp') {
             steps {
                 sh 'ln -s /usr/local/etc/roms/oot-gc-jp.z64 baseroms/gc-jp/baserom.z64'
-                sh 'make -j setup VERSION=gc-jp'
-                sh 'make -j VERSION=gc-jp'
+                sh 'make -j$(nproc) setup VERSION=gc-jp'
+                sh 'make -j$(nproc) VERSION=gc-jp'
                 sh 'make clean assetclean VERSION=gc-jp'
             }
         }
         stage('Build gc-eu-mq') {
             steps {
                 sh 'ln -s /usr/local/etc/roms/oot-gc-eu-mq.z64 baseroms/gc-eu-mq/baserom.z64'
-                sh 'make -j setup VERSION=gc-eu-mq'
-                sh 'make -j VERSION=gc-eu-mq'
+                sh 'make -j$(nproc) setup VERSION=gc-eu-mq'
+                sh 'make -j$(nproc) VERSION=gc-eu-mq'
                 sh 'make clean assetclean VERSION=gc-eu-mq'
             }
         }
         stage('Build gc-eu-mq-dbg') {
             steps {
                 sh 'ln -s /usr/local/etc/roms/oot-gc-eu-mq-dbg.z64 baseroms/gc-eu-mq-dbg/baserom.z64'
-                sh 'make -j setup VERSION=gc-eu-mq-dbg'
-                sh 'make -j VERSION=gc-eu-mq-dbg'
+                sh 'make -j$(nproc) setup VERSION=gc-eu-mq-dbg'
+                sh 'make -j$(nproc) VERSION=gc-eu-mq-dbg'
                 sh 'make clean assetclean VERSION=gc-eu-mq-dbg'
             }
         }
         stage('Build gc-us') {
             steps {
                 sh 'ln -s /usr/local/etc/roms/oot-gc-us.z64 baseroms/gc-us/baserom.z64'
-                sh 'make -j setup VERSION=gc-us'
-                sh 'make -j VERSION=gc-us'
+                sh 'make -j$(nproc) setup VERSION=gc-us'
+                sh 'make -j$(nproc) VERSION=gc-us'
                 sh 'make clean assetclean VERSION=gc-us'
             }
         }
         stage('Build gc-jp-ce') {
             steps {
                 sh 'ln -s /usr/local/etc/roms/oot-gc-jp-ce.z64 baseroms/gc-jp-ce/baserom.z64'
-                sh 'make -j setup VERSION=gc-jp-ce'
-                sh 'make -j VERSION=gc-jp-ce'
+                sh 'make -j$(nproc) setup VERSION=gc-jp-ce'
+                sh 'make -j$(nproc) VERSION=gc-jp-ce'
                 sh 'make clean assetclean VERSION=gc-jp-ce'
             }
         }
         stage('Build gc-eu') {
             steps {
                 sh 'ln -s /usr/local/etc/roms/oot-gc-eu.z64 baseroms/gc-eu/baserom.z64'
-                sh 'make -j setup VERSION=gc-eu'
-                sh 'make -j VERSION=gc-eu'
+                sh 'make -j$(nproc) setup VERSION=gc-eu'
+                sh 'make -j$(nproc) VERSION=gc-eu'
                 sh 'make clean assetclean VERSION=gc-eu'
             }
         }
         stage('Build gc-jp-mq') {
             steps {
                 sh 'ln -s /usr/local/etc/roms/oot-gc-jp-mq.z64 baseroms/gc-jp-mq/baserom.z64'
-                sh 'make -j setup VERSION=gc-jp-mq'
-                sh 'make -j VERSION=gc-jp-mq'
+                sh 'make -j$(nproc) setup VERSION=gc-jp-mq'
+                sh 'make -j$(nproc) VERSION=gc-jp-mq'
                 sh 'make clean assetclean VERSION=gc-jp-mq'
             }
         }
         stage('Build gc-us-mq') {
             steps {
                 sh 'ln -s /usr/local/etc/roms/oot-gc-us-mq.z64 baseroms/gc-us-mq/baserom.z64'
-                sh 'make -j setup VERSION=gc-us-mq'
-                sh 'make -j VERSION=gc-us-mq'
+                sh 'make -j$(nproc) setup VERSION=gc-us-mq'
+                sh 'make -j$(nproc) VERSION=gc-us-mq'
                 sh 'make clean assetclean VERSION=gc-us-mq'
             }
         }


### PR DESCRIPTION
This prevents excessive ram usage, at theoretically the same build time (unless building is IO-bound which it may partly be)

Testing on cadmic-2 through jenkins shows no build time difference. Cadmic testing manually also on cadmic-2 got a speedup (???)