### PR TITLE
Consistently use "OOT_VERSION <" and "OOT_VERSION >="

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ COMPILER ?= ido
 #   ntsc-1.2       N64 NTSC 1.2 (Japan/US depending on REGION)
 #   gc-jp          GameCube Japan
 #   gc-jp-mq       GameCube Japan Master Quest
-#   gc-jp-ce       GameCube Japan (Collector's Edition disc)
 #   gc-us          GameCube US
-#   gc-us-mq       GameCube US
+#   gc-us-mq       GameCube US Master Quest
+#   gc-eu-mq-dbg   GameCube Europe/PAL Master Quest Debug (default)
 #   gc-eu          GameCube Europe/PAL
 #   gc-eu-mq       GameCube Europe/PAL Master Quest
-#   gc-eu-mq-dbg   GameCube Europe/PAL Master Quest Debug (default)
+#   gc-jp-ce       GameCube Japan (Collector's Edition disc)
 # The following versions are work-in-progress and not yet matching:
 #   (none currently)
 VERSION ?= gc-eu-mq-dbg
@@ -61,10 +61,6 @@ else ifeq ($(VERSION),gc-jp-mq)
   REGION ?= JP
   PLATFORM := GC
   DEBUG := 0
-else ifeq ($(VERSION),gc-jp-ce)
-  REGION ?= JP
-  PLATFORM := GC
-  DEBUG := 0
 else ifeq ($(VERSION),gc-us)
   REGION ?= US
   PLATFORM := GC
@@ -73,6 +69,10 @@ else ifeq ($(VERSION),gc-us-mq)
   REGION ?= US
   PLATFORM := GC
   DEBUG := 0
+else ifeq ($(VERSION),gc-eu-mq-dbg)
+  REGION ?= EU
+  PLATFORM := GC
+  DEBUG := 1
 else ifeq ($(VERSION),gc-eu)
   REGION ?= EU
   PLATFORM := GC
@@ -81,10 +81,10 @@ else ifeq ($(VERSION),gc-eu-mq)
   REGION ?= EU
   PLATFORM := GC
   DEBUG := 0
-else ifeq ($(VERSION),gc-eu-mq-dbg)
-  REGION ?= EU
+else ifeq ($(VERSION),gc-jp-ce)
+  REGION ?= JP
   PLATFORM := GC
-  DEBUG := 1
+  DEBUG := 0
 else
 $(error Unsupported version $(VERSION))
 endif

--- a/spec
+++ b/spec
@@ -571,7 +571,7 @@ beginseg
 #if OOT_DEBUG
     include "$(BUILD_DIR)/src/code/ucode_disas.o"
 #endif
-#if OOT_VERSION <= NTSC_1_0 || PLATFORM_GC
+#if OOT_VERSION < NTSC_1_1 || PLATFORM_GC
     pad_text
 #endif
     include "$(BUILD_DIR)/src/audio/lib/data.o"

--- a/src/n64dd/n64dd_801C8000.c
+++ b/src/n64dd/n64dd_801C8000.c
@@ -301,7 +301,7 @@ s32 func_801C885C(void) {
     B_801E0D18.unk_64 = 3;
     func_801C85F0(&B_801E0D18, 1);
 
-#if OOT_VERSION > NTSC_1_0
+#if OOT_VERSION >= NTSC_1_1
     D_801D2E90 = 0;
 #endif
 
@@ -317,7 +317,7 @@ s32 func_801C88AC(void) {
     B_801E0D18.unk_64 = 4;
     func_801C85F0(&B_801E0D18, 1);
 
-#if OOT_VERSION > NTSC_1_0
+#if OOT_VERSION >= NTSC_1_1
     D_801D2E90 = 0;
 #endif
 

--- a/src/n64dd/z_n64dd.c
+++ b/src/n64dd/z_n64dd.c
@@ -131,7 +131,7 @@ s32 func_801C7064(void) {
 s32 func_801C7098(void) {
     s32 phi_v1;
 
-#if OOT_VERSION <= NTSC_1_1
+#if OOT_VERSION < PAL_1_0
     if (0) {}
 #endif
 
@@ -186,7 +186,7 @@ void func_801C711C(void* arg) {
     IrqMgr_RemoveClient(arg0->unk_98, &arg0->unk_90);
 }
 
-#if OOT_VERSION > NTSC_1_0
+#if OOT_VERSION >= NTSC_1_1
 void func_801C7B28_ne2(void) {
     s32 temp;
 
@@ -268,7 +268,7 @@ void func_801C746C(void* arg0, void* arg1, void* arg2) {
             if (arg2 != NULL) {
                 func_801CA1F0(arg2, 0, 176, 320, 32, 11, sp2C, SCREEN_WIDTH);
             }
-#if OOT_VERSION <= NTSC_1_1
+#if OOT_VERSION < PAL_1_0
             osViBlack(0);
 #endif
         }
@@ -306,7 +306,7 @@ s32 func_801C7658(void) {
         return 0;
     }
 
-#if OOT_VERSION <= NTSC_1_1
+#if OOT_VERSION < PAL_1_0
     StackCheck_Init(&B_801DAF88, B_801D9F88, STACK_TOP(B_801D9F88), 0, 0x100, "ddmsg");
     osCreateThread(&B_801D9DD8, THREAD_ID_DDMSG, &func_801C711C, &B_801D9B90, STACK_TOP(B_801D9F88), THREAD_PRI_DDMSG);
     osStartThread(&B_801D9DD8);
@@ -348,7 +348,7 @@ s32 func_801C7658(void) {
 }
 
 s32 func_801C7818(void) {
-#if OOT_VERSION > NTSC_1_0
+#if OOT_VERSION >= NTSC_1_1
     B_801D9DB8 = 1;
     B_801D9DC0 = 0;
 #endif
@@ -361,7 +361,7 @@ s32 func_801C7818(void) {
         Sleep_Usec(1000000 * 1 / 60);
     }
 
-#if OOT_VERSION > NTSC_1_0
+#if OOT_VERSION >= NTSC_1_1
     if (D_801D2EA8 == 1 || B_801E0F60 == 1 || B_801E0F64 == 1) {
         B_801D9DC0 = osGetTime();
     }


### PR DESCRIPTION
The idea being that `OOT_VERSION < FOO` and `OOT_VERSION >= FOO` mean "things changed starting with version FOO". This does require readers to know the version ordering though, in particular that PAL 1.0 comes between NTSC 1.1 and NTSC 1.2. To help with this, I've also ordered versions in build order in the Makefile (and the README too, eventually).