### PR TITLE
Add a PARAMS_PACK macro for building actor params setters

### DIFF
--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -742,6 +742,10 @@ typedef struct NpcInteractInfo {
 #define PARAMS_GET_NOSHIFT(p, s, n) \
     ((p) & (NBITS_TO_MASK(n) << (s)))
 
+// Moves the `n`-bit value `p` to bit position `s` for building actor parameters by OR-ing these together
+#define PARAMS_PACK(p, s, n) \
+    (((p) & NBITS_TO_MASK(n)) << (s))
+
 // Generates a bitmask for bit position `s` of length `n`
 #define PARAMS_MAKE_MASK(s, n) PARAMS_GET_NOSHIFT(~0, s, n)
 


### PR DESCRIPTION
This PR adds a macro `PARAMS_PACK` for use in building per-actor params setter macros.

For example with player params:
`#define PLAYER_PARAMS(startBgCamIndex, startMode) (PARAMS_PACK(startBgCamIndex, 0, 8) | PARAMS_PACK(startMode, 8, 4))`

This is advantageous as it is symmetric with params getters, the bit position and bit width args are the same between both:
```c
#define PLAYER_GET_START_MODE(thisx)         PARAMS_GET_S(thisx->params, 0, 8)
#define PLAYER_GET_START_BG_CAM_INDEX(thisx) PARAMS_GET_S(thisx->params, 8, 4)

#define PLAYER_PARAMS(startBgCamIndex, startMode) (PARAMS_PACK(startBgCamIndex, 0, 8) | PARAMS_PACK(startMode, 8, 4))
```
