### PR TITLE
Document Mido functions and fields

### DIFF
--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -916,7 +916,7 @@ void func_80034BA0(struct PlayState* play, SkelAnime* skelAnime, OverrideLimbDra
                    PostLimbDraw postLimbDraw, Actor* actor, s16 alpha);
 void func_80034CC4(struct PlayState* play, SkelAnime* skelAnime, OverrideLimbDraw overrideLimbDraw,
                    PostLimbDraw postLimbDraw, Actor* actor, s16 alpha);
-s16 func_80034DD4(Actor* actor, struct PlayState* play, s16 arg2, f32 arg3);
+s16 Actor_SmoothStep_Attention(Actor* actor, struct PlayState* play, s16 alpha, f32 threshold);
 void func_80034F54(struct PlayState* play, s16* arg1, s16* arg2, s32 arg3);
 void Actor_Noop(Actor* actor, struct PlayState* play);
 

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -4396,25 +4396,25 @@ void func_80034CC4(PlayState* play, SkelAnime* skelAnime, OverrideLimbDraw overr
     CLOSE_DISPS(play->state.gfxCtx, "../z_actor.c", 8904);
 }
 
-s16 func_80034DD4(Actor* actor, PlayState* play, s16 arg2, f32 arg3) {
+s16 Actor_SmoothStep_Attention(Actor* actor, PlayState* play, s16 alpha, f32 threshold) {
     Player* player = GET_PLAYER(play);
-    f32 var;
+    f32 distance;
 
     if ((play->csCtx.state != CS_STATE_IDLE) || gDebugCamEnabled) {
-        var = Math_Vec3f_DistXYZ(&actor->world.pos, &play->view.eye) * 0.25f;
+        distance = Math_Vec3f_DistXYZ(&actor->world.pos, &play->view.eye) * 0.25f;
     } else {
-        var = Math_Vec3f_DistXYZ(&actor->world.pos, &player->actor.world.pos);
+        distance = Math_Vec3f_DistXYZ(&actor->world.pos, &player->actor.world.pos);
     }
 
-    if (arg3 < var) {
+    if (threshold < distance) {
         actor->flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
-        Math_SmoothStepToS(&arg2, 0, 6, 0x14, 1);
+        Math_SmoothStepToS(&alpha, 0, 6, 0x14, 1);
     } else {
         actor->flags |= ACTOR_FLAG_ATTENTION_ENABLED;
-        Math_SmoothStepToS(&arg2, 0xFF, 6, 0x14, 1);
+        Math_SmoothStepToS(&alpha, 0xFF, 6, 0x14, 1);
     }
 
-    return arg2;
+    return alpha;
 }
 
 void Animation_ChangeByInfo(SkelAnime* skelAnime, AnimationInfo* animationInfo, s32 index) {

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -650,15 +650,15 @@ u8 EnMd_SetMovedPos(EnMd* this, PlayState* play) {
     return 1;
 }
 
-void func_80AAB5A4(EnMd* this, PlayState* play) {
-    f32 temp;
+void EnMd_SmoothStep_Attention(EnMd* this, PlayState* play) {
+    f32 threshold;
 
     if (play->sceneId != SCENE_MIDOS_HOUSE) {
-        temp = (CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD) && !GET_EVENTCHKINF(EVENTCHKINF_1C) &&
-                (play->sceneId == SCENE_KOKIRI_FOREST))
-                   ? 100.0f
-                   : 400.0f;
-        this->alpha = Actor_SmoothStep_Attention(&this->actor, play, this->alpha, temp);
+        threshold = (CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD) && !GET_EVENTCHKINF(EVENTCHKINF_1C) &&
+                     (play->sceneId == SCENE_KOKIRI_FOREST))
+                        ? 100.0f
+                        : 400.0f;
+        this->alpha = Actor_SmoothStep_Attention(&this->actor, play, this->alpha, threshold);
         this->actor.shape.shadowAlpha = this->alpha;
     } else {
         this->alpha = 255;
@@ -843,7 +843,7 @@ void EnMd_Update(Actor* thisx, PlayState* play) {
     CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     SkelAnime_Update(&this->skelAnime);
     EnMd_UpdateEyes(this);
-    func_80AAB5A4(this, play);
+    EnMd_SmoothStep_Attention(this, play);
     Actor_MoveXZGravity(&this->actor);
     EnMd_UpdateTalking(this, play);
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -55,22 +55,22 @@ static ColliderCylinderInit sCylinderInit = {
 
 static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
-typedef enum EnMdAnimation {
-    /*  0 */ ENMD_ANIM_0,
-    /*  1 */ ENMD_ANIM_1,
-    /*  2 */ ENMD_ANIM_2,
-    /*  3 */ ENMD_ANIM_3,
-    /*  4 */ ENMD_ANIM_4,
-    /*  5 */ ENMD_ANIM_5,
-    /*  6 */ ENMD_ANIM_6,
-    /*  7 */ ENMD_ANIM_7,
-    /*  8 */ ENMD_ANIM_8,
-    /*  9 */ ENMD_ANIM_9,
-    /* 10 */ ENMD_ANIM_10,
-    /* 11 */ ENMD_ANIM_11,
-    /* 12 */ ENMD_ANIM_12,
-    /* 13 */ ENMD_ANIM_13
-} EnMdAnimation;
+typedef enum EnMdAnimIndex {
+    /*  0 */ ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V1,
+    /*  1 */ ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V2,
+    /*  2 */ ENMD_ANIM_INDEX_RAISE_HAND_1,
+    /*  3 */ ENMD_ANIM_INDEX_HALT,
+    /*  4 */ ENMD_ANIM_INDEX_PUT_HAND_DOWN,
+    /*  5 */ ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_1,
+    /*  6 */ ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_2,
+    /*  7 */ ENMD_ANIM_INDEX_UNKNOWN_7,
+    /*  8 */ ENMD_ANIM_INDEX_WALKING,
+    /*  9 */ ENMD_ANIM_INDEX_HIPS_ON_HIPS_TRANSITION,
+    /* 10 */ ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3,
+    /* 11 */ ENMD_ANIM_INDEX_SLAM,
+    /* 12 */ ENMD_ANIM_INDEX_RAISE_HAND_2,
+    /* 13 */ ENMD_ANIM_INDEX_ANGRY_HEAD_TURN
+} EnMdAnimIndex;
 
 static AnimationInfo sAnimationInfo[] = {
     { &gMidoHandsOnHipsIdleAnim, 0.0f, 0.0f, -1.0f, ANIMMODE_LOOP, 0.0f },
@@ -102,12 +102,12 @@ void EnMd_ReverseAnimation(EnMd* this) {
 void func_80AAA274(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_2);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_RAISE_HAND_1);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_3);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HALT);
                 this->unk_20A++;
             }
             break;
@@ -117,12 +117,12 @@ void func_80AAA274(EnMd* this) {
 void func_80AAA308(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_4);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_PUT_HAND_DOWN);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_5);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_1);
                 this->unk_20A++;
             }
             break;
@@ -132,13 +132,13 @@ void func_80AAA308(EnMd* this) {
 void func_80AAA39C(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_2);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_RAISE_HAND_1);
             EnMd_ReverseAnimation(this);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_7);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_UNKNOWN_7);
                 this->unk_20A++;
             } else {
                 break;
@@ -146,7 +146,7 @@ void func_80AAA39C(EnMd* this) {
             FALLTHROUGH;
         case 2:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_8);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_WALKING);
                 this->unk_20A++;
             }
             break;
