### PR TITLE
Player Docs: Begin "Start Mode" Documentation

### DIFF
--- a/include/z64player.h
+++ b/include/z64player.h
@@ -7,6 +7,28 @@
 
 struct Player;
 
+#define PLAYER_GET_START_MODE(thisx) PARAMS_GET_S(thisx->params, 8, 4)
+
+typedef enum PlayerStartMode {
+    /*  0 */ PLAYER_START_MODE_0,
+    /*  1 */ PLAYER_START_MODE_1,
+    /*  2 */ PLAYER_START_MODE_2,
+    /*  3 */ PLAYER_START_MODE_3,
+    /*  4 */ PLAYER_START_MODE_4,
+    /*  5 */ PLAYER_START_MODE_5,
+    /*  6 */ PLAYER_START_MODE_6,
+    /*  7 */ PLAYER_START_MODE_7,
+    /*  8 */ PLAYER_START_MODE_8,
+    /*  9 */ PLAYER_START_MODE_9,
+    /* 10 */ PLAYER_START_MODE_10,
+    /* 11 */ PLAYER_START_MODE_11,
+    /* 12 */ PLAYER_START_MODE_12,
+    /* 13 */ PLAYER_START_MODE_13,
+    /* 14 */ PLAYER_START_MODE_14,
+    /* 15 */ PLAYER_START_MODE_15,
+    /* 16 */ PLAYER_START_MODE_MAX
+} PlayerStartMode;
+
 typedef enum PlayerSword {
     /* 0 */ PLAYER_SWORD_NONE,
     /* 1 */ PLAYER_SWORD_KOKIRI,

--- a/include/z64player.h
+++ b/include/z64player.h
@@ -18,11 +18,11 @@ typedef enum PlayerStartMode {
     /*  5 */ PLAYER_START_MODE_5,
     /*  6 */ PLAYER_START_MODE_6,
     /*  7 */ PLAYER_START_MODE_7,
-    /*  8 */ PLAYER_START_MODE_8,
-    /*  9 */ PLAYER_START_MODE_9,
-    /* 10 */ PLAYER_START_MODE_10,
-    /* 11 */ PLAYER_START_MODE_11,
-    /* 12 */ PLAYER_START_MODE_12,
+    /*  8 */ PLAYER_START_MODE_UNUSED_8,  // Unused, behaves the same as PLAYER_START_MODE_14
+    /*  9 */ PLAYER_START_MODE_UNUSED_9,  // Unused, behaves the same as PLAYER_START_MODE_14
+    /* 10 */ PLAYER_START_MODE_UNUSED_10, // Unused, behaves the same as PLAYER_START_MODE_14
+    /* 11 */ PLAYER_START_MODE_UNUSED_11, // Unused, behaves the same as PLAYER_START_MODE_14
+    /* 12 */ PLAYER_START_MODE_UNUSED_12, // Unused, behaves the same as PLAYER_START_MODE_14
     /* 13 */ PLAYER_START_MODE_13,
     /* 14 */ PLAYER_START_MODE_14,
     /* 15 */ PLAYER_START_MODE_15,

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -27,7 +27,7 @@
 #endif
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ntsc-1.2:92 pal-1.0:90 pal-1.1:90"
+                               "ntsc-1.2:88 pal-1.0:86 pal-1.1:86"
 
 StackEntry sDmaMgrStackInfo;
 OSMesgQueue sDmaMgrMsgQueue;

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -1,6 +1,6 @@
 #if PLATFORM_N64
 
-#pragma increment_block_number "ntsc-1.0:0 ntsc-1.1:0 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
+#pragma increment_block_number "ntsc-1.0:0 ntsc-1.1:0 ntsc-1.2:0 pal-1.0:0 pal-1.1:0"
 
 #include "global.h"
 #include "fault.h"
@@ -8,7 +8,7 @@
 #include "stack.h"
 #include "terminal.h"
 
-#pragma increment_block_number "ntsc-1.0:192 ntsc-1.1:192 ntsc-1.2:96 pal-1.0:96 pal-1.1:96"
+#pragma increment_block_number "ntsc-1.0:192 ntsc-1.1:192 ntsc-1.2:192 pal-1.0:192 pal-1.1:192"
 
 typedef struct FaultMgr {
     OSThread thread;

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -8,7 +8,7 @@
 #define GFXPOOL_TAIL_MAGIC 0x5678
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ntsc-1.0:192 ntsc-1.1:192 ntsc-1.2:192 pal-1.0:192 pal-1.1:192"
+                               "ntsc-1.0:160 ntsc-1.1:160 ntsc-1.2:160 pal-1.0:160 pal-1.1:160"
 
 /**
  * The time at which the previous `Graph_Update` ended.

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -24,7 +24,7 @@ extern struct IrqMgr gIrqMgr;
 #endif
 
 #pragma increment_block_number "gc-eu:160 gc-eu-mq:160 gc-jp:160 gc-jp-ce:160 gc-jp-mq:160 gc-us:160 gc-us-mq:160" \
-                               "ntsc-1.0:151 ntsc-1.1:151 ntsc-1.2:151 pal-1.0:149 pal-1.1:149"
+                               "ntsc-1.0:148 ntsc-1.1:148 ntsc-1.2:148 pal-1.0:146 pal-1.1:146"
 
 extern u8 _buffersSegmentEnd[];
 

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -3639,7 +3639,7 @@ s32 Camera_KeepOn3(Camera* camera) {
 }
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ntsc-1.0:93 ntsc-1.1:93 ntsc-1.2:93 pal-1.0:91 pal-1.1:91"
+                               "ntsc-1.0:90 ntsc-1.1:90 ntsc-1.2:90 pal-1.0:88 pal-1.1:88"
 
 s32 Camera_KeepOn4(Camera* camera) {
     static Vec3f D_8015BD50;

--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -124,7 +124,7 @@ u16 gCamAtSplinePointsAppliedFrame;
 u16 gCamEyePointAppliedFrame;
 u16 gCamAtPointAppliedFrame;
 
-#pragma increment_block_number "gc-eu:188 gc-eu-mq:176 gc-jp:188 gc-jp-ce:188 gc-jp-mq:176 gc-us:188 gc-us-mq:176" \
+#pragma increment_block_number "gc-eu:186 gc-eu-mq:176 gc-jp:188 gc-jp-ce:188 gc-jp-mq:176 gc-us:188 gc-us-mq:176" \
                                "ntsc-1.0:80 ntsc-1.1:80 ntsc-1.2:80 pal-1.0:80 pal-1.1:80"
 
 // Cam ID to return to when a scripted cutscene is finished

--- a/src/code/z_kankyo.c
+++ b/src/code/z_kankyo.c
@@ -1,5 +1,5 @@
 #pragma increment_block_number "gc-eu:244 gc-eu-mq:244 gc-jp:224 gc-jp-ce:224 gc-jp-mq:224 gc-us:224 gc-us-mq:224" \
-                               "ntsc-1.0:224 ntsc-1.1:224 ntsc-1.2:224 pal-1.0:252 pal-1.1:252"
+                               "ntsc-1.0:224 ntsc-1.1:224 ntsc-1.2:224 pal-1.0:248 pal-1.1:248"
 
 #include "global.h"
 #include "ultra64.h"

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -35,7 +35,7 @@
 #include "cic6105.h"
 #endif
 
-#pragma increment_block_number "gc-eu:180 gc-eu-mq:180 gc-jp:180 gc-jp-ce:180 gc-jp-mq:180 gc-us:180 gc-us-mq:180" \
+#pragma increment_block_number "gc-eu:177 gc-eu-mq:177 gc-jp:177 gc-jp-ce:177 gc-jp-mq:177 gc-us:177 gc-us-mq:177" \
                                "ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
 
 #define FLAGS ACTOR_FLAG_4

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -153,17 +153,17 @@ s32 func_80835C08(Player* this, PlayState* play);
 void Player_UseItem(PlayState* play, Player* this, s32 item);
 void func_80839F90(Player* this, PlayState* play);
 s32 func_8083C61C(PlayState* play, Player* this);
-void func_8083CA20(PlayState* play, Player* this);
-void func_8083CA54(PlayState* play, Player* this);
-void func_8083CA9C(PlayState* play, Player* this);
-void func_80846648(PlayState* play, Player* this);
-void func_80846660(PlayState* play, Player* this);
-void func_808467D4(PlayState* play, Player* this);
-void func_808468A8(PlayState* play, Player* this);
-void func_808468E8(PlayState* play, Player* this);
-void func_80846978(PlayState* play, Player* this);
-void func_808469BC(PlayState* play, Player* this);
-void func_80846A68(PlayState* play, Player* this);
+void Player_StartMode13(PlayState* play, Player* this);
+void Player_StartModeUnk(PlayState* play, Player* this);
+void Player_StartMode15(PlayState* play, Player* this);
+void Player_StartMode0(PlayState* play, Player* this);
+void Player_StartMode2(PlayState* play, Player* this);
+void Player_StartMode1(PlayState* play, Player* this);
+void Player_StartMode3(PlayState* play, Player* this);
+void Player_StartMode4(PlayState* play, Player* this);
+void Player_StartMode7(PlayState* play, Player* this);
+void Player_StartMode5(PlayState* play, Player* this);
+void Player_StartMode6(PlayState* play, Player* this);
 void Player_UpdateCommon(Player* this, PlayState* play, Input* input);
 void func_8084FF7C(Player* this);
 void Player_UpdateBunnyEars(Player* this);
@@ -6682,13 +6682,13 @@ s32 func_8083C910(PlayState* play, Player* this, f32 arg2) {
     return 1;
 }
 
-void func_8083CA20(PlayState* play, Player* this) {
+void Player_StartMode13(PlayState* play, Player* this) {
     if (func_8083C910(play, this, 180.0f)) {
         this->av2.actionVar2 = -20;
     }
 }
 
-void func_8083CA54(PlayState* play, Player* this) {
+void Player_StartModeUnk(PlayState* play, Player* this) {
     this->speedXZ = 2.0f;
     gSaveContext.entranceSpeed = 2.0f;
     if (func_8083C910(play, this, 120.0f)) {
@@ -6696,7 +6696,7 @@ void func_8083CA54(PlayState* play, Player* this) {
     }
 }
 
-void func_8083CA9C(PlayState* play, Player* this) {
+void Player_StartMode15(PlayState* play, Player* this) {
     if (gSaveContext.entranceSpeed < 0.1f) {
         gSaveContext.entranceSpeed = 0.1f;
     }
@@ -10504,12 +10504,12 @@ static ColliderQuadInit D_808546A0 = {
 void func_8084663C(Actor* thisx, PlayState* play) {
 }
 
-void func_80846648(PlayState* play, Player* this) {
+void Player_StartMode0(PlayState* play, Player* this) {
     this->actor.update = func_8084663C;
     this->actor.draw = NULL;
 }
 
-void func_80846660(PlayState* play, Player* this) {
+void Player_StartMode2(PlayState* play, Player* this) {
     Player_SetupAction(play, this, Player_Action_8084F710, 0);
     if ((play->sceneId == SCENE_LAKE_HYLIA) && IS_CUTSCENE_LAYER) {
         this->av1.actionVar1 = 1;
@@ -10542,7 +10542,7 @@ void func_80846720(PlayState* play, Player* this, s32 arg2) {
 
 static Vec3f D_808546F4 = { -1.0f, 69.0f, 20.0f };
 
-void func_808467D4(PlayState* play, Player* this) {
+void Player_StartMode1(PlayState* play, Player* this) {
     Player_SetupAction(play, this, Player_Action_8084E9AC, 0);
     this->stateFlags1 |= PLAYER_STATE1_29;
     Math_Vec3f_Copy(&this->actor.world.pos, &D_808546F4);
@@ -10559,14 +10559,14 @@ void func_808467D4(PlayState* play, Player* this) {
     this->av2.actionVar2 = 20;
 }
 
-void func_808468A8(PlayState* play, Player* this) {
+void Player_StartMode3(PlayState* play, Player* this) {
     Player_SetupAction(play, this, Player_Action_8084F9A0, 0);
     Player_StartAnimMovement(play, this,
                              ANIM_FLAG_UPDATE_XZ | ANIM_FLAG_UPDATE_Y | ANIM_FLAG_ENABLE_MOVEMENT |
                                  ANIM_FLAG_ADJUST_STARTING_POS | ANIM_FLAG_OVERRIDE_MOVEMENT);
 }
 
-void func_808468E8(PlayState* play, Player* this) {
+void Player_StartMode4(PlayState* play, Player* this) {
     func_808389E8(this, &gPlayerAnim_link_normal_jump, 12.0f, play);
     Player_SetupAction(play, this, Player_Action_8084F9C0, 0);
     this->stateFlags1 |= PLAYER_STATE1_29;
@@ -10574,11 +10574,11 @@ void func_808468E8(PlayState* play, Player* this) {
     OnePointCutscene_Init(play, 5110, 40, &this->actor, CAM_ID_MAIN);
 }
 
-void func_80846978(PlayState* play, Player* this) {
+void Player_StartMode7(PlayState* play, Player* this) {
     func_80837C0C(play, this, PLAYER_HIT_RESPONSE_KNOCKBACK_LARGE, 2.0f, 2.0f, this->actor.shape.rot.y + 0x8000, 0);
 }
 
-void func_808469BC(PlayState* play, Player* this) {
+void Player_StartMode5(PlayState* play, Player* this) {
     Player_SetupAction(play, this, Player_Action_8084F698, 0);
     this->actor.draw = NULL;
     this->stateFlags1 |= PLAYER_STATE1_29;
@@ -10591,7 +10591,7 @@ Actor* Player_SpawnMagicSpell(PlayState* play, Player* this, s32 spell) {
                        this->actor.world.pos.y, this->actor.world.pos.z, 0, 0, 0, 0);
 }
 
-void func_80846A68(PlayState* play, Player* this) {
+void Player_StartMode6(PlayState* play, Player* this) {
     this->actor.draw = NULL;
     Player_SetupAction(play, this, Player_Action_8085076C, 0);
     this->stateFlags1 |= PLAYER_STATE1_29;
@@ -10636,33 +10636,31 @@ void Player_InitCommon(Player* this, PlayState* play, FlexSkeletonHeader* skelHe
     Collider_SetQuad(play, &this->shieldQuad, &this->actor, &D_808546A0);
 }
 
-static void (*D_80854738[])(PlayState* play, Player* this) = {
-    /* 0x0 */ func_80846648,
-    /* 0x1 */ func_808467D4, // From time travel
-    /* 0x2 */ func_80846660,
-    /* 0x3 */ func_808468A8,
-    /* 0x4 */ func_808468E8,
-    /* 0x5 */ func_808469BC,
-    /* 0x6 */ func_80846A68,
-    /* 0x7 */ func_80846978,
-    /* 0x8 */ func_8083CA54,
-    /* 0x9 */ func_8083CA54,
-    /* 0xA */ func_8083CA54,
-    /* 0xB */ func_8083CA54,
-    /* 0xC */ func_8083CA54,
-    /* 0xD */ func_8083CA20,
-    /* 0xE */ func_8083CA54,
-    /* 0xF */ func_8083CA9C,
+static void (*sStartModeFuncs[PLAYER_START_MODE_MAX])(PlayState* play, Player* this) = {
+    Player_StartMode0,   // PLAYER_START_MODE_0
+    Player_StartMode1,   // PLAYER_START_MODE_1
+    Player_StartMode2,   // PLAYER_START_MODE_2
+    Player_StartMode3,   // PLAYER_START_MODE_3
+    Player_StartMode4,   // PLAYER_START_MODE_4
+    Player_StartMode5,   // PLAYER_START_MODE_5
+    Player_StartMode6,   // PLAYER_START_MODE_6
+    Player_StartMode7,   // PLAYER_START_MODE_7
+    Player_StartModeUnk, // PLAYER_START_MODE_8
+    Player_StartModeUnk, // PLAYER_START_MODE_9
+    Player_StartModeUnk, // PLAYER_START_MODE_10
+    Player_StartModeUnk, // PLAYER_START_MODE_11
+    Player_StartModeUnk, // PLAYER_START_MODE_12
+    Player_StartMode13,  // PLAYER_START_MODE_13
+    Player_StartModeUnk, // PLAYER_START_MODE_14
+    Player_StartMode15,  // PLAYER_START_MODE_15
 };
-
-static Vec3f D_80854778 = { 0.0f, 50.0f, 0.0f };
 
 void Player_Init(Actor* thisx, PlayState* play2) {
     Player* this = (Player*)thisx;
     PlayState* play = play2;
     SceneTableEntry* scene = play->loadedScene;
     u32 titleFileSize;
-    s32 initMode;
+    s32 startMode;
     s32 respawnFlag;
     s32 respawnMode;
 
@@ -10684,9 +10682,12 @@ void Player_Init(Actor* thisx, PlayState* play2) {
     this->heldItemId = ITEM_NONE;
 
     Player_UseItem(play, this, ITEM_NONE);
+
     Player_SetEquipmentData(play, this);
     this->prevBoots = this->currentBoots;
+
     Player_InitCommon(this, play, gPlayerSkelHeaders[((void)0, gSaveContext.save.linkAge)]);
+
     // `giObjectSegment` is used for both "get item" objects and title cards. The maximum size for
     // get item objects is 0x2000 (see the assert in func_8083AE40), and the maximum size for
     // title cards is 0x1000 * LANGUAGE_MAX since each title card image includes all languages.
@@ -10722,6 +10723,7 @@ void Player_Init(Actor* thisx, PlayState* play2) {
 
     if ((respawnFlag == 0) || (respawnFlag < -1)) {
         titleFileSize = scene->titleFile.vromEnd - scene->titleFile.vromStart;
+
         if ((titleFileSize != 0) && gSaveContext.showTitleCard) {
             if (!IS_CUTSCENE_LAYER &&
                 (gEntranceTable[((void)0, gSaveContext.save.entranceIndex) + ((void)0, gSaveContext.sceneLayer)].field &
@@ -10736,6 +10738,7 @@ void Player_Init(Actor* thisx, PlayState* play2) {
                 TitleCard_InitPlaceName(play, &play->actorCtx.titleCtx, this->giObjectSegment, 160, 120, 144, 24, 20);
             }
         }
+
         gSaveContext.showTitleCard = true;
     }
 
@@ -10749,18 +10752,22 @@ void Player_Init(Actor* thisx, PlayState* play2) {
         gSaveContext.save.info.infTable[INFTABLE_1AX_INDEX] |= gBitFlags[play->sceneId];
     }
 
-    initMode = PARAMS_GET_S(thisx->params, 8, 4);
-    if ((initMode == 5) || (initMode == 6)) {
+    startMode = PLAYER_GET_START_MODE(thisx);
+
+    if ((startMode == PLAYER_START_MODE_5) || (startMode == PLAYER_START_MODE_6)) {
         if (gSaveContext.save.cutsceneIndex >= 0xFFF0) {
-            initMode = 13;
+            startMode = PLAYER_START_MODE_13;
         }
     }
 
-    D_80854738[initMode](play, this);
+    sStartModeFuncs[startMode](play, this);
 
-    if (initMode != 0) {
+    if (startMode != PLAYER_START_MODE_0) {
         if ((gSaveContext.gameMode == GAMEMODE_NORMAL) || (gSaveContext.gameMode == GAMEMODE_END_CREDITS)) {
-            this->naviActor = Player_SpawnFairy(play, this, &thisx->world.pos, &D_80854778, FAIRY_NAVI);
+            static Vec3f sNaviSpawnPosOffset = { 0.0f, 50.0f, 0.0f };
+
+            this->naviActor = Player_SpawnFairy(play, this, &thisx->world.pos, &sNaviSpawnPosOffset, FAIRY_NAVI);
+
             if (gSaveContext.dogParams != 0) {
                 gSaveContext.dogParams |= 0x8000;
             }

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -154,7 +154,7 @@ void Player_UseItem(PlayState* play, Player* this, s32 item);
 void func_80839F90(Player* this, PlayState* play);
 s32 func_8083C61C(PlayState* play, Player* this);
 void Player_StartMode13(PlayState* play, Player* this);
-void Player_StartModeUnk(PlayState* play, Player* this);
+void Player_StartMode14(PlayState* play, Player* this);
 void Player_StartMode15(PlayState* play, Player* this);
 void Player_StartMode0(PlayState* play, Player* this);
 void Player_StartMode2(PlayState* play, Player* this);
@@ -6688,7 +6688,7 @@ void Player_StartMode13(PlayState* play, Player* this) {
     }
 }
 
-void Player_StartModeUnk(PlayState* play, Player* this) {
+void Player_StartMode14(PlayState* play, Player* this) {
     this->speedXZ = 2.0f;
     gSaveContext.entranceSpeed = 2.0f;
     if (func_8083C910(play, this, 120.0f)) {
@@ -10637,22 +10637,22 @@ void Player_InitCommon(Player* this, PlayState* play, FlexSkeletonHeader* skelHe
 }
 
 static void (*sStartModeFuncs[PLAYER_START_MODE_MAX])(PlayState* play, Player* this) = {
-    Player_StartMode0,   // PLAYER_START_MODE_0
-    Player_StartMode1,   // PLAYER_START_MODE_1
-    Player_StartMode2,   // PLAYER_START_MODE_2
-    Player_StartMode3,   // PLAYER_START_MODE_3
-    Player_StartMode4,   // PLAYER_START_MODE_4
-    Player_StartMode5,   // PLAYER_START_MODE_5
-    Player_StartMode6,   // PLAYER_START_MODE_6
-    Player_StartMode7,   // PLAYER_START_MODE_7
-    Player_StartModeUnk, // PLAYER_START_MODE_8
-    Player_StartModeUnk, // PLAYER_START_MODE_9
-    Player_StartModeUnk, // PLAYER_START_MODE_10
-    Player_StartModeUnk, // PLAYER_START_MODE_11
-    Player_StartModeUnk, // PLAYER_START_MODE_12
-    Player_StartMode13,  // PLAYER_START_MODE_13
-    Player_StartModeUnk, // PLAYER_START_MODE_14
-    Player_StartMode15,  // PLAYER_START_MODE_15
+    Player_StartMode0,  // PLAYER_START_MODE_0
+    Player_StartMode1,  // PLAYER_START_MODE_1
+    Player_StartMode2,  // PLAYER_START_MODE_2
+    Player_StartMode3,  // PLAYER_START_MODE_3
+    Player_StartMode4,  // PLAYER_START_MODE_4
+    Player_StartMode5,  // PLAYER_START_MODE_5
+    Player_StartMode6,  // PLAYER_START_MODE_6
+    Player_StartMode7,  // PLAYER_START_MODE_7
+    Player_StartMode14, // PLAYER_START_MODE_UNUSED_8
+    Player_StartMode14, // PLAYER_START_MODE_UNUSED_9
+    Player_StartMode14, // PLAYER_START_MODE_UNUSED_10
+    Player_StartMode14, // PLAYER_START_MODE_UNUSED_11
+    Player_StartMode14, // PLAYER_START_MODE_UNUSED_12
+    Player_StartMode13, // PLAYER_START_MODE_13
+    Player_StartMode14, // PLAYER_START_MODE_14
+    Player_StartMode15, // PLAYER_START_MODE_15
 };
 
 void Player_Init(Actor* thisx, PlayState* play2) {


### PR DESCRIPTION
Currently this is called "init mode".
We know the canonical name for this is "start mode" from later zelda games, this function is from Wind Waker:
`int getStartMode() { return (fopAcM_GetParam(this) >> 0x0C) & 0xF; }`

I think its fine as a name and helps with cross game symmetry, so why not. I also like it a bit more over "init" which sounds more mechanical and less about links behavior.

I'll start documenting each mode after this PR.