### PR TITLE
Document "override limbs" functions, variables, constants

### DIFF
--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -917,7 +917,7 @@ void func_80034BA0(struct PlayState* play, SkelAnime* skelAnime, OverrideLimbDra
 void func_80034CC4(struct PlayState* play, SkelAnime* skelAnime, OverrideLimbDraw overrideLimbDraw,
                    PostLimbDraw postLimbDraw, Actor* actor, s16 alpha);
 s16 func_80034DD4(Actor* actor, struct PlayState* play, s16 arg2, f32 arg3);
-void func_80034F54(struct PlayState* play, s16* arg1, s16* arg2, s32 arg3);
+void UpdateLimbOverrides(struct PlayState* play, s16* tableY, s16* tableZ, s32 count);
 void Actor_Noop(Actor* actor, struct PlayState* play);
 
 void Gfx_DrawDListOpa(struct PlayState* play, Gfx* dlist);

--- a/include/z64animation.h
+++ b/include/z64animation.h
@@ -16,6 +16,13 @@ struct SkelAnime;
 
 #define LIMB_DONE 0xFF
 
+// These constants are ubiqutous limb override formulas parameters.
+// Some actors call `UpdateLimbOverrides` function and cache their results in `limbOverrides*` tables.
+// Others compute them on the fly. Both variants are applied inside `*_OverrideLimbDraw` as input angles.
+#define LIMB_OVERRIDE_BASE_Y 0x814
+#define LIMB_OVERRIDE_BASE_Z 0x940
+#define LIMB_OVERRIDE_PER_I 0x32
+
 typedef struct StandardLimb {
     /* 0x00 */ Vec3s jointPos; // Root is position in model space, children are relative to parent
     /* 0x06 */ u8 child;

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -4432,13 +4432,16 @@ void Animation_ChangeByInfo(SkelAnime* skelAnime, AnimationInfo* animationInfo, 
                      frameCount, animationInfo->mode, animationInfo->morphFrames);
 }
 
-void func_80034F54(PlayState* play, s16* arg1, s16* arg2, s32 arg3) {
+/*
+ * computes `.limbOverrides` values for `*_OverrideLimbDraw` functions
+ */
+void UpdateLimbOverrides(PlayState* play, s16* tableY, s16* tableZ, s32 count) {
     u32 frames = play->gameplayFrames;
     s32 i;
 
-    for (i = 0; i < arg3; i++) {
-        arg1[i] = (0x814 + 50 * i) * frames;
-        arg2[i] = (0x940 + 50 * i) * frames;
+    for (i = 0; i < count; i++) {
+        tableY[i] = (LIMB_OVERRIDE_BASE_Y + LIMB_OVERRIDE_PER_I * i) * frames;
+        tableZ[i] = (LIMB_OVERRIDE_BASE_Z + LIMB_OVERRIDE_PER_I * i) * frames;
     }
 }
 

--- a/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
+++ b/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
@@ -561,8 +561,9 @@ s32 EnDivingGame_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, V
     }
 
     if (this->notPlayingMinigame && (limbIndex == 8 || limbIndex == 9 || limbIndex == 12)) {
-        rot->y += Math_SinS((play->state.frames * (limbIndex * 50 + 0x814))) * 200.0f;
-        rot->z += Math_CosS((play->state.frames * (limbIndex * 50 + 0x940))) * 200.0f;
+        // pad = limbIndex * LIMB_OVERRIDE_PER_I; // likely
+        rot->y += Math_SinS((play->state.frames * (limbIndex * LIMB_OVERRIDE_PER_I + LIMB_OVERRIDE_BASE_Y))) * 200.0f;
+        rot->z += Math_CosS((play->state.frames * (limbIndex * LIMB_OVERRIDE_PER_I + LIMB_OVERRIDE_BASE_Z))) * 200.0f;
     }
 
     return 0;

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -278,8 +278,9 @@ s32 EnFu_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
     }
 
     if (limbIndex == FU_LIMB_CHEST_MUSIC_BOX) {
-        rot->y += (Math_SinS((play->state.frames * (limbIndex * 50 + 0x814))) * 200.0f);
-        rot->z += (Math_CosS((play->state.frames * (limbIndex * 50 + 0x940))) * 200.0f);
+        // pad = limbIndex * LIMB_OVERRIDE_PER_I; // likely
+        rot->y += Math_SinS((play->state.frames * (limbIndex * LIMB_OVERRIDE_PER_I + LIMB_OVERRIDE_BASE_Y))) * 200.0f;
+        rot->z += Math_CosS((play->state.frames * (limbIndex * LIMB_OVERRIDE_PER_I + LIMB_OVERRIDE_BASE_Z))) * 200.0f;
     }
     return false;
 }

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -777,8 +777,9 @@ s32 EnGe1_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* p
     // The purpose of the state flag GE1_STATE_STOP_FIDGET is to skip this code, which this actor has in lieu of an idle
     // animation.
     if ((limbIndex == GE1_LIMB_TORSO) || (limbIndex == GE1_LIMB_L_FOREARM) || (limbIndex == GE1_LIMB_R_FOREARM)) {
-        rot->y += Math_SinS(play->state.frames * (limbIndex * 50 + 0x814)) * 200.0f;
-        rot->z += Math_CosS(play->state.frames * (limbIndex * 50 + 0x940)) * 200.0f;
+        // pad = limbIndex * LIMB_OVERRIDE_PER_I; // likely
+        rot->y += Math_SinS(play->state.frames * (limbIndex * LIMB_OVERRIDE_PER_I + LIMB_OVERRIDE_BASE_Y)) * 200.0f;
+        rot->z += Math_CosS(play->state.frames * (limbIndex * LIMB_OVERRIDE_PER_I + LIMB_OVERRIDE_BASE_Z)) * 200.0f;
     }
     return 0;
 }

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -1033,7 +1033,7 @@ void EnGo_Update(Actor* thisx, PlayState* play) {
 
     if (this->actionFunc == EnGo_BiggoronActionFunc || this->actionFunc == EnGo_FireGenericActionFunc ||
         this->actionFunc == func_80A40B1C) {
-        func_80034F54(play, this->jointTable, this->morphTable, 18);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, GORON_LIMB_MAX);
     }
 
     EnGo_UpdateShadow(this);
