### PR TITLE
Name some scene cutscenes (Hyrule Field and Kakariko Village)

### DIFF
--- a/assets/xml/scenes/overworld/spot00.xml
+++ b/assets/xml/scenes/overworld/spot00.xml
@@ -7,6 +7,15 @@
         <Cutscene Name="gHyruleFieldSouthEponaJumpCs" Offset="0xF9E0"/>
         <Cutscene Name="gHyruleFieldWestEponaJumpCs" Offset="0x10550"/>
         <Cutscene Name="gHyruleFieldGateEponaJumpCs" Offset="0x10B30"/>
+        <Cutscene Name="gHyruleFieldZeldaFlashbackCs" Offset="0xA000"/>
+        <Cutscene Name="gHyruleFieldTitleScreenCs" Offset="0xA920"/>
+        <Cutscene Name="gHyruleFieldCreditsCs" Offset="0xBF40"/>
+        <Cutscene Name="gHyruleFieldBeforeCreditsCs" Offset="0xC8C0"/>
+        <Cutscene Name="gHyruleFieldGateEponaJump2Cs" Offset="0xC120"/>
+        <Cutscene Name="gHyruleFieldImpaCs" Offset="0xDCB0"/>
+        <Cutscene Name="gHyruleFieldUnusedIntroNightmareCs" Offset="0xE5F0"/>
+        <Cutscene Name="gHyruleFieldZeldaEscapeCs" Offset="0x8494"/>
+        <Cutscene Name="gHyruleFieldIntroNightmareCs" Offset="0x12400"/>
         <Path Name="spot00_scenePathList_011AB4" Offset="0x11AB4" NumPaths="2"/>
         <Scene Name="spot00_scene" Offset="0x0"/>
         <Scene Name="spot00_scene_unused" Offset="0x12340"/>

--- a/assets/xml/scenes/overworld/spot00.xml
+++ b/assets/xml/scenes/overworld/spot00.xml
@@ -13,7 +13,7 @@
         <Cutscene Name="gHyruleFieldBeforeCreditsCs" Offset="0xC8C0"/>
         <Cutscene Name="gHyruleFieldGateEponaJump2Cs" Offset="0xC120"/>
         <Cutscene Name="gHyruleFieldImpaCs" Offset="0xDCB0"/>
-        <Cutscene Name="gHyruleFieldUnusedIntroNightmareCs" Offset="0xE5F0"/>
+        <Cutscene Name="gHyruleFieldZeldaEscapeUnusedCs" Offset="0xE5F0"/>
         <Cutscene Name="gHyruleFieldZeldaEscapeCs" Offset="0x8494"/>
         <Cutscene Name="gHyruleFieldIntroNightmareCs" Offset="0x12400"/>
         <Path Name="spot00_scenePathList_011AB4" Offset="0x11AB4" NumPaths="2"/>

--- a/assets/xml/scenes/overworld/spot00_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot00_pal_n64.xml
@@ -13,7 +13,7 @@
         <Cutscene Name="gHyruleFieldBeforeCreditsCs" Offset="0xC8D4"/>
         <Cutscene Name="gHyruleFieldGateEponaJump2Cs" Offset="0xC130"/>
         <Cutscene Name="gHyruleFieldImpaCs" Offset="0xDCD0"/>
-        <Cutscene Name="gHyruleFieldUnusedIntroNightmareCs" Offset="0xE610"/>
+        <Cutscene Name="gHyruleFieldZeldaEscapeUnusedCs" Offset="0xE610"/>
         <Cutscene Name="gHyruleFieldZeldaEscapeCs" Offset="0x8494"/>
         <Cutscene Name="gHyruleFieldIntroNightmareCs" Offset="0x12420"/>
         <Path Name="spot00_scenePathList_011AB4" Offset="0x11AD4" NumPaths="2"/>

--- a/assets/xml/scenes/overworld/spot00_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot00_pal_n64.xml
@@ -7,6 +7,15 @@
         <Cutscene Name="gHyruleFieldSouthEponaJumpCs" Offset="0xFA00"/>
         <Cutscene Name="gHyruleFieldWestEponaJumpCs" Offset="0x10570"/>
         <Cutscene Name="gHyruleFieldGateEponaJumpCs" Offset="0x10B50"/>
