### PR TITLE
fix_bss.py: Restore z_locale special case

### DIFF
--- a/tools/fix_bss.py
+++ b/tools/fix_bss.py
@@ -797,8 +797,14 @@ def main():
     for file, bss_section in bss_sections.items():
         if not bss_section.pointers:
             continue
+        # The following heuristic doesn't work for z_locale, since the first pointer into BSS is not
+        # at the start of the section. Fortunately z_locale either has one BSS variable (in GC versions)
+        # or none (in N64 versions), so we can just skip it.
+        if str(file) == "src/boot/z_locale.c":
+            continue
         # For the baserom, assume that the lowest address is the start of the BSS section. This might
-        # not be true if the first BSS variable is not referenced, but in practice this doesn't happen.
+        # not be true if the first BSS variable is not referenced, but in practice this doesn't happen
+        # (except for z_locale above).
         base_min_address = min(p.base_value for p in bss_section.pointers)
         build_min_address = bss_section.start_address
         if not all(


### PR DESCRIPTION
https://github.com/zeldaret/oot/pull/2169 removed the z_locale special case, but that PR doesn't actually do anything to help z_locale because `sCartInfo` is in-function static rather than a global symbol. (I didn't catch this in testing because I was running with a list of files rather than no arguments, and didn't notice it complaining about z_locale.c. It does spew a lot of output, maybe we should consider adding a --verbose flag)