### PR TITLE
[PAL N64] Miscellaneous changes

### DIFF
--- a/src/audio/lib/load.c
+++ b/src/audio/lib/load.c
@@ -1,5 +1,6 @@
 #include "ultra64.h"
 #include "global.h"
+#include "versions.h"
 
 #define MK_ASYNC_MSG(retData, tableType, id, loadStatus) \
     (((retData) << 24) | ((tableType) << 16) | ((id) << 8) | (loadStatus))
@@ -1149,6 +1150,7 @@ void AudioLoad_Init(void* heap, u32 heapSize) {
     }
 
     // 1000 is a conversion from seconds to milliseconds
+#if !OOT_PAL_N64
     switch (osTvType) {
         case OS_TV_PAL:
             gAudioCtx.maxTempoTvTypeFactors = 1000 * REFRESH_RATE_DEVIATION_PAL / REFRESH_RATE_PAL;
@@ -1166,6 +1168,15 @@ void AudioLoad_Init(void* heap, u32 heapSize) {
             gAudioCtx.refreshRate = REFRESH_RATE_NTSC;
             break;
     }
+#else
+    switch (osTvType) {
+        case OS_TV_PAL:
+        default:
+            gAudioCtx.maxTempoTvTypeFactors = 1000 * REFRESH_RATE_DEVIATION_PAL / REFRESH_RATE_PAL;
+            gAudioCtx.refreshRate = REFRESH_RATE_PAL;
+            break;
+    }
+#endif
 
     AudioThread_InitMesgQueues();
 
@@ -1195,8 +1206,7 @@ void AudioLoad_Init(void* heap, u32 heapSize) {
         gAudioCtx.audioHeap = gAudioHeap;
         gAudioCtx.audioHeapSize = gAudioHeapInitSizes.heapSize;
     } else {
-        void** hp = &heap;
-        gAudioCtx.audioHeap = *hp;
+        gAudioCtx.audioHeap = heap;
         gAudioCtx.audioHeapSize = heapSize;
     }
 

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -176,8 +176,10 @@ void Play_SetupTransition(PlayState* this, s32 transitionType) {
                 break;
 
             default:
-#if PLATFORM_N64
+#if OOT_VERSION < PAL_1_1
                 HUNGUP_AND_CRASH("../z_play.c", 2269);
+#elif OOT_VERSION < GC_JP
+                HUNGUP_AND_CRASH("../z_play.c", 2272);
 #elif OOT_VERSION < GC_EU_MQ_DBG
                 HUNGUP_AND_CRASH("../z_play.c", 2287);
 #elif OOT_VERSION < GC_JP_CE

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -45,9 +45,9 @@ s32 Object_SpawnPersistent(ObjectContext* objectCtx, s16 objectId) {
     return objectCtx->numEntries - 1;
 }
 
-// PAL N64 versions reduce the size of object space by 4 KiB in order to make more room
-// for the Zelda arena, which can help prevent the "Hyrule Field glitch" where actors
-// do not have enough space to spawn.
+// PAL N64 versions reduce the size of object space by 4 KiB in order to give some space back to
+// the Zelda arena, which can help prevent an issue where actors fail to spawn in specific areas
+// (sometimes referred to as the "Hyrule Field glitch" although it can happen in more places than Hyrule Field).
 #if !OOT_PAL_N64
 #define OBJECT_SPACE_ADJUSTMENT 0
 #else

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -45,6 +45,15 @@ s32 Object_SpawnPersistent(ObjectContext* objectCtx, s16 objectId) {
     return objectCtx->numEntries - 1;
 }
 
+// PAL N64 versions reduce the size of object space by 4 KiB in order to make more room
+// for the Zelda arena, which can help prevent the "Hyrule Field glitch" where actors
+// do not have enough space to spawn.
+#if !OOT_PAL_N64
+#define OBJECT_SPACE_ADJUSTMENT 0
+#else
+#define OBJECT_SPACE_ADJUSTMENT (4 * 1024)
+#endif
+
 void Object_InitContext(PlayState* play, ObjectContext* objectCtx) {
     PlayState* play2 = play;
     s32 pad;
@@ -52,21 +61,21 @@ void Object_InitContext(PlayState* play, ObjectContext* objectCtx) {
     s32 i;
 
     if (play2->sceneId == SCENE_HYRULE_FIELD) {
-        spaceSize = 1000 * 1024;
+        spaceSize = 1000 * 1024 - OBJECT_SPACE_ADJUSTMENT;
     } else if (play2->sceneId == SCENE_GANON_BOSS) {
         if (gSaveContext.sceneLayer != 4) {
-            spaceSize = 1150 * 1024;
+            spaceSize = 1150 * 1024 - OBJECT_SPACE_ADJUSTMENT;
         } else {
-            spaceSize = 1000 * 1024;
+            spaceSize = 1000 * 1024 - OBJECT_SPACE_ADJUSTMENT;
         }
     } else if (play2->sceneId == SCENE_SPIRIT_TEMPLE_BOSS) {
-        spaceSize = 1050 * 1024;
+        spaceSize = 1050 * 1024 - OBJECT_SPACE_ADJUSTMENT;
     } else if (play2->sceneId == SCENE_CHAMBER_OF_THE_SAGES) {
-        spaceSize = 1050 * 1024;
+        spaceSize = 1050 * 1024 - OBJECT_SPACE_ADJUSTMENT;
     } else if (play2->sceneId == SCENE_GANONDORF_BOSS) {
-        spaceSize = 1050 * 1024;
+        spaceSize = 1050 * 1024 - OBJECT_SPACE_ADJUSTMENT;
     } else {
-        spaceSize = 1000 * 1024;
+        spaceSize = 1000 * 1024 - OBJECT_SPACE_ADJUSTMENT;
     }
 
     objectCtx->numEntries = objectCtx->numPersistentEntries = 0;

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -47,7 +47,7 @@ s32 Object_SpawnPersistent(ObjectContext* objectCtx, s16 objectId) {
 
 // PAL N64 versions reduce the size of object space by 4 KiB in order to give some space back to
 // the Zelda arena, which can help prevent an issue where actors fail to spawn in specific areas
-// (sometimes referred to as the "Hyrule Field glitch" although it can happen in more places than Hyrule Field).
+// (sometimes referred to as the "Hyrule Field Glitch" although it can happen in more places than Hyrule Field).
 #if !OOT_PAL_N64
 #define OBJECT_SPACE_ADJUSTMENT 0
 #else

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map.c
@@ -1,4 +1,5 @@
 #include "z_kaleido_scope.h"
+#include "versions.h"
 #include "assets/textures/icon_item_24_static/icon_item_24_static.h"
 #if OOT_NTSC
 #include "assets/textures/icon_item_jpn_static/icon_item_jpn_static.h"
@@ -723,6 +724,12 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
         G_TX_WRAP | G_TX_NOMIRROR, G_TX_WRAP | G_TX_NOMIRROR, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
     gSP1Quadrangle(POLY_OPA_DISP++, j, j + 2, j + 3, j + 1, 0);
+#endif
+
+#if PLATFORM_N64 && OOT_VERSION != NTSC_1_2
+    if (0) {
+        s32 pad[3];
+    }
 #endif
 
     if (ZREG(38) == 0) {

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -14,6 +14,7 @@
 #endif
 #include "assets/textures/icon_item_gameover_static/icon_item_gameover_static.h"
 #include "terminal.h"
+#include "versions.h"
 
 #pragma increment_block_number "ntsc-1.2:128"
 
@@ -1057,7 +1058,7 @@ void KaleidoScope_SetupPageSwitch(PauseContext* pauseCtx, u8 pt) {
         pauseCtx->cursorSpecialPos = PAUSE_CURSOR_PAGE_LEFT;
     }
 
-#if OOT_NTSC
+#if PLATFORM_N64 || OOT_NTSC
     gSaveContext.buttonStatus[0] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + pt][0];
 #endif
     gSaveContext.buttonStatus[1] = gPageSwitchNextButtonStatus[pauseCtx->pageIndex + pt][1];


### PR DESCRIPTION
Stuff that either doesn't fit in another PR or I forgot about. After this it's only file select (waiting for #2205) and bss ordering left before pal-1.0 and pal-1.1 are matching.

For the `z_kaleido_map.c` change, I think the empty if + stack padding actually comes from the else block attached to the `if (HREG(15) == 0)` case. In ntsc-1.2 though it seems like this if statement was written differently. I wasn't sure how to represent this so I went with the fake match instead.