@@ -156,12 +156,12 @@ void func_80AAA39C(EnMd* this) {
 void func_80AAA474(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_7);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_UNKNOWN_7);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_10);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
                 this->unk_20A++;
             }
             break;
@@ -171,13 +171,13 @@ void func_80AAA474(EnMd* this) {
 void func_80AAA508(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_2);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_RAISE_HAND_1);
             EnMd_ReverseAnimation(this);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_10);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
                 this->unk_20A++;
             }
             break;
@@ -187,12 +187,12 @@ void func_80AAA508(EnMd* this) {
 void func_80AAA5A4(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_9);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HIPS_ON_HIPS_TRANSITION);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_6);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_2);
                 this->unk_20A++;
             }
             break;
@@ -202,13 +202,13 @@ void func_80AAA5A4(EnMd* this) {
 void func_80AAA638(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_9);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HIPS_ON_HIPS_TRANSITION);
             EnMd_ReverseAnimation(this);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_10);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
                 this->unk_20A++;
             }
             break;
@@ -218,12 +218,12 @@ void func_80AAA638(EnMd* this) {
 void func_80AAA6D4(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_11);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_SLAM);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_6);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_2);
                 this->unk_20A++;
             }
             break;
@@ -233,12 +233,12 @@ void func_80AAA6D4(EnMd* this) {
 void func_80AAA768(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_12);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_RAISE_HAND_2);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_3);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HALT);
                 this->unk_20A++;
             }
             break;
