### PR TITLE
[PAL N64] Match file select language selection

### DIFF
--- a/assets/xml/overlays/ovl_file_choose_pal_n64.xml
+++ b/assets/xml/overlays/ovl_file_choose_pal_n64.xml
@@ -3,6 +3,18 @@
         <Array Name="gNameEntryVtx" Count="24" Offset="0x0" Static="Off">
             <Vtx/>
         </Array>
+        <Array Name="gOptionsMenuHeadersVtx" Count="24" Offset="0x180" Static="Off">
+            <Vtx/>
+        </Array>
+        <Array Name="gOptionsMenuSettingsVtx" Count="32" Offset="0x300" Static="Off">
+            <Vtx/>
+        </Array>
+        <Array Name="gOptionsMenuBrightnessVtx" Count="8" Offset="0x500" Static="Off">
+            <Vtx/>
+        </Array>
+        <Array Name="gOptionsMenuLanguageVtx" Count="12" Offset="0x580" Static="Off">
+            <Vtx/>
+        </Array>
         <Array Name="gOptionsDividerSoundVtx" Count="4" Offset="0x780" Static="Off">
             <Vtx/>
         </Array>
@@ -10,6 +22,9 @@
             <Vtx/>
         </Array>
         <Array Name="gOptionsDividerBrightnessVtx" Count="4" Offset="0x800" Static="Off">
+            <Vtx/>
+        </Array>
+        <Array Name="gOptionsDividerLanguageVtx" Count="4" Offset="0x840" Static="Off">
             <Vtx/>
         </Array>
         <Array Name="gCharPageEng" Count="65" Offset="0x880" Static="Off">

--- a/assets/xml/textures/title_static_pal_n64.xml
+++ b/assets/xml/textures/title_static_pal_n64.xml
@@ -39,6 +39,14 @@
         <Texture Name="gFileSelCheckBrightnessGERTex" OutName="check_brightness_ger" Format="ia8" Width="128" Height="16" Offset="0x5380"/>
         <Texture Name="gFileSelCheckBrightnessFRATex" OutName="check_brightness_fra" Format="ia8" Width="128" Height="16" Offset="0x5B80"/>
 
+        <Texture Name="gFileSelLanguageChoiceENGTex" OutName="language_choice_eng" Format="ia8" Width="48" Height="16" Offset="0x6380"/>
+        <Texture Name="gFileSelLanguageChoiceGERTex" OutName="language_choice_ger" Format="ia8" Width="48" Height="16" Offset="0x6680"/>
+        <Texture Name="gFileSelLanguageChoiceFRATex" OutName="language_choice_fra" Format="ia8" Width="48" Height="16" Offset="0x6980"/>
+
+        <Texture Name="gFileSelLanguageENGTex" OutName="language_eng" Format="ia8" Width="64" Height="16" Offset="0x6C80"/>
+        <Texture Name="gFileSelLanguageGERTex" OutName="language_ger" Format="ia8" Width="64" Height="16" Offset="0x7080"/>
+        <Texture Name="gFileSelLanguageFRATex" OutName="language_fra" Format="ia8" Width="64" Height="16" Offset="0x7480"/>
+
         <Texture Name="gFileSelWindow1Tex" OutName="window_1" Format="ia16" Width="64" Height="32" Offset="0x7880"/>
         <Texture Name="gFileSelWindow2Tex" OutName="window_2" Format="ia16" Width="64" Height="32" Offset="0x8880"/>
         <Texture Name="gFileSelWindow3Tex" OutName="window_3" Format="ia16" Width="64" Height="32" Offset="0x9880"/>
@@ -180,6 +188,14 @@
         <Texture Name="gFileSelEraseButtonFRATex" OutName="erase_button_fra" Format="ia16" Width="64" Height="16" Offset="0x47300"/>
 
         <Texture Name="gFileSelQuitButtonFRATex" OutName="quit_button_fra" Format="ia16" Width="64" Height="16" Offset="0x47B00"/>
+
+        <Texture Name="gFileSelInitialLanguageChoiceENGTex" OutName="initial_language_choice_eng" Format="ia8" Width="80" Height="32" Offset="0x48300"/>
+        <Texture Name="gFileSelInitialLanguageChoiceGERTex" OutName="initial_language_choice_ger" Format="ia8" Width="80" Height="32" Offset="0x48D00"/>
+        <Texture Name="gFileSelInitialLanguageChoiceFRATex" OutName="initial_language_choice_fra" Format="ia8" Width="80" Height="32" Offset="0x49700"/>
+
+        <Texture Name="gFileSelSelectYourLanguageTex" OutName="select_your_language" Format="ia8" Width="160" Height="60" Offset="0x4A100"/>
+
+        <Texture Name="gFileSelInitialLanguageCursorTex" OutName="initial_language_cursor" Format="i4" Width="48" Height="48" Offset="0x4C900"/>
 
         <DList Name="gFileSelWindow1DL" Offset="0x4CD80"/>
         <DList Name="gFileSelWindow2DL" Offset="0x4CF98"/>

--- a/include/gfx_setupdl.h
+++ b/include/gfx_setupdl.h
@@ -116,6 +116,7 @@ void Gfx_SetupDL_42Overlay(struct GraphicsContext* gfxCtx);
 void Gfx_SetupDL_27Xlu(struct GraphicsContext* gfxCtx);
 void Gfx_SetupDL_60NoCDXlu(struct GraphicsContext* gfxCtx);
 void Gfx_SetupDL_61Xlu(struct GraphicsContext* gfxCtx);
+void Gfx_SetupDL_56Opa(struct GraphicsContext* gfxCtx);
 void Gfx_SetupDL_56Ptr(Gfx** gfxP);
 
 #endif

