### PR TITLE
[ntsc-1.2] Fix size of leoDiskStack

### DIFF
--- a/include/ultra64/leodrive.h
+++ b/include/ultra64/leodrive.h
@@ -187,7 +187,7 @@ extern const s32 LEORAM_BYTE[];
 
 extern s32 __leoActive;
 extern LEOVersion __leoVersion;
-extern STACK(leoDiskStack, 0xFF0);
+extern STACK(leoDiskStack, 0x1000);
 
 extern OSPiHandle* LEOPiInfo;
 

--- a/src/libleo/api/cacreateleomanager.c
+++ b/src/libleo/api/cacreateleomanager.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "ultra64/asm.h"
 #include "ultra64/leo.h"
 #include "ultra64/leoappli.h"
 #include "ultra64/leodrive.h"
@@ -25,7 +26,7 @@ s32 LeoCACreateLeoManager(s32 comPri, s32 intPri, OSMesg* cmdBuf, s32 cmdMsgCnt)
     driveRomHandle = osDriveRomInit();
     __leoActive = true;
 
-    __osSetHWIntrRoutine(OS_INTR_CART, __osLeoInterrupt, STACK_TOP(leoDiskStack));
+    __osSetHWIntrRoutine(OS_INTR_CART, __osLeoInterrupt, (u8*)STACK_TOP(leoDiskStack) - FRAMESZ(SZREG * NARGSAVE));
     leoInitialize(comPri, intPri, cmdBuf, cmdMsgCnt);
 
     if (osResetType == 1) { // NMI

--- a/src/libleo/api/cjcreateleomanager.c
+++ b/src/libleo/api/cjcreateleomanager.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "ultra64/asm.h"
 #include "ultra64/leo.h"
 #include "ultra64/leoappli.h"
 #include "ultra64/leodrive.h"
@@ -25,7 +26,7 @@ s32 LeoCJCreateLeoManager(s32 comPri, s32 intPri, OSMesg* cmdBuf, s32 cmdMsgCnt)
     driveRomHandle = osDriveRomInit();
     __leoActive = true;
 
-    __osSetHWIntrRoutine(OS_INTR_CART, __osLeoInterrupt, STACK_TOP(leoDiskStack));
+    __osSetHWIntrRoutine(OS_INTR_CART, __osLeoInterrupt, (u8*)STACK_TOP(leoDiskStack) - FRAMESZ(SZREG * NARGSAVE));
     leoInitialize(comPri, intPri, cmdBuf, cmdMsgCnt);
 
     if (osResetType == 1) { // NMI

--- a/src/libleo/leo/leointerrupt.c
+++ b/src/libleo/leo/leointerrupt.c
@@ -9,7 +9,7 @@ extern OSHWIntr __OSGlobalIntMask;
 void __osLeoAbnormalResume(void);
 void __osLeoResume(void);
 
-STACK(leoDiskStack, 0xFF0);
+STACK(leoDiskStack, 0x1000);
 
 s32 __osLeoInterrupt(void) {
     u32 stat = 0;


### PR DESCRIPTION
The correct size in mdebug is 0x1000 bytes, and currently the bss size of the n64dd is too short due to this. @Thar0 points out that this is because one needs to reserve 0x10 bytes beyond the stack pointer for function arguments in the MIPS ABI, and that [`osCreateThread` does this for you](https://github.com/zeldaret/oot/blob/bb6177e936c535817eded229d1023d0556a67519/src/libultra/os/createthread.c#L14) but `__osSetHWIntrRoutine` does not.