### PR TITLE
Naming some cutscenes 4 (Gerudo Fortress, Death Mountain Crater and Goron City)

### DIFF
--- a/assets/xml/scenes/overworld/spot12.xml
+++ b/assets/xml/scenes/overworld/spot12.xml
@@ -2,6 +2,8 @@
     <File Name="spot12_scene" Segment="2">
         <Cutscene Name="gGerudoFortressFirstCaptureCs" Offset="0x55C0"/>
         <Cutscene Name="gGerudoFortressIntroCs" Offset="0x6490"/>
+        <Cutscene Name="gGerudoFortressArcheryIntroCs" Offset="0x5060"/>
+        <Cutscene Name="gGerudoFortressCreditsCs" Offset="0x5450"/>
         <Texture Name="gGerudoFortressNightWallTex" Format="rgba16" Width="64" Height="32" Offset="0x9678"/>
         <Texture Name="gGerudoFortressDayWallTex" Format="rgba16" Width="64" Height="32" Offset="0xDE78"/>
         <Scene Name="spot12_scene" Offset="0x0"/>

--- a/assets/xml/scenes/overworld/spot12_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot12_pal_n64.xml
@@ -2,6 +2,8 @@
     <File Name="spot12_scene" Segment="2">
         <Cutscene Name="gGerudoFortressFirstCaptureCs" Offset="0x55D0"/>
         <Cutscene Name="gGerudoFortressIntroCs" Offset="0x64A0"/>
+        <Cutscene Name="gGerudoFortressArcheryIntroCs" Offset="0x5060"/>
+        <Cutscene Name="gGerudoFortressCreditsCs" Offset="0x5454"/>
         <Texture Name="gGerudoFortressNightWallTex" Format="rgba16" Width="64" Height="32" Offset="0x9688"/>
         <Texture Name="gGerudoFortressDayWallTex" Format="rgba16" Width="64" Height="32" Offset="0xDE88"/>
         <Scene Name="spot12_scene" Offset="0x0"/>

--- a/assets/xml/scenes/overworld/spot17.xml
+++ b/assets/xml/scenes/overworld/spot17.xml
@@ -2,6 +2,7 @@
     <File Name="spot17_scene" Segment="2">
         <Cutscene Name="gDeathMountainCraterBoleroCs" Offset="0x45D0"/>
         <Cutscene Name="gDeathMountainCraterIntroCs" Offset="0x76D0"/>
+        <Cutscene Name="gDeathMountainCraterTitleCs" Offset="0x68B0"/>
         <Scene Name="spot17_scene" Offset="0x0"/>
     </File>
     <File Name="spot17_room_0" Segment="3">

--- a/assets/xml/scenes/overworld/spot17_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot17_pal_n64.xml
@@ -2,6 +2,7 @@
     <File Name="spot17_scene" Segment="2">
         <Cutscene Name="gDeathMountainCraterBoleroCs" Offset="0x45D4"/>
         <Cutscene Name="gDeathMountainCraterIntroCs" Offset="0x76E0"/>
+        <Cutscene Name="gDeathMountainCraterTitleCs" Offset="0x68C0"/>
         <Scene Name="spot17_scene" Offset="0x0"/>
     </File>
     <File Name="spot17_room_0" Segment="3">

--- a/assets/xml/scenes/overworld/spot18.xml
+++ b/assets/xml/scenes/overworld/spot18.xml
@@ -3,10 +3,7 @@
         <Cutscene Name="gGoronCityDaruniaCorrectSongCs" Offset="0x59E0"/>
         <Cutscene Name="gGoronCityDaruniaWrongSongCs" Offset="0x7DE0"/>
 
-        <!--
-            This cutscene's implementation makes this cutscene override any other cutscene if Darunia is present in the scene.
-            This was probably used as a debug tool while creating the final cutscene.
-        -->
+        <!-- This cutscene is not used in normal gameplay. -->
         <Cutscene Name="gGoronCityDaruniaDancingCs" Offset="0x6930"/>
 
         <Cutscene Name="gGoronCityIntroCs" Offset="0x8400"/>

--- a/assets/xml/scenes/overworld/spot18.xml
+++ b/assets/xml/scenes/overworld/spot18.xml
@@ -1,9 +1,14 @@
 <Root>
     <File Name="spot18_scene" Segment="2">
