### PR TITLE
Document bug in Camera_BGCheckInfo

### DIFF
--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -399,6 +399,7 @@ s32 Camera_BGCheckInfo(Camera* camera, Vec3f* from, CamColChk* to) {
     to->pos.y = to->norm.y + toNewPos.y;
     to->pos.z = to->norm.z + toNewPos.z;
 
+    //! @bug floorBgId is uninitialized if BgCheck_CameraLineTest1 returned true above
     return floorBgId + 1;
 }
 


### PR DESCRIPTION
Found because gz's camera hook shifts the stack, causing different garbage data to be read here on gz vs vanilla, or between gz versions