### PR TITLE
Move button macros to include/controller.h

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -1,0 +1,27 @@
+#ifndef CONTROLLER_H
+#define CONTROLLER_H
+
+#define BTN_A           0x8000
+#define BTN_B           0x4000
+#define BTN_Z           0x2000
+#define BTN_START       0x1000
+#define BTN_DUP         0x0800
+#define BTN_DDOWN       0x0400
+#define BTN_DLEFT       0x0200
+#define BTN_DRIGHT      0x0100
+#define BTN_L           0x0020
+#define BTN_R           0x0010
+#define BTN_CUP         0x0008
+#define BTN_CDOWN       0x0004
+#define BTN_CLEFT       0x0002
+#define BTN_CRIGHT      0x0001
+
+#define CHECK_BTN_ANY(state, combo) (((state) & (combo)) != 0)
+
+#if PLATFORM_N64
+#define CHECK_BTN_ALL(state, combo) (((state) & (combo)) == (combo))
+#else
+#define CHECK_BTN_ALL(state, combo) (~((state) | ~(combo)) == 0)
+#endif
+
+#endif

--- a/include/macros.h
+++ b/include/macros.h
@@ -105,14 +105,6 @@
                                 ? gSaveContext.save.info.equips.buttonItems[(button) + 1]       \
                                 : ITEM_NONE)
 
-#if PLATFORM_N64
-#define CHECK_BTN_ALL(state, combo) (((state) & (combo)) == (combo))
-#else
-#define CHECK_BTN_ALL(state, combo) (~((state) | ~(combo)) == 0)
-#endif
-
-#define CHECK_BTN_ANY(state, combo) (((state) & (combo)) != 0)
-
 #define CHECK_FLAG_ALL(flags, mask) (((flags) & (mask)) == (mask))
 
 // IDO doesn't support variadic macros, but it merely throws a warning for the

--- a/include/ultra64/controller.h
+++ b/include/ultra64/controller.h
@@ -103,22 +103,6 @@
 #define CONT_BLOCK_GB_BANK   CONT_BLOCKS(CONT_ADDR_GB_BANK)
 #define CONT_BLOCK_GB_STATUS CONT_BLOCKS(CONT_ADDR_GB_STATUS)
 
-/* Buttons */
-#define BTN_CRIGHT      0x0001
-#define BTN_CLEFT       0x0002
-#define BTN_CDOWN       0x0004
-#define BTN_CUP         0x0008
-#define BTN_R           0x0010
-#define BTN_L           0x0020
-#define BTN_DRIGHT      0x0100
-#define BTN_DLEFT       0x0200
-#define BTN_DDOWN       0x0400
-#define BTN_DUP         0x0800
-#define BTN_START       0x1000
-#define BTN_Z           0x2000
-#define BTN_B           0x4000
-#define BTN_A           0x8000
-
 #ifdef __GNUC__
 // Ensure data cache coherency for OSPifRam structures by aligning to the data cache line size.
 // On older compilers such as IDO this was done by placing each OSPifRam at the top of the file it is declared in,

--- a/include/z64.h
+++ b/include/z64.h
@@ -5,6 +5,7 @@
 #include "ultra64/gs2dex.h"
 #include "attributes.h"
 #include "audiomgr.h"
+#include "controller.h"
 #include "z64save.h"
 #include "z64light.h"
 #include "z64bgcheck.h"

--- a/src/audio/general.c
+++ b/src/audio/general.c
@@ -859,7 +859,7 @@ NatureAmbienceDataIO sNatureAmbienceDataIO[20] = {
 };
 
 #if PLATFORM_GC
