### PR TITLE
Fix typos found by codespell

### DIFF
--- a/extract_assets.py
+++ b/extract_assets.py
@@ -78,7 +78,7 @@ def ExtractFunc(assetConfig: version_config.AssetConfig):
     ExtractFile(assetConfig, outPath, outSourcePath)
 
     if not globalAbort.is_set():
-        # Only update timestamp on succesful extractions
+        # Only update timestamp on successful extractions
         if xml_path_str not in globalExtractedAssetsTracker:
             globalExtractedAssetsTracker[xml_path_str] = globalManager.dict()
         globalExtractedAssetsTracker[xml_path_str]["timestamp"] = currentTimeStamp
@@ -188,7 +188,7 @@ def main():
             with mp_context.Pool(numCores, initializer=initializeWorker, initargs=(versionConfig, mainAbort, args.unaccounted, extractedAssetsTracker, manager, baseromSegmentsDir, outputDir)) as p:
                 p.map(ExtractFunc, versionConfig.assets)
         except (multiprocessing.ProcessError, TypeError, CannotMultiprocessError):
-            print("Warning: Multiprocessing exception ocurred.", file=os.sys.stderr)
+            print("Warning: Multiprocessing exception occurred.", file=os.sys.stderr)
             print("Disabling mutliprocessing.", file=os.sys.stderr)
 
             initializeWorker(versionConfig, mainAbort, args.unaccounted, extractedAssetsTracker, manager, baseromSegmentsDir, outputDir)

--- a/include/padmgr.h
+++ b/include/padmgr.h
@@ -76,7 +76,7 @@ void PadMgr_RumbleSet(PadMgr* padMgr, u8* enable);
  * user-provided argument. The callback function should be `void (*)(PadMgr*, void*)`.
  *
  * @param callback callback to run before rumble state is updated for the current VI
- * @param arg the argument to pass to the calback
+ * @param arg the argument to pass to the callback
  *
  * @see PADMGR_UNSET_RETRACE_CALLACK
  */

