### PR TITLE
Rename gBuildTeam to gBuildCreator

### DIFF
--- a/include/variables.h
+++ b/include/variables.h
@@ -41,7 +41,7 @@ extern OSViContext* __osViCurr;
 extern OSViContext* __osViNext;
 extern OSViMode osViModeFpalLan1;
 extern u32 __additional_scanline;
-extern const char gBuildTeam[];
+extern const char gBuildCreator[];
 extern const char gBuildDate[];
 extern const char gBuildMakeOption[];
 extern OSMesgQueue gPiMgrCmdQueue;

--- a/src/boot/build.c
+++ b/src/boot/build.c
@@ -1,9 +1,9 @@
 #include "versions.h"
 
 #if PLATFORM_N64
-const char gBuildTeam[] = "zelda@srd44";
+const char gBuildCreator[] = "zelda@srd44";
 #else
-const char gBuildTeam[] = "zelda@srd022j";
+const char gBuildCreator[] = "zelda@srd022j";
 #endif
 
 #if OOT_VERSION == NTSC_1_2

--- a/src/boot/cic6105.c
+++ b/src/boot/cic6105.c
@@ -5,7 +5,7 @@
 s32 func_80001714(void);
 
 OSTask D_800067C0_unknown = {
-    4, 0, rspbootTextStart, 0x3E8, cic6105TextStart, 0x20, (u64*)gBuildTeam, 8, NULL, 0, NULL, 0, NULL, 0, NULL, 0,
+    4, 0, rspbootTextStart, 0x3E8, cic6105TextStart, 0x20, (u64*)gBuildCreator, 8, NULL, 0, NULL, 0, NULL, 0, NULL, 0,
 };
 
 s32 B_80008EE0;
@@ -34,7 +34,7 @@ void CIC6105_FaultClient(void) {
     }
     Fault_SetCursor(40, 184);
     Fault_Printf("ROM_F");
-    Fault_Printf(" [Creator:%s]", gBuildTeam);
+    Fault_Printf(" [Creator:%s]", gBuildCreator);
     Fault_SetCursor(56, 192);
     Fault_Printf("[Date:%s]", gBuildDate);
     Fault_SetCursor(96, 32);

--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -39,7 +39,7 @@ void Main_ThreadEntry(void* arg) {
 
 void Idle_ThreadEntry(void* arg) {
     PRINTF(T("アイドルスレッド(idleproc)実行開始\n", "Idle thread (idleproc) execution started\n"));
-    PRINTF(T("作製者    : %s\n", "Created by: %s\n"), gBuildTeam);
+    PRINTF(T("作製者    : %s\n", "Created by: %s\n"), gBuildCreator);
     PRINTF(T("作成日時  : %s\n", "Created   : %s\n"), gBuildDate);
     PRINTF("MAKEOPTION: %s\n", gBuildMakeOption);
     PRINTF(VT_FGCOL(GREEN));

--- a/src/overlays/gamestates/ovl_title/z_title.c
+++ b/src/overlays/gamestates/ovl_title/z_title.c
@@ -30,7 +30,7 @@ void ConsoleLogo_PrintBuildInfo(Gfx** gfxP) {
     GfxPrint_Printf(printer, "NOT MARIO CLUB VERSION");
     GfxPrint_SetColor(printer, 255, 255, 255, 255);
     GfxPrint_SetPos(printer, 7, 23);
-    GfxPrint_Printf(printer, "[Creator:%s]", gBuildTeam);
+    GfxPrint_Printf(printer, "[Creator:%s]", gBuildCreator);
     GfxPrint_SetPos(printer, 7, 24);
     GfxPrint_Printf(printer, "[Date:%s]", gBuildDate);
     gfx = GfxPrint_Close(printer);

--- a/tools/disasm/ntsc-1.2/variables.txt
+++ b/tools/disasm/ntsc-1.2/variables.txt
@@ -58,5 +58,5 @@ sGraphThread = 0x8011E2B8;
 rspbootTextStart = 0x800065C0;
 rspbootTextEnd = 0x80006720;
 cic6105TextStart = 0x80006720;
-gBuildTeam = 0x80006D30;
+gBuildCreator = 0x80006D30;
 gBuildDate = 0x80006D3C;


### PR DESCRIPTION
Copy/pasting my reasoning from a different PR discussion here:

"We should probably rename gBuildTeam to gBuildCreator at some point. The point is to identify exactly who built the rom, for example zelda@srd44 and zelda@srd022j likely reference individual computer names/users at srd (the team)

this is supported by the ique strings as well, which are non-srd
build@toad.routefree.com 03-10-22 16:23:19 username "build" @ hostname "toad.routfree.com"
tyu@linuxdev3 06-10-13 14:17:43 username "tyu" @ hostname "linuxdev3" "

also there are multiple prints referring to it as such:
`Fault_Printf(" [Creator:%s]", gBuildCreator);`
`PRINTF(T("作製者    : %s\n", "Created by: %s\n"), gBuildCreator);`