### PR TITLE
Propose wrapper macros for qrand functions

### DIFF
--- a/include/libc64/qrand.h
+++ b/include/libc64/qrand.h
@@ -3,16 +3,16 @@
 
 #include "ultra64.h"
 
-u32 Rand_Next(void);
-void Rand_Seed(u32 seed);
-f32 Rand_ZeroOne(void);
-void Rand_Seed_Variable(u32* rndNum, u32 seed);
-u32 Rand_Next_Variable(u32* rndNum);
-f32 Rand_ZeroOne_Variable(u32* rndNum);
+u32 qrand(void);
+void sqrand(u32 seed);
+f32 fqrand(void);
+void sqrand_r(u32* rndNum, u32 seed);
+u32 qrand_r(u32* rndNum);
+f32 fqrand_r(u32* rndNum);
 
 #if !PLATFORM_N64
-f32 Rand_Centered(void);
-f32 Rand_Centered_Variable(u32* rndNum);
+f32 fqrand2(void);
+f32 fqrand2_r(u32* rndNum);
 #endif
 
 #endif

--- a/include/rand.h
+++ b/include/rand.h
@@ -3,6 +3,20 @@
 
 #include "libc64/qrand.h"
 
+// qrand.c function wrapper defines for more friendly names
+#define Rand_Next             qrand
+#define Rand_Seed             sqrand
+#define Rand_ZeroOne          fqrand
+#define Rand_Seed_Variable    sqrand_r
+#define Rand_Next_Variable    qrand_r
+#define Rand_ZeroOne_Variable fqrand_r
+
+#if !PLATFORM_N64
+#define Rand_Centered          fqrand2
+#define Rand_Centered_Variable fqrand2_r
+#endif
+
+// z_actor.c rand functions
 f32 Rand_ZeroFloat(f32 f);
 f32 Rand_CenteredFloat(f32 f);
 


### PR DESCRIPTION
I know we usually use `ALL_CAPS` for macros, but I feel like these macros for the purposes of giving friendly names to library functions for the sole purpose of better names can be an exception