### PR TITLE
Extract scripts make their own directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,8 +353,8 @@ SOUNDFONT_O_FILES      := $(foreach f,$(SOUNDFONT_BUILD_XMLS),$(f:.xml=.o))
 SOUNDFONT_HEADERS      := $(foreach f,$(SOUNDFONT_BUILD_XMLS),$(f:.xml=.h))
 SOUNDFONT_DEP_FILES    := $(foreach f,$(SOUNDFONT_O_FILES),$(f:.o=.d))
 
-# create extracted directories
-$(shell mkdir -p $(EXTRACTED_DIR) $(EXTRACTED_DIR)/assets $(EXTRACTED_DIR)/text)
+# create extracted directory
+$(shell mkdir -p $(EXTRACTED_DIR))
 
 ASSET_BIN_DIRS_EXTRACTED := $(shell find $(EXTRACTED_DIR)/assets -type d)
 ASSET_BIN_DIRS_COMMITTED := $(shell find assets -type d -not -path "assets/xml*" -not -path assets/text)

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -137,6 +137,8 @@ def main():
     version: str = args.oot_version
     outputDir: Path = args.output_dir
 
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
     versionConfig = version_config.load_version_config(version)
 
     global ZAPDArgs

--- a/tools/msgdis.py
+++ b/tools/msgdis.py
@@ -2060,6 +2060,8 @@ def main():
     version : str = args.oot_version
     output_dir : Path = args.output_dir
 
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
     config = version_config.load_version_config(version)
     code_vram = config.dmadata_segments["code"].vram
 


### PR DESCRIPTION
Have extract_assets.py and msgdis.py create `$(EXTRACTED_DIR)/assets` and `$(EXTRACTED_DIR)/text` respectively.