### PR TITLE
Fix build on certain Linux distributions

### DIFF
--- a/tools/audio/samplebank.c
+++ b/tools/audio/samplebank.c
@@ -7,6 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include <assert.h>
+#include <stdlib.h>
 
 #include "xml.h"
 #include "samplebank.h"

--- a/tools/audio/samplebank_compiler.c
+++ b/tools/audio/samplebank_compiler.c
@@ -8,6 +8,7 @@
  */
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "xml.h"

--- a/tools/audio/soundfont_compiler.c
+++ b/tools/audio/soundfont_compiler.c
@@ -12,6 +12,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "xml.h"

--- a/tools/audio/xml.c
+++ b/tools/audio/xml.c
@@ -10,6 +10,7 @@
 #include <ctype.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "xml.h"


### PR DESCRIPTION
We've gotten reports that the build is broken on Gentoo and Fedora at least (e.g. https://discord.com/channels/688807550715560050/688851337085190255/1290719824925687878). I don't have an easy way to test this fix though.