### PR TITLE
Document `EnGo` and `EnGo2` functions, fields, and animations

### DIFF
--- a/assets/xml/objects/object_oF1d_map.xml
+++ b/assets/xml/objects/object_oF1d_map.xml
@@ -21,9 +21,10 @@
         <DList Name="gGoronDL_00FD40" Offset="0xFD40"/>
         <DList Name="gGoronDL_00FD50" Offset="0xFD50"/>
 
-        <!-- skeleton -->
+        <!-- skeleton, limb none -->
         <Skeleton Name="gGoronSkel" Type="Flex" LimbType="Standard" Offset="0xFEF0"/>
 
+        <!-- limbs -->
         <Limb Name="gGoronRootLimb"         LimbType="Standard" Offset="0xFDE0"/>
         <Limb Name="gGoronWaistLimb"        LimbType="Standard" Offset="0xFDEC"/>
         <Limb Name="gGoronLegsLimb"         LimbType="Standard" Offset="0xFDF8"/>
@@ -41,6 +42,23 @@
         <Limb Name="gGoronRightForearmLimb" LimbType="Standard" Offset="0xFE88"/>
         <Limb Name="gGoronRightHandLimb"    LimbType="Standard" Offset="0xFE94"/>
         <Limb Name="gGoronHeadLimb"         LimbType="Standard" Offset="0xFEA0"/>
+
+        <!-- limb display lists -->
+        <DList Name="gGoronWaistDL"        Offset="0x8708"/>
+        <DList Name="gGoronLeftThighDL"    Offset="0x8C80"/>
+        <DList Name="gGoronLeftShinDL"     Offset="0x8D70"/>
+        <DList Name="gGoronLeftFootDL"     Offset="0x8EC0"/>
+        <DList Name="gGoronRightThighDL"   Offset="0x87D0"/>
+        <DList Name="gGoronRightShinDL"    Offset="0x88C0"/>
+        <DList Name="gGoronRightFootDL"    Offset="0x8A10"/>
+        <DList Name="gGoronTorsoDL"        Offset="0x6F90"/>
+        <DList Name="gGoronLeftArmDL"      Offset="0x8218"/>
+        <DList Name="gGoronLeftForearmDL"  Offset="0x83A0"/>
+        <DList Name="gGoronLeftHandDL"     Offset="0x84E0"/>
+        <DList Name="gGoronRightArmDL"     Offset="0x7D28"/>
+        <DList Name="gGoronRightForearmDL" Offset="0x7EB0"/>
+        <DList Name="gGoronRightHandDL"    Offset="0x7FF0"/>
+        <DList Name="gGoronHeadDL"         Offset="0x7458"/>
 
         <!-- palettes -->
         <Texture Name="object_oF1d_map_TLUT_00C640" OutName="tlut_0000C640" Format="rgba16" Width="16" Height="16" Offset="0xC640"/>

--- a/assets/xml/objects/object_oF1d_map.xml
+++ b/assets/xml/objects/object_oF1d_map.xml
@@ -2,17 +2,17 @@
     <!-- Goron -->
     <File Name="object_oF1d_map" Segment="6">
         <!-- animations -->
-        <Animation Name="gGoronAnim_000750" Offset="0x750"/>
-        <Animation Name="gGoronAnim_000D5C" Offset="0xD5C"/>
-        <Animation Name="gGoronAnim_00161C" Offset="0x161C"/>
-        <Animation Name="gGoronAnim_001A00" Offset="0x1A00"/>
-        <Animation Name="gGoronAnim_0021D0" Offset="0x21D0"/>
-        <Animation Name="gGoronAnim_0029A8" Offset="0x29A8"/>
-        <Animation Name="gGoronAnim_002D80" Offset="0x2D80"/>
-        <Animation Name="gGoronAnim_003768" Offset="0x3768"/>
-        <Animation Name="gGoronAnim_0038E4" Offset="0x38E4"/>
-        <Animation Name="gGoronAnim_004930" Offset="0x4930"/>
-        <Animation Name="gGoronAnim_010590" Offset="0x10590"/>
+        <Animation Name="gGoronSobbingLoopAnim"    Offset="0x750"/>
+        <Animation Name="gGoronShakingLoopAnim"    Offset="0xD5C"/>
+        <Animation Name="gGoronUncurlToProneAnim"  Offset="0x161C"/>
+        <Animation Name="gGoronProneLoopAnim"      Offset="0x1A00"/>
+        <Animation Name="gGoronScratchingLoopAnim" Offset="0x21D0"/>
+        <Animation Name="gGoronWalkingLoopAnim"    Offset="0x29A8"/>
+        <Animation Name="gGoronEyedropsTakenAnim"  Offset="0x2D80"/>
+        <Animation Name="gGoronCryingLoopAnim"     Offset="0x3768"/>
+        <Animation Name="gGoronEyeropsLoopAnim"    Offset="0x38E4"/>
+        <Animation Name="gGoronUncurlSitStandAnim" Offset="0x4930"/>
+        <Animation Name="gGoronSidestepLoopAnim"   Offset="0x10590"/>
 
         <!-- skeleton, limb none -->
         <Skeleton Name="gGoronSkel" Type="Flex" LimbType="Standard" Offset="0xFEF0"/>

--- a/assets/xml/objects/object_oF1d_map.xml
+++ b/assets/xml/objects/object_oF1d_map.xml
@@ -14,13 +14,6 @@
         <Animation Name="gGoronAnim_004930" Offset="0x4930"/>
         <Animation Name="gGoronAnim_010590" Offset="0x10590"/>
 
-        <!-- display lists -->
-        <DList Name="gGoronDL_00BD80" Offset="0xBD80"/>
-        <DList Name="gGoronDL_00C140" Offset="0xC140"/>
-
-        <DList Name="gGoronDL_00FD40" Offset="0xFD40"/>
-        <DList Name="gGoronDL_00FD50" Offset="0xFD50"/>
-
         <!-- skeleton, limb none -->
         <Skeleton Name="gGoronSkel" Type="Flex" LimbType="Standard" Offset="0xFEF0"/>
 
@@ -59,6 +52,12 @@
         <DList Name="gGoronRightForearmDL" Offset="0x7EB0"/>
         <DList Name="gGoronRightHandDL"    Offset="0x7FF0"/>
         <DList Name="gGoronHeadDL"         Offset="0x7458"/>
+
+        <!-- states display lists -->
+        <DList Name="gGoronCurledUpDL"         Offset="0xBD80"/>
+        <DList Name="gGoronRollingDL"          Offset="0xC140"/>
+        <DList Name="gGoronParticleMaterialDL" Offset="0xFD40"/>
+        <DList Name="gGoronParticleDL"         Offset="0xFD50"/>
 
         <!-- palettes -->
         <Texture Name="object_oF1d_map_TLUT_00C640" OutName="tlut_0000C640" Format="rgba16" Width="16" Height="16" Offset="0xC640"/>

--- a/assets/xml/objects/object_oF1d_map.xml
+++ b/assets/xml/objects/object_oF1d_map.xml
@@ -1,4 +1,5 @@
 <Root>
+    <!-- Goron -->
     <File Name="object_oF1d_map" Segment="6">
         <!-- animations -->
         <Animation Name="gGoronAnim_000750" Offset="0x750"/>
@@ -13,14 +14,35 @@
         <Animation Name="gGoronAnim_004930" Offset="0x4930"/>
         <Animation Name="gGoronAnim_010590" Offset="0x10590"/>
 
+        <!-- display lists -->
         <DList Name="gGoronDL_00BD80" Offset="0xBD80"/>
         <DList Name="gGoronDL_00C140" Offset="0xC140"/>
 
         <DList Name="gGoronDL_00FD40" Offset="0xFD40"/>
         <DList Name="gGoronDL_00FD50" Offset="0xFD50"/>
 
+        <!-- skeleton -->
         <Skeleton Name="gGoronSkel" Type="Flex" LimbType="Standard" Offset="0xFEF0"/>
 
+        <Limb Name="gGoronRootLimb"         LimbType="Standard" Offset="0xFDE0"/>
+        <Limb Name="gGoronWaistLimb"        LimbType="Standard" Offset="0xFDEC"/>
+        <Limb Name="gGoronLegsLimb"         LimbType="Standard" Offset="0xFDF8"/>
+        <Limb Name="gGoronLeftThighLimb"    LimbType="Standard" Offset="0xFE04"/>
+        <Limb Name="gGoronLeftShinLimb"     LimbType="Standard" Offset="0xFE10"/>
+        <Limb Name="gGoronLeftFootLimb"     LimbType="Standard" Offset="0xFE1C"/>
+        <Limb Name="gGoronRightThighLimb"   LimbType="Standard" Offset="0xFE28"/>
+        <Limb Name="gGoronRightShinLimb"    LimbType="Standard" Offset="0xFE34"/>
+        <Limb Name="gGoronRightFootLimb"    LimbType="Standard" Offset="0xFE40"/>
+        <Limb Name="gGoronTorsoLimb"        LimbType="Standard" Offset="0xFE4C"/>
+        <Limb Name="gGoronLeftArmLimb"      LimbType="Standard" Offset="0xFE58"/>
+        <Limb Name="gGoronLeftForearmLimb"  LimbType="Standard" Offset="0xFE64"/>
+        <Limb Name="gGoronLeftHandLimb"     LimbType="Standard" Offset="0xFE70"/>
+        <Limb Name="gGoronRightArmLimb"     LimbType="Standard" Offset="0xFE7C"/>
+        <Limb Name="gGoronRightForearmLimb" LimbType="Standard" Offset="0xFE88"/>
+        <Limb Name="gGoronRightHandLimb"    LimbType="Standard" Offset="0xFE94"/>
+        <Limb Name="gGoronHeadLimb"         LimbType="Standard" Offset="0xFEA0"/>
+
+        <!-- palettes -->
         <Texture Name="object_oF1d_map_TLUT_00C640" OutName="tlut_0000C640" Format="rgba16" Width="16" Height="16" Offset="0xC640"/>
 
         <!-- Eye textures -->

--- a/assets/xml/objects/object_oF1d_map.xml
+++ b/assets/xml/objects/object_oF1d_map.xml
@@ -63,14 +63,14 @@
         <Texture Name="object_oF1d_map_TLUT_00C640" OutName="tlut_0000C640" Format="rgba16" Width="16" Height="16" Offset="0xC640"/>
 
         <!-- Eye textures -->
-        <Texture Name="gGoronCsEyeOpenTex" OutName="eye_open" Format="ci8" Width="32" Height="32" Offset="0xCE80" TlutOffset="0xC640"/>
-        <Texture Name="gGoronCsEyeHalfTex" OutName="eye_half" Format="ci8" Width="32" Height="32" Offset="0xD280" TlutOffset="0xC640"/>
-        <Texture Name="gGoronCsEyeClosedTex" OutName="eye_closed" Format="ci8" Width="32" Height="32" Offset="0xD680" TlutOffset="0xC640"/>
+        <Texture Name="gGoronCsEyeOpenTex"    OutName="eye_open"    Format="ci8" Width="32" Height="32" Offset="0xCE80" TlutOffset="0xC640"/>
+        <Texture Name="gGoronCsEyeHalfTex"    OutName="eye_half"    Format="ci8" Width="32" Height="32" Offset="0xD280" TlutOffset="0xC640"/>
+        <Texture Name="gGoronCsEyeClosedTex"  OutName="eye_closed"  Format="ci8" Width="32" Height="32" Offset="0xD680" TlutOffset="0xC640"/>
         <Texture Name="gGoronCsEyeClosed2Tex" OutName="eye_closed2" Format="ci8" Width="32" Height="32" Offset="0xDA80" TlutOffset="0xC640"/>
 
         <!-- Mouth textures -->
         <Texture Name="gGoronCsMouthNeutralTex" OutName="mouth_neutral" Format="ci8" Width="64" Height="32" Offset="0xDE80" TlutOffset="0xC640"/>
-        <Texture Name="gGoronCsMouthSmileTex" OutName="mouth_smile" Format="ci8" Width="64" Height="32" Offset="0xE680" TlutOffset="0xC640"/>
+        <Texture Name="gGoronCsMouthSmileTex"   OutName="mouth_smile"   Format="ci8" Width="64" Height="32" Offset="0xE680" TlutOffset="0xC640"/>
 
     </File>
 </Root>

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -837,7 +837,7 @@ s32 Actor_OfferTalkExchangeEquiCylinder(Actor* actor, struct PlayState* play, f3
 s32 Actor_OfferTalk(Actor* actor, struct PlayState* play, f32 radius);
 s32 Actor_OfferTalkNearColChkInfoCylinder(Actor* actor, struct PlayState* play);
 u32 Actor_TextboxIsClosing(Actor* actor, struct PlayState* play);
-s8 func_8002F368(struct PlayState* play);
+s8 Player_GetExchangeItemId(struct PlayState* play);
 void Actor_GetScreenPos(struct PlayState* play, Actor* actor, s16* x, s16* y);
 u32 Actor_HasParent(Actor* actor, struct PlayState* play);
 s32 Actor_OfferGetItem(Actor* actor, struct PlayState* play, s32 getItemId, f32 xzRange, f32 yRange);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -1759,7 +1759,7 @@ u32 Actor_TextboxIsClosing(Actor* actor, PlayState* play) {
     }
 }
 