@@ -248,12 +248,12 @@ void func_80AAA768(EnMd* this) {
 void func_80AAA7FC(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_13);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANGRY_HEAD_TURN);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_6);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_2);
                 this->unk_20A++;
             }
             break;
@@ -263,13 +263,13 @@ void func_80AAA7FC(EnMd* this) {
 void func_80AAA890(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_7);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_UNKNOWN_7);
             EnMd_ReverseAnimation(this);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_10);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
                 this->unk_20A++;
             }
             break;
@@ -363,7 +363,7 @@ void func_80AAAA24(EnMd* this) {
                 break;
         }
     } else if (this->skelAnime.animation != &gMidoHandsOnHipsIdleAnim) {
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_10);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
         func_80AAA92C(this, 0);
     }
 
@@ -665,7 +665,7 @@ void EnMd_Init(Actor* thisx, PlayState* play) {
         return;
     }
 
-    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_0);
+    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V1);
     Actor_SetScale(&this->actor, 0.01f);
     this->actor.attentionRangeType = ATTENTION_RANGE_6;
     this->alpha = 255;

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -55,6 +55,21 @@ static ColliderCylinderInit sCylinderInit = {
 
 static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
+typedef enum EnMdAnimState {
+    /* 0x0 */ ENMD_ANIM_STATE_0,
+    /* 0x1 */ ENMD_ANIM_STATE_1,
+    /* 0x2 */ ENMD_ANIM_STATE_2,
+    /* 0x3 */ ENMD_ANIM_STATE_3,
+    /* 0x4 */ ENMD_ANIM_STATE_4, // never set
+    /* 0x5 */ ENMD_ANIM_STATE_5,
+    /* 0x6 */ ENMD_ANIM_STATE_6,
+    /* 0x7 */ ENMD_ANIM_STATE_7,
+    /* 0x8 */ ENMD_ANIM_STATE_8,
+    /* 0x9 */ ENMD_ANIM_STATE_9,
+    /* 0xA */ ENMD_ANIM_STATE_A,
+    /* 0xB */ ENMD_ANIM_STATE_B
+} EnMdAnimState;
+
 typedef enum EnMdAnimIndex {
     /*  0 */ ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V1,
     /*  1 */ ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V2,
@@ -99,47 +114,47 @@ void EnMd_ReverseAnimation(EnMd* this) {
     this->skelAnime.playSpeed = -1.0f;
 }
 
-void func_80AAA274(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimState1(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_RAISE_HAND_1);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HALT);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA308(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimState2(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_PUT_HAND_DOWN);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_1);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA39C(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimState3(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_RAISE_HAND_1);
             EnMd_ReverseAnimation(this);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_UNKNOWN_7);
-                this->unk_20A++;
+                this->animEntry++;
             } else {
                 break;
             }
@@ -147,241 +162,242 @@ void func_80AAA39C(EnMd* this) {
         case 2:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_WALKING);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA474(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimState4(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_UNKNOWN_7);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA508(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimState5(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_RAISE_HAND_1);
             EnMd_ReverseAnimation(this);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA5A4(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimState6(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HIPS_ON_HIPS_TRANSITION);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_2);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA638(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimState7(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HIPS_ON_HIPS_TRANSITION);
             EnMd_ReverseAnimation(this);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA6D4(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimState8(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_SLAM);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_2);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA768(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimState9(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_RAISE_HAND_2);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HALT);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA7FC(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimStateA(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANGRY_HEAD_TURN);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_ANNOYED_POINTED_HEAD_IDLE_2);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA890(EnMd* this) {
-    switch (this->unk_20A) {
+void EnMd_UpdateAnimStateB(EnMd* this) {
+    switch (this->animEntry) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_UNKNOWN_7);
             EnMd_ReverseAnimation(this);
-            this->unk_20A++;
+            this->animEntry++;
             FALLTHROUGH;
         case 1:
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
-                this->unk_20A++;
+                this->animEntry++;
             }
             break;
     }
 }
 
-void func_80AAA92C(EnMd* this, u8 arg1) {
-    this->unk_20B = arg1;
-    this->unk_20A = 0;
+void EnMd_SetAnimState(EnMd* this, u8 state) {
+    this->animState = state;
+    this->animEntry = 0;
 }
 
-void func_80AAA93C(EnMd* this) {
-    switch (this->unk_20B) {
-        case 1:
-            func_80AAA274(this);
+void EnMd_UpdateAnimState(EnMd* this) {
+    switch (this->animState) {
+        case ENMD_ANIM_STATE_1:
+            EnMd_UpdateAnimState1(this);
             break;
-        case 2:
-            func_80AAA308(this);
+        case ENMD_ANIM_STATE_2:
+            EnMd_UpdateAnimState2(this);
             break;
-        case 3:
-            func_80AAA39C(this);
+        case ENMD_ANIM_STATE_3:
+            EnMd_UpdateAnimState3(this);
             break;
-        case 4:
-            func_80AAA474(this);
+        case ENMD_ANIM_STATE_4:
+            // unreachable
+            EnMd_UpdateAnimState4(this);
             break;
-        case 5:
-            func_80AAA508(this);
+        case ENMD_ANIM_STATE_5:
+            EnMd_UpdateAnimState5(this);
             break;
-        case 6:
-            func_80AAA5A4(this);
+        case ENMD_ANIM_STATE_6:
+            EnMd_UpdateAnimState6(this);
             break;
-        case 7:
-            func_80AAA638(this);
+        case ENMD_ANIM_STATE_7:
+            EnMd_UpdateAnimState7(this);
             break;
-        case 8:
-            func_80AAA6D4(this);
+        case ENMD_ANIM_STATE_8:
+            EnMd_UpdateAnimState8(this);
             break;
-        case 9:
-            func_80AAA768(this);
+        case ENMD_ANIM_STATE_9:
+            EnMd_UpdateAnimState9(this);
             break;
-        case 10:
-            func_80AAA7FC(this);
+        case ENMD_ANIM_STATE_A:
+            EnMd_UpdateAnimStateA(this);
             break;
-        case 11:
-            func_80AAA890(this);
+        case ENMD_ANIM_STATE_B:
+            EnMd_UpdateAnimStateB(this);
     }
 }
 
-void func_80AAAA24(EnMd* this) {
+void EnMd_UpdateAnimState_WithTalking(EnMd* this) {
     if (this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
         switch (this->actor.textId) {
             case 0x102F:
-                if ((this->unk_208 == 0) && (this->unk_20B != 1)) {
-                    func_80AAA92C(this, 1);
+                if ((this->messageEntry == 0) && (this->animState != ENMD_ANIM_STATE_1)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_1);
                 }
-                if ((this->unk_208 == 2) && (this->unk_20B != 2)) {
-                    func_80AAA92C(this, 2);
+                if ((this->messageEntry == 2) && (this->animState != ENMD_ANIM_STATE_2)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_2);
                 }
-                if ((this->unk_208 == 5) && (this->unk_20B != 8)) {
-                    func_80AAA92C(this, 8);
+                if ((this->messageEntry == 5) && (this->animState != ENMD_ANIM_STATE_8)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_8);
                 }
-                if ((this->unk_208 == 11) && (this->unk_20B != 9)) {
-                    func_80AAA92C(this, 9);
+                if ((this->messageEntry == 11) && (this->animState != ENMD_ANIM_STATE_9)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_9);
                 }
                 break;
             case 0x1033:
-                if ((this->unk_208 == 0) && (this->unk_20B != 1)) {
-                    func_80AAA92C(this, 1);
+                if ((this->messageEntry == 0) && (this->animState != ENMD_ANIM_STATE_1)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_1);
                 }
-                if ((this->unk_208 == 1) && (this->unk_20B != 2)) {
-                    func_80AAA92C(this, 2);
+                if ((this->messageEntry == 1) && (this->animState != ENMD_ANIM_STATE_2)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_2);
                 }
-                if ((this->unk_208 == 5) && (this->unk_20B != 10)) {
-                    func_80AAA92C(this, 10);
+                if ((this->messageEntry == 5) && (this->animState != ENMD_ANIM_STATE_A)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_A);
                 }
-                if ((this->unk_208 == 7) && (this->unk_20B != 9)) {
-                    func_80AAA92C(this, 9);
+                if ((this->messageEntry == 7) && (this->animState != ENMD_ANIM_STATE_9)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_9);
                 }
                 break;
             case 0x1030:
             case 0x1034:
             case 0x1045:
-                if ((this->unk_208 == 0) && (this->unk_20B != 1)) {
-                    func_80AAA92C(this, 1);
+                if ((this->messageEntry == 0) && (this->animState != ENMD_ANIM_STATE_1)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_1);
                 }
                 break;
             case 0x1046:
-                if ((this->unk_208 == 0) && (this->unk_20B != 6)) {
-                    func_80AAA92C(this, 6);
+                if ((this->messageEntry == 0) && (this->animState != ENMD_ANIM_STATE_6)) {
+                    EnMd_SetAnimState(this, ENMD_ANIM_STATE_6);
                 }
                 break;
         }
     } else if (this->skelAnime.animation != &gMidoHandsOnHipsIdleAnim) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_INDEX_HAND_ON_HIPS_IDLE_V3);
-        func_80AAA92C(this, 0);
+        EnMd_SetAnimState(this, ENMD_ANIM_STATE_0);
     }
 
-    func_80AAA93C(this);
+    EnMd_UpdateAnimState(this);
 }
 
-s16 func_80AAAC78(EnMd* this, PlayState* play) {
-    s16 dialogState = Message_GetState(&play->msgCtx);
+s16 EnMd_TrackMessageState(EnMd* this, PlayState* play) {
+    s16 messageState = Message_GetState(&play->msgCtx);
 
-    if ((this->unk_209 == TEXT_STATE_AWAITING_NEXT) || (this->unk_209 == TEXT_STATE_EVENT) ||
-        (this->unk_209 == TEXT_STATE_CLOSING) || (this->unk_209 == TEXT_STATE_DONE_HAS_NEXT)) {
-        if (this->unk_209 != dialogState) {
-            this->unk_208++;
+    if ((this->messageState == TEXT_STATE_AWAITING_NEXT) || (this->messageState == TEXT_STATE_EVENT) ||
+        (this->messageState == TEXT_STATE_CLOSING) || (this->messageState == TEXT_STATE_DONE_HAS_NEXT)) {
+        if (this->messageState != messageState) {
+            this->messageEntry++;
         }
     }
 
-    this->unk_209 = dialogState;
-    return dialogState;
+    this->messageState = messageState;
+    return messageState;
 }
 
 u16 EnMd_GetTextIdKokiriForest(PlayState* play, EnMd* this) {
@@ -391,8 +407,8 @@ u16 EnMd_GetTextIdKokiriForest(PlayState* play, EnMd* this) {
         return textId;
     }
 
-    this->unk_208 = 0;
-    this->unk_209 = TEXT_STATE_NONE;
+    this->messageEntry = 0;
+    this->messageState = TEXT_STATE_NONE;
 
     if (CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD)) {
         return 0x1045;
@@ -415,8 +431,8 @@ u16 EnMd_GetTextIdKokiriForest(PlayState* play, EnMd* this) {
 }
 
 u16 EnMd_GetTextIdMidosHouse(PlayState* play, EnMd* this) {
-    this->unk_208 = 0;
-    this->unk_209 = TEXT_STATE_NONE;
+    this->messageEntry = 0;
+    this->messageState = TEXT_STATE_NONE;
 
     if (GET_EVENTCHKINF(EVENTCHKINF_40)) {
         return 0x1028;
@@ -426,8 +442,8 @@ u16 EnMd_GetTextIdMidosHouse(PlayState* play, EnMd* this) {
 }
 
 u16 EnMd_GetTextIdLostWoods(PlayState* play, EnMd* this) {
-    this->unk_208 = 0;
-    this->unk_209 = TEXT_STATE_NONE;
+    this->messageEntry = 0;
+    this->messageState = TEXT_STATE_NONE;
 
     if (GET_EVENTCHKINF(EVENTCHKINF_48)) {
         if (GET_INFTABLE(INFTABLE_19)) {
@@ -464,7 +480,7 @@ u16 EnMd_GetTextId(PlayState* play, Actor* thisx) {
 
 s16 EnMd_UpdateTalkState(PlayState* play, Actor* thisx) {
     EnMd* this = (EnMd*)thisx;
-    switch (func_80AAAC78(this, play)) {
+    switch (EnMd_TrackMessageState(this, play)) {
         case TEXT_STATE_NONE:
         case TEXT_STATE_DONE_HAS_NEXT:
         case TEXT_STATE_DONE_FADING:
@@ -696,18 +712,18 @@ void EnMd_Destroy(Actor* thisx, PlayState* play) {
 void func_80AAB874(EnMd* this, PlayState* play) {
     if (this->skelAnime.animation == &gMidoHandsOnHipsIdleAnim) {
         func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
-    } else if ((this->interactInfo.talkState == NPC_TALK_STATE_IDLE) && (this->unk_20B != 7)) {
-        func_80AAA92C(this, 7);
+    } else if ((this->interactInfo.talkState == NPC_TALK_STATE_IDLE) && (this->animState != ENMD_ANIM_STATE_7)) {
+        EnMd_SetAnimState(this, ENMD_ANIM_STATE_7);
     }
 
-    func_80AAAA24(this);
+    EnMd_UpdateAnimState_WithTalking(this);
 }
 
 void func_80AAB8F8(EnMd* this, PlayState* play) {
     if (this->skelAnime.animation == &gMidoHandsOnHipsIdleAnim) {
         func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
     }
-    func_80AAA93C(this);
+    EnMd_UpdateAnimState(this);
 }
 
 void func_80AAB948(EnMd* this, PlayState* play) {
@@ -716,7 +732,7 @@ void func_80AAB948(EnMd* this, PlayState* play) {
     Actor* actorToBlock = &GET_PLAYER(play)->actor;
     s16 yaw;
 
-    func_80AAAA24(this);
+    EnMd_UpdateAnimState_WithTalking(this);
 
     if (this->interactInfo.talkState == NPC_TALK_STATE_IDLE) {
         this->actor.world.rot.y = this->actor.yawTowardsPlayer;
@@ -747,8 +763,8 @@ void func_80AAB948(EnMd* this, PlayState* play) {
             SET_EVENTCHKINF(EVENTCHKINF_0A);
         }
 
-        func_80AAA92C(this, 3);
-        func_80AAA93C(this);
+        EnMd_SetAnimState(this, ENMD_ANIM_STATE_3);
+        EnMd_UpdateAnimState(this);
         this->waypoint = 1;
         this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
         this->actionFunc = func_80AABD0C;
@@ -796,7 +812,7 @@ void func_80AABC10(EnMd* this, PlayState* play) {
 
 void func_80AABD0C(EnMd* this, PlayState* play) {
     func_80034F54(play, this->unk_214, this->unk_236, ENMD_LIMB_MAX);
-    func_80AAA93C(this);
+    EnMd_UpdateAnimState(this);
 
     if (!(EnMd_FollowPath(this, play)) || (this->waypoint != 0)) {
         this->actor.shape.rot = this->actor.world.rot;
@@ -811,7 +827,7 @@ void func_80AABD0C(EnMd* this, PlayState* play) {
         return;
     }
 
-    func_80AAA92C(this, 11);
+    EnMd_SetAnimState(this, ENMD_ANIM_STATE_B);
 
     this->skelAnime.playSpeed = 0.0f;
     this->actor.speed = 0.0f;

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -658,7 +658,7 @@ void func_80AAB5A4(EnMd* this, PlayState* play) {
                 (play->sceneId == SCENE_KOKIRI_FOREST))
                    ? 100.0f
                    : 400.0f;
-        this->alpha = func_80034DD4(&this->actor, play, this->alpha, temp);
+        this->alpha = Actor_SmoothStep_Attention(&this->actor, play, this->alpha, temp);
         this->actor.shape.shadowAlpha = this->alpha;
     } else {
         this->alpha = 255;

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -89,7 +89,7 @@ static AnimationInfo sAnimationInfo[] = {
     { &gMidoAngryHeadTurnAnim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, -1.0f },
 };
 
-void func_80AAA250(EnMd* this) {
+void EnMd_ReverseAnimation(EnMd* this) {
     f32 startFrame;
 
     startFrame = this->skelAnime.startFrame;
@@ -133,7 +133,7 @@ void func_80AAA39C(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_2);
-            func_80AAA250(this);
+            EnMd_ReverseAnimation(this);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
@@ -172,7 +172,7 @@ void func_80AAA508(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_2);
-            func_80AAA250(this);
+            EnMd_ReverseAnimation(this);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
@@ -203,7 +203,7 @@ void func_80AAA638(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_9);
-            func_80AAA250(this);
+            EnMd_ReverseAnimation(this);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:
@@ -264,7 +264,7 @@ void func_80AAA890(EnMd* this) {
     switch (this->unk_20A) {
         case 0:
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENMD_ANIM_7);
-            func_80AAA250(this);
+            EnMd_ReverseAnimation(this);
             this->unk_20A++;
             FALLTHROUGH;
         case 1:

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -556,7 +556,7 @@ void EnMd_UpdateTalking(EnMd* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 absYawDiff;
     s16 trackingMode;
-    s16 temp2;
+    s16 canUpdateTalking;
     s16 yawDiff;
 
     if (this->actor.xzDistToPlayer < 170.0f) {
@@ -565,10 +565,10 @@ void EnMd_UpdateTalking(EnMd* this, PlayState* play) {
 
         trackingMode =
             absYawDiff <= Npc_GetTrackingPresetMaxPlayerYaw(2) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
-        temp2 = 1;
+        canUpdateTalking = true;
     } else {
         trackingMode = NPC_TRACKING_NONE;
-        temp2 = 0;
+        canUpdateTalking = false;
     }
 
     if (this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
@@ -577,11 +577,11 @@ void EnMd_UpdateTalking(EnMd* this, PlayState* play) {
 
     if (this->actionFunc == EnMd_Walk) {
         trackingMode = NPC_TRACKING_NONE;
-        temp2 = 0;
+        canUpdateTalking = false;
     }
     if (this->actionFunc == EnMd_Watch) {
         trackingMode = NPC_TRACKING_FULL_BODY;
-        temp2 = 1;
+        canUpdateTalking = true;
     }
 
     if ((play->csCtx.state != CS_STATE_IDLE) || gDebugCamEnabled) {
@@ -595,7 +595,7 @@ void EnMd_UpdateTalking(EnMd* this, PlayState* play) {
 
     Npc_TrackPoint(&this->actor, &this->interactInfo, 2, trackingMode);
     if (this->actionFunc != EnMd_ListenToOcarina) {
-        if (temp2) {
+        if (canUpdateTalking) {
             Npc_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, this->collider.dim.radius + 30.0f,
                               EnMd_GetTextId, EnMd_UpdateTalkState);
         }

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -552,7 +552,7 @@ void EnMd_UpdateEyes(EnMd* this) {
     }
 }
 
-void func_80AAB158(EnMd* this, PlayState* play) {
+void EnMd_UpdateTalking(EnMd* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 absYawDiff;
     s16 trackingMode;
@@ -845,7 +845,7 @@ void EnMd_Update(Actor* thisx, PlayState* play) {
     EnMd_UpdateEyes(this);
     func_80AAB5A4(this, play);
     Actor_MoveXZGravity(&this->actor);
-    func_80AAB158(this, play);
+    EnMd_UpdateTalking(this, play);
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
     this->actionFunc(this, play);
 }

--- a/src/overlays/actors/ovl_En_Md/z_en_md.h
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.h
@@ -35,10 +35,10 @@ typedef struct EnMd {
     /* 0x0190 */ EnMdActionFunc actionFunc;
     /* 0x0194 */ ColliderCylinder collider;
     /* 0x01E0 */ NpcInteractInfo interactInfo;
-    /* 0x0208 */ u8 unk_208;
-    /* 0x0209 */ u8 unk_209;
-    /* 0x020A */ u8 unk_20A;
-    /* 0x020B */ u8 unk_20B;
+    /* 0x0208 */ u8 messageEntry; // tracks message state changes, in place of `.actor.textId`
+    /* 0x0209 */ u8 messageState; // last known result of `Message_GetState`
+    /* 0x020A */ u8 animEntry;    // each one changes animation info and waits
+    /* 0x020B */ u8 animState;    // defines a sequence of animation entries
     /* 0x020C */ s16 blinkTimer;
     /* 0x020E */ s16 eyeIdx;
     /* 0x0210 */ s16 alpha;

--- a/src/overlays/actors/ovl_En_Sa/z_en_sa.c
+++ b/src/overlays/actors/ovl_En_Sa/z_en_sa.c
@@ -738,7 +738,7 @@ void EnSa_Update(Actor* thisx, PlayState* play) {
     }
 
     if (this->actionFunc != func_80AF68E4) {
-        this->alpha = func_80034DD4(&this->actor, play, this->alpha, 400.0f);
+        this->alpha = Actor_SmoothStep_Attention(&this->actor, play, this->alpha, 400.0f);
     } else {
         this->alpha = 255;
     }


### PR DESCRIPTION
additionally, document `func_80034DD4` as `Actor_SmoothStep_Attention` @ `z64actor.h`. it is used for two actors only: Mido and Saria.

might factor this change out as another PR, but it is beneficial for this PR too: otherwise it's not much clear, why `func_80AAB5A4` is being renamed to `EnMd_SmoothStep_Attention`