### PR TITLE
[ntsc-1.2] Match z_map_exp.c, z_map_mark.c

### DIFF
--- a/include/n64dd.h
+++ b/include/n64dd.h
@@ -4,16 +4,19 @@
 #include "ultra64.h"
 #include "z64pause.h"
 #include "z64scene.h"
+#include "z64map_mark.h"
 
 struct Font;
 struct GameState;
-union Gfx;
+struct MapData;
 struct MessageTableEntry;
 struct PlayState;
 struct RegEditor;
 struct RoomContext;
 struct SaveContext;
 struct Scene;
+
+union Gfx;
 
 // TODO Use the specific pointer types instead of void*
 typedef struct n64ddStruct_800FEE70_pointers {
@@ -32,7 +35,13 @@ typedef struct n64ddStruct_80121220 {
     void (*unk_0C)(struct PlayState* play);
     void (*unk_10)(struct PlayState* play);
     void (*unk_14)(struct PlayState* play);
-    char unk_18[0x1C];
+    s32 (*unk_18)(struct MapData**);
+    s32 (*unk_1C)(struct MapData**);
+    s32 (*unk_20)(struct MapData*);
+    s32 (*unk_24)(void);
+    s32 (*unk_28)(struct PlayState*);
+    s32 (*unk_2C)(MapMarkData***);
+    s32 (*unk_30)(MapMarkData***);
     void (*unk_34)(PauseMapMarksData**);
     void (*unk_38)(PauseMapMarksData**);
     void (*unk_3C)(void);

--- a/include/n64dd.h
+++ b/include/n64dd.h
@@ -16,8 +16,6 @@ struct RoomContext;
 struct SaveContext;
 struct Scene;
 
-union Gfx;
-
 // TODO Use the specific pointer types instead of void*
 typedef struct n64ddStruct_800FEE70_pointers {
     void* unk_00;
@@ -70,7 +68,7 @@ void func_800AD590(void);
 void func_800AD598(s32 arg0, s32 arg1, s32 arg2);
 
 u32 func_801C6E80(void);
-void func_801C6EA0(union Gfx** gfxP);
+void func_801C6EA0(Gfx** gfxP);
 s32 func_801C70FC(void);
 void func_801C7268(void);
 s32 func_801C7658(void);

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -2,6 +2,9 @@
 #include "terminal.h"
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include "assets/textures/parameter_static/parameter_static.h"
+#if PLATFORM_N64
+#include "n64dd.h"
+#endif
 
 MapData* gMapData;
 
@@ -160,10 +163,22 @@ void Map_InitData(PlayState* play, s16 room) {
                      "Deku Tree Dungeon MAP Texture DMA(%x) scene_id_offset=%d  VREG(30)=%d\n"),
                    room, mapIndex, VREG(30));
             PRINTF(VT_RST);
+
+#if PLATFORM_N64
+            if ((B_80121220 != NULL) && (B_80121220->unk_28 != NULL) && B_80121220->unk_28(play)) {
+            } else {
+                DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,
+                             (uintptr_t)_map_i_staticSegmentRomStart +
+                                 ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * MAP_I_TEX_SIZE),
+                             MAP_I_TEX_SIZE, "../z_map_exp.c", 346);
+            }
+#else
             DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,
                              (uintptr_t)_map_i_staticSegmentRomStart +
                                  ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * MAP_I_TEX_SIZE),
                              MAP_I_TEX_SIZE, "../z_map_exp.c", 346);
+#endif
+
             R_COMPASS_OFFSET_X = gMapData->roomCompassOffsetX[mapIndex][room];
             R_COMPASS_OFFSET_Y = gMapData->roomCompassOffsetY[mapIndex][room];
             Map_SetFloorPalettesData(play, VREG(30));