@@ -1103,8 +1103,8 @@ s32 EnGo_OverrideLimbDraw(PlayState* play, s32 limb, Gfx** dList, Vec3f* pos, Ve
     }
 
     if ((limb == 10) || (limb == 11) || (limb == 14)) {
-        rot->y += Math_SinS(this->jointTable[limb]) * 200.0f;
-        rot->z += Math_CosS(this->morphTable[limb]) * 200.0f;
+        rot->y += Math_SinS(this->limbOverridesY[limb]) * 200.0f;
+        rot->z += Math_CosS(this->limbOverridesZ[limb]) * 200.0f;
     }
 
     return 0;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -22,8 +22,9 @@ typedef s16 (*callback2_80A3ED24)(PlayState*, struct EnGo*);
 // /* 0x80 */ // Not Used
 // /* 0x90 */ GORON1_DMT_BIGGORON,
 
-
 #define EN_GO_EFFECT_COUNT 20
+
+#define GORON_LIMB_MAX 18
 
 typedef struct EnGoEffect {
     /* 0x0000 */ u8 type;
@@ -55,8 +56,8 @@ typedef struct EnGo {
     /* 0x021A */ s16 unk_21A;
     /* 0x021C */ s16 unk_21C;
     /* 0x021E */ s16 unk_21E;
-    /* 0x0220 */ s16 jointTable[18];
-    /* 0x0244 */ s16 morphTable[18];
+    /* 0x0220 */ s16 limbOverridesY[GORON_LIMB_MAX];
+    /* 0x0244 */ s16 limbOverridesZ[GORON_LIMB_MAX];
     /* 0x0268 */ EnGoEffect effects[EN_GO_EFFECT_COUNT];
 } EnGo; // size = 0x06C8
 

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1995,7 +1995,7 @@ void EnGo2_Update(Actor* thisx, PlayState* play) {
 #endif
     this->actionFunc(this, play);
     if (this->unk_211 == true) {
-        func_80034F54(play, this->unk_226, this->unk_24A, 18);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, GORON2_LIMB_MAX);
     }
     func_80A45288(this, play);
     EnGo2_EyeMouthTexState(this);
@@ -2048,8 +2048,8 @@ s32 EnGo2_OverrideLimbDraw(PlayState* play, s32 limb, Gfx** dList, Vec3f* pos, V
         Matrix_RotateX(BINANG_TO_RAD_ALT(limbRot.x), MTXMODE_APPLY);
     }
     if ((limb == 10) || (limb == 11) || (limb == 14)) {
-        rot->y += Math_SinS(this->unk_226[limb]) * 200.0f;
-        rot->z += Math_CosS(this->unk_24A[limb]) * 200.0f;
+        rot->y += Math_SinS(this->limbOverridesY[limb]) * 200.0f;
+        rot->z += Math_CosS(this->limbOverridesZ[limb]) * 200.0f;
     }
     return 0;
 }

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -67,6 +67,8 @@ typedef struct EnGo2DustEffectData {
 
 #define EN_GO2_EFFECT_COUNT 10
 
+#define GORON2_LIMB_MAX 18
+
 typedef struct EnGo2 {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
@@ -92,14 +94,14 @@ typedef struct EnGo2 {
     /* 0x021C */ char unk_21C[0x04];
     /* 0x0220 */ f32 alpha; // Set to 0, used by func_80A45360, smoothed to this->actor.shape.shadowAlpha from either 0 or 255.0f
     /* 0x0224 */ s16 blinkTimer;
-    /* 0x0226 */ s16 unk_226[18]; // Remains unknown
-    /* 0x024A */ s16 unk_24A[18]; // Remains unknown
+    /* 0x0226 */ s16 limbOverridesY[GORON2_LIMB_MAX];
+    /* 0x024A */ s16 limbOverridesZ[GORON2_LIMB_MAX];
     /* 0x026E */ u16 trackingMode;
     /* 0x0270 */ EnGoEffect effects[EN_GO2_EFFECT_COUNT];
     /* 0x04A0 */ Vec3f subCamEye;
     /* 0x04AC */ Vec3f subCamAt;
-    /* 0x04B8 */ Vec3s jointTable[18];
-    /* 0x0524 */ Vec3s morphTable[18];
+    /* 0x04B8 */ Vec3s jointTable[GORON2_LIMB_MAX];
+    /* 0x0524 */ Vec3s morphTable[GORON2_LIMB_MAX];
     /* 0x0590 */ s16 unk_590; // timer
     /* 0x0592 */ s16 animTimer; // animTimer. Plays NA_SE_EN_MORIBLIN_WALK, NA_SE_EV_IRON_DOOR_OPEN, NA_SE_EV_IRON_DOOR_CLOSE
     /* 0x0594 */ s32 getItemId;

--- a/src/overlays/actors/ovl_En_Guest/z_en_guest.c
+++ b/src/overlays/actors/ovl_En_Guest/z_en_guest.c
@@ -157,7 +157,7 @@ void func_80A505CC(Actor* thisx, PlayState* play) {
     }
     Npc_TrackPoint(&this->actor, &this->interactInfo, 6, NPC_TRACKING_HEAD_AND_TORSO);
 
-    func_80034F54(play, this->unk_2CC, this->unk_2EC, 16);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, GUEST_LIMB_MAX);
 
     gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.slots[this->osAnimeObjectSlot].segment);
 
@@ -200,8 +200,8 @@ s32 EnGuest_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f*
     }
 
     if (limbIndex == 8 || limbIndex == 9 || limbIndex == 12) {
-        rot->y += Math_SinS(this->unk_2CC[limbIndex]) * 200.0f;
-        rot->z += Math_CosS(this->unk_2EC[limbIndex]) * 200.0f;
+        rot->y += Math_SinS(this->limbOverridesY[limbIndex]) * 200.0f;
+        rot->z += Math_CosS(this->limbOverridesZ[limbIndex]) * 200.0f;
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_guest.c", 388);

--- a/src/overlays/actors/ovl_En_Guest/z_en_guest.h
+++ b/src/overlays/actors/ovl_En_Guest/z_en_guest.h
@@ -8,18 +8,20 @@ struct EnGuest;
 
 typedef void (*EnGuestActionFunc)(struct EnGuest* this, PlayState* play);
 
+#define GUEST_LIMB_MAX 16
+
 typedef struct EnGuest {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ Vec3s jointTable[16];
-    /* 0x01F0 */ Vec3s morphTable[16];
+    /* 0x0190 */ Vec3s jointTable[GUEST_LIMB_MAX];
+    /* 0x01F0 */ Vec3s morphTable[GUEST_LIMB_MAX];
     /* 0x0250 */ EnGuestActionFunc actionFunc;
     /* 0x0254 */ ColliderCylinder collider;
     /* 0x02A0 */ NpcInteractInfo interactInfo;
     /* 0x02C8 */ s16 unk_2C8;
     /* 0x02CA */ s16 unk_2CA;
-    /* 0x02CC */ s16 unk_2CC[16];
-    /* 0x02EC */ s16 unk_2EC[16];
+    /* 0x02CC */ s16 limbOverridesY[GUEST_LIMB_MAX];
+    /* 0x02EC */ s16 limbOverridesZ[GUEST_LIMB_MAX];
     /* 0x030C */ s8 osAnimeObjectSlot;
     /* 0x030D */ u8 unk_30D;
     /* 0x030E */ u8 unk_30E;

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -1252,7 +1252,7 @@ void EnHy_Walk(EnHy* this, PlayState* play) {
 }
 
 void EnHy_Fidget(EnHy* this, PlayState* play) {
-    func_80034F54(play, this->fidgetTableY, this->fidgetTableZ, 16);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, ENHY_LIMB_MAX);
 }
 
 void EnHy_DoNothing(EnHy* this, PlayState* play) {
@@ -1265,7 +1265,7 @@ void EnHy_SetupPace(EnHy* this, PlayState* play) {
         this->actionFunc = EnHy_Pace;
     }
 
-    func_80034F54(play, this->fidgetTableY, this->fidgetTableZ, 16);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, ENHY_LIMB_MAX);
 }
 
 void EnHy_Pace(EnHy* this, PlayState* play) {
@@ -1390,8 +1390,8 @@ s32 EnHy_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
 
     if ((limbIndex == ENHY_LIMB_TORSO) || (limbIndex == ENHY_LIMB_LEFT_UPPER_ARM) ||
         (limbIndex == ENHY_LIMB_RIGHT_UPPER_ARM)) {
-        rot->y += Math_SinS(this->fidgetTableY[limbIndex]) * 200.0f;
-        rot->z += Math_CosS(this->fidgetTableZ[limbIndex]) * 200.0f;
+        rot->y += Math_SinS(this->limbOverridesY[limbIndex]) * 200.0f;
+        rot->z += Math_CosS(this->limbOverridesZ[limbIndex]) * 200.0f;
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_hy.c", 2228);

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.h
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.h
@@ -74,8 +74,8 @@ typedef struct EnHy {
     /* 0x0216 */ char unk_216[2]; // unused
     /* 0x0218 */ s16 curEyeIndex;
     /* 0x021A */ s16 nextEyeIndexTimer;
-    /* 0x021C */ s16 fidgetTableY[16];
-    /* 0x023C */ s16 fidgetTableZ[16];
+    /* 0x021C */ s16 limbOverridesY[ENHY_LIMB_MAX];
+    /* 0x023C */ s16 limbOverridesZ[ENHY_LIMB_MAX];
     /* 0x025C */ f32 interactRange;
     /* 0x0260 */ s32 getItemId;
     /* 0x0264 */ Vec3f modelOffset;

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -709,7 +709,7 @@ s32 func_80A97D68(EnKo* this, PlayState* play) {
 s32 func_80A97E18(EnKo* this, PlayState* play) {
     s16 trackingMode;
 
-    func_80034F54(play, this->unk_2E4, this->unk_304, 16);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, KOKIRI_LIMB_MAX);
     if (EnKo_IsWithinTalkAngle(this) == true) {
         trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
     } else {
@@ -728,7 +728,7 @@ s32 func_80A97EB0(EnKo* this, PlayState* play) {
     s16 trackingMode;
     s32 result;
 
-    func_80034F54(play, this->unk_2E4, this->unk_304, 16);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, KOKIRI_LIMB_MAX);
     result = EnKo_IsWithinTalkAngle(this);
     trackingMode = (result == true) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
     Npc_TrackPoint(&this->actor, &this->interactInfo, 2, trackingMode);
@@ -736,7 +736,7 @@ s32 func_80A97EB0(EnKo* this, PlayState* play) {
 }
 
 s32 func_80A97F20(EnKo* this, PlayState* play) {
-    func_80034F54(play, this->unk_2E4, this->unk_304, 16);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, KOKIRI_LIMB_MAX);
     Npc_TrackPoint(&this->actor, &this->interactInfo, 2, NPC_TRACKING_FULL_BODY);
     return 1;
 }
@@ -748,7 +748,7 @@ s32 func_80A97F70(EnKo* this, PlayState* play) {
         if ((this->skelAnime.animation == &gKokiriBlockingAnim) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_BLOCKING_STATIC);
         }
-        func_80034F54(play, this->unk_2E4, this->unk_304, 16);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, KOKIRI_LIMB_MAX);
         trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
     } else {
         if ((this->skelAnime.animation == &gKokiriCuttingGrassAnim) == false) {
@@ -768,7 +768,7 @@ s32 func_80A98034(EnKo* this, PlayState* play) {
         if ((this->skelAnime.animation == &gKokiriBlockingAnim) == false) {
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENKO_ANIM_BLOCKING_STATIC);
         }
-        func_80034F54(play, this->unk_2E4, this->unk_304, 16);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, KOKIRI_LIMB_MAX);
         result = EnKo_IsWithinTalkAngle(this);
         trackingMode = (result == true) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
     } else {
@@ -784,7 +784,7 @@ s32 func_80A98034(EnKo* this, PlayState* play) {
 
 // Same as func_80A97F20
 s32 func_80A98124(EnKo* this, PlayState* play) {
-    func_80034F54(play, this->unk_2E4, this->unk_304, 16);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, KOKIRI_LIMB_MAX);
     Npc_TrackPoint(&this->actor, &this->interactInfo, 2, NPC_TRACKING_FULL_BODY);
     return 1;
 }
@@ -798,7 +798,7 @@ s32 func_80A98174(EnKo* this, PlayState* play) {
         this->skelAnime.playSpeed = 1.0f;
     }
     if (this->skelAnime.playSpeed == 0.0f) {
-        func_80034F54(play, this->unk_2E4, this->unk_304, 16);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, KOKIRI_LIMB_MAX);
     }
     Npc_TrackPoint(&this->actor, &this->interactInfo, 2,
                    (this->skelAnime.playSpeed == 0.0f) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE);
@@ -1335,8 +1335,8 @@ s32 EnKo_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
         Matrix_Translate(-1200.0f, 0.0f, 0.0f, MTXMODE_APPLY);
     }
     if (limbIndex == 8 || limbIndex == 9 || limbIndex == 12) {
-        rot->y += Math_SinS(this->unk_2E4[limbIndex]) * 200.0f;
-        rot->z += Math_CosS(this->unk_304[limbIndex]) * 200.0f;
+        rot->y += Math_SinS(this->limbOverridesY[limbIndex]) * 200.0f;
+        rot->z += Math_CosS(this->limbOverridesZ[limbIndex]) * 200.0f;
     }
     return false;
 }

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.h
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.h
@@ -8,6 +8,8 @@ struct EnKo;
 
 typedef void (*EnKoActionFunc)(struct EnKo*, PlayState*);
 
