### PR TITLE
[ntsc-1.0/1.1] Match audio and loose ends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -635,7 +635,7 @@ $(ROMC): $(ROM) $(ELF) $(BUILD_DIR)/compress_ranges.txt
 
 $(ELF): $(TEXTURE_FILES_OUT) $(ASSET_FILES_OUT) $(O_FILES) $(OVL_RELOC_FILES) $(LDSCRIPT) $(BUILD_DIR)/undefined_syms.txt \
         $(SAMPLEBANK_O_FILES) $(SOUNDFONT_O_FILES) $(SEQUENCE_O_FILES) \
-        $(BUILD_DIR)/assets/audio/sequence_font_table.o $(BUILD_DIR)/assets/audio/audiobank_padding.o $(BUILD_DIR)/assets/audio/audioseq_padding.o
+        $(BUILD_DIR)/assets/audio/sequence_font_table.o $(BUILD_DIR)/assets/audio/audiobank_padding.o
 	$(LD) -T $(LDSCRIPT) -T $(BUILD_DIR)/undefined_syms.txt --no-check-sections --accept-unknown-input-arch --emit-relocs -Map $(MAP) -o $@
 
 ## Order-only prerequisites
@@ -909,10 +909,6 @@ $(BUILD_DIR)/assets/audio/sequence_font_table.o: $(BUILD_DIR)/assets/audio/seque
 
 # Extra audiobank padding that doesn't belong to any soundfont file
 $(BUILD_DIR)/assets/audio/audiobank_padding.o:
-	echo ".section .rodata; .fill 0x20" | $(AS) $(ASFLAGS) -o $@
-
-# Extra audioseq padding that doesn't belong to any sequence file
-$(BUILD_DIR)/assets/audio/audioseq_padding.o:
 	echo ".section .rodata; .fill 0x20" | $(AS) $(ASFLAGS) -o $@
 
 -include $(DEP_FILES)

--- a/Makefile
+++ b/Makefile
@@ -635,7 +635,7 @@ $(ROMC): $(ROM) $(ELF) $(BUILD_DIR)/compress_ranges.txt
 
 $(ELF): $(TEXTURE_FILES_OUT) $(ASSET_FILES_OUT) $(O_FILES) $(OVL_RELOC_FILES) $(LDSCRIPT) $(BUILD_DIR)/undefined_syms.txt \
         $(SAMPLEBANK_O_FILES) $(SOUNDFONT_O_FILES) $(SEQUENCE_O_FILES) \
-        $(BUILD_DIR)/assets/audio/sequence_font_table.o $(BUILD_DIR)/assets/audio/audiobank_padding.o
+        $(BUILD_DIR)/assets/audio/sequence_font_table.o $(BUILD_DIR)/assets/audio/audiobank_padding.o $(BUILD_DIR)/assets/audio/audioseq_padding.o
 	$(LD) -T $(LDSCRIPT) -T $(BUILD_DIR)/undefined_syms.txt --no-check-sections --accept-unknown-input-arch --emit-relocs -Map $(MAP) -o $@
 
 ## Order-only prerequisites
@@ -909,6 +909,10 @@ $(BUILD_DIR)/assets/audio/sequence_font_table.o: $(BUILD_DIR)/assets/audio/seque
 
 # Extra audiobank padding that doesn't belong to any soundfont file
 $(BUILD_DIR)/assets/audio/audiobank_padding.o:
+	echo ".section .rodata; .fill 0x20" | $(AS) $(ASFLAGS) -o $@
+
+# Extra audioseq padding that doesn't belong to any sequence file
+$(BUILD_DIR)/assets/audio/audioseq_padding.o:
 	echo ".section .rodata; .fill 0x20" | $(AS) $(ASFLAGS) -o $@
 
 -include $(DEP_FILES)

--- a/assets/audio/sequences/seq_0.prg.seq
+++ b/assets/audio/sequences/seq_0.prg.seq
@@ -2408,7 +2408,11 @@ CHAN_0EDC:
 
 .layer LAYER_1029
 /* 0x1029 [0xC6 0x2F               ] */ instr       SF0_INST_47
+#if OOT_VERSION < PAL_1_0
+/* 0x102B [0xCB 0x66 0x4C 0xF0     ] */ env         ENVELOPE_664C, 240
+#else
 /* 0x102B [0xCB 0x66 0x4C 0xFF     ] */ env         ENVELOPE_664C, 255
+#endif
 /* 0x102F [0x7E 0x0C 0x6C          ] */ notedv      PITCH_B5, FRAMERATE_CONST(12, 15), 108
 /* 0x1032 [0xFF                    ] */ end
 

--- a/assets/audio/sequences/seq_109.prg.seq
+++ b/assets/audio/sequences/seq_109.prg.seq
@@ -603,7 +603,7 @@ LAYER_0452:
 /* 0x046C [0xE9 0x0E               ] */ notepri     0, 14
 /* 0x046E [0xE5 0x01               ] */ reverbidx   1
 /* 0x0470 [0xD4 0x28               ] */ reverb      40
