### PR TITLE
Document time-specific textures for Deku Tree and Gerudo Fortress similar to other scenes

### DIFF
--- a/assets/xml/scenes/dungeons/ydan.xml
+++ b/assets/xml/scenes/dungeons/ydan.xml
@@ -1,8 +1,8 @@
 <Root>
     <File Name="ydan_scene" Segment="2">
         <Cutscene Name="gDekuTreeIntroCs" Offset="0xB640"/>
-        <Texture Name="gYdanTex_00BA18" Format="rgba16" Width="32" Height="64" Offset="0xBA08"/>
-        <Texture Name="gYdanTex_00CA18" Format="rgba16" Width="32" Height="64" Offset="0xCA08"/>
+        <Texture Name="gDekuTreeDayEntranceTex" Format="rgba16" Width="32" Height="64" Offset="0xBA08"/>
+        <Texture Name="gDekuTreeNightEntranceTex" Format="rgba16" Width="32" Height="64" Offset="0xCA08"/>
 
         <Scene Name="ydan_scene" Offset="0x0"/>
     </File>

--- a/assets/xml/scenes/dungeons/ydan_mq.xml
+++ b/assets/xml/scenes/dungeons/ydan_mq.xml
@@ -1,8 +1,8 @@
 <Root>
     <File Name="ydan_scene" Segment="2">
         <Cutscene Name="gDekuTreeIntroCs" Offset="0xB650"/>
-        <Texture Name="gYdanTex_00BA18" Format="rgba16" Width="32" Height="64" Offset="0xBA18"/>
-        <Texture Name="gYdanTex_00CA18" Format="rgba16" Width="32" Height="64" Offset="0xCA18"/>
+        <Texture Name="gDekuTreeDayEntranceTex" Format="rgba16" Width="32" Height="64" Offset="0xBA18"/>
+        <Texture Name="gDekuTreeNightEntranceTex" Format="rgba16" Width="32" Height="64" Offset="0xCA18"/>
 
         <Scene Name="ydan_scene" Offset="0x0"/>
     </File>

--- a/assets/xml/scenes/overworld/spot12.xml
+++ b/assets/xml/scenes/overworld/spot12.xml
@@ -2,8 +2,8 @@
     <File Name="spot12_scene" Segment="2">
         <Cutscene Name="gGerudoFortressFirstCaptureCs" Offset="0x55C0"/>
         <Cutscene Name="gGerudoFortressIntroCs" Offset="0x6490"/>
-        <Texture Name="gSpot12_009678Tex" Format="rgba16" Width="64" Height="32" Offset="0x9678"/>
-        <Texture Name="gSpot12_00DE78Tex" Format="rgba16" Width="64" Height="32" Offset="0xDE78"/>
+        <Texture Name="gGerudoFortressNightWallTex" Format="rgba16" Width="64" Height="32" Offset="0x9678"/>
+        <Texture Name="gGerudoFortressDayWallTex" Format="rgba16" Width="64" Height="32" Offset="0xDE78"/>
         <Scene Name="spot12_scene" Offset="0x0"/>
     </File>
     <File Name="spot12_room_0" Segment="3">

--- a/assets/xml/scenes/overworld/spot12_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot12_pal_n64.xml
@@ -2,8 +2,8 @@
     <File Name="spot12_scene" Segment="2">
         <Cutscene Name="gGerudoFortressFirstCaptureCs" Offset="0x55D0"/>
         <Cutscene Name="gGerudoFortressIntroCs" Offset="0x64A0"/>
-        <Texture Name="gSpot12_009678Tex" Format="rgba16" Width="64" Height="32" Offset="0x9688"/>
-        <Texture Name="gSpot12_00DE78Tex" Format="rgba16" Width="64" Height="32" Offset="0xDE88"/>
+        <Texture Name="gGerudoFortressNightWallTex" Format="rgba16" Width="64" Height="32" Offset="0x9688"/>
+        <Texture Name="gGerudoFortressDayWallTex" Format="rgba16" Width="64" Height="32" Offset="0xDE88"/>
         <Scene Name="spot12_scene" Offset="0x0"/>
     </File>
     <File Name="spot12_room_0" Segment="3">

--- a/src/code/z_scene_table.c
+++ b/src/code/z_scene_table.c
@@ -215,9 +215,9 @@ void Scene_DrawConfigDefault(PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx, "../z_scene_table.c", 4735);
 }
 
-void* D_8012A2F8[] = {
-    gYdanTex_00BA18,
-    gYdanTex_00CA18,
+void* sDekuTreeEntranceTextures[] = {
+    gDekuTreeDayEntranceTex,
+    gDekuTreeNightEntranceTex,
 };
 
 void Scene_DrawConfigDekuTree(PlayState* play) {
@@ -233,7 +233,7 @@ void Scene_DrawConfigDekuTree(PlayState* play) {
     gDPPipeSync(POLY_XLU_DISP++);
     gDPSetEnvColor(POLY_XLU_DISP++, 128, 128, 128, 128);
 
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(D_8012A2F8[((void)0, gSaveContext.save.nightFlag)]));
+    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sDekuTreeEntranceTextures[((void)0, gSaveContext.save.nightFlag)]));
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_scene_table.c", 4783);
 }
