### PR TITLE
Ignore nonexistent extracted/VERSION/assets dir in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,11 @@ SOUNDFONT_DEP_FILES    := $(foreach f,$(SOUNDFONT_O_FILES),$(f:.o=.d))
 # create extracted directory
 $(shell mkdir -p $(EXTRACTED_DIR))
 
-ASSET_BIN_DIRS_EXTRACTED := $(shell find $(EXTRACTED_DIR)/assets -type d)
+ifneq ($(wildcard $(EXTRACTED_DIR)/assets),)
+  ASSET_BIN_DIRS_EXTRACTED := $(shell find $(EXTRACTED_DIR)/assets -type d)
+else
+  ASSET_BIN_DIRS_EXTRACTED :=
+endif
 ASSET_BIN_DIRS_COMMITTED := $(shell find assets -type d -not -path "assets/xml*" -not -path assets/text)
 ASSET_BIN_DIRS := $(ASSET_BIN_DIRS_EXTRACTED) $(ASSET_BIN_DIRS_COMMITTED)
 


### PR DESCRIPTION
An unintended consequence of #2185 is that `make` currently prints
```
find: extracted/gc-eu-mq-dbg/assets: No such file or directory
```
the first time you invoke it.