+        <Cutscene Name="gHyruleFieldZeldaFlashbackCs" Offset="0xA000"/>
+        <Cutscene Name="gHyruleFieldTitleScreenCs" Offset="0xA920"/>
+        <Cutscene Name="gHyruleFieldCreditsCs" Offset="0xBF44"/>
+        <Cutscene Name="gHyruleFieldBeforeCreditsCs" Offset="0xC8D4"/>
+        <Cutscene Name="gHyruleFieldGateEponaJump2Cs" Offset="0xC130"/>
+        <Cutscene Name="gHyruleFieldImpaCs" Offset="0xDCD0"/>
+        <Cutscene Name="gHyruleFieldUnusedIntroNightmareCs" Offset="0xE610"/>
+        <Cutscene Name="gHyruleFieldZeldaEscapeCs" Offset="0x8494"/>
+        <Cutscene Name="gHyruleFieldIntroNightmareCs" Offset="0x12420"/>
         <Path Name="spot00_scenePathList_011AB4" Offset="0x11AD4" NumPaths="2"/>
         <Scene Name="spot00_scene" Offset="0x0"/>
         <Scene Name="spot00_scene_unused" Offset="0x12360"/>

--- a/assets/xml/scenes/overworld/spot01.xml
+++ b/assets/xml/scenes/overworld/spot01.xml
@@ -2,11 +2,11 @@
     <File Name="spot01_scene" Segment="2">
         <Path Name="spot01_scenePathList_0003D0" Offset="0x03D0" NumPaths="3"/>
         <Cutscene Name="gKakarikoVillageIntroCs" Offset="0xA540"/>
-        <Cutscene Name="gKakarikoVillageRavagedCs" Offset="0x4A50"/>
-        <Cutscene Name="gKakarikoVillageNocturneOfShadowCs" Offset="0x6DF0"/>
+        <Cutscene Name="gKakarikoVillageNocturnePart1Cs" Offset="0x4A50"/>
+        <Cutscene Name="gKakarikoVillageNocturnePart2Cs" Offset="0x6DF0"/>
         <Cutscene Name="gKakarikoVillageCreditsCs" Offset="0x8EE0"/>
-        <Cutscene Name="gKakarikoVillageWellEmptyingCs" Offset="0x8090"/>
-        <Cutscene Name="gKakarikoVillageVolcanoHealingCs" Offset="0x8670"/>
+        <Cutscene Name="gKakarikoVillageWellDrainingCs" Offset="0x8090"/>
+        <Cutscene Name="gKakarikoVillagePostFireTempleCs" Offset="0x8670"/>
         <Texture Name="gKakarikoVillageDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x15B50"/>
         <Texture Name="gKakarikoVillageNightWindowTex" OutName="night_window" Format="rgba16" Width="32" Height="64" Offset="0x16B50"/>
         <Scene Name="spot01_scene" Offset="0x0"/>

--- a/assets/xml/scenes/overworld/spot01.xml
+++ b/assets/xml/scenes/overworld/spot01.xml
@@ -2,6 +2,11 @@
     <File Name="spot01_scene" Segment="2">
         <Path Name="spot01_scenePathList_0003D0" Offset="0x03D0" NumPaths="3"/>
         <Cutscene Name="gKakarikoVillageIntroCs" Offset="0xA540"/>
+        <Cutscene Name="gKakarikoVillageRavagedCs" Offset="0x4A50"/>
+        <Cutscene Name="gKakarikoVillageNocturneOfShadowCs" Offset="0x6DF0"/>
+        <Cutscene Name="gKakarikoVillageCreditsCs" Offset="0x8EE0"/>
+        <Cutscene Name="gKakarikoVillageWellEmptyingCs" Offset="0x8090"/>
+        <Cutscene Name="gKakarikoVillageVolcanoHealingCs" Offset="0x8670"/>
         <Texture Name="gKakarikoVillageDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x15B50"/>
         <Texture Name="gKakarikoVillageNightWindowTex" OutName="night_window" Format="rgba16" Width="32" Height="64" Offset="0x16B50"/>
         <Scene Name="spot01_scene" Offset="0x0"/>

--- a/assets/xml/scenes/overworld/spot01_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot01_pal_n64.xml
@@ -2,6 +2,11 @@
     <File Name="spot01_scene" Segment="2">
         <Path Name="spot01_scenePathList_0003D0" Offset="0x03D0" NumPaths="3"/>
         <Cutscene Name="gKakarikoVillageIntroCs" Offset="0xA560"/>