-s8 func_8002F368(PlayState* play) {
+s8 Player_GetExchangeItemId(PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     return player->exchangeItemId;

--- a/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
+++ b/src/overlays/actors/ovl_Demo_Go/z_demo_go.c
@@ -254,7 +254,7 @@ void func_8097CEEC(DemoGo* this, PlayState* play) {
 }
 
 void func_8097CF20(DemoGo* this, PlayState* play, s32 arg2) {
-    AnimationHeader* animation = &gGoronAnim_0029A8;
+    AnimationHeader* animation = &gGoronWalkingLoopAnim;
     if (arg2 != 0) {
         Animation_Change(&this->skelAnime, animation, 1.0f, 0.0f, Animation_GetLastFrame(animation), ANIMMODE_LOOP,
                          -8.0f);
@@ -328,7 +328,7 @@ void DemoGo_Update(Actor* thisx, PlayState* play) {
 
 void DemoGo_Init(Actor* thisx, PlayState* play) {
     DemoGo* this = (DemoGo*)thisx;
-    AnimationHeader* animation = &gGoronAnim_004930;
+    AnimationHeader* animation = &gGoronUncurlSitStandAnim;
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 30.0f);
     SkelAnime_InitFlex(play, &this->skelAnime, &gGoronSkel, NULL, NULL, NULL, 0);

--- a/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -206,7 +206,7 @@ void EnDs_Wait(EnDs* this, PlayState* play) {
     s16 yawDiff;
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        if (func_8002F368(play) == EXCH_ITEM_ODD_MUSHROOM) {
+        if (Player_GetExchangeItemId(play) == EXCH_ITEM_ODD_MUSHROOM) {
             Audio_PlaySfxGeneral(NA_SE_SY_TRE_BOX_APPEAR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
             player->actor.textId = 0x504A;

--- a/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -284,7 +284,7 @@ void func_80A2F83C(EnGb* this, PlayState* play) {
     if (Actor_TalkOfferAccepted(&this->dyna.actor, play)) {
         s32 pad;
 
-        switch (func_8002F368(play)) {
+        switch (Player_GetExchangeItemId(play)) {
             case EXCH_ITEM_NONE:
                 func_80A2F180(this);
                 this->actionFunc = func_80A2F94C;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -890,7 +890,7 @@ void EnGo_BiggoronActionFunc(EnGo* this, PlayState* play) {
         } else {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYE_DROPS) {
                 EnGo_ChangeAnim(this, ENGO_ANIM_WALKING_LOOP);
-                this->unk_21E = 100;
+                this->eyedropsTimer = 100;
                 this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
                 EnGo_SetupAction(this, EnGo_Eyedrops);
                 play->msgCtx.msgMode = MSGMODE_PAUSED;
@@ -1027,7 +1027,7 @@ void func_80A40C78(EnGo* this, PlayState* play) {
 }
 
 void EnGo_Eyedrops(EnGo* this, PlayState* play) {
-    if (DECR(this->unk_21E) == 0) {
+    if (DECR(this->eyedropsTimer) == 0) {
         this->actor.textId = 0x305A;
         Message_ContinueTextbox(play, this->actor.textId);
         this->interactInfo.talkState = NPC_TALK_STATE_TALKING;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -439,7 +439,7 @@ void EnGo_UpdateBlinking(EnGo* this) {
     }
 }
 
-s32 EnGo_IsCameraModified(EnGo* this, PlayState* play) {
+s32 EnGo_IsAttentionDrawn(EnGo* this, PlayState* play) {
     f32 xyzDistSq;
     s16 yawDiff = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
     Camera* mainCam = play->cameraPtrs[CAM_ID_MAIN];
@@ -459,9 +459,9 @@ s32 EnGo_IsCameraModified(EnGo* this, PlayState* play) {
             Camera_RequestSetting(mainCam, CAM_SET_NORMAL0);
         }
         return 0;
-    } else {
-        return 1;
     }
+
+    return 1;
 }
 
 void EnGo_ReverseAnimation(EnGo* this) {
@@ -794,7 +794,7 @@ void EnGo_FireGenericActionFunc(EnGo* this, PlayState* play) {
 }
 
 void EnGo_CurledUp(EnGo* this, PlayState* play) {
-    if ((DECR(this->curledTimer) == 0) && EnGo_IsCameraModified(this, play)) {
+    if ((DECR(this->curledTimer) == 0) && EnGo_IsAttentionDrawn(this, play)) {
         Audio_PlaySfxGeneral(NA_SE_EN_GOLON_WAKE_UP, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
 
@@ -833,7 +833,7 @@ void EnGo_WakeUp(EnGo* this, PlayState* play) {
         Audio_PlaySfxGeneral(NA_SE_EN_GOLON_SIT_DOWN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         EnGo_SetupAction(this, func_80A405CC);
-    } else if (!EnGo_IsCameraModified(this, play)) {
+    } else if (!EnGo_IsAttentionDrawn(this, play)) {
         EnGo_ReverseAnimation(this);
         this->skelAnime.playSpeed = 0.0f;
         EnGo_SetupAction(this, func_80A40494);
@@ -909,7 +909,7 @@ void EnGo_BiggoronActionFunc(EnGo* this, PlayState* play) {
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
     } else {
-        if ((DECR(this->attentionCooldown) == 0) && !EnGo_IsCameraModified(this, play)) {
+        if ((DECR(this->attentionCooldown) == 0) && !EnGo_IsAttentionDrawn(this, play)) {
             EnGo_ReverseAnimation(this);
             this->skelAnime.playSpeed = -0.1f;
             this->skelAnime.playSpeed *= ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f;
@@ -940,7 +940,7 @@ void func_80A408D8(EnGo* this, PlayState* play) {
 
     if (DECR(this->attentionCooldown) == 0) {
         EnGo_SetupAction(this, func_80A40494);
-    } else if (EnGo_IsCameraModified(this, play)) {
+    } else if (EnGo_IsAttentionDrawn(this, play)) {
         EnGo_ReverseAnimation(this);
         Audio_PlaySfxGeneral(NA_SE_EN_GOLON_SIT_DOWN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -1033,7 +1033,7 @@ void EnGo_Update(Actor* thisx, PlayState* play) {
 
     if (this->actionFunc == EnGo_BiggoronActionFunc || this->actionFunc == EnGo_FireGenericActionFunc ||
         this->actionFunc == func_80A40B1C) {
-        func_80034F54(play, this->jointTable, this->morphTable, 18);
+        func_80034F54(play, this->jointTable, this->morphTable, GORON_LIMB_MAX);
     }
 
     EnGo_UpdateShadow(this);
@@ -1088,7 +1088,7 @@ s32 EnGo_OverrideLimbDraw(PlayState* play, s32 limb, Gfx** dList, Vec3f* pos, Ve
     EnGo* this = (EnGo*)thisx;
     Vec3s limbRot;
 
-    if (limb == 17) {
+    if (limb == GORON_LIMB_HEAD) {
         Matrix_Translate(2800.0f, 0.0f, 0.0f, MTXMODE_APPLY);
         limbRot = this->interactInfo.headRot;
         Matrix_RotateX(BINANG_TO_RAD_ALT(limbRot.y), MTXMODE_APPLY);
@@ -1096,13 +1096,13 @@ s32 EnGo_OverrideLimbDraw(PlayState* play, s32 limb, Gfx** dList, Vec3f* pos, Ve
         Matrix_Translate(-2800.0f, 0.0f, 0.0f, MTXMODE_APPLY);
     }
 
-    if (limb == 10) {
+    if (limb == GORON_LIMB_TORSO) {
         limbRot = this->interactInfo.torsoRot;
         Matrix_RotateY(BINANG_TO_RAD_ALT(limbRot.y), MTXMODE_APPLY);
         Matrix_RotateX(BINANG_TO_RAD_ALT(limbRot.x), MTXMODE_APPLY);
     }
 
-    if ((limb == 10) || (limb == 11) || (limb == 14)) {
+    if ((limb == GORON_LIMB_TORSO) || (limb == GORON_LIMB_LEFT_ARM) || (limb == GORON_LIMB_RIGHT_ARM)) {
         rot->y += Math_SinS(this->jointTable[limb]) * 200.0f;
         rot->z += Math_CosS(this->morphTable[limb]) * 200.0f;
     }
@@ -1114,7 +1114,7 @@ void EnGo_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, 
     EnGo* this = (EnGo*)thisx;
     Vec3f D_80A41BCC = { 600.0f, 0.0f, 0.0f };
 
-    if (limbIndex == 17) {
+    if (limbIndex == GORON_LIMB_HEAD) {
         Matrix_MultVec3f(&D_80A41BCC, &this->actor.focus.pos);
     }
 }

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -21,7 +21,7 @@ void EnGo_AttentionDrawn(EnGo* this, PlayState* play);
 void EnGo_CurlUp(EnGo* this, PlayState* play);
 void EnGo_Sitting(EnGo* this, PlayState* play);
 void EnGo_Standing(EnGo* this, PlayState* play);
-void EnGo_LostAttention(EnGo* this, PlayState* play);
+void EnGo_AttentionLost(EnGo* this, PlayState* play);
 
 void EnGo_GoronDmtBombFlower(EnGo* this, PlayState* play);
 void EnGo_Interact(EnGo* this, PlayState* play);
@@ -915,12 +915,12 @@ void EnGo_Standing(EnGo* this, PlayState* play) {
             EnGo_ReverseAnimation(this);
             this->skelAnime.playSpeed = -0.1f;
             this->skelAnime.playSpeed *= ENGO_GET_SPEED_SCALE(this);
-            EnGo_SetupAction(this, EnGo_LostAttention);
+            EnGo_SetupAction(this, EnGo_AttentionLost);
         }
     }
 }
 
-void EnGo_LostAttention(EnGo* this, PlayState* play) {
+void EnGo_AttentionLost(EnGo* this, PlayState* play) {
     f32 frame;
 
     if (this->skelAnime.playSpeed != 0.0f) {

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -69,17 +69,17 @@ static ColliderCylinderInit sCylinderInit = {
 static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 typedef enum EnGoAnimation {
-    /* 0 */ ENGO_ANIM_0,
-    /* 1 */ ENGO_ANIM_1,
-    /* 2 */ ENGO_ANIM_2,
-    /* 3 */ ENGO_ANIM_3
+    /* 0 */ ENGO_ANIM_UNCURL_SIT_STAND_IDLE, // default idle
+    /* 1 */ ENGO_ANIM_UNCURL_SIT_STAND,
+    /* 2 */ ENGO_ANIM_WALKING_LOOP,
+    /* 3 */ ENGO_ANIM_SIDESTEP_LOOP
 } EnGoAnimation;
 
 static AnimationSpeedInfo sAnimationInfo[] = {
-    { &gGoronAnim_004930, 0.0f, ANIMMODE_LOOP_INTERP, 0.0f },
-    { &gGoronAnim_004930, 0.0f, ANIMMODE_LOOP_INTERP, -10.0f },
-    { &gGoronAnim_0029A8, 1.0f, ANIMMODE_LOOP_INTERP, -10.0f },
-    { &gGoronAnim_010590, 1.0f, ANIMMODE_LOOP_INTERP, -10.0f },
+    { &gGoronUncurlSitStandAnim, 0.0f, ANIMMODE_LOOP_INTERP, 0.0f },
+    { &gGoronUncurlSitStandAnim, 0.0f, ANIMMODE_LOOP_INTERP, -10.0f },
+    { &gGoronWalkingLoopAnim, 1.0f, ANIMMODE_LOOP_INTERP, -10.0f },
+    { &gGoronSidestepLoopAnim, 1.0f, ANIMMODE_LOOP_INTERP, -10.0f },
 };
 
 void EnGo_SetupAction(EnGo* this, EnGoActionFunc actionFunc) {
@@ -455,8 +455,8 @@ void EnGo_ReverseAnimation(EnGo* this) {
 void EnGo_UpdateShadow(EnGo* this) {
     s16 shadowAlpha;
     f32 currentFrame = this->skelAnime.curFrame;
-    s16 shadowAlphaTarget = (this->skelAnime.animation == &gGoronAnim_004930 && currentFrame > 32.0f) ||
-                                    this->skelAnime.animation != &gGoronAnim_004930
+    s16 shadowAlphaTarget = (this->skelAnime.animation == &gGoronUncurlSitStandAnim && currentFrame > 32.0f) ||
+                                    this->skelAnime.animation != &gGoronUncurlSitStandAnim
                                 ? 255
                                 : 0;
 
@@ -643,7 +643,7 @@ void EnGo_Init(Actor* thisx, PlayState* play) {
         this->actor.flags &= ~ACTOR_FLAG_5;
     }
 
-    EnGo_ChangeAnim(this, ENGO_ANIM_0);
+    EnGo_ChangeAnim(this, ENGO_ANIM_UNCURL_SIT_STAND_IDLE);
     this->actor.attentionRangeType = ATTENTION_RANGE_6;
     this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
     this->actor.gravity = -1.0f;
@@ -661,7 +661,7 @@ void EnGo_Init(Actor* thisx, PlayState* play) {
             }
             break;
         case 0x10:
-            this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronAnim_004930);
+            this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronUncurlSitStandAnim);
             Actor_SetScale(&this->actor, 0.01f);
             EnGo_SetupAction(this, EnGo_FireGenericActionFunc);
             break;
@@ -840,7 +840,7 @@ void func_80A405CC(EnGo* this, PlayState* play) {
     f32 lastFrame;
     f32 frame;
 
-    lastFrame = Animation_GetLastFrame(&gGoronAnim_004930);
+    lastFrame = Animation_GetLastFrame(&gGoronUncurlSitStandAnim);
     Math_SmoothStepToF(&this->skelAnime.playSpeed, PARAMS_GET_NOSHIFT(this->actor.params, 4, 4) == 0x90 ? 0.5f : 1.0f,
                        0.1f, 1000.0f, 0.1f);
 
@@ -866,7 +866,7 @@ void EnGo_BiggoronActionFunc(EnGo* this, PlayState* play) {
             this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
         } else {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYE_DROPS) {
-                EnGo_ChangeAnim(this, ENGO_ANIM_2);
+                EnGo_ChangeAnim(this, ENGO_ANIM_WALKING_LOOP);
                 this->unk_21E = 100;
                 this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
                 EnGo_SetupAction(this, EnGo_Eyedrops);
@@ -928,13 +928,13 @@ void func_80A408D8(EnGo* this, PlayState* play) {
 }
 
 void func_80A40A54(EnGo* this, PlayState* play) {
-    f32 float1 = ((f32)0x8000 / Animation_GetLastFrame(&gGoronAnim_010590));
+    f32 float1 = ((f32)0x8000 / Animation_GetLastFrame(&gGoronSidestepLoopAnim));
     f32 float2 = this->skelAnime.curFrame * float1;
 
     this->actor.speed = Math_SinS((s16)float2);
     if (EnGo_FollowPath(this, play) && this->unk_218 == 0) {
-        EnGo_ChangeAnim(this, ENGO_ANIM_1);
-        this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronAnim_004930);
+        EnGo_ChangeAnim(this, ENGO_ANIM_UNCURL_SIT_STAND);
+        this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronUncurlSitStandAnim);
         this->actor.speed = 0.0f;
         EnGo_SetupAction(this, EnGo_BiggoronActionFunc);
     }
@@ -942,7 +942,7 @@ void func_80A40A54(EnGo* this, PlayState* play) {
 
 void func_80A40B1C(EnGo* this, PlayState* play) {
     if (GET_INFTABLE(INFTABLE_EB)) {
-        EnGo_ChangeAnim(this, ENGO_ANIM_3);
+        EnGo_ChangeAnim(this, ENGO_ANIM_SIDESTEP_LOOP);
         EnGo_SetupAction(this, func_80A40A54);
     } else {
         EnGo_BiggoronActionFunc(this, play);
@@ -1015,8 +1015,8 @@ void EnGo_Eyedrops(EnGo* this, PlayState* play) {
 
 void func_80A40DCC(EnGo* this, PlayState* play) {
     if (this->interactInfo.talkState == NPC_TALK_STATE_ACTION) {
-        EnGo_ChangeAnim(this, ENGO_ANIM_1);
-        this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronAnim_004930);
+        EnGo_ChangeAnim(this, ENGO_ANIM_UNCURL_SIT_STAND);
+        this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronUncurlSitStandAnim);
         Message_CloseTextbox(play);
         EnGo_SetupAction(this, EnGo_GetItem);
         EnGo_GetItem(this, play);

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -1145,12 +1145,17 @@ void EnGo_Draw(Actor* thisx, PlayState* play) {
 
     if (this->actionFunc == EnGo_CurledUp) {
         EnGo_DrawCurledUp(this, play);
-        return; // needed for match?
-    } else if (this->actionFunc == EnGo_GoronLinkRolling || this->actionFunc == func_80A3FEB4 ||
-               this->actionFunc == EnGo_StopRolling || this->actionFunc == func_80A3FEB4) {
+        return;
+    }
+
+    if (this->actionFunc == EnGo_GoronLinkRolling || this->actionFunc == func_80A3FEB4 ||
+        this->actionFunc == EnGo_StopRolling || this->actionFunc == func_80A3FEB4) {
         EnGo_DrawRolling(this, play);
-        return; // needed for match?
-    } else {
+        return;
+    }
+
+    // draw normal
+    {
         Gfx_SetupDL_37Opa(play->state.gfxCtx);
 
         gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(gGoronCsEyeOpenTex));

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -1074,7 +1074,7 @@ void EnGo_Update(Actor* thisx, PlayState* play) {
 }
 
 void EnGo_DrawCurledUp(EnGo* this, PlayState* play) {
-    Vec3f D_80A41BB4 = { 0.0f, 0.0f, 0.0f };
+    Vec3f focusOffset = { 0.0f, 0.0f, 0.0f };
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_go.c", 2320);
 
@@ -1085,14 +1085,14 @@ void EnGo_DrawCurledUp(EnGo* this, PlayState* play) {
 
     gSPDisplayList(POLY_OPA_DISP++, gGoronCurledUpDL);
 
-    Matrix_MultVec3f(&D_80A41BB4, &this->actor.focus.pos);
+    Matrix_MultVec3f(&focusOffset, &this->actor.focus.pos);
     Matrix_Pop();
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_go.c", 2341);
 }
 
 void EnGo_DrawRolling(EnGo* this, PlayState* play) {
-    Vec3f D_80A41BC0 = { 0.0f, 0.0f, 0.0f };
+    Vec3f focusOffset = { 0.0f, 0.0f, 0.0f };
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_go.c", 2355);
 
@@ -1102,7 +1102,7 @@ void EnGo_DrawRolling(EnGo* this, PlayState* play) {
                      MTXMODE_APPLY);
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_en_go.c", 2368);
     gSPDisplayList(POLY_OPA_DISP++, gGoronRollingDL);
-    Matrix_MultVec3f(&D_80A41BC0, &this->actor.focus.pos);
+    Matrix_MultVec3f(&focusOffset, &this->actor.focus.pos);
     Matrix_Pop();
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_go.c", 2383);
@@ -1136,10 +1136,10 @@ s32 EnGo_OverrideLimbDraw(PlayState* play, s32 limb, Gfx** dList, Vec3f* pos, Ve
 
 void EnGo_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx) {
     EnGo* this = (EnGo*)thisx;
-    Vec3f D_80A41BCC = { 600.0f, 0.0f, 0.0f };
+    Vec3f focusOffset = { 600.0f, 0.0f, 0.0f }; // ahead, this distance
 
     if (limbIndex == GORON_LIMB_HEAD) {
-        Matrix_MultVec3f(&D_80A41BCC, &this->actor.focus.pos);
+        Matrix_MultVec3f(&focusOffset, &this->actor.focus.pos);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -496,23 +496,23 @@ s32 EnGo_FollowPath(EnGo* this, PlayState* play) {
 
     path = &play->pathList[ENGO_GET_PATH_INDEX(this)];
     pointPos = SEGMENTED_TO_VIRTUAL(path->points);
-    pointPos += this->unk_218;
+    pointPos += this->waypoint;
     xDist = pointPos->x - this->actor.world.pos.x;
     zDist = pointPos->z - this->actor.world.pos.z;
     Math_SmoothStepToS(&this->actor.world.rot.y, RAD_TO_BINANG(Math_FAtan2F(xDist, zDist)), 10, 1000, 1);
 
     if ((SQ(xDist) + SQ(zDist)) < 600.0f) {
-        this->unk_218++;
-        if (this->unk_218 >= path->count) {
-            this->unk_218 = 0;
+        this->waypoint++;
+        if (this->waypoint >= path->count) {
+            this->waypoint = 0;
         }
 
         if (ENGO_GET_TYPE(this) != ENGO_TYPE_CITY_LINK) {
             return true;
         } else if (ENGO2_IS_CAGE_OPEN(this, play)) {
             return true;
-        } else if (this->unk_218 >= this->actor.shape.rot.z) {
-            this->unk_218 = 0;
+        } else if (this->waypoint >= this->actor.shape.rot.z) {
+            this->waypoint = 0;
         }
 
         return true;
@@ -747,7 +747,7 @@ void EnGo_StopRolling(EnGo* this, PlayState* play) {
     }
 
     this->actor.speed = 3.0f;
-    if ((EnGo_FollowPath(this, play) == true) && (this->unk_218 == 0)) {
+    if ((EnGo_FollowPath(this, play) == true) && (this->waypoint == 0)) {
         bomb = (EnBom*)Actor_Spawn(&play->actorCtx, play, ACTOR_EN_BOM, this->actor.world.pos.x,
                                    this->actor.world.pos.y, this->actor.world.pos.z, 0, 0, 0, 0);
         if (bomb != NULL) {
@@ -777,7 +777,7 @@ void func_80A4008C(EnGo* this, PlayState* play) {
 }
 
 void EnGo_GoronLinkRolling(EnGo* this, PlayState* play) {
-    if ((EnGo_FollowPath(this, play) == true) && ENGO2_IS_CAGE_OPEN(this, play) && (this->unk_218 == 0)) {
+    if ((EnGo_FollowPath(this, play) == true) && ENGO2_IS_CAGE_OPEN(this, play) && (this->waypoint == 0)) {
         this->actor.speed = 0.0f;
         EnGo_SetupAction(this, func_80A4008C);
         SET_INFTABLE(INFTABLE_109);
@@ -954,7 +954,7 @@ void func_80A40A54(EnGo* this, PlayState* play) {
     f32 float2 = this->skelAnime.curFrame * float1;
 
     this->actor.speed = Math_SinS((s16)float2);
-    if (EnGo_FollowPath(this, play) && this->unk_218 == 0) {
+    if (EnGo_FollowPath(this, play) && this->waypoint == 0) {
         EnGo_ChangeAnim(this, ENGO_ANIM_UNCURL_SIT_STAND);
         this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronUncurlSitStandAnim);
         this->actor.speed = 0.0f;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -597,7 +597,7 @@ void func_80A3F908(EnGo* this, PlayState* play) {
 
         if ((PARAMS_GET_NOSHIFT(this->actor.params, 4, 4) == 0x90) && (dialogStarted == true)) {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_BROKEN_GORONS_SWORD) {
-                if (func_8002F368(play) == EXCH_ITEM_BROKEN_GORONS_SWORD) {
+                if (Player_GetExchangeItemId(play) == EXCH_ITEM_BROKEN_GORONS_SWORD) {
                     if (GET_INFTABLE(INFTABLE_B4)) {
                         this->actor.textId = 0x3055;
                     } else {
@@ -610,7 +610,7 @@ void func_80A3F908(EnGo* this, PlayState* play) {
             }
 
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYE_DROPS) {
-                if (func_8002F368(play) == EXCH_ITEM_EYE_DROPS) {
+                if (Player_GetExchangeItemId(play) == EXCH_ITEM_EYE_DROPS) {
                     this->actor.textId = 0x3059;
                 } else {
                     this->actor.textId = 0x3058;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -981,11 +981,11 @@ void EnGo_GetItem(EnGo* this, PlayState* play) {
         this->actor.parent = NULL;
         EnGo_SetupAction(this, func_80A40C78);
     } else {
-        this->unk_20C = 0;
+        this->gaveSword = 0;
         if (ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON) {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_CLAIM_CHECK) {
                 getItemId = GI_SWORD_BIGGORON;
-                this->unk_20C = 1;
+                this->gaveSword = 1;
             }
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYE_DROPS) {
                 getItemId = GI_CLAIM_CHECK;
@@ -1010,7 +1010,7 @@ void func_80A40C78(EnGo* this, PlayState* play) {
         EnGo_SetupAction(this, EnGo_BiggoronActionFunc);
         if (ENGO_GET_TYPE(this) != ENGO_TYPE_DMT_BIGGORON) {
             this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
-        } else if (this->unk_20C) {
+        } else if (this->gaveSword) {
             this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
             gSaveContext.save.info.playerData.bgsFlag = true;
         } else if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_PRESCRIPTION) {

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -98,6 +98,9 @@ typedef enum EnGoType {
 #define ENGO_GET_PATH_INDEX(this) PARAMS_GET_U((this)->actor.params, 0, 4)
 #define ENGO_PATH_INDEX_NONE 0xF // likely the count of available paths
 
+#define ENGO2_CAGED_FLAG(this) PARAMS_GET_NOMASK((this)->actor.params, 8)
+#define ENGO2_IS_CAGE_OPEN(this, play) Flags_GetSwitch(play, ENGO2_CAGED_FLAG(this))
+
 void EnGo_SetupAction(EnGo* this, EnGoActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
@@ -149,7 +152,7 @@ u16 EnGo_GetTextID(PlayState* play, Actor* thisx) {
                 }
             }
         case ENGO_TYPE_FIRE_GENERIC:
-            if (Flags_GetSwitch(play, PARAMS_GET_NOMASK(thisx->params, 8))) {
+            if (ENGO2_IS_CAGE_OPEN((EnGo*)thisx, play)) {
                 return 0x3052;
             } else {
                 return 0x3051;
@@ -373,8 +376,8 @@ void EnGo_ChangeAnim(EnGo* this, s32 index) {
 s32 EnGo_IsActorSpawned(EnGo* this, PlayState* play) {
     if (ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON) {
         return true;
-    } else if (play->sceneId == SCENE_FIRE_TEMPLE && !Flags_GetSwitch(play, PARAMS_GET_NOMASK(this->actor.params, 8)) &&
-               LINK_IS_ADULT && ENGO_GET_TYPE(this) == ENGO_TYPE_FIRE_GENERIC) {
+    } else if (play->sceneId == SCENE_FIRE_TEMPLE && !ENGO2_IS_CAGE_OPEN(this, play) && LINK_IS_ADULT &&
+               ENGO_GET_TYPE(this) == ENGO_TYPE_FIRE_GENERIC) {
         return true;
     } else if (play->sceneId == SCENE_GORON_CITY && LINK_IS_ADULT && ENGO_GET_TYPE(this) == ENGO_TYPE_CITY_LINK) {
         return true;
@@ -503,7 +506,7 @@ s32 EnGo_FollowPath(EnGo* this, PlayState* play) {
 
         if (ENGO_GET_TYPE(this) != ENGO_TYPE_CITY_LINK) {
             return true;
-        } else if (Flags_GetSwitch(play, PARAMS_GET_NOMASK(this->actor.params, 8))) {
+        } else if (ENGO2_IS_CAGE_OPEN(this, play)) {
             return true;
         } else if (this->unk_218 >= this->actor.shape.rot.z) {
             this->unk_218 = 0;
@@ -763,8 +766,7 @@ void func_80A4008C(EnGo* this, PlayState* play) {
 }
 
 void EnGo_GoronLinkRolling(EnGo* this, PlayState* play) {
-    if ((EnGo_FollowPath(this, play) == true) && Flags_GetSwitch(play, PARAMS_GET_NOMASK(this->actor.params, 8)) &&
-        (this->unk_218 == 0)) {
+    if ((EnGo_FollowPath(this, play) == true) && ENGO2_IS_CAGE_OPEN(this, play) && (this->unk_218 == 0)) {
         this->actor.speed = 0.0f;
         EnGo_SetupAction(this, func_80A4008C);
         SET_INFTABLE(INFTABLE_109);

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -794,7 +794,7 @@ void EnGo_FireGenericActionFunc(EnGo* this, PlayState* play) {
 }
 
 void EnGo_CurledUp(EnGo* this, PlayState* play) {
-    if ((DECR(this->unk_210) == 0) && EnGo_IsCameraModified(this, play)) {
+    if ((DECR(this->curledTimer) == 0) && EnGo_IsCameraModified(this, play)) {
         Audio_PlaySfxGeneral(NA_SE_EN_GOLON_WAKE_UP, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
 
@@ -855,7 +855,7 @@ void func_80A40494(EnGo* this, PlayState* play) {
         EnGo_ReverseAnimation(this);
         this->skelAnime.playSpeed = 0.0f;
         this->skelAnime.curFrame = 0.0f;
-        this->unk_210 = Rand_S16Offset(30, 30);
+        this->curledTimer = Rand_S16Offset(30, 30);
         EnGo_SetupAction(this, EnGo_CurledUp);
     }
 }

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -72,7 +72,7 @@ static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };
 
 typedef enum EnGoAnimation {
     /* 0 */ ENGO_ANIM_UNCURL_SIT_STAND_IDLE, // default idle
-    /* 1 */ ENGO_ANIM_UNCURL_SIT_STAND,
+    /* 1 */ ENGO_ANIM_UNCURL_SIT_STAND_NORMAL,
     /* 2 */ ENGO_ANIM_WALKING_LOOP,
     /* 3 */ ENGO_ANIM_SIDESTEP_LOOP
 } EnGoAnimation;
@@ -956,7 +956,7 @@ void EnGo_Sidestep(EnGo* this, PlayState* play) {
 
     this->actor.speed = Math_SinS((s16)float2);
     if (EnGo_FollowPath(this, play) && this->waypoint == 0) {
-        EnGo_ChangeAnim(this, ENGO_ANIM_UNCURL_SIT_STAND);
+        EnGo_ChangeAnim(this, ENGO_ANIM_UNCURL_SIT_STAND_NORMAL);
         this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronUncurlSitStandAnim);
         this->actor.speed = 0.0f;
         EnGo_SetupAction(this, EnGo_Standing);
@@ -1039,7 +1039,7 @@ void EnGo_TakingEyedrops(EnGo* this, PlayState* play) {
 
 void EnGo_EyedropsTaken(EnGo* this, PlayState* play) {
     if (this->interactInfo.talkState == NPC_TALK_STATE_ACTION) {
-        EnGo_ChangeAnim(this, ENGO_ANIM_UNCURL_SIT_STAND);
+        EnGo_ChangeAnim(this, ENGO_ANIM_UNCURL_SIT_STAND_NORMAL);
         this->skelAnime.curFrame = Animation_GetLastFrame(&gGoronUncurlSitStandAnim);
         Message_CloseTextbox(play);
         EnGo_SetupAction(this, EnGo_Interact);

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -1059,7 +1059,7 @@ void EnGo_DrawCurledUp(EnGo* this, PlayState* play) {
 
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_en_go.c", 2326);
 
-    gSPDisplayList(POLY_OPA_DISP++, gGoronDL_00BD80);
+    gSPDisplayList(POLY_OPA_DISP++, gGoronCurledUpDL);
 
     Matrix_MultVec3f(&D_80A41BB4, &this->actor.focus.pos);
     Matrix_Pop();
@@ -1077,7 +1077,7 @@ void EnGo_DrawRolling(EnGo* this, PlayState* play) {
     Matrix_RotateZYX((s16)(play->state.frames * ((s16)this->actor.speed * 1400)), 0, this->actor.shape.rot.z,
                      MTXMODE_APPLY);
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_en_go.c", 2368);
-    gSPDisplayList(POLY_OPA_DISP++, gGoronDL_00C140);
+    gSPDisplayList(POLY_OPA_DISP++, gGoronRollingDL);
     Matrix_MultVec3f(&D_80A41BC0, &this->actor.focus.pos);
     Matrix_Pop();
 
@@ -1213,7 +1213,7 @@ void EnGo_DrawEffects(EnGo* this, PlayState* play) {
 
         if (!materialFlag) {
             POLY_XLU_DISP = Gfx_SetupDL(POLY_XLU_DISP, SETUPDL_0);
-            gSPDisplayList(POLY_XLU_DISP++, gGoronDL_00FD40);
+            gSPDisplayList(POLY_XLU_DISP++, gGoronParticleMaterialDL);
             gDPSetEnvColor(POLY_XLU_DISP++, 100, 60, 20, 0);
             materialFlag = true;
         }
@@ -1228,7 +1228,7 @@ void EnGo_DrawEffects(EnGo* this, PlayState* play) {
 
         index = dustEffect->timer * (8.0f / dustEffect->initialTimer);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(dustTex[index]));
-        gSPDisplayList(POLY_XLU_DISP++, gGoronDL_00FD50);
+        gSPDisplayList(POLY_XLU_DISP++, gGoronParticleDL);
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_go.c", 2678);

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -823,13 +823,13 @@ void EnGo_WakeUp(EnGo* this, PlayState* play) {
             this->skelAnime.curFrame = 12.0f;
             this->skelAnime.playSpeed = 0.0f;
             if (ENGO_GET_TYPE(this) != ENGO_TYPE_DMT_BIGGORON) {
-                this->unk_212 = 30;
+                this->attentionCooldown = 30;
                 return;
             }
         }
     }
 
-    if (DECR(this->unk_212) == 0) {
+    if (DECR(this->attentionCooldown) == 0) {
         Audio_PlaySfxGeneral(NA_SE_EN_GOLON_SIT_DOWN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         EnGo_SetupAction(this, func_80A405CC);
@@ -874,7 +874,7 @@ void func_80A405CC(EnGo* this, PlayState* play) {
     if (!(frame < lastFrame)) {
         this->skelAnime.curFrame = lastFrame;
         this->skelAnime.playSpeed = 0.0f;
-        this->unk_212 = Rand_S16Offset(30, 30);
+        this->attentionCooldown = Rand_S16Offset(30, 30);
         if ((ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BOMB_FLOWER) && !GET_INFTABLE(INFTABLE_EB)) {
             EnGo_SetupAction(this, func_80A40B1C);
         } else {
@@ -909,7 +909,7 @@ void EnGo_BiggoronActionFunc(EnGo* this, PlayState* play) {
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
     } else {
-        if ((DECR(this->unk_212) == 0) && !EnGo_IsCameraModified(this, play)) {
+        if ((DECR(this->attentionCooldown) == 0) && !EnGo_IsCameraModified(this, play)) {
             EnGo_ReverseAnimation(this);
             this->skelAnime.playSpeed = -0.1f;
             this->skelAnime.playSpeed *= ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f;
@@ -932,13 +932,13 @@ void func_80A408D8(EnGo* this, PlayState* play) {
             this->skelAnime.curFrame = 12.0f;
             this->skelAnime.playSpeed = 0.0f;
             if (ENGO_GET_TYPE(this) != ENGO_TYPE_DMT_BIGGORON) {
-                this->unk_212 = 30;
+                this->attentionCooldown = 30;
                 return;
             }
         }
     }
 
-    if (DECR(this->unk_212) == 0) {
+    if (DECR(this->attentionCooldown) == 0) {
         EnGo_SetupAction(this, func_80A40494);
     } else if (EnGo_IsCameraModified(this, play)) {
         EnGo_ReverseAnimation(this);

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -737,12 +737,12 @@ void func_80A3FEB4(EnGo* this, PlayState* play) {
 void EnGo_StopRolling(EnGo* this, PlayState* play) {
     EnBom* bomb;
 
-    if (DECR(this->unk_20E) == 0) {
+    if (DECR(this->knockbackCooldown) == 0) {
         if (this->collider.base.ocFlags2 & OC2_HIT_PLAYER) {
             this->collider.base.ocFlags2 &= ~OC2_HIT_PLAYER;
             play->damagePlayer(play, -4);
             Actor_SetPlayerKnockbackLargeNoDamage(play, &this->actor, 4.0f, this->actor.yawTowardsPlayer, 6.0f);
-            this->unk_20E = 0x10;
+            this->knockbackCooldown = 0x10;
         }
     }
 

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -95,6 +95,9 @@ typedef enum EnGoType {
     ENGO_TYPE_DMT_BIGGORON = 0x90
 } EnGoType;
 
+#define ENGO_GET_PATH_INDEX(this) PARAMS_GET_U((this)->actor.params, 0, 4)
+#define ENGO_PATH_INDEX_NONE 0xF // likely the count of available paths
+
 void EnGo_SetupAction(EnGo* this, EnGoActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
@@ -481,11 +484,11 @@ s32 EnGo_FollowPath(EnGo* this, PlayState* play) {
     f32 xDist;
     f32 zDist;
 
-    if (PARAMS_GET_U(this->actor.params, 0, 4) == 15) {
+    if (ENGO_GET_PATH_INDEX(this) == ENGO_PATH_INDEX_NONE) {
         return false;
     }
 
-    path = &play->pathList[PARAMS_GET_U(this->actor.params, 0, 4)];
+    path = &play->pathList[ENGO_GET_PATH_INDEX(this)];
     pointPos = SEGMENTED_TO_VIRTUAL(path->points);
     pointPos += this->unk_218;
     xDist = pointPos->x - this->actor.world.pos.x;
@@ -516,10 +519,10 @@ s32 EnGo_SetMovedPos(EnGo* this, PlayState* play) {
     Path* path;
     Vec3s* pointPos;
 
-    if (PARAMS_GET_U(this->actor.params, 0, 4) == 0xF) {
+    if (ENGO_GET_PATH_INDEX(this) == ENGO_PATH_INDEX_NONE) {
         return false;
     } else {
-        path = &play->pathList[PARAMS_GET_U(this->actor.params, 0, 4)];
+        path = &play->pathList[ENGO_GET_PATH_INDEX(this)];
         pointPos = SEGMENTED_TO_VIRTUAL(path->points);
         pointPos += (path->count - 1);
         this->actor.world.pos.x = pointPos->x;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -443,7 +443,7 @@ void EnGo_UpdateBlinking(EnGo* this) {
     }
 }
 
-s32 EnGo_IsAttentionDrawn(EnGo* this, PlayState* play) {
+s32 EnGo_IsInRange(EnGo* this, PlayState* play) {
     f32 xyzDistSq;
     s16 yawDiff = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
     Camera* mainCam = play->cameraPtrs[CAM_ID_MAIN];
@@ -798,7 +798,7 @@ void EnGo_GoronFireGeneric(EnGo* this, PlayState* play) {
 }
 
 void EnGo_CurledUp(EnGo* this, PlayState* play) {
-    if ((DECR(this->curledTimer) == 0) && EnGo_IsAttentionDrawn(this, play)) {
+    if ((DECR(this->curledTimer) == 0) && EnGo_IsInRange(this, play)) {
         Audio_PlaySfxGeneral(NA_SE_EN_GOLON_WAKE_UP, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
 
@@ -836,7 +836,7 @@ void EnGo_AttentionDrawn(EnGo* this, PlayState* play) {
         Audio_PlaySfxGeneral(NA_SE_EN_GOLON_SIT_DOWN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         EnGo_SetupAction(this, EnGo_Sitting);
-    } else if (!EnGo_IsAttentionDrawn(this, play)) {
+    } else if (!EnGo_IsInRange(this, play)) {
         EnGo_ReverseAnimation(this);
         this->skelAnime.playSpeed = 0.0f;
         EnGo_SetupAction(this, EnGo_CurlUp);
@@ -911,7 +911,7 @@ void EnGo_Standing(EnGo* this, PlayState* play) {
         play->msgCtx.stateTimer = 4;
         play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
     } else {
-        if ((DECR(this->attentionCooldown) == 0) && !EnGo_IsAttentionDrawn(this, play)) {
+        if ((DECR(this->attentionCooldown) == 0) && !EnGo_IsInRange(this, play)) {
             EnGo_ReverseAnimation(this);
             this->skelAnime.playSpeed = -0.1f;
             this->skelAnime.playSpeed *= ENGO_GET_SPEED_SCALE(this);
@@ -941,7 +941,7 @@ void EnGo_AttentionLost(EnGo* this, PlayState* play) {
 
     if (DECR(this->attentionCooldown) == 0) {
         EnGo_SetupAction(this, EnGo_CurlUp);
-    } else if (EnGo_IsAttentionDrawn(this, play)) {
+    } else if (EnGo_IsInRange(this, play)) {
         EnGo_ReverseAnimation(this);
         Audio_PlaySfxGeneral(NA_SE_EN_GOLON_SIT_DOWN, &this->actor.projectedPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -101,6 +101,8 @@ typedef enum EnGoType {
 #define ENGO2_CAGED_FLAG(this) PARAMS_GET_NOMASK((this)->actor.params, 8)
 #define ENGO2_IS_CAGE_OPEN(this, play) Flags_GetSwitch(play, ENGO2_CAGED_FLAG(this))
 
+#define ENGO_GET_SPEED_SCALE(this) (ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f)
+
 void EnGo_SetupAction(EnGo* this, EnGoActionFunc actionFunc) {
     this->actionFunc = actionFunc;
 }
@@ -368,8 +370,8 @@ s32 EnGo_UpdateTalking(PlayState* play, Actor* thisx, s16* talkState, f32 intera
 
 void EnGo_ChangeAnim(EnGo* this, s32 index) {
     Animation_Change(&this->skelAnime, sAnimationInfo[index].animation,
-                     sAnimationInfo[index].playSpeed * (ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f),
-                     0.0f, Animation_GetLastFrame(sAnimationInfo[index].animation), sAnimationInfo[index].mode,
+                     sAnimationInfo[index].playSpeed * ENGO_GET_SPEED_SCALE(this), 0.0f,
+                     Animation_GetLastFrame(sAnimationInfo[index].animation), sAnimationInfo[index].mode,
                      sAnimationInfo[index].morphFrames);
 }
 
@@ -799,7 +801,7 @@ void EnGo_CurledUp(EnGo* this, PlayState* play) {
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
 
         this->skelAnime.playSpeed = 0.1f;
-        this->skelAnime.playSpeed *= ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f;
+        this->skelAnime.playSpeed *= ENGO_GET_SPEED_SCALE(this);
 
         EnGo_SetupAction(this, EnGo_WakeUp);
         if (ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON) {
@@ -812,8 +814,7 @@ void EnGo_WakeUp(EnGo* this, PlayState* play) {
     f32 frame;
 
     if (this->skelAnime.playSpeed != 0.0f) {
-        Math_SmoothStepToF(&this->skelAnime.playSpeed,
-                           (ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f) * 0.5f, 0.1f, 1000.0f, 0.1f);
+        Math_SmoothStepToF(&this->skelAnime.playSpeed, ENGO_GET_SPEED_SCALE(this) * 0.5f, 0.1f, 1000.0f, 0.1f);
         frame = this->skelAnime.curFrame;
         frame += this->skelAnime.playSpeed;
 
@@ -843,8 +844,7 @@ void EnGo_WakeUp(EnGo* this, PlayState* play) {
 void func_80A40494(EnGo* this, PlayState* play) {
     f32 frame;
 
-    Math_SmoothStepToF(&this->skelAnime.playSpeed,
-                       (ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f) * -0.5f, 0.1f, 1000.0f, 0.1f);
+    Math_SmoothStepToF(&this->skelAnime.playSpeed, ENGO_GET_SPEED_SCALE(this) * -0.5f, 0.1f, 1000.0f, 0.1f);
     frame = this->skelAnime.curFrame;
     frame += this->skelAnime.playSpeed;
 
@@ -865,8 +865,7 @@ void func_80A405CC(EnGo* this, PlayState* play) {
     f32 frame;
 
     lastFrame = Animation_GetLastFrame(&gGoronUncurlSitStandAnim);
-    Math_SmoothStepToF(&this->skelAnime.playSpeed, ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f, 0.1f,
-                       1000.0f, 0.1f);
+    Math_SmoothStepToF(&this->skelAnime.playSpeed, ENGO_GET_SPEED_SCALE(this), 0.1f, 1000.0f, 0.1f);
 
     frame = this->skelAnime.curFrame;
     frame += this->skelAnime.playSpeed;
@@ -912,7 +911,7 @@ void EnGo_BiggoronActionFunc(EnGo* this, PlayState* play) {
         if ((DECR(this->attentionCooldown) == 0) && !EnGo_IsAttentionDrawn(this, play)) {
             EnGo_ReverseAnimation(this);
             this->skelAnime.playSpeed = -0.1f;
-            this->skelAnime.playSpeed *= ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f;
+            this->skelAnime.playSpeed *= ENGO_GET_SPEED_SCALE(this);
             EnGo_SetupAction(this, func_80A408D8);
         }
     }
@@ -922,8 +921,7 @@ void func_80A408D8(EnGo* this, PlayState* play) {
     f32 frame;
 
     if (this->skelAnime.playSpeed != 0.0f) {
-        Math_SmoothStepToF(&this->skelAnime.playSpeed,
-                           (ENGO_GET_TYPE(this) == ENGO_TYPE_DMT_BIGGORON ? 0.5f : 1.0f) * -1.0f, 0.1f, 1000.0f, 0.1f);
+        Math_SmoothStepToF(&this->skelAnime.playSpeed, ENGO_GET_SPEED_SCALE(this) * -1.0f, 0.1f, 1000.0f, 0.1f);
         frame = this->skelAnime.curFrame;
         frame += this->skelAnime.playSpeed;
         if (frame >= 12.0f) {

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -426,12 +426,15 @@ void func_80A3F060(EnGo* this, PlayState* play) {
     Npc_TrackPoint(&this->actor, &this->interactInfo, 4, trackingMode);
 }
 
-void func_80A3F0E4(EnGo* this) {
-    if (DECR(this->unk_214) == 0) {
-        this->unk_216++;
-        if (this->unk_216 >= 3) {
-            this->unk_214 = Rand_S16Offset(30, 30);
-            this->unk_216 = 0;
+void EnGo_UpdateBlinking(EnGo* this) {
+    // @unused
+    // although this function runs a similar logic as `EnGo2_EyeMouthTexState`
+    // its results are never used: this Goron always sets `gGoronCsEyeOpenTex`
+    if (DECR(this->blinkTimer) == 0) {
+        this->eyeTexIndex++;
+        if (this->eyeTexIndex >= 3) {
+            this->blinkTimer = Rand_S16Offset(30, 30);
+            this->eyeTexIndex = 0;
         }
     }
 }
@@ -1054,7 +1057,7 @@ void EnGo_Update(Actor* thisx, PlayState* play) {
     }
 
     Actor_UpdateBgCheckInfo(play, &this->actor, 0.0f, 0.0f, 0.0f, UPDBGCHECKINFO_FLAG_2);
-    func_80A3F0E4(this);
+    EnGo_UpdateBlinking(this);
     func_80A3F908(this, play);
     this->actionFunc(this, play);
     func_80A3F060(this, play);

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -58,7 +58,7 @@ typedef struct EnGo {
     /* 0x0212 */ s16 unk_212;
     /* 0x0214 */ s16 blinkTimer;  // unused
     /* 0x0216 */ s16 eyeTexIndex; // unused
-    /* 0x0218 */ s16 unk_218;
+    /* 0x0218 */ s16 waypoint;
     /* 0x021A */ s16 bounceCounter;
     /* 0x021C */ s16 bounceTimer;
     /* 0x021E */ s16 unk_21E;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -7,8 +7,6 @@
 struct EnGo;
 
 typedef void (*EnGoActionFunc)(struct EnGo*, PlayState*);
-typedef u16 (*callback1_80A3ED24)(PlayState*, struct EnGo*);
-typedef s16 (*callback2_80A3ED24)(PlayState*, struct EnGo*);
 
 typedef enum GoronLimb {
     /*  0 */ GORON_LIMB_NONE, // skeleton itself

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -59,8 +59,8 @@ typedef struct EnGo {
     /* 0x0214 */ s16 blinkTimer;  // unused
     /* 0x0216 */ s16 eyeTexIndex; // unused
     /* 0x0218 */ s16 unk_218;
-    /* 0x021A */ s16 unk_21A;
-    /* 0x021C */ s16 unk_21C;
+    /* 0x021A */ s16 bounceCounter;
+    /* 0x021C */ s16 bounceTimer;
     /* 0x021E */ s16 unk_21E;
     /* 0x0220 */ s16 jointTable[GORON_LIMB_MAX];
     /* 0x0244 */ s16 morphTable[GORON_LIMB_MAX];

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -56,8 +56,8 @@ typedef struct EnGo {
     /* 0x020E */ s16 unk_20E;
     /* 0x0210 */ s16 unk_210;
     /* 0x0212 */ s16 unk_212;
-    /* 0x0214 */ s16 unk_214;
-    /* 0x0216 */ s16 unk_216;
+    /* 0x0214 */ s16 blinkTimer;  // unused
+    /* 0x0216 */ s16 eyeTexIndex; // unused
     /* 0x0218 */ s16 unk_218;
     /* 0x021A */ s16 unk_21A;
     /* 0x021C */ s16 unk_21C;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -54,7 +54,7 @@ typedef struct EnGo {
     /* 0x0208 */ char unk_208[0x4];
     /* 0x020C */ s16 unk_20C;
     /* 0x020E */ s16 knockbackCooldown;
-    /* 0x0210 */ s16 unk_210;
+    /* 0x0210 */ s16 curledTimer;
     /* 0x0212 */ s16 attentionCooldown;
     /* 0x0214 */ s16 blinkTimer;  // unused
     /* 0x0216 */ s16 eyeTexIndex; // unused

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -61,7 +61,7 @@ typedef struct EnGo {
     /* 0x0218 */ s16 waypoint;
     /* 0x021A */ s16 bounceCounter;
     /* 0x021C */ s16 bounceTimer;
-    /* 0x021E */ s16 unk_21E;
+    /* 0x021E */ s16 eyedropsTimer;
     /* 0x0220 */ s16 jointTable[GORON_LIMB_MAX];
     /* 0x0244 */ s16 morphTable[GORON_LIMB_MAX];
     /* 0x0268 */ EnGoEffect effects[EN_GO_EFFECT_COUNT];

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -52,7 +52,7 @@ typedef struct EnGo {
     /* 0x0194 */ ColliderCylinder collider;
     /* 0x01E0 */ NpcInteractInfo interactInfo;
     /* 0x0208 */ char unk_208[0x4];
-    /* 0x020C */ s16 unk_20C;
+    /* 0x020C */ s16 gaveSword;
     /* 0x020E */ s16 knockbackCooldown;
     /* 0x0210 */ s16 curledTimer;
     /* 0x0212 */ s16 attentionCooldown;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -30,18 +30,6 @@ typedef enum GoronLimb {
     /* 18 */ GORON_LIMB_MAX
 } GoronLimb;
 
-// WIP type docs
-// /* 0x00 */ GORON1_CITY_LINK,
-// /* 0x10 */ GORON1_FIRE_GENERIC,
-// /* 0x20 */ GORON1_DMT_DC_ENTRANCE,
-// /* 0x30 */ GORON1_DMT_ROLLING_SMALL,
-// /* 0x40 */ GORON1_DMT_BOMB_FLOWER,
-// /* 0x50 */ GORON1_CITY_ENTRANCE,
-// /* 0x60 */ GORON1_CITY_ISLAND,
-// /* 0x70 */ GORON1_CITY_LOST_WOODS,
-// /* 0x80 */ // Not Used
-// /* 0x90 */ GORON1_DMT_BIGGORON,
-
 #define EN_GO_EFFECT_COUNT 20
 
 typedef struct EnGoEffect {

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -55,7 +55,7 @@ typedef struct EnGo {
     /* 0x020C */ s16 unk_20C;
     /* 0x020E */ s16 knockbackCooldown;
     /* 0x0210 */ s16 unk_210;
-    /* 0x0212 */ s16 unk_212;
+    /* 0x0212 */ s16 attentionCooldown;
     /* 0x0214 */ s16 blinkTimer;  // unused
     /* 0x0216 */ s16 eyeTexIndex; // unused
     /* 0x0218 */ s16 waypoint;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -53,7 +53,7 @@ typedef struct EnGo {
     /* 0x01E0 */ NpcInteractInfo interactInfo;
     /* 0x0208 */ char unk_208[0x4];
     /* 0x020C */ s16 unk_20C;
-    /* 0x020E */ s16 unk_20E;
+    /* 0x020E */ s16 knockbackCooldown;
     /* 0x0210 */ s16 unk_210;
     /* 0x0212 */ s16 unk_212;
     /* 0x0214 */ s16 blinkTimer;  // unused

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -10,6 +10,28 @@ typedef void (*EnGoActionFunc)(struct EnGo*, PlayState*);
 typedef u16 (*callback1_80A3ED24)(PlayState*, struct EnGo*);
 typedef s16 (*callback2_80A3ED24)(PlayState*, struct EnGo*);
 
+typedef enum GoronLimb {
+    /*  0 */ GORON_LIMB_NONE, // skeleton itself
+    /*  1 */ GORON_LIMB_ROOT,
+    /*  2 */ GORON_LIMB_WAIST, // drives bottom submesh
+    /*  3 */ GORON_LIMB_LEGS,
+    /*  4 */ GORON_LIMB_LEFT_THIGH,
+    /*  5 */ GORON_LIMB_LEFT_SHIN,
+    /*  6 */ GORON_LIMB_LEFT_FOOT,
+    /*  7 */ GORON_LIMB_RIGHT_THIGH,
+    /*  8 */ GORON_LIMB_RIGHT_SHIN,
+    /*  9 */ GORON_LIMB_RIGHT_FOOT,
+    /* 10 */ GORON_LIMB_TORSO, // drives top submesh
+    /* 11 */ GORON_LIMB_LEFT_ARM,
+    /* 12 */ GORON_LIMB_LEFT_FOREARM,
+    /* 13 */ GORON_LIMB_LEFT_HAND,
+    /* 14 */ GORON_LIMB_RIGHT_ARM,
+    /* 15 */ GORON_LIMB_RIGHT_FOREARM,
+    /* 16 */ GORON_LIMB_RIGHT_HAND,
+    /* 17 */ GORON_LIMB_HEAD,
+    /* 18 */ GORON_LIMB_MAX
+} GoronLimb;
+
 // WIP type docs
 // /* 0x00 */ GORON1_CITY_LINK,
 // /* 0x10 */ GORON1_FIRE_GENERIC,
@@ -21,7 +43,6 @@ typedef s16 (*callback2_80A3ED24)(PlayState*, struct EnGo*);
 // /* 0x70 */ GORON1_CITY_LOST_WOODS,
 // /* 0x80 */ // Not Used
 // /* 0x90 */ GORON1_DMT_BIGGORON,
-
 
 #define EN_GO_EFFECT_COUNT 20
 
@@ -55,8 +76,8 @@ typedef struct EnGo {
     /* 0x021A */ s16 unk_21A;
     /* 0x021C */ s16 unk_21C;
     /* 0x021E */ s16 unk_21E;
-    /* 0x0220 */ s16 jointTable[18];
-    /* 0x0244 */ s16 morphTable[18];
+    /* 0x0220 */ s16 jointTable[GORON_LIMB_MAX];
+    /* 0x0244 */ s16 morphTable[GORON_LIMB_MAX];
     /* 0x0268 */ EnGoEffect effects[EN_GO_EFFECT_COUNT];
 } EnGo; // size = 0x06C8
 

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -149,6 +149,24 @@ static AnimationInfo sAnimationInfo[] = {
     { &gGoronShakingLoopAnim, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
 };
 
+#define ENGO2_GET_TYPE(this) PARAMS_GET_S((this)->actor.params, 0, 5)
+typedef enum GoronType {
+    /* 0x00 */ GORON_CITY_ROLLING_BIG,
+    /* 0x01 */ GORON_CITY_LINK,
+    /* 0x02 */ GORON_DMT_BIGGORON,
+    /* 0x03 */ GORON_FIRE_GENERIC,
+    /* 0x04 */ GORON_DMT_BOMB_FLOWER,
+    /* 0x05 */ GORON_DMT_ROLLING_SMALL,
+    /* 0x06 */ GORON_DMT_DC_ENTRANCE,
+    /* 0x07 */ GORON_CITY_ENTRANCE,
+    /* 0x08 */ GORON_CITY_ISLAND,
+    /* 0x09 */ GORON_CITY_LOWEST_FLOOR,
+    /* 0x0A */ GORON_CITY_STAIRWELL,
+    /* 0x0B */ GORON_CITY_LOST_WOODS,
+    /* 0x0C */ GORON_DMT_FAIRY_HINT,
+    /* 0x0D */ GORON_MARKET_BAZAAR
+} GoronType;
+
 static EnGo2DustEffectData sDustEffectData[2][4] = {
     {
         { 12, 0.2f, 0.2f, 1, 18.0f, 0.0f },
@@ -742,7 +760,7 @@ u16 EnGo2_GetTextId(PlayState* play, Actor* thisx) {
     if (textId != 0) {
         return textId;
     } else {
-        switch (PARAMS_GET_S(this->actor.params, 0, 5)) {
+        switch (ENGO2_GET_TYPE(this)) {
             case GORON_CITY_ROLLING_BIG:
                 return EnGo2_GetTextIdGoronCityRollingBig(play, this);
             case GORON_CITY_LINK:
@@ -780,7 +798,7 @@ u16 EnGo2_GetTextId(PlayState* play, Actor* thisx) {
 
 s16 EnGo2_UpdateTalkState(PlayState* play, Actor* thisx) {
     EnGo2* this = (EnGo2*)thisx;
-    switch (PARAMS_GET_S(this->actor.params, 0, 5)) {
+    switch (ENGO2_GET_TYPE(this)) {
         case GORON_CITY_ROLLING_BIG:
             return EnGo2_UpdateTalkStateGoronCityRollingBig(play, this);
         case GORON_CITY_LINK:
@@ -818,12 +836,10 @@ s16 EnGo2_UpdateTalkState(PlayState* play, Actor* thisx) {
 }
 
 s32 func_80A44790(EnGo2* this, PlayState* play) {
-    if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_DMT_BIGGORON &&
-        PARAMS_GET_S(this->actor.params, 0, 5) != GORON_CITY_ROLLING_BIG) {
+    if (ENGO2_GET_TYPE(this) != GORON_DMT_BIGGORON && ENGO2_GET_TYPE(this) != GORON_CITY_ROLLING_BIG) {
         return Npc_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, this->interactRange,
                                  EnGo2_GetTextId, EnGo2_UpdateTalkState);
-    } else if ((PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) &&
-               !(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
+    } else if ((ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) && !(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
         return false;
     } else {
         if (Actor_TalkOfferAccepted(&this->actor, play)) {
@@ -840,14 +856,14 @@ s32 func_80A44790(EnGo2* this, PlayState* play) {
 }
 
 void EnGo2_SetColliderDim(EnGo2* this) {
-    u8 index = PARAMS_GET_S(this->actor.params, 0, 5);
+    u8 index = ENGO2_GET_TYPE(this);
 
     this->collider.dim.radius = D_80A4816C[index].radius;
     this->collider.dim.height = D_80A4816C[index].height;
 }
 
 void EnGo2_SetShape(EnGo2* this) {
-    u8 index = PARAMS_GET_S(this->actor.params, 0, 5);
+    u8 index = ENGO2_GET_TYPE(this);
 
     this->actor.shape.shadowScale = D_80A481F8[index].shape_unk_10;
     Actor_SetScale(&this->actor, D_80A481F8[index].scale);
@@ -863,10 +879,10 @@ void EnGo2_CheckCollision(EnGo2* this, PlayState* play) {
     pos.x = this->actor.world.pos.x;
     pos.y = this->actor.world.pos.y;
     pos.z = this->actor.world.pos.z;
-    xzDist = D_80A4816C[PARAMS_GET_S(this->actor.params, 0, 5)].xzDist;
+    xzDist = D_80A4816C[ENGO2_GET_TYPE(this)].xzDist;
     pos.x += (s16)(xzDist * Math_SinS(this->actor.shape.rot.y));
     pos.z += (s16)(xzDist * Math_CosS(this->actor.shape.rot.y));
-    pos.y += D_80A4816C[PARAMS_GET_S(this->actor.params, 0, 5)].yDist;
+    pos.y += D_80A4816C[ENGO2_GET_TYPE(this)].yDist;
     this->collider.dim.pos = pos;
     CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
@@ -884,7 +900,7 @@ s32 func_80A44AB0(EnGo2* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     f32 arg2;
 
-    if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
+    if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
         return false;
     } else {
         if ((this->actionFunc != EnGo2_ActionRollingSlow) && (this->actionFunc != EnGo2_ActionRollingReverse) &&
@@ -964,11 +980,11 @@ s32 func_80A44D84(EnGo2* this) {
 
 s32 EnGo2_IsAttentionDrawn(EnGo2* this) {
     s16 yawDiff;
-    f32 xyzDist = PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON ? 800.0f : 200.0f;
-    f32 yDist = PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON ? 400.0f : 60.0f;
+    f32 xyzDist = (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) ? 800.0f : 200.0f;
+    f32 yDist = (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) ? 400.0f : 60.0f;
     s16 yawDiffAbs;
 
-    if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
+    if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
         if (!(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
             this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
             return false;
@@ -1010,9 +1026,8 @@ s32 EnGo2_IsRollingOnGround(EnGo2* this, s16 bounceCount, f32 boundSpeed, s16 ru
     // bounce!
     {
         if (this->bounceCounter >= 2) {
-            Actor_PlaySfx(&this->actor, (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_CITY_ROLLING_BIG)
-                                            ? NA_SE_EN_GOLON_LAND_BIG
-                                            : NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, (ENGO2_GET_TYPE(this) == GORON_CITY_ROLLING_BIG) ? NA_SE_EN_GOLON_LAND_BIG
+                                                                                         : NA_SE_EN_DODO_M_GND);
         }
 
         this->bounceCounter--;
@@ -1035,7 +1050,7 @@ s32 EnGo2_IsRollingOnGround(EnGo2* this, s16 bounceCount, f32 boundSpeed, s16 ru
 void EnGo2_BiggoronSetTextId(EnGo2* this, PlayState* play, Player* player) {
     u16 textId;
 
-    if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
+    if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
         if (gSaveContext.save.info.playerData.bgsFlag) {
             if (Player_GetExchangeItemId(play) == EXCH_ITEM_CLAIM_CHECK) {
                 this->actor.textId = 0x3003;
@@ -1099,7 +1114,7 @@ void func_80A45288(EnGo2* this, PlayState* play) {
     if (this->actionFunc != EnGo2_GoronFireGenericAction) {
         this->interactInfo.trackPos = player->actor.world.pos;
         this->interactInfo.yOffset =
-            sPlayerTrackingYOffsets[PARAMS_GET_S(this->actor.params, 0, 5)][((void)0, gSaveContext.save.linkAge)];
+            sPlayerTrackingYOffsets[ENGO2_GET_TYPE(this)][((void)0, gSaveContext.save.linkAge)];
         Npc_TrackPoint(&this->actor, &this->interactInfo, 4, this->trackingMode);
     }
     if ((this->actionFunc != EnGo2_SetGetItem) && (this->isAwake == true)) {
@@ -1132,7 +1147,7 @@ void EnGo2_RollForward(EnGo2* this) {
 }
 
 void func_80A454CC(EnGo2* this) {
-    switch (PARAMS_GET_S(this->actor.params, 0, 5)) {
+    switch (ENGO2_GET_TYPE(this)) {
         case GORON_CITY_ROLLING_BIG:
         case GORON_DMT_DC_ENTRANCE:
         case GORON_CITY_ENTRANCE:
@@ -1154,8 +1169,8 @@ void func_80A454CC(EnGo2* this) {
 }
 
 f32 EnGo2_GetTargetXZSpeed(EnGo2* this) {
-    f32 yDist = PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON ? 400.0f : 60.0f;
-    s32 index = PARAMS_GET_S(this->actor.params, 0, 5);
+    f32 yDist = (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) ? 400.0f : 60.0f;
+    s32 index = ENGO2_GET_TYPE(this);
 
     if (index == GORON_CITY_LINK && (fabsf(this->actor.yDistToPlayer) < yDist) &&
         (this->actor.xzDistToPlayer < 400.0f)) {
@@ -1168,7 +1183,7 @@ f32 EnGo2_GetTargetXZSpeed(EnGo2* this) {
 s32 EnGo2_IsAttentionDrawnExtented(EnGo2* this, PlayState* play) {
     Camera* mainCam = play->cameraPtrs[CAM_ID_MAIN];
 
-    if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
+    if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
         if (EnGo2_IsAttentionDrawn(this)) {
             Camera_RequestSetting(mainCam, CAM_SET_DIRECTED_YAW);
             Camera_UnsetStateFlag(mainCam, CAM_STATE_CHECK_BG);
@@ -1178,11 +1193,9 @@ s32 EnGo2_IsAttentionDrawnExtented(EnGo2* this, PlayState* play) {
         }
     }
 
-    if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_FIRE_GENERIC ||
-        PARAMS_GET_S(this->actor.params, 0, 5) == GORON_CITY_ROLLING_BIG ||
-        PARAMS_GET_S(this->actor.params, 0, 5) == GORON_CITY_STAIRWELL ||
-        PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON ||
-        PARAMS_GET_S(this->actor.params, 0, 5) == GORON_MARKET_BAZAAR) {
+    if (ENGO2_GET_TYPE(this) == GORON_FIRE_GENERIC || ENGO2_GET_TYPE(this) == GORON_CITY_ROLLING_BIG ||
+        ENGO2_GET_TYPE(this) == GORON_CITY_STAIRWELL || (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) ||
+        ENGO2_GET_TYPE(this) == GORON_MARKET_BAZAAR) {
         return true;
     }
 
@@ -1208,7 +1221,7 @@ void EnGo2_DefaultWakingUp(EnGo2* this) {
 }
 
 void EnGo2_WakingUp(EnGo2* this) {
-    f32 xyzDist = PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON ? 800.0f : 200.0f;
+    f32 xyzDist = (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) ? 800.0f : 200.0f;
     s32 isTrue = true;
 
     xyzDist = SQ(xyzDist);
@@ -1231,7 +1244,7 @@ void EnGo2_BiggoronWakingUp(EnGo2* this) {
 }
 
 void EnGo2_SelectGoronWakingUp(EnGo2* this) {
-    switch (PARAMS_GET_S(this->actor.params, 0, 5)) {
+    switch (ENGO2_GET_TYPE(this)) {
         case GORON_DMT_BOMB_FLOWER:
             this->isAwake = true;
             this->trackingMode = EnGo2_IsAttentionDrawn(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
@@ -1286,7 +1299,7 @@ void EnGo2_EyeMouthTexState(EnGo2* this) {
 void EnGo2_SitDownAnimation(EnGo2* this) {
     if ((this->skelAnime.playSpeed != 0.0f) && (this->skelAnime.animation == &gGoronUncurlSitStandAnim)) {
         if (this->skelAnime.playSpeed > 0.0f && this->skelAnime.curFrame == 14.0f) {
-            if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_DMT_BIGGORON) {
+            if (ENGO2_GET_TYPE(this) != GORON_DMT_BIGGORON) {
                 Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_SIT_DOWN);
             } else {
                 func_800F4524(&gSfxDefaultPos, NA_SE_EN_GOLON_SIT_DOWN, 60);
@@ -1304,7 +1317,7 @@ void EnGo2_SitDownAnimation(EnGo2* this) {
 }
 
 void EnGo2_GetDustData(EnGo2* this, s32 index2) {
-    s32 index1 = PARAMS_GET_S(this->actor.params, 0, 5) == GORON_CITY_ROLLING_BIG ? 1 : 0;
+    s32 index1 = ENGO2_GET_TYPE(this) == GORON_CITY_ROLLING_BIG ? 1 : 0;
     EnGo2DustEffectData* dustEffectData = &sDustEffectData[index1][index2];
 
     EnGo2_SpawnDust(this, dustEffectData->initialTimer, dustEffectData->scale, dustEffectData->scaleStep,
@@ -1312,7 +1325,7 @@ void EnGo2_GetDustData(EnGo2* this, s32 index2) {
 }
 
 void EnGo2_RollingAnimation(EnGo2* this, PlayState* play) {
-    if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
+    if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
         this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_BIG);
         this->skelAnime.playSpeed = -0.5f;
@@ -1329,13 +1342,13 @@ void EnGo2_RollingAnimation(EnGo2* this, PlayState* play) {
 
 void EnGo2_WakeUp(EnGo2* this, PlayState* play) {
     if (this->skelAnime.playSpeed == 0.0f) {
-        if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_DMT_BIGGORON) {
+        if (ENGO2_GET_TYPE(this) != GORON_DMT_BIGGORON) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_WAKE_UP);
         } else {
             func_800F4524(&gSfxDefaultPos, NA_SE_EN_GOLON_WAKE_UP, 60);
         }
     }
-    if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
+    if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
         OnePointCutscene_Init(play, 4200, -99, &this->actor, CAM_ID_MAIN);
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_BIG);
         this->skelAnime.playSpeed = 0.5f;
@@ -1356,8 +1369,7 @@ void EnGo2_GetItemAnimation(EnGo2* this, PlayState* play) {
 }
 
 void EnGo2_SetupRolling(EnGo2* this, PlayState* play) {
-    if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_CITY_ROLLING_BIG ||
-        PARAMS_GET_S(this->actor.params, 0, 5) == GORON_CITY_LINK) {
+    if (ENGO2_GET_TYPE(this) == GORON_CITY_ROLLING_BIG || ENGO2_GET_TYPE(this) == GORON_CITY_LINK) {
         this->collider.elem.acElemFlags = ACELEM_ON;
         this->actor.speed = GET_INFTABLE(INFTABLE_11E) ? 6.0f : 3.6000001f;
     } else {
@@ -1373,9 +1385,8 @@ void EnGo2_SetupRolling(EnGo2* this, PlayState* play) {
 void EnGo2_StopRolling(EnGo2* this, PlayState* play) {
     EnBom* bomb;
 
-    if ((PARAMS_GET_S(this->actor.params, 0, 5) != GORON_CITY_ROLLING_BIG) &&
-        (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_CITY_LINK)) {
-        if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_ROLLING_SMALL) {
+    if ((ENGO2_GET_TYPE(this) != GORON_CITY_ROLLING_BIG) && (ENGO2_GET_TYPE(this) != GORON_CITY_LINK)) {
+        if (ENGO2_GET_TYPE(this) == GORON_DMT_ROLLING_SMALL) {
             bomb = (EnBom*)Actor_Spawn(&play->actorCtx, play, ACTOR_EN_BOM, this->actor.world.pos.x,
                                        this->actor.world.pos.y, this->actor.world.pos.z, 0, 0, 0, 0);
             if (bomb != NULL) {
@@ -1395,7 +1406,7 @@ void EnGo2_StopRolling(EnGo2* this, PlayState* play) {
 }
 
 s32 EnGo2_IsFreeingGoronInFire(EnGo2* this, PlayState* play) {
-    if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_FIRE_GENERIC) {
+    if (ENGO2_GET_TYPE(this) != GORON_FIRE_GENERIC) {
         return false;
     }
 
@@ -1408,8 +1419,7 @@ s32 EnGo2_IsFreeingGoronInFire(EnGo2* this, PlayState* play) {
 }
 
 s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
-    if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_DMT_BOMB_FLOWER ||
-        this->interactInfo.talkState != NPC_TALK_STATE_ACTION) {
+    if (ENGO2_GET_TYPE(this) != GORON_DMT_BOMB_FLOWER || this->interactInfo.talkState != NPC_TALK_STATE_ACTION) {
         return false;
     }
 
@@ -1422,8 +1432,7 @@ s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
 }
 
 s32 EnGo2_IsGoronRollingBig(EnGo2* this, PlayState* play) {
-    if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_CITY_ROLLING_BIG ||
-        (this->interactInfo.talkState != NPC_TALK_STATE_ACTION)) {
+    if (ENGO2_GET_TYPE(this) != GORON_CITY_ROLLING_BIG || (this->interactInfo.talkState != NPC_TALK_STATE_ACTION)) {
         return false;
     }
     this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
@@ -1433,8 +1442,7 @@ s32 EnGo2_IsGoronRollingBig(EnGo2* this, PlayState* play) {
 }
 
 s32 EnGo2_IsGoronFireGeneric(EnGo2* this) {
-    if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_FIRE_GENERIC ||
-        this->interactInfo.talkState == NPC_TALK_STATE_IDLE) {
+    if (ENGO2_GET_TYPE(this) != GORON_FIRE_GENERIC || this->interactInfo.talkState == NPC_TALK_STATE_IDLE) {
         return false;
     }
     this->actionFunc = EnGo2_GoronFireGenericAction;
@@ -1442,7 +1450,7 @@ s32 EnGo2_IsGoronFireGeneric(EnGo2* this) {
 }
 
 s32 EnGo2_IsGoronLinkReversing(EnGo2* this) {
-    if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_CITY_LINK || (this->waypoint >= this->reverseWaypoint) ||
+    if (ENGO2_GET_TYPE(this) != GORON_CITY_LINK || (this->waypoint >= this->reverseWaypoint) ||
         !EnGo2_IsAttentionDrawn(this)) {
         return false;
     }
@@ -1465,7 +1473,7 @@ s32 EnGo2_IsRolling(EnGo2* this) {
 void EnGo2_GoronLinkAnimation(EnGo2* this, PlayState* play) {
     s32 animation = ARRAY_COUNT(sAnimationInfo);
 
-    if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_CITY_LINK) {
+    if (ENGO2_GET_TYPE(this) == GORON_CITY_LINK) {
         if ((this->actor.textId == 0x3035 && this->messageEntry == 0) ||
             (this->actor.textId == 0x3036 && this->messageEntry == 0)) {
             if (this->skelAnime.animation != &gGoronShakingLoopAnim) {
@@ -1518,8 +1526,7 @@ void EnGo2_GoronFireClearCamera(EnGo2* this, PlayState* play) {
 
 void EnGo2_BiggoronAnimation(EnGo2* this) {
     if (INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_BROKEN_GORONS_SWORD && INV_CONTENT(ITEM_TRADE_ADULT) <= ITEM_EYE_DROPS &&
-        PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON &&
-        this->interactInfo.talkState == NPC_TALK_STATE_IDLE) {
+        (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) && this->interactInfo.talkState == NPC_TALK_STATE_IDLE) {
         if (DECR(this->animTimer) == 0) {
             this->animTimer = Rand_S16Offset(30, 30);
             func_800F4524(&gSfxDefaultPos, NA_SE_EN_GOLON_EYE_BIG, 60);
@@ -1538,7 +1545,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
 
     // Not GORON_CITY_ROLLING_BIG, GORON_CITY_LINK, GORON_DMT_BIGGORON
-    switch (PARAMS_GET_S(this->actor.params, 0, 5)) {
+    switch (ENGO2_GET_TYPE(this)) {
         case GORON_FIRE_GENERIC:
         case GORON_DMT_BOMB_FLOWER:
         case GORON_DMT_ROLLING_SMALL:
@@ -1567,7 +1574,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
     this->reverseWaypoint = this->actor.shape.rot.z;
     this->trackingMode = NPC_TRACKING_NONE;
     this->path = Path_GetByIndex(play, PARAMS_GET_S(this->actor.params, 5, 5), 0x1F);
-    switch (PARAMS_GET_S(this->actor.params, 0, 5)) {
+    switch (ENGO2_GET_TYPE(this)) {
         case GORON_CITY_ENTRANCE:
         case GORON_CITY_ISLAND:
         case GORON_CITY_LOWEST_FLOOR:
@@ -1598,14 +1605,14 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
 #if OOT_VERSION >= PAL_1_1
                 CLEAR_INFTABLE(INFTABLE_10C);
 #endif
-                this->collider.dim.height = (D_80A4816C[PARAMS_GET_S(this->actor.params, 0, 5)].height * 0.6f);
+                this->collider.dim.height = (D_80A4816C[ENGO2_GET_TYPE(this)].height * 0.6f);
                 EnGo2_SetupRolling(this, play);
                 this->isAwake = true;
             }
             break;
         case GORON_CITY_ROLLING_BIG:
         case GORON_DMT_ROLLING_SMALL:
-            this->collider.dim.height = (D_80A4816C[PARAMS_GET_S(this->actor.params, 0, 5)].height * 0.6f);
+            this->collider.dim.height = (D_80A4816C[ENGO2_GET_TYPE(this)].height * 0.6f);
             EnGo2_SetupRolling(this, play);
             break;
         case GORON_FIRE_GENERIC:
@@ -1645,12 +1652,12 @@ void EnGo2_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void EnGo2_ActionCurledUp(EnGo2* this, PlayState* play) {
-    u8 index = PARAMS_GET_S(this->actor.params, 0, 5);
+    u8 index = ENGO2_GET_TYPE(this);
     s16 height;
     s32 quakeIndex;
 
     if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-        if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
+        if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
             quakeIndex = Quake_Request(GET_ACTIVE_CAM(play), QUAKE_TYPE_3);
             Quake_SetSpeed(quakeIndex, -0x3CB0);
             Quake_SetPerturbations(quakeIndex, 8, 0, 0, 0);
@@ -1673,13 +1680,13 @@ void EnGo2_ActionCurledUp(EnGo2* this, PlayState* play) {
         this->isAwake = false;
         EnGo2_WakeUp(this, play);
     }
-    if ((PARAMS_GET_S(this->actor.params, 0, 5) != GORON_FIRE_GENERIC) && EnGo2_IsAttentionDrawn(this)) {
+    if ((ENGO2_GET_TYPE(this) != GORON_FIRE_GENERIC) && EnGo2_IsAttentionDrawn(this)) {
         EnGo2_WakeUp(this, play);
     }
 }
 
 void func_80A46B40(EnGo2* this, PlayState* play) {
-    u8 index = PARAMS_GET_S(this->actor.params, 0, 5);
+    u8 index = ENGO2_GET_TYPE(this);
     f32 height;
 
     if (this->isUncurled == true) {
@@ -1696,7 +1703,7 @@ void func_80A46B40(EnGo2* this, PlayState* play) {
         }
     } else {
         if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-            if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
+            if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
                 this->actor.flags |= ACTOR_FLAG_ATTENTION_ENABLED;
             }
             func_80A454CC(this);
@@ -1734,8 +1741,7 @@ void EnGo2_GoronRollingBigContinueRolling(EnGo2* this, PlayState* play) {
 void EnGo2_ActionRollingContinue(EnGo2* this, PlayState* play) {
     f32 float1 = 1000.0f;
 
-    if ((PARAMS_GET_S(this->actor.params, 0, 5) != GORON_DMT_ROLLING_SMALL ||
-         !(this->actor.xyzDistToPlayerSq > SQ(float1))) &&
+    if ((ENGO2_GET_TYPE(this) != GORON_DMT_ROLLING_SMALL || !(this->actor.xyzDistToPlayerSq > SQ(float1))) &&
         DECR(this->animTimer) == 0) {
         this->actionFunc = EnGo2_ActionRollingSlow;
         this->actor.speed *= 0.5f; // slowdown
@@ -1756,7 +1762,7 @@ void EnGo2_ActionRollingSlow(EnGo2* this, PlayState* play) {
             EnGo2_GetDustData(this, 3);
         }
         orientation = EnGo2_Orient(this, play);
-        index = PARAMS_GET_S(this->actor.params, 0, 5);
+        index = ENGO2_GET_TYPE(this);
         if (index != GORON_CITY_LINK) {
             if ((index == GORON_DMT_ROLLING_SMALL) && (orientation == 1) && (this->waypoint == 0)) {
                 EnGo2_StopRolling(this, play);
@@ -1775,7 +1781,7 @@ void EnGo2_GroundRolling(EnGo2* this, PlayState* play) {
     if (EnGo2_IsRollingOnGround(this, 4, 8.0f, 0)) {
         EnGo2_GetDustData(this, 0);
         if (this->bounceCounter == 0) {
-            switch (PARAMS_GET_S(this->actor.params, 0, 5)) {
+            switch (ENGO2_GET_TYPE(this)) {
                 case GORON_CITY_LINK:
                     this->goronState = 0;
                     this->actionFunc = EnGo2_GoronLinkStopRolling;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -851,7 +851,7 @@ s32 EnGo2_UpdateTalking(EnGo2* this, PlayState* play) {
         }
     }
 
-    // `GORON_DMT_BIGGORON`, attention wasn't drawn; see `EnGo2_IsAttentionDrawn`
+    // `GORON_DMT_BIGGORON`, close enough; see `EnGo2_IsInRange`
     if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
         if (!(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
             return false;
@@ -999,7 +999,7 @@ s32 EnGo2_OrientInstant(EnGo2* this) {
     return 1;
 }
 
-s32 EnGo2_IsAttentionDrawn(EnGo2* this) {
+s32 EnGo2_IsInRange(EnGo2* this) {
     s16 yawDiff;
     f32 xyzDist = (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) ? 800.0f : 200.0f;
     f32 yDist = (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) ? 400.0f : 60.0f;
@@ -1205,10 +1205,10 @@ s32 EnGo2_ShouldStay(EnGo2* this, PlayState* play) {
     Camera* mainCam = play->cameraPtrs[CAM_ID_MAIN];
 
     if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
-        if (EnGo2_IsAttentionDrawn(this)) {
+        if (EnGo2_IsInRange(this)) {
             Camera_RequestSetting(mainCam, CAM_SET_DIRECTED_YAW);
             Camera_UnsetStateFlag(mainCam, CAM_STATE_CHECK_BG);
-        } else if (!EnGo2_IsAttentionDrawn(this) && (mainCam->setting == CAM_SET_DIRECTED_YAW)) {
+        } else if (!EnGo2_IsInRange(this) && (mainCam->setting == CAM_SET_DIRECTED_YAW)) {
             Camera_RequestSetting(mainCam, CAM_SET_DUNGEON1);
             Camera_SetStateFlag(mainCam, CAM_STATE_CHECK_BG);
         }
@@ -1228,7 +1228,7 @@ s32 EnGo2_ShouldStay(EnGo2* this, PlayState* play) {
 }
 
 void EnGo2_SetupUncurledFlags_Default(EnGo2* this) {
-    this->trackingMode = EnGo2_IsAttentionDrawn(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
+    this->trackingMode = EnGo2_IsInRange(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
 
     if (this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
         this->trackingMode = NPC_TRACKING_FULL_BODY;
@@ -1252,7 +1252,7 @@ void EnGo2_SetupUncurledFlags_NearTracking(EnGo2* this) {
 }
 
 void EnGo2_SetupUncurledFlags_Biggoron(EnGo2* this) {
-    if (EnGo2_IsAttentionDrawn(this) || this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
+    if (EnGo2_IsInRange(this) || this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
         this->trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
         this->isTalkative = true;
     } else {
@@ -1265,7 +1265,7 @@ void EnGo2_SetupUncurledFlags(EnGo2* this) {
     switch (ENGO2_GET_TYPE(this)) {
         case GORON_DMT_BOMB_FLOWER:
             this->isTalkative = true;
-            this->trackingMode = EnGo2_IsAttentionDrawn(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
+            this->trackingMode = EnGo2_IsInRange(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
             break;
         case GORON_FIRE_GENERIC:
             EnGo2_SetupUncurledFlags_NearTracking(this);
@@ -1472,7 +1472,7 @@ s32 EnGo2_IsGoronFireGeneric(EnGo2* this) {
 
 s32 EnGo2_IsGoronLinkReversing(EnGo2* this) {
     if (ENGO2_GET_TYPE(this) != GORON_CITY_LINK || (this->waypoint >= this->reverseWaypoint) ||
-        !EnGo2_IsAttentionDrawn(this)) {
+        !EnGo2_IsInRange(this)) {
         return false;
     }
     return true;
@@ -1701,7 +1701,7 @@ void EnGo2_CurledUp(EnGo2* this, PlayState* play) {
         this->isTalkative = false;
         EnGo2_WakeUpAnimated(this, play);
     }
-    if ((ENGO2_GET_TYPE(this) != GORON_FIRE_GENERIC) && EnGo2_IsAttentionDrawn(this)) {
+    if ((ENGO2_GET_TYPE(this) != GORON_FIRE_GENERIC) && EnGo2_IsInRange(this)) {
         EnGo2_WakeUpAnimated(this, play);
     }
 }
@@ -1736,7 +1736,7 @@ void EnGo2_Standing(EnGo2* this, PlayState* play) {
                 (s16)((height * 0.4f * (this->skelAnime.curFrame / this->skelAnime.endFrame)) + (height * 0.6f));
         }
     }
-    if ((!EnGo2_ShouldStay(this, play)) && (!EnGo2_IsAttentionDrawn(this))) {
+    if ((!EnGo2_ShouldStay(this, play)) && (!EnGo2_IsInRange(this))) {
         EnGo2_AnimateRolling(this, play);
     }
 }

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -118,29 +118,35 @@ static f32 sPlayerTrackingYOffsets[14][2] = {
 };
 
 typedef enum EnGo2Animation {
-    /*  0 */ ENGO2_ANIM_0,
-    /*  1 */ ENGO2_ANIM_1,
-    /*  2 */ ENGO2_ANIM_2,
-    /*  3 */ ENGO2_ANIM_3,
-    /*  4 */ ENGO2_ANIM_4,
-    /*  5 */ ENGO2_ANIM_5,
-    /*  6 */ ENGO2_ANIM_6,
-    /*  7 */ ENGO2_ANIM_7,
-    /*  8 */ ENGO2_ANIM_8,
-    /*  9 */ ENGO2_ANIM_9,
-    /* 10 */ ENGO2_ANIM_10,
-    /* 11 */ ENGO2_ANIM_11,
-    /* 12 */ ENGO2_ANIM_12
+    /*  0 */ ENGO2_ANIM_UNCURL_SIT_STAND_IDLE, // default idle
+    /*  1 */ ENGO2_ANIM_UNCURL_SIT_STAND,
+    /*  2 */ ENGO2_ANIM_WALKING_LOOP,
+    /*  3 */ ENGO2_ANIM_SIDESTEP_LOOP,
+    /*  4 */ ENGO2_ANIM_CRYING_LOOP,
+    /*  5 */ ENGO2_ANIM_EYEDROPS_LOOP,
+    /*  6 */ ENGO2_ANIM_EYEDROPS_TAKEN,
+    /*  7 */ ENGO2_ANIM_UNCURL_PRONE_UNUSED,
+    /*  8 */ ENGO2_ANIM_PRONE_LOOP_UNUSED,
+    /*  9 */ ENGO2_ANIM_SCRATCHING_LOOP,
+    /* 10 */ ENGO2_ANIM_UNCURL_SIT_STAND_BIG,
+    /* 11 */ ENGO2_ANIM_SOBBING_LOOP,
+    /* 12 */ ENGO2_ANIM_SHAKING_LOOP
 } EnGo2Animation;
 
 static AnimationInfo sAnimationInfo[] = {
-    { &gGoronAnim_004930, 0.0f, 0.0f, -1.0f, 0x00, 0.0f },  { &gGoronAnim_004930, 0.0f, 0.0f, -1.0f, 0x00, -8.0f },
-    { &gGoronAnim_0029A8, 1.0f, 0.0f, -1.0f, 0x00, -8.0f }, { &gGoronAnim_010590, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
-    { &gGoronAnim_003768, 1.0f, 0.0f, -1.0f, 0x00, -8.0f }, { &gGoronAnim_0038E4, 1.0f, 0.0f, -1.0f, 0x02, -8.0f },
-    { &gGoronAnim_002D80, 1.0f, 0.0f, -1.0f, 0x02, -8.0f }, { &gGoronAnim_00161C, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
-    { &gGoronAnim_001A00, 1.0f, 0.0f, -1.0f, 0x00, -8.0f }, { &gGoronAnim_0021D0, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
-    { &gGoronAnim_004930, 0.0f, 0.0f, -1.0f, 0x01, -8.0f }, { &gGoronAnim_000750, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
-    { &gGoronAnim_000D5C, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronUncurlSitStandAnim, 0.0f, 0.0f, -1.0f, 0x00, 0.0f },
+    { &gGoronUncurlSitStandAnim, 0.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronWalkingLoopAnim, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronSidestepLoopAnim, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronCryingLoopAnim, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronEyeropsLoopAnim, 1.0f, 0.0f, -1.0f, 0x02, -8.0f },
+    { &gGoronEyedropsTakenAnim, 1.0f, 0.0f, -1.0f, 0x02, -8.0f },
+    { &gGoronUncurlToProneAnim, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronProneLoopAnim, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronScratchingLoopAnim, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronUncurlSitStandAnim, 0.0f, 0.0f, -1.0f, 0x01, -8.0f },
+    { &gGoronSobbingLoopAnim, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
+    { &gGoronShakingLoopAnim, 1.0f, 0.0f, -1.0f, 0x00, -8.0f },
 };
 
 static EnGo2DustEffectData sDustEffectData[2][4] = {
@@ -1099,7 +1105,7 @@ void func_80A45288(EnGo2* this, PlayState* play) {
 
 void func_80A45360(EnGo2* this, f32* alpha) {
     f32 alphaTarget =
-        (this->skelAnime.animation == &gGoronAnim_004930) && (this->skelAnime.curFrame <= 32.0f) ? 0.0f : 255.0f;
+        (this->skelAnime.animation == &gGoronUncurlSitStandAnim) && (this->skelAnime.curFrame <= 32.0f) ? 0.0f : 255.0f;
 
     Math_ApproachF(alpha, alphaTarget, 0.4f, 100.0f);
     this->actor.shape.shadowAlpha = (u8)(u32)*alpha;
@@ -1126,12 +1132,12 @@ void func_80A454CC(EnGo2* this) {
         case GORON_CITY_ENTRANCE:
         case GORON_CITY_STAIRWELL:
         case GORON_DMT_FAIRY_HINT:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_9);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_SCRATCHING_LOOP);
             break;
         case GORON_DMT_BIGGORON:
             if (INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_BROKEN_GORONS_SWORD &&
                 INV_CONTENT(ITEM_TRADE_ADULT) <= ITEM_EYE_DROPS) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_4);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_CRYING_LOOP);
                 break;
             }
             FALLTHROUGH;
@@ -1270,7 +1276,7 @@ void EnGo2_EyeMouthTexState(EnGo2* this) {
 }
 
 void EnGo2_SitDownAnimation(EnGo2* this) {
-    if ((this->skelAnime.playSpeed != 0.0f) && (this->skelAnime.animation == &gGoronAnim_004930)) {
+    if ((this->skelAnime.playSpeed != 0.0f) && (this->skelAnime.animation == &gGoronUncurlSitStandAnim)) {
         if (this->skelAnime.playSpeed > 0.0f && this->skelAnime.curFrame == 14.0f) {
             if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_DMT_BIGGORON) {
                 Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_SIT_DOWN);
@@ -1300,10 +1306,10 @@ void EnGo2_GetDustData(EnGo2* this, s32 index2) {
 void EnGo2_RollingAnimation(EnGo2* this, PlayState* play) {
     if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
         this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_10);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_BIG);
         this->skelAnime.playSpeed = -0.5f;
     } else {
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_1);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND);
         this->skelAnime.playSpeed = -1.0f;
     }
     EnGo2_SwapInitialFrameAnimFrameCount(this);
@@ -1323,17 +1329,17 @@ void EnGo2_WakeUp(EnGo2* this, PlayState* play) {
     }
     if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
         OnePointCutscene_Init(play, 4200, -99, &this->actor, CAM_ID_MAIN);
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_10);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_BIG);
         this->skelAnime.playSpeed = 0.5f;
     } else {
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_1);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND);
         this->skelAnime.playSpeed = 1.0f;
     }
     this->actionFunc = func_80A46B40;
 }
 
 void EnGo2_GetItemAnimation(EnGo2* this, PlayState* play) {
-    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_1);
+    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND);
     this->unk_211 = true;
     this->actionFunc = func_80A46B40;
     this->skelAnime.playSpeed = 0.0f;
@@ -1399,7 +1405,7 @@ s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
         return false;
     }
 
-    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_3);
+    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_SIDESTEP_LOOP);
     this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
     this->isAwake = false;
     this->trackingMode = NPC_TRACKING_NONE;
@@ -1454,21 +1460,21 @@ void EnGo2_GoronLinkAnimation(EnGo2* this, PlayState* play) {
     if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_CITY_LINK) {
         if ((this->actor.textId == 0x3035 && this->unk_20C == 0) ||
             (this->actor.textId == 0x3036 && this->unk_20C == 0)) {
-            if (this->skelAnime.animation != &gGoronAnim_000D5C) {
-                animation = ENGO2_ANIM_12;
+            if (this->skelAnime.animation != &gGoronShakingLoopAnim) {
+                animation = ENGO2_ANIM_SHAKING_LOOP;
                 this->eyeMouthTexState = 0;
             }
         }
 
         if ((this->actor.textId == 0x3032 && this->unk_20C == 12) || (this->actor.textId == 0x3033) ||
             (this->actor.textId == 0x3035 && this->unk_20C == 6)) {
-            if (this->skelAnime.animation != &gGoronAnim_000750) {
-                animation = ENGO2_ANIM_11;
+            if (this->skelAnime.animation != &gGoronSobbingLoopAnim) {
+                animation = ENGO2_ANIM_SOBBING_LOOP;
                 this->eyeMouthTexState = 1;
             }
         }
 
-        if (this->skelAnime.animation == &gGoronAnim_000750) {
+        if (this->skelAnime.animation == &gGoronSobbingLoopAnim) {
             if (this->skelAnime.curFrame == 20.0f) {
                 Actor_PlaySfx(&this->actor, NA_SE_EN_GOLON_CRY);
             }
@@ -1542,7 +1548,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
 
     EnGo2_SetColliderDim(this);
     EnGo2_SetShape(this);
-    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_0);
+    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_IDLE);
     this->actor.gravity = -1.0f;
     this->alpha = this->actor.shape.shadowAlpha = 0;
     this->reverse = 0;
@@ -1832,7 +1838,7 @@ void EnGo2_SetGetItem(EnGo2* this, PlayState* play) {
 void EnGo2_BiggoronEyedrops(EnGo2* this, PlayState* play) {
     switch (this->goronState) {
         case 0:
-            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_5);
+            Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_EYEDROPS_LOOP);
             this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
             this->actor.shape.rot.y += 0x5B0;
             this->trackingMode = NPC_TRACKING_NONE;
@@ -1851,7 +1857,7 @@ void EnGo2_BiggoronEyedrops(EnGo2* this, PlayState* play) {
                 }
             } else {
                 func_800F4524(&gSfxDefaultPos, NA_SE_EN_GOLON_GOOD_BIG, 60);
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_6);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_EYEDROPS_TAKEN);
                 Message_ContinueTextbox(play, 0x305A);
                 this->eyeMouthTexState = 3;
                 this->goronState++;
@@ -1863,7 +1869,7 @@ void EnGo2_BiggoronEyedrops(EnGo2* this, PlayState* play) {
                 this->eyeMouthTexState = 0;
             }
             if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_1);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND);
                 this->actor.flags |= ACTOR_FLAG_ATTENTION_ENABLED;
                 this->trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
                 this->skelAnime.playSpeed = 0.0f;
@@ -1914,7 +1920,7 @@ void EnGo2_GoronFireGenericAction(EnGo2* this, PlayState* play) {
             if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
                 EnGo2_GoronFireCamera(this, play);
                 play->msgCtx.msgMode = MSGMODE_PAUSED;
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_2);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_WALKING_LOOP);
                 this->waypoint = 1;
                 this->skelAnime.playSpeed = 2.0f;
                 func_80A44D84(this);

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1772,7 +1772,6 @@ void EnGo2_RollingStart(EnGo2* this, PlayState* play) {
 
 void EnGo2_RollingSlow(EnGo2* this, PlayState* play) {
     s32 updatedWaypoint;
-    s32 index;
 
     if (!EnGo2_IsRolling(this)) {
         if (EnGo2_IsRollingOnGround(this, 4, 8.0f, 1) == true) {
@@ -1783,16 +1782,20 @@ void EnGo2_RollingSlow(EnGo2* this, PlayState* play) {
             EnGo2_SpawnDust(this, 3);
         }
         updatedWaypoint = EnGo2_FollowPath(this, play);
-        index = ENGO2_GET_TYPE(this);
-        if (index != GORON_CITY_LINK) {
-            if ((index == GORON_DMT_ROLLING_SMALL) && (updatedWaypoint == 1) && (this->waypoint == 0)) {
-                EnGo2_StopRolling(this, play);
-                return;
-            }
-        } else if ((updatedWaypoint == 2) && (this->waypoint == 1)) {
-            // @unreachable: `EnGo2_FollowPath` returns `0` or `1`
-            EnGo2_StopRolling(this, play);
-            return;
+        switch (ENGO2_GET_TYPE(this)) {
+            case GORON_DMT_ROLLING_SMALL:
+                if ((updatedWaypoint == 1) && (this->waypoint == 0)) {
+                    EnGo2_StopRolling(this, play);
+                    return;
+                }
+                break;
+            case GORON_CITY_LINK:
+                if ((updatedWaypoint == 2) && (this->waypoint == 1)) {
+                    // @unreachable: `EnGo2_FollowPath` returns `0` or `1`
+                    EnGo2_StopRolling(this, play);
+                    return;
+                }
+                break;
         }
         Math_ApproachF(&this->actor.speed, EnGo2_GetTargetXZSpeed(this), 0.4f, 0.6f);
         this->actor.shape.rot = this->actor.world.rot;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -281,14 +281,14 @@ void EnGo2_GetItem(EnGo2* this, PlayState* play, s32 getItemId) {
 s32 EnGo2_GetDialogState(EnGo2* this, PlayState* play) {
     s16 dialogState = Message_GetState(&play->msgCtx);
 
-    if ((this->dialogState == TEXT_STATE_AWAITING_NEXT) || (this->dialogState == TEXT_STATE_EVENT) ||
-        (this->dialogState == TEXT_STATE_CLOSING) || (this->dialogState == TEXT_STATE_DONE_HAS_NEXT)) {
-        if (dialogState != this->dialogState) {
-            this->unk_20C++;
+    if ((this->messageState == TEXT_STATE_AWAITING_NEXT) || (this->messageState == TEXT_STATE_EVENT) ||
+        (this->messageState == TEXT_STATE_CLOSING) || (this->messageState == TEXT_STATE_DONE_HAS_NEXT)) {
+        if (dialogState != this->messageState) {
+            this->messageEntry++;
         }
     }
 
-    this->dialogState = dialogState;
+    this->messageState = dialogState;
     return dialogState;
 }
 
@@ -492,8 +492,8 @@ u16 EnGo2_GetTextIdGoronCityLink(PlayState* play, EnGo2* this) {
     } else if (CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON)) {
         return GET_INFTABLE(INFTABLE_10E) ? 0x3038 : 0x3037;
     } else if (GET_INFTABLE(INFTABLE_10C)) {
-        this->unk_20C = 0;
-        this->dialogState = TEXT_STATE_NONE;
+        this->messageEntry = 0;
+        this->messageState = TEXT_STATE_NONE;
         return GET_INFTABLE(INFTABLE_10A) ? 0x3033 : 0x3032;
     } else {
         return 0x3030;
@@ -529,7 +529,7 @@ s16 EnGo2_UpdateTalkStateGoronCityLink(PlayState* play, EnGo2* this) {
                         }
                     }
                     Message_ContinueTextbox(play, this->actor.textId);
-                    this->unk_20C = 0;
+                    this->messageEntry = 0;
                 }
             } else {
                 break;
@@ -575,7 +575,7 @@ u16 EnGo2_GetTextIdGoronDmtBiggoron(PlayState* play, EnGo2* this) {
 
 s16 EnGo2_UpdateTalkStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
     s32 unusedPad;
-    u8 dialogState = this->dialogState;
+    u8 dialogState = this->messageState;
 
     switch (EnGo2_GetDialogState(this, play)) {
 #if OOT_VERSION < PAL_1_0
@@ -1464,16 +1464,16 @@ void EnGo2_GoronLinkAnimation(EnGo2* this, PlayState* play) {
     s32 animation = ARRAY_COUNT(sAnimationInfo);
 
     if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_CITY_LINK) {
-        if ((this->actor.textId == 0x3035 && this->unk_20C == 0) ||
-            (this->actor.textId == 0x3036 && this->unk_20C == 0)) {
+        if ((this->actor.textId == 0x3035 && this->messageEntry == 0) ||
+            (this->actor.textId == 0x3036 && this->messageEntry == 0)) {
             if (this->skelAnime.animation != &gGoronShakingLoopAnim) {
                 animation = ENGO2_ANIM_SHAKING_LOOP;
                 this->eyeMouthTexState = 0;
             }
         }
 
-        if ((this->actor.textId == 0x3032 && this->unk_20C == 12) || (this->actor.textId == 0x3033) ||
-            (this->actor.textId == 0x3035 && this->unk_20C == 6)) {
+        if ((this->actor.textId == 0x3032 && this->messageEntry == 12) || (this->actor.textId == 0x3033) ||
+            (this->actor.textId == 0x3035 && this->messageEntry == 6)) {
             if (this->skelAnime.animation != &gGoronSobbingLoopAnim) {
                 animation = ENGO2_ANIM_SOBBING_LOOP;
                 this->eyeMouthTexState = 1;
@@ -1850,7 +1850,7 @@ void EnGo2_BiggoronEyedrops(EnGo2* this, PlayState* play) {
             this->trackingMode = NPC_TRACKING_NONE;
             this->animTimer = this->skelAnime.endFrame + 60.0f + 60.0f; // eyeDrops animation timer
             this->eyeMouthTexState = 2;
-            this->unk_20C = 0;
+            this->messageEntry = 0;
             this->goronState++;
             Audio_SetMainBgmVolume(0x28, 5);
             OnePointCutscene_Init(play, 4190, -99, &this->actor, CAM_ID_MAIN);

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -591,7 +591,7 @@ s16 EnGo2_UpdateTalkStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
         case TEXT_STATE_DONE_FADING:
             switch (this->actor.textId) {
                 case 0x305E:
-                    if (func_8002F368(play) != EXCH_ITEM_CLAIM_CHECK) {
+                    if (Player_GetExchangeItemId(play) != EXCH_ITEM_CLAIM_CHECK) {
                         break;
                     }
                     FALLTHROUGH;
@@ -1025,7 +1025,7 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, PlayState* play, Player* player) {
 
     if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
         if (gSaveContext.save.info.playerData.bgsFlag) {
-            if (func_8002F368(play) == EXCH_ITEM_CLAIM_CHECK) {
+            if (Player_GetExchangeItemId(play) == EXCH_ITEM_CLAIM_CHECK) {
                 this->actor.textId = 0x3003;
             } else {
                 this->actor.textId = 0x305E;
@@ -1033,7 +1033,7 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, PlayState* play, Player* player) {
             player->actor.textId = this->actor.textId;
 
         } else if (!gSaveContext.save.info.playerData.bgsFlag && (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_CLAIM_CHECK)) {
-            if (func_8002F368(play) == EXCH_ITEM_CLAIM_CHECK) {
+            if (Player_GetExchangeItemId(play) == EXCH_ITEM_CLAIM_CHECK) {
                 if (Environment_GetBgsDayCount() >= 3) {
                     textId = 0x305E;
                 } else {
@@ -1052,7 +1052,7 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, PlayState* play, Player* player) {
 
         } else if ((INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_PRESCRIPTION) &&
                    (INV_CONTENT(ITEM_TRADE_ADULT) <= ITEM_CLAIM_CHECK)) {
-            if (func_8002F368(play) == EXCH_ITEM_EYE_DROPS) {
+            if (Player_GetExchangeItemId(play) == EXCH_ITEM_EYE_DROPS) {
                 this->actor.textId = 0x3059;
             } else {
                 this->actor.textId = 0x3058;
@@ -1063,7 +1063,7 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, PlayState* play, Player* player) {
             player->actor.textId = this->actor.textId;
 
         } else if (INV_CONTENT(ITEM_TRADE_ADULT) <= ITEM_BROKEN_GORONS_SWORD) {
-            if (func_8002F368(play) == EXCH_ITEM_BROKEN_GORONS_SWORD) {
+            if (Player_GetExchangeItemId(play) == EXCH_ITEM_BROKEN_GORONS_SWORD) {
                 if (GET_INFTABLE(INFTABLE_B4)) {
                     textId = 0x3055;
                 } else {

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -842,7 +842,7 @@ s16 EnGo2_UpdateTalkState(PlayState* play, Actor* thisx) {
 #endif
 }
 
-s32 func_80A44790(EnGo2* this, PlayState* play) {
+s32 EnGo2_UpdateTalking(EnGo2* this, PlayState* play) {
     if (ENGO2_GET_TYPE(this) != GORON_DMT_BIGGORON && ENGO2_GET_TYPE(this) != GORON_CITY_ROLLING_BIG) {
         return Npc_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, this->interactRange,
                                  EnGo2_GetTextId, EnGo2_UpdateTalkState);
@@ -1127,8 +1127,8 @@ void EnGo2_TrackPlayer(EnGo2* this, PlayState* play) {
             sPlayerTrackingYOffsets[ENGO2_GET_TYPE(this)][((void)0, gSaveContext.save.linkAge)];
         Npc_TrackPoint(&this->actor, &this->interactInfo, 4, this->trackingMode);
     }
-    if ((this->actionFunc != EnGo2_HandleOfferParented) && (this->isAwake == true)) {
-        if (func_80A44790(this, play)) {
+    if ((this->actionFunc != EnGo2_HandleOfferParented) && (this->isTalkative == true)) {
+        if (EnGo2_UpdateTalking(this, play)) {
             EnGo2_BiggoronSetTextId(this, play, player);
         }
     }
@@ -1223,7 +1223,7 @@ void EnGo2_SetupUncurledFlags_Default(EnGo2* this) {
         this->trackingMode = NPC_TRACKING_FULL_BODY;
     }
 
-    this->isAwake = true;
+    this->isTalkative = true;
 }
 
 void EnGo2_SetupUncurledFlags_NearTracking(EnGo2* this) {
@@ -1237,23 +1237,23 @@ void EnGo2_SetupUncurledFlags_NearTracking(EnGo2* this) {
         this->trackingMode = NPC_TRACKING_FULL_BODY;
     }
 
-    this->isAwake = isTrue;
+    this->isTalkative = isTrue;
 }
 
 void EnGo2_SetupUncurledFlags_Biggoron(EnGo2* this) {
     if (EnGo2_IsAttentionDrawn(this) || this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
         this->trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
-        this->isAwake = true;
+        this->isTalkative = true;
     } else {
         this->trackingMode = NPC_TRACKING_NONE;
-        this->isAwake = false;
+        this->isTalkative = false;
     }
 }
 
 void EnGo2_SetupUncurledFlags(EnGo2* this) {
     switch (ENGO2_GET_TYPE(this)) {
         case GORON_DMT_BOMB_FLOWER:
-            this->isAwake = true;
+            this->isTalkative = true;
             this->trackingMode = EnGo2_IsAttentionDrawn(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
             break;
         case GORON_FIRE_GENERIC:
@@ -1343,7 +1343,7 @@ void EnGo2_AnimateRolling(EnGo2* this, PlayState* play) {
     EnGo2_SwapInitialFrameAnimFrameCount(this);
     this->trackingMode = NPC_TRACKING_NONE;
     this->isUncurled = false;
-    this->isAwake = false;
+    this->isTalkative = false;
     this->actionFunc = EnGo2_CurledUp;
 }
 
@@ -1435,7 +1435,7 @@ s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
 
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_SIDESTEP_LOOP);
     this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
-    this->isAwake = false;
+    this->isTalkative = false;
     this->trackingMode = NPC_TRACKING_NONE;
     this->actionFunc = EnGo2_GoronDmtBombFlower;
     return true;
@@ -1577,7 +1577,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
     this->actor.gravity = -1.0f;
     this->shadownAlpha = this->actor.shape.shadowAlpha = 0;
     this->reverse = 0;
-    this->isAwake = false;
+    this->isTalkative = false;
     this->isUncurled = false;
     this->goronState = 0;
     this->waypoint = 0;
@@ -1617,7 +1617,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
 #endif
                 this->collider.dim.height = (sColliderData[ENGO2_GET_TYPE(this)].height * 0.6f);
                 EnGo2_StartRolling(this, play);
-                this->isAwake = true;
+                this->isTalkative = true;
             }
             break;
         case GORON_CITY_ROLLING_BIG:
@@ -1629,7 +1629,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
             if (ENGO2_IS_CAGE_OPEN(play, this)) {
                 Actor_Kill(&this->actor);
             } else {
-                this->isAwake = true;
+                this->isTalkative = true;
                 this->actionFunc = EnGo2_CurledUp;
             }
             break;
@@ -1687,7 +1687,7 @@ void EnGo2_CurledUp(EnGo2* this, PlayState* play) {
              (height * 0.6f));
     }
     if (EnGo2_IsGoronFireGenericFreed(this, play)) {
-        this->isAwake = false;
+        this->isTalkative = false;
         EnGo2_WakeUpAnimated(this, play);
     }
     if ((ENGO2_GET_TYPE(this) != GORON_FIRE_GENERIC) && EnGo2_IsAttentionDrawn(this)) {
@@ -1932,7 +1932,7 @@ void EnGo2_GoronLink(EnGo2* this, PlayState* play) {
         SET_INFTABLE(INFTABLE_10C);
         this->trackingMode = NPC_TRACKING_NONE;
         this->isUncurled = false;
-        this->isAwake = false;
+        this->isTalkative = false;
         this->actionFunc = EnGo2_CurledUp;
     }
 }

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -2034,21 +2034,21 @@ void EnGo2_Update(Actor* thisx, PlayState* play) {
 }
 
 s32 EnGo2_DrawCurledUp(EnGo2* this, PlayState* play) {
-    Vec3f D_80A48554 = { 0.0f, 0.0f, 0.0f };
+    Vec3f focusOffset = { 0.0f, 0.0f, 0.0f };
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_go2.c", 2881);
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_en_go2.c", 2884);
     gSPDisplayList(POLY_OPA_DISP++, gGoronCurledUpDL);
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_go2.c", 2889);
-    Matrix_MultVec3f(&D_80A48554, &this->actor.focus.pos);
+    Matrix_MultVec3f(&focusOffset, &this->actor.focus.pos);
 
     return 1;
 }
 
 s32 EnGo2_DrawRolling(EnGo2* this, PlayState* play) {
     s32 pad;
-    Vec3f D_80A48560 = { 0.0f, 0.0f, 0.0f };
+    Vec3f focusOffset = { 0.0f, 0.0f, 0.0f };
     f32 speedXZ;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_go2.c", 2914);
@@ -2058,7 +2058,7 @@ s32 EnGo2_DrawRolling(EnGo2* this, PlayState* play) {
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_en_go2.c", 2926);
     gSPDisplayList(POLY_OPA_DISP++, gGoronRollingDL);
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_go2.c", 2930);
-    Matrix_MultVec3f(&D_80A48560, &this->actor.focus.pos);
+    Matrix_MultVec3f(&focusOffset, &this->actor.focus.pos);
     return 1;
 }
 
@@ -2087,10 +2087,10 @@ s32 EnGo2_OverrideLimbDraw(PlayState* play, s32 limb, Gfx** dList, Vec3f* pos, V
 
 void EnGo2_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx) {
     EnGo2* this = (EnGo2*)thisx;
-    Vec3f D_80A4856C = { 600.0f, 0.0f, 0.0f };
+    Vec3f focusOffset = { 600.0f, 0.0f, 0.0f }; // ahead, this distance
 
     if (limbIndex == GORON_LIMB_HEAD) {
-        Matrix_MultVec3f(&D_80A4856C, &this->actor.focus.pos);
+        Matrix_MultVec3f(&focusOffset, &this->actor.focus.pos);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -851,9 +851,11 @@ s32 EnGo2_UpdateTalking(EnGo2* this, PlayState* play) {
         }
     }
 
-    // `GORON_DMT_BIGGORON`, attention wasn't drawn
-    if ((ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) && !(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
-        return false;
+    // `GORON_DMT_BIGGORON`, attention wasn't drawn; see `EnGo2_IsAttentionDrawn`
+    if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
+        if (!(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
+            return false;
+        }
     }
 
     // `GORON_DMT_BIGGORON` || `GORON_CITY_ROLLING_BIG`
@@ -1199,7 +1201,7 @@ f32 EnGo2_GetTargetXZSpeed(EnGo2* this) {
     }
 }
 
-s32 EnGo2_IsAttentionDrawnExtented(EnGo2* this, PlayState* play) {
+s32 EnGo2_ShouldStay(EnGo2* this, PlayState* play) {
     Camera* mainCam = play->cameraPtrs[CAM_ID_MAIN];
 
     if (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) {
@@ -1734,7 +1736,7 @@ void EnGo2_Standing(EnGo2* this, PlayState* play) {
                 (s16)((height * 0.4f * (this->skelAnime.curFrame / this->skelAnime.endFrame)) + (height * 0.6f));
         }
     }
-    if ((!EnGo2_IsAttentionDrawnExtented(this, play)) && (!EnGo2_IsAttentionDrawn(this))) {
+    if ((!EnGo2_ShouldStay(this, play)) && (!EnGo2_IsAttentionDrawn(this))) {
         EnGo2_AnimateRolling(this, play);
     }
 }

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1320,7 +1320,7 @@ void EnGo2_RollingAnimation(EnGo2* this, PlayState* play) {
     }
     EnGo2_SwapInitialFrameAnimFrameCount(this);
     this->trackingMode = NPC_TRACKING_NONE;
-    this->unk_211 = false;
+    this->isUncurled = false;
     this->isAwake = false;
     this->actionFunc = EnGo2_ActionCurledUp;
 }
@@ -1346,7 +1346,7 @@ void EnGo2_WakeUp(EnGo2* this, PlayState* play) {
 
 void EnGo2_GetItemAnimation(EnGo2* this, PlayState* play) {
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND);
-    this->unk_211 = true;
+    this->isUncurled = true;
     this->actionFunc = func_80A46B40;
     this->skelAnime.playSpeed = 0.0f;
     this->actor.speed = 0.0f;
@@ -1559,7 +1559,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
     this->alpha = this->actor.shape.shadowAlpha = 0;
     this->reverse = 0;
     this->isAwake = false;
-    this->unk_211 = false;
+    this->isUncurled = false;
     this->goronState = 0;
     this->waypoint = 0;
     this->unk_216 = this->actor.shape.rot.z;
@@ -1680,7 +1680,7 @@ void func_80A46B40(EnGo2* this, PlayState* play) {
     u8 index = PARAMS_GET_S(this->actor.params, 0, 5);
     f32 height;
 
-    if (this->unk_211 == true) {
+    if (this->isUncurled == true) {
         EnGo2_BiggoronAnimation(this);
         EnGo2_GoronLinkAnimation(this, play);
         EnGo2_SelectGoronWakingUp(this);
@@ -1698,7 +1698,7 @@ void func_80A46B40(EnGo2* this, PlayState* play) {
                 this->actor.flags |= ACTOR_FLAG_ATTENTION_ENABLED;
             }
             func_80A454CC(this);
-            this->unk_211 = true;
+            this->isUncurled = true;
             this->collider.dim.height = D_80A4816C[index].height;
         } else {
             height = D_80A4816C[index].height;
@@ -1911,7 +1911,7 @@ void EnGo2_GoronLinkStopRolling(EnGo2* this, PlayState* play) {
     } else {
         SET_INFTABLE(INFTABLE_10C);
         this->trackingMode = NPC_TRACKING_NONE;
-        this->unk_211 = false;
+        this->isUncurled = false;
         this->isAwake = false;
         this->actionFunc = EnGo2_ActionCurledUp;
     }
@@ -2006,7 +2006,7 @@ void EnGo2_Update(Actor* thisx, PlayState* play) {
     }
 #endif
     this->actionFunc(this, play);
-    if (this->unk_211 == true) {
+    if (this->isUncurled == true) {
         func_80034F54(play, this->unk_226, this->unk_24A, GORON_LIMB_MAX);
     }
     func_80A45288(this, play);

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -168,6 +168,9 @@ typedef enum GoronType {
 } GoronType;
 
 #define ENGO2_GET_PATH_INDEX(this) PARAMS_GET_S((this)->actor.params, 5, 5)
+#define ENGO2_CAGED_FLAG(this) PARAMS_GET_S((this)->actor.params, 10, 6)
+#define ENGO2_IS_CAGE_OPEN(play, this) Flags_GetSwitch(play, ENGO2_CAGED_FLAG(this))
+
 static EnGo2DustEffectData sDustEffectData[2][4] = {
     {
         { 12, 0.2f, 0.2f, 1, 18.0f, 0.0f },
@@ -312,7 +315,7 @@ s32 EnGo2_GetDialogState(EnGo2* this, PlayState* play) {
 }
 
 u16 EnGo2_GoronFireGenericGetTextId(EnGo2* this) {
-    switch (PARAMS_GET_S(this->actor.params, 10, 6)) {
+    switch (ENGO2_CAGED_FLAG(this)) {
         case 3:
             return 0x3069;
         case 5:
@@ -661,7 +664,7 @@ s16 EnGo2_UpdateTalkStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
 }
 
 u16 EnGo2_GetTextIdGoronFireGeneric(PlayState* play, EnGo2* this) {
-    if (Flags_GetSwitch(play, PARAMS_GET_S(this->actor.params, 10, 6))) {
+    if (ENGO2_IS_CAGE_OPEN(play, this)) {
         return 0x3071;
     } else {
         return 0x3051;
@@ -1413,7 +1416,7 @@ s32 EnGo2_IsFreeingGoronInFire(EnGo2* this, PlayState* play) {
 
     // shaking curled up
     this->actor.world.pos.x += (play->state.frames & 1) ? 1.0f : -1.0f;
-    if (Flags_GetSwitch(play, PARAMS_GET_S(this->actor.params, 10, 6))) {
+    if (ENGO2_IS_CAGE_OPEN(play, this)) {
         return true;
     }
     return false;
@@ -1617,7 +1620,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
             EnGo2_SetupRolling(this, play);
             break;
         case GORON_FIRE_GENERIC:
-            if (Flags_GetSwitch(play, PARAMS_GET_S(this->actor.params, 10, 6))) {
+            if (ENGO2_IS_CAGE_OPEN(play, this)) {
                 Actor_Kill(&this->actor);
             } else {
                 this->isAwake = true;
@@ -1966,9 +1969,8 @@ void EnGo2_GoronFireGenericAction(EnGo2* this, PlayState* play) {
             } else {
                 this->animTimer = 0;
                 this->actor.speed = 0.0f;
-                if ((PARAMS_GET_S(this->actor.params, 10, 6) != 1) && (PARAMS_GET_S(this->actor.params, 10, 6) != 2) &&
-                    (PARAMS_GET_S(this->actor.params, 10, 6) != 4) && (PARAMS_GET_S(this->actor.params, 10, 6) != 5) &&
-                    (PARAMS_GET_S(this->actor.params, 10, 6) != 9) && (PARAMS_GET_S(this->actor.params, 10, 6) != 11)) {
+                if ((ENGO2_CAGED_FLAG(this) != 1) && (ENGO2_CAGED_FLAG(this) != 2) && (ENGO2_CAGED_FLAG(this) != 4) &&
+                    (ENGO2_CAGED_FLAG(this) != 5) && (ENGO2_CAGED_FLAG(this) != 9) && (ENGO2_CAGED_FLAG(this) != 11)) {
                     this->goronState++;
                 }
                 this->goronState++;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -98,13 +98,13 @@ ActorProfile En_Go2_Profile = {
     /**/ EnGo2_Draw,
 };
 
-static EnGo2DataStruct1 D_80A4816C[14] = {
+static EnGo2ColliderData sColliderData[14] = {
     { 0, 0, 0, 68, 148 }, { 0, 0, 0, 24, 52 }, { 0, 320, 380, 400, 120 }, { 0, 0, 0, 30, 68 }, { 0, 0, 0, 46, 90 },
     { 0, 0, 0, 30, 68 },  { 0, 0, 0, 30, 68 }, { 0, 0, 0, 30, 68 },       { 0, 0, 0, 30, 68 }, { 0, 0, 0, 30, 68 },
     { 0, 0, 0, 30, 68 },  { 0, 0, 0, 30, 68 }, { 0, 0, 0, 30, 68 },       { 0, 0, 0, 30, 68 },
 };
 
-static EnGo2DataStruct2 D_80A481F8[14] = {
+static EnGo2ShapeData sShapeData[14] = {
     { 30.0f, 0.026f, 6, 60.0f }, { 24.0f, 0.008f, 6, 30.0f }, { 28.0f, 0.16f, 5, 380.0f }, { 28.0f, 0.01f, 7, 40.0f },
     { 30.0f, 0.015f, 6, 30.0f }, { 28.0f, 0.01f, 6, 30.0f },  { 28.0f, 0.01f, 6, 30.0f },  { 28.0f, 0.01f, 6, 30.0f },
     { 28.0f, 0.01f, 6, 30.0f },  { 28.0f, 0.01f, 6, 30.0f },  { 28.0f, 0.01f, 6, 30.0f },  { 28.0f, 0.01f, 6, 30.0f },
@@ -862,17 +862,17 @@ s32 func_80A44790(EnGo2* this, PlayState* play) {
 void EnGo2_SetColliderDim(EnGo2* this) {
     u8 index = ENGO2_GET_TYPE(this);
 
-    this->collider.dim.radius = D_80A4816C[index].radius;
-    this->collider.dim.height = D_80A4816C[index].height;
+    this->collider.dim.radius = sColliderData[index].radius;
+    this->collider.dim.height = sColliderData[index].height;
 }
 
 void EnGo2_SetShape(EnGo2* this) {
     u8 index = ENGO2_GET_TYPE(this);
 
-    this->actor.shape.shadowScale = D_80A481F8[index].shape_unk_10;
-    Actor_SetScale(&this->actor, D_80A481F8[index].scale);
-    this->actor.attentionRangeType = D_80A481F8[index].actor_unk_1F;
-    this->interactRange = D_80A481F8[index].interactRange;
+    this->actor.shape.shadowScale = sShapeData[index].shadowScale;
+    Actor_SetScale(&this->actor, sShapeData[index].scale);
+    this->actor.attentionRangeType = sShapeData[index].attentionRangeType;
+    this->interactRange = sShapeData[index].interactRange;
     this->interactRange += this->collider.dim.radius;
 }
 
@@ -883,10 +883,10 @@ void EnGo2_CheckCollision(EnGo2* this, PlayState* play) {
     pos.x = this->actor.world.pos.x;
     pos.y = this->actor.world.pos.y;
     pos.z = this->actor.world.pos.z;
-    xzDist = D_80A4816C[ENGO2_GET_TYPE(this)].xzDist;
+    xzDist = sColliderData[ENGO2_GET_TYPE(this)].xzDist;
     pos.x += (s16)(xzDist * Math_SinS(this->actor.shape.rot.y));
     pos.z += (s16)(xzDist * Math_CosS(this->actor.shape.rot.y));
-    pos.y += D_80A4816C[ENGO2_GET_TYPE(this)].yDist;
+    pos.y += sColliderData[ENGO2_GET_TYPE(this)].yDist;
     this->collider.dim.pos = pos;
     CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
@@ -1609,14 +1609,14 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
 #if OOT_VERSION >= PAL_1_1
                 CLEAR_INFTABLE(INFTABLE_10C);
 #endif
-                this->collider.dim.height = (D_80A4816C[ENGO2_GET_TYPE(this)].height * 0.6f);
+                this->collider.dim.height = (sColliderData[ENGO2_GET_TYPE(this)].height * 0.6f);
                 EnGo2_SetupRolling(this, play);
                 this->isAwake = true;
             }
             break;
         case GORON_CITY_ROLLING_BIG:
         case GORON_DMT_ROLLING_SMALL:
-            this->collider.dim.height = (D_80A4816C[ENGO2_GET_TYPE(this)].height * 0.6f);
+            this->collider.dim.height = (sColliderData[ENGO2_GET_TYPE(this)].height * 0.6f);
             EnGo2_SetupRolling(this, play);
             break;
         case GORON_FIRE_GENERIC:
@@ -1673,11 +1673,11 @@ void EnGo2_ActionCurledUp(EnGo2* this, PlayState* play) {
     }
 
     if ((s32)this->skelAnime.curFrame == 0) {
-        this->collider.dim.height = (D_80A4816C[index].height * 0.6f);
+        this->collider.dim.height = (sColliderData[index].height * 0.6f);
     } else {
-        height = D_80A4816C[index].height;
+        height = sColliderData[index].height;
         this->collider.dim.height =
-            ((D_80A4816C[index].height * 0.4f * (this->skelAnime.curFrame / this->skelAnime.startFrame)) +
+            ((sColliderData[index].height * 0.4f * (this->skelAnime.curFrame / this->skelAnime.startFrame)) +
              (height * 0.6f));
     }
     if (EnGo2_IsFreeingGoronInFire(this, play)) {
@@ -1712,9 +1712,9 @@ void func_80A46B40(EnGo2* this, PlayState* play) {
             }
             func_80A454CC(this);
             this->isUncurled = true;
-            this->collider.dim.height = D_80A4816C[index].height;
+            this->collider.dim.height = sColliderData[index].height;
         } else {
-            height = D_80A4816C[index].height;
+            height = sColliderData[index].height;
             this->collider.dim.height =
                 (s16)((height * 0.4f * (this->skelAnime.curFrame / this->skelAnime.endFrame)) + (height * 0.6f));
         }

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1440,7 +1440,7 @@ s32 EnGo2_IsGoronFireGeneric(EnGo2* this) {
 }
 
 s32 EnGo2_IsGoronLinkReversing(EnGo2* this) {
-    if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_CITY_LINK || (this->waypoint >= this->unk_216) ||
+    if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_CITY_LINK || (this->waypoint >= this->reverseWaypoint) ||
         !EnGo2_IsWakingUp(this)) {
         return false;
     }
@@ -1562,7 +1562,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
     this->isUncurled = false;
     this->goronState = 0;
     this->waypoint = 0;
-    this->unk_216 = this->actor.shape.rot.z;
+    this->reverseWaypoint = this->actor.shape.rot.z;
     this->trackingMode = NPC_TRACKING_NONE;
     this->path = Path_GetByIndex(play, PARAMS_GET_S(this->actor.params, 5, 5), 0x1F);
     switch (PARAMS_GET_S(this->actor.params, 0, 5)) {

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1395,16 +1395,19 @@ void EnGo2_StartRolling(EnGo2* this, PlayState* play) {
 void EnGo2_StopRolling(EnGo2* this, PlayState* play) {
     EnBom* bomb;
 
-    if ((ENGO2_GET_TYPE(this) != GORON_CITY_ROLLING_BIG) && (ENGO2_GET_TYPE(this) != GORON_CITY_LINK)) {
-        if (ENGO2_GET_TYPE(this) == GORON_DMT_ROLLING_SMALL) {
+    switch (ENGO2_GET_TYPE(this)) {
+        case GORON_DMT_ROLLING_SMALL:
             bomb = (EnBom*)Actor_Spawn(&play->actorCtx, play, ACTOR_EN_BOM, this->actor.world.pos.x,
                                        this->actor.world.pos.y, this->actor.world.pos.z, 0, 0, 0, 0);
             if (bomb != NULL) {
                 bomb->timer = 0;
             }
-        }
-    } else {
-        this->collider.elem.acElemFlags = ACELEM_NONE;
+            break;
+
+        case GORON_CITY_LINK:
+        case GORON_CITY_ROLLING_BIG:
+            this->collider.elem.acElemFlags = ACELEM_NONE;
+            break;
     }
 
     this->actor.shape.rot = this->actor.world.rot;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -223,7 +223,7 @@ void EnGo2_DrawEffects(EnGo2* this, PlayState* play) {
 
         if (!materialFlag) {
             POLY_XLU_DISP = Gfx_SetupDL(POLY_XLU_DISP, SETUPDL_0);
-            gSPDisplayList(POLY_XLU_DISP++, gGoronDL_00FD40);
+            gSPDisplayList(POLY_XLU_DISP++, gGoronParticleMaterialDL);
             gDPSetEnvColor(POLY_XLU_DISP++, 100, 60, 20, 0);
             materialFlag = true;
         }
@@ -237,7 +237,7 @@ void EnGo2_DrawEffects(EnGo2* this, PlayState* play) {
         MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, play->state.gfxCtx, "../z_en_go2_eff.c", 137);
         index = dustEffect->timer * (8.0f / dustEffect->initialTimer);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sDustTex[index]));
-        gSPDisplayList(POLY_XLU_DISP++, gGoronDL_00FD50);
+        gSPDisplayList(POLY_XLU_DISP++, gGoronParticleDL);
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_go2_eff.c", 151);
@@ -2008,7 +2008,7 @@ s32 EnGo2_DrawCurledUp(EnGo2* this, PlayState* play) {
     OPEN_DISPS(play->state.gfxCtx, "../z_en_go2.c", 2881);
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_en_go2.c", 2884);
-    gSPDisplayList(POLY_OPA_DISP++, gGoronDL_00BD80);
+    gSPDisplayList(POLY_OPA_DISP++, gGoronCurledUpDL);
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_go2.c", 2889);
     Matrix_MultVec3f(&D_80A48554, &this->actor.focus.pos);
 
@@ -2025,7 +2025,7 @@ s32 EnGo2_DrawRolling(EnGo2* this, PlayState* play) {
     speedXZ = this->actionFunc == EnGo2_ReverseRolling ? 0.0f : this->actor.speed;
     Matrix_RotateZYX((play->state.frames * ((s16)speedXZ * 1400)), 0, this->actor.shape.rot.z, MTXMODE_APPLY);
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_en_go2.c", 2926);
-    gSPDisplayList(POLY_OPA_DISP++, gGoronDL_00C140);
+    gSPDisplayList(POLY_OPA_DISP++, gGoronRollingDL);
     CLOSE_DISPS(play->state.gfxCtx, "../z_en_go2.c", 2930);
     Matrix_MultVec3f(&D_80A48560, &this->actor.focus.pos);
     return 1;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -167,6 +167,7 @@ typedef enum GoronType {
     /* 0x0D */ GORON_MARKET_BAZAAR
 } GoronType;
 
+#define ENGO2_GET_PATH_INDEX(this) PARAMS_GET_S((this)->actor.params, 5, 5)
 static EnGo2DustEffectData sDustEffectData[2][4] = {
     {
         { 12, 0.2f, 0.2f, 1, 18.0f, 0.0f },
@@ -1573,7 +1574,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
     this->waypoint = 0;
     this->reverseWaypoint = this->actor.shape.rot.z;
     this->trackingMode = NPC_TRACKING_NONE;
-    this->path = Path_GetByIndex(play, PARAMS_GET_S(this->actor.params, 5, 5), 0x1F);
+    this->path = Path_GetByIndex(play, ENGO2_GET_PATH_INDEX(this), 0x1F);
     switch (ENGO2_GET_TYPE(this)) {
         case GORON_CITY_ENTRANCE:
         case GORON_CITY_ISLAND:

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -120,7 +120,7 @@ static f32 sPlayerTrackingYOffsets[14][2] = {
 
 typedef enum EnGo2Animation {
     /*  0 */ ENGO2_ANIM_UNCURL_SIT_STAND_IDLE, // default idle
-    /*  1 */ ENGO2_ANIM_UNCURL_SIT_STAND,
+    /*  1 */ ENGO2_ANIM_UNCURL_SIT_STAND_NORMAL,
     /*  2 */ ENGO2_ANIM_WALKING_LOOP,
     /*  3 */ ENGO2_ANIM_SIDESTEP_LOOP,
     /*  4 */ ENGO2_ANIM_CRYING_LOOP,
@@ -152,7 +152,7 @@ static AnimationInfo sAnimationInfo[] = {
 
 #define ENGO2_GET_TYPE(this) PARAMS_GET_S((this)->actor.params, 0, 5)
 typedef enum GoronType {
-    /* 0x00 */ GORON_CITY_ROLLING_BIG,
+    /* 0x00 */ GORON_CITY_HOT_RODDER,
     /* 0x01 */ GORON_CITY_LINK,
     /* 0x02 */ GORON_DMT_BIGGORON,
     /* 0x03 */ GORON_FIRE_GENERIC,
@@ -181,7 +181,7 @@ static EnGo2DustEffectData sDustEffectData[2][4] = {
         { 12, 0.2f, 0.2f, 1, 18.0f, 0.0f },
     },
     {
-        // GORON_CITY_ROLLING_BIG
+        // GORON_CITY_HOT_RODDER
         { 12, 0.5f, 0.4f, 3, 42.0f, 0.0f },
         { 12, 0.5f, 0.4f, 3, 42.0f, 0.0f },
         { 12, 0.5f, 0.4f, 3, 42.0f, 0.0f },
@@ -768,7 +768,7 @@ u16 EnGo2_GetTextId(PlayState* play, Actor* thisx) {
         return textId;
     } else {
         switch (ENGO2_GET_TYPE(this)) {
-            case GORON_CITY_ROLLING_BIG:
+            case GORON_CITY_HOT_RODDER:
                 return EnGo2_GetTextIdGoronCityRollingBig(play, this);
             case GORON_CITY_LINK:
                 return EnGo2_GetTextIdGoronCityLink(play, this);
@@ -806,7 +806,7 @@ u16 EnGo2_GetTextId(PlayState* play, Actor* thisx) {
 s16 EnGo2_UpdateTalkState(PlayState* play, Actor* thisx) {
     EnGo2* this = (EnGo2*)thisx;
     switch (ENGO2_GET_TYPE(this)) {
-        case GORON_CITY_ROLLING_BIG:
+        case GORON_CITY_HOT_RODDER:
             return EnGo2_UpdateTalkStateGoronCityRollingBig(play, this);
         case GORON_CITY_LINK:
             return EnGo2_UpdateTalkStateGoronCityLink(play, this);
@@ -845,7 +845,7 @@ s16 EnGo2_UpdateTalkState(PlayState* play, Actor* thisx) {
 s32 EnGo2_UpdateTalking(EnGo2* this, PlayState* play) {
     // default:
     if (ENGO2_GET_TYPE(this) != GORON_DMT_BIGGORON) {
-        if (ENGO2_GET_TYPE(this) != GORON_CITY_ROLLING_BIG) {
+        if (ENGO2_GET_TYPE(this) != GORON_CITY_HOT_RODDER) {
             return Npc_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, this->interactRange,
                                      EnGo2_GetTextId, EnGo2_UpdateTalkState);
         }
@@ -858,7 +858,7 @@ s32 EnGo2_UpdateTalking(EnGo2* this, PlayState* play) {
         }
     }
 
-    // `GORON_DMT_BIGGORON` || `GORON_CITY_ROLLING_BIG`
+    // `GORON_DMT_BIGGORON` || `GORON_CITY_HOT_RODDER`
     {
         if (Actor_TalkOfferAccepted(&this->actor, play)) {
             this->interactInfo.talkState = NPC_TALK_STATE_TALKING;
@@ -1047,8 +1047,8 @@ s32 EnGo2_IsRollingOnGround(EnGo2* this, s16 bounceCount, f32 boundSpeed, s16 ru
     // bounce!
     {
         if (this->bounceCounter >= 2) {
-            Actor_PlaySfx(&this->actor, (ENGO2_GET_TYPE(this) == GORON_CITY_ROLLING_BIG) ? NA_SE_EN_GOLON_LAND_BIG
-                                                                                         : NA_SE_EN_DODO_M_GND);
+            Actor_PlaySfx(&this->actor, (ENGO2_GET_TYPE(this) == GORON_CITY_HOT_RODDER) ? NA_SE_EN_GOLON_LAND_BIG
+                                                                                        : NA_SE_EN_DODO_M_GND);
         }
 
         this->bounceCounter--;
@@ -1169,7 +1169,7 @@ void EnGo2_RollForward(EnGo2* this) {
 
 void EnGo2_ChooseIdleAnimation(EnGo2* this) {
     switch (ENGO2_GET_TYPE(this)) {
-        case GORON_CITY_ROLLING_BIG:
+        case GORON_CITY_HOT_RODDER:
         case GORON_DMT_DC_ENTRANCE:
         case GORON_CITY_ENTRANCE:
         case GORON_CITY_STAIRWELL:
@@ -1197,7 +1197,7 @@ f32 EnGo2_GetTargetXZSpeed(EnGo2* this) {
         (this->actor.xzDistToPlayer < 400.0f)) {
         return 9.0f;
     } else {
-        return index == GORON_CITY_ROLLING_BIG ? 3.6000001f : 6.0f;
+        return index == GORON_CITY_HOT_RODDER ? 3.6000001f : 6.0f;
     }
 }
 
@@ -1214,7 +1214,7 @@ s32 EnGo2_ShouldStay(EnGo2* this, PlayState* play) {
         }
     }
 
-    if (ENGO2_GET_TYPE(this) == GORON_FIRE_GENERIC || ENGO2_GET_TYPE(this) == GORON_CITY_ROLLING_BIG ||
+    if (ENGO2_GET_TYPE(this) == GORON_FIRE_GENERIC || ENGO2_GET_TYPE(this) == GORON_CITY_HOT_RODDER ||
         ENGO2_GET_TYPE(this) == GORON_CITY_STAIRWELL || (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) ||
         ENGO2_GET_TYPE(this) == GORON_MARKET_BAZAAR) {
         return true;
@@ -1335,7 +1335,7 @@ void EnGo2_PlayStandingChangeSfx(EnGo2* this) {
 }
 
 void EnGo2_SpawnDust(EnGo2* this, s32 index2) {
-    s32 index1 = ENGO2_GET_TYPE(this) == GORON_CITY_ROLLING_BIG ? 1 : 0;
+    s32 index1 = ENGO2_GET_TYPE(this) == GORON_CITY_HOT_RODDER ? 1 : 0;
     EnGo2DustEffectData* dustEffectData = &sDustEffectData[index1][index2];
 
     EnGo2_SpawnDustExplicitly(this, dustEffectData->initialTimer, dustEffectData->scale, dustEffectData->scaleStep,
@@ -1348,7 +1348,7 @@ void EnGo2_AnimateRolling(EnGo2* this, PlayState* play) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_BIG);
         this->skelAnime.playSpeed = -0.5f;
     } else {
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_NORMAL);
         this->skelAnime.playSpeed = -1.0f;
     }
     EnGo2_SwapInitialFrameAnimFrameCount(this);
@@ -1371,14 +1371,14 @@ void EnGo2_WakeUpAnimated(EnGo2* this, PlayState* play) {
         Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_BIG);
         this->skelAnime.playSpeed = 0.5f;
     } else {
-        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND);
+        Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_NORMAL);
         this->skelAnime.playSpeed = 1.0f;
     }
     this->actionFunc = EnGo2_Standing;
 }
 
 void EnGo2_WakeUpInstant(EnGo2* this, PlayState* play) {
-    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND);
+    Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_NORMAL);
     this->isUncurled = true;
     this->actionFunc = EnGo2_Standing;
     this->skelAnime.playSpeed = 0.0f;
@@ -1387,7 +1387,7 @@ void EnGo2_WakeUpInstant(EnGo2* this, PlayState* play) {
 }
 
 void EnGo2_StartRolling(EnGo2* this, PlayState* play) {
-    if (ENGO2_GET_TYPE(this) == GORON_CITY_ROLLING_BIG || ENGO2_GET_TYPE(this) == GORON_CITY_LINK) {
+    if (ENGO2_GET_TYPE(this) == GORON_CITY_HOT_RODDER || ENGO2_GET_TYPE(this) == GORON_CITY_LINK) {
         this->collider.elem.acElemFlags = ACELEM_ON;
         this->actor.speed = GET_INFTABLE(INFTABLE_11E) ? 6.0f : 3.6000001f;
     } else {
@@ -1413,7 +1413,7 @@ void EnGo2_StopRolling(EnGo2* this, PlayState* play) {
             break;
 
         case GORON_CITY_LINK:
-        case GORON_CITY_ROLLING_BIG:
+        case GORON_CITY_HOT_RODDER:
             this->collider.elem.acElemFlags = ACELEM_NONE;
             break;
     }
@@ -1453,7 +1453,7 @@ s32 EnGo2_IsGoronDmtBombFlower(EnGo2* this) {
 }
 
 s32 EnGo2_IsGoronRollingBig(EnGo2* this, PlayState* play) {
-    if (ENGO2_GET_TYPE(this) != GORON_CITY_ROLLING_BIG || (this->interactInfo.talkState != NPC_TALK_STATE_ACTION)) {
+    if (ENGO2_GET_TYPE(this) != GORON_CITY_HOT_RODDER || (this->interactInfo.talkState != NPC_TALK_STATE_ACTION)) {
         return false;
     }
     this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
@@ -1565,7 +1565,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
     Collider_SetCylinder(play, &this->collider, &this->actor, &sCylinderInit);
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
 
-    // Not GORON_CITY_ROLLING_BIG, GORON_CITY_LINK, GORON_DMT_BIGGORON
+    // Not GORON_CITY_HOT_RODDER, GORON_CITY_LINK, GORON_DMT_BIGGORON
     switch (ENGO2_GET_TYPE(this)) {
         case GORON_FIRE_GENERIC:
         case GORON_DMT_BOMB_FLOWER:
@@ -1631,7 +1631,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
                 this->isTalkative = true;
             }
             break;
-        case GORON_CITY_ROLLING_BIG:
+        case GORON_CITY_HOT_RODDER:
         case GORON_DMT_ROLLING_SMALL:
             this->collider.dim.height = (sColliderData[ENGO2_GET_TYPE(this)].height * 0.6f);
             EnGo2_StartRolling(this, play);
@@ -1808,7 +1808,7 @@ void EnGo2_GroundRolling(EnGo2* this, PlayState* play) {
                     this->goronState = 0;
                     this->actionFunc = EnGo2_GoronLink;
                     break;
-                case GORON_CITY_ROLLING_BIG:
+                case GORON_CITY_HOT_RODDER:
                     EnGo2_WakeUpAnimated(this, play);
                     break;
                 default:
@@ -1906,7 +1906,7 @@ void EnGo2_BiggoronEyedrops(EnGo2* this, PlayState* play) {
                 this->eyeMouthTexState = 0;
             }
             if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND);
+                Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_NORMAL);
                 this->actor.flags |= ACTOR_FLAG_ATTENTION_ENABLED;
                 this->trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
                 this->skelAnime.playSpeed = 0.0f;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -42,16 +42,16 @@ void EnGo2_Update(Actor* thisx, PlayState* play);
 void EnGo2_Draw(Actor* thisx, PlayState* play);
 
 void EnGo2_StopRolling(EnGo2* this, PlayState* play);
-void EnGo2_CurledUp(EnGo2* this, PlayState* play);
+void EnGo2_ActionCurledUp(EnGo2* this, PlayState* play);
 
 void func_80A46B40(EnGo2* this, PlayState* play);
 void EnGo2_GoronDmtBombFlowerAnimation(EnGo2* this, PlayState* play);
 void EnGo2_GoronRollingBigContinueRolling(EnGo2* this, PlayState* play);
-void EnGo2_ContinueRolling(EnGo2* this, PlayState* play);
-void EnGo2_SlowRolling(EnGo2* this, PlayState* play);
+void EnGo2_ActionRollingContinue(EnGo2* this, PlayState* play);
+void EnGo2_ActionRollingSlow(EnGo2* this, PlayState* play);
 void EnGo2_GroundRolling(EnGo2* this, PlayState* play);
 
-void EnGo2_ReverseRolling(EnGo2* this, PlayState* play);
+void EnGo2_ActionRollingReverse(EnGo2* this, PlayState* play);
 void EnGo2_SetupGetItem(EnGo2* this, PlayState* play);
 void EnGo2_SetGetItem(EnGo2* this, PlayState* play);
 void EnGo2_BiggoronEyedrops(EnGo2* this, PlayState* play);
@@ -887,8 +887,8 @@ s32 func_80A44AB0(EnGo2* this, PlayState* play) {
     if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
         return false;
     } else {
-        if ((this->actionFunc != EnGo2_SlowRolling) && (this->actionFunc != EnGo2_ReverseRolling) &&
-            (this->actionFunc != EnGo2_ContinueRolling)) {
+        if ((this->actionFunc != EnGo2_ActionRollingSlow) && (this->actionFunc != EnGo2_ActionRollingReverse) &&
+            (this->actionFunc != EnGo2_ActionRollingContinue)) {
             return false;
         } else {
             if (this->collider.base.acFlags & AC_HIT) {
@@ -907,7 +907,7 @@ s32 func_80A44AB0(EnGo2* this, PlayState* play) {
             if (this->collider.base.ocFlags2 & OC2_HIT_PLAYER) {
                 this->collider.base.ocFlags2 &= ~OC2_HIT_PLAYER;
 
-                arg2 = this->actionFunc == EnGo2_ContinueRolling ? 1.5f : this->actor.speed * 1.5f;
+                arg2 = this->actionFunc == EnGo2_ActionRollingContinue ? 1.5f : this->actor.speed * 1.5f;
 
                 play->damagePlayer(play, -4);
                 Actor_SetPlayerKnockbackLargeNoDamage(play, &this->actor, arg2, this->actor.yawTowardsPlayer, 6.0f);
@@ -1118,7 +1118,7 @@ void EnGo2_RollForward(EnGo2* this) {
         this->actor.speed = 0.0f;
     }
 
-    if (this->actionFunc != EnGo2_ContinueRolling) {
+    if (this->actionFunc != EnGo2_ActionRollingContinue) {
         Actor_MoveXZGravity(&this->actor);
     }
 
@@ -1316,7 +1316,7 @@ void EnGo2_RollingAnimation(EnGo2* this, PlayState* play) {
     this->trackingMode = NPC_TRACKING_NONE;
     this->unk_211 = false;
     this->isAwake = false;
-    this->actionFunc = EnGo2_CurledUp;
+    this->actionFunc = EnGo2_ActionCurledUp;
 }
 
 void EnGo2_WakeUp(EnGo2* this, PlayState* play) {
@@ -1359,7 +1359,7 @@ void EnGo2_SetupRolling(EnGo2* this, PlayState* play) {
     this->animTimer = 10;
     this->actor.shape.yOffset = 1800.0f;
     this->actor.speed *= 2.0f; // Speeding up
-    this->actionFunc = EnGo2_ContinueRolling;
+    this->actionFunc = EnGo2_ActionRollingContinue;
 }
 
 void EnGo2_StopRolling(EnGo2* this, PlayState* play) {
@@ -1568,7 +1568,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
             if (!CHECK_QUEST_ITEM(QUEST_MEDALLION_FIRE) && LINK_IS_ADULT) {
                 Actor_Kill(&this->actor);
             }
-            this->actionFunc = EnGo2_CurledUp;
+            this->actionFunc = EnGo2_ActionCurledUp;
             break;
         case GORON_MARKET_BAZAAR:
             if ((LINK_IS_ADULT) || !CHECK_QUEST_ITEM(QUEST_GORON_RUBY)) {
@@ -1584,7 +1584,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
                     CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON)) {
                     EnGo2_GetItemAnimation(this, play);
                 } else {
-                    this->actionFunc = EnGo2_CurledUp;
+                    this->actionFunc = EnGo2_ActionCurledUp;
                 }
             } else {
 #if OOT_VERSION >= PAL_1_1
@@ -1605,7 +1605,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
                 Actor_Kill(&this->actor);
             } else {
                 this->isAwake = true;
-                this->actionFunc = EnGo2_CurledUp;
+                this->actionFunc = EnGo2_ActionCurledUp;
             }
             break;
         case GORON_DMT_BIGGORON:
@@ -1617,7 +1617,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
             }
             this->collider.base.acFlags = AC_NONE;
             this->collider.base.ocFlags1 = OC1_ON | OC1_NO_PUSH | OC1_TYPE_PLAYER;
-            this->actionFunc = EnGo2_CurledUp;
+            this->actionFunc = EnGo2_ActionCurledUp;
             break;
         case GORON_DMT_BOMB_FLOWER:
             if (GET_INFTABLE(INFTABLE_EB)) {
@@ -1628,7 +1628,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
         case GORON_DMT_DC_ENTRANCE:
         case GORON_DMT_FAIRY_HINT:
         default:
-            this->actionFunc = EnGo2_CurledUp;
+            this->actionFunc = EnGo2_ActionCurledUp;
             break;
     }
 }
@@ -1636,7 +1636,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
 void EnGo2_Destroy(Actor* thisx, PlayState* play) {
 }
 
-void EnGo2_CurledUp(EnGo2* this, PlayState* play) {
+void EnGo2_ActionCurledUp(EnGo2* this, PlayState* play) {
     u8 index = PARAMS_GET_S(this->actor.params, 0, 5);
     s16 height;
     s32 quakeIndex;
@@ -1723,26 +1723,26 @@ void EnGo2_GoronRollingBigContinueRolling(EnGo2* this, PlayState* play) {
     }
 }
 
-void EnGo2_ContinueRolling(EnGo2* this, PlayState* play) {
+void EnGo2_ActionRollingContinue(EnGo2* this, PlayState* play) {
     f32 float1 = 1000.0f;
 
     if ((PARAMS_GET_S(this->actor.params, 0, 5) != GORON_DMT_ROLLING_SMALL ||
          !(this->actor.xyzDistToPlayerSq > SQ(float1))) &&
         DECR(this->animTimer) == 0) {
-        this->actionFunc = EnGo2_SlowRolling;
+        this->actionFunc = EnGo2_ActionRollingSlow;
         this->actor.speed *= 0.5f; // slowdown
     }
     EnGo2_GetDustData(this, 2);
 }
 
-void EnGo2_SlowRolling(EnGo2* this, PlayState* play) {
+void EnGo2_ActionRollingSlow(EnGo2* this, PlayState* play) {
     s32 orientation;
     s32 index;
 
     if (!EnGo2_IsRolling(this)) {
         if (EnGo2_IsRollingOnGround(this, 4, 8.0f, 1) == true) {
             if (EnGo2_IsGoronLinkReversing(this)) {
-                this->actionFunc = EnGo2_ReverseRolling;
+                this->actionFunc = EnGo2_ActionRollingReverse;
                 return;
             }
             EnGo2_GetDustData(this, 3);
@@ -1776,13 +1776,13 @@ void EnGo2_GroundRolling(EnGo2* this, PlayState* play) {
                     EnGo2_WakeUp(this, play);
                     break;
                 default:
-                    this->actionFunc = EnGo2_CurledUp;
+                    this->actionFunc = EnGo2_ActionCurledUp;
             }
         }
     }
 }
 
-void EnGo2_ReverseRolling(EnGo2* this, PlayState* play) {
+void EnGo2_ActionRollingReverse(EnGo2* this, PlayState* play) {
     if (!EnGo2_IsRolling(this)) {
         Math_ApproachF(&this->actor.speed, 0.0f, 0.6f, 0.8f);
         if (this->actor.speed >= 1.0f) {
@@ -1907,7 +1907,7 @@ void EnGo2_GoronLinkStopRolling(EnGo2* this, PlayState* play) {
         this->trackingMode = NPC_TRACKING_NONE;
         this->unk_211 = false;
         this->isAwake = false;
-        this->actionFunc = EnGo2_CurledUp;
+        this->actionFunc = EnGo2_ActionCurledUp;
     }
 }
 
@@ -2028,7 +2028,7 @@ s32 EnGo2_DrawRolling(EnGo2* this, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_go2.c", 2914);
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
-    speedXZ = this->actionFunc == EnGo2_ReverseRolling ? 0.0f : this->actor.speed;
+    speedXZ = this->actionFunc == EnGo2_ActionRollingReverse ? 0.0f : this->actor.speed;
     Matrix_RotateZYX((play->state.frames * ((s16)speedXZ * 1400)), 0, this->actor.shape.rot.z, MTXMODE_APPLY);
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_en_go2.c", 2926);
     gSPDisplayList(POLY_OPA_DISP++, gGoronRollingDL);
@@ -2079,14 +2079,21 @@ void EnGo2_Draw(Actor* thisx, PlayState* play) {
     EnGo2_DrawEffects(this, play);
     Matrix_Pop();
 
-    if ((this->actionFunc == EnGo2_CurledUp) && (this->skelAnime.playSpeed == 0.0f) &&
+    if ((this->actionFunc == EnGo2_ActionCurledUp) && (this->skelAnime.playSpeed == 0.0f) &&
         (this->skelAnime.curFrame == 0.0f)) {
         if (1) {}
         EnGo2_DrawCurledUp(this, play);
-    } else if (this->actionFunc == EnGo2_SlowRolling || this->actionFunc == EnGo2_ReverseRolling ||
-               this->actionFunc == EnGo2_ContinueRolling) {
+        return;
+    }
+
+    if (this->actionFunc == EnGo2_ActionRollingSlow || this->actionFunc == EnGo2_ActionRollingReverse ||
+        this->actionFunc == EnGo2_ActionRollingContinue) {
         EnGo2_DrawRolling(this, play);
-    } else {
+        return;
+    }
+
+    // draw skeleton normally
+    {
         OPEN_DISPS(play->state.gfxCtx, "../z_en_go2.c", 3063);
         Gfx_SetupDL_25Opa(play->state.gfxCtx);
 

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1843,7 +1843,7 @@ void EnGo2_SetGetItem(EnGo2* this, PlayState* play) {
 
 void EnGo2_BiggoronEyedrops(EnGo2* this, PlayState* play) {
     switch (this->goronState) {
-        case 0:
+        case 0: // give eyedrops
             Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_EYEDROPS_LOOP);
             this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
             this->actor.shape.rot.y += 0x5B0;
@@ -1855,7 +1855,7 @@ void EnGo2_BiggoronEyedrops(EnGo2* this, PlayState* play) {
             Audio_SetMainBgmVolume(0x28, 5);
             OnePointCutscene_Init(play, 4190, -99, &this->actor, CAM_ID_MAIN);
             break;
-        case 1:
+        case 1: // applying eyedrops
             if (DECR(this->animTimer)) {
                 if (this->animTimer == 60 || this->animTimer == 120) {
                     Camera_SetFinishedFlag(GET_ACTIVE_CAM(play));
@@ -1870,7 +1870,7 @@ void EnGo2_BiggoronEyedrops(EnGo2* this, PlayState* play) {
                 Audio_SetMainBgmVolume(0x7F, 5);
             }
             break;
-        case 2:
+        case 2: // getting claimcheck
             if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
                 this->eyeMouthTexState = 0;
             }
@@ -1892,7 +1892,7 @@ void EnGo2_GoronLinkStopRolling(EnGo2* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     switch (this->goronState) {
-        case 0:
+        case 0: // rolling
             if (Message_GetState(&play->msgCtx) != TEXT_STATE_NONE) {
                 return;
             } else {
@@ -1900,7 +1900,7 @@ void EnGo2_GoronLinkStopRolling(EnGo2* this, PlayState* play) {
                 player->actor.freezeTimer = 10;
                 this->goronState++;
             }
-        case 1:
+        case 1: // stunned
             break;
         default:
             return;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1518,7 +1518,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
     s32 pad;
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 28.0f);
-    SkelAnime_InitFlex(play, &this->skelAnime, &gGoronSkel, NULL, this->jointTable, this->morphTable, 18);
+    SkelAnime_InitFlex(play, &this->skelAnime, &gGoronSkel, NULL, this->jointTable, this->morphTable, GORON_LIMB_MAX);
     Collider_InitCylinder(play, &this->collider);
     Collider_SetCylinder(play, &this->collider, &this->actor, &sCylinderInit);
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
@@ -1995,7 +1995,7 @@ void EnGo2_Update(Actor* thisx, PlayState* play) {
 #endif
     this->actionFunc(this, play);
     if (this->unk_211 == true) {
-        func_80034F54(play, this->unk_226, this->unk_24A, 18);
+        func_80034F54(play, this->unk_226, this->unk_24A, GORON_LIMB_MAX);
     }
     func_80A45288(this, play);
     EnGo2_EyeMouthTexState(this);
@@ -2035,19 +2035,19 @@ s32 EnGo2_OverrideLimbDraw(PlayState* play, s32 limb, Gfx** dList, Vec3f* pos, V
     EnGo2* this = (EnGo2*)thisx;
     Vec3s limbRot;
 
-    if (limb == 17) {
+    if (limb == GORON_LIMB_HEAD) {
         Matrix_Translate(2800.0f, 0.0f, 0.0f, MTXMODE_APPLY);
         limbRot = this->interactInfo.headRot;
         Matrix_RotateX(BINANG_TO_RAD_ALT(limbRot.y), MTXMODE_APPLY);
         Matrix_RotateZ(BINANG_TO_RAD_ALT(limbRot.x), MTXMODE_APPLY);
         Matrix_Translate(-2800.0f, 0.0f, 0.0f, MTXMODE_APPLY);
     }
-    if (limb == 10) {
+    if (limb == GORON_LIMB_TORSO) {
         limbRot = this->interactInfo.torsoRot;
         Matrix_RotateY(BINANG_TO_RAD_ALT(limbRot.y), MTXMODE_APPLY);
         Matrix_RotateX(BINANG_TO_RAD_ALT(limbRot.x), MTXMODE_APPLY);
     }
-    if ((limb == 10) || (limb == 11) || (limb == 14)) {
+    if ((limb == GORON_LIMB_TORSO) || (limb == GORON_LIMB_LEFT_ARM) || (limb == GORON_LIMB_RIGHT_ARM)) {
         rot->y += Math_SinS(this->unk_226[limb]) * 200.0f;
         rot->z += Math_CosS(this->unk_24A[limb]) * 200.0f;
     }
@@ -2058,7 +2058,7 @@ void EnGo2_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot,
     EnGo2* this = (EnGo2*)thisx;
     Vec3f D_80A4856C = { 600.0f, 0.0f, 0.0f };
 
-    if (limbIndex == 17) {
+    if (limbIndex == GORON_LIMB_HEAD) {
         Matrix_MultVec3f(&D_80A4856C, &this->actor.focus.pos);
     }
 }

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -962,7 +962,7 @@ s32 func_80A44D84(EnGo2* this) {
     return 1;
 }
 
-s32 EnGo2_IsWakingUp(EnGo2* this) {
+s32 EnGo2_IsAttentionDrawn(EnGo2* this) {
     s16 yawDiff;
     f32 xyzDist = PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON ? 800.0f : 200.0f;
     f32 yDist = PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON ? 400.0f : 60.0f;
@@ -1165,14 +1165,14 @@ f32 EnGo2_GetTargetXZSpeed(EnGo2* this) {
     }
 }
 
-s32 EnGo2_IsCameraModified(EnGo2* this, PlayState* play) {
+s32 EnGo2_IsAttentionDrawnExtented(EnGo2* this, PlayState* play) {
     Camera* mainCam = play->cameraPtrs[CAM_ID_MAIN];
 
     if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
-        if (EnGo2_IsWakingUp(this)) {
+        if (EnGo2_IsAttentionDrawn(this)) {
             Camera_RequestSetting(mainCam, CAM_SET_DIRECTED_YAW);
             Camera_UnsetStateFlag(mainCam, CAM_STATE_CHECK_BG);
-        } else if (!EnGo2_IsWakingUp(this) && (mainCam->setting == CAM_SET_DIRECTED_YAW)) {
+        } else if (!EnGo2_IsAttentionDrawn(this) && (mainCam->setting == CAM_SET_DIRECTED_YAW)) {
             Camera_RequestSetting(mainCam, CAM_SET_DUNGEON1);
             Camera_SetStateFlag(mainCam, CAM_STATE_CHECK_BG);
         }
@@ -1184,15 +1184,17 @@ s32 EnGo2_IsCameraModified(EnGo2* this, PlayState* play) {
         PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON ||
         PARAMS_GET_S(this->actor.params, 0, 5) == GORON_MARKET_BAZAAR) {
         return true;
-    } else if (!CHECK_QUEST_ITEM(QUEST_MEDALLION_FIRE) && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON)) {
-        return true;
-    } else {
-        return false;
     }
+
+    if (!CHECK_QUEST_ITEM(QUEST_MEDALLION_FIRE) && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON)) {
+        return true;
+    }
+
+    return false;
 }
 
 void EnGo2_DefaultWakingUp(EnGo2* this) {
-    if (EnGo2_IsWakingUp(this)) {
+    if (EnGo2_IsAttentionDrawn(this)) {
         this->trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
     } else {
         this->trackingMode = NPC_TRACKING_NONE;
@@ -1219,7 +1221,7 @@ void EnGo2_WakingUp(EnGo2* this) {
 }
 
 void EnGo2_BiggoronWakingUp(EnGo2* this) {
-    if (EnGo2_IsWakingUp(this) || this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
+    if (EnGo2_IsAttentionDrawn(this) || this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
         this->trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
         this->isAwake = true;
     } else {
@@ -1232,7 +1234,7 @@ void EnGo2_SelectGoronWakingUp(EnGo2* this) {
     switch (PARAMS_GET_S(this->actor.params, 0, 5)) {
         case GORON_DMT_BOMB_FLOWER:
             this->isAwake = true;
-            this->trackingMode = EnGo2_IsWakingUp(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
+            this->trackingMode = EnGo2_IsAttentionDrawn(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
             break;
         case GORON_FIRE_GENERIC:
             EnGo2_WakingUp(this);
@@ -1441,7 +1443,7 @@ s32 EnGo2_IsGoronFireGeneric(EnGo2* this) {
 
 s32 EnGo2_IsGoronLinkReversing(EnGo2* this) {
     if (PARAMS_GET_S(this->actor.params, 0, 5) != GORON_CITY_LINK || (this->waypoint >= this->reverseWaypoint) ||
-        !EnGo2_IsWakingUp(this)) {
+        !EnGo2_IsAttentionDrawn(this)) {
         return false;
     }
     return true;
@@ -1671,7 +1673,7 @@ void EnGo2_ActionCurledUp(EnGo2* this, PlayState* play) {
         this->isAwake = false;
         EnGo2_WakeUp(this, play);
     }
-    if ((PARAMS_GET_S(this->actor.params, 0, 5) != GORON_FIRE_GENERIC) && EnGo2_IsWakingUp(this)) {
+    if ((PARAMS_GET_S(this->actor.params, 0, 5) != GORON_FIRE_GENERIC) && EnGo2_IsAttentionDrawn(this)) {
         EnGo2_WakeUp(this, play);
     }
 }
@@ -1706,7 +1708,7 @@ void func_80A46B40(EnGo2* this, PlayState* play) {
                 (s16)((height * 0.4f * (this->skelAnime.curFrame / this->skelAnime.endFrame)) + (height * 0.6f));
         }
     }
-    if ((!EnGo2_IsCameraModified(this, play)) && (!EnGo2_IsWakingUp(this))) {
+    if ((!EnGo2_IsAttentionDrawnExtented(this, play)) && (!EnGo2_IsAttentionDrawn(this))) {
         EnGo2_RollingAnimation(this, play);
     }
 }

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1109,7 +1109,7 @@ void func_80A45288(EnGo2* this, PlayState* play) {
     }
 }
 
-void func_80A45360(EnGo2* this, f32* alpha) {
+void EnGo2_UpdateShadowAlpha(EnGo2* this, f32* alpha) {
     f32 alphaTarget =
         (this->skelAnime.animation == &gGoronUncurlSitStandAnim) && (this->skelAnime.curFrame <= 32.0f) ? 0.0f : 255.0f;
 
@@ -1556,7 +1556,7 @@ void EnGo2_Init(Actor* thisx, PlayState* play) {
     EnGo2_SetShape(this);
     Animation_ChangeByInfo(&this->skelAnime, sAnimationInfo, ENGO2_ANIM_UNCURL_SIT_STAND_IDLE);
     this->actor.gravity = -1.0f;
-    this->alpha = this->actor.shape.shadowAlpha = 0;
+    this->shadownAlpha = this->actor.shape.shadowAlpha = 0;
     this->reverse = 0;
     this->isAwake = false;
     this->isUncurled = false;
@@ -1992,8 +1992,8 @@ void EnGo2_GoronFireGenericAction(EnGo2* this, PlayState* play) {
 void EnGo2_Update(Actor* thisx, PlayState* play) {
     EnGo2* this = (EnGo2*)thisx;
 
-    func_80A45360(this, &this->alpha);
-    EnGo2_SitDownAnimation(this);
+    EnGo2_UpdateShadowAlpha(this, &this->shadownAlpha);
+    EnGo2_UpdateStandUpAnim(this);
     SkelAnime_Update(&this->skelAnime);
     EnGo2_RollForward(this);
     Actor_UpdateBgCheckInfo(play, &this->actor, this->collider.dim.height * 0.5f, this->collider.dim.radius * 0.6f,

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -1216,12 +1216,8 @@ s32 EnGo2_IsAttentionDrawnExtented(EnGo2* this, PlayState* play) {
     return false;
 }
 
-void EnGo2_DefaultWakingUp(EnGo2* this) {
-    if (EnGo2_IsAttentionDrawn(this)) {
-        this->trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
-    } else {
-        this->trackingMode = NPC_TRACKING_NONE;
-    }
+void EnGo2_SetupUncurledFlags_Default(EnGo2* this) {
+    this->trackingMode = EnGo2_IsAttentionDrawn(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
 
     if (this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
         this->trackingMode = NPC_TRACKING_FULL_BODY;
@@ -1230,7 +1226,8 @@ void EnGo2_DefaultWakingUp(EnGo2* this) {
     this->isAwake = true;
 }
 
-void EnGo2_WakingUp(EnGo2* this) {
+void EnGo2_SetupUncurledFlags_NearTracking(EnGo2* this) {
+    // always false, he wakes up with `EnGo2_SetupUncurledFlags_Biggoron`
     f32 xyzDist = (ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) ? 800.0f : 200.0f;
     s32 isTrue = true;
 
@@ -1243,7 +1240,7 @@ void EnGo2_WakingUp(EnGo2* this) {
     this->isAwake = isTrue;
 }
 
-void EnGo2_BiggoronWakingUp(EnGo2* this) {
+void EnGo2_SetupUncurledFlags_Biggoron(EnGo2* this) {
     if (EnGo2_IsAttentionDrawn(this) || this->interactInfo.talkState != NPC_TALK_STATE_IDLE) {
         this->trackingMode = NPC_TRACKING_HEAD_AND_TORSO;
         this->isAwake = true;
@@ -1253,26 +1250,26 @@ void EnGo2_BiggoronWakingUp(EnGo2* this) {
     }
 }
 
-void EnGo2_AnimateGoronWakingUp(EnGo2* this) {
+void EnGo2_SetupUncurledFlags(EnGo2* this) {
     switch (ENGO2_GET_TYPE(this)) {
         case GORON_DMT_BOMB_FLOWER:
             this->isAwake = true;
             this->trackingMode = EnGo2_IsAttentionDrawn(this) ? NPC_TRACKING_HEAD_AND_TORSO : NPC_TRACKING_NONE;
             break;
         case GORON_FIRE_GENERIC:
-            EnGo2_WakingUp(this);
+            EnGo2_SetupUncurledFlags_NearTracking(this);
             break;
         case GORON_DMT_BIGGORON:
-            EnGo2_BiggoronWakingUp(this);
+            EnGo2_SetupUncurledFlags_Biggoron(this);
             break;
         case GORON_CITY_LINK:
             if (!CHECK_QUEST_ITEM(QUEST_MEDALLION_FIRE) && CHECK_OWNED_EQUIP(EQUIP_TYPE_TUNIC, EQUIP_INV_TUNIC_GORON)) {
-                EnGo2_WakingUp(this);
+                EnGo2_SetupUncurledFlags_NearTracking(this);
                 break;
             }
             FALLTHROUGH;
         default:
-            EnGo2_DefaultWakingUp(this);
+            EnGo2_SetupUncurledFlags_Default(this);
             break;
     }
 }
@@ -1705,7 +1702,7 @@ void EnGo2_Standing(EnGo2* this, PlayState* play) {
     if (this->isUncurled == true) {
         EnGo2_AnimateBiggoronAndDoSfx(this);
         EnGo2_AnimateGoronLinkAndDoSfx(this, play);
-        EnGo2_AnimateGoronWakingUp(this);
+        EnGo2_SetupUncurledFlags(this);
 
         if (!EnGo2_IsGoronRollingBig(this, play) && !EnGo2_IsGoronFireGeneric(this)) {
             if (EnGo2_IsGoronDmtBombFlower(this)) {

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -843,12 +843,21 @@ s16 EnGo2_UpdateTalkState(PlayState* play, Actor* thisx) {
 }
 
 s32 EnGo2_UpdateTalking(EnGo2* this, PlayState* play) {
-    if (ENGO2_GET_TYPE(this) != GORON_DMT_BIGGORON && ENGO2_GET_TYPE(this) != GORON_CITY_ROLLING_BIG) {
-        return Npc_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, this->interactRange,
-                                 EnGo2_GetTextId, EnGo2_UpdateTalkState);
-    } else if ((ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) && !(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
+    // default:
+    if (ENGO2_GET_TYPE(this) != GORON_DMT_BIGGORON) {
+        if (ENGO2_GET_TYPE(this) != GORON_CITY_ROLLING_BIG) {
+            return Npc_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, this->interactRange,
+                                     EnGo2_GetTextId, EnGo2_UpdateTalkState);
+        }
+    }
+
+    // `GORON_DMT_BIGGORON`, attention wasn't drawn
+    if ((ENGO2_GET_TYPE(this) == GORON_DMT_BIGGORON) && !(this->collider.base.ocFlags2 & OC2_HIT_PLAYER)) {
         return false;
-    } else {
+    }
+
+    // `GORON_DMT_BIGGORON` || `GORON_CITY_ROLLING_BIG`
+    {
         if (Actor_TalkOfferAccepted(&this->actor, play)) {
             this->interactInfo.talkState = NPC_TALK_STATE_TALKING;
             return true;
@@ -1830,7 +1839,7 @@ void EnGo2_HandleOffer(EnGo2* this, PlayState* play) {
 #endif
         this->actionFunc = EnGo2_HandleOfferParented;
     } else {
-        // @redundant: this action is always paired with `EnGo2_OfferItem`, which itself calls Actor_OfferGetItem
+        // @redundant: this action is always paired with `EnGo2_OfferItem`, which itself calls `Actor_OfferGetItem`
         Actor_OfferGetItem(&this->actor, play, this->getItemId, this->actor.xzDistToPlayer + 1.0f,
                            fabsf(this->actor.yDistToPlayer) + 1.0f);
     }

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -86,7 +86,7 @@ typedef struct EnGo2 {
     /* 0x0213 */ u8 eyeMouthTexState; // 0, 1, 2, 3
     /* 0x0214 */ u8 eyeTexIndex;
     /* 0x0215 */ u8 mouthTexIndex;
-    /* 0x0216 */ u8 unk_216; // Set to z rotation, checked by waypoint
+    /* 0x0216 */ u8 reverseWaypoint; // Set to z rotation, checked by waypoint
     /* 0x0218 */ f32 interactRange;
     /* 0x021C */ char unk_21C[0x04];
     /* 0x0220 */ f32

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -79,9 +79,8 @@ typedef struct EnGo2 {
     /* 0x04AC */ Vec3f subCamAt;
     /* 0x04B8 */ Vec3s jointTable[GORON_LIMB_MAX];
     /* 0x0524 */ Vec3s morphTable[GORON_LIMB_MAX];
-    /* 0x0590 */ s16 bounceTimer; // timer
-    /* 0x0592 */ s16
-        animTimer; // animTimer. Plays NA_SE_EN_MORIBLIN_WALK, NA_SE_EV_IRON_DOOR_OPEN, NA_SE_EV_IRON_DOOR_CLOSE
+    /* 0x0590 */ s16 bounceTimer;
+    /* 0x0592 */ s16 animTimer;
     /* 0x0594 */ s32 getItemId;
     /* 0x0598 */ char unk_598[0x02];
     /* 0x059A */ s16 subCamId;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -40,7 +40,6 @@ typedef enum GoronType {
 // /* 0x0A */ GORON_FIRE_MAZE_UPPER,
 // /* 0x0B */ GORON_FIRE_HIGHEST
 
-
 typedef struct EnGo2DataStruct1 {
     s16 unused;
     s16 yDist;
@@ -77,9 +76,9 @@ typedef struct EnGo2 {
     /* 0x020C */ u8 unk_20C; // counter for GORON_CITY_LINK animation
     /* 0x020D */ u8 dialogState;
     /* 0x020E */ u8 reverse;
-    /* 0x020F */ u8 isAwake; // Conditional
+    /* 0x020F */ u8 isAwake;
     /* 0x0210 */ s8 waypoint;
-    /* 0x0211 */ u8 unk_211; // Conditional
+    /* 0x0211 */ u8 isUncurled;
     // goron link: 0 - rolling, 1 - frozen
     // biggoron: 0 - give eyedrops, 1 - applying eyedrops, 2 - getting claimcheck
     // generic fire: 0 -
@@ -90,7 +89,8 @@ typedef struct EnGo2 {
     /* 0x0216 */ u8 unk_216; // Set to z rotation, checked by waypoint
     /* 0x0218 */ f32 interactRange;
     /* 0x021C */ char unk_21C[0x04];
-    /* 0x0220 */ f32 alpha; // Set to 0, used by func_80A45360, smoothed to this->actor.shape.shadowAlpha from either 0 or 255.0f
+    /* 0x0220 */ f32
+        alpha; // Set to 0, used by func_80A45360, smoothed to this->actor.shape.shadowAlpha from either 0 or 255.0f
     /* 0x0224 */ s16 blinkTimer;
     /* 0x0226 */ s16 unk_226[GORON_LIMB_MAX]; // Remains unknown
     /* 0x024A */ s16 unk_24A[GORON_LIMB_MAX]; // Remains unknown
@@ -101,7 +101,8 @@ typedef struct EnGo2 {
     /* 0x04B8 */ Vec3s jointTable[GORON_LIMB_MAX];
     /* 0x0524 */ Vec3s morphTable[GORON_LIMB_MAX];
     /* 0x0590 */ s16 bounceTimer; // timer
-    /* 0x0592 */ s16 animTimer; // animTimer. Plays NA_SE_EN_MORIBLIN_WALK, NA_SE_EV_IRON_DOOR_OPEN, NA_SE_EV_IRON_DOOR_CLOSE
+    /* 0x0592 */ s16
+        animTimer; // animTimer. Plays NA_SE_EN_MORIBLIN_WALK, NA_SE_EV_IRON_DOOR_OPEN, NA_SE_EV_IRON_DOOR_CLOSE
     /* 0x0594 */ s32 getItemId;
     /* 0x0598 */ char unk_598[0x02];
     /* 0x059A */ s16 subCamId;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -9,23 +9,6 @@ struct EnGo2;
 
 typedef void (*EnGo2ActionFunc)(struct EnGo2*, PlayState*);
 
-typedef enum GoronType {
-    /* 0x00 */ GORON_CITY_ROLLING_BIG,
-    /* 0x01 */ GORON_CITY_LINK,
-    /* 0x02 */ GORON_DMT_BIGGORON,
-    /* 0x03 */ GORON_FIRE_GENERIC,
-    /* 0x04 */ GORON_DMT_BOMB_FLOWER,
-    /* 0x05 */ GORON_DMT_ROLLING_SMALL,
-    /* 0x06 */ GORON_DMT_DC_ENTRANCE,
-    /* 0x07 */ GORON_CITY_ENTRANCE,
-    /* 0x08 */ GORON_CITY_ISLAND,
-    /* 0x09 */ GORON_CITY_LOWEST_FLOOR,
-    /* 0x0A */ GORON_CITY_STAIRWELL,
-    /* 0x0B */ GORON_CITY_LOST_WOODS,
-    /* 0x0C */ GORON_DMT_FAIRY_HINT,
-    /* 0x0D */ GORON_MARKET_BAZAAR
-} GoronType;
-
 // WIP fire temple type docs
 // /* 0x00 */ UNUSED
 // /* 0x01 */ GORON_FIRE_LAVA_ROOM_OPEN

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -86,8 +86,7 @@ typedef struct EnGo2 {
     /* 0x0216 */ u8 reverseWaypoint; // Set to z rotation, checked by waypoint
     /* 0x0218 */ f32 interactRange;
     /* 0x021C */ char unk_21C[0x04];
-    /* 0x0220 */ f32
-        alpha; // Set to 0, used by func_80A45360, smoothed to this->actor.shape.shadowAlpha from either 0 or 255.0f
+    /* 0x0220 */ f32 shadownAlpha;
     /* 0x0224 */ s16 blinkTimer;
     /* 0x0226 */ s16 unk_226[GORON_LIMB_MAX]; // Remains unknown
     /* 0x024A */ s16 unk_24A[GORON_LIMB_MAX]; // Remains unknown

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -100,12 +100,12 @@ typedef struct EnGo2 {
     /* 0x04AC */ Vec3f subCamAt;
     /* 0x04B8 */ Vec3s jointTable[GORON_LIMB_MAX];
     /* 0x0524 */ Vec3s morphTable[GORON_LIMB_MAX];
-    /* 0x0590 */ s16 unk_590; // timer
+    /* 0x0590 */ s16 bounceTimer; // timer
     /* 0x0592 */ s16 animTimer; // animTimer. Plays NA_SE_EN_MORIBLIN_WALK, NA_SE_EV_IRON_DOOR_OPEN, NA_SE_EV_IRON_DOOR_CLOSE
     /* 0x0594 */ s32 getItemId;
     /* 0x0598 */ char unk_598[0x02];
     /* 0x059A */ s16 subCamId;
-    /* 0x059C */ s16 unk_59C;
+    /* 0x059C */ s16 bounceCounter;
 } EnGo2; // size = 0x05A0
 
 #endif

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -73,8 +73,8 @@ typedef struct EnGo2 {
     /* 0x0194 */ NpcInteractInfo interactInfo;
     /* 0x01BC */ ColliderCylinder collider;
     /* 0x0208 */ Path* path;
-    /* 0x020C */ u8 unk_20C; // counter for GORON_CITY_LINK animation
-    /* 0x020D */ u8 dialogState;
+    /* 0x020C */ u8 messageEntry; // tracks message state changes, like with `BOX_BREAK` or `TEXTID`
+    /* 0x020D */ u8 messageState; // last known result of `Message_GetState`
     /* 0x020E */ u8 reverse;
     /* 0x020F */ u8 isAwake;
     /* 0x0210 */ s8 waypoint;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -79,11 +79,8 @@ typedef struct EnGo2 {
     /* 0x020F */ u8 isAwake;
     /* 0x0210 */ s8 waypoint;
     /* 0x0211 */ u8 isUncurled;
-    // goron link: 0 - rolling, 1 - frozen
-    // biggoron: 0 - give eyedrops, 1 - applying eyedrops, 2 - getting claimcheck
-    // generic fire: 0 -
     /* 0x0212 */ u8 goronState;
-    /* 0x0213 */ u8 eyeMouthTexState; // 0, 1, 2, 3
+    /* 0x0213 */ u8 eyeMouthTexState;
     /* 0x0214 */ u8 eyeTexIndex;
     /* 0x0215 */ u8 mouthTexIndex;
     /* 0x0216 */ u8 reverseWaypoint; // Set to z rotation, checked by waypoint

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -92,14 +92,14 @@ typedef struct EnGo2 {
     /* 0x021C */ char unk_21C[0x04];
     /* 0x0220 */ f32 alpha; // Set to 0, used by func_80A45360, smoothed to this->actor.shape.shadowAlpha from either 0 or 255.0f
     /* 0x0224 */ s16 blinkTimer;
-    /* 0x0226 */ s16 unk_226[18]; // Remains unknown
-    /* 0x024A */ s16 unk_24A[18]; // Remains unknown
+    /* 0x0226 */ s16 unk_226[GORON_LIMB_MAX]; // Remains unknown
+    /* 0x024A */ s16 unk_24A[GORON_LIMB_MAX]; // Remains unknown
     /* 0x026E */ u16 trackingMode;
     /* 0x0270 */ EnGoEffect effects[EN_GO2_EFFECT_COUNT];
     /* 0x04A0 */ Vec3f subCamEye;
     /* 0x04AC */ Vec3f subCamAt;
-    /* 0x04B8 */ Vec3s jointTable[18];
-    /* 0x0524 */ Vec3s morphTable[18];
+    /* 0x04B8 */ Vec3s jointTable[GORON_LIMB_MAX];
+    /* 0x0524 */ Vec3s morphTable[GORON_LIMB_MAX];
     /* 0x0590 */ s16 unk_590; // timer
     /* 0x0592 */ s16 animTimer; // animTimer. Plays NA_SE_EN_MORIBLIN_WALK, NA_SE_EV_IRON_DOOR_OPEN, NA_SE_EV_IRON_DOOR_CLOSE
     /* 0x0594 */ s32 getItemId;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -59,7 +59,7 @@ typedef struct EnGo2 {
     /* 0x020C */ u8 messageEntry; // tracks message state changes, like with `BOX_BREAK` or `TEXTID`
     /* 0x020D */ u8 messageState; // last known result of `Message_GetState`
     /* 0x020E */ u8 reverse;
-    /* 0x020F */ u8 isAwake;
+    /* 0x020F */ u8 isTalkative;
     /* 0x0210 */ s8 waypoint;
     /* 0x0211 */ u8 isUncurled;
     /* 0x0212 */ u8 goronState;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.h
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.h
@@ -23,20 +23,20 @@ typedef void (*EnGo2ActionFunc)(struct EnGo2*, PlayState*);
 // /* 0x0A */ GORON_FIRE_MAZE_UPPER,
 // /* 0x0B */ GORON_FIRE_HIGHEST
 
-typedef struct EnGo2DataStruct1 {
+typedef struct EnGo2ColliderData {
     s16 unused;
     s16 yDist;
     s16 xzDist;
     s16 radius;
     s16 height;
-} EnGo2DataStruct1; // size = 0xA
+} EnGo2ColliderData; // size = 0xA
 
-typedef struct EnGo2DataStruct2 {
-    f32 shape_unk_10;
+typedef struct EnGo2ShapeData {
+    f32 shadowScale;
     f32 scale;
-    s8 actor_unk_1F;
+    s8 attentionRangeType;
     f32 interactRange;
-} EnGo2DataStruct2; // size = 0x10
+} EnGo2ShapeData; // size = 0x10
 
 typedef struct EnGo2DustEffectData {
     u8 initialTimer;

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -402,7 +402,7 @@ void func_80A53AD4(EnHeishi2* this, PlayState* play) {
     this->unk_300 = TEXT_STATE_DONE;
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        s32 exchangeItemId = func_8002F368(play);
+        s32 exchangeItemId = Player_GetExchangeItemId(play);
 
         if (exchangeItemId == EXCH_ITEM_ZELDAS_LETTER) {
             Sfx_PlaySfxCentered(NA_SE_SY_CORRECT_CHIME);

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -206,7 +206,7 @@ void func_80A6E9AC(EnHs* this, PlayState* play) {
     s16 yawDiff;
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        if (func_8002F368(play) == EXCH_ITEM_COJIRO) {
+        if (Player_GetExchangeItemId(play) == EXCH_ITEM_COJIRO) {
             player->actor.textId = 0x10B2;
             func_80A6E3A0(this, func_80A6E8CC);
             Animation_Change(&this->skelAnime, &object_hs_Anim_000304, 1.0f, 0.0f,

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -957,7 +957,7 @@ void EnHy_OfferBuyBottledItem(EnHy* this, PlayState* play) {
     if (ENHY_GET_TYPE(&this->actor) == ENHY_TYPE_BEGGAR) {
         if (!Inventory_HasSpecificBottle(ITEM_BOTTLE_BLUE_FIRE) && !Inventory_HasSpecificBottle(ITEM_BOTTLE_BUG) &&
             !Inventory_HasSpecificBottle(ITEM_BOTTLE_FISH)) {
-            switch (func_8002F368(play)) {
+            switch (Player_GetExchangeItemId(play)) {
                 case EXCH_ITEM_BOTTLE_POE:
                 case EXCH_ITEM_BOTTLE_BIG_POE:
                 case EXCH_ITEM_BOTTLE_RUTOS_LETTER:
@@ -971,7 +971,7 @@ void EnHy_OfferBuyBottledItem(EnHy* this, PlayState* play) {
                     break;
             }
         } else {
-            switch (func_8002F368(play)) {
+            switch (Player_GetExchangeItemId(play)) {
                 case EXCH_ITEM_BOTTLE_BLUE_FIRE:
                     this->actor.textId = 0x70F0;
                     break;

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -980,7 +980,7 @@ void func_80A9877C(EnKo* this, PlayState* play) {
         ENKO_TYPE == ENKO_TYPE_CHILD_FADO && play->sceneId == SCENE_LOST_WOODS) {
         this->actor.textId = INV_CONTENT(ITEM_TRADE_ADULT) > ITEM_ODD_POTION ? 0x10B9 : 0x10DF;
 
-        if (func_8002F368(play) == EXCH_ITEM_ODD_POTION) {
+        if (Player_GetExchangeItemId(play) == EXCH_ITEM_ODD_POTION) {
 #if OOT_VERSION < NTSC_1_1
             this->actor.textId = GET_INFTABLE(INFTABLE_B6) ? 0x10B8 : 0x10B7;
 #else

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -292,7 +292,7 @@ void func_80A9CB18(EnKz* this, PlayState* play) {
     if (EnKz_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, 340.0f, EnKz_GetTextId,
                            EnKz_UpdateTalkState)) {
         if ((this->actor.textId == 0x401A) && !GET_EVENTCHKINF(EVENTCHKINF_33)) {
-            if (func_8002F368(play) == EXCH_ITEM_BOTTLE_RUTOS_LETTER) {
+            if (Player_GetExchangeItemId(play) == EXCH_ITEM_BOTTLE_RUTOS_LETTER) {
                 this->actor.textId = 0x401B;
                 this->sfxPlayed = false;
             } else {
@@ -304,7 +304,7 @@ void func_80A9CB18(EnKz* this, PlayState* play) {
 
         if (LINK_IS_ADULT) {
             if ((INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_PRESCRIPTION) &&
-                (func_8002F368(play) == EXCH_ITEM_PRESCRIPTION)) {
+                (Player_GetExchangeItemId(play) == EXCH_ITEM_PRESCRIPTION)) {
                 this->actor.textId = 0x4014;
                 this->sfxPlayed = false;
                 player->actor.textId = this->actor.textId;
@@ -494,7 +494,7 @@ void EnKz_SetupGetItem(EnKz* this, PlayState* play) {
         this->actionFunc = EnKz_StartTimer;
     } else {
 #if OOT_VERSION < PAL_1_0
-        getItemId = func_8002F368(play) == EXCH_ITEM_PRESCRIPTION ? GI_EYEBALL_FROG : GI_TUNIC_ZORA;
+        getItemId = Player_GetExchangeItemId(play) == EXCH_ITEM_PRESCRIPTION ? GI_EYEBALL_FROG : GI_TUNIC_ZORA;
 #else
         getItemId = this->isTrading == true ? GI_EYEBALL_FROG : GI_TUNIC_ZORA;
 #endif

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -216,7 +216,7 @@ void EnMk_Wait(EnMk* this, PlayState* play) {
     s32 playerExchangeItem;
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        playerExchangeItem = func_8002F368(play);
+        playerExchangeItem = Player_GetExchangeItemId(play);
 
         if (this->actor.textId != 0x4018) {
             player->actor.textId = this->actor.textId;

--- a/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -374,7 +374,7 @@ void func_80ABA878(EnNiwLady* this, PlayState* play) {
         this->unk_26E = 11;
     }
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        s8 playerExchangeItemId = func_8002F368(play);
+        s8 playerExchangeItemId = Player_GetExchangeItemId(play);
 
         if ((playerExchangeItemId == EXCH_ITEM_POCKET_CUCCO) && GET_EVENTCHKINF(EVENTCHKINF_TALON_WOKEN_IN_KAKARIKO)) {
             Sfx_PlaySfxCentered(NA_SE_SY_TRE_BOX_APPEAR);

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -368,7 +368,7 @@ void EnTa_IdleAsleepInCastle(EnTa* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        s32 exchangeItemId = func_8002F368(play);
+        s32 exchangeItemId = Player_GetExchangeItemId(play);
 
         switch (exchangeItemId) {
             case EXCH_ITEM_CHICKEN:
@@ -403,7 +403,7 @@ void EnTa_IdleAsleepInKakariko(EnTa* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        s32 exchangeItemId = func_8002F368(play);
+        s32 exchangeItemId = Player_GetExchangeItemId(play);
 
         switch (exchangeItemId) {
             case EXCH_ITEM_POCKET_CUCCO:

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -318,7 +318,7 @@ void EnToryo_HandleTalking(EnToryo* this, PlayState* play) {
 
     if (this->messageState == 0) {
         if (Actor_TalkOfferAccepted(&this->actor, play)) {
-            this->exchangeItemId = func_8002F368(play);
+            this->exchangeItemId = Player_GetExchangeItemId(play);
             if (this->exchangeItemId != EXCH_ITEM_NONE) {
                 player->actor.textId = EnToryo_ReactToExchangeItem(this, play);
                 this->actor.textId = player->actor.textId;

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -537,7 +537,7 @@ void ObjBean_SetupWaitForBean(ObjBean* this) {
 
 void ObjBean_WaitForBean(ObjBean* this, PlayState* play) {
     if (Actor_TalkOfferAccepted(&this->dyna.actor, play)) {
-        if (func_8002F368(play) == EXCH_ITEM_MAGIC_BEAN) {
+        if (Player_GetExchangeItemId(play) == EXCH_ITEM_MAGIC_BEAN) {
             func_80B8FE00(this);
             Flags_SetSwitch(play, PARAMS_GET_U(this->dyna.actor.params, 0, 6));
         }


### PR DESCRIPTION
additonally:
- renamed `func_8002F368` as `Player_GetExchangeItemId`
- marked `En_Go` as unused (which is also stated in the web too)
- this PR will a conflict bit with https://github.com/zeldaret/oot/pull/2287
- restructured `EnGo2_StopRolling` with a switch
- restructured `EnGo2_RollingSlow` with a switch
- restructured `EnGo2_UpdateTalking ` with separate if (can't do any better)
  - but it was fun to mess with the tools for a while