### PR TITLE
`ACTOR_FLAG_ENKUSA_CUT` -> `ACTOR_FLAG_GRASS_DESTROYED`

### DIFF
--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -146,9 +146,9 @@ typedef struct ActorShape {
 //
 #define ACTOR_FLAG_10 (1 << 10)
 
-// A bush (EN_KUSA) has been destroyed.
+// A grass bushel (EN_KUSA) has been destroyed.
 // This flag is used to communicate with the spawner actor (OBJ_MURE).
-#define ACTOR_FLAG_BUSH_DESTROYED (1 << 11)
+#define ACTOR_FLAG_GRASS_DESTROYED (1 << 11)
 
 // Actor will not shake when a quake occurs
 #define ACTOR_FLAG_IGNORE_QUAKE (1 << 12)

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -146,8 +146,9 @@ typedef struct ActorShape {
 //
 #define ACTOR_FLAG_10 (1 << 10)
 
-//
-#define ACTOR_FLAG_ENKUSA_CUT (1 << 11)
+// A bush (EN_KUSA) has been destroyed.
+// This flag is used to communicate with the spawner actor (OBJ_MURE).
+#define ACTOR_FLAG_BUSH_DESTROYED (1 << 11)
 
 // Actor will not shake when a quake occurs
 #define ACTOR_FLAG_IGNORE_QUAKE (1 << 12)

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -146,7 +146,7 @@ typedef struct ActorShape {
 //
 #define ACTOR_FLAG_10 (1 << 10)
 
-// A grass bushel (EN_KUSA) has been destroyed.
+// A clump of grass (EN_KUSA) has been destroyed.
 // This flag is used to communicate with the spawner actor (OBJ_MURE).
 #define ACTOR_FLAG_GRASS_DESTROYED (1 << 11)
 

--- a/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
+++ b/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
@@ -278,7 +278,7 @@ void EnKusa_SetupWaitForObject(EnKusa* this) {
 
 void EnKusa_WaitForObject(EnKusa* this, PlayState* play) {
     if (Object_IsLoaded(&play->objectCtx, this->requiredObjectSlot)) {
-        if (this->actor.flags & ACTOR_FLAG_ENKUSA_CUT) {
+        if (this->actor.flags & ACTOR_FLAG_BUSH_DESTROYED) {
             EnKusa_SetupCut(this);
         } else {
             EnKusa_SetupMain(this);
@@ -317,7 +317,7 @@ void EnKusa_Main(EnKusa* this, PlayState* play) {
         }
 
         EnKusa_SetupCut(this);
-        this->actor.flags |= ACTOR_FLAG_ENKUSA_CUT;
+        this->actor.flags |= ACTOR_FLAG_BUSH_DESTROYED;
     } else {
         if (!(this->collider.base.ocFlags1 & OC1_TYPE_PLAYER) && (this->actor.xzDistToPlayer > 12.0f)) {
             this->collider.base.ocFlags1 |= OC1_TYPE_PLAYER;
@@ -466,7 +466,7 @@ void EnKusa_SetupRegrow(EnKusa* this) {
     EnKusa_SetupAction(this, EnKusa_Regrow);
     EnKusa_SetScaleSmall(this);
     this->actor.shape.rot = this->actor.home.rot;
-    this->actor.flags &= ~ACTOR_FLAG_ENKUSA_CUT;
+    this->actor.flags &= ~ACTOR_FLAG_BUSH_DESTROYED;
 }
 
 void EnKusa_Regrow(EnKusa* this, PlayState* play) {
@@ -490,7 +490,7 @@ void EnKusa_Update(Actor* thisx, PlayState* play) {
 
     this->actionFunc(this, play);
 
-    if (this->actor.flags & ACTOR_FLAG_ENKUSA_CUT) {
+    if (this->actor.flags & ACTOR_FLAG_BUSH_DESTROYED) {
         this->actor.shape.yOffset = -6.25f;
     } else {
         this->actor.shape.yOffset = 0.0f;
@@ -501,7 +501,7 @@ void EnKusa_Draw(Actor* thisx, PlayState* play) {
     static Gfx* dLists[] = { gFieldBushDL, object_kusa_DL_000140, object_kusa_DL_000140 };
     EnKusa* this = (EnKusa*)thisx;
 
-    if (this->actor.flags & ACTOR_FLAG_ENKUSA_CUT) {
+    if (this->actor.flags & ACTOR_FLAG_BUSH_DESTROYED) {
         Gfx_DrawDListOpa(play, object_kusa_DL_0002E0);
     } else {
         Gfx_DrawDListOpa(play, dLists[PARAMS_GET_U(thisx->params, 0, 2)]);

--- a/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
+++ b/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
@@ -278,7 +278,7 @@ void EnKusa_SetupWaitForObject(EnKusa* this) {
 
 void EnKusa_WaitForObject(EnKusa* this, PlayState* play) {
     if (Object_IsLoaded(&play->objectCtx, this->requiredObjectSlot)) {
-        if (this->actor.flags & ACTOR_FLAG_BUSH_DESTROYED) {
+        if (this->actor.flags & ACTOR_FLAG_GRASS_DESTROYED) {
             EnKusa_SetupCut(this);
         } else {
             EnKusa_SetupMain(this);
@@ -317,7 +317,7 @@ void EnKusa_Main(EnKusa* this, PlayState* play) {
         }
 
         EnKusa_SetupCut(this);
-        this->actor.flags |= ACTOR_FLAG_BUSH_DESTROYED;
+        this->actor.flags |= ACTOR_FLAG_GRASS_DESTROYED;
     } else {
         if (!(this->collider.base.ocFlags1 & OC1_TYPE_PLAYER) && (this->actor.xzDistToPlayer > 12.0f)) {
             this->collider.base.ocFlags1 |= OC1_TYPE_PLAYER;
@@ -466,7 +466,7 @@ void EnKusa_SetupRegrow(EnKusa* this) {
     EnKusa_SetupAction(this, EnKusa_Regrow);
     EnKusa_SetScaleSmall(this);
     this->actor.shape.rot = this->actor.home.rot;
-    this->actor.flags &= ~ACTOR_FLAG_BUSH_DESTROYED;
+    this->actor.flags &= ~ACTOR_FLAG_GRASS_DESTROYED;
 }
 
 void EnKusa_Regrow(EnKusa* this, PlayState* play) {
@@ -490,7 +490,7 @@ void EnKusa_Update(Actor* thisx, PlayState* play) {
 
     this->actionFunc(this, play);
 
-    if (this->actor.flags & ACTOR_FLAG_BUSH_DESTROYED) {
+    if (this->actor.flags & ACTOR_FLAG_GRASS_DESTROYED) {
         this->actor.shape.yOffset = -6.25f;
     } else {
         this->actor.shape.yOffset = 0.0f;
@@ -501,7 +501,7 @@ void EnKusa_Draw(Actor* thisx, PlayState* play) {
     static Gfx* dLists[] = { gFieldBushDL, object_kusa_DL_000140, object_kusa_DL_000140 };
     EnKusa* this = (EnKusa*)thisx;
 
-    if (this->actor.flags & ACTOR_FLAG_BUSH_DESTROYED) {
+    if (this->actor.flags & ACTOR_FLAG_GRASS_DESTROYED) {
         Gfx_DrawDListOpa(play, object_kusa_DL_0002E0);
     } else {
         Gfx_DrawDListOpa(play, dLists[PARAMS_GET_U(thisx->params, 0, 2)]);

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -161,7 +161,7 @@ void ObjMure_SpawnActors0(ObjMure* this, PlayState* play) {
                     Actor_Spawn(&play->actorCtx, play, sSpawnActorIds[this->type], pos.x, pos.y, pos.z,
                                 actor->world.rot.x, actor->world.rot.y, actor->world.rot.z, sSpawnParams[this->type]);
                 if (this->children[i] != NULL) {
-                    this->children[i]->flags |= ACTOR_FLAG_BUSH_DESTROYED;
+                    this->children[i]->flags |= ACTOR_FLAG_GRASS_DESTROYED;
                     this->children[i]->room = actor->room;
                 } else {
                     PRINTF("warning 発生失敗 (%s %d)\n", "../z_obj_mure.c", 359);
@@ -262,7 +262,7 @@ void ObjMure_CheckChildren(ObjMure* this, PlayState* play) {
         if (this->children[i] != NULL) {
             if (this->childrenStates[i] == OBJMURE_CHILD_STATE_0) {
                 if (this->children[i]->update != NULL) {
-                    if (this->children[i]->flags & ACTOR_FLAG_BUSH_DESTROYED) {
+                    if (this->children[i]->flags & ACTOR_FLAG_GRASS_DESTROYED) {
                         this->childrenStates[i] = OBJMURE_CHILD_STATE_2;
                     }
                 } else {

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -161,7 +161,7 @@ void ObjMure_SpawnActors0(ObjMure* this, PlayState* play) {
                     Actor_Spawn(&play->actorCtx, play, sSpawnActorIds[this->type], pos.x, pos.y, pos.z,
                                 actor->world.rot.x, actor->world.rot.y, actor->world.rot.z, sSpawnParams[this->type]);
                 if (this->children[i] != NULL) {
-                    this->children[i]->flags |= ACTOR_FLAG_ENKUSA_CUT;
+                    this->children[i]->flags |= ACTOR_FLAG_BUSH_DESTROYED;
                     this->children[i]->room = actor->room;
                 } else {
                     PRINTF("warning 発生失敗 (%s %d)\n", "../z_obj_mure.c", 359);
@@ -262,7 +262,7 @@ void ObjMure_CheckChildren(ObjMure* this, PlayState* play) {
         if (this->children[i] != NULL) {
             if (this->childrenStates[i] == OBJMURE_CHILD_STATE_0) {
                 if (this->children[i]->update != NULL) {
-                    if (this->children[i]->flags & ACTOR_FLAG_ENKUSA_CUT) {
+                    if (this->children[i]->flags & ACTOR_FLAG_BUSH_DESTROYED) {
                         this->childrenStates[i] = OBJMURE_CHILD_STATE_2;
                     }
                 } else {


### PR DESCRIPTION
1) Would rather say "bush" than "ENKUSA"
2) "Cut" implies being destroyed by a sword specifically when it can be destroyed by anything (a bomb, for example)