-u32 sOcarinaAllowedButtonMask = (BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP);
+u32 sOcarinaAllowedButtonMask = (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
 s32 sOcarinaAButtonMap = BTN_A;
 s32 sOcarinaCUpButtonMap = BTN_CUP;
 s32 sOcarinaCDownButtonMap = BTN_CDOWN;
@@ -1310,7 +1310,7 @@ s32 Audio_SetGanonsTowerBgmVolume(u8 targetVol);
 
 #if PLATFORM_N64
 
-#define OCARINA_ALLOWED_BUTTON_MASK (BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP)
+#define OCARINA_ALLOWED_BUTTON_MASK (BTN_A | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT)
 #define OCARINA_A_MAP BTN_A
 #define OCARINA_CUP_MAP BTN_CUP
 #define OCARINA_CDOWN_MAP BTN_CDOWN

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -109,7 +109,7 @@ void Fault_WaitForInputImpl(void) {
         Fault_SleepImpl(0x10);
         PadMgr_RequestPadData(&gPadMgr, inputs, 0);
         btnPress = inputs[0].press.button;
-    } while (!CHECK_BTN_ANY(btnPress, (BTN_A | BTN_B | BTN_START | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP)));
+    } while (!CHECK_BTN_ANY(btnPress, (BTN_A | BTN_B | BTN_START | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT)));
 }
 
 void Fault_WaitForInput(void) {

--- a/src/code/z_debug.c
+++ b/src/code/z_debug.c
@@ -168,7 +168,7 @@ void Regs_UpdateEditor(Input* input) {
     s32 increment;
     s32 i;
 
-    dPadInputCur = input->cur.button & (BTN_DUP | BTN_DLEFT | BTN_DRIGHT | BTN_DDOWN);
+    dPadInputCur = input->cur.button & (BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT);
 
     if (CHECK_BTN_ALL(input->cur.button, BTN_L) || CHECK_BTN_ALL(input->cur.button, BTN_R) ||
         CHECK_BTN_ALL(input->cur.button, BTN_START)) {

--- a/src/code/z_frame_advance.c
+++ b/src/code/z_frame_advance.c
@@ -2,6 +2,7 @@
 
 #include "stdbool.h"
 
+#include "controller.h"
 #include "padmgr.h"
 #include "macros.h"
 

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -287,7 +287,7 @@ void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
             }
         } else if (CHECK_BTN_ANY(play->state.input[0].press.button,
-                                 (BTN_A | BTN_B | BTN_R | BTN_CUP | BTN_CLEFT | BTN_CRIGHT | BTN_CDOWN))) {
+                                 (BTN_A | BTN_B | BTN_R | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT))) {
             this->timer = 0;
         }
     }

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -151,8 +151,8 @@ void EnMag_CheckSramResetCode(PlayState* play, EnMag* this) {
     s32 var_v1;
 
     var_v1 =
-        play->state.input[2].cur.button & (BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP | BTN_R | BTN_L | BTN_DRIGHT |
-                                           BTN_DLEFT | BTN_DDOWN | BTN_DUP | BTN_START | BTN_Z | BTN_B | BTN_A);
+        play->state.input[2].cur.button & (BTN_A | BTN_B | BTN_Z | BTN_START | BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_L |
+                                           BTN_R | BTN_DRIGHT | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
     if (this->unk_E31C == var_v1) {
         this->unk_E320--;
         if (this->unk_E320 < 0) {

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -151,8 +151,8 @@ void EnMag_CheckSramResetCode(PlayState* play, EnMag* this) {
     s32 var_v1;
 
     var_v1 =
-        play->state.input[2].cur.button & (BTN_A | BTN_B | BTN_Z | BTN_START | BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_L |
-                                           BTN_R | BTN_DRIGHT | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
+        play->state.input[2].cur.button & (BTN_A | BTN_B | BTN_Z | BTN_START | BTN_DUP | BTN_DDOWN | BTN_DLEFT |
+                                           BTN_DRIGHT | BTN_L | BTN_R | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT);
     if (this->unk_E31C == var_v1) {
         this->unk_E320--;
         if (this->unk_E320 < 0) {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2789,7 +2789,7 @@ int func_80834E44(PlayState* play) {
 int func_80834E7C(PlayState* play) {
     return (play->shootingGalleryStatus != 0) &&
            ((play->shootingGalleryStatus < 0) ||
-            CHECK_BTN_ANY(sControlInput->cur.button, BTN_A | BTN_B | BTN_CUP | BTN_CLEFT | BTN_CRIGHT | BTN_CDOWN));
+            CHECK_BTN_ANY(sControlInput->cur.button, BTN_A | BTN_B | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT));
 }
 
 s32 func_80834EB8(Player* this, PlayState* play) {
@@ -6957,7 +6957,7 @@ s32 func_8083EAF0(Player* this, Actor* actor) {
 
 s32 Player_ActionChange_9(Player* this, PlayState* play) {
     if ((this->stateFlags1 & PLAYER_STATE1_11) && (this->heldActor != NULL) &&
-        CHECK_BTN_ANY(sControlInput->press.button, BTN_A | BTN_B | BTN_CLEFT | BTN_CRIGHT | BTN_CDOWN)) {
+        CHECK_BTN_ANY(sControlInput->press.button, BTN_A | BTN_B | BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT)) {
         if (!func_80835644(play, this, this->heldActor)) {
             if (!func_8083EAF0(this, this->heldActor)) {
                 Player_SetupAction(play, this, Player_Action_808464B0, 1);
@@ -8999,7 +8999,7 @@ void Player_Action_8084411C(Player* this, PlayState* play) {
             heldActor = this->heldActor;
 
             if (!func_80835644(play, this, heldActor) && (heldActor->id == ACTOR_EN_NIW) &&
-                CHECK_BTN_ANY(sControlInput->press.button, BTN_A | BTN_B | BTN_CLEFT | BTN_CRIGHT | BTN_CDOWN)) {
+                CHECK_BTN_ANY(sControlInput->press.button, BTN_A | BTN_B | BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT)) {
                 func_8084409C(play, this, this->speedXZ + 2.0f, this->actor.velocity.y + 2.0f);
             }
         }
@@ -9785,7 +9785,7 @@ void Player_Action_80846260(Player* this, PlayState* play) {
         } else if (LinkAnimation_OnFrame(&this->skelAnime, 25.0f)) {
             Player_PlayVoiceSfx(this, NA_SE_VO_LI_SWORD_L);
         }
-    } else if (CHECK_BTN_ANY(sControlInput->press.button, BTN_A | BTN_B | BTN_CLEFT | BTN_CRIGHT | BTN_CDOWN)) {
+    } else if (CHECK_BTN_ANY(sControlInput->press.button, BTN_A | BTN_B | BTN_CLEFT | BTN_CDOWN | BTN_CRIGHT)) {
         Player_SetupAction(play, this, Player_Action_80846358, 1);
         Player_AnimPlayOnce(play, this, &gPlayerAnim_link_silver_throw);
     }
@@ -11866,7 +11866,7 @@ void Player_Action_8084B1D8(Player* this, PlayState* play) {
                                    func_80833B2C(this) || (!func_8002DD78(this) && !func_808334B4(this)))) ||
          ((this->unk_6AD == 1) &&
           CHECK_BTN_ANY(sControlInput->press.button,
-                        BTN_A | BTN_B | BTN_R | BTN_CUP | BTN_CLEFT | BTN_CRIGHT | BTN_CDOWN)))) {
+                        BTN_A | BTN_B | BTN_R | BTN_CUP | BTN_CDOWN | BTN_CLEFT | BTN_CRIGHT)))) {
         func_8083C148(this, play);
         Sfx_PlaySfxCentered(NA_SE_SY_CAMERA_ZOOM_UP);
     } else if ((DECR(this->av2.actionVar2) == 0) || (this->unk_6AD != 2)) {
@@ -13816,7 +13816,7 @@ void Player_Action_8084FBF4(Player* this, PlayState* play) {
 s32 Player_UpdateNoclip(Player* this, PlayState* play) {
     sControlInput = &play->state.input[0];
 
-    if ((CHECK_BTN_ALL(sControlInput->cur.button, BTN_L | BTN_R | BTN_A) &&
+    if ((CHECK_BTN_ALL(sControlInput->cur.button, BTN_A | BTN_L | BTN_R) &&
          CHECK_BTN_ALL(sControlInput->press.button, BTN_B)) ||
         (CHECK_BTN_ALL(sControlInput->cur.button, BTN_L) && CHECK_BTN_ALL(sControlInput->press.button, BTN_DRIGHT))) {
 
@@ -13845,7 +13845,7 @@ s32 Player_UpdateNoclip(Player* this, PlayState* play) {
                 this->actor.world.pos.y -= speed;
             }
 
-            if (CHECK_BTN_ANY(sControlInput->cur.button, BTN_DUP | BTN_DLEFT | BTN_DDOWN | BTN_DRIGHT)) {
+            if (CHECK_BTN_ANY(sControlInput->cur.button, BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT)) {
                 s16 angle;
                 s16 temp;
 


### PR DESCRIPTION
More stuff from #2062. I also reversed the order since it seemed more natural and tried to use this order everywhere, except in the item-handling parts of player and kaleido where I felt CLEFT, CDOWN, CRIGHT was more natural.

Is the name controller.h confusing given that there's already ultra64/controller.h? Perhaps we should name this buttons.h or something, although I don't know what else would go in here.