### PR TITLE
Use debug macros even in N64-only code

### DIFF
--- a/include/unk.h
+++ b/include/unk.h
@@ -11,6 +11,9 @@
 #define UNK_FUN_PTR(name) void(*name)(void)
 #define UNK_ARGS
 #define UNK_SIZE 1
-#define UNK_LINE 1
+
+// Unknown filename and line number for debug macros
+#define UNK_FILE "<unknown>"
+#define UNK_LINE 0
 
 #endif

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -541,11 +541,9 @@ s32 DmaMgr_RequestAsync(DmaRequest* req, void* ram, uintptr_t vrom, size_t size,
 #if OOT_DEBUG
     if ((ram == NULL) || (osMemSize < OS_K0_TO_PHYSICAL(ram) + size) || (vrom & 1) || (vrom > 0x4000000) ||
         (size == 0) || (size & 1)) {
-        // The line numbers for `DMA_ERROR` are only used in retail builds, but this usage was removed so
-        // its line number is unknown.
         //! @bug `req` is passed to `DMA_ERROR` without rom, ram and size being set
         DMA_ERROR(req, NULL, "ILLIGAL DMA-FUNCTION CALL", T("パラメータ異常です", "Parameter error"), "../z_std_dma.c",
-                  0, 0, 0);
+                  UNK_LINE, UNK_LINE, UNK_LINE);
     }
 #endif
 