-#if VERSION >= PAL_1_0
+#if OOT_VERSION >= PAL_1_0
 /* 0x0472 [0xC6 0x00               ] */ font        Soundfont_0_ID
 #endif
 /* 0x0474 [0xFC 0x01 0x56          ] */ call        CHAN_0156

--- a/assets/audio/sequences/seq_109.prg.seq
+++ b/assets/audio/sequences/seq_109.prg.seq
@@ -1149,4 +1149,12 @@ ENVELOPE_08BA:
     point 20, 20000
     hang
 
+#if OOT_VERSION == NTSC_1_2 || PLATFORM_GC
+.filter FILTER_0932
+    filter 0, 0, 0, 0, 0, 0, 0, 0
+
+.filter FILTER_0942
+    filter 0, 0, 0, 0, 0, 0, 0, 0
+#endif
+
 .endseq Sequence_109

--- a/assets/audio/sequences/seq_109.prg.seq
+++ b/assets/audio/sequences/seq_109.prg.seq
@@ -603,7 +603,9 @@ LAYER_0452:
 /* 0x046C [0xE9 0x0E               ] */ notepri     0, 14
 /* 0x046E [0xE5 0x01               ] */ reverbidx   1
 /* 0x0470 [0xD4 0x28               ] */ reverb      40
+#if VERSION >= PAL_1_0
 /* 0x0472 [0xC6 0x00               ] */ font        Soundfont_0_ID
+#endif
 /* 0x0474 [0xFC 0x01 0x56          ] */ call        CHAN_0156
 /* 0x0477 [0xFD 0x60               ] */ delay       96
 /* 0x0479 [0xFC 0x01 0x56          ] */ call        CHAN_0156
@@ -1146,13 +1148,5 @@ ENVELOPE_08BA:
     point 800, 25000
     point 20, 20000
     hang
-
-#if !OOT_PAL_N64
-.filter FILTER_0932
-    filter 0, 0, 0, 0, 0, 0, 0, 0
-
-.filter FILTER_0942
-    filter 0, 0, 0, 0, 0, 0, 0, 0
-#endif
 
 .endseq Sequence_109

