### PR TITLE
[includes] z_fishing

### DIFF
--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -5,18 +5,38 @@
  */
 
 #include "z_fishing.h"
-#include "global.h"
 
 #include "overlays/actors/ovl_En_Kanban/z_en_kanban.h"
 #include "assets/objects/object_fish/object_fish.h"
+#include "libc64/math64.h"
+#include "attributes.h"
+#include "controller.h"
+#include "gfx.h"
+#include "gfx_setupdl.h"
 #include "ichain.h"
+#include "letterbox.h"
+#include "rand.h"
+#include "regs.h"
+#include "rumble.h"
+#include "segmented_address.h"
+#include "seqcmd.h"
+#include "sequence.h"
+#include "sfx.h"
+#include "sys_math.h"
+#include "sys_matrix.h"
 #include "terminal.h"
 #include "versions.h"
+#include "z64audio.h"
+#include "z64play.h"
+#include "z64player.h"
+#include "z64skin_matrix.h"
+#include "z_lib.h"
 #if PLATFORM_N64
 #include "cic6105.h"
 #endif
 
-#pragma increment_block_number "gc-eu:119 gc-eu-mq:119 gc-jp:121 gc-jp-ce:121 gc-jp-mq:121 gc-us:121 gc-us-mq:121"
+#pragma increment_block_number "gc-eu:199 gc-eu-mq:199 gc-jp:199 gc-jp-ce:199 gc-jp-mq:199 gc-us:199 gc-us-mq:199" \
+                               "ntsc-1.2:128"
 
 #define FLAGS ACTOR_FLAG_4
 


### PR DESCRIPTION
don't include global.h in z_fishing.c anymore, include the relevant headers instead

(poggers!)