### PR TITLE
Document `Save.cutsceneIndex` and adjacent data / code

### DIFF
--- a/include/z64cutscene.h
+++ b/include/z64cutscene.h
@@ -344,26 +344,40 @@ typedef enum CutsceneDestination {
     /* 0x77 */ CS_DEST_ZELDAS_COURTYARD_RECEIVE_LETTER
 } CutsceneDestination;
 
+/*
+correlation with `enum SceneLayer`:
+  CS_INDEX_MANUAL:     [SCENE_LAYER_CHILD_DAY .. SCENE_LAYER_ADULT_NIGHT]
+  CS_INDEX_SCRIPTED_*: SCENE_LAYER_CUTSCENE_FIRST
+
+correlation with `enum EntranceIndex`
+  CS_INDEX_MANUAL:     base entrance index + scene layer
+  CS_INDEX_SCRIPTED_*: base entrance index + SCENE_LAYER_CUTSCENE_FIRST + (cutscene index & 0xF)
+
+`z_select.c` naming:
+  CS_INDEX_NONE:       "Stage: night"
+  CS_INDEX_LAST:       "Stage: day"
+  CS_INDEX_SCRIPTED_*: "Stage demo 0*", between [0xFFF0 .. 0xFFFA]
+*/
 typedef enum CutsceneIndex {
     CS_INDEX_NONE = 0x0000,
-    CS_INDEX_FFEF = 0xFFEF,
-    CS_INDEX_FFF0 = 0xFFF0,
-    CS_INDEX_FFF1 = 0xFFF1,
-    CS_INDEX_FFF2 = 0xFFF2,
-    CS_INDEX_FFF3 = 0xFFF3,
-    CS_INDEX_FFF4 = 0xFFF4,
-    CS_INDEX_FFF5 = 0xFFF5,
-    CS_INDEX_FFF6 = 0xFFF6,
-    CS_INDEX_FFF7 = 0xFFF7,
-    CS_INDEX_FFF8 = 0xFFF8,
-    CS_INDEX_FFF9 = 0xFFF9,
-    CS_INDEX_FFFA = 0xFFFA,
-    CS_INDEX_FFFB = 0xFFFB,
-    CS_INDEX_FFFC = 0xFFFC,
-    CS_INDEX_FFFD = 0xFFFD,
-    CS_INDEX_FFFE = 0xFFFE,
-    CS_INDEX_FFFF = 0xFFFF,
-    CS_INDEX_8000 = 0x8000,
+    CS_INDEX_MANUAL = 0xFFEF,
+    CS_INDEX_SCRIPTED_0 = 0xFFF0,
+    CS_INDEX_SCRIPTED_1 = 0xFFF1,
+    CS_INDEX_SCRIPTED_2 = 0xFFF2,
+    CS_INDEX_SCRIPTED_3 = 0xFFF3,
+    CS_INDEX_SCRIPTED_4 = 0xFFF4,
+    CS_INDEX_SCRIPTED_5 = 0xFFF5,
+    CS_INDEX_SCRIPTED_6 = 0xFFF6,
+    CS_INDEX_SCRIPTED_7 = 0xFFF7,
+    CS_INDEX_SCRIPTED_8 = 0xFFF8,
+    CS_INDEX_SCRIPTED_9 = 0xFFF9,
+    CS_INDEX_SCRIPTED_A = 0xFFFA,
+    CS_INDEX_SCRIPTED_B = 0xFFFB,
+    CS_INDEX_SCRIPTED_C = 0xFFFC,
+    CS_INDEX_SCRIPTED_D = 0xFFFD,
+    CS_INDEX_SCRIPTED_E = 0xFFFE,
+    CS_INDEX_SCRIPTED_F = 0xFFFF,
+    CS_INDEX_LAST = 0x8000,
 } CutsceneIndex;
 
 typedef union CsCmdCam {

--- a/include/z64cutscene.h
+++ b/include/z64cutscene.h
@@ -344,6 +344,28 @@ typedef enum CutsceneDestination {
     /* 0x77 */ CS_DEST_ZELDAS_COURTYARD_RECEIVE_LETTER
 } CutsceneDestination;
 
+typedef enum CutsceneIndex {
+    CS_INDEX_NONE = 0x0000,
+    CS_INDEX_FFEF = 0xFFEF,
+    CS_INDEX_FFF0 = 0xFFF0,
+    CS_INDEX_FFF1 = 0xFFF1,
+    CS_INDEX_FFF2 = 0xFFF2,
+    CS_INDEX_FFF3 = 0xFFF3,
+    CS_INDEX_FFF4 = 0xFFF4,
+    CS_INDEX_FFF5 = 0xFFF5,
+    CS_INDEX_FFF6 = 0xFFF6,
+    CS_INDEX_FFF7 = 0xFFF7,
+    CS_INDEX_FFF8 = 0xFFF8,
+    CS_INDEX_FFF9 = 0xFFF9,
+    CS_INDEX_FFFA = 0xFFFA,
+    CS_INDEX_FFFB = 0xFFFB,
+    CS_INDEX_FFFC = 0xFFFC,
+    CS_INDEX_FFFD = 0xFFFD,
+    CS_INDEX_FFFE = 0xFFFE,
+    CS_INDEX_FFFF = 0xFFFF,
+    CS_INDEX_8000 = 0x8000,
+} CutsceneIndex;
+
 typedef union CsCmdCam {
     struct {
         /* 0x00 */ u16 unused0;

--- a/src/code/db_camera.c
+++ b/src/code/db_camera.c
@@ -2185,7 +2185,7 @@ s32 DebugCamera_UpdateDemoControl(DebugCam* debugCam, Camera* cam) {
 
             if (CHECK_BTN_ALL(sPlay->state.input[1].press.button, BTN_CRIGHT)) {
                 gUseCutsceneCam = false;
-                gSaveContext.save.cutsceneIndex = 0xFFFD;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
                 gSaveContext.cutsceneTrigger = 1;
                 sDebugCamAnim.curFrame = 0.0f;
                 sDebugCamAnim.keyframe = 0;

--- a/src/code/db_camera.c
+++ b/src/code/db_camera.c
@@ -2185,7 +2185,7 @@ s32 DebugCamera_UpdateDemoControl(DebugCam* debugCam, Camera* cam) {
 
             if (CHECK_BTN_ALL(sPlay->state.input[1].press.button, BTN_CRIGHT)) {
                 gUseCutsceneCam = false;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_D;
                 gSaveContext.cutsceneTrigger = 1;
                 sDebugCamAnim.curFrame = 0.0f;
                 sDebugCamAnim.keyframe = 0;

--- a/src/code/z_common_data.c
+++ b/src/code/z_common_data.c
@@ -16,7 +16,7 @@ void SaveContext_Init(void) {
     gSaveContext.seqId = (u8)NA_BGM_DISABLED;
     gSaveContext.natureAmbienceId = NATURE_ID_DISABLED;
     gSaveContext.forcedSeqId = NA_BGM_GENERAL_SFX;
-    gSaveContext.nextCutsceneIndex = 0xFFEF;
+    gSaveContext.nextCutsceneIndex = CS_INDEX_FFEF;
     gSaveContext.cutsceneTrigger = 0;
     gSaveContext.chamberCutsceneNum = CHAMBER_CS_FOREST;
     gSaveContext.nextDayTime = NEXT_TIME_NONE;

--- a/src/code/z_common_data.c
+++ b/src/code/z_common_data.c
@@ -16,7 +16,7 @@ void SaveContext_Init(void) {
     gSaveContext.seqId = (u8)NA_BGM_DISABLED;
     gSaveContext.natureAmbienceId = NATURE_ID_DISABLED;
     gSaveContext.forcedSeqId = NA_BGM_GENERAL_SFX;
-    gSaveContext.nextCutsceneIndex = CS_INDEX_FFEF;
+    gSaveContext.nextCutsceneIndex = CS_INDEX_MANUAL;
     gSaveContext.cutsceneTrigger = 0;
     gSaveContext.chamberCutsceneNum = CHAMBER_CS_FOREST;
     gSaveContext.nextDayTime = NEXT_TIME_NONE;

--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -177,7 +177,7 @@ void Cutscene_StopManual(PlayState* play, CutsceneContext* csCtx) {
 }
 
 void Cutscene_UpdateManual(PlayState* play, CutsceneContext* csCtx) {
-    if (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) {
+    if (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0) {
         sManualCutsceneHandlers[csCtx->state](play, csCtx);
     }
 }
@@ -189,14 +189,14 @@ void Cutscene_UpdateScripted(PlayState* play, CutsceneContext* csCtx) {
 
         if (CHECK_BTN_ALL(input->press.button, BTN_DLEFT) && (csCtx->state == CS_STATE_IDLE) && IS_CUTSCENE_LAYER) {
             gUseCutsceneCam = false;
-            gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_D;
             gSaveContext.cutsceneTrigger = 1;
         }
 
         if (CHECK_BTN_ALL(input->press.button, BTN_DUP) && (csCtx->state == CS_STATE_IDLE) && IS_CUTSCENE_LAYER &&
             !gDebugCamEnabled) {
             gUseCutsceneCam = true;
-            gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_D;
             gSaveContext.cutsceneTrigger = 1;
         }
     }
@@ -208,11 +208,11 @@ void Cutscene_UpdateScripted(PlayState* play, CutsceneContext* csCtx) {
 
     if ((gSaveContext.cutsceneTrigger != 0) && (csCtx->state == CS_STATE_IDLE)) {
         PRINTF(T("\nデモ開始要求 発令！", "\nDemo start request issued!"));
-        gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_D;
         gSaveContext.cutsceneTrigger = 1;
     }
 
-    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
+    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0) {
         Cutscene_SetupScripted(play, csCtx);
         sScriptedCutsceneHandlers[csCtx->state](play, csCtx);
     }
@@ -596,49 +596,49 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
         switch (cmd->destination) {
             case CS_DEST_CUTSCENE_MAP_GANON_HORSE:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_CUTSCENE_MAP_THREE_GODDESSES:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_GERUDO_VALLEY_DIN_PART_1:
                 play->nextEntranceIndex = ENTR_GERUDO_VALLEY_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_DEATH_MOUNTAIN_TRAIL_NAYRU:
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_KOKIRI_FOREST_FARORE:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_CUTSCENE_MAP_TRIFORCE_CREATION:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_KOKIRI_FOREST_RECEIVE_KOKIRI_EMERALD:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_INSTANT;
                 break;
@@ -651,7 +651,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     SET_EVENTCHKINF(EVENTCHKINF_45);
                     play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                     play->transitionTrigger = TRANS_TRIGGER_START;
-                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
                     play->transitionType = TRANS_TYPE_INSTANT;
                 } else {
                     if (!IS_CUTSCENE_LAYER) {
@@ -671,21 +671,21 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
 
             case CS_DEST_GERUDO_VALLEY_DIN_PART_2:
                 play->nextEntranceIndex = ENTR_GERUDO_VALLEY_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_BROWN;
                 break;
 
             case CS_DEST_LINKS_HOUSE_INTRO:
                 play->nextEntranceIndex = ENTR_LINKS_HOUSE_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_KOKIRI_FOREST_INTRO:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
@@ -712,21 +712,21 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_TEMPLE_OF_TIME_KOKIRI_EMERALD_RESTORED:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_4;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_GORON_RUBY_RESTORED:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_5;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_ZORAS_SAPPHIRE_RESTORED:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_6;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
@@ -744,13 +744,13 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_8000;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_LAST;
                 break;
 
             case CS_DEST_LAKE_HYLIA_WATER_RESTORED:
                 play->nextEntranceIndex = ENTR_LAKE_HYLIA_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
@@ -758,14 +758,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 Item_Give(play, ITEM_SONG_REQUIEM);
                 play->nextEntranceIndex = ENTR_DESERT_COLOSSUS_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_CUTSCENE_MAP_GANONDORF_DEFEATED_CREDITS:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_8;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
@@ -779,28 +779,28 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_KOKIRI_EMERALD_RESTORED_2:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_4;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_GORON_RUBY_RESTORED_2:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_5;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_ZORAS_SAPPHIRE_RESTORED_2:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_6;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
@@ -830,7 +830,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
                 play->transitionType = TRANS_TYPE_INSTANT;
                 break;
 
@@ -843,28 +843,28 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_CUTSCENE_MAP_GANONDORF_FROM_MASTER_SWORD:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_HYRULE_FIELD_INTRO_DREAM:
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
             case CS_DEST_CUTSCENE_MAP_SHEIKAH_LEGEND:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_4;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_ZELDA_REVEAL:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF9;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_9;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
@@ -872,7 +872,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFFA;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_A;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
@@ -885,7 +885,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_KAKARIKO_VILLAGE_DRAIN_WELL:
                 play->nextEntranceIndex = ENTR_KAKARIKO_VILLAGE_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
@@ -915,7 +915,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 SET_EVENTCHKINF(EVENTCHKINF_54);
                 play->nextEntranceIndex = ENTR_KAKARIKO_VILLAGE_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
@@ -940,14 +940,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
 
             case CS_DEST_HYRULE_FIELD_FROM_ZELDAS_COURTYARD:
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_8;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_CIRCLE(TCA_NORMAL, TCC_WHITE, TCS_SLOW);
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_SONG_OF_TIME:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_7;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_INSTANT;
                 break;
@@ -965,56 +965,56 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
 #endif
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_GERUDO_VALLEY_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_GERUDO_FORTRESS_CREDITS:
                 play->nextEntranceIndex = ENTR_GERUDOS_FORTRESS_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_KAKARIKO_VILLAGE_CREDITS:
                 play->nextEntranceIndex = ENTR_KAKARIKO_VILLAGE_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_4;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_DEATH_MOUNTAIN_TRAIL_CREDITS_PART_1:
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_GORON_CITY_CREDITS:
                 play->nextEntranceIndex = ENTR_GORON_CITY_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_LAKE_HYLIA_CREDITS:
                 play->nextEntranceIndex = ENTR_LAKE_HYLIA_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_ZORAS_FOUNTAIN_CREDITS:
                 play->nextEntranceIndex = ENTR_ZORAS_FOUNTAIN_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_ZORAS_DOMAIN_CREDITS:
                 play->nextEntranceIndex = ENTR_ZORAS_DOMAIN_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1022,21 +1022,21 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_KOKIRI_FOREST_CREDITS_PART_1:
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_6;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_KOKIRI_FOREST_CREDITS_PART_2:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_7;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_HYRULE_FIELD_CREDITS:
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_5;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1044,7 +1044,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_LON_LON_RANCH_CREDITS_PART_1_ALT:
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1064,7 +1064,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_CUTSCENE_MAP_DEKU_SPROUT_PART_2:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_5;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1077,7 +1077,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_DEATH_MOUNTAIN_TRAIL_CREDITS_PART_2:
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_4;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1090,14 +1090,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_ZELDAS_COURTYARD_CREDITS:
                 play->nextEntranceIndex = ENTR_CASTLE_COURTYARD_ZELDA_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1106,14 +1106,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_LON_LON_RANCH_CREDITS_PART_2:
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_WHITE;
                 break;
@@ -1122,7 +1122,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_4;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1130,7 +1130,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_5;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1138,14 +1138,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_6;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_LON_LON_RANCH_CREDITS_PART_6:
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_7;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1185,7 +1185,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     GET_EVENTCHKINF(EVENTCHKINF_4A)) {
                     play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                     play->transitionTrigger = TRANS_TRIGGER_START;
-                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
                     play->transitionType = TRANS_TYPE_FADE_BLACK;
                 } else {
                     switch (gSaveContext.sceneLayer) {
@@ -1204,7 +1204,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                         case 10:
                             play->nextEntranceIndex = ENTR_LAKE_HYLIA_0;
                             play->transitionTrigger = TRANS_TRIGGER_START;
-                            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+                            gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
                             play->transitionType = TRANS_TYPE_FADE_WHITE;
                             break;
                     }
@@ -1215,7 +1215,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW)) {
                     play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
                     play->transitionTrigger = TRANS_TRIGGER_START;
-                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                     play->transitionType = TRANS_TYPE_FADE_WHITE_FAST;
                 } else {
                     SET_EVENTCHKINF(EVENTCHKINF_C8);
@@ -1230,7 +1230,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT)) {
                     play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
                     play->transitionTrigger = TRANS_TRIGGER_START;
-                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                     play->transitionType = TRANS_TYPE_FADE_WHITE_FAST;
                 } else {
                     play->nextEntranceIndex = ENTR_GRAVEYARD_8;
@@ -1256,7 +1256,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
 
             case CS_DEST_KOKIRI_FOREST_FROM_CHAMBER_OF_SAGES:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_8;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_WHITE;
@@ -1277,7 +1277,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_HYRULE_FIELD_TITLE_SCREEN:
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1286,7 +1286,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     case TITLE_DEMO_SPIRIT_TEMPLE:
                         play->nextEntranceIndex = ENTR_SPIRIT_TEMPLE_BOSS_0;
                         play->transitionTrigger = TRANS_TRIGGER_START;
-                        gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+                        gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
                         play->transitionType = TRANS_TYPE_FADE_BLACK;
                         sTitleDemoDestination++;
                         break;
@@ -1294,7 +1294,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     case TITLE_DEMO_DEATH_MOUNTAIN_CRATER:
                         play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_CRATER_0;
                         play->transitionTrigger = TRANS_TRIGGER_START;
-                        gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                        gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                         play->transitionType = TRANS_TYPE_FADE_BLACK;
                         sTitleDemoDestination++;
                         break;
@@ -1302,7 +1302,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     case TITLE_DEMO_GANONDORF_HORSE:
                         play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                         play->transitionTrigger = TRANS_TRIGGER_START;
-                        gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
+                        gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_6;
                         play->transitionType = TRANS_TYPE_FADE_BLACK;
                         sTitleDemoDestination = TITLE_DEMO_SPIRIT_TEMPLE;
                         break;
@@ -1312,7 +1312,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_GRAVEYARD_SUNS_SONG_PART_2:
                 play->nextEntranceIndex = ENTR_GRAVEYARD_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1365,10 +1365,10 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     play->csCtx.script = SEGMENTED_TO_VIRTUAL(gTowerBarrierCs);
                     play->csCtx.curFrame = 0;
                     gSaveContext.cutsceneTrigger = 1;
-                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFFF;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_F;
                     csCtx->state = CS_STATE_STOP;
                 } else {
-                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFFF;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_F;
                     csCtx->state = CS_STATE_STOP;
                 }
                 break;
@@ -1405,7 +1405,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 Audio_SetSfxBanksMute(0x6F);
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_7;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
@@ -2214,7 +2214,7 @@ void Cutscene_ProcessScript(PlayState* play, CutsceneContext* csCtx, u8* script)
 }
 
 void CutsceneHandler_RunScript(PlayState* play, CutsceneContext* csCtx) {
-    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
+    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0) {
 #if OOT_DEBUG
         if (BREG(0) != 0) {
             Gfx* displayList;
@@ -2293,10 +2293,10 @@ void Cutscene_SetupScripted(PlayState* play, CutsceneContext* csCtx) {
     u8 i;
 
     if ((gSaveContext.cutsceneTrigger != 0) && (csCtx->state == CS_STATE_IDLE) && !Player_InCsMode(play)) {
-        gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_D;
     }
 
-    if ((gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) && (csCtx->state == CS_STATE_IDLE)) {
+    if ((gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0) && (csCtx->state == CS_STATE_IDLE)) {
         CutsceneFlags_Unset(play, 0);
 
         sCurTextId = 0;
@@ -2378,7 +2378,7 @@ void Cutscene_HandleEntranceTriggers(PlayState* play) {
 
         if ((gSaveContext.save.entranceIndex == entranceCutscene->entrance) &&
             (!Flags_GetEventChkInf(entranceCutscene->flag) || (entranceCutscene->flag == EVENTCHKINF_EPONA_OBTAINED)) &&
-            (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) && ((u8)gSaveContext.save.linkAge == requiredAge) &&
+            (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0) && ((u8)gSaveContext.save.linkAge == requiredAge) &&
             (gSaveContext.respawnFlag <= 0)) {
             Flags_SetEventChkInf(entranceCutscene->flag);
             Cutscene_SetScript(play, entranceCutscene->script);
@@ -2393,32 +2393,32 @@ void Cutscene_HandleConditionalTriggers(PlayState* play) {
     PRINTF("\ngame_info.mode=[%d] restart_flag", ((void)0, gSaveContext.respawnFlag));
 
     if ((gSaveContext.gameMode == GAMEMODE_NORMAL) && (gSaveContext.respawnFlag <= 0) &&
-        (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) {
+        (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0)) {
         if ((gSaveContext.save.entranceIndex == ENTR_DESERT_COLOSSUS_1) && !Flags_GetEventChkInf(EVENTCHKINF_AC)) {
             Flags_SetEventChkInf(EVENTCHKINF_AC);
             gSaveContext.save.entranceIndex = ENTR_DESERT_COLOSSUS_0;
-            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
         } else if ((gSaveContext.save.entranceIndex == ENTR_KAKARIKO_VILLAGE_0) && LINK_IS_ADULT &&
                    GET_EVENTCHKINF(EVENTCHKINF_48) && GET_EVENTCHKINF(EVENTCHKINF_49) &&
                    GET_EVENTCHKINF(EVENTCHKINF_4A) && !Flags_GetEventChkInf(EVENTCHKINF_AA)) {
             Flags_SetEventChkInf(EVENTCHKINF_AA);
-            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
         } else if ((gSaveContext.save.entranceIndex == ENTR_LOST_WOODS_9) && !Flags_GetEventChkInf(EVENTCHKINF_C1)) {
             Flags_SetEventChkInf(EVENTCHKINF_C1);
             Item_Give(play, ITEM_OCARINA_FAIRY);
             gSaveContext.save.entranceIndex = ENTR_LOST_WOODS_0;
-            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
         } else if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT) && CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW) &&
                    LINK_IS_ADULT && !Flags_GetEventChkInf(EVENTCHKINF_C4) &&
                    (gEntranceTable[((void)0, gSaveContext.save.entranceIndex)].sceneId == SCENE_TEMPLE_OF_TIME)) {
             Flags_SetEventChkInf(EVENTCHKINF_C4);
             gSaveContext.save.entranceIndex = ENTR_TEMPLE_OF_TIME_0;
-            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_8;
         } else if (!Flags_GetEventChkInf(EVENTCHKINF_C7) &&
                    (gEntranceTable[((void)0, gSaveContext.save.entranceIndex)].sceneId == SCENE_GANON_BOSS)) {
             Flags_SetEventChkInf(EVENTCHKINF_C7);
             gSaveContext.save.entranceIndex = ENTR_GANON_BOSS_0;
-            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
         }
     }
 }

--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -177,7 +177,7 @@ void Cutscene_StopManual(PlayState* play, CutsceneContext* csCtx) {
 }
 
 void Cutscene_UpdateManual(PlayState* play, CutsceneContext* csCtx) {
-    if (gSaveContext.save.cutsceneIndex < 0xFFF0) {
+    if (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) {
         sManualCutsceneHandlers[csCtx->state](play, csCtx);
     }
 }
@@ -189,14 +189,14 @@ void Cutscene_UpdateScripted(PlayState* play, CutsceneContext* csCtx) {
 
         if (CHECK_BTN_ALL(input->press.button, BTN_DLEFT) && (csCtx->state == CS_STATE_IDLE) && IS_CUTSCENE_LAYER) {
             gUseCutsceneCam = false;
-            gSaveContext.save.cutsceneIndex = 0xFFFD;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
             gSaveContext.cutsceneTrigger = 1;
         }
 
         if (CHECK_BTN_ALL(input->press.button, BTN_DUP) && (csCtx->state == CS_STATE_IDLE) && IS_CUTSCENE_LAYER &&
             !gDebugCamEnabled) {
             gUseCutsceneCam = true;
-            gSaveContext.save.cutsceneIndex = 0xFFFD;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
             gSaveContext.cutsceneTrigger = 1;
         }
     }
@@ -208,11 +208,11 @@ void Cutscene_UpdateScripted(PlayState* play, CutsceneContext* csCtx) {
 
     if ((gSaveContext.cutsceneTrigger != 0) && (csCtx->state == CS_STATE_IDLE)) {
         PRINTF(T("\nデモ開始要求 発令！", "\nDemo start request issued!"));
-        gSaveContext.save.cutsceneIndex = 0xFFFD;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
         gSaveContext.cutsceneTrigger = 1;
     }
 
-    if (gSaveContext.save.cutsceneIndex >= 0xFFF0) {
+    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
         Cutscene_SetupScripted(play, csCtx);
         sScriptedCutsceneHandlers[csCtx->state](play, csCtx);
     }
@@ -591,54 +591,54 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             gSaveContext.forceRisingButtonAlphas = true;
         }
 
-        gSaveContext.save.cutsceneIndex = 0;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
 
         switch (cmd->destination) {
             case CS_DEST_CUTSCENE_MAP_GANON_HORSE:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_CUTSCENE_MAP_THREE_GODDESSES:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_GERUDO_VALLEY_DIN_PART_1:
                 play->nextEntranceIndex = ENTR_GERUDO_VALLEY_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_DEATH_MOUNTAIN_TRAIL_NAYRU:
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_KOKIRI_FOREST_FARORE:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_CUTSCENE_MAP_TRIFORCE_CREATION:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_WHITE;
                 break;
 
             case CS_DEST_KOKIRI_FOREST_RECEIVE_KOKIRI_EMERALD:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_INSTANT;
                 break;
@@ -651,7 +651,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     SET_EVENTCHKINF(EVENTCHKINF_45);
                     play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                     play->transitionTrigger = TRANS_TRIGGER_START;
-                    gSaveContext.save.cutsceneIndex = 0xFFF3;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
                     play->transitionType = TRANS_TYPE_INSTANT;
                 } else {
                     if (!IS_CUTSCENE_LAYER) {
@@ -671,21 +671,21 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
 
             case CS_DEST_GERUDO_VALLEY_DIN_PART_2:
                 play->nextEntranceIndex = ENTR_GERUDO_VALLEY_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FILL_BROWN;
                 break;
 
             case CS_DEST_LINKS_HOUSE_INTRO:
                 play->nextEntranceIndex = ENTR_LINKS_HOUSE_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_KOKIRI_FOREST_INTRO:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
@@ -712,21 +712,21 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_TEMPLE_OF_TIME_KOKIRI_EMERALD_RESTORED:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_GORON_RUBY_RESTORED:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_ZORAS_SAPPHIRE_RESTORED:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF6;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
@@ -744,13 +744,13 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
-                gSaveContext.save.cutsceneIndex = 0x8000;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_8000;
                 break;
 
             case CS_DEST_LAKE_HYLIA_WATER_RESTORED:
                 play->nextEntranceIndex = ENTR_LAKE_HYLIA_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
@@ -758,14 +758,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 Item_Give(play, ITEM_SONG_REQUIEM);
                 play->nextEntranceIndex = ENTR_DESERT_COLOSSUS_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_CUTSCENE_MAP_GANONDORF_DEFEATED_CREDITS:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF8;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
@@ -779,28 +779,28 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_KOKIRI_EMERALD_RESTORED_2:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_GORON_RUBY_RESTORED_2:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_ZORAS_SAPPHIRE_RESTORED_2:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF6;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
@@ -830,7 +830,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
                 play->transitionType = TRANS_TYPE_INSTANT;
                 break;
 
@@ -843,28 +843,28 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_CUTSCENE_MAP_GANONDORF_FROM_MASTER_SWORD:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
 
             case CS_DEST_HYRULE_FIELD_INTRO_DREAM:
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
             case CS_DEST_CUTSCENE_MAP_SHEIKAH_LEGEND:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_ZELDA_REVEAL:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF9;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF9;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
@@ -872,7 +872,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFFA;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFFA;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
@@ -885,7 +885,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_KAKARIKO_VILLAGE_DRAIN_WELL:
                 play->nextEntranceIndex = ENTR_KAKARIKO_VILLAGE_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
@@ -915,7 +915,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 SET_EVENTCHKINF(EVENTCHKINF_54);
                 play->nextEntranceIndex = ENTR_KAKARIKO_VILLAGE_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                 play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 break;
 
@@ -940,14 +940,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
 
             case CS_DEST_HYRULE_FIELD_FROM_ZELDAS_COURTYARD:
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF8;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_CIRCLE(TCA_NORMAL, TCC_WHITE, TCS_SLOW);
                 break;
 
             case CS_DEST_TEMPLE_OF_TIME_SONG_OF_TIME:
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF7;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_INSTANT;
                 break;
@@ -965,56 +965,56 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
 #endif
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_GERUDO_VALLEY_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_GERUDO_FORTRESS_CREDITS:
                 play->nextEntranceIndex = ENTR_GERUDOS_FORTRESS_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_KAKARIKO_VILLAGE_CREDITS:
                 play->nextEntranceIndex = ENTR_KAKARIKO_VILLAGE_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_DEATH_MOUNTAIN_TRAIL_CREDITS_PART_1:
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_GORON_CITY_CREDITS:
                 play->nextEntranceIndex = ENTR_GORON_CITY_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_LAKE_HYLIA_CREDITS:
                 play->nextEntranceIndex = ENTR_LAKE_HYLIA_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_ZORAS_FOUNTAIN_CREDITS:
                 play->nextEntranceIndex = ENTR_ZORAS_FOUNTAIN_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_ZORAS_DOMAIN_CREDITS:
                 play->nextEntranceIndex = ENTR_ZORAS_DOMAIN_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1022,21 +1022,21 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_KOKIRI_FOREST_CREDITS_PART_1:
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF6;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_KOKIRI_FOREST_CREDITS_PART_2:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF7;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_HYRULE_FIELD_CREDITS:
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1044,7 +1044,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_LON_LON_RANCH_CREDITS_PART_1_ALT:
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1064,7 +1064,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_CUTSCENE_MAP_DEKU_SPROUT_PART_2:
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1077,7 +1077,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_DEATH_MOUNTAIN_TRAIL_CREDITS_PART_2:
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1090,14 +1090,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_ZELDAS_COURTYARD_CREDITS:
                 play->nextEntranceIndex = ENTR_CASTLE_COURTYARD_ZELDA_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK;
                 break;
@@ -1106,14 +1106,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_LON_LON_RANCH_CREDITS_PART_2:
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_WHITE;
                 break;
@@ -1122,7 +1122,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF4;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1130,7 +1130,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF5;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1138,14 +1138,14 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 play->linkAgeOnLoad = LINK_AGE_CHILD;
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF6;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
             case CS_DEST_LON_LON_RANCH_CREDITS_PART_6:
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF7;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1185,7 +1185,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     GET_EVENTCHKINF(EVENTCHKINF_4A)) {
                     play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_0;
                     play->transitionTrigger = TRANS_TRIGGER_START;
-                    gSaveContext.save.cutsceneIndex = 0xFFF3;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
                     play->transitionType = TRANS_TYPE_FADE_BLACK;
                 } else {
                     switch (gSaveContext.sceneLayer) {
@@ -1204,7 +1204,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                         case 10:
                             play->nextEntranceIndex = ENTR_LAKE_HYLIA_0;
                             play->transitionTrigger = TRANS_TRIGGER_START;
-                            gSaveContext.save.cutsceneIndex = 0xFFF0;
+                            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
                             play->transitionType = TRANS_TYPE_FADE_WHITE;
                             break;
                     }
@@ -1215,7 +1215,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW)) {
                     play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
                     play->transitionTrigger = TRANS_TRIGGER_START;
-                    gSaveContext.save.cutsceneIndex = 0xFFF1;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                     play->transitionType = TRANS_TYPE_FADE_WHITE_FAST;
                 } else {
                     SET_EVENTCHKINF(EVENTCHKINF_C8);
@@ -1230,7 +1230,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT)) {
                     play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
                     play->transitionTrigger = TRANS_TRIGGER_START;
-                    gSaveContext.save.cutsceneIndex = 0xFFF1;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                     play->transitionType = TRANS_TYPE_FADE_WHITE_FAST;
                 } else {
                     play->nextEntranceIndex = ENTR_GRAVEYARD_8;
@@ -1256,7 +1256,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
 
             case CS_DEST_KOKIRI_FOREST_FROM_CHAMBER_OF_SAGES:
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF8;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_WHITE;
@@ -1277,7 +1277,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_HYRULE_FIELD_TITLE_SCREEN:
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF3;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1286,7 +1286,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     case TITLE_DEMO_SPIRIT_TEMPLE:
                         play->nextEntranceIndex = ENTR_SPIRIT_TEMPLE_BOSS_0;
                         play->transitionTrigger = TRANS_TRIGGER_START;
-                        gSaveContext.save.cutsceneIndex = 0xFFF2;
+                        gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
                         play->transitionType = TRANS_TYPE_FADE_BLACK;
                         sTitleDemoDestination++;
                         break;
@@ -1294,7 +1294,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     case TITLE_DEMO_DEATH_MOUNTAIN_CRATER:
                         play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_CRATER_0;
                         play->transitionTrigger = TRANS_TRIGGER_START;
-                        gSaveContext.save.cutsceneIndex = 0xFFF1;
+                        gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                         play->transitionType = TRANS_TYPE_FADE_BLACK;
                         sTitleDemoDestination++;
                         break;
@@ -1302,7 +1302,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     case TITLE_DEMO_GANONDORF_HORSE:
                         play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
                         play->transitionTrigger = TRANS_TRIGGER_START;
-                        gSaveContext.save.cutsceneIndex = 0xFFF6;
+                        gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
                         play->transitionType = TRANS_TYPE_FADE_BLACK;
                         sTitleDemoDestination = TITLE_DEMO_SPIRIT_TEMPLE;
                         break;
@@ -1312,7 +1312,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
             case CS_DEST_GRAVEYARD_SUNS_SONG_PART_2:
                 play->nextEntranceIndex = ENTR_GRAVEYARD_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                 break;
 
@@ -1365,10 +1365,10 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                     play->csCtx.script = SEGMENTED_TO_VIRTUAL(gTowerBarrierCs);
                     play->csCtx.curFrame = 0;
                     gSaveContext.cutsceneTrigger = 1;
-                    gSaveContext.save.cutsceneIndex = 0xFFFF;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFFF;
                     csCtx->state = CS_STATE_STOP;
                 } else {
-                    gSaveContext.save.cutsceneIndex = 0xFFFF;
+                    gSaveContext.save.cutsceneIndex = CS_INDEX_FFFF;
                     csCtx->state = CS_STATE_STOP;
                 }
                 break;
@@ -1405,7 +1405,7 @@ void CutsceneCmd_Destination(PlayState* play, CutsceneContext* csCtx, CsCmdDesti
                 Audio_SetSfxBanksMute(0x6F);
                 play->linkAgeOnLoad = LINK_AGE_ADULT;
                 play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
-                gSaveContext.save.cutsceneIndex = 0xFFF7;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
                 break;
@@ -2214,7 +2214,7 @@ void Cutscene_ProcessScript(PlayState* play, CutsceneContext* csCtx, u8* script)
 }
 
 void CutsceneHandler_RunScript(PlayState* play, CutsceneContext* csCtx) {
-    if (gSaveContext.save.cutsceneIndex >= 0xFFF0) {
+    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
 #if OOT_DEBUG
         if (BREG(0) != 0) {
             Gfx* displayList;
@@ -2267,7 +2267,7 @@ void CutsceneHandler_StopScript(PlayState* play, CutsceneContext* csCtx) {
 
         PRINTF(T("\n\n\n\n\nやっぱりここかいな", "\n\n\n\n\nThis is it after all"));
 
-        gSaveContext.save.cutsceneIndex = 0;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
         gSaveContext.gameMode = GAMEMODE_NORMAL;
 
         if (gUseCutsceneCam) {
@@ -2293,10 +2293,10 @@ void Cutscene_SetupScripted(PlayState* play, CutsceneContext* csCtx) {
     u8 i;
 
     if ((gSaveContext.cutsceneTrigger != 0) && (csCtx->state == CS_STATE_IDLE) && !Player_InCsMode(play)) {
-        gSaveContext.save.cutsceneIndex = 0xFFFD;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_FFFD;
     }
 
-    if ((gSaveContext.save.cutsceneIndex >= 0xFFF0) && (csCtx->state == CS_STATE_IDLE)) {
+    if ((gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) && (csCtx->state == CS_STATE_IDLE)) {
         CutsceneFlags_Unset(play, 0);
 
         sCurTextId = 0;
@@ -2378,7 +2378,7 @@ void Cutscene_HandleEntranceTriggers(PlayState* play) {
 
         if ((gSaveContext.save.entranceIndex == entranceCutscene->entrance) &&
             (!Flags_GetEventChkInf(entranceCutscene->flag) || (entranceCutscene->flag == EVENTCHKINF_EPONA_OBTAINED)) &&
-            (gSaveContext.save.cutsceneIndex < 0xFFF0) && ((u8)gSaveContext.save.linkAge == requiredAge) &&
+            (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) && ((u8)gSaveContext.save.linkAge == requiredAge) &&
             (gSaveContext.respawnFlag <= 0)) {
             Flags_SetEventChkInf(entranceCutscene->flag);
             Cutscene_SetScript(play, entranceCutscene->script);
@@ -2393,32 +2393,32 @@ void Cutscene_HandleConditionalTriggers(PlayState* play) {
     PRINTF("\ngame_info.mode=[%d] restart_flag", ((void)0, gSaveContext.respawnFlag));
 
     if ((gSaveContext.gameMode == GAMEMODE_NORMAL) && (gSaveContext.respawnFlag <= 0) &&
-        (gSaveContext.save.cutsceneIndex < 0xFFF0)) {
+        (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) {
         if ((gSaveContext.save.entranceIndex == ENTR_DESERT_COLOSSUS_1) && !Flags_GetEventChkInf(EVENTCHKINF_AC)) {
             Flags_SetEventChkInf(EVENTCHKINF_AC);
             gSaveContext.save.entranceIndex = ENTR_DESERT_COLOSSUS_0;
-            gSaveContext.save.cutsceneIndex = 0xFFF0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
         } else if ((gSaveContext.save.entranceIndex == ENTR_KAKARIKO_VILLAGE_0) && LINK_IS_ADULT &&
                    GET_EVENTCHKINF(EVENTCHKINF_48) && GET_EVENTCHKINF(EVENTCHKINF_49) &&
                    GET_EVENTCHKINF(EVENTCHKINF_4A) && !Flags_GetEventChkInf(EVENTCHKINF_AA)) {
             Flags_SetEventChkInf(EVENTCHKINF_AA);
-            gSaveContext.save.cutsceneIndex = 0xFFF0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
         } else if ((gSaveContext.save.entranceIndex == ENTR_LOST_WOODS_9) && !Flags_GetEventChkInf(EVENTCHKINF_C1)) {
             Flags_SetEventChkInf(EVENTCHKINF_C1);
             Item_Give(play, ITEM_OCARINA_FAIRY);
             gSaveContext.save.entranceIndex = ENTR_LOST_WOODS_0;
-            gSaveContext.save.cutsceneIndex = 0xFFF0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
         } else if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT) && CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW) &&
                    LINK_IS_ADULT && !Flags_GetEventChkInf(EVENTCHKINF_C4) &&
                    (gEntranceTable[((void)0, gSaveContext.save.entranceIndex)].sceneId == SCENE_TEMPLE_OF_TIME)) {
             Flags_SetEventChkInf(EVENTCHKINF_C4);
             gSaveContext.save.entranceIndex = ENTR_TEMPLE_OF_TIME_0;
-            gSaveContext.save.cutsceneIndex = 0xFFF8;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
         } else if (!Flags_GetEventChkInf(EVENTCHKINF_C7) &&
                    (gEntranceTable[((void)0, gSaveContext.save.entranceIndex)].sceneId == SCENE_GANON_BOSS)) {
             Flags_SetEventChkInf(EVENTCHKINF_C7);
             gSaveContext.save.entranceIndex = ENTR_GANON_BOSS_0;
-            gSaveContext.save.cutsceneIndex = 0xFFF0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
         }
     }
 }

--- a/src/code/z_horse.c
+++ b/src/code/z_horse.c
@@ -192,7 +192,7 @@ void func_8006D684(PlayState* play, Player* player) {
                 (((void)0, gSaveContext.save.cutsceneIndex) == D_8011F9B8[i].cutsceneIndex)) {
                 if (D_8011F9B8[i].type == 7) {
                     if ((play->sceneId == SCENE_LON_LON_RANCH) &&
-                        (((void)0, gSaveContext.save.cutsceneIndex) == CS_INDEX_FFF1)) {
+                        (((void)0, gSaveContext.save.cutsceneIndex) == CS_INDEX_SCRIPTED_1)) {
                         D_8011F9B8[i].pos.x = player->actor.world.pos.x;
                         D_8011F9B8[i].pos.y = player->actor.world.pos.y;
                         D_8011F9B8[i].pos.z = player->actor.world.pos.z;

--- a/src/code/z_horse.c
+++ b/src/code/z_horse.c
@@ -192,7 +192,7 @@ void func_8006D684(PlayState* play, Player* player) {
                 (((void)0, gSaveContext.save.cutsceneIndex) == D_8011F9B8[i].cutsceneIndex)) {
                 if (D_8011F9B8[i].type == 7) {
                     if ((play->sceneId == SCENE_LON_LON_RANCH) &&
-                        (((void)0, gSaveContext.save.cutsceneIndex) == 0xFFF1)) {
+                        (((void)0, gSaveContext.save.cutsceneIndex) == CS_INDEX_FFF1)) {
                         D_8011F9B8[i].pos.x = player->actor.world.pos.x;
                         D_8011F9B8[i].pos.y = player->actor.world.pos.y;
                         D_8011F9B8[i].pos.z = player->actor.world.pos.z;

--- a/src/code/z_kaleido_setup.c
+++ b/src/code/z_kaleido_setup.c
@@ -66,9 +66,9 @@ void KaleidoSetup_Update(PlayState* play) {
 
     if (!IS_PAUSED(pauseCtx) && play->gameOverCtx.state == GAMEOVER_INACTIVE &&
         play->transitionTrigger == TRANS_TRIGGER_OFF && play->transitionMode == TRANS_MODE_OFF &&
-        gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0 && gSaveContext.nextCutsceneIndex < CS_INDEX_SCRIPTED_0 && !Play_InCsMode(play) &&
-        play->shootingGalleryStatus <= 1 && gSaveContext.magicState != MAGIC_STATE_STEP_CAPACITY &&
-        gSaveContext.magicState != MAGIC_STATE_FILL &&
+        gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0 && gSaveContext.nextCutsceneIndex < CS_INDEX_SCRIPTED_0 &&
+        !Play_InCsMode(play) && play->shootingGalleryStatus <= 1 &&
+        gSaveContext.magicState != MAGIC_STATE_STEP_CAPACITY && gSaveContext.magicState != MAGIC_STATE_FILL &&
         (play->sceneId != SCENE_BOMBCHU_BOWLING_ALLEY || !Flags_GetSwitch(play, 0x38))) {
 
         if (CHECK_BTN_ALL(input->cur.button, BTN_L) && CHECK_BTN_ALL(input->press.button, BTN_CUP)) {

--- a/src/code/z_kaleido_setup.c
+++ b/src/code/z_kaleido_setup.c
@@ -66,7 +66,7 @@ void KaleidoSetup_Update(PlayState* play) {
 
     if (!IS_PAUSED(pauseCtx) && play->gameOverCtx.state == GAMEOVER_INACTIVE &&
         play->transitionTrigger == TRANS_TRIGGER_OFF && play->transitionMode == TRANS_MODE_OFF &&
-        gSaveContext.save.cutsceneIndex < 0xFFF0 && gSaveContext.nextCutsceneIndex < 0xFFF0 && !Play_InCsMode(play) &&
+        gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0 && gSaveContext.nextCutsceneIndex < CS_INDEX_FFF0 && !Play_InCsMode(play) &&
         play->shootingGalleryStatus <= 1 && gSaveContext.magicState != MAGIC_STATE_STEP_CAPACITY &&
         gSaveContext.magicState != MAGIC_STATE_FILL &&
         (play->sceneId != SCENE_BOMBCHU_BOWLING_ALLEY || !Flags_GetSwitch(play, 0x38))) {

--- a/src/code/z_kaleido_setup.c
+++ b/src/code/z_kaleido_setup.c
@@ -66,7 +66,7 @@ void KaleidoSetup_Update(PlayState* play) {
 
     if (!IS_PAUSED(pauseCtx) && play->gameOverCtx.state == GAMEOVER_INACTIVE &&
         play->transitionTrigger == TRANS_TRIGGER_OFF && play->transitionMode == TRANS_MODE_OFF &&
-        gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0 && gSaveContext.nextCutsceneIndex < CS_INDEX_FFF0 && !Play_InCsMode(play) &&
+        gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0 && gSaveContext.nextCutsceneIndex < CS_INDEX_SCRIPTED_0 && !Play_InCsMode(play) &&
         play->shootingGalleryStatus <= 1 && gSaveContext.magicState != MAGIC_STATE_STEP_CAPACITY &&
         gSaveContext.magicState != MAGIC_STATE_FILL &&
         (play->sceneId != SCENE_BOMBCHU_BOWLING_ALLEY || !Flags_GetSwitch(play, 0x38))) {

--- a/src/code/z_kankyo.c
+++ b/src/code/z_kankyo.c
@@ -2618,7 +2618,7 @@ void Environment_StopStormNatureAmbience(PlayState* play) {
 
 void Environment_WarpSongLeave(PlayState* play) {
     gWeatherMode = WEATHER_MODE_CLEAR;
-    gSaveContext.save.cutsceneIndex = 0;
+    gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
     gSaveContext.respawnFlag = -3;
     play->nextEntranceIndex = gSaveContext.respawn[RESPAWN_MODE_RETURN].entranceIndex;
     play->transitionTrigger = TRANS_TRIGGER_START;

--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -4294,7 +4294,7 @@ void Message_Update(PlayState* play) {
 
                     if (msgCtx->textId != 0x2061 && msgCtx->textId != 0x2025 && msgCtx->textId != 0x208C &&
                         ((msgCtx->textId < 0x88D || msgCtx->textId >= 0x893) || msgCtx->choiceIndex != 0) &&
-                        (msgCtx->textId != 0x3055 && gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) {
+                        (msgCtx->textId != 0x3055 && gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0)) {
                         PRINTF("=== day_time=%x ", ((void)0, gSaveContext.save.cutsceneIndex));
                         if (play->activeCamId == CAM_ID_MAIN) {
                             if (gSaveContext.prevHudVisibilityMode == HUD_VISIBILITY_NO_CHANGE ||

--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -4294,7 +4294,7 @@ void Message_Update(PlayState* play) {
 
                     if (msgCtx->textId != 0x2061 && msgCtx->textId != 0x2025 && msgCtx->textId != 0x208C &&
                         ((msgCtx->textId < 0x88D || msgCtx->textId >= 0x893) || msgCtx->choiceIndex != 0) &&
-                        (msgCtx->textId != 0x3055 && gSaveContext.save.cutsceneIndex < 0xFFF0)) {
+                        (msgCtx->textId != 0x3055 && gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) {
                         PRINTF("=== day_time=%x ", ((void)0, gSaveContext.save.cutsceneIndex));
                         if (play->activeCamId == CAM_ID_MAIN) {
                             if (gSaveContext.prevHudVisibilityMode == HUD_VISIBILITY_NO_CHANGE ||

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -644,8 +644,8 @@ void func_80083108(PlayState* play) {
     s16 i;
     s16 sp28 = false;
 
-    if ((gSaveContext.save.cutsceneIndex < 0xFFF0) ||
-        ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == 0xFFF0))) {
+    if ((gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) ||
+        ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF0))) {
         gSaveContext.forceRisingButtonAlphas = false;
 
         if ((player->stateFlags1 & PLAYER_STATE1_23) || (play->shootingGalleryStatus > 1) ||
@@ -3523,7 +3523,7 @@ void Interface_Draw(PlayState* play) {
             (Message_GetState(&play->msgCtx) == TEXT_STATE_EVENT)) {
             // Trade quest timer reached 0
             sSubTimerStateTimer = 40;
-            gSaveContext.save.cutsceneIndex = 0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
             play->transitionTrigger = TRANS_TRIGGER_START;
             play->transitionType = TRANS_TYPE_FADE_WHITE;
             gSaveContext.subTimerState = SUBTIMER_STATE_OFF;
@@ -3861,7 +3861,7 @@ void Interface_Draw(PlayState* play) {
                                                  (play->sceneId != SCENE_INSIDE_GANONS_CASTLE_COLLAPSE))) {
                                                 sSubTimerStateTimer = 40;
                                                 gSaveContext.subTimerState = SUBTIMER_STATE_RESPAWN;
-                                                gSaveContext.save.cutsceneIndex = 0;
+                                                gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
                                                 Message_StartTextbox(play, 0x71B0, NULL);
                                                 Player_SetCsActionWithHaltedActors(play, NULL, PLAYER_CSACTION_8);
                                             } else {

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -644,8 +644,8 @@ void func_80083108(PlayState* play) {
     s16 i;
     s16 sp28 = false;
 
-    if ((gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) ||
-        ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF0))) {
+    if ((gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0) ||
+        ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_0))) {
         gSaveContext.forceRisingButtonAlphas = false;
 
         if ((player->stateFlags1 & PLAYER_STATE1_23) || (play->shootingGalleryStatus > 1) ||

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -55,7 +55,8 @@ void Play_SetViewpoint(PlayState* this, s16 viewpoint) {
 
     this->viewpoint = viewpoint;
 
-    if ((R_SCENE_CAM_TYPE != SCENE_CAM_TYPE_FIXED_SHOP_VIEWPOINT) && (gSaveContext.save.cutsceneIndex < 0xFFF0)) {
+    if ((R_SCENE_CAM_TYPE != SCENE_CAM_TYPE_FIXED_SHOP_VIEWPOINT) &&
+        (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) {
         // Play a sfx when the player toggles the camera
         Audio_PlaySfxGeneral((viewpoint == VIEWPOINT_LOCKED) ? NA_SE_SY_CAMERA_ZOOM_DOWN : NA_SE_SY_CAMERA_ZOOM_UP,
                              &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
@@ -324,12 +325,12 @@ void Play_Init(GameState* thisx) {
     AnimTaskQueue_Reset(&this->animTaskQueue);
     Cutscene_InitContext(this, &this->csCtx);
 
-    if (gSaveContext.nextCutsceneIndex != 0xFFEF) {
+    if (gSaveContext.nextCutsceneIndex != CS_INDEX_FFEF) {
         gSaveContext.save.cutsceneIndex = gSaveContext.nextCutsceneIndex;
-        gSaveContext.nextCutsceneIndex = 0xFFEF;
+        gSaveContext.nextCutsceneIndex = CS_INDEX_FFEF;
     }
 
-    if (gSaveContext.save.cutsceneIndex == 0xFFFD) {
+    if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFFD) {
         gSaveContext.save.cutsceneIndex = 0;
     }
 
@@ -346,7 +347,7 @@ void Play_Init(GameState* thisx) {
 
     Cutscene_HandleConditionalTriggers(this);
 
-    if (gSaveContext.gameMode != GAMEMODE_NORMAL || gSaveContext.save.cutsceneIndex >= 0xFFF0) {
+    if (gSaveContext.gameMode != GAMEMODE_NORMAL || gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
         gSaveContext.nayrusLoveTimer = 0;
         Magic_Reset(this);
         gSaveContext.sceneLayer = SCENE_LAYER_CUTSCENE_FIRST + (gSaveContext.save.cutsceneIndex & 0xF);
@@ -596,7 +597,7 @@ void Play_Update(PlayState* this) {
 
                         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_NOTHING);
 
-                        if (gSaveContext.save.cutsceneIndex >= 0xFFF0) {
+                        if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
                             sceneLayer = SCENE_LAYER_CUTSCENE_FIRST + (gSaveContext.save.cutsceneIndex & 0xF);
                         }
 

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -56,7 +56,7 @@ void Play_SetViewpoint(PlayState* this, s16 viewpoint) {
     this->viewpoint = viewpoint;
 
     if ((R_SCENE_CAM_TYPE != SCENE_CAM_TYPE_FIXED_SHOP_VIEWPOINT) &&
-        (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) {
+        (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0)) {
         // Play a sfx when the player toggles the camera
         Audio_PlaySfxGeneral((viewpoint == VIEWPOINT_LOCKED) ? NA_SE_SY_CAMERA_ZOOM_DOWN : NA_SE_SY_CAMERA_ZOOM_UP,
                              &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
@@ -325,13 +325,13 @@ void Play_Init(GameState* thisx) {
     AnimTaskQueue_Reset(&this->animTaskQueue);
     Cutscene_InitContext(this, &this->csCtx);
 
-    if (gSaveContext.nextCutsceneIndex != CS_INDEX_FFEF) {
+    if (gSaveContext.nextCutsceneIndex != CS_INDEX_MANUAL) {
         gSaveContext.save.cutsceneIndex = gSaveContext.nextCutsceneIndex;
-        gSaveContext.nextCutsceneIndex = CS_INDEX_FFEF;
+        gSaveContext.nextCutsceneIndex = CS_INDEX_MANUAL;
     }
 
-    if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFFD) {
-        gSaveContext.save.cutsceneIndex = 0;
+    if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_D) {
+        gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
     }
 
     if (gSaveContext.nextDayTime != NEXT_TIME_NONE) {
@@ -347,7 +347,7 @@ void Play_Init(GameState* thisx) {
 
     Cutscene_HandleConditionalTriggers(this);
 
-    if (gSaveContext.gameMode != GAMEMODE_NORMAL || gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
+    if (gSaveContext.gameMode != GAMEMODE_NORMAL || gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0) {
         gSaveContext.nayrusLoveTimer = 0;
         Magic_Reset(this);
         gSaveContext.sceneLayer = SCENE_LAYER_CUTSCENE_FIRST + (gSaveContext.save.cutsceneIndex & 0xF);
@@ -597,7 +597,7 @@ void Play_Update(PlayState* this) {
 
                         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_NOTHING);
 
-                        if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
+                        if (gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0) {
                             sceneLayer = SCENE_LAYER_CUTSCENE_FIRST + (gSaveContext.save.cutsceneIndex & 0xF);
                         }
 

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -382,7 +382,7 @@ BAD_RETURN(s32) Scene_CommandTimeSettings(PlayState* play, SceneCmd* cmd) {
     play->envCtx.sunPos.y = (Math_CosS(((void)0, gSaveContext.save.dayTime) - CLOCK_TIME(12, 0)) * 120.0f) * 25.0f;
     play->envCtx.sunPos.z = (Math_CosS(((void)0, gSaveContext.save.dayTime) - CLOCK_TIME(12, 0)) * 20.0f) * 25.0f;
 
-    if (((play->envCtx.sceneTimeSpeed == 0) && (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) ||
+    if (((play->envCtx.sceneTimeSpeed == 0) && (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0)) ||
         (gSaveContext.save.entranceIndex == ENTR_LAKE_HYLIA_8)) {
 #if OOT_VERSION >= PAL_1_0
         gSaveContext.skyboxTime = ((void)0, gSaveContext.save.dayTime);
@@ -488,7 +488,7 @@ BAD_RETURN(s32) Scene_CommandMiscSettings(PlayState* play, SceneCmd* cmd) {
 
     if (((play->sceneId >= SCENE_HYRULE_FIELD) && (play->sceneId <= SCENE_OUTSIDE_GANONS_CASTLE)) ||
         ((play->sceneId >= SCENE_MARKET_ENTRANCE_DAY) && (play->sceneId <= SCENE_TEMPLE_OF_TIME_EXTERIOR_RUINS))) {
-        if (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) {
+        if (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0) {
             gSaveContext.save.info.worldMapAreaData |= gBitFlags[((void)0, gSaveContext.worldMapArea)];
             PRINTF("０００  ａｒｅａ＿ａｒｒｉｖａｌ＝%x (%d)\n", gSaveContext.save.info.worldMapAreaData,
                    ((void)0, gSaveContext.worldMapArea));

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -382,7 +382,7 @@ BAD_RETURN(s32) Scene_CommandTimeSettings(PlayState* play, SceneCmd* cmd) {
     play->envCtx.sunPos.y = (Math_CosS(((void)0, gSaveContext.save.dayTime) - CLOCK_TIME(12, 0)) * 120.0f) * 25.0f;
     play->envCtx.sunPos.z = (Math_CosS(((void)0, gSaveContext.save.dayTime) - CLOCK_TIME(12, 0)) * 20.0f) * 25.0f;
 
-    if (((play->envCtx.sceneTimeSpeed == 0) && (gSaveContext.save.cutsceneIndex < 0xFFF0)) ||
+    if (((play->envCtx.sceneTimeSpeed == 0) && (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) ||
         (gSaveContext.save.entranceIndex == ENTR_LAKE_HYLIA_8)) {
 #if OOT_VERSION >= PAL_1_0
         gSaveContext.skyboxTime = ((void)0, gSaveContext.save.dayTime);
@@ -488,7 +488,7 @@ BAD_RETURN(s32) Scene_CommandMiscSettings(PlayState* play, SceneCmd* cmd) {
 
     if (((play->sceneId >= SCENE_HYRULE_FIELD) && (play->sceneId <= SCENE_OUTSIDE_GANONS_CASTLE)) ||
         ((play->sceneId >= SCENE_MARKET_ENTRANCE_DAY) && (play->sceneId <= SCENE_TEMPLE_OF_TIME_EXTERIOR_RUINS))) {
-        if (gSaveContext.save.cutsceneIndex < 0xFFF0) {
+        if (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) {
             gSaveContext.save.info.worldMapAreaData |= gBitFlags[((void)0, gSaveContext.worldMapArea)];
             PRINTF("０００  ａｒｅａ＿ａｒｒｉｖａｌ＝%x (%d)\n", gSaveContext.save.info.worldMapAreaData,
                    ((void)0, gSaveContext.worldMapArea));

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -793,7 +793,7 @@ void Sram_InitSave(FileSelectState* fileSelect, SramContext* sramCtx) {
     gSaveContext.save.entranceIndex = ENTR_LINKS_HOUSE_0;
     gSaveContext.save.linkAge = LINK_AGE_CHILD;
     gSaveContext.save.dayTime = CLOCK_TIME(10, 0);
-    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+    gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
 
 #if OOT_DEBUG
     if (fileSelect->buttonIndex == 0) {

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -793,11 +793,11 @@ void Sram_InitSave(FileSelectState* fileSelect, SramContext* sramCtx) {
     gSaveContext.save.entranceIndex = ENTR_LINKS_HOUSE_0;
     gSaveContext.save.linkAge = LINK_AGE_CHILD;
     gSaveContext.save.dayTime = CLOCK_TIME(10, 0);
-    gSaveContext.save.cutsceneIndex = 0xFFF1;
+    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
 
 #if OOT_DEBUG
     if (fileSelect->buttonIndex == 0) {
-        gSaveContext.save.cutsceneIndex = 0;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
     }
 #endif
 

--- a/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
+++ b/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
@@ -45,7 +45,7 @@ void BgInGate_Init(Actor* thisx, PlayState* play) {
     this->dyna.bgId = DynaPoly_SetBgActor(play, &play->colCtx.dyna, &this->dyna.actor, colHeader);
 
     if ((play->sceneId != SCENE_LON_LON_RANCH || !LINK_IS_ADULT) ||
-        (GET_EVENTCHKINF(EVENTCHKINF_EPONA_OBTAINED) && (gSaveContext.save.cutsceneIndex != 0xFFF0))) {
+        (GET_EVENTCHKINF(EVENTCHKINF_EPONA_OBTAINED) && (gSaveContext.save.cutsceneIndex != CS_INDEX_FFF0))) {
         Actor_Kill(&this->dyna.actor);
         return;
     }

--- a/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
+++ b/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
@@ -45,7 +45,7 @@ void BgInGate_Init(Actor* thisx, PlayState* play) {
     this->dyna.bgId = DynaPoly_SetBgActor(play, &play->colCtx.dyna, &this->dyna.actor, colHeader);
 
     if ((play->sceneId != SCENE_LON_LON_RANCH || !LINK_IS_ADULT) ||
-        (GET_EVENTCHKINF(EVENTCHKINF_EPONA_OBTAINED) && (gSaveContext.save.cutsceneIndex != CS_INDEX_FFF0))) {
+        (GET_EVENTCHKINF(EVENTCHKINF_EPONA_OBTAINED) && (gSaveContext.save.cutsceneIndex != CS_INDEX_SCRIPTED_0))) {
         Actor_Kill(&this->dyna.actor);
         return;
     }

--- a/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
+++ b/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
@@ -108,7 +108,8 @@ void BgRelayObjects_Destroy(Actor* thisx, PlayState* play) {
     BgRelayObjects* this = (BgRelayObjects*)thisx;
 
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
-    if ((this->dyna.actor.params == WINDMILL_ROTATING_GEAR) && (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0)) {
+    if ((this->dyna.actor.params == WINDMILL_ROTATING_GEAR) &&
+        (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0)) {
         CLEAR_EVENTCHKINF(EVENTCHKINF_65);
     }
 }

--- a/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
+++ b/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
@@ -108,7 +108,7 @@ void BgRelayObjects_Destroy(Actor* thisx, PlayState* play) {
     BgRelayObjects* this = (BgRelayObjects*)thisx;
 
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
-    if ((this->dyna.actor.params == WINDMILL_ROTATING_GEAR) && (gSaveContext.save.cutsceneIndex < 0xFFF0)) {
+    if ((this->dyna.actor.params == WINDMILL_ROTATING_GEAR) && (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) {
         CLEAR_EVENTCHKINF(EVENTCHKINF_65);
     }
 }

--- a/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
+++ b/src/overlays/actors/ovl_Bg_Relay_Objects/z_bg_relay_objects.c
@@ -108,7 +108,7 @@ void BgRelayObjects_Destroy(Actor* thisx, PlayState* play) {
     BgRelayObjects* this = (BgRelayObjects*)thisx;
 
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
-    if ((this->dyna.actor.params == WINDMILL_ROTATING_GEAR) && (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0)) {
+    if ((this->dyna.actor.params == WINDMILL_ROTATING_GEAR) && (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0)) {
         CLEAR_EVENTCHKINF(EVENTCHKINF_65);
     }
 }

--- a/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
+++ b/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
@@ -217,7 +217,7 @@ void BgSpot00Hanebasi_Update(Actor* thisx, PlayState* play) {
                     this->actionFunc = BgSpot00Hanebasi_DoNothing;
                     Player_SetCsActionWithHaltedActors(play, &player->actor, PLAYER_CSACTION_8);
                     play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
-                    gSaveContext.nextCutsceneIndex = 0xFFF1;
+                    gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
                     play->transitionTrigger = TRANS_TRIGGER_START;
                     play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 } else if (Actor_IsFacingAndNearPlayer(&this->dyna.actor, 3000.0f, 0x7530)) {

--- a/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
+++ b/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
@@ -217,7 +217,7 @@ void BgSpot00Hanebasi_Update(Actor* thisx, PlayState* play) {
                     this->actionFunc = BgSpot00Hanebasi_DoNothing;
                     Player_SetCsActionWithHaltedActors(play, &player->actor, PLAYER_CSACTION_8);
                     play->nextEntranceIndex = ENTR_HYRULE_FIELD_0;
-                    gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
+                    gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_1;
                     play->transitionTrigger = TRANS_TRIGGER_START;
                     play->transitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 } else if (Actor_IsFacingAndNearPlayer(&this->dyna.actor, 3000.0f, 0x7530)) {

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -2104,7 +2104,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
             FALLTHROUGH;
         case 20:
             play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
-            gSaveContext.nextCutsceneIndex = CS_INDEX_FFF2;
+            gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_2;
             play->transitionTrigger = TRANS_TRIGGER_START;
             play->transitionType = TRANS_TYPE_FADE_WHITE;
             play->linkAgeOnLoad = LINK_AGE_CHILD;

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -2104,7 +2104,7 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
             FALLTHROUGH;
         case 20:
             play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
-            gSaveContext.nextCutsceneIndex = 0xFFF2;
+            gSaveContext.nextCutsceneIndex = CS_INDEX_FFF2;
             play->transitionTrigger = TRANS_TRIGGER_START;
             play->transitionType = TRANS_TYPE_FADE_WHITE;
             play->linkAgeOnLoad = LINK_AGE_CHILD;

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -489,7 +489,7 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
     Math_SmoothStepToF(&this->lightRayAlpha, 0.0f, 0.2f, 6.0f, 0.01f);
     this->warpTimer++;
 
-    if (sWarpTimerTarget < this->warpTimer && gSaveContext.nextCutsceneIndex == 0xFFEF) {
+    if (sWarpTimerTarget < this->warpTimer && gSaveContext.nextCutsceneIndex == CS_INDEX_FFEF) {
         PRINTF("\n\n\nじかんがきたからおーしまい fade_direction=[%d]", play->transitionTrigger, TRANS_TRIGGER_START);
 
         if (play->sceneId == SCENE_DODONGOS_CAVERN_BOSS) {
@@ -497,10 +497,10 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
                 Flags_SetEventChkInf(EVENTCHKINF_25);
                 Item_Give(play, ITEM_GORON_RUBY);
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
-                gSaveContext.nextCutsceneIndex = 0xFFF1;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
             } else {
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_5;
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
             }
         } else if (play->sceneId == SCENE_DEKU_TREE_BOSS) {
             if (!Flags_GetEventChkInf(EVENTCHKINF_07)) {
@@ -508,14 +508,14 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
                 Flags_SetEventChkInf(EVENTCHKINF_09);
                 Item_Give(play, ITEM_KOKIRI_EMERALD);
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.nextCutsceneIndex = 0xFFF1;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
             } else {
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_11;
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
             }
         } else if (play->sceneId == SCENE_JABU_JABU_BOSS) {
             play->nextEntranceIndex = ENTR_ZORAS_FOUNTAIN_0;
-            gSaveContext.nextCutsceneIndex = 0;
+            gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
         }
         PRINTF("\n\n\nおわりおわり");
         play->transitionTrigger = TRANS_TRIGGER_START;
@@ -600,11 +600,11 @@ void DoorWarp1_RutoWarpOut(DoorWarp1* this, PlayState* play) {
     Math_SmoothStepToF(&this->lightRayAlpha, 0.0f, 0.2f, 6.0f, 0.01f);
     this->warpTimer++;
 
-    if (this->warpTimer > sWarpTimerTarget && gSaveContext.nextCutsceneIndex == 0xFFEF) {
+    if (this->warpTimer > sWarpTimerTarget && gSaveContext.nextCutsceneIndex == CS_INDEX_FFEF) {
         SET_EVENTCHKINF(EVENTCHKINF_37);
         Item_Give(play, ITEM_ZORA_SAPPHIRE);
         play->nextEntranceIndex = ENTR_ZORAS_FOUNTAIN_0;
-        gSaveContext.nextCutsceneIndex = 0xFFF0;
+        gSaveContext.nextCutsceneIndex = CS_INDEX_FFF0;
         play->transitionTrigger = TRANS_TRIGGER_START;
         play->transitionType = TRANS_TYPE_FADE_WHITE_SLOW;
     }
@@ -700,13 +700,13 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
     }
     this->warpTimer++;
 
-    if (this->warpTimer > sWarpTimerTarget && gSaveContext.nextCutsceneIndex == 0xFFEF) {
+    if (this->warpTimer > sWarpTimerTarget && gSaveContext.nextCutsceneIndex == CS_INDEX_FFEF) {
         if (play->sceneId == SCENE_FOREST_TEMPLE_BOSS) {
             if (!GET_EVENTCHKINF(EVENTCHKINF_48)) {
                 SET_EVENTCHKINF(EVENTCHKINF_48);
                 Item_Give(play, ITEM_MEDALLION_FOREST);
                 play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
                 gSaveContext.chamberCutsceneNum = CHAMBER_CS_FOREST;
             } else {
                 if (!LINK_IS_ADULT) {
@@ -714,28 +714,28 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
                 } else {
                     play->nextEntranceIndex = ENTR_SACRED_FOREST_MEADOW_3;
                 }
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
             }
         } else if (play->sceneId == SCENE_FIRE_TEMPLE_BOSS) {
             if (!GET_EVENTCHKINF(EVENTCHKINF_49)) {
                 SET_EVENTCHKINF(EVENTCHKINF_49);
                 Item_Give(play, ITEM_MEDALLION_FIRE);
                 play->nextEntranceIndex = ENTR_KAKARIKO_VILLAGE_0;
-                gSaveContext.nextCutsceneIndex = 0xFFF3;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF3;
             } else {
                 if (!LINK_IS_ADULT) {
                     play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_CRATER_4;
                 } else {
                     play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_CRATER_5;
                 }
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
             }
         } else if (play->sceneId == SCENE_WATER_TEMPLE_BOSS) {
             if (!GET_EVENTCHKINF(EVENTCHKINF_4A)) {
                 SET_EVENTCHKINF(EVENTCHKINF_4A);
                 Item_Give(play, ITEM_MEDALLION_WATER);
                 play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
                 gSaveContext.chamberCutsceneNum = CHAMBER_CS_WATER;
             } else {
                 if (!LINK_IS_ADULT) {
@@ -743,13 +743,13 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
                 } else {
                     play->nextEntranceIndex = ENTR_LAKE_HYLIA_9;
                 }
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
             }
         } else if (play->sceneId == SCENE_SPIRIT_TEMPLE_BOSS) {
             if (!CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT)) {
                 Item_Give(play, ITEM_MEDALLION_SPIRIT);
                 play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
                 gSaveContext.chamberCutsceneNum = CHAMBER_CS_SPIRIT;
             } else {
                 if (!LINK_IS_ADULT) {
@@ -757,13 +757,13 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
                 } else {
                     play->nextEntranceIndex = ENTR_DESERT_COLOSSUS_8;
                 }
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
             }
         } else if (play->sceneId == SCENE_SHADOW_TEMPLE_BOSS) {
             if (!CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW)) {
                 Item_Give(play, ITEM_MEDALLION_SHADOW);
                 play->nextEntranceIndex = ENTR_CHAMBER_OF_THE_SAGES_0;
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
                 gSaveContext.chamberCutsceneNum = CHAMBER_CS_SHADOW;
             } else {
                 if (!LINK_IS_ADULT) {
@@ -771,7 +771,7 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
                 } else {
                     play->nextEntranceIndex = ENTR_GRAVEYARD_8;
                 }
-                gSaveContext.nextCutsceneIndex = 0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
             }
         }
         play->transitionTrigger = TRANS_TRIGGER_START;

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -489,7 +489,7 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
     Math_SmoothStepToF(&this->lightRayAlpha, 0.0f, 0.2f, 6.0f, 0.01f);
     this->warpTimer++;
 
-    if (sWarpTimerTarget < this->warpTimer && gSaveContext.nextCutsceneIndex == CS_INDEX_FFEF) {
+    if (sWarpTimerTarget < this->warpTimer && gSaveContext.nextCutsceneIndex == CS_INDEX_MANUAL) {
         PRINTF("\n\n\nじかんがきたからおーしまい fade_direction=[%d]", play->transitionTrigger, TRANS_TRIGGER_START);
 
         if (play->sceneId == SCENE_DODONGOS_CAVERN_BOSS) {
@@ -497,7 +497,7 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
                 Flags_SetEventChkInf(EVENTCHKINF_25);
                 Item_Give(play, ITEM_GORON_RUBY);
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_0;
-                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_1;
             } else {
                 play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_TRAIL_5;
                 gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
@@ -508,7 +508,7 @@ void DoorWarp1_ChildWarpOut(DoorWarp1* this, PlayState* play) {
                 Flags_SetEventChkInf(EVENTCHKINF_09);
                 Item_Give(play, ITEM_KOKIRI_EMERALD);
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_0;
-                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_1;
             } else {
                 play->nextEntranceIndex = ENTR_KOKIRI_FOREST_11;
                 gSaveContext.nextCutsceneIndex = CS_INDEX_NONE;
@@ -600,11 +600,11 @@ void DoorWarp1_RutoWarpOut(DoorWarp1* this, PlayState* play) {
     Math_SmoothStepToF(&this->lightRayAlpha, 0.0f, 0.2f, 6.0f, 0.01f);
     this->warpTimer++;
 
-    if (this->warpTimer > sWarpTimerTarget && gSaveContext.nextCutsceneIndex == CS_INDEX_FFEF) {
+    if (this->warpTimer > sWarpTimerTarget && gSaveContext.nextCutsceneIndex == CS_INDEX_MANUAL) {
         SET_EVENTCHKINF(EVENTCHKINF_37);
         Item_Give(play, ITEM_ZORA_SAPPHIRE);
         play->nextEntranceIndex = ENTR_ZORAS_FOUNTAIN_0;
-        gSaveContext.nextCutsceneIndex = CS_INDEX_FFF0;
+        gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_0;
         play->transitionTrigger = TRANS_TRIGGER_START;
         play->transitionType = TRANS_TYPE_FADE_WHITE_SLOW;
     }
@@ -700,7 +700,7 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
     }
     this->warpTimer++;
 
-    if (this->warpTimer > sWarpTimerTarget && gSaveContext.nextCutsceneIndex == CS_INDEX_FFEF) {
+    if (this->warpTimer > sWarpTimerTarget && gSaveContext.nextCutsceneIndex == CS_INDEX_MANUAL) {
         if (play->sceneId == SCENE_FOREST_TEMPLE_BOSS) {
             if (!GET_EVENTCHKINF(EVENTCHKINF_48)) {
                 SET_EVENTCHKINF(EVENTCHKINF_48);
@@ -721,7 +721,7 @@ void DoorWarp1_AdultWarpOut(DoorWarp1* this, PlayState* play) {
                 SET_EVENTCHKINF(EVENTCHKINF_49);
                 Item_Give(play, ITEM_MEDALLION_FIRE);
                 play->nextEntranceIndex = ENTR_KAKARIKO_VILLAGE_0;
-                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF3;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_3;
             } else {
                 if (!LINK_IS_ADULT) {
                     play->nextEntranceIndex = ENTR_DEATH_MOUNTAIN_CRATER_4;

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -292,7 +292,7 @@ void EnDu_Init(Actor* thisx, PlayState* play) {
     this->actor.attentionRangeType = ATTENTION_RANGE_1;
     this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
 
-    if (gSaveContext.save.cutsceneIndex >= 0xFFF0) {
+    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
         play->csCtx.script = SEGMENTED_TO_VIRTUAL(gGoronCityDarunia01Cs);
         gSaveContext.cutsceneTrigger = 1;
         EnDu_SetupAction(this, func_809FE890);

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -292,7 +292,7 @@ void EnDu_Init(Actor* thisx, PlayState* play) {
     this->actor.attentionRangeType = ATTENTION_RANGE_1;
     this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
 
-    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
+    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0) {
         play->csCtx.script = SEGMENTED_TO_VIRTUAL(gGoronCityDarunia01Cs);
         gSaveContext.cutsceneTrigger = 1;
         EnDu_SetupAction(this, func_809FE890);

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -577,7 +577,7 @@ void EnGe1_BeginGame_Archery(EnGe1* this, PlayState* play) {
                 } else {
                     Rupees_ChangeBy(-20);
                     play->nextEntranceIndex = ENTR_GERUDOS_FORTRESS_0;
-                    gSaveContext.nextCutsceneIndex = 0xFFF0;
+                    gSaveContext.nextCutsceneIndex = CS_INDEX_FFF0;
                     play->transitionType = TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST);
                     play->transitionTrigger = TRANS_TRIGGER_START;
                     SET_EVENTINF(EVENTINF_HORSES_08);

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -577,7 +577,7 @@ void EnGe1_BeginGame_Archery(EnGe1* this, PlayState* play) {
                 } else {
                     Rupees_ChangeBy(-20);
                     play->nextEntranceIndex = ENTR_GERUDOS_FORTRESS_0;
-                    gSaveContext.nextCutsceneIndex = CS_INDEX_FFF0;
+                    gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_0;
                     play->transitionType = TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST);
                     play->transitionTrigger = TRANS_TRIGGER_START;
                     SET_EVENTINF(EVENTINF_HORSES_08);

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -2544,7 +2544,7 @@ void EnHorse_UpdateHorsebackArchery(EnHorse* this, PlayState* play) {
     EnHorse_UpdateHbaRaceInfo(this, play, &sHbaInfo);
     if ((this->hbaFlags & 1) || (this->hbaTimer >= 46)) {
         if ((isFanfarePlaying != true) && (gSaveContext.minigameState != 3)) {
-            gSaveContext.save.cutsceneIndex = 0;
+            gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
             play->nextEntranceIndex = ENTR_GERUDOS_FORTRESS_16;
             play->transitionTrigger = TRANS_TRIGGER_START;
             play->transitionType = TRANS_TYPE_CIRCLE(TCA_NORMAL, TCC_BLACK, TCS_FAST);

--- a/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
+++ b/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
@@ -110,7 +110,7 @@ s32 EnHorseGameCheck_DestroyIngoRace(EnHorseGameCheckBase* base, PlayState* play
 }
 
 void EnHorseGameCheck_FinishIngoRace(EnHorseGameCheckIngoRace* this, PlayState* play) {
-    gSaveContext.save.cutsceneIndex = 0;
+    gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
     if (this->result == INGORACE_PLAYER_WIN) {
         play->nextEntranceIndex = ENTR_LON_LON_RANCH_7;
         if (GET_EVENTINF(EVENTINF_HORSES_06)) {
@@ -297,21 +297,21 @@ s32 EnHorseGameCheck_DestroyMalonRace(EnHorseGameCheckBase* base, PlayState* pla
 
 void EnHorseGameCheck_FinishMalonRace(EnHorseGameCheckMalonRace* this, PlayState* play) {
     if ((this->result == MALONRACE_SUCCESS) || (this->result == MALONRACE_TIME_UP)) {
-        gSaveContext.save.cutsceneIndex = 0;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
         play->nextEntranceIndex = ENTR_LON_LON_RANCH_7;
         play->transitionType = TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_WHITE, TCS_FAST);
         play->transitionTrigger = TRANS_TRIGGER_START;
     } else if (this->result == MALONRACE_FAILURE) {
         gSaveContext.timerSeconds = 240;
         gSaveContext.timerState = TIMER_STATE_UP_FREEZE;
-        gSaveContext.save.cutsceneIndex = 0;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
         play->nextEntranceIndex = ENTR_LON_LON_RANCH_7;
         play->transitionType = TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_WHITE, TCS_FAST);
         play->transitionTrigger = TRANS_TRIGGER_START;
     } else {
         // "not supported"
         PRINTF("En_HGC_Spot20_Ta_end():対応せず\n");
-        gSaveContext.save.cutsceneIndex = 0;
+        gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
         play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
         play->transitionType = TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_WHITE, TCS_FAST);
         play->transitionTrigger = TRANS_TRIGGER_START;

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
@@ -357,7 +357,7 @@ void func_80A6A068(EnHorseLinkChild* this, PlayState* play) {
     }
 
     if ((GET_EVENTCHKINF(EVENTCHKINF_CAN_LEARN_EPONAS_SONG) && R_EPONAS_SONG_PLAYED) ||
-        ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == 0xFFF1))) {
+        ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF1))) {
         func_80A6A4DC(this);
     } else {
         this->unk_2A0 = GET_EVENTCHKINF(EVENTCHKINF_CAN_LEARN_EPONAS_SONG);

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
@@ -357,7 +357,7 @@ void func_80A6A068(EnHorseLinkChild* this, PlayState* play) {
     }
 
     if ((GET_EVENTCHKINF(EVENTCHKINF_CAN_LEARN_EPONAS_SONG) && R_EPONAS_SONG_PLAYED) ||
-        ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF1))) {
+        ((play->sceneId == SCENE_LON_LON_RANCH) && (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_1))) {
         func_80A6A4DC(this);
     } else {
         this->unk_2A0 = GET_EVENTCHKINF(EVENTCHKINF_CAN_LEARN_EPONAS_SONG);

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -427,7 +427,7 @@ void func_80A79BAC(EnIn* this, PlayState* play, s32 index, u32 transitionType) {
 
     play->nextEntranceIndex = entrances[index];
     if (index == 2) {
-        gSaveContext.nextCutsceneIndex = CS_INDEX_FFF0;
+        gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_0;
     }
     play->transitionType = transitionType;
     play->transitionTrigger = TRANS_TRIGGER_START;

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -427,7 +427,7 @@ void func_80A79BAC(EnIn* this, PlayState* play, s32 index, u32 transitionType) {
 
     play->nextEntranceIndex = entrances[index];
     if (index == 2) {
-        gSaveContext.nextCutsceneIndex = 0xFFF0;
+        gSaveContext.nextCutsceneIndex = CS_INDEX_FFF0;
     }
     play->transitionType = transitionType;
     play->transitionTrigger = TRANS_TRIGGER_START;

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -380,7 +380,7 @@ void EnMa1_WaitForPlayback(EnMa1* this, PlayState* play) {
     GET_PLAYER(play)->stateFlags2 |= PLAYER_STATE2_23;
     if (play->msgCtx.ocarinaMode == OCARINA_MODE_03) {
         play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
-        gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
+        gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_1;
         play->transitionType = TRANS_TYPE_CIRCLE(TCA_WAVE, TCC_WHITE, TCS_FAST);
         play->transitionTrigger = TRANS_TRIGGER_START;
         this->actionFunc = EnMa1_DoNothing;

--- a/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
+++ b/src/overlays/actors/ovl_En_Ma1/z_en_ma1.c
@@ -380,7 +380,7 @@ void EnMa1_WaitForPlayback(EnMa1* this, PlayState* play) {
     GET_PLAYER(play)->stateFlags2 |= PLAYER_STATE2_23;
     if (play->msgCtx.ocarinaMode == OCARINA_MODE_03) {
         play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
-        gSaveContext.nextCutsceneIndex = 0xFFF1;
+        gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
         play->transitionType = TRANS_TYPE_CIRCLE(TCA_WAVE, TCC_WHITE, TCS_FAST);
         play->transitionTrigger = TRANS_TRIGGER_START;
         this->actionFunc = EnMa1_DoNothing;

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -118,7 +118,7 @@ s16 EnMa3_UpdateTalkState(PlayState* play, Actor* thisx) {
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
-                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_0;
                 play->transitionType = TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST);
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 SET_EVENTINF(EVENTINF_HORSES_0A);

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.c
@@ -118,7 +118,7 @@ s16 EnMa3_UpdateTalkState(PlayState* play, Actor* thisx) {
         case TEXT_STATE_EVENT:
             if (Message_ShouldAdvance(play)) {
                 play->nextEntranceIndex = ENTR_LON_LON_RANCH_0;
-                gSaveContext.nextCutsceneIndex = 0xFFF0;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF0;
                 play->transitionType = TRANS_TYPE_CIRCLE(TCA_STARBURST, TCC_BLACK, TCS_FAST);
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 SET_EVENTINF(EVENTINF_HORSES_0A);

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -379,7 +379,7 @@ void EnSa_ChangeAnim(EnSa* this, s32 index) {
 }
 
 s32 func_80AF5DFC(EnSa* this, PlayState* play) {
-    if (gSaveContext.save.cutsceneIndex >= 0xFFF0 && gSaveContext.save.cutsceneIndex != 0xFFFD) {
+    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0 && gSaveContext.save.cutsceneIndex != CS_INDEX_FFFD) {
         if (play->sceneId == SCENE_KOKIRI_FOREST) {
             return 4;
         }

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -379,7 +379,7 @@ void EnSa_ChangeAnim(EnSa* this, s32 index) {
 }
 
 s32 func_80AF5DFC(EnSa* this, PlayState* play) {
-    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0 && gSaveContext.save.cutsceneIndex != CS_INDEX_FFFD) {
+    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0 && gSaveContext.save.cutsceneIndex != CS_INDEX_SCRIPTED_D) {
         if (play->sceneId == SCENE_KOKIRI_FOREST) {
             return 4;
         }

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -379,7 +379,8 @@ void EnSa_ChangeAnim(EnSa* this, s32 index) {
 }
 
 s32 func_80AF5DFC(EnSa* this, PlayState* play) {
-    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0 && gSaveContext.save.cutsceneIndex != CS_INDEX_SCRIPTED_D) {
+    if (gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0 &&
+        gSaveContext.save.cutsceneIndex != CS_INDEX_SCRIPTED_D) {
         if (play->sceneId == SCENE_KOKIRI_FOREST) {
             return 4;
         }

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -779,7 +779,7 @@ s32 EnZl4_CsAskName(EnZl4* this, PlayState* play) {
             if (this->talkTimer2 == 130) {
                 play->msgCtx.msgMode = MSGMODE_PAUSED;
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
-                gSaveContext.nextCutsceneIndex = 0xFFF7;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF7;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
             }

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -779,7 +779,7 @@ s32 EnZl4_CsAskName(EnZl4* this, PlayState* play) {
             if (this->talkTimer2 == 130) {
                 play->msgCtx.msgMode = MSGMODE_PAUSED;
                 play->nextEntranceIndex = ENTR_CUTSCENE_MAP_0;
-                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF7;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_7;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
             }

--- a/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
+++ b/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
@@ -44,7 +44,7 @@ void ObjDekujr_Init(Actor* thisx, PlayState* play) {
     ObjDekujr* this = (ObjDekujr*)thisx;
     s32 pad;
 
-    if (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) {
+    if (gSaveContext.save.cutsceneIndex < CS_INDEX_SCRIPTED_0) {
         if (!LINK_IS_ADULT) {
             Actor_Kill(thisx);
             return;
@@ -140,7 +140,7 @@ void ObjDekujr_Update(Actor* thisx, PlayState* play) {
 
     Collider_UpdateCylinder(&this->actor, &this->collider);
     CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
-    if ((gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) && (this->unk_19B == 0)) {
+    if ((gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0) && (this->unk_19B == 0)) {
         this->unk_19C = 0;
         this->unk_19B = 1;
     }

--- a/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
+++ b/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
@@ -44,7 +44,7 @@ void ObjDekujr_Init(Actor* thisx, PlayState* play) {
     ObjDekujr* this = (ObjDekujr*)thisx;
     s32 pad;
 
-    if (gSaveContext.save.cutsceneIndex < 0xFFF0) {
+    if (gSaveContext.save.cutsceneIndex < CS_INDEX_FFF0) {
         if (!LINK_IS_ADULT) {
             Actor_Kill(thisx);
             return;
@@ -140,7 +140,7 @@ void ObjDekujr_Update(Actor* thisx, PlayState* play) {
 
     Collider_UpdateCylinder(&this->actor, &this->collider);
     CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
-    if ((gSaveContext.save.cutsceneIndex >= 0xFFF0) && (this->unk_19B == 0)) {
+    if ((gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) && (this->unk_19B == 0)) {
         this->unk_19C = 0;
         this->unk_19B = 1;
     }

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -81,10 +81,10 @@ typedef enum AnimSfxType {
 
 #define ANIMSFX_SHIFT_TYPE(type) ((type) << 11)
 
-#define ANIMSFX_DATA(type, frame) ((ANIMSFX_SHIFT_TYPE(type) | ((frame)&0x7FF)))
+#define ANIMSFX_DATA(type, frame) ((ANIMSFX_SHIFT_TYPE(type) | ((frame) & 0x7FF)))
 
-#define ANIMSFX_GET_TYPE(data) ((data)&0x7800)
-#define ANIMSFX_GET_FRAME(data) ((data)&0x7FF)
+#define ANIMSFX_GET_TYPE(data) ((data) & 0x7800)
+#define ANIMSFX_GET_FRAME(data) ((data) & 0x7FF)
 
 typedef struct AnimSfxEntry {
     /* 0x00 */ u16 sfxId;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10751,7 +10751,7 @@ void Player_Init(Actor* thisx, PlayState* play2) {
 
     initMode = PARAMS_GET_S(thisx->params, 8, 4);
     if ((initMode == 5) || (initMode == 6)) {
-        if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
+        if (gSaveContext.save.cutsceneIndex >= CS_INDEX_SCRIPTED_0) {
             initMode = 13;
         }
     }
@@ -13670,7 +13670,7 @@ s32 func_8084DFF4(PlayState* play, Player* this) {
             if (this->getItemId == GI_SILVER_GAUNTLETS) {
                 play->nextEntranceIndex = ENTR_DESERT_COLOSSUS_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_SCRIPTED_1;
                 play->transitionType = TRANS_TYPE_SANDSTORM_END;
                 this->stateFlags1 &= ~PLAYER_STATE1_29;
                 Player_TryCsAction(play, NULL, PLAYER_CSACTION_8);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10751,7 +10751,7 @@ void Player_Init(Actor* thisx, PlayState* play2) {
 
     initMode = PARAMS_GET_S(thisx->params, 8, 4);
     if ((initMode == 5) || (initMode == 6)) {
-        if (gSaveContext.save.cutsceneIndex >= 0xFFF0) {
+        if (gSaveContext.save.cutsceneIndex >= CS_INDEX_FFF0) {
             initMode = 13;
         }
     }
@@ -13670,7 +13670,7 @@ s32 func_8084DFF4(PlayState* play, Player* this) {
             if (this->getItemId == GI_SILVER_GAUNTLETS) {
                 play->nextEntranceIndex = ENTR_DESERT_COLOSSUS_0;
                 play->transitionTrigger = TRANS_TRIGGER_START;
-                gSaveContext.nextCutsceneIndex = 0xFFF1;
+                gSaveContext.nextCutsceneIndex = CS_INDEX_FFF1;
                 play->transitionType = TRANS_TYPE_SANDSTORM_END;
                 this->stateFlags1 &= ~PLAYER_STATE1_29;
                 Player_TryCsAction(play, NULL, PLAYER_CSACTION_8);

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1890,7 +1890,7 @@ void FileSelect_LoadGame(GameState* thisx) {
     gSaveContext.forcedSeqId = NA_BGM_GENERAL_SFX;
     gSaveContext.skyboxTime = CLOCK_TIME(0, 0);
     gSaveContext.nextTransitionType = TRANS_NEXT_TYPE_DEFAULT;
-    gSaveContext.nextCutsceneIndex = CS_INDEX_FFEF;
+    gSaveContext.nextCutsceneIndex = CS_INDEX_MANUAL;
     gSaveContext.cutsceneTrigger = 0;
     gSaveContext.chamberCutsceneNum = CHAMBER_CS_FOREST;
     gSaveContext.nextDayTime = NEXT_TIME_NONE;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1890,7 +1890,7 @@ void FileSelect_LoadGame(GameState* thisx) {
     gSaveContext.forcedSeqId = NA_BGM_GENERAL_SFX;
     gSaveContext.skyboxTime = CLOCK_TIME(0, 0);
     gSaveContext.nextTransitionType = TRANS_NEXT_TYPE_DEFAULT;
-    gSaveContext.nextCutsceneIndex = 0xFFEF;
+    gSaveContext.nextCutsceneIndex = CS_INDEX_FFEF;
     gSaveContext.cutsceneTrigger = 0;
     gSaveContext.chamberCutsceneNum = CHAMBER_CS_FOREST;
     gSaveContext.nextDayTime = NEXT_TIME_NONE;

--- a/src/overlays/gamestates/ovl_opening/z_opening.c
+++ b/src/overlays/gamestates/ovl_opening/z_opening.c
@@ -11,7 +11,7 @@ void TitleSetup_SetupTitleScreen(TitleSetupState* this) {
     this->state.running = false;
     gSaveContext.save.linkAge = LINK_AGE_ADULT;
     Sram_InitDebugSave();
-    gSaveContext.save.cutsceneIndex = 0xFFF3;
+    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
     gSaveContext.sceneLayer = 7;
     SET_NEXT_GAMESTATE(&this->state, Play_Init, PlayState);
 }

--- a/src/overlays/gamestates/ovl_opening/z_opening.c
+++ b/src/overlays/gamestates/ovl_opening/z_opening.c
@@ -11,8 +11,12 @@ void TitleSetup_SetupTitleScreen(TitleSetupState* this) {
     this->state.running = false;
     gSaveContext.save.linkAge = LINK_AGE_ADULT;
     Sram_InitDebugSave();
-    gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+    gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
     gSaveContext.sceneLayer = 7;
+    // assigning scene layer here is redundant, as Play_Init sets it to
+    // SCENE_LAYER_CUTSCENE_FIRST + (gSaveContext.save.cutsceneIndex & 0xF)
+    // or one of the other `enum SceneLayer` values; even so, `7` is exactly
+    // the value this formula equals to for CS_INDEX_SCRIPTED_3
     SET_NEXT_GAMESTATE(&this->state, Play_Init, PlayState);
 }
 

--- a/src/overlays/gamestates/ovl_select/z_select.c
+++ b/src/overlays/gamestates/ovl_select/z_select.c
@@ -335,60 +335,60 @@ void MapSelect_UpdateMenu(MapSelectState* this) {
         }
 
         if (CHECK_BTN_ALL(input->press.button, BTN_Z)) {
-            if (gSaveContext.save.cutsceneIndex == CS_INDEX_8000) {
+            if (gSaveContext.save.cutsceneIndex == CS_INDEX_LAST) {
                 gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
             } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_NONE) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF0) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF1) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF2) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF3) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF4) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF5) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF6) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF7) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF8) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF9;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF9) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFFA;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFFA) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_8000;
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_0) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_1) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_2) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_3) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_4;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_4) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_5;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_5) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_6;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_6) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_7;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_7) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_8;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_8) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_9;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_9) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_A;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_A) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_LAST;
             }
         } else if (CHECK_BTN_ALL(input->press.button, BTN_R)) {
-            if (gSaveContext.save.cutsceneIndex == CS_INDEX_8000) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFFA;
+            if (gSaveContext.save.cutsceneIndex == CS_INDEX_LAST) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_A;
             } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_NONE) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_8000;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF0) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_LAST;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_0) {
                 gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF1) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF2) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF3) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF4) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF5) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF6) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF7) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF8) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF9) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
-            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFFA) {
-                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF9;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_1) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_0;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_2) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_1;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_3) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_2;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_4) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_3;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_5) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_4;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_6) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_5;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_7) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_6;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_8) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_7;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_9) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_8;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_SCRIPTED_A) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_SCRIPTED_9;
             }
         }
 
@@ -607,48 +607,48 @@ void MapSelect_PrintCutsceneSetting(MapSelectState* this, GfxPrint* printer, u16
     GfxPrint_SetColor(printer, 255, 255, 55, 255);
 
     switch (csIndex) {
-        case 0:
+        case CS_INDEX_NONE:
             label = GFXP_HIRAGANA " ﾖﾙ " GFXP_KATAKANA "ｺﾞﾛﾝ";
             gSaveContext.save.dayTime = CLOCK_TIME(0, 0);
             break;
-        case 0x8000:
+        case CS_INDEX_LAST:
             // clang-format off
             gSaveContext.save.dayTime = CLOCK_TIME(12, 0); label = GFXP_HIRAGANA "ｵﾋﾙ " GFXP_KATAKANA "ｼﾞｬﾗ";
             // clang-format on
             break;
-        case 0xFFF0:
+        case CS_INDEX_SCRIPTED_0:
             // clang-format off
             gSaveContext.save.dayTime = CLOCK_TIME(12, 0); label = "ﾃﾞﾓ00";
             // clang-format on
             break;
-        case 0xFFF1:
+        case CS_INDEX_SCRIPTED_1:
             label = "ﾃﾞﾓ01";
             break;
-        case 0xFFF2:
+        case CS_INDEX_SCRIPTED_2:
             label = "ﾃﾞﾓ02";
             break;
-        case 0xFFF3:
+        case CS_INDEX_SCRIPTED_3:
             label = "ﾃﾞﾓ03";
             break;
-        case 0xFFF4:
+        case CS_INDEX_SCRIPTED_4:
             label = "ﾃﾞﾓ04";
             break;
-        case 0xFFF5:
+        case CS_INDEX_SCRIPTED_5:
             label = "ﾃﾞﾓ05";
             break;
-        case 0xFFF6:
+        case CS_INDEX_SCRIPTED_6:
             label = "ﾃﾞﾓ06";
             break;
-        case 0xFFF7:
+        case CS_INDEX_SCRIPTED_7:
             label = "ﾃﾞﾓ07";
             break;
-        case 0xFFF8:
+        case CS_INDEX_SCRIPTED_8:
             label = "ﾃﾞﾓ08";
             break;
-        case 0xFFF9:
+        case CS_INDEX_SCRIPTED_9:
             label = "ﾃﾞﾓ09";
             break;
-        case 0xFFFA:
+        case CS_INDEX_SCRIPTED_A:
             label = "ﾃﾞﾓ0A";
             break;
     };
@@ -778,6 +778,6 @@ void MapSelect_Init(GameState* thisx) {
         DMA_REQUEST_SYNC(this->staticSegment, (uintptr_t)_z_select_staticSegmentRomStart, size, "../z_select.c", 1115);
     }
 
-    gSaveContext.save.cutsceneIndex = CS_INDEX_8000;
+    gSaveContext.save.cutsceneIndex = CS_INDEX_LAST;
     gSaveContext.save.linkAge = LINK_AGE_CHILD;
 }

--- a/src/overlays/gamestates/ovl_select/z_select.c
+++ b/src/overlays/gamestates/ovl_select/z_select.c
@@ -335,65 +335,65 @@ void MapSelect_UpdateMenu(MapSelectState* this) {
         }
 
         if (CHECK_BTN_ALL(input->press.button, BTN_Z)) {
-            if (gSaveContext.save.cutsceneIndex == 0x8000) {
-                gSaveContext.save.cutsceneIndex = 0;
-            } else if (gSaveContext.save.cutsceneIndex == 0) {
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF0) {
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF1) {
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF2) {
-                gSaveContext.save.cutsceneIndex = 0xFFF3;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF3) {
-                gSaveContext.save.cutsceneIndex = 0xFFF4;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF4) {
-                gSaveContext.save.cutsceneIndex = 0xFFF5;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF5) {
-                gSaveContext.save.cutsceneIndex = 0xFFF6;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF6) {
-                gSaveContext.save.cutsceneIndex = 0xFFF7;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF7) {
-                gSaveContext.save.cutsceneIndex = 0xFFF8;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF8) {
-                gSaveContext.save.cutsceneIndex = 0xFFF9;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF9) {
-                gSaveContext.save.cutsceneIndex = 0xFFFA;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFFA) {
-                gSaveContext.save.cutsceneIndex = 0x8000;
+            if (gSaveContext.save.cutsceneIndex == CS_INDEX_8000) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_NONE) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF0) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF1) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF2) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF3) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF4) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF5) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF6) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF7) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF8) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF9;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF9) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFFA;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFFA) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_8000;
             }
         } else if (CHECK_BTN_ALL(input->press.button, BTN_R)) {
-            if (gSaveContext.save.cutsceneIndex == 0x8000) {
-                gSaveContext.save.cutsceneIndex = 0xFFFA;
-            } else if (gSaveContext.save.cutsceneIndex == 0) {
-                gSaveContext.save.cutsceneIndex = 0x8000;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF0) {
-                gSaveContext.save.cutsceneIndex = 0;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF1) {
-                gSaveContext.save.cutsceneIndex = 0xFFF0;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF2) {
-                gSaveContext.save.cutsceneIndex = 0xFFF1;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF3) {
-                gSaveContext.save.cutsceneIndex = 0xFFF2;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF4) {
-                gSaveContext.save.cutsceneIndex = 0xFFF3;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF5) {
-                gSaveContext.save.cutsceneIndex = 0xFFF4;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF6) {
-                gSaveContext.save.cutsceneIndex = 0xFFF5;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF7) {
-                gSaveContext.save.cutsceneIndex = 0xFFF6;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF8) {
-                gSaveContext.save.cutsceneIndex = 0xFFF7;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFF9) {
-                gSaveContext.save.cutsceneIndex = 0xFFF8;
-            } else if (gSaveContext.save.cutsceneIndex == 0xFFFA) {
-                gSaveContext.save.cutsceneIndex = 0xFFF9;
+            if (gSaveContext.save.cutsceneIndex == CS_INDEX_8000) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFFA;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_NONE) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_8000;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF0) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_NONE;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF1) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF0;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF2) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF1;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF3) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF2;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF4) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF3;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF5) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF4;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF6) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF5;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF7) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF6;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF8) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF7;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFF9) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF8;
+            } else if (gSaveContext.save.cutsceneIndex == CS_INDEX_FFFA) {
+                gSaveContext.save.cutsceneIndex = CS_INDEX_FFF9;
             }
         }
 
         gSaveContext.save.nightFlag = 0;
-        if (gSaveContext.save.cutsceneIndex == 0) {
+        if (gSaveContext.save.cutsceneIndex == CS_INDEX_NONE) {
             gSaveContext.save.nightFlag = 1;
         }
 
@@ -778,6 +778,6 @@ void MapSelect_Init(GameState* thisx) {
         DMA_REQUEST_SYNC(this->staticSegment, (uintptr_t)_z_select_staticSegmentRomStart, size, "../z_select.c", 1115);
     }
 
-    gSaveContext.save.cutsceneIndex = 0x8000;
+    gSaveContext.save.cutsceneIndex = CS_INDEX_8000;
     gSaveContext.save.linkAge = LINK_AGE_CHILD;
 }


### PR DESCRIPTION
while studying the game logic flow, i saw there's a pattern between
- `Save.entranceIndex`
- `Save.cutsceneIndex`
- `SaveContext.sceneLayer`

but values weren't yet described. so, it's time to cleanup my notes and shape them in a proper PR. it's a WIP, but i'll start with a draft for visibility

P.S.:
the closest thing i see here is https://github.com/zeldaret/oot/pull/1300, but
- documented `SaveContext.sceneLayer`
- it's merged already