### PR TITLE
Minor en_changer and en_bom_bowl_man documentation update

### DIFF
--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -417,7 +417,7 @@ void EnBomBowlMan_ChooseShowPrize(EnBomBowlMan* this, PlayState* play) {
         this->exItem = (EnExItem*)Actor_SpawnAsChild(
             &play->actorCtx, &this->actor, play, ACTOR_EN_EX_ITEM, sPrizePosOffset[this->prizeIndex].x + 148.0f,
             sPrizePosOffset[this->prizeIndex].y + 40.0f, sPrizePosOffset[this->prizeIndex].z + 300.0f, 0,
-            sPrizeRot[this->prizeIndex], 0, this->prizeIndex + EXITEM_COUNTER);
+            sPrizeRot[this->prizeIndex], 0, this->prizeIndex + EXITEM_BOMB_BAG_COUNTER);
 
         if (!this->startedPlaying) {
             this->bowlPit = (EnBomBowlPit*)Actor_SpawnAsChild(&play->actorCtx, &this->actor, play,

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.c
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.c
@@ -225,7 +225,8 @@ void EnChanger_OpenChests(EnChanger* this, PlayState* play) {
     right = this->rightChest;
 
     if (this->timer == 0) {
-        unopenedChestItemType = selectedChest = this->selectedChest; // Required to use the right registers
+        // `unopenedChestItemType` being set here is required for matching, but doesn't do anything useful
+        unopenedChestItemType = selectedChest = this->selectedChest;
 
         switch (selectedChest) {
             case CHEST_LEFT:

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.c
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.c
@@ -216,8 +216,8 @@ void EnChanger_OpenChests(EnChanger* this, PlayState* play) {
     f32 zPos;
     f32 yPos;
     f32 xPos;
-    s16 temp_s0;
-    s16 temp_s0_2;
+    s16 openedChestSide;
+    s16 unopenedChestItemType;
     EnBox* left;
     EnBox* right;
 
@@ -225,22 +225,22 @@ void EnChanger_OpenChests(EnChanger* this, PlayState* play) {
     right = this->rightChest;
 
     if (this->timer == 0) {
-        temp_s0_2 = temp_s0 = this->chestOpened; // Required to use the right registers
+        unopenedChestItemType = openedChestSide = this->chestOpened; // Required to use the right registers
 
-        switch (temp_s0_2) {
+        switch (openedChestSide) {
             case CHEST_LEFT:
                 xPos = right->dyna.actor.world.pos.x;
                 yPos = right->dyna.actor.world.pos.y;
                 zPos = right->dyna.actor.world.pos.z;
 
                 if (this->rightChestGetItemId == GI_DOOR_KEY) {
-                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, 0xF);
+                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, EXITEM_SMALL_KEY_CHEST);
                     Flags_SetSwitch(play, 0x32);
                 } else {
-                    temp_s0_2 = (s16)(this->rightChestGetItemId - GI_RUPEE_GREEN_LOSE) + EXITEM_CHEST;
+                    unopenedChestItemType = (s16)(this->rightChestGetItemId - GI_RUPEE_GREEN_LOSE) + EXITEM_GREEN_RUPEE_CHEST;
                     // "Open right treasure (chest)"
-                    PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ 右宝開く ☆☆☆☆☆ %d\n" VT_RST, temp_s0_2);
-                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, temp_s0_2);
+                    PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ 右宝開く ☆☆☆☆☆ %d\n" VT_RST, unopenedChestItemType);
+                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, unopenedChestItemType);
                 }
                 break;
             case CHEST_RIGHT:
@@ -249,13 +249,13 @@ void EnChanger_OpenChests(EnChanger* this, PlayState* play) {
                 zPos = left->dyna.actor.world.pos.z;
 
                 if (this->leftChestGetItemId == GI_DOOR_KEY) {
-                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, 0xF);
+                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, EXITEM_SMALL_KEY_CHEST);
                     Flags_SetSwitch(play, 0x32);
                 } else {
-                    temp_s0_2 = (s16)(this->leftChestGetItemId - 0x72) + 0xA;
+                    unopenedChestItemType = (s16)(this->leftChestGetItemId - GI_RUPEE_GREEN_LOSE) + EXITEM_GREEN_RUPEE_CHEST;
                     // "Open left treasure (chest)"
-                    PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ 左宝開く ☆☆☆☆☆ %d\n" VT_RST, temp_s0_2);
-                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, temp_s0_2);
+                    PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ 左宝開く ☆☆☆☆☆ %d\n" VT_RST, unopenedChestItemType);
+                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, unopenedChestItemType);
                 }
                 break;
         }

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.c
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.c
@@ -204,7 +204,7 @@ void EnChanger_Wait(EnChanger* this, PlayState* play) {
         Flags_SetTreasure(play, this->rightChestNum & 0x1F);
         this->actionFunc = EnChanger_OpenChests;
     } else if (this->rightChest->unk_1F4 != 0) {
-        this->chestOpened = CHEST_RIGHT;
+        this->selectedChest = CHEST_RIGHT;
         this->timer = 80;
         Flags_SetTreasure(play, this->leftChestNum & 0x1F);
         this->actionFunc = EnChanger_OpenChests;
@@ -216,7 +216,7 @@ void EnChanger_OpenChests(EnChanger* this, PlayState* play) {
     f32 zPos;
     f32 yPos;
     f32 xPos;
-    s16 openedChestSide;
+    s16 selectedChest;
     s16 unopenedChestItemType;
     EnBox* left;
     EnBox* right;
@@ -225,22 +225,25 @@ void EnChanger_OpenChests(EnChanger* this, PlayState* play) {
     right = this->rightChest;
 
     if (this->timer == 0) {
-        unopenedChestItemType = openedChestSide = this->chestOpened; // Required to use the right registers
+        unopenedChestItemType = selectedChest = this->selectedChest; // Required to use the right registers
 
-        switch (openedChestSide) {
+        switch (selectedChest) {
             case CHEST_LEFT:
                 xPos = right->dyna.actor.world.pos.x;
                 yPos = right->dyna.actor.world.pos.y;
                 zPos = right->dyna.actor.world.pos.z;
 
                 if (this->rightChestGetItemId == GI_DOOR_KEY) {
-                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, EXITEM_SMALL_KEY_CHEST);
+                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0,
+                                EXITEM_SMALL_KEY_CHEST);
                     Flags_SetSwitch(play, 0x32);
                 } else {
-                    unopenedChestItemType = (s16)(this->rightChestGetItemId - GI_RUPEE_GREEN_LOSE) + EXITEM_GREEN_RUPEE_CHEST;
+                    unopenedChestItemType =
+                        (s16)(this->rightChestGetItemId - GI_RUPEE_GREEN_LOSE) + EXITEM_GREEN_RUPEE_CHEST;
                     // "Open right treasure (chest)"
                     PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ 右宝開く ☆☆☆☆☆ %d\n" VT_RST, unopenedChestItemType);
-                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, unopenedChestItemType);
+                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0,
+                                unopenedChestItemType);
                 }
                 break;
             case CHEST_RIGHT:
@@ -249,13 +252,16 @@ void EnChanger_OpenChests(EnChanger* this, PlayState* play) {
                 zPos = left->dyna.actor.world.pos.z;
 
                 if (this->leftChestGetItemId == GI_DOOR_KEY) {
-                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, EXITEM_SMALL_KEY_CHEST);
+                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0,
+                                EXITEM_SMALL_KEY_CHEST);
                     Flags_SetSwitch(play, 0x32);
                 } else {
-                    unopenedChestItemType = (s16)(this->leftChestGetItemId - GI_RUPEE_GREEN_LOSE) + EXITEM_GREEN_RUPEE_CHEST;
+                    unopenedChestItemType =
+                        (s16)(this->leftChestGetItemId - GI_RUPEE_GREEN_LOSE) + EXITEM_GREEN_RUPEE_CHEST;
                     // "Open left treasure (chest)"
                     PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ 左宝開く ☆☆☆☆☆ %d\n" VT_RST, unopenedChestItemType);
-                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0, unopenedChestItemType);
+                    Actor_Spawn(&play->actorCtx, play, ACTOR_EN_EX_ITEM, xPos, yPos, zPos, 0, 0, 0,
+                                unopenedChestItemType);
                 }
                 break;
         }

--- a/src/overlays/actors/ovl_En_Changer/z_en_changer.h
+++ b/src/overlays/actors/ovl_En_Changer/z_en_changer.h
@@ -19,7 +19,7 @@ typedef struct EnChanger {
     /* 0x015E */ s16 rightChestNum;
     /* 0x0160 */ s16 leftChestGetItemId;
     /* 0x0162 */ s16 rightChestGetItemId;
-    /* 0x0164 */ s16 chestOpened;
+    /* 0x0164 */ s16 selectedChest;
     /* 0x0166 */ s16 timer;
     /* 0x0168 */ s16 roomChestsOpened;
 } EnChanger; // size = 0x016C

--- a/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.h
+++ b/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.h
@@ -53,7 +53,5 @@ typedef enum EnExItemType {
 } EnExItemType;
 
 #define EXITEM_COUNTER 5
-#define EXITEM_CHEST 10
-#define EXITEM_MAGIC 16
 
 #endif

--- a/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.h
+++ b/src/overlays/actors/ovl_En_Ex_Item/z_en_ex_item.h
@@ -52,6 +52,4 @@ typedef enum EnExItemType {
     /* 19 */ EXITEM_BULLET_BAG
 } EnExItemType;
 
-#define EXITEM_COUNTER 5
-
 #endif


### PR DESCRIPTION
`EnChanger_OpenChests` has symmetrical handling for the right/left unopened chests. This PR aligns the two branches and renames a couple variables for clarity.

`EXITEM_CHEST` define was eliminated with this change by using the `EnExItemType` enum instead. `EXITEM_MAGIC` was not in use anywhere in the project and was also deleted. `EXITEM_COUNTER` is still in use by the Bombchu Bowling minigame.