### PR TITLE
[ntsc-1.0/1.1] Match line numbers in debug strings

### DIFF
--- a/src/boot/z_locale.c
+++ b/src/boot/z_locale.c
@@ -39,7 +39,11 @@ void Locale_Init(void) {
             PRINTF(VT_COL(RED, WHITE));
             PRINTF(T("z_locale_init: 日本用かアメリカ用か判別できません\n",
                      "z_locale_init: Can't tell if it's for Japan or America\n"));
-#if PLATFORM_N64
+#if OOT_VERSION < NTSC_1_1
+            LogUtils_HungupThread("../z_locale.c", 86);
+#elif OOT_VERSION < PAL_1_0
+            LogUtils_HungupThread("../z_locale.c", 92);
+#elif OOT_VERSION < GC_JP
             LogUtils_HungupThread("../z_locale.c", 101);
 #else
             LogUtils_HungupThread("../z_locale.c", 118);

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -386,7 +386,11 @@ void GameState_InitArena(GameState* gameState, size_t size) {
     } else {
         THA_Init(&gameState->tha, NULL, 0);
         PRINTF(T("ハイラル確保失敗\n", "Failure to secure Hyrule\n"));
-#if PLATFORM_N64
+#if OOT_VERSION < NTSC_1_1
+        HUNGUP_AND_CRASH("../game.c", 895);
+#elif OOT_VERSION < PAL_1_0
+        HUNGUP_AND_CRASH("../game.c", 898);
+#elif OOT_VERSION < GC_JP
         HUNGUP_AND_CRASH("../game.c", 985);
 #else
         HUNGUP_AND_CRASH("../game.c", 999);
@@ -431,7 +435,11 @@ void GameState_Realloc(GameState* gameState, size_t size) {
         SystemArena_Display();
 #endif
 
-#if PLATFORM_N64
+#if OOT_VERSION < NTSC_1_1
+        HUNGUP_AND_CRASH("../game.c", 940);
+#elif OOT_VERSION < PAL_1_0
+        HUNGUP_AND_CRASH("../game.c", 943);
+#elif OOT_VERSION < GC_JP
         HUNGUP_AND_CRASH("../game.c", 1030);
 #else
         HUNGUP_AND_CRASH("../game.c", 1044);

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -379,7 +379,11 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
             PRINTF("%c", BEL);
             PRINTF(VT_COL(RED, WHITE) T("ダイナミック領域先頭が破壊されています\n", "Dynamic area head is destroyed\n")
                        VT_RST);
-#if PLATFORM_N64
+#if OOT_VERSION < NTSC_1_1
+            Fault_AddHungupAndCrash("../graph.c", 937);
+#elif OOT_VERSION < PAL_1_0
+            Fault_AddHungupAndCrash("../graph.c", 940);
+#elif OOT_VERSION < GC_JP
             Fault_AddHungupAndCrash("../graph.c", 951);
 #else
             Fault_AddHungupAndCrash("../graph.c", 1070);
@@ -390,7 +394,11 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
             PRINTF("%c", BEL);
             PRINTF(VT_COL(RED, WHITE)
                        T("ダイナミック領域末尾が破壊されています\n", "Dynamic region tail is destroyed\n") VT_RST);
-#if PLATFORM_N64
+#if OOT_VERSION < NTSC_1_1
+            Fault_AddHungupAndCrash("../graph.c", 943);
+#elif OOT_VERSION < PAL_1_0
+            Fault_AddHungupAndCrash("../graph.c", 946);
+#elif OOT_VERSION < GC_JP
             Fault_AddHungupAndCrash("../graph.c", 957);
 #else
             Fault_AddHungupAndCrash("../graph.c", 1076);
@@ -486,7 +494,11 @@ void Graph_ThreadEntry(void* arg0) {
 
             sprintf(faultMsg, "CLASS SIZE= %d bytes", size);
             Fault_AddHungupAndCrashImpl("GAME CLASS MALLOC FAILED", faultMsg);
-#elif PLATFORM_N64
+#elif OOT_VERSION < NTSC_1_1
+            Fault_AddHungupAndCrash("../graph.c", 1067);
+#elif OOT_VERSION < PAL_1_0
+            Fault_AddHungupAndCrash("../graph.c", 1070);
+#elif OOT_VERSION < GC_JP
             Fault_AddHungupAndCrash("../graph.c", 1081);
 #else
             Fault_AddHungupAndCrash("../graph.c", 1200);

--- a/src/code/padmgr.c
+++ b/src/code/padmgr.c
@@ -326,7 +326,9 @@ void PadMgr_UpdateInputs(PadMgr* padMgr) {
             default:
                 // Unknown error response
                 LOG_HEX("padnow1->errno", pad->errno, "../padmgr.c", 396);
-#if PLATFORM_N64
+#if OOT_VERSION < NTSC_1_1
+                Fault_AddHungupAndCrash("../padmgr.c", 379);
+#elif OOT_VERSION < GC_JP
                 Fault_AddHungupAndCrash("../padmgr.c", 382);
 #else
                 Fault_AddHungupAndCrash("../padmgr.c", 397);

--- a/src/code/sys_cfb.c
+++ b/src/code/sys_cfb.c
@@ -33,7 +33,11 @@ void SysCfb_Init(s32 n64dd) {
         PRINTF("RAM4M mode\n");
         sSysCfbEnd = 0x80400000;
     } else {
-#if PLATFORM_N64
+#if OOT_VERSION < NTSC_1_1
+        LogUtils_HungupThread("../sys_cfb.c", 305);
+#elif OOT_VERSION < PAL_1_0
+        LogUtils_HungupThread("../sys_cfb.c", 308);
+#elif OOT_VERSION < GC_JP
         LogUtils_HungupThread("../sys_cfb.c", 322);
 #else
         LogUtils_HungupThread("../sys_cfb.c", 354);

--- a/src/code/z_bgcheck.c
+++ b/src/code/z_bgcheck.c
@@ -1611,7 +1611,11 @@ void BgCheck_Allocate(CollisionContext* colCtx, PlayState* play, CollisionHeader
                                                colCtx->subdivAmount.z,
                                            ALIGNOF_MASK(StaticLookup));
     if (colCtx->lookupTbl == NULL) {
+#if OOT_VERSION < NTSC_1_1
+        LogUtils_HungupThread("../z_bgcheck.c", 4173);
+#else
         LogUtils_HungupThread("../z_bgcheck.c", 4176);
+#endif
     }
     colCtx->minBounds.x = colCtx->colHeader->minBounds.x;
     colCtx->minBounds.y = colCtx->colHeader->minBounds.y;
@@ -1635,7 +1639,11 @@ void BgCheck_Allocate(CollisionContext* colCtx, PlayState* play, CollisionHeader
         tblMax = customNodeListMax;
     } else {
         if (colCtx->memSize < memSize) {
+#if OOT_VERSION < NTSC_1_1
+            LogUtils_HungupThread("../z_bgcheck.c", 4227);
+#else
             LogUtils_HungupThread("../z_bgcheck.c", 4230);
+#endif
         }
         tblMax = (colCtx->memSize - memSize) / sizeof(SSNode);
     }

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -176,7 +176,11 @@ void Play_SetupTransition(PlayState* this, s32 transitionType) {
                 break;
 
             default:
-#if OOT_VERSION < PAL_1_1
+#if OOT_VERSION < NTSC_1_1
+                HUNGUP_AND_CRASH("../z_play.c", 2263);
+#elif OOT_VERSION < PAL_1_0
+                HUNGUP_AND_CRASH("../z_play.c", 2266);
+#elif OOT_VERSION < PAL_1_1
                 HUNGUP_AND_CRASH("../z_play.c", 2269);
 #elif OOT_VERSION < GC_JP
                 HUNGUP_AND_CRASH("../z_play.c", 2272);

--- a/src/code/z_room.c
+++ b/src/code/z_room.c
@@ -456,7 +456,11 @@ RoomShapeImageMultiBgEntry* Room_GetImageMultiBgEntry(RoomShapeImageMulti* roomS
     PRINTF(VT_COL(RED, WHITE) T("z_room.c:カメラＩＤに一致するデータが存在しません camid=%d\n",
                                 "z_room.c: Data consistent with camera id does not exist camid=%d\n") VT_RST,
            bgCamIndex);
-#if PLATFORM_N64
+#if OOT_VERSION < NTSC_1_1
+    Fault_AddHungupAndCrash("../z_room.c", 724);
+#elif OOT_VERSION < PAL_1_0
+    Fault_AddHungupAndCrash("../z_room.c", 727);
+#elif OOT_VERSION < GC_JP
     Fault_AddHungupAndCrash("../z_room.c", 721);
 #else
     LogUtils_HungupThread("../z_room.c", 726);
@@ -543,7 +547,11 @@ void Room_DrawImage(PlayState* play, Room* room, u32 flags) {
     } else if (roomShape->amountType == ROOM_SHAPE_IMAGE_AMOUNT_MULTI) {
         Room_DrawImageMulti(play, room, flags);
     } else {
-#if PLATFORM_N64
+#if OOT_VERSION < NTSC_1_1
+        Fault_AddHungupAndCrash("../z_room.c", 849);
+#elif OOT_VERSION < PAL_1_0
+        Fault_AddHungupAndCrash("../z_room.c", 852);
+#elif OOT_VERSION < GC_JP
         Fault_AddHungupAndCrash("../z_room.c", 836);
 #else
         LogUtils_HungupThread("../z_room.c", 841);

--- a/src/n64dd/z_n64dd.c
+++ b/src/n64dd/z_n64dd.c
@@ -112,9 +112,9 @@ void func_801C6FD8(void) {
 // Adds a HungupAndCrash
 void func_801C7018(void) {
     if (D_80121213 != 0) {
-#if OOT_VERSION == NTSC_1_0
+#if OOT_VERSION < NTSC_1_1
         Fault_AddHungupAndCrash("../z_n64dd.c", 503);
-#elif OOT_VERSION == NTSC_1_1
+#elif OOT_VERSION < PAL_1_0
         Fault_AddHungupAndCrash("../z_n64dd.c", 551);
 #else
         Fault_AddHungupAndCrash("../z_n64dd.c", 573);
@@ -215,7 +215,7 @@ void func_801C7268(void) {
     } else if (B_801D9DC8 != 0) {
         B_801D9DC8 = 0;
     }
-#if OOT_VERSION == NTSC_1_0
+#if OOT_VERSION < NTSC_1_1
     if (B_801D9DC0 != 0) {
         sp1C = (osGetTime() - B_801D9DC0) * 64 / 3000;
 
@@ -338,7 +338,7 @@ s32 func_801C7658(void) {
     B_801D9D50.unk_00 = 13;
     (&func_801C8000)(&B_801D9D50);
 
-#if OOT_VERSION > NTSC_1_1
+#if OOT_VERSION >= PAL_1_0
     StackCheck_Init(&B_801DAF88, B_801D9F88, STACK_TOP(B_801D9F88), 0, 0x100, "ddmsg");
     osCreateThread(&B_801D9DD8, THREAD_ID_DDMSG, &func_801C711C, &B_801D9B90, STACK_TOP(B_801D9F88), THREAD_PRI_DDMSG);
     osStartThread(&B_801D9DD8);
@@ -519,7 +519,7 @@ void func_801C7C1C(void* dest, s32 offset, s32 size) {
             bcopy((u8*)sp4C, (u8*)dest + func_801C7BEC(sp5C) - sp54 + var_s1, sp50);
         }
     }
-#if OOT_VERSION == NTSC_1_0
+#if OOT_VERSION < NTSC_1_1
     if (B_801D9DC0 != 0) {
         temp_v1_2 = (osGetTime() - B_801D9DC0) * 64 / 3000;
         if (1000000 - temp_v1_2 > 0) {

--- a/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
+++ b/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
@@ -90,7 +90,11 @@ s32 EnHorseGameCheck_InitIngoRace(EnHorseGameCheckBase* base, PlayState* play) {
     this->ingoHorse = Actor_Spawn(&play->actorCtx, play, ACTOR_EN_HORSE, -250.0f, 1.0f, -1650.0f, 0, 0x4000, 0, 0x8003);
 
     if (this->ingoHorse == NULL) {
+#if OOT_VERSION < NTSC_1_1
+        LogUtils_HungupThread("../z_en_horse_game_check.c", 382);
+#else
         LogUtils_HungupThread("../z_en_horse_game_check.c", 385);
+#endif
     }
     this->startTimer = 0;
     this->finishTimer = 0;


### PR DESCRIPTION
Last change for ntsc-1.0/1.1, besides audio extraction and bss ordering.

This is potentially getting out of hand. I notice the line numbers tend to change by the same amount (usually a multiple of 3)