### PR TITLE
Fix VROM address handling in sym_info.py

### DIFF
--- a/sym_info.py
+++ b/sym_info.py
@@ -20,7 +20,23 @@ def symInfoMain():
     if args.use_expected:
         mapPath = "expected" / BUILTMAP
 
-    mapfile_parser.frontends.sym_info.doSymInfo(mapPath, args.symname)
+    # Guess if the input is an VROM/VRAM or a symbol name
+    as_vram = False
+    as_vrom = False
+    as_name = False
+    try:
+        address = int(args.symname, 0)
+        if address >= 0x01000000:
+            as_vram = True
+        else:
+            as_vrom = True
+    except ValueError:
+        as_name = True
+
+    mapfile_parser.frontends.sym_info.doSymInfo(
+        mapPath, args.symname, as_vram=as_vram, as_vrom=as_vrom, as_name=as_name
+    )
+
 
 if __name__ == "__main__":
     symInfoMain()


### PR DESCRIPTION
Ever since [mapfile_parser 2.7.0](https://github.com/Decompollaborate/mapfile_parser/releases/tag/2.7.0), `sym_info.py` always treats address as VRAM addresses instead of VROM addresses, even for very low numbers:

```
$ ./sym_info.py -v ntsc-1.0 0x1F20
0x1F20 is at 0x1F20 bytes inside 'Soundfont_0_Start' (VRAM: 0x00000000, VROM: 0x00D390, SIZE: 0x3AA0, build/ntsc-1.0/assets/audio/soundfonts/Soundfont_0.o)
```

This restores the previous logic where a number `>= 0x01000000` is treated as a VRAM address and a number `< 0x01000000` is treated as a VROM address.