-        <Cutscene Name="gGoronCityDaruniaCorrectCs" Offset="0x59E0"/>
-        <Cutscene Name="gGoronCityDarunia01Cs" Offset="0x6930"/>
-        <Cutscene Name="gGoronCityDaruniaWrongCs" Offset="0x7DE0"/>
+        <Cutscene Name="gGoronCityDaruniaCorrectSongCs" Offset="0x59E0"/>
+        <Cutscene Name="gGoronCityDaruniaWrongSongCs" Offset="0x7DE0"/>
+        
+        <!-- like `gGoronCityDaruniaCorrectSongCs` but dancing a second time -->
+        <Cutscene Name="gGoronCityDaruniaDancingCs" Offset="0x6930"/>
+        
         <Cutscene Name="gGoronCityIntroCs" Offset="0x8400"/>
+        <Cutscene Name="gGoronCityCreditsCs" Offset="0x7840"/>
+        
         <Texture Name="gGoronCityNightEntranceTex" OutName="night_entrance" Format="ia8" Width="8" Height="8" Offset="0x8FC8"/>
         <Texture Name="gGoronCityDayEntranceTex" OutName="day_entrance" Format="ia8" Width="8" Height="8" Offset="0x9808"/>
         <Scene Name="spot18_scene" Offset="0x0"/>

--- a/assets/xml/scenes/overworld/spot18.xml
+++ b/assets/xml/scenes/overworld/spot18.xml
@@ -2,13 +2,16 @@
     <File Name="spot18_scene" Segment="2">
         <Cutscene Name="gGoronCityDaruniaCorrectSongCs" Offset="0x59E0"/>
         <Cutscene Name="gGoronCityDaruniaWrongSongCs" Offset="0x7DE0"/>
-        
-        <!-- like `gGoronCityDaruniaCorrectSongCs` but dancing a second time -->
+
+        <!--
+            This cutscene's implementation makes this cutscene override any other cutscene if Darunia is present in the scene.
+            This was probably used as a debug tool while creating the final cutscene.
+        -->
         <Cutscene Name="gGoronCityDaruniaDancingCs" Offset="0x6930"/>
-        
+
         <Cutscene Name="gGoronCityIntroCs" Offset="0x8400"/>
         <Cutscene Name="gGoronCityCreditsCs" Offset="0x7840"/>
-        
+
         <Texture Name="gGoronCityNightEntranceTex" OutName="night_entrance" Format="ia8" Width="8" Height="8" Offset="0x8FC8"/>
         <Texture Name="gGoronCityDayEntranceTex" OutName="day_entrance" Format="ia8" Width="8" Height="8" Offset="0x9808"/>
         <Scene Name="spot18_scene" Offset="0x0"/>

--- a/assets/xml/scenes/overworld/spot18_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot18_pal_n64.xml
@@ -3,10 +3,7 @@
         <Cutscene Name="gGoronCityDaruniaCorrectSongCs" Offset="0x59E0"/>
         <Cutscene Name="gGoronCityDaruniaWrongSongCs" Offset="0x7DF4"/>
 
-        <!--
-            This cutscene's implementation makes this cutscene override any other cutscene if Darunia is present in the scene.
-            This was probably used as a debug tool while creating the final cutscene.
-        -->
+        <!-- This cutscene is not used in normal gameplay. -->
         <Cutscene Name="gGoronCityDaruniaDancingCs" Offset="0x6930"/>
 
         <Cutscene Name="gGoronCityIntroCs" Offset="0x8380"/>

--- a/assets/xml/scenes/overworld/spot18_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot18_pal_n64.xml
@@ -1,9 +1,14 @@
 <Root>
     <File Name="spot18_scene" Segment="2">
-        <Cutscene Name="gGoronCityDaruniaCorrectCs" Offset="0x59E0"/>
-        <Cutscene Name="gGoronCityDarunia01Cs" Offset="0x6930"/>
-        <Cutscene Name="gGoronCityDaruniaWrongCs" Offset="0x7DF4"/>
+        <Cutscene Name="gGoronCityDaruniaCorrectSongCs" Offset="0x59E0"/>
+        <Cutscene Name="gGoronCityDaruniaWrongSongCs" Offset="0x7DF4"/>
+    
+        <!-- like `gGoronCityDaruniaCorrectSongCs` but dancing a second time -->
+        <Cutscene Name="gGoronCityDaruniaDancingCs" Offset="0x6930"/>
+
         <Cutscene Name="gGoronCityIntroCs" Offset="0x8380"/>