--- a/src/code/code_n64dd_800AD410.c
+++ b/src/code/code_n64dd_800AD410.c
@@ -12,7 +12,7 @@ vu8 D_80121214;
 void func_800AD410(void) {
     if (!D_80121210) {
         DMA_REQUEST_SYNC(_n64ddSegmentStart, (uintptr_t)_n64ddSegmentRomStart,
-                         _n64ddSegmentRomEnd - _n64ddSegmentRomStart, "../code_n64dd_800AD410.c", 0);
+                         _n64ddSegmentRomEnd - _n64ddSegmentRomStart, UNK_FILE, UNK_LINE);
         bzero(_n64ddSegmentBssStart, _n64ddSegmentBssEnd - _n64ddSegmentBssStart);
         D_80121210 = true;
         D_80121211 = func_801C6E80();

--- a/src/code/code_n64dd_800AD410.c
+++ b/src/code/code_n64dd_800AD410.c
@@ -11,8 +11,8 @@ vu8 D_80121214;
 
 void func_800AD410(void) {
     if (!D_80121210) {
-        DmaMgr_RequestSync(_n64ddSegmentStart, (uintptr_t)_n64ddSegmentRomStart,
-                           _n64ddSegmentRomEnd - _n64ddSegmentRomStart);
+        DMA_REQUEST_SYNC(_n64ddSegmentStart, (uintptr_t)_n64ddSegmentRomStart,
+                         _n64ddSegmentRomEnd - _n64ddSegmentRomStart, "../code_n64dd_800AD410.c", 0);
         bzero(_n64ddSegmentBssStart, _n64ddSegmentBssEnd - _n64ddSegmentBssStart);
         D_80121210 = true;
         D_80121211 = func_801C6E80();

--- a/src/code/z_kanfont.c
+++ b/src/code/z_kanfont.c
@@ -8,8 +8,9 @@
  */
 void Font_LoadCharWide(Font* font, u16 character, u16 codePointIndex) {
 #if OOT_NTSC
-    DmaMgr_RequestSync(&font->charTexBuf[codePointIndex],
-                       (uintptr_t)_kanjiSegmentRomStart + Kanji_OffsetFromShiftJIS(character), FONT_CHAR_TEX_SIZE);
+    DMA_REQUEST_SYNC(&font->charTexBuf[codePointIndex],
+                     (uintptr_t)_kanjiSegmentRomStart + Kanji_OffsetFromShiftJIS(character), FONT_CHAR_TEX_SIZE,
+                     "../z_kanfont.c", 0);
 #endif
 }
 
@@ -53,7 +54,8 @@ void Font_LoadOrderedFont(Font* font) {
 
 #if OOT_NTSC
     len = (u32)size / 2;
-    DmaMgr_RequestSync(font->msgBufWide, (uintptr_t)_jpn_message_data_staticSegmentRomStart + font->msgOffset, size);
+    DMA_REQUEST_SYNC(font->msgBufWide, (uintptr_t)_jpn_message_data_staticSegmentRomStart + font->msgOffset, size,
+                     "../z_kanfont.c", 0);
 
     fontBufIndex = 0;
     for (codePointIndex = 0; font->msgBufWide[codePointIndex] != MESSAGE_WIDE_END; codePointIndex++) {
@@ -63,8 +65,8 @@ void Font_LoadOrderedFont(Font* font) {
 
         if (font->msgBufWide[codePointIndex] != MESSAGE_WIDE_NEWLINE) {
             offset = Kanji_OffsetFromShiftJIS(font->msgBufWide[codePointIndex]);
-            DmaMgr_RequestSync(&font->fontBuf[fontBufIndex * 8], (uintptr_t)_kanjiSegmentRomStart + offset,
-                               FONT_CHAR_TEX_SIZE);
+            DMA_REQUEST_SYNC(&font->fontBuf[fontBufIndex * 8], (uintptr_t)_kanjiSegmentRomStart + offset,
+                             FONT_CHAR_TEX_SIZE, "../z_kanfont.c", 0);
             fontBufIndex += FONT_CHAR_TEX_SIZE / 8;
         }
     }

--- a/src/code/z_kanfont.c
+++ b/src/code/z_kanfont.c
@@ -10,7 +10,7 @@ void Font_LoadCharWide(Font* font, u16 character, u16 codePointIndex) {
 #if OOT_NTSC
     DMA_REQUEST_SYNC(&font->charTexBuf[codePointIndex],
                      (uintptr_t)_kanjiSegmentRomStart + Kanji_OffsetFromShiftJIS(character), FONT_CHAR_TEX_SIZE,
-                     "../z_kanfont.c", 0);
+                     "../z_kanfont.c", UNK_LINE);
 #endif
 }
 
@@ -55,7 +55,7 @@ void Font_LoadOrderedFont(Font* font) {
 #if OOT_NTSC
     len = (u32)size / 2;
     DMA_REQUEST_SYNC(font->msgBufWide, (uintptr_t)_jpn_message_data_staticSegmentRomStart + font->msgOffset, size,
-                     "../z_kanfont.c", 0);
+                     "../z_kanfont.c", UNK_LINE);
 
     fontBufIndex = 0;
     for (codePointIndex = 0; font->msgBufWide[codePointIndex] != MESSAGE_WIDE_END; codePointIndex++) {
@@ -66,7 +66,7 @@ void Font_LoadOrderedFont(Font* font) {
         if (font->msgBufWide[codePointIndex] != MESSAGE_WIDE_NEWLINE) {
             offset = Kanji_OffsetFromShiftJIS(font->msgBufWide[codePointIndex]);
             DMA_REQUEST_SYNC(&font->fontBuf[fontBufIndex * 8], (uintptr_t)_kanjiSegmentRomStart + offset,
-                             FONT_CHAR_TEX_SIZE, "../z_kanfont.c", 0);
+                             FONT_CHAR_TEX_SIZE, "../z_kanfont.c", UNK_LINE);
             fontBufIndex += FONT_CHAR_TEX_SIZE / 8;
         }
     }

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -167,10 +167,10 @@ void Map_InitData(PlayState* play, s16 room) {
 #if PLATFORM_N64
             if ((B_80121220 != NULL) && (B_80121220->unk_28 != NULL) && B_80121220->unk_28(play)) {
             } else {
-                DmaMgr_RequestSync(play->interfaceCtx.mapSegment,
-                                   (uintptr_t)_map_i_staticSegmentRomStart +
-                                       ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * MAP_I_TEX_SIZE),
-                                   MAP_I_TEX_SIZE);
+                DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,
+                                 (uintptr_t)_map_i_staticSegmentRomStart +
+                                     ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * MAP_I_TEX_SIZE),
+                                 MAP_I_TEX_SIZE, "../z_map_exp.c", 0);
             }
 #else
             DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -170,7 +170,7 @@ void Map_InitData(PlayState* play, s16 room) {
                 DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,
                                  (uintptr_t)_map_i_staticSegmentRomStart +
                                      ((gMapData->dgnMinimapTexIndexOffset[mapIndex] + room) * MAP_I_TEX_SIZE),
-                                 MAP_I_TEX_SIZE, "../z_map_exp.c", 0);
+                                 MAP_I_TEX_SIZE, "../z_map_exp.c", UNK_LINE);
             }
 #else
             DMA_REQUEST_SYNC(play->interfaceCtx.mapSegment,

--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -2039,11 +2039,11 @@ void Message_Decode(PlayState* play) {
                 DMA_REQUEST_SYNC(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE,
                                  (uintptr_t)_message_texture_staticSegmentRomStart +
                                      msgCtx->textboxBackgroundIdx * MESSAGE_TEXTURE_STATIC_TEX_SIZE,
-                                 MESSAGE_TEXTURE_STATIC_TEX_SIZE, "../z_message_PAL.c", 0);
+                                 MESSAGE_TEXTURE_STATIC_TEX_SIZE, "../z_message_PAL.c", UNK_LINE);
                 DMA_REQUEST_SYNC(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE + MESSAGE_TEXTURE_STATIC_TEX_SIZE,
                                  (uintptr_t)_message_texture_staticSegmentRomStart +
                                      (msgCtx->textboxBackgroundIdx + 1) * MESSAGE_TEXTURE_STATIC_TEX_SIZE,
-                                 MESSAGE_TEXTURE_STATIC_TEX_SIZE, "../z_message_PAL.c", 0);
+                                 MESSAGE_TEXTURE_STATIC_TEX_SIZE, "../z_message_PAL.c", UNK_LINE);
                 numLines = 2;
                 msgCtx->msgBufPos += 2;
                 R_TEXTBOX_BG_YPOS = R_TEXTBOX_Y + 8;