@@ -221,6 +236,16 @@ void Map_InitRoomData(PlayState* play, s16 room) {
 
 void Map_Destroy(PlayState* play) {
     MapMark_ClearPointers(play);
+
+#if PLATFORM_N64
+        if ((B_80121220 != NULL) && (B_80121220->unk_24 != NULL)) {
+            B_80121220->unk_24();
+        }
+        if ((B_80121220 != NULL) && (B_80121220->unk_1C != NULL)) {
+            B_80121220->unk_1C(&gMapData);
+        }
+#endif
+
     gMapData = NULL;
 }
 
@@ -229,6 +254,12 @@ void Map_Init(PlayState* play) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
     gMapData = &gMapDataTable;
+
+#if PLATFORM_N64
+    if ((B_80121220 != NULL) && (B_80121220->unk_18 != NULL)) {
+        B_80121220->unk_18(&gMapData);
+    }
+#endif
 
     interfaceCtx->unk_258 = -1;
     interfaceCtx->unk_25A = -1;
@@ -303,6 +334,11 @@ void Map_Init(PlayState* play) {
                 R_COMPASS_OFFSET_X = gMapData->dgnCompassInfo[mapIndex][2];
                 R_COMPASS_OFFSET_Y = gMapData->dgnCompassInfo[mapIndex][3];
                 R_MAP_TEX_INDEX = R_MAP_TEX_INDEX_BASE = gMapData->dgnTexIndexBase[mapIndex];
+#if PLATFORM_N64
+                if ((B_80121220 != NULL) && (B_80121220->unk_20 != NULL)) {
+                    B_80121220->unk_20(gMapData);
+                }
+#endif
                 Map_InitRoomData(play, play->roomCtx.curRoom.num);
                 MapMark_Init(play);
             }

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -167,10 +167,10 @@ void Map_InitData(PlayState* play, s16 room) {
 #if PLATFORM_N64
             if ((B_80121220 != NULL) && (B_80121220->unk_28 != NULL) && B_80121220->unk_28(play)) {
             } else {
-                DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,
-                                 (uintptr_t)_map_i_staticSegmentRomStart +
-                                     ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * MAP_I_TEX_SIZE),
-                                 MAP_I_TEX_SIZE, "../z_map_exp.c", 346);
+                DmaMgr_RequestSync(play->interfaceCtx.mapSegment,
+                                   (uintptr_t)_map_i_staticSegmentRomStart +
+                                       ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * MAP_I_TEX_SIZE),
+                                   MAP_I_TEX_SIZE);
             }
 #else
             DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -168,9 +168,9 @@ void Map_InitData(PlayState* play, s16 room) {
             if ((B_80121220 != NULL) && (B_80121220->unk_28 != NULL) && B_80121220->unk_28(play)) {
             } else {
                 DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,
-                             (uintptr_t)_map_i_staticSegmentRomStart +
-                                 ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * MAP_I_TEX_SIZE),
-                             MAP_I_TEX_SIZE, "../z_map_exp.c", 346);
+                                 (uintptr_t)_map_i_staticSegmentRomStart +
+                                     ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * MAP_I_TEX_SIZE),
+                                 MAP_I_TEX_SIZE, "../z_map_exp.c", 346);
             }
 #else
             DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,
@@ -238,12 +238,12 @@ void Map_Destroy(PlayState* play) {
     MapMark_ClearPointers(play);
 
 #if PLATFORM_N64
-        if ((B_80121220 != NULL) && (B_80121220->unk_24 != NULL)) {
-            B_80121220->unk_24();
-        }
-        if ((B_80121220 != NULL) && (B_80121220->unk_1C != NULL)) {
-            B_80121220->unk_1C(&gMapData);
-        }
+    if ((B_80121220 != NULL) && (B_80121220->unk_24 != NULL)) {
+        B_80121220->unk_24();
+    }
+    if ((B_80121220 != NULL) && (B_80121220->unk_1C != NULL)) {
+        B_80121220->unk_1C(&gMapData);
+    }
 #endif
 
     gMapData = NULL;

--- a/src/code/z_map_mark.c
+++ b/src/code/z_map_mark.c
@@ -1,6 +1,9 @@
 #include "global.h"
 #include "terminal.h"
 #include "assets/textures/parameter_static/parameter_static.h"
+#if PLATFORM_N64
+#include "n64dd.h"
+#endif
 
 typedef struct MapMarkInfo {
     /* 0x00 */ void* texture;
@@ -52,9 +55,21 @@ void MapMark_Init(PlayState* play) {
                                ? (void*)((uintptr_t)overlay->vramTable -
                                          (intptr_t)((uintptr_t)overlay->vramStart - (uintptr_t)overlay->loadedRamAddr))
                                : NULL);
+
+#if PLATFORM_N64
+    if ((B_80121220 != NULL) && (B_80121220->unk_2C != NULL)) {
+        B_80121220->unk_2C(&sLoadedMarkDataTable);
+    }
+#endif
 }
 
 void MapMark_ClearPointers(PlayState* play) {
+#if PLATFORM_N64
+    if ((B_80121220 != NULL) && (B_80121220->unk_30 != NULL)) {
+        B_80121220->unk_30(&sLoadedMarkDataTable);
+    }
+#endif
+
     sMapMarkDataOvl.loadedRamAddr = NULL;
     sLoadedMarkDataTable = NULL;
 }


### PR DESCRIPTION
The last of the n64dd callbacks. Annoyingly there's still a few gaps in the function pointers struct