@@ -527,7 +527,7 @@ void Scene_DrawConfigThievesHideout(PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx, "../z_scene_table.c", 5507);
 }
 
-void* D_8012A330[] = {
+void* sWaterTempleEntranceTextures[] = {
     gWaterTempleDayEntranceTex,
     gWaterTempleNightEntranceTex,
 };
@@ -544,9 +544,9 @@ void Scene_DrawConfigWaterTemple(PlayState* play) {
     gameplayFrames = play->gameplayFrames;
 
 #if !OOT_MQ
-    gSPSegment(POLY_XLU_DISP++, 0x06, SEGMENTED_TO_VIRTUAL(D_8012A330[((void)0, gSaveContext.save.nightFlag)]));
+    gSPSegment(POLY_XLU_DISP++, 0x06, SEGMENTED_TO_VIRTUAL(sWaterTempleEntranceTextures[((void)0, gSaveContext.save.nightFlag)]));
 #else
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(D_8012A330[((void)0, gSaveContext.save.nightFlag)]));
+    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sWaterTempleEntranceTextures[((void)0, gSaveContext.save.nightFlag)]));
 #endif
 
     if (spB0 == 1) {
@@ -966,11 +966,11 @@ void Scene_DrawConfigLonLonBuildings(PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx, "../z_scene_table.c", 6528);
 }
 
-void* sGuardHouseView2Textures[] = {
+void* sGuardHouseView1Textures[] = {
     gGuardHouseOutSideView1DayTex,
     gGuardHouseOutSideView1NightTex,
 };
-void* sGuardHouseView1Textures[] = {
+void* sGuardHouseView2Textures[] = {
     gGuardHouseOutSideView2DayTex,
     gGuardHouseOutSideView2NightTex,
 };
@@ -986,8 +986,8 @@ void Scene_DrawConfigMarketGuardHouse(PlayState* play) {
         var = gSaveContext.save.nightFlag;
     }
 
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sGuardHouseView1Textures[var]));
-    gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(sGuardHouseView2Textures[var]));
+    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sGuardHouseView2Textures[var]));
+    gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(sGuardHouseView1Textures[var]));
 
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetEnvColor(POLY_OPA_DISP++, 128, 128, 128, 128);
@@ -1377,15 +1377,15 @@ void Scene_DrawConfigDesertColossus(PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx, "../z_scene_table.c", 7339);
 }
 
-void* D_8012A380[] = {
-    gSpot12_009678Tex,
-    gSpot12_00DE78Tex,
+void* sGerudoFortressWallTextures[] = {
+    gGerudoFortressNightWallTex,
+    gGerudoFortressDayWallTex,
 };
 
 void Scene_DrawConfigGerudosFortress(PlayState* play) {
     OPEN_DISPS(play->state.gfxCtx, "../z_scene_table.c", 7363);
 
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(D_8012A380[((void)0, gSaveContext.save.nightFlag)]));
+    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sGerudoFortressWallTextures[((void)0, gSaveContext.save.nightFlag)]));
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_scene_table.c", 7371);
 }

--- a/src/code/z_scene_table.c
+++ b/src/code/z_scene_table.c
@@ -233,7 +233,8 @@ void Scene_DrawConfigDekuTree(PlayState* play) {
     gDPPipeSync(POLY_XLU_DISP++);
     gDPSetEnvColor(POLY_XLU_DISP++, 128, 128, 128, 128);
 
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sDekuTreeEntranceTextures[((void)0, gSaveContext.save.nightFlag)]));
+    gSPSegment(POLY_OPA_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sDekuTreeEntranceTextures[((void)0, gSaveContext.save.nightFlag)]));
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_scene_table.c", 4783);
 }
@@ -544,9 +545,11 @@ void Scene_DrawConfigWaterTemple(PlayState* play) {
     gameplayFrames = play->gameplayFrames;
 
 #if !OOT_MQ
-    gSPSegment(POLY_XLU_DISP++, 0x06, SEGMENTED_TO_VIRTUAL(sWaterTempleEntranceTextures[((void)0, gSaveContext.save.nightFlag)]));
+    gSPSegment(POLY_XLU_DISP++, 0x06,
+               SEGMENTED_TO_VIRTUAL(sWaterTempleEntranceTextures[((void)0, gSaveContext.save.nightFlag)]));
 #else
-    gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sWaterTempleEntranceTextures[((void)0, gSaveContext.save.nightFlag)]));
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sWaterTempleEntranceTextures[((void)0, gSaveContext.save.nightFlag)]));
 #endif
 
     if (spB0 == 1) {
@@ -1385,7 +1388,8 @@ void* sGerudoFortressWallTextures[] = {
 void Scene_DrawConfigGerudosFortress(PlayState* play) {
     OPEN_DISPS(play->state.gfxCtx, "../z_scene_table.c", 7363);
 
-    gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sGerudoFortressWallTextures[((void)0, gSaveContext.save.nightFlag)]));
+    gSPSegment(POLY_OPA_DISP++, 0x08,
+               SEGMENTED_TO_VIRTUAL(sGerudoFortressWallTextures[((void)0, gSaveContext.save.nightFlag)]));
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_scene_table.c", 7371);
 }


### PR DESCRIPTION
Minor name changes for some scene file assets to line up with the names for other scenes. I also made the guard house texture array names line up with their contents.