### PR TITLE
Player: Special Idle Animations

### DIFF
--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1199,7 +1199,6 @@ typedef enum SpecialIdleAnimSfxType {
     /* 0x8 */ SPECIAL_IDLE_ANIMSFX_SWORD_1,
     /* 0x9 */ SPECIAL_IDLE_ANIMSFX_SWORD_2,
     /* 0xA */ SPECIAL_IDLE_ANIMSFX_RELAX,
-    /* 0xB */ SPECIAL_IDLE_ANIMSFX_MAX
 } SpecialIdleAnimSfxType;
 
 static AnimSfxEntry* sSpecialIdleAnimSfxLists[] = {
@@ -1213,7 +1212,7 @@ static AnimSfxEntry* sSpecialIdleAnimSfxLists[] = {
     sSpecialIdleAnimSfxSword1,  // SPECIAL_IDLE_ANIMSFX_SWORD_1
     sSpecialIdleAnimSfxSword2,  // SPECIAL_IDLE_ANIMSFX_SWORD_2
     sSpecialIdleAnimSfxRelax,   // SPECIAL_IDLE_ANIMSFX_RELAX
-    NULL,                       // SPECIAL_IDLE_ANIMSFX_MAX
+    NULL,                       // unused entry
 };
 
 /**

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2210,11 +2210,11 @@ LinkAnimationHeader* Player_GetIdleAnim(Player* this) {
  */
 s32 Player_CheckSpecialIdleAnim(Player* this) {
     if (Player_GetIdleAnim(this) != this->skelAnime.animation) {
-        LinkAnimationHeader** special;
+        LinkAnimationHeader** specialAnim;
         s32 i;
 
-        for (i = 0, special = &sSpecialIdleAnimations[0][0]; i < 28; i++, special++) {
-            if (this->skelAnime.animation == *special) {
+        for (i = 0, specialAnim = &sSpecialIdleAnimations[0][0]; i < 28; i++, specialAnim++) {
+            if (this->skelAnime.animation == *specialAnim) {
                 return i + 1;
             }
         }
@@ -2225,9 +2225,9 @@ s32 Player_CheckSpecialIdleAnim(Player* this) {
     return -1;
 }
 
-void Player_ProcessSpecialIdleAnimSfxList(Player* this, s32 speicalIdleAnimIndex) {
-    if (sSpecialIdleAnimSfxTypes[speicalIdleAnimIndex] != SPECIAL_IDLE_ANIMSFX_NONE) {
-        Player_ProcessAnimSfxList(this, sSpecialIdleAnimSfxLists[sSpecialIdleAnimSfxTypes[speicalIdleAnimIndex] - 1]);
+void Player_ProcessSpecialIdleAnimSfxList(Player* this, s32 specialIdleAnimIndex) {
+    if (sSpecialIdleAnimSfxTypes[specialIdleAnimIndex] != SPECIAL_IDLE_ANIMSFX_NONE) {
+        Player_ProcessAnimSfxList(this, sSpecialIdleAnimSfxLists[sSpecialIdleAnimSfxTypes[specialIdleAnimIndex] - 1]);
     }
 }
 

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2194,7 +2194,7 @@ void func_808332F4(Player* this, PlayState* play) {
 /**
  * Get the appropriate Idle animation based on current `modelAnimType`.
  * This is used as the "primary" idle animation.
- * 
+ *
  * For special idle animations (which for example, change based on environment)
  * see `sSpecialIdleAnimations`.
  */

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1118,7 +1118,7 @@ static LinkAnimationHeader* D_80853D4C[][3] = {
       &gPlayerAnim_link_fighter_Rside_jump_endR },
 };
 
-static LinkAnimationHeader* sIdleAnimations[][2] = {
+static LinkAnimationHeader* sSpecialIdleAnimations[][2] = {
     { &gPlayerAnim_link_normal_wait_typeA_20f, &gPlayerAnim_link_normal_waitF_typeA_20f },
     { &gPlayerAnim_link_normal_wait_typeC_20f, &gPlayerAnim_link_normal_waitF_typeC_20f },
     { &gPlayerAnim_link_normal_wait_typeB_20f, &gPlayerAnim_link_normal_waitF_typeB_20f },
@@ -1135,23 +1135,23 @@ static LinkAnimationHeader* sIdleAnimations[][2] = {
     { &gPlayerAnim_link_wait_itemD2_20f, &gPlayerAnim_link_wait_itemD2_20f }
 };
 
-static AnimSfxEntry sIdleSneezeSfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxSneeze[] = {
     { NA_SE_VO_LI_SNEEZE, -ANIMSFX_DATA(ANIMSFX_TYPE_VOICE, 8) },
 };
 
-static AnimSfxEntry sIdleSweatSfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxSweat[] = {
     { NA_SE_VO_LI_SWEAT, -ANIMSFX_DATA(ANIMSFX_TYPE_VOICE, 18) },
 };
 
-static AnimSfxEntry sIdleHeat1Sfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxHeat1[] = {
     { NA_SE_VO_LI_BREATH_REST, -ANIMSFX_DATA(ANIMSFX_TYPE_VOICE, 13) },
 };
 
-static AnimSfxEntry sIdleHeat2Sfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxHeat2[] = {
     { NA_SE_VO_LI_BREATH_REST, -ANIMSFX_DATA(ANIMSFX_TYPE_VOICE, 10) },
 };
 
-static AnimSfxEntry sIdleBeltSfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxBelt[] = {
     { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 44) },
     { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 48) },
     { NA_SE_PL_CALM_HIT, ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 52) },
@@ -1159,80 +1159,97 @@ static AnimSfxEntry sIdleBeltSfx[] = {
     { NA_SE_PL_CALM_HIT, -ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 60) },
 };
 
-static AnimSfxEntry sIdleFootTappingSfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxFootTap[] = {
     { 0, ANIMSFX_DATA(ANIMSFX_TYPE_WALKING, 25) }, { 0, ANIMSFX_DATA(ANIMSFX_TYPE_WALKING, 30) },
     { 0, ANIMSFX_DATA(ANIMSFX_TYPE_WALKING, 44) }, { 0, ANIMSFX_DATA(ANIMSFX_TYPE_WALKING, 48) },
     { 0, ANIMSFX_DATA(ANIMSFX_TYPE_WALKING, 52) }, { 0, -ANIMSFX_DATA(ANIMSFX_TYPE_WALKING, 56) },
 };
 
-static AnimSfxEntry sIdleShieldPostureSfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxShield[] = {
     { NA_SE_IT_SHIELD_POSTURE, ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 16) },
     { NA_SE_IT_SHIELD_POSTURE, ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 20) },
     { NA_SE_IT_SHIELD_POSTURE, -ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 70) },
 };
 
-static AnimSfxEntry sIdleUnknownSfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxSword1[] = {
     { NA_SE_IT_HAMMER_SWING, ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 10) },
     { NA_SE_VO_LI_AUTO_JUMP, ANIMSFX_DATA(ANIMSFX_TYPE_VOICE, 10) },
     { NA_SE_IT_SWORD_SWING, ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 22) },
     { NA_SE_VO_LI_SWORD_N, -ANIMSFX_DATA(ANIMSFX_TYPE_VOICE, 22) },
 };
 
-static AnimSfxEntry sIdleSwordThrustSfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxSword2[] = {
     { NA_SE_IT_SWORD_SWING, ANIMSFX_DATA(ANIMSFX_TYPE_GENERAL, 39) },
     { NA_SE_VO_LI_SWORD_N, -ANIMSFX_DATA(ANIMSFX_TYPE_VOICE, 39) },
 };
 
-static AnimSfxEntry sIdleRelaxSfx[] = {
+static AnimSfxEntry sSpecialIdleAnimSfxRelax[] = {
     { NA_SE_VO_LI_RELAX, -ANIMSFX_DATA(ANIMSFX_TYPE_VOICE, 20) },
 };
 
-typedef enum {
-    /* 0x0 */ IDLE_ANIMATION_SFX_NONE,
-    /* 0x1 */ IDLE_ANIMATION_SFX_SNEEZE,
-    /* 0x2 */ IDLE_ANIMATION_SFX_SWEAT,
-    /* 0x3 */ IDLE_ANIMATION_SFX_HEAT_1,
-    /* 0x4 */ IDLE_ANIMATION_SFX_HEAT_2,
-    /* 0x5 */ IDLE_ANIMATION_SFX_BELT,
-    /* 0x6 */ IDLE_ANIMATION_SFX_FOOT_TAPPING,
-    /* 0x7 */ IDLE_ANIMATION_SFX_SHIELD_POSTURE,
-    /* 0x8 */ IDLE_ANIMATION_SFX_UNKNOWN,
-    /* 0x9 */ IDLE_ANIMATION_SFX_SWORD_THRUST,
-    /* 0xA */ IDLE_ANIMATION_SFX_RELAX,
-    /* 0xB */ IDLE_ANIMATION_SFX_MAX
-} IdleAnimationSfxIndex;
+typedef enum SpecialIdleAnimSfxType {
+    /* 0x0 */ SPECIAL_IDLE_ANIMSFX_NONE,
+    /* 0x1 */ SPECIAL_IDLE_ANIMSFX_SNEEZE,
+    /* 0x2 */ SPECIAL_IDLE_ANIMSFX_SWEAT,
+    /* 0x3 */ SPECIAL_IDLE_ANIMSFX_HEAT_1,
+    /* 0x4 */ SPECIAL_IDLE_ANIMSFX_HEAT_2,
+    /* 0x5 */ SPECIAL_IDLE_ANIMSFX_BELT,
+    /* 0x6 */ SPECIAL_IDLE_ANIMSFX_FOOT_TAP,
+    /* 0x7 */ SPECIAL_IDLE_ANIMSFX_SHIELD,
+    /* 0x8 */ SPECIAL_IDLE_ANIMSFX_SWORD_1,
+    /* 0x9 */ SPECIAL_IDLE_ANIMSFX_SWORD_2,
+    /* 0xA */ SPECIAL_IDLE_ANIMSFX_RELAX,
+    /* 0xB */ SPECIAL_IDLE_ANIMSFX_MAX
+} SpecialIdleAnimSfxType;
 
-static AnimSfxEntry* sIdleSfxEntries[] = {
-    sIdleSneezeSfx,        // IDLE_ANIMATION_SFX_SNEEZE
-    sIdleSweatSfx,         // IDLE_ANIMATION_SFX_SWEAT
-    sIdleHeat1Sfx,         // IDLE_ANIMATION_SFX_HEAT_1
-    sIdleHeat2Sfx,         // IDLE_ANIMATION_SFX_HEAT_2
-    sIdleBeltSfx,          // IDLE_ANIMATION_SFX_BELT
-    sIdleFootTappingSfx,   // IDLE_ANIMATION_SFX_FOOT_TAPPING
-    sIdleShieldPostureSfx, // IDLE_ANIMATION_SFX_SHIELD_POSTURE
-    sIdleUnknownSfx,       // IDLE_ANIMATION_SFX_UNKNOWN
-    sIdleSwordThrustSfx,   // IDLE_ANIMATION_SFX_SWORD_THRUST
-    sIdleRelaxSfx,         // IDLE_ANIMATION_SFX_RELAX
-    NULL,                  // IDLE_ANIMATION_SFX_MAX
+static AnimSfxEntry* sSpecialIdleAnimSfxLists[] = {
+    sSpecialIdleAnimSfxSneeze,  // SPECIAL_IDLE_ANIMSFX_SNEEZE
+    sSpecialIdleAnimSfxSweat,   // SPECIAL_IDLE_ANIMSFX_SWEAT
+    sSpecialIdleAnimSfxHeat1,   // SPECIAL_IDLE_ANIMSFX_HEAT_1
+    sSpecialIdleAnimSfxHeat2,   // SPECIAL_IDLE_ANIMSFX_HEAT_2
+    sSpecialIdleAnimSfxBelt,    // SPECIAL_IDLE_ANIMSFX_BELT
+    sSpecialIdleAnimSfxFootTap, // SPECIAL_IDLE_ANIMSFX_FOOT_TAP
+    sSpecialIdleAnimSfxShield,  // SPECIAL_IDLE_ANIMSFX_SHIELD
+    sSpecialIdleAnimSfxSword1,  // SPECIAL_IDLE_ANIMSFX_SWORD_1
+    sSpecialIdleAnimSfxSword2,  // SPECIAL_IDLE_ANIMSFX_SWORD_2
+    sSpecialIdleAnimSfxRelax,   // SPECIAL_IDLE_ANIMSFX_RELAX
+    NULL,                       // SPECIAL_IDLE_ANIMSFX_MAX
 };
 
 /**
- * The indices in this array correspond 1 to 1 with the entries of sIdleAnimations.
- * There is also an extra IDLE_ANIMATION_SFX_NONE at the end that doesn't correspond to any animation.
- *
- * @see sIdleAnimations for all the animations that correspond to this array
+ * The indices in this array correspond 1 to 1 with the entries of sSpecialIdleAnimations.
+ * There is also an extra SPECIAL_IDLE_ANIMSFX_NONE at the end that doesn't correspond to any animation.
  */
-static u8 sIdleSfxEntryIndices[] = {
-    IDLE_ANIMATION_SFX_NONE,           IDLE_ANIMATION_SFX_NONE,           IDLE_ANIMATION_SFX_SNEEZE,
-    IDLE_ANIMATION_SFX_SNEEZE,         IDLE_ANIMATION_SFX_SWEAT,          IDLE_ANIMATION_SFX_SWEAT,
-    IDLE_ANIMATION_SFX_SWEAT,          IDLE_ANIMATION_SFX_SWEAT,          IDLE_ANIMATION_SFX_RELAX,
-    IDLE_ANIMATION_SFX_RELAX,          IDLE_ANIMATION_SFX_RELAX,          IDLE_ANIMATION_SFX_RELAX,
-    IDLE_ANIMATION_SFX_RELAX,          IDLE_ANIMATION_SFX_RELAX,          IDLE_ANIMATION_SFX_HEAT_1,
-    IDLE_ANIMATION_SFX_HEAT_1,         IDLE_ANIMATION_SFX_HEAT_2,         IDLE_ANIMATION_SFX_HEAT_2,
-    IDLE_ANIMATION_SFX_UNKNOWN,        IDLE_ANIMATION_SFX_UNKNOWN,        IDLE_ANIMATION_SFX_BELT,
-    IDLE_ANIMATION_SFX_BELT,           IDLE_ANIMATION_SFX_FOOT_TAPPING,   IDLE_ANIMATION_SFX_FOOT_TAPPING,
-    IDLE_ANIMATION_SFX_SHIELD_POSTURE, IDLE_ANIMATION_SFX_SHIELD_POSTURE, IDLE_ANIMATION_SFX_SWORD_THRUST,
-    IDLE_ANIMATION_SFX_SWORD_THRUST,   IDLE_ANIMATION_SFX_NONE,
+static u8 sSpecialIdleAnimSfxTypes[] = {
+    SPECIAL_IDLE_ANIMSFX_NONE,     // used by gPlayerAnim_link_normal_wait_typeA_20f
+    SPECIAL_IDLE_ANIMSFX_NONE,     // used by gPlayerAnim_link_normal_waitF_typeA_20f
+    SPECIAL_IDLE_ANIMSFX_SNEEZE,   // used by gPlayerAnim_link_normal_wait_typeC_20f
+    SPECIAL_IDLE_ANIMSFX_SNEEZE,   // used by gPlayerAnim_link_normal_waitF_typeC_20f
+    SPECIAL_IDLE_ANIMSFX_SWEAT,    // used by gPlayerAnim_link_normal_wait_typeB_20f
+    SPECIAL_IDLE_ANIMSFX_SWEAT,    // used by gPlayerAnim_link_normal_waitF_typeB_20f
+    SPECIAL_IDLE_ANIMSFX_SWEAT,    // used by gPlayerAnim_link_normal_wait_typeB_20f
+    SPECIAL_IDLE_ANIMSFX_SWEAT,    // used by gPlayerAnim_link_normal_waitF_typeB_20f
+    SPECIAL_IDLE_ANIMSFX_RELAX,    // used by gPlayerAnim_link_wait_typeD_20f
+    SPECIAL_IDLE_ANIMSFX_RELAX,    // used by gPlayerAnim_link_waitF_typeD_20f
+    SPECIAL_IDLE_ANIMSFX_RELAX,    // used by gPlayerAnim_link_wait_typeD_20f
+    SPECIAL_IDLE_ANIMSFX_RELAX,    // used by gPlayerAnim_link_waitF_typeD_20f
+    SPECIAL_IDLE_ANIMSFX_RELAX,    // used by gPlayerAnim_link_wait_typeD_20f
+    SPECIAL_IDLE_ANIMSFX_RELAX,    // used by gPlayerAnim_link_waitF_typeD_20f
+    SPECIAL_IDLE_ANIMSFX_HEAT_1,   // used by gPlayerAnim_link_wait_heat1_20f
+    SPECIAL_IDLE_ANIMSFX_HEAT_1,   // used by gPlayerAnim_link_waitF_heat1_20f
+    SPECIAL_IDLE_ANIMSFX_HEAT_2,   // used by gPlayerAnim_link_wait_heat2_20f
+    SPECIAL_IDLE_ANIMSFX_HEAT_2,   // used by gPlayerAnim_link_waitF_heat2_20f
+    SPECIAL_IDLE_ANIMSFX_SWORD_1,  // used by gPlayerAnim_link_wait_itemD1_20f
+    SPECIAL_IDLE_ANIMSFX_SWORD_1,  // used by gPlayerAnim_link_wait_itemD1_20f
+    SPECIAL_IDLE_ANIMSFX_BELT,     // used by gPlayerAnim_link_wait_itemA_20f
+    SPECIAL_IDLE_ANIMSFX_BELT,     // used by gPlayerAnim_link_waitF_itemA_20f
+    SPECIAL_IDLE_ANIMSFX_FOOT_TAP, // used by gPlayerAnim_link_wait_itemB_20f
+    SPECIAL_IDLE_ANIMSFX_FOOT_TAP, // used by gPlayerAnim_link_waitF_itemB_20f
+    SPECIAL_IDLE_ANIMSFX_SHIELD,   // used by gPlayerAnim_link_wait_itemC_20f
+    SPECIAL_IDLE_ANIMSFX_SHIELD,   // used by gPlayerAnim_link_wait_itemC_20f
+    SPECIAL_IDLE_ANIMSFX_SWORD_2,  // used by gPlayerAnim_link_wait_itemD2_20f
+    SPECIAL_IDLE_ANIMSFX_SWORD_2,  // used by gPlayerAnim_link_wait_itemD2_20f
+    SPECIAL_IDLE_ANIMSFX_NONE,     // unused, doesnt correspond to any animation
 };
 
 // Used to map item IDs to item actions
@@ -2174,29 +2191,43 @@ void func_808332F4(Player* this, PlayState* play) {
     this->unk_862 = ABS(giEntry->gi);
 }
 
-LinkAnimationHeader* Player_GetIdleAnimationForCurrentModelAnimType(Player* this) {
+/**
+ * Get the appropriate Idle animation based on current `modelAnimType`.
+ * This is used as the "primary" idle animation.
+ * 
+ * For special idle animations (which for example, change based on environment)
+ * see `sSpecialIdleAnimations`.
+ */
+LinkAnimationHeader* Player_GetIdleAnim(Player* this) {
     return GET_PLAYER_ANIM(PLAYER_ANIMGROUP_wait, this->modelAnimType);
 }
 
-s32 func_80833350(Player* this) {
-    if (Player_GetIdleAnimationForCurrentModelAnimType(this) != this->skelAnime.animation) {
-        LinkAnimationHeader** entry;
+/**
+ * Checks if the current animation is a "special" idle animation.
+ * If it is, the index into `sSpecialIdleAnimations` is returned (plus one).
+ * If the current animation is a "primary" idle animation, -1 is returned.
+ * Lastly if the current animation is neither of these, 0 is returned.
+ */
+s32 Player_CheckSpecialIdleAnim(Player* this) {
+    if (Player_GetIdleAnim(this) != this->skelAnime.animation) {
+        LinkAnimationHeader** special;
         s32 i;
 
-        for (i = 0, entry = &sIdleAnimations[0][0]; i < 28; i++, entry++) {
-            if (this->skelAnime.animation == *entry) {
+        for (i = 0, special = &sSpecialIdleAnimations[0][0]; i < 28; i++, special++) {
+            if (this->skelAnime.animation == *special) {
                 return i + 1;
             }
         }
+
         return 0;
     }
 
     return -1;
 }
 
-void Player_ProcessIdleAnimSfxList(Player* this, s32 arg1) {
-    if (sIdleSfxEntryIndices[arg1] != IDLE_ANIMATION_SFX_NONE) {
-        Player_ProcessAnimSfxList(this, sIdleSfxEntries[sIdleSfxEntryIndices[arg1] - 1]);
+void Player_ProcessSpecialIdleAnimSfxList(Player* this, s32 speicalIdleAnimIndex) {
+    if (sSpecialIdleAnimSfxTypes[speicalIdleAnimIndex] != SPECIAL_IDLE_ANIMSFX_NONE) {
+        Player_ProcessAnimSfxList(this, sSpecialIdleAnimSfxLists[sSpecialIdleAnimSfxTypes[speicalIdleAnimIndex] - 1]);
     }
 }
 
@@ -2866,9 +2897,9 @@ s32 Player_UpperAction_ChangeHeldItem(Player* this, PlayState* play) {
         return this->upperActionFunc(this, play);
     }
 
-    if (func_80833350(this) != 0) {
+    if (Player_CheckSpecialIdleAnim(this) != 0) {
         Player_WaitToFinishItemChange(play, this);
-        Player_AnimPlayOnce(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+        Player_AnimPlayOnce(play, this, Player_GetIdleAnim(this));
         this->unk_6AC = 0;
     } else {
         Player_WaitToFinishItemChange(play, this);
@@ -3062,7 +3093,7 @@ s32 func_808351D4(Player* this, PlayState* play) {
     Math_ScaledStepToS(&this->unk_6C0, 1200, 400);
     this->unk_6AE |= 0x100;
 
-    if ((this->unk_836 == 0) && (func_80833350(this) == 0) &&
+    if ((this->unk_836 == 0) && (Player_CheckSpecialIdleAnim(this) == 0) &&
         (this->skelAnime.animation == &gPlayerAnim_link_bow_side_walk)) {
         LinkAnimation_PlayOnce(play, &this->upperSkelAnime, D_808543CC[sp2C]);
         this->unk_836 = -1;
@@ -3612,14 +3643,14 @@ s32 Player_UpdateUpperBody(Player* this, PlayState* play) {
     if (this->upperAnimInterpWeight != 0.0f) {
         // The functionality contained within this block of code is never used in practice
         // because `upperAnimInterpWeight` is always 0.
-        if ((func_80833350(this) == 0) || (this->speedXZ != 0.0f)) {
+        if ((Player_CheckSpecialIdleAnim(this) == 0) || (this->speedXZ != 0.0f)) {
             AnimTaskQueue_AddCopyUsingMapInverted(play, this->skelAnime.limbCount, this->upperSkelAnime.jointTable,
                                                   this->skelAnime.jointTable, sUpperBodyLimbCopyMap);
         }
         Math_StepToF(&this->upperAnimInterpWeight, 0.0f, 0.25f);
         AnimTaskQueue_AddInterp(play, this->skelAnime.limbCount, this->skelAnime.jointTable,
                                 this->upperSkelAnime.jointTable, 1.0f - this->upperAnimInterpWeight);
-    } else if ((func_80833350(this) == 0) || (this->speedXZ != 0.0f)) {
+    } else if ((Player_CheckSpecialIdleAnim(this) == 0) || (this->speedXZ != 0.0f)) {
         // Only copy the upper body animation to the upper body limbs in the main skeleton.
         // Doing so allows the main skeleton to play its own animation for the lower body limbs.
         AnimTaskQueue_AddCopyUsingMap(play, this->skelAnime.limbCount, this->skelAnime.jointTable,
@@ -4967,7 +4998,7 @@ void func_80838E70(PlayState* play, Player* this, f32 arg2, s16 arg3) {
     this->unk_450.x = (Math_SinS(arg3) * arg2) + this->actor.world.pos.x;
     this->unk_450.z = (Math_CosS(arg3) * arg2) + this->actor.world.pos.z;
 
-    Player_AnimPlayOnce(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+    Player_AnimPlayOnce(play, this, Player_GetIdleAnim(this));
 }
 
 void func_80838F18(PlayState* play, Player* this) {
@@ -5287,7 +5318,7 @@ s32 Player_ActionHandler_1(Player* this, PlayState* play) {
 
                 if (this->doorTimer != 0) {
                     this->av2.actionVar2 = 0;
-                    Player_AnimChangeOnceMorph(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+                    Player_AnimChangeOnceMorph(play, this, Player_GetIdleAnim(this));
                     this->skelAnime.endFrame = 0.0f;
                 } else {
                     this->speedXZ = 0.1f;
@@ -5429,7 +5460,7 @@ void func_80839E88(Player* this, PlayState* play) {
 
 void func_80839F30(Player* this, PlayState* play) {
     Player_SetupAction(play, this, Player_Action_808407CC, 1);
-    Player_AnimChangeOnceMorph(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+    Player_AnimChangeOnceMorph(play, this, Player_GetIdleAnim(this));
     this->yaw = this->actor.shape.rot.y;
 }
 
@@ -5905,7 +5936,7 @@ s32 Player_ActionHandler_13(Player* this, PlayState* play) {
                     } else {
                         Player_SetupAction(play, this, Player_Action_8085063C, 1);
                         this->stateFlags1 |= PLAYER_STATE1_28 | PLAYER_STATE1_29;
-                        Player_AnimPlayOnce(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+                        Player_AnimPlayOnce(play, this, Player_GetIdleAnim(this));
                         func_80835EA4(play, 4);
                     }
 
@@ -6315,7 +6346,7 @@ void func_8083C0B8(Player* this, PlayState* play) {
 
 void func_8083C0E8(Player* this, PlayState* play) {
     Player_SetupAction(play, this, Player_Action_80840BC8, 1);
-    Player_AnimPlayOnce(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+    Player_AnimPlayOnce(play, this, Player_GetIdleAnim(this));
     this->yaw = this->actor.shape.rot.y;
 }
 
@@ -7986,7 +8017,7 @@ void Player_Action_808407CC(Player* this, PlayState* play) {
 
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         Player_FinishAnimMovement(this);
-        Player_AnimPlayOnce(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+        Player_AnimPlayOnce(play, this, Player_GetIdleAnim(this));
     }
 
     func_8083721C(this);
@@ -8051,11 +8082,11 @@ void func_808409CC(PlayState* play, Player* this) {
     if ((this->focusActor != NULL) ||
         (!(heathIsCritical = Health_IsCritical()) && ((this->unk_6AC = (this->unk_6AC + 1) & 1) != 0))) {
         this->stateFlags2 &= ~PLAYER_STATE2_28;
-        anim = Player_GetIdleAnimationForCurrentModelAnimType(this);
+        anim = Player_GetIdleAnim(this);
     } else {
         this->stateFlags2 |= PLAYER_STATE2_28;
         if (this->stateFlags1 & PLAYER_STATE1_CARRYING_ACTOR) {
-            anim = Player_GetIdleAnimationForCurrentModelAnimType(this);
+            anim = Player_GetIdleAnim(this);
         } else {
             sp38 = play->roomCtx.curRoom.behaviorType2;
             if (heathIsCritical) {
@@ -8077,9 +8108,9 @@ void func_808409CC(PlayState* play, Player* this) {
                     }
                 }
             }
-            animPtr = &sIdleAnimations[sp38][0];
+            animPtr = &sSpecialIdleAnimations[sp38][0];
             if (this->modelAnimType != PLAYER_ANIMTYPE_1) {
-                animPtr = &sIdleAnimations[sp38][1];
+                animPtr = &sSpecialIdleAnimations[sp38][1];
             }
             anim = *animPtr;
         }
@@ -8090,14 +8121,14 @@ void func_808409CC(PlayState* play, Player* this) {
 }
 
 void Player_Action_80840BC8(Player* this, PlayState* play) {
-    s32 idleAnimationToChangeToPlusOne = func_80833350(this);
+    s32 specialIdleAnimIndex = Player_CheckSpecialIdleAnim(this);
     s32 sp40 = LinkAnimation_Update(play, &this->skelAnime);
     f32 speedTarget;
     s16 yawTarget;
     s16 temp;
 
-    if (idleAnimationToChangeToPlusOne > 0) {
-        Player_ProcessIdleAnimSfxList(this, idleAnimationToChangeToPlusOne - 1);
+    if (specialIdleAnimIndex > 0) {
+        Player_ProcessSpecialIdleAnimSfxList(this, specialIdleAnimIndex - 1);
     }
 
     if (sp40 != 0) {
@@ -8142,7 +8173,7 @@ void Player_Action_80840BC8(Player* this, PlayState* play) {
 
             Math_ScaledStepToS(&this->actor.shape.rot.y, yawTarget, 1200);
             this->yaw = this->actor.shape.rot.y;
-            if (Player_GetIdleAnimationForCurrentModelAnimType(this) == this->skelAnime.animation) {
+            if (Player_GetIdleAnim(this) == this->skelAnime.animation) {
                 func_8083DC54(this, play);
             }
         }
@@ -8461,8 +8492,8 @@ void Player_Action_80841BA8(Player* this, PlayState* play) {
     LinkAnimation_Update(play, &this->skelAnime);
 
     if (Player_HoldsTwoHandedWeapon2(this)) {
-        AnimTaskQueue_AddLoadPlayerFrame(play, Player_GetIdleAnimationForCurrentModelAnimType(this), 0,
-                                         this->skelAnime.limbCount, this->skelAnime.morphTable);
+        AnimTaskQueue_AddLoadPlayerFrame(play, Player_GetIdleAnim(this), 0, this->skelAnime.limbCount,
+                                         this->skelAnime.morphTable);
         AnimTaskQueue_AddCopyUsingMap(play, this->skelAnime.limbCount, this->skelAnime.jointTable,
                                       this->skelAnime.morphTable, sUpperBodyLimbCopyMap);
     }
@@ -10418,8 +10449,8 @@ void Player_InitCommon(Player* this, PlayState* play, FlexSkeletonHeader* skelHe
     SkelAnime_InitLink(play, &this->skelAnime, skelHeader, GET_PLAYER_ANIM(PLAYER_ANIMGROUP_wait, this->modelAnimType),
                        9, this->jointTable, this->morphTable, PLAYER_LIMB_MAX);
     this->skelAnime.baseTransl = sSkeletonBaseTransl;
-    SkelAnime_InitLink(play, &this->upperSkelAnime, skelHeader, Player_GetIdleAnimationForCurrentModelAnimType(this), 9,
-                       this->upperJointTable, this->upperMorphTable, PLAYER_LIMB_MAX);
+    SkelAnime_InitLink(play, &this->upperSkelAnime, skelHeader, Player_GetIdleAnim(this), 9, this->upperJointTable,
+                       this->upperMorphTable, PLAYER_LIMB_MAX);
     this->upperSkelAnime.baseTransl = sSkeletonBaseTransl;
 
     Effect_Add(play, &this->meleeWeaponEffectIndex, EFFECT_BLURE2, 0, 0, &D_8085470C);
@@ -12277,7 +12308,7 @@ s32 func_8084B3CC(PlayState* play, Player* this) {
         }
 
         this->stateFlags1 |= PLAYER_STATE1_20;
-        Player_AnimPlayOnce(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+        Player_AnimPlayOnce(play, this, Player_GetIdleAnim(this));
         Player_ZeroSpeedXZ(this);
         func_8083B010(this);
         return 1;
@@ -12344,7 +12375,7 @@ void Player_Action_8084B530(Player* this, PlayState* play) {
             if ((this->talkActor->category == ACTORCAT_NPC) && (this->heldItemAction != PLAYER_IA_FISHING_POLE)) {
                 Player_AnimPlayOnceAdjusted(play, this, &gPlayerAnim_link_normal_talk_free);
             } else {
-                Player_AnimPlayLoop(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+                Player_AnimPlayLoop(play, this, Player_GetIdleAnim(this));
             }
         } else {
             Player_AnimPlayLoopAdjusted(play, this, &gPlayerAnim_link_normal_talk_free_wait);
@@ -15832,7 +15863,7 @@ s32 Player_TryCsAction(PlayState* play, Actor* actor, s32 csAction) {
 
 void func_80853080(Player* this, PlayState* play) {
     Player_SetupAction(play, this, Player_Action_80840BC8, 1);
-    Player_AnimChangeOnceMorph(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+    Player_AnimChangeOnceMorph(play, this, Player_GetIdleAnim(this));
     this->yaw = this->actor.shape.rot.y;
 }
 
@@ -15890,7 +15921,7 @@ void func_80853148(PlayState* play, Actor* actor) {
                     if ((actor != this->naviActor) && (actor->xzDistToPlayer < 40.0f)) {
                         Player_AnimPlayOnceAdjusted(play, this, &gPlayerAnim_link_normal_backspace);
                     } else {
-                        Player_AnimPlayLoop(play, this, Player_GetIdleAnimationForCurrentModelAnimType(this));
+                        Player_AnimPlayLoop(play, this, Player_GetIdleAnim(this));
                     }
                 }
             } else {


### PR DESCRIPTION
This is a continuation of existing work from @Pepe20129 

There needs to be a distinction between "primary" idle anims and the "special" ones that Link does, which can vary based on his current state and the environment he is in. He alternates back and forth between the primary ones and the special ones.

Im not fully sold on calling these "special" and am open to suggestions.

I also added back the comments on `sSpecialIdleAnimSfxTypes`. I said "used by x" to try and clarify the problem we had in the previous discussion. But I think these are necessary, I found myself counting entries in this array too many times.