@@ -2529,7 +2529,7 @@ void Message_OpenText(PlayState* play, u16 textId) {
 
         } else {
             DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_staff_message_data_staticSegmentRomStart + font->msgOffset,
-                             font->msgLength, "../z_message_PAL.c", 0);
+                             font->msgLength, "../z_message_PAL.c", UNK_LINE);
         }
 #else
         DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_staff_message_data_staticSegmentRomStart + font->msgOffset,
@@ -2545,11 +2545,11 @@ void Message_OpenText(PlayState* play, u16 textId) {
 
             } else {
                 DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_jpn_message_data_staticSegmentRomStart + font->msgOffset,
-                                 font->msgLength, "../z_message_PAL.c", 0);
+                                 font->msgLength, "../z_message_PAL.c", UNK_LINE);
             }
 #else
             DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_jpn_message_data_staticSegmentRomStart + font->msgOffset,
-                             font->msgLength, "../z_message_PAL.c", 0);
+                             font->msgLength, "../z_message_PAL.c", UNK_LINE);
 #endif
         } else {
             Message_FindMessageNES(play, textId);
@@ -2559,11 +2559,11 @@ void Message_OpenText(PlayState* play, u16 textId) {
 
             } else {
                 DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
-                                 font->msgLength, "../z_message_PAL.c", 0);
+                                 font->msgLength, "../z_message_PAL.c", UNK_LINE);
             }
 #else
             DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
-                             font->msgLength, "../z_message_PAL.c", 0);
+                             font->msgLength, "../z_message_PAL.c", UNK_LINE);
 #endif
         }
 #else
@@ -2575,7 +2575,7 @@ void Message_OpenText(PlayState* play, u16 textId) {
 
             } else {
                 DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
-                                 font->msgLength, "../z_message_PAL.c", 0);
+                                 font->msgLength, "../z_message_PAL.c", UNK_LINE);
             }
 #else
             DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
