### PR TITLE
Move audio/general.c debug bss with the rest of bss

### DIFF
--- a/src/audio/debug.inc.c
+++ b/src/audio/debug.inc.c
@@ -1,9 +1,3 @@
-u32 sDebugPadHold;
-u32 sDebugPadBtnLast;
-u32 sDebugPadPress;
-s32 sAudioUpdateTaskStart;
-s32 sAudioUpdateTaskEnd;
-
 f32 D_80131C8C = 0.0f;
 f32 sAudioUpdateDuration = 0.0f;
 f32 sAudioUpdateDurationMax = 0.0f;

--- a/src/audio/debug_bss.inc.c
+++ b/src/audio/debug_bss.inc.c
@@ -1,0 +1,5 @@
+u32 sDebugPadHold;
+u32 sDebugPadBtnLast;
+u32 sDebugPadPress;
+s32 sAudioUpdateTaskStart;
+s32 sAudioUpdateTaskEnd;

--- a/src/audio/debug_bss.inc.c
+++ b/src/audio/debug_bss.inc.c
@@ -1,5 +1,0 @@
-u32 sDebugPadHold;
-u32 sDebugPadBtnLast;
-u32 sDebugPadPress;
-s32 sAudioUpdateTaskStart;
-s32 sAudioUpdateTaskEnd;

--- a/src/audio/general.c
+++ b/src/audio/general.c
@@ -1297,6 +1297,9 @@ OcarinaNote sScarecrowsLongSongSecondNote;
 #if OOT_DEBUG
 u8 sIsMalonSinging;
 f32 sMalonSingingDist;
+
+#include "debug_bss.inc.c"
+
 #endif
 
 void PadMgr_RequestPadData(PadMgr* padMgr, Input* inputs, s32 gameRequest);

--- a/src/audio/general.c
+++ b/src/audio/general.c
@@ -1297,9 +1297,11 @@ OcarinaNote sScarecrowsLongSongSecondNote;
 #if OOT_DEBUG
 u8 sIsMalonSinging;
 f32 sMalonSingingDist;
-
-#include "debug_bss.inc.c"
-
+u32 sDebugPadHold;
+u32 sDebugPadBtnLast;
+u32 sDebugPadPress;
+s32 sAudioUpdateTaskStart;
+s32 sAudioUpdateTaskEnd;
 #endif
 
 void PadMgr_RequestPadData(PadMgr* padMgr, Input* inputs, s32 gameRequest);


### PR DESCRIPTION
Untangling some headers causes gc-eu-mq-dbg to not match due to the debug portion of audio/general.c bss.
This PR moves the debug bss portion definitions together with the rest of the file bss, solving reorderings at least for now.
(for example #2147 and #2151 are hitting this)

I tried cleaning up headers included by audio/general.c instead of doing this but it didn't help with the problem. It was also a lot of changes that were uneasy to split into simpler PRs