### PR TITLE
Remove hardcoded bash location in tools/preprocess.sh

### DIFF
--- a/tools/preprocess.sh
+++ b/tools/preprocess.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # SPDX-FileCopyrightText: © 2024 ZeldaRET
 # SPDX-License-Identifier: CC0-1.0
 

--- a/tools/preprocess.sh
+++ b/tools/preprocess.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # SPDX-FileCopyrightText: © 2024 ZeldaRET
 # SPDX-License-Identifier: CC0-1.0
 


### PR DESCRIPTION
`tools/preprocess.sh` contains a hardcoded shebang to `/bin/bash` that ignores the `SHELL` variable in `Makefile`. This breaks the build process for NixOS (or anyone else who doesn't have a `/bin/bash`) with a cryptic error. I've removed the shebang.