--- a/include/regs.h
+++ b/include/regs.h
@@ -280,7 +280,7 @@ typedef enum HRegMode {
 // HREG_MODE_UCODE_DISAS
 #define R_UCODE_DISAS_TOGGLE      HREG(81) // < 0 enables and prints some hardware reg info for 1 frame, > 0 enables constant disas
 #define R_UCODE_DISAS_LOG_MODE    HREG(82) // 1 and 2 print counts, 3 enables fault client, 4 disables open/close disps
-#define R_UCODE_DISAS_LOG_LEVEL   HREG(83) // enables various logging within the dissasembler itself
+#define R_UCODE_DISAS_LOG_LEVEL   HREG(83) // enables various logging within the dissassembler itself
 #define R_UCODE_DISAS_TOTAL_COUNT HREG(84) // read-only
 #define R_UCODE_DISAS_VTX_COUNT   HREG(85) // read-only
 #define R_UCODE_DISAS_SPVTX_COUNT HREG(86) // read-only

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -119,7 +119,7 @@ typedef struct ActorShape {
 #define ACTOR_FLAG_HOSTILE (1 << 2)
 
 // Actor is considered "friendly"; Opposite flag of `ACTOR_FLAG_HOSTILE`.
-// Note that this flag doesn't have any effect on either the actor, or Player's behvaior.
+// Note that this flag doesn't have any effect on either the actor, or Player's behavior.
 // What actually matters is the presence or lack of `ACTOR_FLAG_HOSTILE`.
 #define ACTOR_FLAG_FRIENDLY (1 << 3)
 

--- a/include/z64animation.h
+++ b/include/z64animation.h
@@ -133,13 +133,13 @@ typedef enum AnimationTapers {
 // starting a new animation. This is helpful when an animation's translation data starts at the "origin"
 // (in this case, the origin refers to `baseTransl`, in model space).
 // Some animations have translation data that does not begin at the "origin". This is common when a
-// longer sequence of animation is broken up into different parts as seperate animations.
+// longer sequence of animation is broken up into different parts as separate animations.
 // In this case, when one animation starts its translation at the same position where a different animation
 // left off, resetting `prevTransl` is not desirable. This will cause the actor's position to noticeably change
 // when the translation data from the first frame of the new animation is applied.
 //
 // When this flag is used during a transition between two animations, the first frame of movement is not applied.
-// This allows the actor's world postiion to stay at the same location as where the previous animation ended.
+// This allows the actor's world position to stay at the same location as where the previous animation ended.
 // Because translations are calculated as a difference from the current and previous frame, all subsequent
 // frames have their translation occur relative to this new starting point.
 //

--- a/include/z64camera.h
+++ b/include/z64camera.h
@@ -101,7 +101,7 @@ struct View;
 #define CAM_STATE_CHECK_BG (1 << 2) //  Must be set for the camera to change settings based on the bg surface
 #define CAM_STATE_EXTERNAL_FINISHED (1 << 3) // Signal from the external systems to camera that the current cam-update function is no longer needed
 #define CAM_STATE_CAM_FUNC_FINISH (1 << 4) // Signal from camera to player that the cam-update function is finished its primary purpose
-#define CAM_STATE_LOCK_MODE (1 << 5) // Prevents camera from changing mode, unless overriden by `forceModeChange` passed to `Camera_RequestModeImpl`
+#define CAM_STATE_LOCK_MODE (1 << 5) // Prevents camera from changing mode, unless overridden by `forceModeChange` passed to `Camera_RequestModeImpl`
 #define CAM_STATE_DISTORTION (1 << 6) // Set when camera distortion is on
 #define CAM_STATE_PLAY_INIT (1 << 7) // Set in Play_Init, never used or changed
 #define CAM_STATE_CAMERA_IN_WATER (1 << 8) // Camera (eye) is underwater
@@ -797,7 +797,7 @@ typedef struct KeepOn3ReadOnlyData {
     /* 0x00 */ f32 yOffset;
     /* 0x04 */ f32 minDist;
     /* 0x08 */ f32 maxDist;
-    /* 0x0C */ f32 swingYawInital;
+    /* 0x0C */ f32 swingYawInitial;
     /* 0x10 */ f32 swingYawFinal;
     /* 0x14 */ f32 swingPitchInitial;
     /* 0x18 */ f32 swingPitchFinal;
@@ -1185,7 +1185,7 @@ typedef struct Unique0ReadOnlyData {
 } Unique0ReadOnlyData; // size = 0x4
 
 typedef struct Unique0ReadWriteData {
-    /* 0x00 */ Vec3f initalPos;
+    /* 0x00 */ Vec3f initialPos;
     /* 0x0C */ s16 animTimer;
     /* 0x10 */ InfiniteLine eyeAndDirection;
 } Unique0ReadWriteData; // size = 0x28
@@ -1410,7 +1410,7 @@ typedef struct Special0 {
     { interfaceField, CAM_DATA_INTERFACE_FIELD }
 
 typedef struct Special4ReadWriteData {
-    /* 0x0 */ s16 initalTimer;
+    /* 0x0 */ s16 initialTimer;
 } Special4ReadWriteData; // size = 0x4
 
 typedef struct Special4 {
@@ -1472,7 +1472,7 @@ typedef struct Special6ReadOnlyData {
 } Special6ReadOnlyData; // size = 0x4
 
 typedef struct Special6ReadWriteData {
-    /* 0x0 */ f32 initalPlayerY;
+    /* 0x0 */ f32 initialPlayerY;
     /* 0x4 */ s16 animTimer;
 } Special6ReadWriteData; // size = 0x8
 

--- a/include/z64player.h
+++ b/include/z64player.h
@@ -72,7 +72,7 @@ typedef enum PlayerEnvHazard {
 
 typedef enum PlayerItemAction {
     /* 0x00 */ PLAYER_IA_NONE,
-    /* 0x01 */ PLAYER_IA_SWORD_CS, // Hold sword without shield in hand. The sword is not useable.
+    /* 0x01 */ PLAYER_IA_SWORD_CS, // Hold sword without shield in hand. The sword is not usable.
     /* 0x02 */ PLAYER_IA_FISHING_POLE,
     /* 0x03 */ PLAYER_IA_SWORD_MASTER,
     /* 0x04 */ PLAYER_IA_SWORD_KOKIRI,

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -91,7 +91,7 @@ void Main(void* arg) {
 #endif
     fb = (uintptr_t)SysCfb_GetFbPtr(0);
     gSystemHeapSize = fb - systemHeapStart;
-    PRINTF(T("システムヒープ初期化 %08x-%08x %08x\n", "System heap initalization %08x-%08x %08x\n"), systemHeapStart,
+    PRINTF(T("システムヒープ初期化 %08x-%08x %08x\n", "System heap initialization %08x-%08x %08x\n"), systemHeapStart,
            fb, gSystemHeapSize);
     SystemHeap_Init((void*)systemHeapStart, gSystemHeapSize); // initializes the system heap
 

--- a/src/code/title_setup.c
+++ b/src/code/title_setup.c
@@ -1,7 +1,7 @@
 #include "global.h"
 
 void Setup_InitImpl(SetupState* this) {
-    PRINTF(T("ゼルダ共通データ初期化\n", "Zelda common data initalization\n"));
+    PRINTF(T("ゼルダ共通データ初期化\n", "Zelda common data initialization\n"));
     SaveContext_Init();
     this->state.running = false;
     SET_NEXT_GAMESTATE(&this->state, ConsoleLogo_Init, ConsoleLogoState);

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -3504,7 +3504,7 @@ s32 Camera_KeepOn3(Camera* camera) {
         roData->yOffset = GET_NEXT_SCALED_RO_DATA(values) * playerHeight * yNormal;
         roData->minDist = GET_NEXT_RO_DATA(values);
         roData->maxDist = GET_NEXT_RO_DATA(values);
-        roData->swingYawInital = GET_NEXT_RO_DATA(values);
+        roData->swingYawInitial = GET_NEXT_RO_DATA(values);
         roData->swingYawFinal = GET_NEXT_RO_DATA(values);
         roData->swingPitchInitial = GET_NEXT_RO_DATA(values);
         roData->swingPitchFinal = GET_NEXT_RO_DATA(values);
@@ -3536,7 +3536,7 @@ s32 Camera_KeepOn3(Camera* camera) {
         spBC = ((1.0f - temp_f0) * targetToPlayerDir.r) / rwData->animTimer;
         swingAngle = F32_LERPIMP(roData->swingPitchInitial, roData->swingPitchFinal, temp_f0);
         atToEyeAdj.pitch = CAM_DEG_TO_BINANG(swingAngle) + ((s16)(-(targetToPlayerDir.pitch * roData->swingPitchAdj)));
-        swingAngle = F32_LERPIMP(roData->swingYawInital, roData->swingYawFinal, temp_f0);
+        swingAngle = F32_LERPIMP(roData->swingYawInitial, roData->swingYawFinal, temp_f0);
         if (roData->interfaceField & KEEPON3_FLAG_4) {
             if ((s16)(targetToPlayerDir.yaw - atToEyeNextDir.yaw) < 0) {
                 atToEyeAdj.yaw = targetToPlayerDir.yaw + CAM_DEG_TO_BINANG(swingAngle);
@@ -5074,20 +5074,20 @@ s32 Camera_Unique0(Camera* camera) {
         atPlayerOffset.pitch = -bgCamRot.x;
         rwData->eyeAndDirection.dir = OLib_VecGeoToVec3f(&atPlayerOffset);
         Math3D_LineClosestToPoint(&rwData->eyeAndDirection, &playerPosRot->pos, &camera->at);
-        rwData->initalPos = playerPosRot->pos;
+        rwData->initialPos = playerPosRot->pos;
         camera->animState++;
     }
 
     if (player->stateFlags1 & PLAYER_STATE1_29) {
-        rwData->initalPos = playerPosRot->pos;
+        rwData->initialPos = playerPosRot->pos;
     }
 
     if (roData->interfaceField & UNIQUE0_FLAG_0) {
         if (rwData->animTimer > 0) {
             rwData->animTimer--;
-            rwData->initalPos = playerPosRot->pos;
+            rwData->initialPos = playerPosRot->pos;
         } else if (!(player->stateFlags1 & PLAYER_STATE1_29) &&
-                   ((OLib_Vec3fDistXZ(&playerPosRot->pos, &rwData->initalPos) >= 10.0f) ||
+                   ((OLib_Vec3fDistXZ(&playerPosRot->pos, &rwData->initialPos) >= 10.0f) ||
                     CAMERA_CHECK_BTN(&D_8015BD7C->state.input[0], BTN_A) ||
                     CAMERA_CHECK_BTN(&D_8015BD7C->state.input[0], BTN_B) ||
                     CAMERA_CHECK_BTN(&D_8015BD7C->state.input[0], BTN_CLEFT) ||
@@ -5111,7 +5111,7 @@ s32 Camera_Unique0(Camera* camera) {
                 sCameraInterfaceField = CAM_INTERFACE_FIELD(CAM_LETTERBOX_NONE, CAM_HUD_VISIBILITY_ALL, 0);
             }
         } else {
-            rwData->initalPos = playerPosRot->pos;
+            rwData->initialPos = playerPosRot->pos;
         }
 
         if (!(player->stateFlags1 & PLAYER_STATE1_29) &&
@@ -6935,11 +6935,11 @@ s32 Camera_Special4(Camera* camera) {
         sCameraInterfaceField = CAM_INTERFACE_FIELD(CAM_LETTERBOX_LARGE, CAM_HUD_VISIBILITY_NOTHING_ALT, 0);
         camera->fov = 40.0f;
         camera->animState++;
-        rwData->initalTimer = camera->timer;
+        rwData->initialTimer = camera->timer;
     }
 
     camera->fov = Camera_LERPCeilF(80.0f, camera->fov, 1.0f / *timer, 0.1f);
-    if ((rwData->initalTimer - *timer) < 0xF) {
+    if ((rwData->initialTimer - *timer) < 0xF) {
         (*timer)--;
         return false;
     } else {
@@ -7219,7 +7219,7 @@ s32 Camera_Special6(Camera* camera) {
         // Overwrite hud visibility to CAM_HUD_VISIBILITY_HEARTS_FORCE
         sCameraInterfaceField = (sCameraInterfaceField & (u16)~CAM_HUD_VISIBILITY_MASK) |
                                 CAM_HUD_VISIBILITY(CAM_HUD_VISIBILITY_HEARTS_FORCE);
-        rwData->initalPlayerY = playerPosRot->pos.y;
+        rwData->initialPlayerY = playerPosRot->pos.y;
         rwData->animTimer = 12;
         *eyeNext = bgCamPos;
         if (camera->animState == 0) {
@@ -7232,7 +7232,7 @@ s32 Camera_Special6(Camera* camera) {
         timerF = rwData->animTimer;
         eyePosCalc = *eyeNext;
         eyePosCalc.x += (playerPosRot->pos.x - eyePosCalc.x) * 0.5f;
-        eyePosCalc.y += (playerPosRot->pos.y - rwData->initalPlayerY) * 0.2f;
+        eyePosCalc.y += (playerPosRot->pos.y - rwData->initialPlayerY) * 0.2f;
         eyeAnim = eyePosCalc;
         eyeAnim.y = Camera_LERPCeilF(eyePosCalc.y, eye->y, 0.5f, 0.01f);
 
@@ -7258,7 +7258,7 @@ s32 Camera_Special6(Camera* camera) {
             (sCameraInterfaceField & (u16)~CAM_HUD_VISIBILITY_MASK) | CAM_HUD_VISIBILITY(CAM_HUD_VISIBILITY_ALL);
         eyePosCalc = *eyeNext;
         eyePosCalc.x += (playerPosRot->pos.x - eyePosCalc.x) * 0.5f;
-        eyePosCalc.y += (playerPosRot->pos.y - rwData->initalPlayerY) * 0.2f;
+        eyePosCalc.y += (playerPosRot->pos.y - rwData->initialPlayerY) * 0.2f;
         *eye = eyePosCalc;
         eye->y = Camera_LERPCeilF(eyePosCalc.y, eye->y, 0.5f, 0.01f);
 

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -233,7 +233,7 @@ static s16 D_8094C87C;
 static u8 D_8094C87E;
 static BossTwEffect sEffects[BOSS_TW_EFFECT_COUNT];
 
-void BossTw_AddDotEffect(PlayState* play, Vec3f* initalPos, Vec3f* initalSpeed, Vec3f* accel, f32 scale, s16 args,
+void BossTw_AddDotEffect(PlayState* play, Vec3f* initialPos, Vec3f* initialSpeed, Vec3f* accel, f32 scale, s16 args,
                          s16 countLimit) {
     s16 i;
     BossTwEffect* eff;
@@ -241,8 +241,8 @@ void BossTw_AddDotEffect(PlayState* play, Vec3f* initalPos, Vec3f* initalSpeed, 
     for (i = 0, eff = play->specialEffects; i < countLimit; i++, eff++) {
         if (eff->type == TWEFF_NONE) {
             eff->type = TWEFF_DOT;
-            eff->pos = *initalPos;
-            eff->curSpeed = *initalSpeed;
+            eff->pos = *initialPos;
+            eff->curSpeed = *initialSpeed;
             eff->accel = *accel;
             eff->workf[EFF_SCALE] = scale / 1000.0f;
             eff->alpha = 255;
@@ -253,7 +253,7 @@ void BossTw_AddDotEffect(PlayState* play, Vec3f* initalPos, Vec3f* initalSpeed, 
     }
 }
 
-void BossTw_AddDmgCloud(PlayState* play, s16 type, Vec3f* initialPos, Vec3f* initalSpeed, Vec3f* accel, f32 scale,
+void BossTw_AddDmgCloud(PlayState* play, s16 type, Vec3f* initialPos, Vec3f* initialSpeed, Vec3f* accel, f32 scale,
                         s16 alpha, s16 args, s16 countLimit) {
     s16 i;
     BossTwEffect* eff;
@@ -262,7 +262,7 @@ void BossTw_AddDmgCloud(PlayState* play, s16 type, Vec3f* initialPos, Vec3f* ini
         if (eff->type == TWEFF_NONE) {
             eff->type = type;
             eff->pos = *initialPos;
-            eff->curSpeed = *initalSpeed;
+            eff->curSpeed = *initialSpeed;
             eff->accel = *accel;
             eff->workf[EFF_SCALE] = scale / 1000.0f;
             eff->work[EFF_ARGS] = args;
@@ -273,7 +273,7 @@ void BossTw_AddDmgCloud(PlayState* play, s16 type, Vec3f* initialPos, Vec3f* ini
     }
 }
 
-void BossTw_AddRingEffect(PlayState* play, Vec3f* initalPos, f32 scale, f32 arg3, s16 alpha, s16 args, s16 arg6,
+void BossTw_AddRingEffect(PlayState* play, Vec3f* initialPos, f32 scale, f32 arg3, s16 alpha, s16 args, s16 arg6,
                           s16 countLimit) {
     s16 i;
     BossTwEffect* eff;
@@ -281,7 +281,7 @@ void BossTw_AddRingEffect(PlayState* play, Vec3f* initalPos, f32 scale, f32 arg3
     for (i = 0, eff = play->specialEffects; i < countLimit; i++, eff++) {
         if (eff->type == TWEFF_NONE) {
             eff->type = TWEFF_RING;
-            eff->pos = *initalPos;
+            eff->pos = *initialPos;
             eff->curSpeed = sZeroVector;
             eff->accel = sZeroVector;
             eff->workf[EFF_SCALE] = scale * 0.0025f;
@@ -320,15 +320,15 @@ void BossTw_AddPlayerFreezeEffect(PlayState* play, Actor* target) {
     }
 }
 
-void BossTw_AddFlameEffect(PlayState* play, Vec3f* initalPos, Vec3f* initalSpeed, Vec3f* accel, f32 scale, s16 args) {
+void BossTw_AddFlameEffect(PlayState* play, Vec3f* initialPos, Vec3f* initialSpeed, Vec3f* accel, f32 scale, s16 args) {
     s16 i;
     BossTwEffect* eff;
 
     for (i = 0, eff = play->specialEffects; i < BOSS_TW_EFFECT_COUNT; i++, eff++) {
         if (eff->type == TWEFF_NONE) {
             eff->type = TWEFF_FLAME;
-            eff->pos = *initalPos;
-            eff->curSpeed = *initalSpeed;
+            eff->pos = *initialPos;
+            eff->curSpeed = *initialSpeed;
             eff->accel = *accel;
             eff->workf[EFF_SCALE] = scale / 1000.0f;
             eff->work[EFF_ARGS] = args;
@@ -362,7 +362,7 @@ void BossTw_AddMergeFlameEffect(PlayState* play, Vec3f* initialPos, f32 scale, f
     }
 }
 
-void BossTw_AddShieldBlastEffect(PlayState* play, Vec3f* initalPos, Vec3f* initalSpeed, Vec3f* accel, f32 scale,
+void BossTw_AddShieldBlastEffect(PlayState* play, Vec3f* initialPos, Vec3f* initialSpeed, Vec3f* accel, f32 scale,
                                  f32 arg5, s16 alpha, s16 args) {
     s16 i;
     BossTwEffect* eff;
@@ -370,8 +370,8 @@ void BossTw_AddShieldBlastEffect(PlayState* play, Vec3f* initalPos, Vec3f* inita
     for (i = 0, eff = play->specialEffects; i < BOSS_TW_EFFECT_COUNT; i++, eff++) {
         if (eff->type == TWEFF_NONE) {
             eff->type = TWEFF_SHLD_BLST;
-            eff->pos = *initalPos;
-            eff->curSpeed = *initalSpeed;
+            eff->pos = *initialPos;
+            eff->curSpeed = *initialSpeed;
             eff->accel = *accel;
             eff->workf[EFF_SCALE] = scale / 1000.0f;
             eff->workf[EFF_DIST] = arg5 / 1000.0f;
@@ -1757,7 +1757,7 @@ void BossTw_SetupCSWait(BossTw* this, PlayState* play) {
 }
 
 /**
- * Do nothing while waiting for the inital cutscene to start
+ * Do nothing while waiting for the initial cutscene to start
  */
 void BossTw_CSWait(BossTw* this, PlayState* play) {
 }

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1094,7 +1094,7 @@ void DemoEffect_UpdateLightEffect(DemoEffect* this, PlayState* play) {
 
 /**
  * Update action for the Lgt Shower Actor.
- * The Lgt Shower Actor is the green light effect spawned by Farore in the Kokiri Forst creation cutscene.
+ * The Lgt Shower Actor is the green light effect spawned by Farore in the Kokiri Forest creation cutscene.
  * This function updates the scale and alpha of the Actor.
  */
 void DemoEffect_UpdateLgtShower(DemoEffect* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Am/z_en_am.c
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.c
@@ -112,7 +112,7 @@ static ColliderQuadInit sQuadInit = {
 };
 
 typedef enum ArmosDamageEffect {
-    /*  0 */ AM_DMGEFF_NONE, // used by anything that cant kill the armos
+    /*  0 */ AM_DMGEFF_NONE, // used by anything that can't kill the armos
     /*  1 */ AM_DMGEFF_NUT,
     /*  6 */ AM_DMGEFF_STUN = 6, // doesn't include deku nuts
     /* 13 */ AM_DMGEFF_ICE = 13,

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -138,7 +138,7 @@ void EnBoom_Fly(EnBoom* this, PlayState* play) {
 
         if ((target != &player->actor) && ((target->update == NULL) || (ABS(yawDiff) > 0x4000))) {
             //! @bug  This condition is why the boomerang will randomly fly off in a the down left direction sometimes.
-            //      If the actor targetted is not Link and the difference between the 2 y angles is greater than 0x4000,
+            //      If the actor targeted is not Link and the difference between the 2 y angles is greater than 0x4000,
             //      the moveTo pointer is nulled and it flies off in a seemingly random direction.
             this->moveTo = NULL;
         } else {

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -431,7 +431,7 @@ void EnClearTag_Update(Actor* thisx, PlayState* play2) {
                     Math_ApproachZeroF(&this->roll, 0.1f, 0.2f);
                 }
 
-                // Calculate a vector towards the targetted position.
+                // Calculate a vector towards the targeted position.
                 vectorToTargetX = this->targetPosition.x - this->actor.world.pos.x;
                 vectorToTargetY = this->targetPosition.y - this->actor.world.pos.y;
                 vectorToTargetZ = this->targetPosition.z - this->actor.world.pos.z;
@@ -680,7 +680,7 @@ void EnClearTag_Update(Actor* thisx, PlayState* play2) {
 /**
  * EnClear_Tag draw function.
  * Laser clear tag type will draw two lasers.
- * Arwing clear tage types will draw the Arwing, the backfire, and a shadow.
+ * Arwing clear tag types will draw the Arwing, the backfire, and a shadow.
  */
 void EnClearTag_Draw(Actor* thisx, PlayState* play) {
     s32 pad;

--- a/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
+++ b/src/overlays/actors/ovl_En_Daiku_Kakariko/z_en_daiku_kakariko.c
@@ -124,7 +124,7 @@ void EnDaikuKakariko_ChangeAnim(EnDaikuKakariko* this, s32 index, s32* currentIn
 }
 
 void EnDaikuKakariko_Init(Actor* thisx, PlayState* play) {
-    static u16 initFlags[] = { 0x0080, 0x00B0, 0x0070, 0x0470 }; // List of inital values for this->flags
+    static u16 initFlags[] = { 0x0080, 0x00B0, 0x0070, 0x0470 }; // List of initial values for this->flags
     EnDaikuKakariko* this = (EnDaikuKakariko*)thisx;
     s32 pad;
 

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -326,7 +326,7 @@ s32 EnFd_CanSeeActor(EnFd* this, Actor* actor, PlayState* play) {
         return false;
     }
 
-    // Check to see if the angle between this facing angle and `actor` is withing ~40 degrees
+    // Check to see if the angle between this facing angle and `actor` is within ~40 degrees
     angle = (f32)Math_Vec3f_Yaw(&this->actor.world.pos, &actor->world.pos) - this->actor.shape.rot.y;
     if (ABS(angle) > 0x1C70) {
         return false;

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -77,7 +77,7 @@ sEnFrPointers.flags = 1 to 11:
          - 5: frog 0 (Yellow)
          - 7: frog 2 (Red)
          - 9: frog 4 (White)
-     - Will proceed when counter reachers 11
+     - Will proceed when counter reaches 11
 
 sEnFrPointers.flags = 12
      - Deactivate frogs, frogs will jump back into the water

--- a/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.c
+++ b/src/overlays/actors/ovl_En_Ganon_Mant/z_en_ganon_mant.c
@@ -425,7 +425,7 @@ void EnGanonMant_Draw(Actor* thisx, PlayState* play) {
         midpoint.y = rightPos->y + yDiff * 0.5f;
         midpoint.z = rightPos->z + zDiff * 0.5f;
 
-        // Calculte base orientation for chosen endpoints
+        // Calculate base orientation for chosen endpoints
         yaw = Math_Atan2F(zDiff, xDiff);
         pitch = -Math_Atan2F(sqrtf(SQ(xDiff) + SQ(zDiff)), yDiff);
         diffHalfDist = sqrtf(SQ(xDiff) + SQ(yDiff) + SQ(zDiff)) * 0.5f;

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.h
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.h
@@ -5,8 +5,8 @@
 #include "global.h"
 
 // The switch flag value for this actor is constructed in a unique way.
-// There are two seperate param values which get OR'd together to create one final switch flag index.
-// These two values are seperated within the overall actor param value. See below:
+// There are two separate param values which get OR'd together to create one final switch flag index.
+// These two values are separated within the overall actor param value. See below:
 //
 //  | A B C D | _ _ _ _ | E F | _ _ _ _ _ _ |
 // 16        12         8     6             0

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -365,7 +365,7 @@ void EnRd_WalkToPlayer(EnRd* this, PlayState* play) {
                     // `player->actor.freezeTimer` gets set above which will prevent Player from updating.
                     // Because of this, he cannot update things related to Z-Targeting.
                     // If Player can't update, `player->zTargetActiveTimer` won't update, which means
-                    // the Attention system will not be notified of a new actor lock-on occuring.
+                    // the Attention system will not be notified of a new actor lock-on occurring.
                     // So, no reticle will appear. But the camera will still focus on the actor.
                     Player_SetAutoLockOnActor(play, &this->actor);
 

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -352,7 +352,7 @@ s32 EnSt_SetCylinderOC(EnSt* this, PlayState* play) {
         cyloffsets[i].z *= this->colliderScale;
         Matrix_Push();
         Matrix_Translate(cylPos.x, cylPos.y, cylPos.z, MTXMODE_NEW);
-        Matrix_RotateY(BINANG_TO_RAD_ALT(this->initalYaw), MTXMODE_APPLY);
+        Matrix_RotateY(BINANG_TO_RAD_ALT(this->initialYaw), MTXMODE_APPLY);
         Matrix_MultVec3f(&cyloffsets[i], &cylPos);
         Matrix_Pop();
         this->colCylinder[i + 3].dim.pos.x = cylPos.x;
@@ -623,7 +623,7 @@ void EnSt_UpdateYaw(EnSt* this, PlayState* play) {
 
         // calculate the new yaw to or away from the player.
         rot = this->actor.shape.rot;
-        yawTarget = (this->actionFunc == EnSt_WaitOnGround ? this->actor.yawTowardsPlayer : this->initalYaw);
+        yawTarget = (this->actionFunc == EnSt_WaitOnGround ? this->actor.yawTowardsPlayer : this->initialYaw);
         yawDiff = rot.y - (yawTarget ^ yawDir);
         if (ABS(yawDiff) <= 0x4000) {
             Math_SmoothStepToS(&rot.y, yawTarget ^ yawDir, 4, 0x2000, 1);
@@ -714,7 +714,7 @@ s32 EnSt_IsCloseToPlayer(EnSt* this, PlayState* play) {
     return true;
 }
 
-s32 EnSt_IsCloseToInitalPos(EnSt* this) {
+s32 EnSt_IsCloseToInitialPos(EnSt* this) {
     f32 velY = this->actor.velocity.y;
     f32 checkY = this->actor.world.pos.y + (velY * 2.0f);
 
@@ -802,7 +802,7 @@ void EnSt_Init(Actor* thisx, PlayState* play) {
     this->actor.flags |= ACTOR_FLAG_24;
     EnSt_SetColliderScale(this);
     this->actor.gravity = 0.0f;
-    this->initalYaw = this->actor.world.rot.y;
+    this->initialYaw = this->actor.world.rot.y;
     EnSt_SetupAction(this, EnSt_StartOnCeilingOrGround);
 }
 
@@ -926,7 +926,7 @@ void EnSt_ReturnToCeiling(EnSt* this, PlayState* play) {
         // player came back into range
         EnSt_SetDropAnimAndVel(this);
         EnSt_SetupAction(this, EnSt_MoveToGround);
-    } else if (EnSt_IsCloseToInitalPos(this)) {
+    } else if (EnSt_IsCloseToInitialPos(this)) {
         // the Skulltula is close to the initial postion.
         EnSt_SetWaitingAnimation(this);
         EnSt_SetupAction(this, EnSt_WaitOnCeiling);

--- a/src/overlays/actors/ovl_En_St/z_en_st.h
+++ b/src/overlays/actors/ovl_En_St/z_en_st.h
@@ -15,7 +15,7 @@ typedef struct EnSt {
     /* 0x0194 */ ColliderCylinder colCylinder[6];
     /* 0x035C */ ColliderJntSph colSph;
     /* 0x037C */ ColliderJntSphElement colSphItems[1];
-    /* 0x03BC */ s16 initalYaw;
+    /* 0x03BC */ s16 initialYaw;
     /* 0x03BE */ s16 deathYawTarget;
     /* 0x03C0 */ s16 groundBounces;
     /* 0x03C2 */ s16 animFrames;

--- a/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.h
+++ b/src/overlays/actors/ovl_En_Syateki_Niw/z_en_syateki_niw.h
@@ -34,7 +34,7 @@ typedef struct EnSyatekiNiw {
     /* 0x025A */ s16 archeryTimer;
     /* 0x025C */ s16 hopTimer; // intervals of jumping
     /* 0x025E */ s16 movementTimer; // intervals of changing location
-    /* 0x0260 */ s16 sootTimer; // cucco is covered in soot, smoke emmits
+    /* 0x0260 */ s16 sootTimer; // cucco is covered in soot, smoke emits
     /* 0x0262 */ s16 cluckTimer; // intervals of clucking SFX
     /* 0x0264 */ f32 headRotXTarget;
     /* 0x0268 */ f32 rightWingRotXTarget;

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -248,7 +248,7 @@ u32 EnToryo_ReactToExchangeItem(EnToryo* this, PlayState* play) {
             ret = 0x200F;
         }
     }
-    //! @bug return value may be unitialized
+    //! @bug return value may be uninitialized
     return ret;
 }
 

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -379,7 +379,7 @@ static s16 sFishingPlayingState;
 static s16 sLureTimer; // AND'd for various effects/checks
 static s16 D_80B7E0B0;
 static s16 D_80B7E0B2;
-static s16 sRodCastTimer; // used for the inital line casting
+static s16 sRodCastTimer; // used for the initial line casting
 static u8 sLureEquipped;
 static Vec3f sLurePos;
 static Vec3f sLureDrawPos;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3768,7 +3768,7 @@ void Player_UpdateZTargeting(Player* this, PlayState* play) {
                     this->focusActor->attentionPriority = 40;
                 }
             } else if (this->autoLockOnActor != NULL) {
-                // Becaue of the previous if condition above, `autoLockOnActor` does not take precedence
+                // Because of the previous if condition above, `autoLockOnActor` does not take precedence
                 // over `focusActor` if it already exists.
                 // However, `autoLockOnActor` is expected to be set with `Player_SetAutoLockOnActor`
                 // which will release any existing lock-on before setting the new one.
@@ -7418,7 +7418,7 @@ s32 func_8083F524(PlayState* play, Player* this) {
 
 /**
  * Two exit walls are placed at each end of the crawlspace, separate to the two entrance walls used to enter the
- * crawlspace. These front and back exit walls are futher into the crawlspace than the front and
+ * crawlspace. These front and back exit walls are further into the crawlspace than the front and
  * back entrance walls. When player interacts with either of these two interior exit walls, start the leaving-crawlspace
  * cutscene and return true. Else, return false
  */
@@ -10635,7 +10635,7 @@ s32 Player_UpdateHoverBoots(Player* this) {
 }
 
 /**
- * Peforms various tasks related to scene collision.
+ * Performs various tasks related to scene collision.
  *
  * This includes:
  * - Update BgCheckInfo, parameters adjusted due to various state flags

--- a/tools/audio/soundfont_compiler.c
+++ b/tools/audio/soundfont_compiler.c
@@ -929,7 +929,7 @@ emit_c_header(FILE *out, soundfont *sf)
 }
 
 /**
- * Convert the compression type as indicated in the AIFC to the correspoding SampleCodec enum value.
+ * Convert the compression type as indicated in the AIFC to the corresponding SampleCodec enum value.
  * These must be kept in sync with the SampleCodec definition!
  */
 static const char *

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -27,7 +27,7 @@ def get_modified_files_to_format(compare_to):
 
     all_src_files, all_extra_files = format.list_files_to_format()
     # Split modified_files between source files and extra files (see format.py)
-    # This also filters out deleted files that no logner exist
+    # This also filters out deleted files that no longer exist
     modified_src_files_existing = list(modified_files.intersection(all_src_files))
     modified_extra_files_existing = list(modified_files.intersection(all_extra_files))
 

--- a/tools/disasm/sym_info.py
+++ b/tools/disasm/sym_info.py
@@ -31,7 +31,7 @@ LABELS_TYPES = {"@branchlabel", "@jumptablelabel"}
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Print informations on a symbol/address"
+        description="Print information on a symbol/address"
         " (and possibly surrounding symbols)"
         " from the spimdisasm disassembly context saved in"
         " expected/build/VERSION/context.csv"

--- a/tools/namefixer.py
+++ b/tools/namefixer.py
@@ -111,7 +111,7 @@ simpleReplace = {
 }
 
 # all occurrences of keys will be replaced by associated value,
-# if the occurence is the whole word
+# if the occurrence is the whole word
 # for example, if there is a space before and an open parenthesis after,
 # like for a function call: ` func_8002E4B4(`
 wordReplace = {
@@ -451,7 +451,7 @@ def replace_single(file):
                 custom_behavior_ignore_offset, custom_behavior_ignore_match = custom_behavior_ignore_data
         else:
             custom_behavior = False
-        # replace `old` with `new` if the occurence of `old` is the whole word
+        # replace `old` with `new` if the occurrence of `old` is the whole word
         oldStartIdx = srcdata.find(old)
         if oldStartIdx >= 0:
             old_start_as_word = is_word_char(old[0])

--- a/tools/preprocess.sh
+++ b/tools/preprocess.sh
@@ -24,7 +24,7 @@ do
     then
         # flags before --
         flags=("${@:1:$(($i - 1))}")
-        # compile command, betwen -- and the input source file
+        # compile command, between -- and the input source file
         compilecmd="${@:$(($i + 1)):$((${#@} - $i - 1))}"
         # The last argument, the input source file to be compiled
         srcfile="${@: -1}"


### PR DESCRIPTION
I ignored some typos in ultra64.h which are in the original headers (e.g. "not implemeted"). I also happened to notice that "inital" is a common misspelling in variable names even though codespell didn't explicitly flag these, so I fixed all those too.