+#define KOKIRI_LIMB_MAX 16
+
 typedef struct EnKo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
@@ -26,10 +28,10 @@ typedef struct EnKo {
     /* 0x0218 */ f32 appearDist;
     /* 0x021C */ f32 lookDist; // distance to start looking at player
     /* 0x0220 */ f32 modelAlpha;
-    /* 0x0224 */ Vec3s jointTable[16];
-    /* 0x0284 */ Vec3s morphTable[16];
-    /* 0x02E4 */ s16 unk_2E4[16];
-    /* 0x0304 */ s16 unk_304[16];
+    /* 0x0224 */ Vec3s jointTable[KOKIRI_LIMB_MAX];
+    /* 0x0284 */ Vec3s morphTable[KOKIRI_LIMB_MAX];
+    /* 0x02E4 */ s16 limbOverridesY[KOKIRI_LIMB_MAX];
+    /* 0x0304 */ s16 limbOverridesZ[KOKIRI_LIMB_MAX];
 } EnKo; // size = 0x0324
 
 typedef enum KokiriChildren {

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -416,7 +416,7 @@ void EnKz_PreMweepWait(EnKz* this, PlayState* play) {
         this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
         this->actionFunc = EnKz_SetupMweep;
     } else {
-        func_80034F54(play, this->unk_2A6, this->unk_2BE, 12);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, KINGZORA_LIMB_MAX);
     }
 }
 
