### PR TITLE
[PAL N64] Match VI mode setup

### DIFF
--- a/spec
+++ b/spec
@@ -105,15 +105,21 @@ beginseg
     include "$(BUILD_DIR)/src/libultra/libc/bcopy.o"
     include "$(BUILD_DIR)/src/libultra/os/resetglobalintmask.o"
     include "$(BUILD_DIR)/src/libultra/os/interrupt.o"
+#if !OOT_PAL_N64
     include "$(BUILD_DIR)/src/libultra/io/vimodentsclan1.o"
     include "$(BUILD_DIR)/src/libultra/io/vimodempallan1.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/io/vi.o"
+#if OOT_PAL_N64
+    include "$(BUILD_DIR)/src/libultra/io/vimodentsclan1.o"
+    include "$(BUILD_DIR)/src/libultra/io/vimodempallan1.o"
+#endif
     include "$(BUILD_DIR)/src/libultra/io/viswapcontext.o"
     include "$(BUILD_DIR)/src/libultra/io/pigetcmdq.o"
     include "$(BUILD_DIR)/src/libultra/io/epiread.o"
     include "$(BUILD_DIR)/src/libultra/io/visetspecial.o"
     include "$(BUILD_DIR)/src/libultra/io/cartrominit.o"
-#if OOT_DEBUG
+#if OOT_PAL_N64 || OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/vimodefpallan1.o"
 #endif
     include "$(BUILD_DIR)/src/libultra/os/setfpccsr.o"
@@ -581,6 +587,11 @@ beginseg
     include "$(BUILD_DIR)/src/audio/lib/thread.o"
     include "$(BUILD_DIR)/src/audio/lib/dcache.o"
     include "$(BUILD_DIR)/src/audio/lib/aisetnextbuf.o"
+#if OOT_PAL_N64
+    pad_text
+    pad_text
+    pad_text
+#endif
     include "$(BUILD_DIR)/src/audio/lib/playback.o"
     include "$(BUILD_DIR)/src/audio/lib/effects.o"
     include "$(BUILD_DIR)/src/audio/lib/seqplayer.o"
@@ -731,8 +742,10 @@ beginseg
     include "$(BUILD_DIR)/src/libultra/mgu/translate.o"
 #endif
     include "$(BUILD_DIR)/src/libultra/io/contramwrite.o"
-#if !OOT_DEBUG
+#if !OOT_PAL_N64 && !OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/vimodefpallan1.o"
+#endif
+#if !OOT_DEBUG
     include "$(BUILD_DIR)/src/libultra/io/pfsgetstatus.o"
     include "$(BUILD_DIR)/src/libultra/io/contpfs.o"
 #endif

--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "stack.h"
 #include "terminal.h"
+#include "versions.h"
 
 #pragma increment_block_number "gc-eu:64 gc-eu-mq:64 gc-jp:64 gc-jp-ce:64 gc-jp-mq:64 gc-us:64 gc-us-mq:64 ntsc-1.2:64"
 
@@ -63,10 +64,9 @@ void Idle_ThreadEntry(void* arg) {
     gViConfigXScale = 1.0f;
     gViConfigYScale = 1.0f;
 
+#if OOT_DEBUG
+    // Allow both 60 Hz and 50 Hz
     switch (osTvType) {
-#if !OOT_DEBUG
-        case OS_TV_PAL:
-#endif
         case OS_TV_NTSC:
             gViConfigModeType = OS_VI_NTSC_LAN1;
             gViConfigMode = osViModeNtscLan1;
@@ -77,14 +77,38 @@ void Idle_ThreadEntry(void* arg) {
             gViConfigMode = osViModeMpalLan1;
             break;
 
-#if OOT_DEBUG
         case OS_TV_PAL:
             gViConfigModeType = OS_VI_FPAL_LAN1;
             gViConfigMode = osViModeFpalLan1;
             gViConfigYScale = 0.833f;
             break;
-#endif
     }
+#elif !OOT_PAL_N64
+    // 60 Hz only (GameCube and NTSC N64)
+    switch (osTvType) {
+        case OS_TV_PAL:
+        case OS_TV_NTSC:
+            gViConfigModeType = OS_VI_NTSC_LAN1;
+            gViConfigMode = osViModeNtscLan1;
+            break;
+
+        case OS_TV_MPAL:
+            gViConfigModeType = OS_VI_MPAL_LAN1;
+            gViConfigMode = osViModeMpalLan1;
+            break;
+    }
+#else
+    // 50 Hz only (PAL N64)
+    switch (osTvType) {
+        case OS_TV_NTSC:
+        case OS_TV_MPAL:
+        case OS_TV_PAL:
+            gViConfigModeType = OS_VI_FPAL_LAN1;
+            gViConfigMode = osViModeFpalLan1;
+            gViConfigYScale = 0.833f;
+            break;
+    }
+#endif
 
     D_80009430 = 1;
     osViSetMode(&gViConfigMode);


### PR DESCRIPTION
I gave up on trying to make this look nice as a single switch so I made it 3 separate cases (debug, 60 Hz, 50 Hz). The best way to check matching is by building my [pal-n64](https://github.com/cadmic/oot/tree/pal-n64) branch, but I'm hoping you can just trust me that it matches (and if it doesn't, it's not a big deal).

Side note: For libultra spec order, I feel like the linker "collects" missing dependencies when scanning a file and adds them shortly after in some DFS-like order, based on the way `vimodentsclan1` and `vimodempallan1` move around here (their first reference changed from `idle.o` to `vi.o`). It seems possible to simulate that but idk if it's really worth it.