--- a/include/z64.h
+++ b/include/z64.h
@@ -206,7 +206,7 @@ typedef struct FileSelectState {
     /* 0x000A8 */ u8* staticSegment;
     /* 0x000AC */ u8* parameterSegment;
 #if OOT_PAL
-    /* 0x000B0 */ char unk_B0[0x8];
+    /* 0x000B0 */ u8* objectMagSegment;
 #endif
     /* 0x000B8 */ View view;
     /* 0x001E0 */ SramContext sramCtx;

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -919,13 +919,13 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
     for (i = 0; i < ARRAY_COUNTU(sZeldaMagic) - 3; i++) {
         if (sZeldaMagic[i + SRAM_HEADER_MAGIC] != sramCtx->readBuff[i + SRAM_HEADER_MAGIC]) {
             PRINTF(T("ＳＲＡＭ破壊！！！！！！\n", "SRAM destruction!!!!!!\n"));
-#if OOT_PAL
+#if PLATFORM_GC && OOT_PAL
             gSaveContext.language = sramCtx->readBuff[SRAM_HEADER_LANGUAGE];
 #endif
 
             MemCpy(sramCtx->readBuff, sZeldaMagic, sizeof(sZeldaMagic));
 
-#if OOT_PAL
+#if PLATFORM_GC && OOT_PAL
             sramCtx->readBuff[SRAM_HEADER_LANGUAGE] = gSaveContext.language;
 #endif
             Sram_WriteSramHeader(sramCtx);

--- a/src/overlays/gamestates/ovl_file_choose/file_select.h
+++ b/src/overlays/gamestates/ovl_file_choose/file_select.h
@@ -4,6 +4,7 @@
 #include "libc/stddef.h"
 #include "ultra64.h"
 #include "global.h"
+#include "versions.h"
 
 
 #define GET_NEWF(sramCtx, slotNum, index) (sramCtx->readBuff[gSramSlotOffsets[slotNum] + offsetof(SaveContext, save.info.playerData.newf[index])])
@@ -16,7 +17,7 @@
      (GET_NEWF(sramCtx, slotNum, 4) == 'A') || \
      (GET_NEWF(sramCtx, slotNum, 5) == 'Z'))
 
-// Init mode: Initial setup as the file select is starting up, fades and slides in various menu elements
+// Init mode: Loads saves from SRAM, handles initial language selection in PAL N64 versions
 // Config mode: Handles the bulk of the file select, various configuration tasks like picking a file, copy/erase, and the options menu
 // Select mode: Displays the selected file with various details about it, and allows the player to confirm and open it
 typedef enum MenuMode {
@@ -144,7 +145,11 @@ typedef enum ActionButtonIndex {
 
 typedef enum SettingIndex {
     /* 0 */ FS_SETTING_AUDIO,
-    /* 1 */ FS_SETTING_TARGET
+    /* 1 */ FS_SETTING_TARGET,
+#if OOT_PAL_N64
+    /* 2 */ FS_SETTING_LANGUAGE,
+#endif
+    /*   */ FS_SETTING_MAX
 } SettingIndex;
 
 typedef enum AudioOption {
@@ -219,5 +224,9 @@ void FileSelect_DrawOptions(GameState* thisx);
 
 void FileSelect_DrawNameEntry(GameState* thisx);
 void FileSelect_DrawCharacter(GraphicsContext* gfxCtx, void* texture, s16 vtx);
+
+#if OOT_VERSION == PAL_1_1
+extern s16 D_808124C0[];
+#endif
 
 #endif

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1,10 +1,52 @@
 #include "file_select.h"
 #include "terminal.h"
 #include "versions.h"
+#if OOT_PAL_N64
+#include "assets/objects/object_mag/object_mag.h"
+#endif
 #include "assets/textures/title_static/title_static.h"
 #include "assets/textures/parameter_static/parameter_static.h"
 #if PLATFORM_N64
 #include "n64dd.h"
+#endif
+
+#if OOT_PAL_N64
+static s32 sInitialLanguageAlphaAsInt = 100;
+static f32 sInitialLanguageAlphaStep = 8.0f;
+static f32 sInitialLanguageAlpha = 100.0f;
+
+static s16 sInitialLanguageStickAdjX;
+static s16 sInitialLanguageStickXDir;
+static s16 sInitialLanguageInputTimerY;
+
+typedef struct InitialLanguageTextureInfo {
+    /* 0x00 */ void* texture;
+    /* 0x04 */ u16 width;
+    /* 0x06 */ u16 height;
+    /* 0x08 */ u32 x1;
+    /* 0x0C */ u32 y1;
+    /* 0x10 */ u32 x2;
+    /* 0x14 */ u32 y2;
+} InitialLanguageTextureInfo; // size = 0x18
+
+static InitialLanguageTextureInfo sInitialLanguageTextures[] = {
+    { gFileSelInitialLanguageChoiceENGTex, 80, 32, 40, 70, 120, 102 },
+    { gFileSelInitialLanguageChoiceGERTex, 80, 32, 120, 70, 200, 102 },
+    { gFileSelInitialLanguageChoiceFRATex, 80, 32, 200, 70, 280, 102 },
+};
+
+typedef struct InitialLanguageCursorInfo {
+    /* 0x00 */ u32 x1;
+    /* 0x04 */ u32 y1;
+    /* 0x08 */ u32 x2;
+    /* 0x0C */ u32 y2;
+} InitialLanguageCursorInfo; // size = 0x10
+
+static InitialLanguageCursorInfo sInitialLanguageCursors[] = {
+    { 48, 52, 120, 124 },
+    { 128, 52, 200, 124 },
+    { 208, 52, 280, 124 },
+};
 #endif
 
 static s16 sUnused = 106;
@@ -28,6 +70,233 @@ static s16 sWindowContentColors[2][3] = {
     { 100, 150, 255 }, // blue
     { 100, 100, 100 }, // gray
 };
+
+#if OOT_PAL_N64
+void FileSelect_UpdateInitialLanguageMenu(FileSelectState* this) {
+    SramContext* sramCtx = &this->sramCtx;
+    Input* input = &this->state.input[0];
+
+    if (gSaveContext.language >= LANGUAGE_MAX) {
+        gSaveContext.language = 0;
+    }
+
+    sInitialLanguageAlpha += sInitialLanguageAlphaStep;
+    if (sInitialLanguageAlphaStep < 0.0f) {
+        if (sInitialLanguageAlpha < 100.0f) {
+            sInitialLanguageAlpha = 100.0f;
+            sInitialLanguageAlphaStep *= -1.0f;
+        }
+    } else if (sInitialLanguageAlphaStep > 0.0f) {
+        if (sInitialLanguageAlpha > 255.0f) {
+            sInitialLanguageAlpha = 255.0f;
+            sInitialLanguageAlphaStep *= -1.0f;
+        }
+    }
+
+    sInitialLanguageAlphaAsInt = (s32)sInitialLanguageAlpha;
+    sInitialLanguageStickAdjX = (s16)input->rel.stick_x;
+    if (sInitialLanguageStickAdjX < -30) {
+        if (sInitialLanguageStickXDir == -1) {
+            sInitialLanguageInputTimerY -= 1;
+            if (sInitialLanguageInputTimerY < 0) {
+                sInitialLanguageInputTimerY = 2;
+            } else {
+                sInitialLanguageStickAdjX = 0;
+            }
+        } else {
+            sInitialLanguageInputTimerY = 10;
+            sInitialLanguageStickXDir = -1;
+        }
+    } else if (sInitialLanguageStickAdjX > 30) {
+        if (sInitialLanguageStickXDir == 1) {
+            sInitialLanguageInputTimerY -= 1;
+            if (sInitialLanguageInputTimerY < 0) {
+                sInitialLanguageInputTimerY = 2;
+            } else {
+                sInitialLanguageStickAdjX = 0;
+            }
+        } else {
+            sInitialLanguageInputTimerY = 10;
+            sInitialLanguageStickXDir = 1;
+        }
+    } else {
+        sInitialLanguageStickXDir = 0;
+    }
+
+    if (CHECK_BTN_ALL(input->press.button, BTN_A) || CHECK_BTN_ALL(input->press.button, BTN_B) ||
+        CHECK_BTN_ALL(input->press.button, BTN_START)) {
+        Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_L, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                             &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+        Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_L, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                             &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+        sramCtx->readBuff[2] = gSaveContext.language;
+        Sram_WriteSramHeader(sramCtx);
+        this->configMode++;
+        return;
+    }
+
+    if (sInitialLanguageStickAdjX < -30) {
+        Audio_PlaySfxGeneral(NA_SE_SY_FSEL_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                             &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+        gSaveContext.language--;
+        if (gSaveContext.language >= LANGUAGE_MAX) {
+            gSaveContext.language = LANGUAGE_MAX - 1;
+        }
+    } else if (sInitialLanguageStickAdjX > 30) {
+        Audio_PlaySfxGeneral(NA_SE_SY_FSEL_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                             &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+        gSaveContext.language++;
+        if (gSaveContext.language >= LANGUAGE_MAX) {
+            gSaveContext.language = 0;
+        }
+    }
+}
+
+void FileSelect_DrawImageRGBA32(GraphicsContext* gfxCtx, s16 centerX, s16 centerY, u8* source, u32 width, u32 height) {
+    u8* curTexture;
+    s32 textureCount;
+    s32 rectLeft;
+    s32 rectTop;
+    u32 textureHeight;
+    s32 remainingSize;
+    s32 textureSize;
+    s32 pad;
+    s32 i;
+
+    OPEN_DISPS(gfxCtx, "../z_file_choose.c", 0);
+
+    Gfx_SetupDL_56Opa(gfxCtx);
+
+    curTexture = source;
+    rectLeft = centerX - (width / 2);
+    rectTop = centerY - (height / 2);
+    remainingSize = (width * height) << 2;
+    textureHeight = 4096 / (width << 2);
+    textureSize = (width * textureHeight) << 2;
+    textureCount = remainingSize / textureSize;
+    if ((remainingSize % textureSize) != 0) {
+        textureCount++;
+    }
+
+    gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
+                     G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                     G_TX_NOLOD);
+
+    remainingSize -= textureSize;
+
+    for (i = 0; i < textureCount; i++) {
+        gDPSetTextureImage(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, width, curTexture);
+
+        gDPLoadSync(POLY_OPA_DISP++);
+        gDPLoadTile(POLY_OPA_DISP++, G_TX_LOADTILE, 0, 0, (width - 1) << 2, (textureHeight - 1) << 2);
+
+        gSPTextureRectangle(POLY_OPA_DISP++, rectLeft << 2, rectTop << 2, (rectLeft + (s32)width) << 2,
+                            (rectTop + textureHeight) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+
+        curTexture += textureSize;
+        rectTop += textureHeight;
+
+        if ((remainingSize - textureSize) < 0) {
+            if (remainingSize > 0) {
+                textureHeight = remainingSize / (s32)(width << 2);
+                remainingSize -= textureSize;
+
+                gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
+                                 G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
+                                 G_TX_NOLOD, G_TX_NOLOD);
+            }
+        } else {
+            remainingSize -= textureSize;
+        }
+    }
+
+    CLOSE_DISPS(gfxCtx, "../z_file_choose.c", 0);
+}
+
+void FileSelect_DrawInitialLanguageMenu(FileSelectState* this) {
+    u8* source;
+    s32 i;
+    s32 y1;
+    s32 y2;
+
+    OPEN_DISPS(this->state.gfxCtx, "../z_file_choose.c", 0);
+
+    gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 70 + WREG(0));
+    FileSelect_DrawImageRGBA32(this->state.gfxCtx, 160, 85 + WREG(1), (u8*)gTitleZeldaShieldLogoTex, 160, 160);
+
+    Gfx_SetupDL_39Opa(this->state.gfxCtx);
+
+    gDPSetAlphaCompare(POLY_OPA_DISP++, G_AC_NONE);
+    gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+    gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 255);
+
+    gDPLoadTextureBlock(POLY_OPA_DISP++, gTitleCopyright1998Tex, G_IM_FMT_IA, G_IM_SIZ_8b, 128, 16, 0,
+                        G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                        G_TX_NOLOD);
+
+    gSPTextureRectangle(POLY_OPA_DISP++, 94 << 2, 198 << 2, 222 << 2, 214 << 2, G_TX_RENDERTILE, 0, 0, 1 << 10,
+                        1 << 10);
+
+    Gfx_SetupDL_39Opa(this->state.gfxCtx);
+
+    gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 100, 100, 255, sInitialLanguageAlphaAsInt);
+
+    gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gFileSelInitialLanguageCursorTex, G_IM_FMT_I, 48, 48, 0,
+                           G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                           G_TX_NOLOD);
+
+    gSPTextureRectangle(POLY_OPA_DISP++, (sInitialLanguageCursors[gSaveContext.language].x1 + GREG(1)) << 2,
+                        (sInitialLanguageCursors[gSaveContext.language].y1 + GREG(2)) << 2,
+                        (sInitialLanguageCursors[gSaveContext.language].x2 + GREG(1)) << 2,
+                        (sInitialLanguageCursors[gSaveContext.language].y2 + GREG(2)) << 2, G_TX_RENDERTILE, 0, 0,
+                        3 << 8, 3 << 8);
+
+    gDPPipeSync(POLY_OPA_DISP++);
+    gDPSetRenderMode(POLY_OPA_DISP++, G_RM_XLU_SURF, G_RM_XLU_SURF2);
+    gDPSetCombineMode(POLY_OPA_DISP++, G_CC_BLENDPEDECALA, G_CC_BLENDPEDECALA);
+    gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 50, 255);
+
+    for (i = 0; i < LANGUAGE_MAX; i++) {
+        gDPPipeSync(POLY_OPA_DISP++);
+
+        if (i == gSaveContext.language) {
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 255);
+        } else {
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 50, 50, 100, 255);
+        }
+
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sInitialLanguageTextures[i].texture, G_IM_FMT_IA, G_IM_SIZ_8b,
+                            sInitialLanguageTextures[i].width, sInitialLanguageTextures[i].height, 0,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                            G_TX_NOLOD);
+
+        gSPTextureRectangle(POLY_OPA_DISP++, (sInitialLanguageTextures[i].x1 + GREG(1)) << 2,
+                            (sInitialLanguageTextures[i].y1 + GREG(2)) << 2,
+                            (sInitialLanguageTextures[i].x2 + GREG(1)) << 2,
+                            (sInitialLanguageTextures[i].y2 + GREG(2)) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+    }
+
+    gDPPipeSync(POLY_OPA_DISP++);
+
+    gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 220, 180, 30, 255);
+    gDPSetEnvColor(POLY_OPA_DISP++, 60, 20, 0, 255);
+
+    source = (u8*)gFileSelSelectYourLanguageTex;
+    y1 = 120 + GREG(3);
+    for (i = 0; i < 8; i++, source += 0x500) {
+        y2 = y1 + 8;
+        gDPLoadTextureBlock(POLY_OPA_DISP++, source, G_IM_FMT_IA, G_IM_SIZ_8b, 160, 8, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+
+        gSPTextureRectangle(POLY_OPA_DISP++, (80 + GREG(4)) << 2, y1 << 2, (240 + GREG(4)) << 2, y2 << 2,
+                            G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+
+        y1 = y2;
+    }
+
+    CLOSE_DISPS(this->state.gfxCtx, "../z_file_choose.c", 0);
+}
+#endif
 
 void FileSelect_SetView(FileSelectState* this, f32 eyeX, f32 eyeY, f32 eyeZ) {
     Vec3f eye;
@@ -58,18 +327,57 @@ Gfx* FileSelect_QuadTextureIA8(Gfx* gfx, void* texture, s16 width, s16 height, s
 
 void FileSelect_InitModeUpdate(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
+    SramContext* sramCtx = &this->sramCtx;
 
+#if !OOT_PAL_N64
     if (this->menuMode == FS_MENU_MODE_INIT) {
         this->menuMode = FS_MENU_MODE_CONFIG;
         this->configMode = CM_FADE_IN_START;
         this->nextTitleLabel = FS_TITLE_OPEN_FILE;
         PRINTF("Ｓｒａｍ Ｓｔａｒｔ─Ｌｏａｄ  》》》》》  ");
-        Sram_VerifyAndLoadAllSaves(this, &this->sramCtx);
+        Sram_VerifyAndLoadAllSaves(this, sramCtx);
         PRINTF("終了！！！\n");
     }
+#else
+    if (this->configMode == CM_FADE_IN_START) {
+        Sram_VerifyAndLoadAllSaves(this, sramCtx);
+
+        if (!SLOT_OCCUPIED(sramCtx, 0) && !SLOT_OCCUPIED(sramCtx, 1) && !SLOT_OCCUPIED(sramCtx, 2)) {
+            this->configMode++; // = CM_FADE_IN_END
+        } else {
+            this->menuMode = FS_MENU_MODE_CONFIG;
+            this->configMode = CM_FADE_IN_START;
+            this->nextTitleLabel = FS_TITLE_OPEN_FILE;
+        }
+    }
+
+    if (this->configMode == CM_FADE_IN_END) {
+        sScreenFillAlpha -= 40;
+        if (sScreenFillAlpha <= 0) {
+            sScreenFillAlpha = 0;
+            this->configMode++; // = CM_MAIN_MENU
+        }
+    } else if (this->configMode == CM_MAIN_MENU) {
+        FileSelect_UpdateInitialLanguageMenu(this);
+    } else {
+        sScreenFillAlpha += 40;
+        if (sScreenFillAlpha >= 255) {
+            sScreenFillAlpha = 255;
+            this->menuMode = FS_MENU_MODE_CONFIG;
+            this->configMode = CM_FADE_IN_START;
+            this->nextTitleLabel = FS_TITLE_OPEN_FILE;
+        }
+    }
+#endif
 }
 
 void FileSelect_InitModeDraw(GameState* thisx) {
+#if OOT_PAL_N64
+    FileSelectState* this = (FileSelectState*)thisx;
+
+    Gfx_SetupDL_39Opa(this->state.gfxCtx);
+    FileSelect_DrawInitialLanguageMenu(this);
+#endif
 }
 
 /**
@@ -530,13 +838,16 @@ static s16 D_80812848[] = { 0x0274, 0x0278 };
 
 void FileSelect_SetWindowContentVtx(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
+    SramContext* sramCtx = &this->sramCtx;
     s16 phi_t2;
     s16 phi_t0;
     s16 phi_t5;
     s16 phi_a1;
     s16 phi_ra;
     s16 temp_t1;
-    SramContext* sramCtx = &this->sramCtx;
+#if OOT_PAL_N64
+    u8 fileNameChar;
+#endif
 
     this->windowContentVtx = GRAPH_ALLOC(this->state.gfxCtx, 0x288 * sizeof(Vtx));
 
@@ -689,8 +1000,14 @@ void FileSelect_SetWindowContentVtx(GameState* thisx) {
             temp_t1 += 2;
 
             for (phi_a1 = 0; phi_a1 < 8; phi_a1++, phi_t2 += 4, phi_t0 += WREG(40)) {
+#if OOT_VERSION == PAL_1_1
+                fileNameChar = this->fileNames[phi_t5][phi_a1];
                 this->windowContentVtx[phi_t2].v.ob[0] = this->windowContentVtx[phi_t2 + 2].v.ob[0] =
-                    WREG(41) + phi_t0 + 0x40;
+                    phi_t0 + 0x40 + WREG(41) + D_808124C0[fileNameChar];
+#else
+                this->windowContentVtx[phi_t2].v.ob[0] = this->windowContentVtx[phi_t2 + 2].v.ob[0] =
+                    phi_t0 + 0x40 + WREG(41);
+#endif
                 this->windowContentVtx[phi_t2 + 1].v.ob[0] = this->windowContentVtx[phi_t2 + 3].v.ob[0] =
                     this->windowContentVtx[phi_t2].v.ob[0] + WREG(42);
                 this->windowContentVtx[phi_t2].v.ob[1] = this->windowContentVtx[phi_t2 + 1].v.ob[1] = temp_t1 - 3;
@@ -825,18 +1142,33 @@ static void* sSaveXTextures[] = { gFileSelSaveXJPNTex, gFileSelSaveXENGTex };
 #endif
 
 static s16 sNamePrimColors[2][3] = { { 255, 255, 255 }, { 100, 100, 100 } };
+
+#if !OOT_PAL_N64
 static void* sHeartTextures[] = { gHeartFullTex, gDefenseHeartFullTex };
+#else
+static void* sHeartTextures[][5] = {
+    { gHeartEmptyTex, gHeartQuarterTex, gHeartHalfTex, gHeartThreeQuarterTex, gHeartFullTex },
+    { gDefenseHeartEmptyTex, gDefenseHeartQuarterTex, gDefenseHeartHalfTex, gDefenseHeartThreeQuarterTex,
+      gDefenseHeartFullTex },
+};
+static u8 sHeartTextureIndices[16] = { 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3 };
+#endif
+
 static s16 sHeartPrimColors[2][3] = { { 255, 70, 50 }, { 200, 0, 0 } };
 static s16 sHeartEnvColors[2][3] = { { 50, 40, 60 }, { 255, 255, 255 } };
 
 void FileSelect_DrawFileInfo(GameState* thisx, s16 fileIndex, s16 isActive) {
     FileSelectState* this = (FileSelectState*)thisx;
     Font* sp54 = &this->font;
-    s16 heartType;
-    s16 vtxOffset;
     s16 i;
     s16 j;
     s16 k;
+#if OOT_PAL_N64
+    s16 health;
+    s16 heartTextureIndex;
+#endif
+    s16 heartType;
+    s16 vtxOffset;
     s16 deathCountSplit[3];
 
     OPEN_DISPS(this->state.gfxCtx, "../z_file_choose.c", 1709);
@@ -886,12 +1218,37 @@ void FileSelect_DrawFileInfo(GameState* thisx, s16 fileIndex, s16 isActive) {
 
         k = this->healthCapacities[fileIndex] / 0x10;
 
+#if !OOT_PAL_N64
         // draw hearts
         for (vtxOffset = 0, j = 0; j < k; j++, vtxOffset += 4) {
             gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[D_8081284C[fileIndex] + vtxOffset] + 0x30, 4, 0);
-
             POLY_OPA_DISP = FileSelect_QuadTextureIA8(POLY_OPA_DISP, sHeartTextures[heartType], 0x10, 0x10, 0);
         }
+#else
+        health = this->health[fileIndex];
+        if (health <= 48) { // 3 hearts
+            health = 48;
+        }
+        heartTextureIndex = 4;
+
+        // draw hearts
+        for (vtxOffset = 0, j = 0; j < k; j++, vtxOffset += 4) {
+            if (health < 16) {
+                if (health != 0) {
+                    heartTextureIndex = sHeartTextureIndices[health];
+                    health = 0;
+                } else {
+                    heartTextureIndex = 0;
+                }
+            } else {
+                health -= 16;
+            }
+
+            gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[D_8081284C[fileIndex] + vtxOffset] + 0x30, 4, 0);
+            POLY_OPA_DISP =
+                FileSelect_QuadTextureIA8(POLY_OPA_DISP, sHeartTextures[heartType][heartTextureIndex], 0x10, 0x10, 0);
+        }
+#endif
 
         gDPPipeSync(POLY_OPA_DISP++);
 
@@ -1672,6 +2029,9 @@ void FileSelect_Main(GameState* thisx) {
     gSPSegment(POLY_OPA_DISP++, 0x00, NULL);
     gSPSegment(POLY_OPA_DISP++, 0x01, this->staticSegment);
     gSPSegment(POLY_OPA_DISP++, 0x02, this->parameterSegment);
+#if OOT_PAL_N64
+    gSPSegment(POLY_OPA_DISP++, 0x06, this->objectMagSegment);
+#endif
 
     Gfx_SetupFrame(this->state.gfxCtx, 0, 0, 0);
 
@@ -1766,7 +2126,7 @@ void FileSelect_Main(GameState* thisx) {
 void FileSelect_InitContext(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
     EnvironmentContext* envCtx = &this->envCtx;
-#if OOT_PAL
+#if PLATFORM_GC && OOT_PAL
     SramContext* sramCtx = &this->sramCtx;
 #endif
 
@@ -1927,7 +2287,7 @@ void FileSelect_InitContext(GameState* thisx) {
     this->n64ddFlags[0] = this->n64ddFlags[1] = this->n64ddFlags[2] = this->defense[0] = this->defense[1] =
         this->defense[2] = 0;
 
-#if OOT_PAL
+#if PLATFORM_GC && OOT_PAL
     SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, SRAM_SIZE, OS_READ);
 
     gSaveContext.language = sramCtx->readBuff[SRAM_HEADER_LANGUAGE];
@@ -1943,8 +2303,8 @@ void FileSelect_Destroy(GameState* thisx) {
 
 void FileSelect_Init(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
-    u32 size = (uintptr_t)_title_staticSegmentRomEnd - (uintptr_t)_title_staticSegmentRomStart;
     s32 pad;
+    u32 size = (uintptr_t)_title_staticSegmentRomEnd - (uintptr_t)_title_staticSegmentRomStart;
 
 #if PLATFORM_N64
     if (D_80121212 != 0) {
@@ -1952,7 +2312,11 @@ void FileSelect_Init(GameState* thisx) {
     }
 #endif
 
+#if !OOT_PAL_N64
     SREG(30) = 1;
+#else
+    SREG(30) = 2;
+#endif
     PRINTF("SIZE=%x\n", size);
 
     this->staticSegment = GAME_STATE_ALLOC(&this->state, size, "../z_file_choose.c", 3392);
@@ -1964,6 +2328,12 @@ void FileSelect_Init(GameState* thisx) {
     ASSERT(this->parameterSegment != NULL, "this->parameterSegment != NULL", "../z_file_choose.c", 3399);
     DMA_REQUEST_SYNC(this->parameterSegment, (uintptr_t)_parameter_staticSegmentRomStart, size, "../z_file_choose.c",
                      3400);
+
+#if OOT_PAL_N64
+    size = gObjectTable[OBJECT_MAG].vromEnd - gObjectTable[OBJECT_MAG].vromStart;
+    this->objectMagSegment = GAME_STATE_ALLOC(&this->state, size, "../z_file_choose.c", 0);
+    DMA_REQUEST_SYNC(this->objectMagSegment, gObjectTable[OBJECT_MAG].vromStart, size, "../z_file_choose.c", 0);
+#endif
 
     Matrix_Init(&this->state);
     View_Init(&this->view, this->state.gfxCtx);

--- a/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
@@ -29,21 +29,25 @@ void FileSelect_DrawCharacterTransition(GraphicsContext* gfxCtx, void* texture1,
 #endif
 
 #if OOT_PAL
-static s16 D_808124C0[] = {
-    0x0002, 0x0003, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0001, 0x0002, 0x0000, 0x0001,
-    0x0001, 0x0002, 0x0001, 0x0001, 0x0004, 0x0002, 0x0002, 0x0002, 0x0001, 0x0001, 0x0000, 0x0002, 0x0000, 0x0001,
-    0x0001, 0x0001, 0x0001, 0x0001, 0x0000, 0x0001, 0x0001, 0x0001, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0003,
-    0x0002, 0x0002, 0x0004, 0x0003, 0x0002, 0x0004, 0x0001, 0x0002, 0x0002, 0x0001, 0x0001, 0x0002, 0x0002, 0x0003,
-    0x0002, 0x0002, 0x0000, 0x0002, 0x0002, 0x0002, 0x0000, 0x0003, 0x0001, 0x0000,
+
+#if OOT_VERSION >= PAL_1_1
+s16 D_808124C0[] = {
+    2, 3, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 0, 1, 1, 2, 1, 1, 4, 2, 2, 2, 1, 1, 0, 2, 0, 1, 1, 1, 1, 1, 0,
+    1, 1, 1, 2, 2, 2, 2, 2, 3, 2, 2, 4, 3, 2, 4, 1, 2, 2, 1, 1, 2, 2, 3, 2, 2, 0, 2, 2, 2, 0, 3, 1, 0,
+};
+#endif
+
+s16 D_80812544[] = {
+#if OOT_VERSION < PAL_1_1
+    1, 2, 0, 1, 1, 2, 1, 2, 4, 2, 2, 2, 1, 1, 0, 2, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 2, 2, 2, 2, 2, 3,
+    2, 2, 4, 3, 2, 4, 1, 2, 2, 1, 1, 2, 2, 3, 2, 2, 0, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 3,
+#else
+    // Differs only at index 7
+    1, 2, 0, 1, 1, 2, 1, 1, 4, 2, 2, 2, 1, 1, 0, 2, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 2, 2, 2, 2, 2, 3,
+    2, 2, 4, 3, 2, 4, 1, 2, 2, 1, 1, 2, 2, 3, 2, 2, 0, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 3,
+#endif
 };
 
-static s16 D_80812544[] = {
-    0x0001, 0x0002, 0x0000, 0x0001, 0x0001, 0x0002, 0x0001, 0x0001, 0x0004, 0x0002, 0x0002, 0x0002, 0x0001,
-    0x0001, 0x0000, 0x0002, 0x0000, 0x0001, 0x0001, 0x0001, 0x0001, 0x0001, 0x0000, 0x0001, 0x0001, 0x0001,
-    0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0003, 0x0002, 0x0002, 0x0004, 0x0003, 0x0002, 0x0004, 0x0001,
-    0x0002, 0x0002, 0x0001, 0x0001, 0x0002, 0x0002, 0x0003, 0x0002, 0x0002, 0x0000, 0x0002, 0x0002, 0x0002,
-    0x0003, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0002, 0x0001, 0x0003,
-};
 #endif
 
 void FileSelect_SetKeyboardVtx(GameState* thisx) {
@@ -245,10 +249,15 @@ void FileSelect_SetNameEntryVtx(GameState* thisx) {
             this->nameEntryVtx[phi_t1].v.ob[0] + 0xA;
 #else
         if ((phi_s0 > 0) && (phi_s0 < 9)) {
+#if OOT_VERSION >= PAL_1_1
             temp = this->fileNames[this->buttonIndex][phi_s0 - 1];
 
             this->nameEntryVtx[phi_t1].v.ob[0] = this->nameEntryVtx[phi_t1 + 2].v.ob[0] =
                 D_808125EC[phi_s0] + this->nameEntryBoxPosX + D_808124C0[temp];
+#else
+            this->nameEntryVtx[phi_t1].v.ob[0] = this->nameEntryVtx[phi_t1 + 2].v.ob[0] =
+                D_808125EC[phi_s0] + this->nameEntryBoxPosX;
+#endif
 
             this->nameEntryVtx[phi_t1 + 1].v.ob[0] = this->nameEntryVtx[phi_t1 + 3].v.ob[0] =
                 this->nameEntryVtx[phi_t1].v.ob[0] + 0xA;
@@ -985,11 +994,12 @@ void FileSelect_StartNameEntry(GameState* thisx) {
 void FileSelect_UpdateKeyboardCursor(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
     s16 prevKbdX;
-
-#if OOT_NTSC
+#if !(PLATFORM_GC && OOT_PAL)
     Input* input = &this->state.input[0];
     s32 pad;
+#endif
 
+#if OOT_NTSC
     if (this->charPage <= FS_CHAR_PAGE_ENG) {
         if (CHECK_BTN_ALL(input->press.button, BTN_R)) {
             if (gSaveContext.language == LANGUAGE_JPN) {
@@ -1332,6 +1342,9 @@ void FileSelect_UpdateOptionsMenu(GameState* thisx) {
         this->configMode = CM_OPTIONS_TO_MAIN;
         sramCtx->readBuff[0] = gSaveContext.audioSetting;
         sramCtx->readBuff[1] = gSaveContext.zTargetSetting;
+#if OOT_PAL_N64
+        sramCtx->readBuff[2] = gSaveContext.language;
+#endif
         PRINTF("ＳＡＶＥ");
         Sram_WriteSramHeader(sramCtx);
         PRINTF(VT_FGCOL(YELLOW));
@@ -1358,7 +1371,18 @@ void FileSelect_UpdateOptionsMenu(GameState* thisx) {
                 gSaveContext.audioSetting = FS_AUDIO_SURROUND;
             }
         } else {
+#if !OOT_PAL_N64
             gSaveContext.zTargetSetting ^= 1;
+#else
+            if (sSelectedSetting == FS_SETTING_TARGET) {
+                gSaveContext.zTargetSetting ^= 1;
+            } else {
+                gSaveContext.language--;
+                if (gSaveContext.language >= LANGUAGE_MAX) {
+                    gSaveContext.language = LANGUAGE_MAX - 1;
+                }
+            }
+#endif
         }
     } else if (this->stickAdjX > 30) {
         Audio_PlaySfxGeneral(NA_SE_SY_FSEL_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
@@ -1371,10 +1395,22 @@ void FileSelect_UpdateOptionsMenu(GameState* thisx) {
                 gSaveContext.audioSetting = FS_AUDIO_STEREO;
             }
         } else {
+#if !OOT_PAL_N64
             gSaveContext.zTargetSetting ^= 1;
+#else
+            if (sSelectedSetting == FS_SETTING_TARGET) {
+                gSaveContext.zTargetSetting ^= 1;
+            } else {
+                gSaveContext.language++;
+                if (gSaveContext.language >= LANGUAGE_MAX) {
+                    gSaveContext.language = 0;
+                }
+            }
+#endif
         }
     }
 
+#if !OOT_PAL_N64
     if ((this->stickAdjY < -30) || (this->stickAdjY > 30)) {
         Audio_PlaySfxGeneral(NA_SE_SY_FSEL_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
@@ -1384,19 +1420,108 @@ void FileSelect_UpdateOptionsMenu(GameState* thisx) {
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         sSelectedSetting ^= 1;
     }
+#else
+    if (this->stickAdjY < -30) {
+        Audio_PlaySfxGeneral(NA_SE_SY_FSEL_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                             &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+        sSelectedSetting++;
+        if (sSelectedSetting >= FS_SETTING_MAX) {
+            sSelectedSetting = 0;
+        }
+    } else if (this->stickAdjY > 30) {
+        Audio_PlaySfxGeneral(NA_SE_SY_FSEL_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                             &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+        sSelectedSetting--;
+        if (sSelectedSetting >= FS_SETTING_MAX) {
+            sSelectedSetting = FS_SETTING_MAX - 1;
+        }
+    } else if (CHECK_BTN_ALL(input->press.button, BTN_A)) {
+        Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_L, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
+                             &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+        sSelectedSetting++;
+        if (sSelectedSetting >= FS_SETTING_MAX) {
+            sSelectedSetting = 0;
+        }
+    }
+#endif
 }
 
 #if OOT_NTSC
+
 typedef struct OptionsMenuTextureInfo {
     /* 0x00 */ void* texture[2];
     /* 0x08 */ u16 width;
     /* 0x0A */ u16 height;
 } OptionsMenuTextureInfo; // size = 0x0C
 
-#define OPTIONS_MENU_TEXTURE_WIDTHS(jpn, eng, ger, fra) jpn
 #define OPTIONS_MENU_TEXTURE_WIDTH(info) info.width
 #define OPTIONS_MENU_TEXTURE_HEIGHT(info) info.height
+
+static OptionsMenuTextureInfo sOptionsMenuHeaders[] = {
+    { { gFileSelOptionsJPNTex, gFileSelOptionsENGTex }, 128, 16 },
+    { { gFileSelSOUNDENGTex, gFileSelSOUNDENGTex }, 64, 16 },
+    { { gFileSelZTargetingJPNTex, gFileSelZTargetingENGTex }, 64, 16 },
+    { { gFileSelCheckBrightnessJPNTex, gFileSelCheckBrightnessENGTex }, 96, 16 },
+};
+
+static OptionsMenuTextureInfo sOptionsMenuSettings[] = {
+    { { gFileSelStereoJPNTex, gFileSelStereoENGTex }, 48, 16 },
+    { { gFileSelMonoJPNTex, gFileSelMonoENGTex }, 48, 16 },
+    { { gFileSelHeadsetJPNTex, gFileSelHeadsetENGTex }, 48, 16 },
+    { { gFileSelSurroundJPNTex, gFileSelSurroundENGTex }, 48, 16 },
+    { { gFileSelSwitchJPNTex, gFileSelSwitchENGTex }, 48, 16 },
+    { { gFileSelHoldJPNTex, gFileSelHoldENGTex }, 48, 16 },
+};
+
+#elif OOT_PAL_N64
+
+static u16 sZTargetSettingWidths[2][3] = {
+    { 48, 80, 48 },
+    { 48, 80, 48 },
+};
+
+typedef struct LanguageChoiceTextureInfo {
+    /* 0x00 */ void* texture;
+    /* 0x04 */ u16 width;
+    /* 0x06 */ u16 height;
+} LanguageChoiceTextureInfo; // size = 0x10
+
+static LanguageChoiceTextureInfo sLanguageChoices[] = {
+    { gFileSelLanguageChoiceENGTex, 48, 16 },
+    { gFileSelLanguageChoiceGERTex, 48, 16 },
+    { gFileSelLanguageChoiceFRATex, 48, 16 },
+};
+
+typedef struct OptionsMenuTextureInfo {
+    /* 0x00 */ void* texture[3];
+    /* 0x0C */ u16 width;
+    /* 0x0E */ u16 height;
+} OptionsMenuTextureInfo; // size = 0x10
+
+#define OPTIONS_MENU_TEXTURE_WIDTH(info) info.width
+#define OPTIONS_MENU_TEXTURE_HEIGHT(info) info.height
+
+static OptionsMenuTextureInfo sOptionsMenuHeaders[] = {
+    { { gFileSelOptionsENGTex, gFileSelOptionsGERTex, gFileSelOptionsENGTex }, 128, 16 },
+    { { gFileSelSOUNDENGTex, gFileSelSOUNDENGTex, gFileSelSOUNDFRATex }, 64, 16 },
+    { { gFileSelZTargetingENGTex, gFileSelZTargetingGERTex, gFileSelZTargetingFRATex }, 64, 16 },
+    { { gFileSelCheckBrightnessENGTex, gFileSelCheckBrightnessGERTex, gFileSelCheckBrightnessFRATex }, 128, 16 },
+    { { gFileSelLanguageENGTex, gFileSelLanguageGERTex, gFileSelLanguageFRATex }, 64, 16 },
+};
+
+static OptionsMenuTextureInfo sOptionsMenuSettings[] = {
+    { { gFileSelStereoENGTex, gFileSelStereoENGTex, gFileSelStereoFRATex }, 48, 16 },
+    { { gFileSelMonoENGTex, gFileSelMonoENGTex, gFileSelMonoENGTex }, 48, 16 },
+    { { gFileSelHeadsetENGTex, gFileSelHeadsetGERTex, gFileSelHeadsetFRATex }, 48, 16 },
+    { { gFileSelSurroundENGTex, gFileSelSurroundENGTex, gFileSelSurroundENGTex }, 48, 16 },
+    { { gFileSelSwitchENGTex, gFileSelSwitchGERTex, gFileSelSwitchFRATex }, 48, 16 },
+    { { gFileSelHoldENGTex, gFileSelHoldGERTex, gFileSelHoldFRATex }, 48, 16 },
+    { { gFileSelSwitchENGTex, gFileSelSwitchGERTex, gFileSelSwitchFRATex }, 48, 16 },
+    { { gFileSelHoldENGTex, gFileSelHoldGERTex, gFileSelHoldFRATex }, 48, 16 },
+};
+
 #else
+
 typedef struct OptionsMenuTextureInfo {
     /* 0x00 */ void* texture[3];
     /* 0x0C */ u16 width[3];
@@ -1407,65 +1532,26 @@ typedef struct OptionsMenuTextureInfo {
     { eng, ger, fra }
 #define OPTIONS_MENU_TEXTURE_WIDTH(info) info.width[gSaveContext.language]
 #define OPTIONS_MENU_TEXTURE_HEIGHT(info) info.height
-#endif
 
 static OptionsMenuTextureInfo sOptionsMenuHeaders[] = {
-    {
-        LANGUAGE_ARRAY(gFileSelOptionsJPNTex, gFileSelOptionsENGTex, gFileSelOptionsGERTex, gFileSelOptionsENGTex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(128, 128, 128, 128),
-        16,
-    },
-    {
-        LANGUAGE_ARRAY(gFileSelSOUNDENGTex, gFileSelSOUNDENGTex, gFileSelSOUNDENGTex, gFileSelSOUNDFRATex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(64, 64, 64, 64),
-        16,
-    },
-    {
-        LANGUAGE_ARRAY(gFileSelZTargetingJPNTex, gFileSelZTargetingENGTex, gFileSelZTargetingGERTex,
-                       gFileSelZTargetingFRATex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(64, 64, 144, 64),
-        16,
-    },
-    {
-        LANGUAGE_ARRAY(gFileSelCheckBrightnessJPNTex, gFileSelCheckBrightnessENGTex, gFileSelCheckBrightnessGERTex,
-                       gFileSelCheckBrightnessFRATex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(96, 128, 128, 128),
-        16,
-    },
+    { { gFileSelOptionsENGTex, gFileSelOptionsGERTex, gFileSelOptionsENGTex }, { 128, 128, 128 }, 16 },
+    { { gFileSelSOUNDENGTex, gFileSelSOUNDENGTex, gFileSelSOUNDFRATex }, { 64, 64, 64 }, 16 },
+    { { gFileSelZTargetingENGTex, gFileSelZTargetingGERTex, gFileSelZTargetingFRATex }, { 64, 144, 64 }, 16 },
+    { { gFileSelCheckBrightnessENGTex, gFileSelCheckBrightnessGERTex, gFileSelCheckBrightnessFRATex },
+      { 128, 128, 128 },
+      16 },
 };
 
 static OptionsMenuTextureInfo sOptionsMenuSettings[] = {
-    {
-        LANGUAGE_ARRAY(gFileSelStereoJPNTex, gFileSelStereoENGTex, gFileSelStereoENGTex, gFileSelStereoFRATex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(48, 48, 48, 48),
-        16,
-    },
-    {
-        LANGUAGE_ARRAY(gFileSelMonoJPNTex, gFileSelMonoENGTex, gFileSelMonoENGTex, gFileSelMonoENGTex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(48, 48, 48, 48),
-        16,
-    },
-    {
-        LANGUAGE_ARRAY(gFileSelHeadsetJPNTex, gFileSelHeadsetENGTex, gFileSelHeadsetGERTex, gFileSelHeadsetFRATex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(48, 48, 48, 48),
-        16,
-    },
-    {
-        LANGUAGE_ARRAY(gFileSelSurroundJPNTex, gFileSelSurroundENGTex, gFileSelSurroundENGTex, gFileSelSurroundENGTex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(48, 48, 48, 48),
-        16,
-    },
-    {
-        LANGUAGE_ARRAY(gFileSelSwitchJPNTex, gFileSelSwitchENGTex, gFileSelSwitchGERTex, gFileSelSwitchFRATex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(48, 48, 80, 48),
-        16,
-    },
-    {
-        LANGUAGE_ARRAY(gFileSelHoldJPNTex, gFileSelHoldENGTex, gFileSelHoldGERTex, gFileSelHoldFRATex),
-        OPTIONS_MENU_TEXTURE_WIDTHS(48, 48, 80, 48),
-        16,
-    },
+    { { gFileSelStereoENGTex, gFileSelStereoENGTex, gFileSelStereoFRATex }, { 48, 48, 48 }, 16 },
+    { { gFileSelMonoENGTex, gFileSelMonoENGTex, gFileSelMonoENGTex }, { 48, 48, 48 }, 16 },
+    { { gFileSelHeadsetENGTex, gFileSelHeadsetGERTex, gFileSelHeadsetFRATex }, { 48, 48, 48 }, 16 },
+    { { gFileSelSurroundENGTex, gFileSelSurroundENGTex, gFileSelSurroundENGTex }, { 48, 48, 48 }, 16 },
+    { { gFileSelSwitchENGTex, gFileSelSwitchGERTex, gFileSelSwitchFRATex }, { 48, 80, 48 }, 16 },
+    { { gFileSelHoldENGTex, gFileSelHoldGERTex, gFileSelHoldFRATex }, { 48, 80, 48 }, 16 },
 };
+
+#endif
 
 void FileSelect_DrawOptionsImpl(GameState* thisx) {
     static s16 cursorPrimRed = 255;
@@ -1488,9 +1574,17 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
     s16 cursorRed;
     s16 cursorGreen;
     s16 cursorBlue;
+#if !OOT_PAL_N64
     s16 i;
     s16 j;
     s16 vtx;
+#else
+    s16 startIndex;
+    s32 endIndex;
+    s32 i;
+    s32 vtx;
+    s32 pad;
+#endif
 
     OPEN_DISPS(this->state.gfxCtx, "../z_file_nameset_PAL.c", 848);
 
@@ -1557,7 +1651,7 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
 #if OOT_NTSC
     gSPVertex(POLY_OPA_DISP++, gOptionsMenuHeadersVtx, 32, 0);
 #elif OOT_PAL_N64
-                          // TODO: implement PAL N64 version
+    gSPVertex(POLY_OPA_DISP++, gOptionsMenuHeadersVtx, 24, 0);
 #else
     if (gSaveContext.language == LANGUAGE_GER) {
         gSPVertex(POLY_OPA_DISP++, gOptionsMenuHeadersGERVtx, 32, 0);
@@ -1572,6 +1666,7 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->titleAlpha[0]);
     gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
 
+#if !OOT_PAL_N64
     for (i = 0, vtx = 0; i < 4; i++, vtx += 4) {
         gDPLoadTextureBlock(POLY_OPA_DISP++, sOptionsMenuHeaders[i].texture[gSaveContext.language], G_IM_FMT_IA,
                             G_IM_SIZ_8b, OPTIONS_MENU_TEXTURE_WIDTH(sOptionsMenuHeaders[i]),
@@ -1579,11 +1674,28 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
                             G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
     }
+#else
+    for (i = 0, vtx = 0; i < 5; i++, vtx += 4) {
+        if (i == 2 && gSaveContext.language == LANGUAGE_GER) {
+            gDPLoadTextureBlock(POLY_OPA_DISP++, sOptionsMenuHeaders[i].texture[gSaveContext.language], G_IM_FMT_IA,
+                                G_IM_SIZ_8b, 144, OPTIONS_MENU_TEXTURE_HEIGHT(sOptionsMenuHeaders[i]), 0,
+                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
+                                G_TX_NOLOD, G_TX_NOLOD);
+            gSP1Quadrangle(POLY_OPA_DISP++, vtx + 12, vtx + 14, vtx + 15, vtx + 13, 0);
+        } else {
+            gDPLoadTextureBlock(POLY_OPA_DISP++, sOptionsMenuHeaders[i].texture[gSaveContext.language], G_IM_FMT_IA,
+                                G_IM_SIZ_8b, OPTIONS_MENU_TEXTURE_WIDTH(sOptionsMenuHeaders[i]),
+                                OPTIONS_MENU_TEXTURE_HEIGHT(sOptionsMenuHeaders[i]), 0, G_TX_NOMIRROR | G_TX_WRAP,
+                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
+        }
+    }
+#endif
 
 #if OOT_NTSC
     gSPVertex(POLY_OPA_DISP++, gOptionsMenuSettingsVtx, 32, 0);
 #elif OOT_PAL_N64
-                          // TODO: implement PAL N64 version
+    gSPVertex(POLY_OPA_DISP++, gOptionsMenuSettingsVtx, 32, 0);
 #else
     if (gSaveContext.language == LANGUAGE_GER) {
         gSPVertex(POLY_OPA_DISP++, gOptionsMenuSettingsGERVtx, 32, 0);
@@ -1617,6 +1729,7 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
         gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
     }
 
+#if !OOT_PAL_N64
     for (; i < 6; i++, vtx += 4) {
         gDPPipeSync(POLY_OPA_DISP++);
 
@@ -1643,6 +1756,46 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
                             G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
     }
+#else
+    if (gSaveContext.language == LANGUAGE_GER) {
+        endIndex = 8;
+        startIndex = 6;
+        i += 2;
+        vtx += 8;
+    } else {
+        endIndex = 6;
+        startIndex = 4;
+    }
+
+    for (; i < endIndex; i++, vtx += 4) {
+        s32 j = i - startIndex;
+
+        gDPPipeSync(POLY_OPA_DISP++);
+
+        if (j == gSaveContext.zTargetSetting) {
+            if (sSelectedSetting == FS_SETTING_TARGET) {
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, cursorPrimRed, cursorPrimGreen, cursorPrimBlue,
+                                this->titleAlpha[0]);
+                gDPSetEnvColor(POLY_OPA_DISP++, cursorEnvRed, cursorEnvGreen, cursorEnvBlue, 0xFF);
+            } else {
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->titleAlpha[0]);
+                gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
+            }
+        } else {
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 120, 120, 120, this->titleAlpha[0]);
+            gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
+        }
+
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sOptionsMenuSettings[i].texture[gSaveContext.language], G_IM_FMT_IA,
+                            G_IM_SIZ_8b, sZTargetSettingWidths[j][gSaveContext.language],
+                            OPTIONS_MENU_TEXTURE_HEIGHT(sOptionsMenuHeaders[i]), 0, G_TX_NOMIRROR | G_TX_WRAP,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+        gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
+    }
+
+    gSPVertex(POLY_OPA_DISP++, gOptionsMenuBrightnessVtx, 8, 0);
+    vtx = 0;
+#endif
 
     gDPPipeSync(POLY_OPA_DISP++);
 
@@ -1662,6 +1815,33 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
     gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
 
     vtx += 4;
+
+#if OOT_PAL_N64
+    gSPVertex(POLY_OPA_DISP++, gOptionsMenuLanguageVtx, 12, 0);
+
+    for (i = 0, vtx = 0; i != LANGUAGE_MAX; i++, vtx += 4) {
+        gDPPipeSync(POLY_OPA_DISP++);
+
+        if (i == gSaveContext.language) {
+            if (sSelectedSetting == FS_SETTING_LANGUAGE) {
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, cursorPrimRed, cursorPrimGreen, cursorPrimBlue,
+                                this->titleAlpha[0]);
+                gDPSetEnvColor(POLY_OPA_DISP++, cursorEnvRed, cursorEnvGreen, cursorEnvBlue, 0xFF);
+            } else {
+                gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->titleAlpha[0]);
+                gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
+            }
+        } else {
+            gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 120, 120, 120, this->titleAlpha[0]);
+            gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
+        }
+
+        gDPLoadTextureBlock(POLY_OPA_DISP++, sLanguageChoices[i].texture, G_IM_FMT_IA, G_IM_SIZ_8b,
+                            sLanguageChoices[i].width, sLanguageChoices[i].height, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+        gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
+    }
+#endif
 
     // blue divider lines
     gDPPipeSync(POLY_OPA_DISP++);
@@ -1693,6 +1873,15 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
     gSPVertex(POLY_OPA_DISP++, gOptionsDividerBrightnessVtx, 4, 0);
     gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
     Matrix_Pop();
+
+#if OOT_PAL_N64
+    Matrix_Push();
+    Matrix_Translate(0.0f, 0.8f, 0.0f, MTXMODE_APPLY);
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, this->state.gfxCtx, "../z_file_nameset_PAL.c", 0);
+    gSPVertex(POLY_OPA_DISP++, gOptionsDividerLanguageVtx, 4, 0);
+    gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
+    Matrix_Pop();
+#endif
 
     CLOSE_DISPS(this->state.gfxCtx, "../z_file_nameset_PAL.c", 1040);
 }


### PR DESCRIPTION
Last change for PAL N64 besides bss ordering, but it's a big one sorry.

Changes for PAL N64:
* An "initial language selection" screen when the game first boots and finds no existing files. It reuses title screen (`object_mag`) assets for the shield logo and copyright text.
* A 4th option for language selection in the options menu. The implementation in z_file_nameset.c is getting a little messy but there's still a fair amount of shared code.
* Some tweaks to filename character positioning (slightly different between PAL 1.0 and PAL 1.1)
* The hearts on the file selection screen show empty/quarter/half/three-quarters/full based on how much health you actually have

Initial language selection:
<img width="633" alt="Screenshot 2024-09-26 at 8 48 52 PM" src="https://github.com/user-attachments/assets/e8b505a9-7be8-414a-a09a-1d3717aafe1e">
Options menu:
<img width="624" alt="Screenshot 2024-09-26 at 8 49 13 PM" src="https://github.com/user-attachments/assets/d6ec0e0d-add0-49ca-a10c-8f989bba49bc">
