### PR TITLE
Use gSpiritBossNabooruKnuckleDefeatCs instead of gMinuetCs in sCutscenesUnknownList

### DIFF
--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -115,7 +115,8 @@ EntranceCutscene sEntranceCutsceneTable[] = {
 };
 
 void* sCutscenesUnknownList[] = {
-    gDekuTreeIntroCs, gJabuJabuIntroCs, gDcOpeningCs, gMinuetCs, gIceCavernSerenadeCs, gTowerBarrierCs,
+    gDekuTreeIntroCs,     gJabuJabuIntroCs, gDcOpeningCs, gSpiritBossNabooruKnuckleDefeatCs,
+    gIceCavernSerenadeCs, gTowerBarrierCs,
 };
 
 // Stores the frame the relevant cam data was last applied on


### PR DESCRIPTION
These two cutscenes happen to be at the same segmented address in most versions, but not in PAL N64. Thanks to @AngheloAlf for the idea