@@ -2590,7 +2590,7 @@ void Message_OpenText(PlayState* play, u16 textId) {
 
             } else {
                 DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_ger_message_data_staticSegmentRomStart + font->msgOffset,
-                                 font->msgLength, "../z_message_PAL.c", 0);
+                                 font->msgLength, "../z_message_PAL.c", UNK_LINE);
             }
 #else
             DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_ger_message_data_staticSegmentRomStart + font->msgOffset,
@@ -2605,7 +2605,7 @@ void Message_OpenText(PlayState* play, u16 textId) {
 
             } else {
                 DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_fra_message_data_staticSegmentRomStart + font->msgOffset,
-                                 font->msgLength, "../z_message_PAL.c", 0);
+                                 font->msgLength, "../z_message_PAL.c", UNK_LINE);
             }
 #else
             DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_fra_message_data_staticSegmentRomStart + font->msgOffset,

--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -2036,14 +2036,14 @@ void Message_Decode(PlayState* play) {
                 msgCtx->textboxBackgroundBackColorIdx = (font->msgBufWide[msgCtx->msgBufPos + 2] & 0xF00) >> 8;
                 msgCtx->textboxBackgroundYOffsetIdx = (font->msgBufWide[msgCtx->msgBufPos + 2] & 0xF0) >> 4;
                 msgCtx->textboxBackgroundUnkArg = font->msgBufWide[msgCtx->msgBufPos + 2] & 0xF;
-                DmaMgr_RequestSync(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE,
-                                   (uintptr_t)_message_texture_staticSegmentRomStart +
-                                       msgCtx->textboxBackgroundIdx * MESSAGE_TEXTURE_STATIC_TEX_SIZE,
-                                   MESSAGE_TEXTURE_STATIC_TEX_SIZE);
-                DmaMgr_RequestSync(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE + MESSAGE_TEXTURE_STATIC_TEX_SIZE,
-                                   (uintptr_t)_message_texture_staticSegmentRomStart +
-                                       (msgCtx->textboxBackgroundIdx + 1) * MESSAGE_TEXTURE_STATIC_TEX_SIZE,
-                                   MESSAGE_TEXTURE_STATIC_TEX_SIZE);
+                DMA_REQUEST_SYNC(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE,
+                                 (uintptr_t)_message_texture_staticSegmentRomStart +
+                                     msgCtx->textboxBackgroundIdx * MESSAGE_TEXTURE_STATIC_TEX_SIZE,
+                                 MESSAGE_TEXTURE_STATIC_TEX_SIZE, "../z_message_PAL.c", 0);
+                DMA_REQUEST_SYNC(msgCtx->textboxSegment + MESSAGE_STATIC_TEX_SIZE + MESSAGE_TEXTURE_STATIC_TEX_SIZE,
+                                 (uintptr_t)_message_texture_staticSegmentRomStart +
+                                     (msgCtx->textboxBackgroundIdx + 1) * MESSAGE_TEXTURE_STATIC_TEX_SIZE,
+                                 MESSAGE_TEXTURE_STATIC_TEX_SIZE, "../z_message_PAL.c", 0);
                 numLines = 2;
                 msgCtx->msgBufPos += 2;
                 R_TEXTBOX_BG_YPOS = R_TEXTBOX_Y + 8;
@@ -2528,8 +2528,8 @@ void Message_OpenText(PlayState* play, u16 textId) {
         if ((B_80121220 != NULL) && (B_80121220->unk_60 != NULL) && B_80121220->unk_60(&play->msgCtx.font)) {
 
         } else {
-            DmaMgr_RequestSync(font->msgBuf, (uintptr_t)_staff_message_data_staticSegmentRomStart + font->msgOffset,
-                               font->msgLength);
+            DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_staff_message_data_staticSegmentRomStart + font->msgOffset,
+                             font->msgLength, "../z_message_PAL.c", 0);
         }
 #else
         DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_staff_message_data_staticSegmentRomStart + font->msgOffset,
@@ -2544,12 +2544,12 @@ void Message_OpenText(PlayState* play, u16 textId) {
             if ((B_80121220 != NULL) && (B_80121220->unk_64 != NULL) && B_80121220->unk_64(&play->msgCtx.font)) {
 
             } else {
-                DmaMgr_RequestSync(font->msgBuf, (uintptr_t)_jpn_message_data_staticSegmentRomStart + font->msgOffset,
-                                   font->msgLength);
+                DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_jpn_message_data_staticSegmentRomStart + font->msgOffset,
+                                 font->msgLength, "../z_message_PAL.c", 0);
             }
 #else
-            DmaMgr_RequestSync(font->msgBuf, (uintptr_t)_jpn_message_data_staticSegmentRomStart + font->msgOffset,
-                               font->msgLength);
+            DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_jpn_message_data_staticSegmentRomStart + font->msgOffset,
+                             font->msgLength, "../z_message_PAL.c", 0);
 #endif
         } else {
             Message_FindMessageNES(play, textId);
@@ -2558,12 +2558,12 @@ void Message_OpenText(PlayState* play, u16 textId) {
             if ((B_80121220 != NULL) && (B_80121220->unk_68 != NULL) && B_80121220->unk_68(&play->msgCtx.font)) {
 
             } else {
-                DmaMgr_RequestSync(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
-                                   font->msgLength);
+                DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
+                                 font->msgLength, "../z_message_PAL.c", 0);
             }
 #else
-            DmaMgr_RequestSync(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
-                               font->msgLength);
+            DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
+                             font->msgLength, "../z_message_PAL.c", 0);
 #endif
         }
 #else
