### PR TITLE
Rename RoomBehaviorType1 to RoomType

### DIFF
--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -152,14 +152,14 @@ typedef union RoomShape {
     RoomShapeCullable cullable;
 } RoomShape; // "Ground Shape"
 
-typedef enum RoomBehaviorType1 {
-    /* 0 */ ROOM_BEHAVIOR_TYPE1_0,
-    /* 1 */ ROOM_BEHAVIOR_TYPE1_1,
-    /* 2 */ ROOM_BEHAVIOR_TYPE1_2,
-    /* 3 */ ROOM_BEHAVIOR_TYPE1_3, // unused
-    /* 4 */ ROOM_BEHAVIOR_TYPE1_4, // unused
-    /* 5 */ ROOM_BEHAVIOR_TYPE1_5
-} RoomBehaviorType1;
+typedef enum RoomType {
+    /* 0 */ ROOM_TYPE_FIELD,
+    /* 1 */ ROOM_TYPE_DUNGEON, // Blocks Sun's Song's time advance effect.
+    /* 2 */ ROOM_TYPE_INDOORS, // Reduces player run speed and blocks player from attacking or jumping.
+    /* 3 */ ROOM_TYPE_TEST_NO_COLOR_DITHERING, // Unused. Color dithering is turned off when drawing the room and other things
+    /* 4 */ ROOM_TYPE_4, // unused. Prevents switching to CAM_SET_HORSE when mounting a horse.
+    /* 5 */ ROOM_TYPE_BOSS // Disables Environment_AdjustLights
+} RoomType;
 
 typedef enum RoomBehaviorType2 {
     /* 0 */ ROOM_BEHAVIOR_TYPE2_0,
@@ -175,7 +175,7 @@ typedef struct Room {
     /* 0x00 */ s8 num; // -1 is invalid room
     /* 0x01 */ u8 unk_01;
     /* 0x02 */ u8 behaviorType2;
-    /* 0x03 */ u8 behaviorType1;
+    /* 0x03 */ u8 type;
     /* 0x04 */ s8 echo;
     /* 0x05 */ u8 lensMode;
     /* 0x08 */ RoomShape* roomShape; // original name: "ground_shape"

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -156,8 +156,8 @@ typedef enum RoomType {
     /* 0 */ ROOM_TYPE_NORMAL,
     /* 1 */ ROOM_TYPE_DUNGEON, // Blocks Sun's Song's time advance effect. Not exclusively used by typical dungeon rooms.
     /* 2 */ ROOM_TYPE_INDOORS, // Reduces player run speed and blocks player from attacking or jumping.
-    /* 3 */ ROOM_TYPE_3, // Unused. Color dithering is turned off when drawing the room and other things
-    /* 4 */ ROOM_TYPE_4, // unused. Prevents switching to CAM_SET_HORSE when mounting a horse.
+    /* 3 */ ROOM_TYPE_3, // Unused. Color dithering is turned off when drawing the room and other things.
+    /* 4 */ ROOM_TYPE_4, // Unused. Prevents switching to CAM_SET_HORSE when mounting a horse.
     /* 5 */ ROOM_TYPE_BOSS // Disables Environment_AdjustLights
 } RoomType;
 

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -153,10 +153,10 @@ typedef union RoomShape {
 } RoomShape; // "Ground Shape"
 
 typedef enum RoomType {
-    /* 0 */ ROOM_TYPE_FIELD,
-    /* 1 */ ROOM_TYPE_DUNGEON, // Blocks Sun's Song's time advance effect.
+    /* 0 */ ROOM_TYPE_NORMAL,
+    /* 1 */ ROOM_TYPE_DUNGEON, // Blocks Sun's Song's time advance effect. Not exclusively used by typical dungeon rooms.
     /* 2 */ ROOM_TYPE_INDOORS, // Reduces player run speed and blocks player from attacking or jumping.
-    /* 3 */ ROOM_TYPE_TEST_NO_COLOR_DITHERING, // Unused. Color dithering is turned off when drawing the room and other things
+    /* 3 */ ROOM_TYPE_3, // Unused. Color dithering is turned off when drawing the room and other things
     /* 4 */ ROOM_TYPE_4, // unused. Prevents switching to CAM_SET_HORSE when mounting a horse.
     /* 5 */ ROOM_TYPE_BOSS // Disables Environment_AdjustLights
 } RoomType;
@@ -605,9 +605,9 @@ typedef enum SceneCommandTypeID {
 #define SCENE_CMD_SPECIAL_FILES(naviQuestHintFileId, keepObjectId) \
     { SCENE_CMD_ID_SPECIAL_FILES, naviQuestHintFileId, CMD_W(keepObjectId) }
 
-#define SCENE_CMD_ROOM_BEHAVIOR(curRoomUnk3, curRoomUnk2, showInvisActors, disableWarpSongs) \
-    { SCENE_CMD_ID_ROOM_BEHAVIOR, curRoomUnk3, \
-        curRoomUnk2 | _SHIFTL(showInvisActors, 8, 1) | _SHIFTL(disableWarpSongs, 10, 1) }
+#define SCENE_CMD_ROOM_BEHAVIOR(type, environment, showInvisActors, disableWarpSongs) \
+    { SCENE_CMD_ID_ROOM_BEHAVIOR, type, \
+        environment | _SHIFTL(showInvisActors, 8, 1) | _SHIFTL(disableWarpSongs, 10, 1) }
 
 #define SCENE_CMD_UNK_09() \
     { SCENE_CMD_ID_UNDEFINED_9, 0, CMD_W(0) }

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -1131,7 +1131,7 @@ void func_8002DE04(PlayState* play, Actor* actorA, Actor* actorB) {
 }
 
 void func_8002DE74(PlayState* play, Player* player) {
-    if ((play->roomCtx.curRoom.behaviorType1 != ROOM_BEHAVIOR_TYPE1_4) && Play_CamIsNotFixed(play)) {
+    if ((play->roomCtx.curRoom.type != ROOM_TYPE_4) && Play_CamIsNotFixed(play)) {
         Camera_RequestSetting(Play_GetCamera(play, CAM_ID_MAIN), CAM_SET_HORSE);
     }
 }

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -7540,18 +7540,18 @@ void func_80057FC4(Camera* camera) {
         camera->prevSetting = camera->setting = CAM_SET_FREE0;
         camera->stateFlags &= ~CAM_STATE_CHECK_BG;
     } else if (camera->play->roomCtx.curRoom.roomShape->base.type != ROOM_SHAPE_TYPE_IMAGE) {
-        switch (camera->play->roomCtx.curRoom.behaviorType1) {
-            case ROOM_BEHAVIOR_TYPE1_1:
+        switch (camera->play->roomCtx.curRoom.type) {
+            case ROOM_TYPE_DUNGEON:
                 Camera_ChangeDoorCam(camera, NULL, -99, 0, 0, 18, 10);
                 camera->prevSetting = camera->setting = CAM_SET_DUNGEON0;
                 break;
-            case ROOM_BEHAVIOR_TYPE1_0:
+            case ROOM_TYPE_FIELD:
                 PRINTF("camera: room type: default set field\n");
                 Camera_ChangeDoorCam(camera, NULL, -99, 0, 0, 18, 10);
                 camera->prevSetting = camera->setting = CAM_SET_NORMAL0;
                 break;
             default:
-                PRINTF("camera: room type: default set etc (%d)\n", camera->play->roomCtx.curRoom.behaviorType1);
+                PRINTF("camera: room type: default set etc (%d)\n", camera->play->roomCtx.curRoom.type);
                 Camera_ChangeDoorCam(camera, NULL, -99, 0, 0, 18, 10);
                 camera->prevSetting = camera->setting = CAM_SET_NORMAL0;
                 camera->stateFlags |= CAM_STATE_CHECK_BG;
@@ -8466,7 +8466,7 @@ s32 Camera_RequestModeImpl(Camera* camera, s16 requestedMode, u8 forceModeChange
                 break;
 
             case CAM_REQUEST_MODE_SFX_ATTENTION:
-                if (camera->play->roomCtx.curRoom.behaviorType1 == ROOM_BEHAVIOR_TYPE1_1) {
+                if (camera->play->roomCtx.curRoom.type == ROOM_TYPE_DUNGEON) {
                     Sfx_PlaySfxCentered(NA_SE_SY_ATTENTION_URGENCY);
                 } else {
                     Sfx_PlaySfxCentered(NA_SE_SY_ATTENTION_ON);

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -7545,7 +7545,7 @@ void func_80057FC4(Camera* camera) {
                 Camera_ChangeDoorCam(camera, NULL, -99, 0, 0, 18, 10);
                 camera->prevSetting = camera->setting = CAM_SET_DUNGEON0;
                 break;
-            case ROOM_TYPE_FIELD:
+            case ROOM_TYPE_NORMAL:
                 PRINTF("camera: room type: default set field\n");
                 Camera_ChangeDoorCam(camera, NULL, -99, 0, 0, 18, 10);
                 camera->prevSetting = camera->setting = CAM_SET_NORMAL0;

--- a/src/code/z_kankyo.c
+++ b/src/code/z_kankyo.c
@@ -2531,7 +2531,7 @@ void Environment_AdjustLights(PlayState* play, f32 arg1, f32 arg2, f32 arg3, f32
     f32 temp;
     s32 i;
 
-    if (play->roomCtx.curRoom.behaviorType1 != ROOM_BEHAVIOR_TYPE1_5 && Play_CamIsNotFixed(play)) {
+    if (play->roomCtx.curRoom.type != ROOM_TYPE_BOSS && Play_CamIsNotFixed(play)) {
         arg1 = CLAMP_MIN(arg1, 0.0f);
         arg1 = CLAMP_MAX(arg1, 1.0f);
 

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -632,7 +632,7 @@ void Interface_UpdateHudAlphas(PlayState* play, s16 dimmingAlpha) {
             break;
     }
 
-    if ((play->roomCtx.curRoom.behaviorType1 == ROOM_BEHAVIOR_TYPE1_1) && (interfaceCtx->minimapAlpha >= 255)) {
+    if ((play->roomCtx.curRoom.type == ROOM_TYPE_DUNGEON) && (interfaceCtx->minimapAlpha >= 255)) {
         interfaceCtx->minimapAlpha = 255;
     }
 }
@@ -4368,8 +4368,7 @@ void Interface_Update(PlayState* play) {
                 gTimeSpeed = sPrevTimeSpeed;
                 play->msgCtx.ocarinaMode = OCARINA_MODE_04;
             }
-        } else if ((play->roomCtx.curRoom.behaviorType1 != ROOM_BEHAVIOR_TYPE1_1) &&
-                   (interfaceCtx->restrictions.sunsSong != 3)) {
+        } else if ((play->roomCtx.curRoom.type != ROOM_TYPE_DUNGEON) && (interfaceCtx->restrictions.sunsSong != 3)) {
             if ((gSaveContext.save.dayTime >= CLOCK_TIME(6, 30)) &&
                 (gSaveContext.save.dayTime < CLOCK_TIME(18, 0) + 1)) {
                 gSaveContext.nextDayTime = NEXT_TIME_NIGHT;

--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -599,7 +599,7 @@ void Player_SetBootData(PlayState* play, Player* this) {
     IREG(69) = bootRegs[15];
     MREG(95) = bootRegs[16];
 
-    if (play->roomCtx.curRoom.behaviorType1 == ROOM_BEHAVIOR_TYPE1_2) {
+    if (play->roomCtx.curRoom.type == ROOM_TYPE_INDOORS) {
         R_RUN_SPEED_LIMIT = 500;
     }
 }

--- a/src/code/z_rcp.c
+++ b/src/code/z_rcp.c
@@ -1012,7 +1012,7 @@ void func_80093C80(PlayState* play) {
 
     Gfx_SetupDL_25Opa(gfxCtx);
 
-    if (play->roomCtx.curRoom.type == ROOM_TYPE_TEST_NO_COLOR_DITHERING) {
+    if (play->roomCtx.curRoom.type == ROOM_TYPE_3) {
         OPEN_DISPS(gfxCtx, "../z_rcp.c", 1460);
 
         gDPSetColorDither(POLY_OPA_DISP++, G_CD_DISABLE);

--- a/src/code/z_rcp.c
+++ b/src/code/z_rcp.c
@@ -1012,7 +1012,7 @@ void func_80093C80(PlayState* play) {
 
     Gfx_SetupDL_25Opa(gfxCtx);
 
-    if (play->roomCtx.curRoom.behaviorType1 == ROOM_BEHAVIOR_TYPE1_3) {
+    if (play->roomCtx.curRoom.type == ROOM_TYPE_TEST_NO_COLOR_DITHERING) {
         OPEN_DISPS(gfxCtx, "../z_rcp.c", 1460);
 
         gDPSetColorDither(POLY_OPA_DISP++, G_CD_DISABLE);

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -261,7 +261,7 @@ BAD_RETURN(s32) Scene_CommandSpecialFiles(PlayState* play, SceneCmd* cmd) {
 }
 
 BAD_RETURN(s32) Scene_CommandRoomBehavior(PlayState* play, SceneCmd* cmd) {
-    play->roomCtx.curRoom.behaviorType1 = cmd->roomBehavior.gpFlag1;
+    play->roomCtx.curRoom.type = cmd->roomBehavior.gpFlag1;
     play->roomCtx.curRoom.behaviorType2 = cmd->roomBehavior.gpFlag2 & 0xFF;
     play->roomCtx.curRoom.lensMode = (cmd->roomBehavior.gpFlag2 >> 8) & 1;
     play->msgCtx.disableWarpSongs = (cmd->roomBehavior.gpFlag2 >> 0xA) & 1;

--- a/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
+++ b/src/overlays/actors/ovl_Magic_Dark/z_magic_dark.c
@@ -144,7 +144,7 @@ void MagicDark_DimLighting(PlayState* play, f32 intensity) {
     f32 colorScale;
     f32 fogScale;
 
-    if (play->roomCtx.curRoom.behaviorType1 != ROOM_BEHAVIOR_TYPE1_5) {
+    if (play->roomCtx.curRoom.type != ROOM_TYPE_BOSS) {
         intensity = CLAMP_MIN(intensity, 0.0f);
         intensity = CLAMP_MAX(intensity, 1.0f);
         fogScale = intensity - 0.2f;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6359,8 +6359,8 @@ void func_8083BCD0(Player* this, PlayState* play, s32 controlStickDirection) {
 s32 Player_ActionHandler_10(Player* this, PlayState* play) {
     s32 controlStickDirection;
 
-    if (CHECK_BTN_ALL(sControlInput->press.button, BTN_A) &&
-        (play->roomCtx.curRoom.behaviorType1 != ROOM_BEHAVIOR_TYPE1_2) && (sFloorType != FLOOR_TYPE_7) &&
+    if (CHECK_BTN_ALL(sControlInput->press.button, BTN_A) && (play->roomCtx.curRoom.type != ROOM_TYPE_INDOORS) &&
+        (sFloorType != FLOOR_TYPE_7) &&
         (SurfaceType_GetFloorEffect(&play->colCtx, this->actor.floorPoly, this->actor.floorBgId) != FLOOR_EFFECT_1)) {
         controlStickDirection = this->controlStickDirections[this->controlStickDataIndex];
 
@@ -6562,8 +6562,8 @@ s32 Player_ActionHandler_8(Player* this, PlayState* play) {
 }
 
 s32 func_8083C61C(PlayState* play, Player* this) {
-    if ((play->roomCtx.curRoom.behaviorType1 != ROOM_BEHAVIOR_TYPE1_2) &&
-        (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (AMMO(ITEM_DEKU_NUT) != 0)) {
+    if ((play->roomCtx.curRoom.type != ROOM_TYPE_INDOORS) && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) &&
+        (AMMO(ITEM_DEKU_NUT) != 0)) {
         Player_SetupAction(play, this, Player_Action_8084E604, 0);
         Player_AnimPlayOnce(play, this, &gPlayerAnim_link_normal_light_bom);
         this->unk_6AD = 0;
@@ -10919,14 +10919,13 @@ void Player_UpdateInterface(PlayState* play, Player* this) {
                     if ((!(this->stateFlags1 & PLAYER_STATE1_14) &&
                          (controlStickDirection <= PLAYER_STICK_DIR_FORWARD) &&
                          (Player_CheckHostileLockOn(this) ||
-                          ((sFloorType != FLOOR_TYPE_7) &&
-                           (Player_FriendlyLockOnOrParallel(this) ||
-                            ((play->roomCtx.curRoom.behaviorType1 != ROOM_BEHAVIOR_TYPE1_2) &&
-                             !(this->stateFlags1 & PLAYER_STATE1_22) &&
-                             (controlStickDirection == PLAYER_STICK_DIR_FORWARD))))))) {
+                          ((sFloorType != FLOOR_TYPE_7) && (Player_FriendlyLockOnOrParallel(this) ||
+                                                            ((play->roomCtx.curRoom.type != ROOM_TYPE_INDOORS) &&
+                                                             !(this->stateFlags1 & PLAYER_STATE1_22) &&
+                                                             (controlStickDirection == PLAYER_STICK_DIR_FORWARD))))))) {
                         doAction = DO_ACTION_ATTACK;
-                    } else if ((play->roomCtx.curRoom.behaviorType1 != ROOM_BEHAVIOR_TYPE1_2) &&
-                               Player_IsZTargeting(this) && (controlStickDirection >= PLAYER_STICK_DIR_LEFT)) {
+                    } else if ((play->roomCtx.curRoom.type != ROOM_TYPE_INDOORS) && Player_IsZTargeting(this) &&
+                               (controlStickDirection >= PLAYER_STICK_DIR_LEFT)) {
                         doAction = DO_ACTION_JUMP;
                     } else if ((this->heldItemAction >= PLAYER_IA_SWORD_MASTER) ||
                                ((this->stateFlags2 & PLAYER_STATE2_NAVI_ACTIVE) &&


### PR DESCRIPTION
Contributions made in this pr are licensed under CC0

I cross-referenced with MM scene data, and I believe the names work across both games (though in MM, all logic for Type 3 was removed). I'm not sure what to name `ROOM_TYPE_4`, due to it being unused in OoT. That said, it actually ends up being used in MM in East/West Clocktown and in the Laundry Pool, three places where Epona shouldn't normally spawn. In that game, the main difference between using `ROOM_TYPE_FIELD` and `ROOM_TYPE_4` is that the grass actors won't "sway" in the wind. 