### PR TITLE
Document `enum PauseState` game over parts

### DIFF
--- a/include/z64pause.h
+++ b/include/z64pause.h
@@ -69,8 +69,8 @@ typedef enum PauseState {
     /* 11 */ PAUSE_STATE_GAME_OVER_SHOW, // Show the "GAME OVER" message
     /* 12 */ PAUSE_STATE_GAME_OVER_DELAY, // Wait for the delay
     /* 13 */ PAUSE_STATE_GAME_OVER_FRAME, // Show background and animate
-    /* 14 */ PAUSE_STATE_GAME_OVER_SAVE_PROMPT, // Ask "Would you like to save?"
-    /* 15 */ PAUSE_STATE_GAME_OVER_SAVE_YES, // Wait for the delay or input after the "Yes" choice
+    /* 14 */ PAUSE_STATE_GAME_OVER_SAVE_PROMPT, // Ask "Would you like to save?", apply the choice
+    /* 15 */ PAUSE_STATE_GAME_OVER_SAVE_YES, // Show "Game saved.", wait for the delay or input
     /* 16 */ PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT, // Ask "Continue playing?"
     /* 17 */ PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE, // Fade out, then apply the choice
     /* 18 */ PAUSE_STATE_CLOSING, // Animate the pause menu closing

--- a/include/z64pause.h
+++ b/include/z64pause.h
@@ -63,22 +63,22 @@ typedef enum PauseState {
     /*  5 */ PAUSE_STATE_OPENING_2, // Finish some animations for opening the menu.
     /*  6 */ PAUSE_STATE_MAIN, // Pause menu ready for player inputs.
     /*  7 */ PAUSE_STATE_SAVE_PROMPT,  // Save prompt in the pause menu
-    /*  8 */ PAUSE_STATE_8,
-    /*  9 */ PAUSE_STATE_9,
-    /* 10 */ PAUSE_STATE_10,
-    /* 11 */ PAUSE_STATE_11,
-    /* 12 */ PAUSE_STATE_12,
-    /* 13 */ PAUSE_STATE_13,
-    /* 14 */ PAUSE_STATE_14,
-    /* 15 */ PAUSE_STATE_15,
-    /* 16 */ PAUSE_STATE_16,
-    /* 17 */ PAUSE_STATE_17,
+    /*  8 */ PAUSE_STATE_GAME_OVER_REQUEST,
+    /*  9 */ PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER,
+    /* 10 */ PAUSE_STATE_GAME_OVER_INIT,
+    /* 11 */ PAUSE_STATE_GAME_OVER_SHOW, // "GAME OVER" message appears
+    /* 12 */ PAUSE_STATE_GAME_OVER_DELAY,
+    /* 13 */ PAUSE_STATE_GAME_OVER_FRAME, // prompts frame appears with a rotation
+    /* 14 */ PAUSE_STATE_GAME_OVER_SAVE_PROMPT,
+    /* 15 */ PAUSE_STATE_GAME_OVER_SAVE_YES,
+    /* 16 */ PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT,
+    /* 17 */ PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE,
     /* 18 */ PAUSE_STATE_CLOSING, // Animate the pause menu closing
     /* 19 */ PAUSE_STATE_RESUME_GAMEPLAY // Handles returning to normal gameplay once the pause menu is visually closed
 } PauseState;
 
 #define IS_PAUSE_STATE_GAMEOVER(pauseCtx) \
-    (((pauseCtx)->state >= PAUSE_STATE_8) && ((pauseCtx)->state <= PAUSE_STATE_17))
+    (((pauseCtx)->state >= PAUSE_STATE_GAME_OVER_REQUEST) && ((pauseCtx)->state <= PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE))
 
 #define IS_PAUSED(pauseCtx) \
     (((pauseCtx)->state != PAUSE_STATE_OFF) || ((pauseCtx)->debugState != 0))

--- a/include/z64pause.h
+++ b/include/z64pause.h
@@ -63,22 +63,22 @@ typedef enum PauseState {
     /*  5 */ PAUSE_STATE_OPENING_2, // Finish some animations for opening the menu.
     /*  6 */ PAUSE_STATE_MAIN, // Pause menu ready for player inputs.
     /*  7 */ PAUSE_STATE_SAVE_PROMPT,  // Save prompt in the pause menu
-    /*  8 */ PAUSE_STATE_GAME_OVER_REQUEST,
+    /*  8 */ PAUSE_STATE_GAME_OVER_START,
     /*  9 */ PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER,
     /* 10 */ PAUSE_STATE_GAME_OVER_INIT,
-    /* 11 */ PAUSE_STATE_GAME_OVER_SHOW, // Show the "GAME OVER" message
-    /* 12 */ PAUSE_STATE_GAME_OVER_DELAY, // Wait for the delay
-    /* 13 */ PAUSE_STATE_GAME_OVER_FRAME, // Show background and animate
+    /* 11 */ PAUSE_STATE_GAME_OVER_SHOW_MESSAGE,
+    /* 12 */ PAUSE_STATE_GAME_OVER_WINDOW_DELAY,
+    /* 13 */ PAUSE_STATE_GAME_OVER_SHOW_WINDOW, // Show background and animate
     /* 14 */ PAUSE_STATE_GAME_OVER_SAVE_PROMPT, // Ask "Would you like to save?", apply the choice
-    /* 15 */ PAUSE_STATE_GAME_OVER_SAVE_YES, // Show "Game saved.", wait for the delay or input
+    /* 15 */ PAUSE_STATE_GAME_OVER_SAVED, // Show "Game saved.", wait for the delay or input
     /* 16 */ PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT, // Ask "Continue playing?"
-    /* 17 */ PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE, // Fade out, then apply the choice
+    /* 17 */ PAUSE_STATE_GAME_OVER_FINISH, // Fade out, then apply the choice
     /* 18 */ PAUSE_STATE_CLOSING, // Animate the pause menu closing
     /* 19 */ PAUSE_STATE_RESUME_GAMEPLAY // Handles returning to normal gameplay once the pause menu is visually closed
 } PauseState;
 
 #define IS_PAUSE_STATE_GAMEOVER(pauseCtx) \
-    (((pauseCtx)->state >= PAUSE_STATE_GAME_OVER_REQUEST) && ((pauseCtx)->state <= PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE))
+    (((pauseCtx)->state >= PAUSE_STATE_GAME_OVER_START) && ((pauseCtx)->state <= PAUSE_STATE_GAME_OVER_FINISH))
 
 #define IS_PAUSED(pauseCtx) \
     (((pauseCtx)->state != PAUSE_STATE_OFF) || ((pauseCtx)->debugState != 0))

--- a/include/z64pause.h
+++ b/include/z64pause.h
@@ -66,13 +66,13 @@ typedef enum PauseState {
     /*  8 */ PAUSE_STATE_GAME_OVER_REQUEST,
     /*  9 */ PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER,
     /* 10 */ PAUSE_STATE_GAME_OVER_INIT,
-    /* 11 */ PAUSE_STATE_GAME_OVER_SHOW, // "GAME OVER" message appears
-    /* 12 */ PAUSE_STATE_GAME_OVER_DELAY,
-    /* 13 */ PAUSE_STATE_GAME_OVER_FRAME, // prompts frame appears with a rotation
-    /* 14 */ PAUSE_STATE_GAME_OVER_SAVE_PROMPT,
-    /* 15 */ PAUSE_STATE_GAME_OVER_SAVE_YES,
-    /* 16 */ PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT,
-    /* 17 */ PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE,
+    /* 11 */ PAUSE_STATE_GAME_OVER_SHOW, // Show the "GAME OVER" message
+    /* 12 */ PAUSE_STATE_GAME_OVER_DELAY, // Wait for the delay
+    /* 13 */ PAUSE_STATE_GAME_OVER_FRAME, // Show background and animate
+    /* 14 */ PAUSE_STATE_GAME_OVER_SAVE_PROMPT, // Ask "Would you like to save?"
+    /* 15 */ PAUSE_STATE_GAME_OVER_SAVE_YES, // Wait for the delay or input after the "Yes" choice
+    /* 16 */ PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT, // Ask "Continue playing?"
+    /* 17 */ PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE, // Fade out, then apply the choice
     /* 18 */ PAUSE_STATE_CLOSING, // Animate the pause menu closing
     /* 19 */ PAUSE_STATE_RESUME_GAMEPLAY // Handles returning to normal gameplay once the pause menu is visually closed
 } PauseState;

--- a/src/code/z_game_over.c
+++ b/src/code/z_game_over.c
@@ -102,7 +102,7 @@ void GameOver_Update(PlayState* play) {
             sGameOverTimer--;
 
             if (sGameOverTimer == 0) {
-                play->pauseCtx.state = PAUSE_STATE_8;
+                play->pauseCtx.state = PAUSE_STATE_GAME_OVER_REQUEST;
                 gameOverCtx->state++;
                 Rumble_Reset();
             }

--- a/src/code/z_game_over.c
+++ b/src/code/z_game_over.c
@@ -102,7 +102,7 @@ void GameOver_Update(PlayState* play) {
             sGameOverTimer--;
 
             if (sGameOverTimer == 0) {
-                play->pauseCtx.state = PAUSE_STATE_GAME_OVER_REQUEST;
+                play->pauseCtx.state = PAUSE_STATE_GAME_OVER_START;
                 gameOverCtx->state++;
                 Rumble_Reset();
             }

--- a/src/code/z_kaleido_scope_call.c
+++ b/src/code/z_kaleido_scope_call.c
@@ -70,7 +70,7 @@ void KaleidoScopeCall_Update(PlayState* play) {
                 pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_APPEARING;
                 pauseCtx->state = (pauseCtx->state & 0xFFFF) + 1; // PAUSE_STATE_WAIT_BG_PRERENDER
             }
-        } else if (pauseCtx->state == PAUSE_STATE_GAME_OVER_REQUEST) {
+        } else if (pauseCtx->state == PAUSE_STATE_GAME_OVER_START) {
 #if OOT_DEBUG
             R_HREG_MODE = HREG_MODE_UCODE_DISAS;
             R_UCODE_DISAS_LOG_MODE = 3;
@@ -78,7 +78,7 @@ void KaleidoScopeCall_Update(PlayState* play) {
 
             R_PAUSE_BG_PRERENDER_STATE = PAUSE_BG_PRERENDER_SETUP;
             pauseCtx->mainState = PAUSE_MAIN_STATE_IDLE;
-            pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_APPEARING; // redundant for game over
+            pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_APPEARING; // copied from pause menu, not needed here
             pauseCtx->state = (pauseCtx->state & 0xFFFF) + 1;              // PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER
         } else if ((pauseCtx->state == PAUSE_STATE_WAIT_BG_PRERENDER) ||
                    (pauseCtx->state == PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER)) {
@@ -125,7 +125,8 @@ void KaleidoScopeCall_Draw(PlayState* play) {
 
     if (R_PAUSE_BG_PRERENDER_STATE >= PAUSE_BG_PRERENDER_READY) {
         if (((play->pauseCtx.state >= PAUSE_STATE_OPENING_1) && (play->pauseCtx.state <= PAUSE_STATE_SAVE_PROMPT)) ||
-            ((play->pauseCtx.state >= PAUSE_STATE_GAME_OVER_SHOW) && (play->pauseCtx.state <= PAUSE_STATE_CLOSING))) {
+            ((play->pauseCtx.state >= PAUSE_STATE_GAME_OVER_SHOW_MESSAGE) &&
+             (play->pauseCtx.state <= PAUSE_STATE_CLOSING))) {
             if (gKaleidoMgrCurOvl == kaleidoScopeOvl) {
                 sKaleidoScopeDrawFunc(play);
             }

--- a/src/code/z_kaleido_scope_call.c
+++ b/src/code/z_kaleido_scope_call.c
@@ -83,8 +83,9 @@ void KaleidoScopeCall_Update(PlayState* play) {
             R_PAUSE_BG_PRERENDER_STATE = PAUSE_BG_PRERENDER_SETUP;
             pauseCtx->mainState = PAUSE_MAIN_STATE_IDLE;
             pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_APPEARING; // redundant for game over
-            pauseCtx->state = (pauseCtx->state & 0xFFFF) + 1; // PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER
-        } else if ((pauseCtx->state == PAUSE_STATE_WAIT_BG_PRERENDER) || (pauseCtx->state == PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER)) {
+            pauseCtx->state = (pauseCtx->state & 0xFFFF) + 1;              // PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER
+        } else if ((pauseCtx->state == PAUSE_STATE_WAIT_BG_PRERENDER) ||
+                   (pauseCtx->state == PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER)) {
             PRINTF("PR_KAREIDOSCOPE_MODE=%d\n", R_PAUSE_BG_PRERENDER_STATE);
 
             if (R_PAUSE_BG_PRERENDER_STATE >= PAUSE_BG_PRERENDER_READY) {

--- a/src/code/z_kaleido_scope_call.c
+++ b/src/code/z_kaleido_scope_call.c
@@ -60,6 +60,8 @@ void KaleidoScopeCall_Update(PlayState* play) {
     if (IS_PAUSED(&play->pauseCtx)) {
         if (pauseCtx->state == PAUSE_STATE_WAIT_LETTERBOX) {
             if (Letterbox_GetSize() == 0) {
+                // @note: line by line matches with the PAUSE_STATE_GAME_OVER_REQUEST below
+                // likely was an inlined function or a macro; or a copy-and-paste
 #if OOT_DEBUG
                 R_HREG_MODE = HREG_MODE_UCODE_DISAS;
                 R_UCODE_DISAS_LOG_MODE = 3;
@@ -70,7 +72,9 @@ void KaleidoScopeCall_Update(PlayState* play) {
                 pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_APPEARING;
                 pauseCtx->state = (pauseCtx->state & 0xFFFF) + 1; // PAUSE_STATE_WAIT_BG_PRERENDER
             }
-        } else if (pauseCtx->state == PAUSE_STATE_8) {
+        } else if (pauseCtx->state == PAUSE_STATE_GAME_OVER_REQUEST) {
+            // @note: line by line matches with the PAUSE_STATE_WAIT_LETTERBOX above
+            // likely was an inlined function or a macro; or a copy-and-paste
 #if OOT_DEBUG
             R_HREG_MODE = HREG_MODE_UCODE_DISAS;
             R_UCODE_DISAS_LOG_MODE = 3;
@@ -78,13 +82,13 @@ void KaleidoScopeCall_Update(PlayState* play) {
 
             R_PAUSE_BG_PRERENDER_STATE = PAUSE_BG_PRERENDER_SETUP;
             pauseCtx->mainState = PAUSE_MAIN_STATE_IDLE;
-            pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_APPEARING;
-            pauseCtx->state = (pauseCtx->state & 0xFFFF) + 1; // PAUSE_STATE_9
-        } else if ((pauseCtx->state == PAUSE_STATE_WAIT_BG_PRERENDER) || (pauseCtx->state == PAUSE_STATE_9)) {
+            pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_APPEARING; // redundant for game over
+            pauseCtx->state = (pauseCtx->state & 0xFFFF) + 1; // PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER
+        } else if ((pauseCtx->state == PAUSE_STATE_WAIT_BG_PRERENDER) || (pauseCtx->state == PAUSE_STATE_GAME_OVER_WAIT_BG_PRERENDER)) {
             PRINTF("PR_KAREIDOSCOPE_MODE=%d\n", R_PAUSE_BG_PRERENDER_STATE);
 
             if (R_PAUSE_BG_PRERENDER_STATE >= PAUSE_BG_PRERENDER_READY) {
-                pauseCtx->state++; // PAUSE_STATE_INIT or PAUSE_STATE_10
+                pauseCtx->state++; // PAUSE_STATE_INIT or PAUSE_STATE_GAME_OVER_INIT
             }
         } else if (pauseCtx->state != PAUSE_STATE_OFF) {
             if (gKaleidoMgrCurOvl != kaleidoScopeOvl) {
@@ -124,7 +128,7 @@ void KaleidoScopeCall_Draw(PlayState* play) {
 
     if (R_PAUSE_BG_PRERENDER_STATE >= PAUSE_BG_PRERENDER_READY) {
         if (((play->pauseCtx.state >= PAUSE_STATE_OPENING_1) && (play->pauseCtx.state <= PAUSE_STATE_SAVE_PROMPT)) ||
-            ((play->pauseCtx.state >= PAUSE_STATE_11) && (play->pauseCtx.state <= PAUSE_STATE_CLOSING))) {
+            ((play->pauseCtx.state >= PAUSE_STATE_GAME_OVER_SHOW) && (play->pauseCtx.state <= PAUSE_STATE_CLOSING))) {
             if (gKaleidoMgrCurOvl == kaleidoScopeOvl) {
                 sKaleidoScopeDrawFunc(play);
             }

--- a/src/code/z_kaleido_scope_call.c
+++ b/src/code/z_kaleido_scope_call.c
@@ -60,8 +60,6 @@ void KaleidoScopeCall_Update(PlayState* play) {
     if (IS_PAUSED(&play->pauseCtx)) {
         if (pauseCtx->state == PAUSE_STATE_WAIT_LETTERBOX) {
             if (Letterbox_GetSize() == 0) {
-                // @note: line by line matches with the PAUSE_STATE_GAME_OVER_REQUEST below
-                // likely was an inlined function or a macro; or a copy-and-paste
 #if OOT_DEBUG
                 R_HREG_MODE = HREG_MODE_UCODE_DISAS;
                 R_UCODE_DISAS_LOG_MODE = 3;
@@ -73,8 +71,6 @@ void KaleidoScopeCall_Update(PlayState* play) {
                 pauseCtx->state = (pauseCtx->state & 0xFFFF) + 1; // PAUSE_STATE_WAIT_BG_PRERENDER
             }
         } else if (pauseCtx->state == PAUSE_STATE_GAME_OVER_REQUEST) {
-            // @note: line by line matches with the PAUSE_STATE_WAIT_LETTERBOX above
-            // likely was an inlined function or a macro; or a copy-and-paste
 #if OOT_DEBUG
             R_HREG_MODE = HREG_MODE_UCODE_DISAS;
             R_UCODE_DISAS_LOG_MODE = 3;

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_prompt.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_prompt.c
@@ -10,7 +10,8 @@ void KaleidoScope_UpdatePrompt(PlayState* play) {
 
     if (((pauseCtx->state == PAUSE_STATE_SAVE_PROMPT) &&
          (pauseCtx->savePromptState == PAUSE_SAVE_PROMPT_STATE_WAIT_CHOICE)) ||
-        (pauseCtx->state == PAUSE_STATE_GAME_OVER_SAVE_PROMPT) || (pauseCtx->state == PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT)) {
+        (pauseCtx->state == PAUSE_STATE_GAME_OVER_SAVE_PROMPT) ||
+        (pauseCtx->state == PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT)) {
 
         if ((pauseCtx->promptChoice == 0) && (stickAdjX >= 30)) {
             Audio_PlaySfxGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_prompt.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_prompt.c
@@ -10,7 +10,7 @@ void KaleidoScope_UpdatePrompt(PlayState* play) {
 
     if (((pauseCtx->state == PAUSE_STATE_SAVE_PROMPT) &&
          (pauseCtx->savePromptState == PAUSE_SAVE_PROMPT_STATE_WAIT_CHOICE)) ||
-        (pauseCtx->state == PAUSE_STATE_14) || (pauseCtx->state == PAUSE_STATE_16)) {
+        (pauseCtx->state == PAUSE_STATE_GAME_OVER_SAVE_PROMPT) || (pauseCtx->state == PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT)) {
 
         if ((pauseCtx->promptChoice == 0) && (stickAdjX >= 30)) {
             Audio_PlaySfxGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -1544,7 +1544,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
 
         if (((pauseCtx->state == PAUSE_STATE_SAVE_PROMPT) &&
              (pauseCtx->savePromptState < PAUSE_SAVE_PROMPT_STATE_SAVED)) ||
-            (pauseCtx->state == PAUSE_STATE_14)) {
+            (pauseCtx->state == PAUSE_STATE_GAME_OVER_SAVE_PROMPT)) {
             POLY_OPA_DISP = KaleidoScope_QuadTextureIA8(POLY_OPA_DISP, sSavePromptMessageTexs[gSaveContext.language],
                                                         152, 16, PROMPT_QUAD_MESSAGE * 4);
 
@@ -1572,12 +1572,12 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
                                                         16, PROMPT_QUAD_CHOICE_NO * 4);
         } else if (((pauseCtx->state == PAUSE_STATE_SAVE_PROMPT) &&
                     (pauseCtx->savePromptState >= PAUSE_SAVE_PROMPT_STATE_SAVED)) ||
-                   pauseCtx->state == PAUSE_STATE_15) {
+                   pauseCtx->state == PAUSE_STATE_GAME_OVER_SAVE_YES) {
 #if PLATFORM_N64
             POLY_OPA_DISP = KaleidoScope_QuadTextureIA8(POLY_OPA_DISP, sSaveConfirmationTexs[gSaveContext.language],
                                                         152, 16, PROMPT_QUAD_MESSAGE * 4);
 #endif
-        } else if (((pauseCtx->state == PAUSE_STATE_16) || (pauseCtx->state == PAUSE_STATE_17))) {
+        } else if (((pauseCtx->state == PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT) || (pauseCtx->state == PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE))) {
             POLY_OPA_DISP = KaleidoScope_QuadTextureIA8(POLY_OPA_DISP, sContinuePromptTexs[gSaveContext.language], 152,
                                                         16, PROMPT_QUAD_MESSAGE * 4);
 
@@ -1609,7 +1609,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
         gDPSetCombineLERP(POLY_OPA_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
 
-        if ((pauseCtx->state != PAUSE_STATE_16) && (pauseCtx->state != PAUSE_STATE_17)) {
+        if ((pauseCtx->state != PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT) && (pauseCtx->state != PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE)) {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 0, pauseCtx->alpha);
             gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
         }
@@ -2828,7 +2828,7 @@ void KaleidoScope_SetVertices(PlayState* play, GraphicsContext* gfxCtx) {
         ((pauseCtx->state == PAUSE_STATE_SAVE_PROMPT) &&
          ((pauseCtx->savePromptState == PAUSE_SAVE_PROMPT_STATE_CLOSING) ||
           (pauseCtx->savePromptState == PAUSE_SAVE_PROMPT_STATE_CLOSING_AFTER_SAVED))) ||
-        ((pauseCtx->state >= PAUSE_STATE_8) && (pauseCtx->state <= PAUSE_STATE_13))) {
+        ((pauseCtx->state >= PAUSE_STATE_GAME_OVER_REQUEST) && (pauseCtx->state <= PAUSE_STATE_GAME_OVER_FRAME))) {
         // When opening/closing, translate the page vertices so that the pages rotate around their lower edge
         // instead of the middle.
         pauseCtx->pagesYOrigin1 = PAUSE_PAGES_Y_ORIGIN_1_LOWER;
@@ -3355,7 +3355,7 @@ void KaleidoScope_Draw(PlayState* play) {
         }
     }
 
-    if ((pauseCtx->state >= PAUSE_STATE_11) && (pauseCtx->state <= PAUSE_STATE_17)) {
+    if ((pauseCtx->state >= PAUSE_STATE_GAME_OVER_SHOW) && (pauseCtx->state <= PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE)) {
         KaleidoScope_DrawGameOver(play);
     }
 
@@ -3581,7 +3581,7 @@ void KaleidoScope_Update(PlayState* play) {
 
     if ((R_PAUSE_BG_PRERENDER_STATE >= PAUSE_BG_PRERENDER_READY) &&
         (((pauseCtx->state >= PAUSE_STATE_OPENING_1) && (pauseCtx->state <= PAUSE_STATE_SAVE_PROMPT)) ||
-         ((pauseCtx->state >= PAUSE_STATE_10) && (pauseCtx->state <= PAUSE_STATE_CLOSING)))) {
+         ((pauseCtx->state >= PAUSE_STATE_GAME_OVER_INIT) && (pauseCtx->state <= PAUSE_STATE_CLOSING)))) {
 
         if ((((u32)pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE) ||
              (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE_CURSOR_ON_SONG)) &&
@@ -4260,7 +4260,7 @@ void KaleidoScope_Update(PlayState* play) {
             }
             break;
 
-        case PAUSE_STATE_10:
+        case PAUSE_STATE_GAME_OVER_INIT:
             pauseCtx->cursorSlot[PAUSE_MAP] = pauseCtx->cursorPoint[PAUSE_MAP] = pauseCtx->dungeonMapSlot =
                 VREG(30) + 3;
             WREG(16) = -175;
@@ -4329,10 +4329,10 @@ void KaleidoScope_Update(PlayState* play) {
             D_8082B260 = 30;
             VREG(88) = 98;
             pauseCtx->promptChoice = 0;
-            pauseCtx->state++; // PAUSE_STATE_11
+            pauseCtx->state++; // PAUSE_STATE_GAME_OVER_SHOW
             break;
 
-        case PAUSE_STATE_11:
+        case PAUSE_STATE_GAME_OVER_SHOW:
             stepR = ABS(D_8082AB8C - 30) / D_8082B260;
             stepG = ABS(D_8082AB90) / D_8082B260;
             stepB = ABS(D_8082AB94) / D_8082B260;
@@ -4388,19 +4388,19 @@ void KaleidoScope_Update(PlayState* play) {
                 D_8082ABA0 = 130;
                 D_8082ABA4 = 0;
 
-                pauseCtx->state++; // PAUSE_STATE_12
+                pauseCtx->state++; // PAUSE_STATE_GAME_OVER_DELAY
                 D_8082B260 = 40;
             }
             break;
 
-        case PAUSE_STATE_12:
+        case PAUSE_STATE_GAME_OVER_DELAY:
             D_8082B260--;
             if (D_8082B260 == 0) {
-                pauseCtx->state = PAUSE_STATE_13;
+                pauseCtx->state = PAUSE_STATE_GAME_OVER_FRAME;
             }
             break;
 
-        case PAUSE_STATE_13:
+        case PAUSE_STATE_GAME_OVER_FRAME:
             pauseCtx->itemPagePitch = pauseCtx->equipPagePitch = pauseCtx->mapPagePitch = pauseCtx->questPagePitch =
                 pauseCtx->promptPitch -= 160.0f / WREG(6);
             pauseCtx->infoPanelOffsetY += 40 / WREG(6);
@@ -4416,7 +4416,7 @@ void KaleidoScope_Update(PlayState* play) {
                 VREG(88) = 66;
                 R_PAUSE_PAGES_Y_ORIGIN_2 = 0;
                 pauseCtx->alpha = 255;
-                pauseCtx->state = PAUSE_STATE_14;
+                pauseCtx->state = PAUSE_STATE_GAME_OVER_SAVE_PROMPT;
                 gSaveContext.save.info.playerData.deaths++;
                 if (gSaveContext.save.info.playerData.deaths > 999) {
                     gSaveContext.save.info.playerData.deaths = 999;
@@ -4425,13 +4425,13 @@ void KaleidoScope_Update(PlayState* play) {
             PRINTF("kscope->angle_s = %f\n", pauseCtx->promptPitch);
             break;
 
-        case PAUSE_STATE_14:
+        case PAUSE_STATE_GAME_OVER_SAVE_PROMPT:
             if (CHECK_BTN_ALL(input->press.button, BTN_A)) {
                 if (pauseCtx->promptChoice != 0) {
                     pauseCtx->promptChoice = 0;
                     Audio_PlaySfxGeneral(NA_SE_SY_DECIDE, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                          &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
-                    pauseCtx->state = PAUSE_STATE_16;
+                    pauseCtx->state = PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT;
                     gameOverCtx->state++;
                 } else {
                     Audio_PlaySfxGeneral(NA_SE_SY_PIECE_OF_HEART, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
@@ -4440,7 +4440,7 @@ void KaleidoScope_Update(PlayState* play) {
                     Play_SaveSceneFlags(play);
                     gSaveContext.save.info.playerData.savedSceneId = play->sceneId;
                     Sram_WriteSave(&play->sramCtx);
-                    pauseCtx->state = PAUSE_STATE_15;
+                    pauseCtx->state = PAUSE_STATE_GAME_OVER_SAVE_YES;
 #if PLATFORM_N64
                     sDelayTimer = 90;
 #else
@@ -4450,20 +4450,20 @@ void KaleidoScope_Update(PlayState* play) {
             }
             break;
 
-        case PAUSE_STATE_15:
+        case PAUSE_STATE_GAME_OVER_SAVE_YES:
             sDelayTimer--;
             if (sDelayTimer == 0) {
-                pauseCtx->state = PAUSE_STATE_16;
+                pauseCtx->state = PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT;
                 gameOverCtx->state++;
             } else if ((sDelayTimer <= 80) &&
                        (CHECK_BTN_ALL(input->press.button, BTN_A) || CHECK_BTN_ALL(input->press.button, BTN_START))) {
-                pauseCtx->state = PAUSE_STATE_16;
+                pauseCtx->state = PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT;
                 gameOverCtx->state++;
                 func_800F64E0(0);
             }
             break;
 
-        case PAUSE_STATE_16:
+        case PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT:
             if (CHECK_BTN_ALL(input->press.button, BTN_A) || CHECK_BTN_ALL(input->press.button, BTN_START)) {
                 if (pauseCtx->promptChoice == 0) {
                     Audio_PlaySfxGeneral(NA_SE_SY_PIECE_OF_HEART, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
@@ -4529,11 +4529,11 @@ void KaleidoScope_Update(PlayState* play) {
                                          &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
                 }
 
-                pauseCtx->state = PAUSE_STATE_17;
+                pauseCtx->state = PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE;
             }
             break;
 
-        case PAUSE_STATE_17:
+        case PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE:
             if (interfaceCtx->unk_244 != 255) {
                 interfaceCtx->unk_244 += 10;
                 if (interfaceCtx->unk_244 >= 255) {

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -1577,7 +1577,8 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             POLY_OPA_DISP = KaleidoScope_QuadTextureIA8(POLY_OPA_DISP, sSaveConfirmationTexs[gSaveContext.language],
                                                         152, 16, PROMPT_QUAD_MESSAGE * 4);
 #endif
-        } else if (((pauseCtx->state == PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT) || (pauseCtx->state == PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE))) {
+        } else if (((pauseCtx->state == PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT) ||
+                    (pauseCtx->state == PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE))) {
             POLY_OPA_DISP = KaleidoScope_QuadTextureIA8(POLY_OPA_DISP, sContinuePromptTexs[gSaveContext.language], 152,
                                                         16, PROMPT_QUAD_MESSAGE * 4);
 
@@ -1609,7 +1610,8 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
         gDPSetCombineLERP(POLY_OPA_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
 
-        if ((pauseCtx->state != PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT) && (pauseCtx->state != PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE)) {
+        if ((pauseCtx->state != PAUSE_STATE_GAME_OVER_CONTINUE_PROMPT) &&
+            (pauseCtx->state != PAUSE_STATE_GAME_OVER_CONTINUE_CHOICE)) {
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 0, pauseCtx->alpha);
             gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
         }


### PR DESCRIPTION
renamed a set of pause states related to game over sequence

P.S.:
hi, new here 🌞

thank you for the titanic work you've accomplished so far! i've been rummaging around and [studying](https://github.com/Feacur/settings/tree/master/__notes/zeldaret_oot) the repo and thought to try and join

also i see there's a quite old [kaleido_scope PR](https://github.com/zeldaret/oot/pull/1366), which explicitly didn't touch game over pause states, thus this one should not conflict; much at least