### PR TITLE
Add names for Medallion cutscene data

### DIFF
--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
@@ -201,7 +201,7 @@ void DemoDu_CsFireMedallion_AdvanceTo01(DemoDu* this, PlayState* play) {
         Player* player = GET_PLAYER(play);
 
         this->updateIndex = CS_FIREMEDALLION_SUBSCENE(1);
-        play->csCtx.script = D_8096C1A4;
+        play->csCtx.script = gFireMedallionCS;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_FIRE);
 

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du.c
@@ -201,7 +201,7 @@ void DemoDu_CsFireMedallion_AdvanceTo01(DemoDu* this, PlayState* play) {
         Player* player = GET_PLAYER(play);
 
         this->updateIndex = CS_FIREMEDALLION_SUBSCENE(1);
-        play->csCtx.script = gFireMedallionCS;
+        play->csCtx.script = gFireMedallionCs;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_FIRE);
 

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du_cutscene_data.inc.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du_cutscene_data.inc.c
@@ -2,7 +2,7 @@
 #include "z64cutscene_commands.h"
 
 // clang-format off
-static CutsceneData gFireMedallionCS[] = {
+static CutsceneData gFireMedallionCs[] = {
     CS_HEADER(31, 3000),
     CS_UNK_DATA_LIST(0x00000020, 1),
         CS_UNK_DATA(0x00010000, 0x0BB80000, 0x00000000, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0x00000000, 0x00000000),

--- a/src/overlays/actors/ovl_Demo_Du/z_demo_du_cutscene_data.inc.c
+++ b/src/overlays/actors/ovl_Demo_Du/z_demo_du_cutscene_data.inc.c
@@ -2,7 +2,7 @@
 #include "z64cutscene_commands.h"
 
 // clang-format off
-static CutsceneData D_8096C1A4[] = {
+static CutsceneData gFireMedallionCS[] = {
     CS_HEADER(31, 3000),
     CS_UNK_DATA_LIST(0x00000020, 1),
         CS_UNK_DATA(0x00010000, 0x0BB80000, 0x00000000, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0x00000000, 0x00000000),

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -333,7 +333,7 @@ void func_8098544C(DemoIm* this, PlayState* play) {
         Player* player = GET_PLAYER(play);
 
         this->action = 1;
-        play->csCtx.script = gShadowMedallionCS;
+        play->csCtx.script = gShadowMedallionCs;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_SHADOW);
         player->actor.world.rot.y = player->actor.shape.rot.y = this->actor.world.rot.y + 0x8000;

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -333,7 +333,7 @@ void func_8098544C(DemoIm* this, PlayState* play) {
         Player* player = GET_PLAYER(play);
 
         this->action = 1;
-        play->csCtx.script = D_8098786C;
+        play->csCtx.script = gShadowMedallionCS;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_SHADOW);
         player->actor.world.rot.y = player->actor.shape.rot.y = this->actor.world.rot.y + 0x8000;

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im_cutscene_data.inc.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im_cutscene_data.inc.c
@@ -2,7 +2,7 @@
 #include "z64cutscene_commands.h"
 
 // clang-format off
-static CutsceneData D_8098786C[] = {
+static CutsceneData gShadowMedallionCS[] = {
     CS_HEADER(32, 3000),
     CS_UNK_DATA_LIST(0x00000020, 1),
         CS_UNK_DATA(0x00010000, 0x0BB80000, 0x00000000, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0x00000000, 0x00000000),

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im_cutscene_data.inc.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im_cutscene_data.inc.c
@@ -2,7 +2,7 @@
 #include "z64cutscene_commands.h"
 
 // clang-format off
-static CutsceneData gShadowMedallionCS[] = {
+static CutsceneData gShadowMedallionCs[] = {
     CS_HEADER(32, 3000),
     CS_UNK_DATA_LIST(0x00000020, 1),
         CS_UNK_DATA(0x00010000, 0x0BB80000, 0x00000000, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0x00000000, 0x00000000),

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
@@ -261,7 +261,7 @@ void func_8098E960(DemoSa* this, PlayState* play) {
     if ((gSaveContext.chamberCutsceneNum == CHAMBER_CS_FOREST) && !IS_CUTSCENE_LAYER) {
         player = GET_PLAYER(play);
         this->action = 1;
-        play->csCtx.script = gForestMedallionCS;
+        play->csCtx.script = gForestMedallionCs;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_FOREST);
         player->actor.world.rot.y = player->actor.shape.rot.y = this->actor.world.rot.y + 0x8000;

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa.c
@@ -261,7 +261,7 @@ void func_8098E960(DemoSa* this, PlayState* play) {
     if ((gSaveContext.chamberCutsceneNum == CHAMBER_CS_FOREST) && !IS_CUTSCENE_LAYER) {
         player = GET_PLAYER(play);
         this->action = 1;
-        play->csCtx.script = D_8099010C;
+        play->csCtx.script = gForestMedallionCS;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_FOREST);
         player->actor.world.rot.y = player->actor.shape.rot.y = this->actor.world.rot.y + 0x8000;

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa_cutscene_data.inc.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa_cutscene_data.inc.c
@@ -2,7 +2,7 @@
 #include "z64cutscene_commands.h"
 
 // clang-format off
-static CutsceneData D_8099010C[] = {
+static CutsceneData gForestMedallionCS[] = {
     CS_HEADER(29, 3001),
     CS_UNK_DATA_LIST(0x00000020, 1),
         CS_UNK_DATA(0x00010000, 0x0BB80000, 0x00000000, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0x00000000, 0x00000000),

--- a/src/overlays/actors/ovl_Demo_Sa/z_demo_sa_cutscene_data.inc.c
+++ b/src/overlays/actors/ovl_Demo_Sa/z_demo_sa_cutscene_data.inc.c
@@ -2,7 +2,7 @@
 #include "z64cutscene_commands.h"
 
 // clang-format off
-static CutsceneData gForestMedallionCS[] = {
+static CutsceneData gForestMedallionCs[] = {
     CS_HEADER(29, 3001),
     CS_UNK_DATA_LIST(0x00000020, 1),
         CS_UNK_DATA(0x00010000, 0x0BB80000, 0x00000000, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0x00000000, 0x00000000),

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -349,7 +349,7 @@ void EnNb_SetupChamberCsImpl(EnNb* this, PlayState* play) {
     if ((gSaveContext.chamberCutsceneNum == CHAMBER_CS_SPIRIT) && !IS_CUTSCENE_LAYER) {
         player = GET_PLAYER(play);
         this->action = NB_CHAMBER_UNDERGROUND;
-        play->csCtx.script = D_80AB431C;
+        play->csCtx.script = gSpiritMedallionCS;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_SPIRIT);
         player->actor.world.rot.y = player->actor.shape.rot.y = this->actor.world.rot.y + 0x8000;

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -349,7 +349,7 @@ void EnNb_SetupChamberCsImpl(EnNb* this, PlayState* play) {
     if ((gSaveContext.chamberCutsceneNum == CHAMBER_CS_SPIRIT) && !IS_CUTSCENE_LAYER) {
         player = GET_PLAYER(play);
         this->action = NB_CHAMBER_UNDERGROUND;
-        play->csCtx.script = gSpiritMedallionCS;
+        play->csCtx.script = gSpiritMedallionCs;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_SPIRIT);
         player->actor.world.rot.y = player->actor.shape.rot.y = this->actor.world.rot.y + 0x8000;

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb_cutscene_data.inc.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb_cutscene_data.inc.c
@@ -2,7 +2,7 @@
 #include "z64cutscene_commands.h"
 
 // clang-format off
-static CutsceneData D_80AB431C[] = {
+static CutsceneData gSpiritMedallionCS[] = {
     CS_HEADER(27, 3011),
     CS_UNK_DATA_LIST(0x00000020, 1),
         CS_UNK_DATA(0x00010000, 0x0BB80000, 0x00000000, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0x00000000, 0x00000000),

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb_cutscene_data.inc.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb_cutscene_data.inc.c
@@ -2,7 +2,7 @@
 #include "z64cutscene_commands.h"
 
 // clang-format off
-static CutsceneData gSpiritMedallionCS[] = {
+static CutsceneData gSpiritMedallionCs[] = {
     CS_HEADER(27, 3011),
     CS_UNK_DATA_LIST(0x00000020, 1),
         CS_UNK_DATA(0x00010000, 0x0BB80000, 0x00000000, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0x00000000, 0x00000000),

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -345,7 +345,7 @@ void EnRu2_CheckWaterMedallionCutscene(EnRu2* this, PlayState* play) {
     if ((gSaveContext.chamberCutsceneNum == CHAMBER_CS_WATER) && !IS_CUTSCENE_LAYER) {
         player = GET_PLAYER(play);
         this->action = ENRU2_AWAIT_BLUE_WARP;
-        play->csCtx.script = gWaterMedallionCS;
+        play->csCtx.script = gWaterMedallionCs;
         gSaveContext.cutsceneTrigger = 2;
         Item_Give(play, ITEM_MEDALLION_WATER);
         temp = this->actor.world.rot.y + 0x8000;

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2_cutscene_data.inc.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2_cutscene_data.inc.c
@@ -2,7 +2,7 @@
 #include "z64cutscene_commands.h"
 
 // clang-format off
-static CutsceneData gWaterMedallionCS[] = {
+static CutsceneData gWaterMedallionCs[] = {
     CS_HEADER(35, 3338),
     CS_UNK_DATA_LIST(0x00000020, 1),
         CS_UNK_DATA(0x00010000, 0x0BB80000, 0x00000000, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0xFFFFFFFC, 0x00000002, 0x00000000, 0x00000000, 0x00000000),

--- a/tools/csdis_re.py
+++ b/tools/csdis_re.py
@@ -23,7 +23,7 @@ MAPFILE_P = Path("build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.map")
 BASEROM_SEGMENTS_P = Path("extracted/gc-eu-mq-dbg/baserom/")
 
 HARDCODED_SYM_ROM = {
-    "D_8096C1A4": 0xD25834,
+    "gFireMedallionCS": 0xD25834,
     "D_80AF0880": 0xEA6860,
     "D_80AF10A4": 0xEA7084,
     "D_80AF1728": 0xEA7708,
@@ -31,8 +31,8 @@ HARDCODED_SYM_ROM = {
     "D_808BD2A0": 0xC8BFA0,
     "D_808BD520": 0xC8C220,
     "D_808BD790": 0xC8C490,
-    "D_80AB431C": 0xE6A38C,
-    "D_8098786C": 0xD40EFC,
+    "gSpiritMedallionCS": 0xE6A38C,
+    "gShadowMedallionCS": 0xD40EFC,
     "D_80B4C5D0": 0xF022D0,
     "D_80ABF9D0": 0xE75A40,
     "D_80ABFB40": 0xE75BB0,
@@ -49,7 +49,7 @@ HARDCODED_SYM_ROM = {
     "gAdultWarpInCS": 0xD44FA0,
     "gChildWarpOutCS": 0xD45590,
     "gAdultWarpOutCS": 0xD450B0,
-    "D_8099010C": 0xD4974C,
+    "gForestMedallionCS": 0xD4974C,
 }
 
 mapfile = mapfile_parser.MapFile()

--- a/tools/csdis_re.py
+++ b/tools/csdis_re.py
@@ -23,7 +23,7 @@ MAPFILE_P = Path("build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.map")
 BASEROM_SEGMENTS_P = Path("extracted/gc-eu-mq-dbg/baserom/")
 
 HARDCODED_SYM_ROM = {
-    "gFireMedallionCS": 0xD25834,
+    "gFireMedallionCs": 0xD25834,
     "D_80AF0880": 0xEA6860,
     "D_80AF10A4": 0xEA7084,
     "D_80AF1728": 0xEA7708,
@@ -31,12 +31,12 @@ HARDCODED_SYM_ROM = {
     "D_808BD2A0": 0xC8BFA0,
     "D_808BD520": 0xC8C220,
     "D_808BD790": 0xC8C490,
-    "gSpiritMedallionCS": 0xE6A38C,
-    "gShadowMedallionCS": 0xD40EFC,
+    "gSpiritMedallionCs": 0xE6A38C,
+    "gShadowMedallionCs": 0xD40EFC,
     "D_80B4C5D0": 0xF022D0,
     "D_80ABF9D0": 0xE75A40,
     "D_80ABFB40": 0xE75BB0,
-    "gWaterMedallionCS": 0xEAA0FC,
+    "gWaterMedallionCs": 0xEAA0FC,
     "D_80A88164": 0xE3ED34,
     "D_808BB2F0": 0xC89FF0,
     "D_808BB7A0": 0xC8A4A0,
@@ -49,7 +49,7 @@ HARDCODED_SYM_ROM = {
     "gAdultWarpInCS": 0xD44FA0,
     "gChildWarpOutCS": 0xD45590,
     "gAdultWarpOutCS": 0xD450B0,
-    "gForestMedallionCS": 0xD4974C,
+    "gForestMedallionCs": 0xD4974C,
 }
 
 mapfile = mapfile_parser.MapFile()


### PR DESCRIPTION
After renaming `gWaterMedallionCS` for Adult Ruto, I'm now renaming the cutscene data objects for the other four Medallions (except Light).