@@ -2574,8 +2574,8 @@ void Message_OpenText(PlayState* play, u16 textId) {
             if ((B_80121220 != NULL) && (B_80121220->unk_64 != NULL) && B_80121220->unk_64(&play->msgCtx.font)) {
 
             } else {
-                DmaMgr_RequestSync(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
-                                   font->msgLength);
+                DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
+                                 font->msgLength, "../z_message_PAL.c", 0);
             }
 #else
             DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_nes_message_data_staticSegmentRomStart + font->msgOffset,
@@ -2589,8 +2589,8 @@ void Message_OpenText(PlayState* play, u16 textId) {
             if ((B_80121220 != NULL) && (B_80121220->unk_64 != NULL) && B_80121220->unk_68(&play->msgCtx.font)) {
 
             } else {
-                DmaMgr_RequestSync(font->msgBuf, (uintptr_t)_ger_message_data_staticSegmentRomStart + font->msgOffset,
-                                   font->msgLength);
+                DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_ger_message_data_staticSegmentRomStart + font->msgOffset,
+                                 font->msgLength, "../z_message_PAL.c", 0);
             }
 #else
             DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_ger_message_data_staticSegmentRomStart + font->msgOffset,
@@ -2604,8 +2604,8 @@ void Message_OpenText(PlayState* play, u16 textId) {
             if ((B_80121220 != NULL) && (B_80121220->unk_64 != NULL) && B_80121220->unk_6C_PAL(&play->msgCtx.font)) {
 
             } else {
-                DmaMgr_RequestSync(font->msgBuf, (uintptr_t)_fra_message_data_staticSegmentRomStart + font->msgOffset,
-                                   font->msgLength);
+                DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_fra_message_data_staticSegmentRomStart + font->msgOffset,
+                                 font->msgLength, "../z_message_PAL.c", 0);
             }
 #else
             DMA_REQUEST_SYNC(font->msgBuf, (uintptr_t)_fra_message_data_staticSegmentRomStart + font->msgOffset,

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -1505,7 +1505,7 @@ void* Play_LoadFileFromDiskDrive(PlayState* this, RomFile* file) {
     void* allocp;
 
     size = file->vromEnd - file->vromStart;
-    allocp = THA_AllocTailAlign16(&this->state.tha, size);
+    allocp = GAME_STATE_ALLOC(&this->state, size, "../z_play.c", 0);
     func_801C7C1C(allocp, file->vromStart, size);
 
     return allocp;

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -1505,7 +1505,7 @@ void* Play_LoadFileFromDiskDrive(PlayState* this, RomFile* file) {
     void* allocp;
 
     size = file->vromEnd - file->vromStart;
-    allocp = GAME_STATE_ALLOC(&this->state, size, "../z_play.c", 0);
+    allocp = GAME_STATE_ALLOC(&this->state, size, "../z_play.c", UNK_LINE);
     func_801C7C1C(allocp, file->vromStart, size);
 
     return allocp;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -163,7 +163,7 @@ void FileSelect_DrawImageRGBA32(GraphicsContext* gfxCtx, s16 centerX, s16 center
     s32 pad;
     s32 i;
 
-    OPEN_DISPS(gfxCtx, "../z_file_choose.c", 0);
+    OPEN_DISPS(gfxCtx, "../z_file_choose.c", UNK_LINE);
 
     Gfx_SetupDL_56Opa(gfxCtx);
 
@@ -210,7 +210,7 @@ void FileSelect_DrawImageRGBA32(GraphicsContext* gfxCtx, s16 centerX, s16 center
         }
     }
 
-    CLOSE_DISPS(gfxCtx, "../z_file_choose.c", 0);
+    CLOSE_DISPS(gfxCtx, "../z_file_choose.c", UNK_LINE);
 }
 
 void FileSelect_DrawInitialLanguageMenu(FileSelectState* this) {
@@ -219,7 +219,7 @@ void FileSelect_DrawInitialLanguageMenu(FileSelectState* this) {
     s32 y1;
     s32 y2;
 
-    OPEN_DISPS(this->state.gfxCtx, "../z_file_choose.c", 0);
+    OPEN_DISPS(this->state.gfxCtx, "../z_file_choose.c", UNK_LINE);
 
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 70 + WREG(0));
     FileSelect_DrawImageRGBA32(this->state.gfxCtx, 160, 85 + WREG(1), (u8*)gTitleZeldaShieldLogoTex, 160, 160);
@@ -294,7 +294,7 @@ void FileSelect_DrawInitialLanguageMenu(FileSelectState* this) {
         y1 = y2;
     }
 
-    CLOSE_DISPS(this->state.gfxCtx, "../z_file_choose.c", 0);
+    CLOSE_DISPS(this->state.gfxCtx, "../z_file_choose.c", UNK_LINE);
 }
 #endif
 
@@ -2334,8 +2334,8 @@ void FileSelect_Init(GameState* thisx) {
 
 #if OOT_PAL_N64
     size = gObjectTable[OBJECT_MAG].vromEnd - gObjectTable[OBJECT_MAG].vromStart;
-    this->objectMagSegment = GAME_STATE_ALLOC(&this->state, size, "../z_file_choose.c", 0);
-    DMA_REQUEST_SYNC(this->objectMagSegment, gObjectTable[OBJECT_MAG].vromStart, size, "../z_file_choose.c", 0);
+    this->objectMagSegment = GAME_STATE_ALLOC(&this->state, size, "../z_file_choose.c", UNK_LINE);
+    DMA_REQUEST_SYNC(this->objectMagSegment, gObjectTable[OBJECT_MAG].vromStart, size, "../z_file_choose.c", UNK_LINE);
 #endif
 
     Matrix_Init(&this->state);

--- a/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
@@ -16,7 +16,7 @@ void FileSelect_DrawCharacter(GraphicsContext* gfxCtx, void* texture, s16 vtx) {
 
 #if OOT_NTSC
 void FileSelect_DrawCharacterTransition(GraphicsContext* gfxCtx, void* texture1, void* texture2, s16 vtx) {
-    OPEN_DISPS(gfxCtx, "../z_file_nameset_PAL.c", 0);
+    OPEN_DISPS(gfxCtx, "../z_file_nameset_PAL.c", UNK_LINE);
 
     gDPLoadTextureBlock_4b(POLY_OPA_DISP++, texture1, G_IM_FMT_I, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
@@ -24,7 +24,7 @@ void FileSelect_DrawCharacterTransition(GraphicsContext* gfxCtx, void* texture1,
                          G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
     gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
 
-    CLOSE_DISPS(gfxCtx, "../z_file_nameset_PAL.c", 0);
+    CLOSE_DISPS(gfxCtx, "../z_file_nameset_PAL.c", UNK_LINE);
 }
 #endif
 
@@ -1877,7 +1877,7 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
 #if OOT_PAL_N64
     Matrix_Push();
     Matrix_Translate(0.0f, 0.8f, 0.0f, MTXMODE_APPLY);
-    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, this->state.gfxCtx, "../z_file_nameset_PAL.c", 0);
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, this->state.gfxCtx, "../z_file_nameset_PAL.c", UNK_LINE);
     gSPVertex(POLY_OPA_DISP++, gOptionsDividerLanguageVtx, 4, 0);
     gSP1Quadrangle(POLY_OPA_DISP++, 0, 2, 3, 1, 0);
     Matrix_Pop();

--- a/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
@@ -16,7 +16,7 @@ void FileSelect_DrawCharacter(GraphicsContext* gfxCtx, void* texture, s16 vtx) {
 
 #if OOT_NTSC
 void FileSelect_DrawCharacterTransition(GraphicsContext* gfxCtx, void* texture1, void* texture2, s16 vtx) {
-    OPEN_DISPS(gfxCtx, "", 0);
+    OPEN_DISPS(gfxCtx, "../z_file_nameset_PAL.c", 0);
 
     gDPLoadTextureBlock_4b(POLY_OPA_DISP++, texture1, G_IM_FMT_I, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
@@ -24,7 +24,7 @@ void FileSelect_DrawCharacterTransition(GraphicsContext* gfxCtx, void* texture1,
                          G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
     gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
 
-    CLOSE_DISPS(gfxCtx, "", 0);
+    CLOSE_DISPS(gfxCtx, "../z_file_nameset_PAL.c", 0);
 }
 #endif
 

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -3697,11 +3697,11 @@ void KaleidoScope_Update(PlayState* play) {
             if (gSaveContext.language == LANGUAGE_JPN) {
                 size = (uintptr_t)_icon_item_jpn_staticSegmentRomEnd - (uintptr_t)_icon_item_jpn_staticSegmentRomStart;
                 DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_jpn_staticSegmentRomStart, size,
-                                 "../z_kaleido_scope_PAL.c", 0);
+                                 "../z_kaleido_scope_PAL.c", UNK_LINE);
             } else {
                 size = (uintptr_t)_icon_item_nes_staticSegmentRomEnd - (uintptr_t)_icon_item_nes_staticSegmentRomStart;
                 DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_nes_staticSegmentRomStart, size,
-                                 "../z_kaleido_scope_PAL.c", 0);
+                                 "../z_kaleido_scope_PAL.c", UNK_LINE);
             }
 #else
             if (gSaveContext.language == LANGUAGE_ENG) {
@@ -3736,13 +3736,13 @@ void KaleidoScope_Update(PlayState* play) {
                                      (uintptr_t)_map_name_staticSegmentRomStart +
                                          (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
                                          24 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_JPN * MAP_NAME_TEX2_SIZE,
-                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 0);
+                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", UNK_LINE);
                 } else {
                     DMA_REQUEST_SYNC(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
                                      (uintptr_t)_map_name_staticSegmentRomStart +
                                          (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
                                          24 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_ENG * MAP_NAME_TEX2_SIZE,
-                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 0);
+                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", UNK_LINE);
                 }
 #else
                 if (gSaveContext.language == LANGUAGE_ENG) {
@@ -4294,11 +4294,11 @@ void KaleidoScope_Update(PlayState* play) {
             if (gSaveContext.language == LANGUAGE_JPN) {
                 size = (uintptr_t)_icon_item_jpn_staticSegmentRomEnd - (uintptr_t)_icon_item_jpn_staticSegmentRomStart;
                 DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_jpn_staticSegmentRomStart, size,
-                                 "../z_kaleido_scope_PAL.c", 0);
+                                 "../z_kaleido_scope_PAL.c", UNK_LINE);
             } else {
                 size = (uintptr_t)_icon_item_nes_staticSegmentRomEnd - (uintptr_t)_icon_item_nes_staticSegmentRomStart;
                 DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_nes_staticSegmentRomStart, size,
-                                 "../z_kaleido_scope_PAL.c", 0);
+                                 "../z_kaleido_scope_PAL.c", UNK_LINE);
             }
 #else
             if (gSaveContext.language == LANGUAGE_ENG) {

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -3696,12 +3696,12 @@ void KaleidoScope_Update(PlayState* play) {
 #if OOT_NTSC
             if (gSaveContext.language == LANGUAGE_JPN) {
                 size = (uintptr_t)_icon_item_jpn_staticSegmentRomEnd - (uintptr_t)_icon_item_jpn_staticSegmentRomStart;
-                DmaMgr_RequestSync(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_jpn_staticSegmentRomStart,
-                                   size);
+                DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_jpn_staticSegmentRomStart, size,
+                                 "../z_kaleido_scope_PAL.c", 0);
             } else {
                 size = (uintptr_t)_icon_item_nes_staticSegmentRomEnd - (uintptr_t)_icon_item_nes_staticSegmentRomStart;
-                DmaMgr_RequestSync(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_nes_staticSegmentRomStart,
-                                   size);
+                DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_nes_staticSegmentRomStart, size,
+                                 "../z_kaleido_scope_PAL.c", 0);
             }
 #else
             if (gSaveContext.language == LANGUAGE_ENG) {
@@ -3732,17 +3732,17 @@ void KaleidoScope_Update(PlayState* play) {
             if (((void)0, gSaveContext.worldMapArea) < WORLD_MAP_AREA_MAX) {
 #if OOT_NTSC
                 if (gSaveContext.language == LANGUAGE_JPN) {
-                    DmaMgr_RequestSync(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
-                                       (uintptr_t)_map_name_staticSegmentRomStart +
-                                           (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
-                                           24 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_JPN * MAP_NAME_TEX2_SIZE,
-                                       MAP_NAME_TEX2_SIZE);
+                    DMA_REQUEST_SYNC(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
+                                     (uintptr_t)_map_name_staticSegmentRomStart +
+                                         (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
+                                         24 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_JPN * MAP_NAME_TEX2_SIZE,
+                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 0);
                 } else {
-                    DmaMgr_RequestSync(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
-                                       (uintptr_t)_map_name_staticSegmentRomStart +
-                                           (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
-                                           24 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_ENG * MAP_NAME_TEX2_SIZE,
-                                       MAP_NAME_TEX2_SIZE);
+                    DMA_REQUEST_SYNC(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
+                                     (uintptr_t)_map_name_staticSegmentRomStart +
+                                         (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
+                                         24 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_ENG * MAP_NAME_TEX2_SIZE,
+                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 0);
                 }
 #else
                 if (gSaveContext.language == LANGUAGE_ENG) {
@@ -4293,12 +4293,12 @@ void KaleidoScope_Update(PlayState* play) {
 #if OOT_NTSC
             if (gSaveContext.language == LANGUAGE_JPN) {
                 size = (uintptr_t)_icon_item_jpn_staticSegmentRomEnd - (uintptr_t)_icon_item_jpn_staticSegmentRomStart;
-                DmaMgr_RequestSync(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_jpn_staticSegmentRomStart,
-                                   size);
+                DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_jpn_staticSegmentRomStart, size,
+                                 "../z_kaleido_scope_PAL.c", 0);
             } else {
                 size = (uintptr_t)_icon_item_nes_staticSegmentRomEnd - (uintptr_t)_icon_item_nes_staticSegmentRomStart;
-                DmaMgr_RequestSync(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_nes_staticSegmentRomStart,
-                                   size);
+                DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_nes_staticSegmentRomStart, size,
+                                 "../z_kaleido_scope_PAL.c", 0);
             }
 #else
             if (gSaveContext.language == LANGUAGE_ENG) {


### PR DESCRIPTION
After #2296 building N64 ROMs with debug features will be supported, so it would be nice to use e.g. DMA_REQUEST_SYNC instead of DmaMgr_RequestSync everywhere so things are consistent. For the filename, I used whatever filename the existing debug macros used (except for code_n64dd_800AD410.c which we don't know). For unknown file names or line numbers, I used macros `UNK_FILE` and `UNK_LINE` which expand to `"<unknown>"` and `0` respectively.