+        <Cutscene Name="gKakarikoVillageRavagedCs" Offset="0x4A50"/>
+        <Cutscene Name="gKakarikoVillageNocturneOfShadowCs" Offset="0x6DF4"/>
+        <Cutscene Name="gKakarikoVillageCreditsCs" Offset="0x8EF4"/>
+        <Cutscene Name="gKakarikoVillageWellEmptyingCs" Offset="0x80A0"/>
+        <Cutscene Name="gKakarikoVillageVolcanoHealingCs" Offset="0x8680"/>
         <Texture Name="gKakarikoVillageDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x15B70"/>
         <Texture Name="gKakarikoVillageNightWindowTex" OutName="night_window" Format="rgba16" Width="32" Height="64" Offset="0x16B70"/>
         <Scene Name="spot01_scene" Offset="0x0"/>

--- a/assets/xml/scenes/overworld/spot01_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot01_pal_n64.xml
@@ -2,11 +2,11 @@
     <File Name="spot01_scene" Segment="2">
         <Path Name="spot01_scenePathList_0003D0" Offset="0x03D0" NumPaths="3"/>
         <Cutscene Name="gKakarikoVillageIntroCs" Offset="0xA560"/>
-        <Cutscene Name="gKakarikoVillageRavagedCs" Offset="0x4A50"/>
-        <Cutscene Name="gKakarikoVillageNocturneOfShadowCs" Offset="0x6DF4"/>
+        <Cutscene Name="gKakarikoVillageNocturnePart1Cs" Offset="0x4A50"/>
+        <Cutscene Name="gKakarikoVillageNocturnePart2Cs" Offset="0x6DF4"/>
         <Cutscene Name="gKakarikoVillageCreditsCs" Offset="0x8EF4"/>
-        <Cutscene Name="gKakarikoVillageWellEmptyingCs" Offset="0x80A0"/>
-        <Cutscene Name="gKakarikoVillageVolcanoHealingCs" Offset="0x8680"/>
+        <Cutscene Name="gKakarikoVillageWellDrainingCs" Offset="0x80A0"/>
+        <Cutscene Name="gKakarikoVillagePostFireTempleCs" Offset="0x8680"/>
         <Texture Name="gKakarikoVillageDayWindowTex" OutName="day_window" Format="rgba16" Width="32" Height="64" Offset="0x15B70"/>
         <Texture Name="gKakarikoVillageNightWindowTex" OutName="night_window" Format="rgba16" Width="32" Height="64" Offset="0x16B70"/>
         <Scene Name="spot01_scene" Offset="0x0"/>


### PR DESCRIPTION
There is a lot to name, this is naming cutscenes from Hyrule Field and Kakariko Village, details:

<details>
<summary>Hyrule Field</summary>

- `gHyruleFieldZeldaFlashbackCs`: zelda's escape flashback part of the light arrow cutscene
- `gHyruleFieldTitleScreenCs`: the main title screen cutscene
- `gHyruleFieldCreditsCs`: the hyrule field sequence of the credits where Epona runs alone
- `gHyruleFieldBeforeCreditsCs`: this is the cutscene where Zelda talks to Link "in the sky" right after Ganon's fight
- `gHyruleFieldGateEponaJump2Cs`: same as `gHyruleFieldGateEponaJumpCs`
- `gHyruleFieldImpaCs`: this is the cutscene that plays after learning Zelda's Lullaby where Impa tells you to go to Kakariko
- `gHyruleFieldUnusedIntroNightmareCs`: this is an unused "link's nightmare" part of the intro ([video here](https://youtu.be/IiSA1YAs9Rk))
- `gHyruleFieldZeldaEscapeCs`: that's the cutscene where Zelda escapes from Hyrule Castle and throws the ocarina of time in the water
- `gHyruleFieldIntroNightmareCs`: this is the "link's nightmare" part of the intro
</details>

<details>
<summary>Kakariko Village</summary>

- `gKakarikoVillageRavagedCs`: that's the cutscene that plays before the one where you learn the nocturne of shadow where the whole village is on fire
- `gKakarikoVillageNocturneOfShadowCs`: nocturne of shadow cutscene, name inspired by other songs cutscenes (maybe we should remove ``OfShadow``?)
- `gKakarikoVillageCreditsCs`: kakariko during the credits
- `gKakarikoVillageWellEmptyingCs`: this is the cutscene where you see the well's water going away
- `gKakarikoVillageVolcanoHealingCs`: ok I have to admit this name isn't great lol, that's the cutscene where you see the ring above the death mountain volcano going back to normal, I couldn't find a good name for this one so feel free
</details>

More names soon™ (for the other "spot" scenes)