--- a/include/z64.h
+++ b/include/z64.h
@@ -389,12 +389,18 @@ ALIGNED(4) typedef struct PreNmiBuff {
 } PreNmiBuff; // size = 0x18 (actually osAppNMIBuffer is 0x40 bytes large but the rest is unused)
 
 typedef enum ViModeEditState {
+#if OOT_VERSION < PAL_1_0
     /* -2 */ VI_MODE_EDIT_STATE_NEGATIVE_2 = -2,
     /* -1 */ VI_MODE_EDIT_STATE_NEGATIVE_1,
+    /*  0 */ VI_MODE_EDIT_STATE_INACTIVE,
+    /*  1 */ VI_MODE_EDIT_STATE_2, // active, more adjustments
+    /*  2 */ VI_MODE_EDIT_STATE_3  // active, more adjustments, print comparison with NTSC LAN1 mode
+#else
     /*  0 */ VI_MODE_EDIT_STATE_INACTIVE,
     /*  1 */ VI_MODE_EDIT_STATE_ACTIVE,
     /*  2 */ VI_MODE_EDIT_STATE_2, // active, more adjustments
     /*  3 */ VI_MODE_EDIT_STATE_3  // active, more adjustments, print comparison with NTSC LAN1 mode
+#endif
 } ViModeEditState;
 
 typedef struct ViMode {

--- a/spec
+++ b/spec
@@ -336,9 +336,6 @@ beginseg
     include "$(BUILD_DIR)/assets/audio/sequences/seq_107.o"
     include "$(BUILD_DIR)/assets/audio/sequences/seq_108.o"
     include "$(BUILD_DIR)/assets/audio/sequences/seq_109.prg.o"
-#if OOT_VERSION == NTSC_1_2 || PLATFORM_GC
-    include "$(BUILD_DIR)/assets/audio/audioseq_padding.o"
-#endif
 endseg
 
 beginseg

--- a/spec
+++ b/spec
@@ -219,7 +219,9 @@ beginseg
     include "$(BUILD_DIR)/assets/audio/soundfonts/Soundfont_35.o"
     include "$(BUILD_DIR)/assets/audio/soundfonts/Soundfont_36.o"
     include "$(BUILD_DIR)/assets/audio/soundfonts/Soundfont_37.o"
+#if OOT_VERSION >= PAL_1_0
     include "$(BUILD_DIR)/assets/audio/audiobank_padding.o"
+#endif
 endseg
 
 beginseg
@@ -334,6 +336,9 @@ beginseg
     include "$(BUILD_DIR)/assets/audio/sequences/seq_107.o"
     include "$(BUILD_DIR)/assets/audio/sequences/seq_108.o"
     include "$(BUILD_DIR)/assets/audio/sequences/seq_109.prg.o"
+#if OOT_VERSION == NTSC_1_2 || PLATFORM_GC
+    include "$(BUILD_DIR)/assets/audio/audioseq_padding.o"
+#endif
 endseg
 
 beginseg

--- a/src/code/z_scene_table.c
+++ b/src/code/z_scene_table.c
@@ -1190,7 +1190,13 @@ void Scene_DrawConfigKokiriForest(PlayState* play) {
         spA3 = 255 - (u8)play->roomCtx.drawParams[0];
     } else if (gSaveContext.sceneLayer == 6) {
         spA0 = play->roomCtx.drawParams[0] + 500;
-    } else if ((!IS_CUTSCENE_LAYER || LINK_IS_ADULT) && GET_EVENTCHKINF(EVENTCHKINF_07)) {
+    } else if (
+#if OOT_VERSION < PAL_1_0
+        !IS_CUTSCENE_LAYER && GET_EVENTCHKINF(EVENTCHKINF_07)
+#else
+        (!IS_CUTSCENE_LAYER || LINK_IS_ADULT) && GET_EVENTCHKINF(EVENTCHKINF_07)
+#endif
+    ) {
         spA0 = 2150;
     }
 

--- a/src/overlays/effects/ovl_Effect_Ss_En_Ice/z_eff_ss_en_ice.c
+++ b/src/overlays/effects/ovl_Effect_Ss_En_Ice/z_eff_ss_en_ice.c
@@ -5,6 +5,7 @@
  */
 
 #include "z_eff_ss_en_ice.h"
+#include "versions.h"
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 
 #define rLifespan regs[0]
@@ -133,9 +134,9 @@ void EffectSsEnIce_Draw(PlayState* play, u32 index, EffectSs* this) {
 }
 
 void EffectSsEnIce_UpdateFlying(PlayState* play, u32 index, EffectSs* this) {
-    s16 rand;
-
+#if OOT_VERSION >= NTSC_1_1
     if ((this->actor != NULL) && (this->actor->update != NULL)) {
+#endif
         if ((this->life >= 9) && (this->actor->colorFilterTimer != 0) && !(this->actor->colorFilterParams & 0xC000)) {
             this->pos.x = this->actor->world.pos.x + this->vec.x;
             this->pos.y = this->actor->world.pos.y + this->vec.y;
@@ -147,9 +148,11 @@ void EffectSsEnIce_UpdateFlying(PlayState* play, u32 index, EffectSs* this) {
             this->accel.y = -1.5f;
             this->velocity.y = 5.0f;
         }
+#if OOT_VERSION >= NTSC_1_1
     } else {
         if (this->life >= 9) {
-            rand = Rand_CenteredFloat(65535.0f);
+            s16 rand = Rand_CenteredFloat(65535.0f);
+
             this->accel.x = Math_SinS(rand) * (Rand_ZeroOne() + 1.0f);
             this->accel.z = Math_CosS(rand) * (Rand_ZeroOne() + 1.0f);
             this->life = 8;
@@ -157,6 +160,7 @@ void EffectSsEnIce_UpdateFlying(PlayState* play, u32 index, EffectSs* this) {
             this->velocity.y = 5.0f;
         }
     }
+#endif
 }
 
 void EffectSsEnIce_Update(PlayState* play, u32 index, EffectSs* this) {

--- a/src/overlays/effects/ovl_Effect_Ss_Kakera/z_eff_ss_kakera.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Kakera/z_eff_ss_kakera.c
@@ -5,6 +5,7 @@
  */
 
 #include "z_eff_ss_kakera.h"
+#include "versions.h"
 
 #define rReg0 regs[0]
 #define rGravity regs[1]
@@ -54,7 +55,11 @@ u32 EffectSsKakera_Init(PlayState* play, u32 index, EffectSs* this, void* initPa
 
     } else {
         PRINTF("shape_modelがNULL\n");
+#if OOT_VERSION < NTSC_1_1
+        LogUtils_HungupThread("../z_eff_kakera.c", 175);
+#else
         LogUtils_HungupThread("../z_eff_kakera.c", 178);
+#endif
     }
 
     this->draw = EffectSsKakera_Draw;


### PR DESCRIPTION
Includes some stuff I apparently forgot to PR but found while testing #2291. ~~The audio tweaks affect padding in a way I don't understand, and I added `audioseq_padding.o` here to help even though it's identical to `audiobank_padding.o`.~~ 

For `EffectSsEnIce_UpdateFlying`, I'm not sure where to copy-paste the shared logic, or ifdef-out single braces. Same with `Scene_DrawConfigKokiriForest`, I've kinda forgotten what style we were using.

After this it's for reals only bss ordering now