@@ -479,7 +479,7 @@ void EnKz_Wait(EnKz* this, PlayState* play) {
         this->actionFunc = EnKz_SetupGetItem;
         EnKz_SetupGetItem(this, play);
     } else {
-        func_80034F54(play, this->unk_2A6, this->unk_2BE, 12);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, KINGZORA_LIMB_MAX);
     }
 }
 
@@ -546,8 +546,8 @@ s32 EnKz_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
     EnKz* this = (EnKz*)thisx;
 
     if (limbIndex == 8 || limbIndex == 9 || limbIndex == 10) {
-        rot->y += Math_SinS(this->unk_2A6[limbIndex]) * 200.0f;
-        rot->z += Math_CosS(this->unk_2BE[limbIndex]) * 200.0f;
+        rot->y += Math_SinS(this->limbOverridesY[limbIndex]) * 200.0f;
+        rot->z += Math_CosS(this->limbOverridesZ[limbIndex]) * 200.0f;
     }
     if (limbIndex) {}
     return false;

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.h
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.h
@@ -8,6 +8,8 @@ struct EnKz;
 
 typedef void (*EnKzActionFunc)(struct EnKz*, PlayState*);
 
+#define KINGZORA_LIMB_MAX 12
+
 typedef struct EnKz {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelanime;
@@ -22,10 +24,10 @@ typedef struct EnKz {
     /* 0x0210 */ s16 eyeIdx;
     /* 0x0212 */ s16 subCamId;
     /* 0x0214 */ s16 returnToCamId;
-    /* 0x0216 */ Vec3s jointTable[12];
-    /* 0x025E */ Vec3s morphTable[12];
-    /* 0x02A6 */ s16 unk_2A6[12];
-    /* 0x02BE */ s16 unk_2BE[12];
+    /* 0x0216 */ Vec3s jointTable[KINGZORA_LIMB_MAX];
+    /* 0x025E */ Vec3s morphTable[KINGZORA_LIMB_MAX];
+    /* 0x02A6 */ s16 limbOverridesY[KINGZORA_LIMB_MAX];
+    /* 0x02BE */ s16 limbOverridesZ[KINGZORA_LIMB_MAX];
 } EnKz; // size = 0x02D8
 
 #endif

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -695,7 +695,7 @@ void EnMd_Destroy(Actor* thisx, PlayState* play) {
 
 void func_80AAB874(EnMd* this, PlayState* play) {
     if (this->skelAnime.animation == &gMidoHandsOnHipsIdleAnim) {
-        func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, ENMD_LIMB_MAX);
     } else if ((this->interactInfo.talkState == NPC_TALK_STATE_IDLE) && (this->unk_20B != 7)) {
         func_80AAA92C(this, 7);
     }
@@ -705,7 +705,7 @@ void func_80AAB874(EnMd* this, PlayState* play) {
 
 void func_80AAB8F8(EnMd* this, PlayState* play) {
     if (this->skelAnime.animation == &gMidoHandsOnHipsIdleAnim) {
-        func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, ENMD_LIMB_MAX);
     }
     func_80AAA93C(this);
 }
@@ -757,7 +757,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
     }
 
     if (this->skelAnime.animation == &gMidoHandsOnHipsIdleAnim) {
-        func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
+        UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, ENMD_LIMB_MAX);
     }
 
     if ((this->interactInfo.talkState == NPC_TALK_STATE_IDLE) && (play->sceneId == SCENE_LOST_WOODS)) {
@@ -795,7 +795,7 @@ void func_80AABC10(EnMd* this, PlayState* play) {
 }
 
 void func_80AABD0C(EnMd* this, PlayState* play) {
-    func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, ENMD_LIMB_MAX);
     func_80AAA93C(this);
 
     if (!(EnMd_FollowPath(this, play)) || (this->waypoint != 0)) {
@@ -853,8 +853,8 @@ s32 EnMd_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
 
     if (((limbIndex == ENMD_LIMB_TORSO) || (limbIndex == ENMD_LIMB_LEFT_UPPER_ARM)) ||
         (limbIndex == ENMD_LIMB_RIGHT_UPPER_ARM)) {
-        rot->y += Math_SinS(this->unk_214[limbIndex]) * 200.0f;
-        rot->z += Math_CosS(this->unk_236[limbIndex]) * 200.0f;
+        rot->y += Math_SinS(this->limbOverridesY[limbIndex]) * 200.0f;
+        rot->z += Math_CosS(this->limbOverridesZ[limbIndex]) * 200.0f;
     }
 
     return false;

--- a/src/overlays/actors/ovl_En_Md/z_en_md.h
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.h
@@ -43,8 +43,8 @@ typedef struct EnMd {
     /* 0x020E */ s16 eyeIdx;
     /* 0x0210 */ s16 alpha;
     /* 0x0212 */ s16 waypoint;
-    /* 0x0214 */ s16 unk_214[ENMD_LIMB_MAX];
-    /* 0x0236 */ s16 unk_236[ENMD_LIMB_MAX];
+    /* 0x0214 */ s16 limbOverridesY[ENMD_LIMB_MAX];
+    /* 0x0236 */ s16 limbOverridesZ[ENMD_LIMB_MAX];
     /* 0x0258 */ Vec3s jointTable[ENMD_LIMB_MAX];
     /* 0x02BE */ Vec3s morphTable[ENMD_LIMB_MAX];
 } EnMd; // size = 0x0324

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.c
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.c
@@ -152,7 +152,7 @@ void EnMu_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnMu_Pose(EnMu* this, PlayState* play) {
-    func_80034F54(play, this->unk_20A, this->unk_22A, 16);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, MU_LIMB_MAX);
 }
 
 void EnMu_Update(Actor* thisx, PlayState* play) {
@@ -183,8 +183,8 @@ s32 EnMu_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
 
     if ((limbIndex == 5) || (limbIndex == 6) || (limbIndex == 7) || (limbIndex == 11) || (limbIndex == 12) ||
         (limbIndex == 13) || (limbIndex == 14)) {
-        rot->y += Math_SinS(this->unk_20A[limbIndex]) * 200.0f;
-        rot->z += Math_CosS(this->unk_22A[limbIndex]) * 200.0f;
+        rot->y += Math_SinS(this->limbOverridesY[limbIndex]) * 200.0f;
+        rot->z += Math_CosS(this->limbOverridesZ[limbIndex]) * 200.0f;
     }
     return false;
 }

--- a/src/overlays/actors/ovl_En_Mu/z_en_mu.h
+++ b/src/overlays/actors/ovl_En_Mu/z_en_mu.h
@@ -8,6 +8,9 @@ struct EnMu;
 
 typedef void (*EnMuActionFunc)(struct EnMu*, struct PlayState*);
 
+#define MU_LIMB_MAX 16     // @note: correct, because `UpdateLimbOverrides` uses it
+#define MU_LIMB_MAX_BUG 17 // @bug: should be the same value
+
 typedef struct EnMu {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
@@ -15,8 +18,8 @@ typedef struct EnMu {
     /* 0x0194 */ ColliderCylinder collider;
     /* 0x01E0 */ NpcInteractInfo npcInfo;
     /* 0x0208 */ u16 defaultTextId;
-    /* 0x020A */ s16 unk_20A[16];
-    /* 0x022A */ s16 unk_22A[17];
+    /* 0x020A */ s16 limbOverridesY[MU_LIMB_MAX];
+    /* 0x022A */ s16 limbOverridesZ[MU_LIMB_MAX_BUG];
 } EnMu; // size = 0x024C
 
 #endif

--- a/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -578,8 +578,11 @@ s32 EnNiwLady_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3
     }
     if (this->unk_275 != 0) {
         if ((limbIndex == 8) || (limbIndex == 10) || (limbIndex == 13)) {
-            rot->y += (Math_SinS((play->state.frames * ((limbIndex * 0x32) + 0x814))) * 200.0f);
-            rot->z += (Math_CosS((play->state.frames * ((limbIndex * 0x32) + 0x940))) * 200.0f);
+            // pad = limbIndex * LIMB_OVERRIDE_PER_I; // likely
+            rot->y +=
+                Math_SinS((play->state.frames * (limbIndex * LIMB_OVERRIDE_PER_I + LIMB_OVERRIDE_BASE_Y))) * 200.0f;
+            rot->z +=
+                Math_CosS((play->state.frames * (limbIndex * LIMB_OVERRIDE_PER_I + LIMB_OVERRIDE_BASE_Z))) * 200.0f;
         }
     }
     return false;

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -336,7 +336,7 @@ void EnSth_Update2(Actor* thisx, PlayState* play) {
 s32 EnSth_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {
     EnSth* this = (EnSth*)thisx;
 
-    s32 temp_v1;
+    s32 overridePerLimb;
 
     if (limbIndex == 15) {
         rot->x += this->headRot.y;
@@ -350,9 +350,9 @@ s32 EnSth_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* p
     }
 
     if ((limbIndex == 8) || (limbIndex == 10) || (limbIndex == 13)) {
-        temp_v1 = limbIndex * 0x32;
-        rot->y += (Math_SinS(play->state.frames * (temp_v1 + 0x814)) * 200.0f);
-        rot->z += (Math_CosS(play->state.frames * (temp_v1 + 0x940)) * 200.0f);
+        overridePerLimb = limbIndex * LIMB_OVERRIDE_PER_I;
+        rot->y += Math_SinS(play->state.frames * (overridePerLimb + LIMB_OVERRIDE_BASE_Y)) * 200.0f;
+        rot->z += Math_CosS(play->state.frames * (overridePerLimb + LIMB_OVERRIDE_BASE_Z)) * 200.0f;
     }
     return 0;
 }

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -1282,10 +1282,10 @@ s32 EnTa_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
         this->stateFlags &= ~TALON_STATE_FLAG_SUPPRESS_ROCKING_ANIM;
     } else if ((limbIndex == ENTA_LIMB_CHEST) || (limbIndex == ENTA_LIMB_LEFT_ARM) ||
                (limbIndex == ENTA_LIMB_RIGHT_ARM)) {
-        s32 limbIdx50 = limbIndex * 50;
+        s32 overridePerLimb = limbIndex * LIMB_OVERRIDE_PER_I;
 
-        rot->y += Math_SinS(play->state.frames * (limbIdx50 + 0x814)) * 200.0f;
-        rot->z += Math_CosS(play->state.frames * (limbIdx50 + 0x940)) * 200.0f;
+        rot->y += Math_SinS(play->state.frames * (overridePerLimb + LIMB_OVERRIDE_BASE_Y)) * 200.0f;
+        rot->z += Math_CosS(play->state.frames * (overridePerLimb + LIMB_OVERRIDE_BASE_Z)) * 200.0f;
     }
 
     return false;

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -612,7 +612,7 @@ void EnZo_Destroy(Actor* thisx, PlayState* play) {
 void EnZo_Standing(EnZo* this, PlayState* play) {
     s16 angle;
 
-    func_80034F54(play, this->unk_656, this->unk_67E, 20);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, ZORA_LIMB_MAX);
     EnZo_SetAnimation(this);
     if (this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
         this->trackingMode = NPC_TRACKING_FULL_BODY;
@@ -654,7 +654,7 @@ void EnZo_Surface(EnZo* this, PlayState* play) {
 }
 
 void EnZo_TreadWater(EnZo* this, PlayState* play) {
-    func_80034F54(play, this->unk_656, this->unk_67E, 20);
+    UpdateLimbOverrides(play, this->limbOverridesY, this->limbOverridesZ, ZORA_LIMB_MAX);
     if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
         this->canSpeak = true;
         this->trackingMode = NPC_TRACKING_FULL_BODY;
@@ -770,8 +770,8 @@ s32 EnZo_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
     }
 
     if ((limbIndex == 8) || (limbIndex == 9) || (limbIndex == 12)) {
-        rot->y += (Math_SinS(this->unk_656[limbIndex]) * 200.0f);
-        rot->z += (Math_CosS(this->unk_67E[limbIndex]) * 200.0f);
+        rot->y += (Math_SinS(this->limbOverridesY[limbIndex]) * 200.0f);
+        rot->z += (Math_CosS(this->limbOverridesZ[limbIndex]) * 200.0f);
     }
 
     return 0;

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.h
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.h
@@ -21,6 +21,8 @@ typedef struct EnZoEffect {
 
 typedef void (*EnZoActionFunc)(struct EnZo*, PlayState*);
 
+#define ZORA_LIMB_MAX 20
+
 typedef struct EnZo {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
@@ -28,8 +30,8 @@ typedef struct EnZo {
     /* 0x0194 */ NpcInteractInfo interactInfo;
     /* 0x01BC */ ColliderCylinder collider;
     /* 0x0208 */ u8 canSpeak;
-    /* 0x020A */ Vec3s jointTable[20];
-    /* 0x0282 */ Vec3s morphTable[20];
+    /* 0x020A */ Vec3s jointTable[ZORA_LIMB_MAX];
+    /* 0x0282 */ Vec3s morphTable[ZORA_LIMB_MAX];
     /* 0x02FC */ EnZoEffect effects[EN_ZO_EFFECT_COUNT];
     /* 0x0644 */ f32 dialogRadius;
     /* 0x0648 */ f32 alpha;
@@ -38,8 +40,8 @@ typedef struct EnZo {
     /* 0x0650 */ s16 timeToDive;
     /* 0x0652 */ s16 blinkTimer;
     /* 0x0654 */ s16 eyeTexture;
-    /* 0x0656 */ s16 unk_656[20];
-    /* 0x067E */ s16 unk_67E[20];
+    /* 0x0656 */ s16 limbOverridesY[ZORA_LIMB_MAX];
+    /* 0x067E */ s16 limbOverridesZ[ZORA_LIMB_MAX];
 } EnZo; // size = 0x06A8
 
 #endif


### PR DESCRIPTION
rename `func_80034F54` -> `UpdateLimbOverrides`, because:
- `0x814` and `0x940` constants
- `*_OverrideLimbDraw` functions association

consequent changes:
- move the constants into `z64animation.h`
- use these constant for existing formulas
- properly name corresponding actors' fields
- add occasional explicit limbs limit constants




P.S., as a side note:
`*_OverrideLimbDraw` and `*_PostLimbDraw` functions look more like
`*_PreProcessLimb` and `*_PostProcessLimb` to me
so, is there a strong or any reason why they should be names as they are now?

my question comes from the following observations:
- these functions does not draw anything
- they can update collider as a "post processing" step
- synchronize transforms or other parameters

obviously, the change by itself would be meaningless, leave alone huge. it's just curiosity