+        <Cutscene Name="gGoronCityCreditsCs" Offset="0x7844"/>
+
         <Texture Name="gGoronCityNightEntranceTex" OutName="night_entrance" Format="ia8" Width="8" Height="8" Offset="0x8F48"/>
         <Texture Name="gGoronCityDayEntranceTex" OutName="day_entrance" Format="ia8" Width="8" Height="8" Offset="0x9788"/>
         <Scene Name="spot18_scene" Offset="0x0"/>

--- a/assets/xml/scenes/overworld/spot18_pal_n64.xml
+++ b/assets/xml/scenes/overworld/spot18_pal_n64.xml
@@ -2,8 +2,11 @@
     <File Name="spot18_scene" Segment="2">
         <Cutscene Name="gGoronCityDaruniaCorrectSongCs" Offset="0x59E0"/>
         <Cutscene Name="gGoronCityDaruniaWrongSongCs" Offset="0x7DF4"/>
-    
-        <!-- like `gGoronCityDaruniaCorrectSongCs` but dancing a second time -->
+
+        <!--
+            This cutscene's implementation makes this cutscene override any other cutscene if Darunia is present in the scene.
+            This was probably used as a debug tool while creating the final cutscene.
+        -->
         <Cutscene Name="gGoronCityDaruniaDancingCs" Offset="0x6930"/>
 
         <Cutscene Name="gGoronCityIntroCs" Offset="0x8380"/>

--- a/src/overlays/actors/ovl_En_Du/z_en_du.c
+++ b/src/overlays/actors/ovl_En_Du/z_en_du.c
@@ -293,7 +293,7 @@ void EnDu_Init(Actor* thisx, PlayState* play) {
     this->interactInfo.talkState = NPC_TALK_STATE_IDLE;
 
     if (gSaveContext.save.cutsceneIndex >= 0xFFF0) {
-        play->csCtx.script = SEGMENTED_TO_VIRTUAL(gGoronCityDarunia01Cs);
+        play->csCtx.script = SEGMENTED_TO_VIRTUAL(gGoronCityDaruniaDancingCs);
         gSaveContext.cutsceneTrigger = 1;
         EnDu_SetupAction(this, func_809FE890);
     } else if (play->sceneId == SCENE_FIRE_TEMPLE) {
@@ -341,7 +341,7 @@ void func_809FE4A4(EnDu* this, PlayState* play) {
         play->msgCtx.ocarinaMode = OCARINA_MODE_00;
         EnDu_SetupAction(this, func_809FE3C0);
     } else if (play->msgCtx.ocarinaMode >= OCARINA_MODE_06) {
-        play->csCtx.script = SEGMENTED_TO_VIRTUAL(gGoronCityDaruniaWrongCs);
+        play->csCtx.script = SEGMENTED_TO_VIRTUAL(gGoronCityDaruniaWrongSongCs);
         gSaveContext.cutsceneTrigger = 1;
         this->unk_1E8 = 1;
         EnDu_SetupAction(this, func_809FE890);
@@ -349,7 +349,7 @@ void func_809FE4A4(EnDu* this, PlayState* play) {
     } else if (play->msgCtx.ocarinaMode == OCARINA_MODE_03) {
         Audio_PlaySfxGeneral(NA_SE_SY_CORRECT_CHIME, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
-        play->csCtx.script = SEGMENTED_TO_VIRTUAL(gGoronCityDaruniaCorrectCs);
+        play->csCtx.script = SEGMENTED_TO_VIRTUAL(gGoronCityDaruniaCorrectSongCs);
         gSaveContext.cutsceneTrigger = 1;
         this->unk_1E8 = 0;
         EnDu_SetupAction(this, func_809FE890);


### PR DESCRIPTION
I took the liberty of renaming the existing cutscenes from Goron City, I was thinking the names weren't descriptive enough, also I learned the horseback archery intro is an actual cutscene, I was expecting it to use the "one point demo" system

about Goron City, the cutscene where darunia is dancing after playing a song are still named "correct" and "wrong", I just added "song" after it to be more precise, and about `gGoronCityDarunia01Cs` I named it `gGoronCityDaruniaDancingCs` because it's not related to playing a song on the ocarina at all (despite the dialogs being mostly the same), also darunia is dancing twice (load goron city with cutscene index 0 to watch it) but it doesn't do the dancing animation the second time lol

though I just realised that one could be some easter egg when playing saria's song after obtaining the bracelet but it's played in the init function (and only there it seems) so it's probably not that, if you have informations about this feel free