### PR TITLE
rename `func_8002F368`, a getter for `struct Player -> exchangeItemId`

### DIFF
--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -868,7 +868,7 @@ s32 Actor_OfferTalkExchangeEquiCylinder(Actor* actor, struct PlayState* play, f3
 s32 Actor_OfferTalk(Actor* actor, struct PlayState* play, f32 radius);
 s32 Actor_OfferTalkNearColChkInfoCylinder(Actor* actor, struct PlayState* play);
 u32 Actor_TextboxIsClosing(Actor* actor, struct PlayState* play);
-s8 func_8002F368(struct PlayState* play);
+s8 Actor_GetPlayerExchangeItemId(struct PlayState* play);
 void Actor_GetScreenPos(struct PlayState* play, Actor* actor, s16* x, s16* y);
 u32 Actor_HasParent(Actor* actor, struct PlayState* play);
 s32 Actor_OfferGetItem(Actor* actor, struct PlayState* play, s32 getItemId, f32 xzRange, f32 yRange);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -1768,7 +1768,7 @@ u32 Actor_TextboxIsClosing(Actor* actor, PlayState* play) {
     }
 }
 
-s8 func_8002F368(PlayState* play) {
+s8 Actor_GetPlayerExchangeItemId(PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     return player->exchangeItemId;

--- a/src/overlays/actors/ovl_En_Ds/z_en_ds.c
+++ b/src/overlays/actors/ovl_En_Ds/z_en_ds.c
@@ -206,7 +206,7 @@ void EnDs_Wait(EnDs* this, PlayState* play) {
     s16 yawDiff;
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        if (func_8002F368(play) == EXCH_ITEM_ODD_MUSHROOM) {
+        if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_ODD_MUSHROOM) {
             Audio_PlaySfxGeneral(NA_SE_SY_TRE_BOX_APPEAR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
             player->actor.textId = 0x504A;

--- a/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -284,7 +284,7 @@ void func_80A2F83C(EnGb* this, PlayState* play) {
     if (Actor_TalkOfferAccepted(&this->dyna.actor, play)) {
         s32 pad;
 
-        switch (func_8002F368(play)) {
+        switch (Actor_GetPlayerExchangeItemId(play)) {
             case EXCH_ITEM_NONE:
                 func_80A2F180(this);
                 this->actionFunc = func_80A2F94C;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -599,7 +599,7 @@ void func_80A3F908(EnGo* this, PlayState* play) {
 
         if ((PARAMS_GET_NOSHIFT(this->actor.params, 4, 4) == 0x90) && (dialogStarted == true)) {
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_BROKEN_GORONS_SWORD) {
-                if (func_8002F368(play) == EXCH_ITEM_BROKEN_GORONS_SWORD) {
+                if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_BROKEN_GORONS_SWORD) {
                     if (GET_INFTABLE(INFTABLE_B4)) {
                         this->actor.textId = 0x3055;
                     } else {
@@ -612,7 +612,7 @@ void func_80A3F908(EnGo* this, PlayState* play) {
             }
 
             if (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_EYE_DROPS) {
-                if (func_8002F368(play) == EXCH_ITEM_EYE_DROPS) {
+                if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_EYE_DROPS) {
                     this->actor.textId = 0x3059;
                 } else {
                     this->actor.textId = 0x3058;

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -593,7 +593,7 @@ s16 EnGo2_UpdateTalkStateGoronDmtBiggoron(PlayState* play, EnGo2* this) {
         case TEXT_STATE_DONE_FADING:
             switch (this->actor.textId) {
                 case 0x305E:
-                    if (func_8002F368(play) != EXCH_ITEM_CLAIM_CHECK) {
+                    if (Actor_GetPlayerExchangeItemId(play) != EXCH_ITEM_CLAIM_CHECK) {
                         break;
                     }
                     FALLTHROUGH;
@@ -1027,7 +1027,7 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, PlayState* play, Player* player) {
 
     if (PARAMS_GET_S(this->actor.params, 0, 5) == GORON_DMT_BIGGORON) {
         if (gSaveContext.save.info.playerData.bgsFlag) {
-            if (func_8002F368(play) == EXCH_ITEM_CLAIM_CHECK) {
+            if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_CLAIM_CHECK) {
                 this->actor.textId = 0x3003;
             } else {
                 this->actor.textId = 0x305E;
@@ -1035,7 +1035,7 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, PlayState* play, Player* player) {
             player->actor.textId = this->actor.textId;
 
         } else if (!gSaveContext.save.info.playerData.bgsFlag && (INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_CLAIM_CHECK)) {
-            if (func_8002F368(play) == EXCH_ITEM_CLAIM_CHECK) {
+            if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_CLAIM_CHECK) {
                 if (Environment_GetBgsDayCount() >= 3) {
                     textId = 0x305E;
                 } else {
@@ -1054,7 +1054,7 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, PlayState* play, Player* player) {
 
         } else if ((INV_CONTENT(ITEM_TRADE_ADULT) >= ITEM_PRESCRIPTION) &&
                    (INV_CONTENT(ITEM_TRADE_ADULT) <= ITEM_CLAIM_CHECK)) {
-            if (func_8002F368(play) == EXCH_ITEM_EYE_DROPS) {
+            if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_EYE_DROPS) {
                 this->actor.textId = 0x3059;
             } else {
                 this->actor.textId = 0x3058;
@@ -1065,7 +1065,7 @@ void EnGo2_BiggoronSetTextId(EnGo2* this, PlayState* play, Player* player) {
             player->actor.textId = this->actor.textId;
 
         } else if (INV_CONTENT(ITEM_TRADE_ADULT) <= ITEM_BROKEN_GORONS_SWORD) {
-            if (func_8002F368(play) == EXCH_ITEM_BROKEN_GORONS_SWORD) {
+            if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_BROKEN_GORONS_SWORD) {
                 if (GET_INFTABLE(INFTABLE_B4)) {
                     textId = 0x3055;
                 } else {

--- a/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
+++ b/src/overlays/actors/ovl_En_Heishi2/z_en_heishi2.c
@@ -402,7 +402,7 @@ void func_80A53AD4(EnHeishi2* this, PlayState* play) {
     this->unk_300 = TEXT_STATE_DONE;
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        s32 exchangeItemId = func_8002F368(play);
+        s32 exchangeItemId = Actor_GetPlayerExchangeItemId(play);
 
         if (exchangeItemId == EXCH_ITEM_ZELDAS_LETTER) {
             Sfx_PlaySfxCentered(NA_SE_SY_CORRECT_CHIME);

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -206,7 +206,7 @@ void func_80A6E9AC(EnHs* this, PlayState* play) {
     s16 yawDiff;
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        if (func_8002F368(play) == EXCH_ITEM_COJIRO) {
+        if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_COJIRO) {
             player->actor.textId = 0x10B2;
             func_80A6E3A0(this, func_80A6E8CC);
             Animation_Change(&this->skelAnime, &object_hs_Anim_000304, 1.0f, 0.0f,

--- a/src/overlays/actors/ovl_En_Hy/z_en_hy.c
+++ b/src/overlays/actors/ovl_En_Hy/z_en_hy.c
@@ -957,7 +957,7 @@ void EnHy_OfferBuyBottledItem(EnHy* this, PlayState* play) {
     if (ENHY_GET_TYPE(&this->actor) == ENHY_TYPE_BEGGAR) {
         if (!Inventory_HasSpecificBottle(ITEM_BOTTLE_BLUE_FIRE) && !Inventory_HasSpecificBottle(ITEM_BOTTLE_BUG) &&
             !Inventory_HasSpecificBottle(ITEM_BOTTLE_FISH)) {
-            switch (func_8002F368(play)) {
+            switch (Actor_GetPlayerExchangeItemId(play)) {
                 case EXCH_ITEM_BOTTLE_POE:
                 case EXCH_ITEM_BOTTLE_BIG_POE:
                 case EXCH_ITEM_BOTTLE_RUTOS_LETTER:
@@ -971,7 +971,7 @@ void EnHy_OfferBuyBottledItem(EnHy* this, PlayState* play) {
                     break;
             }
         } else {
-            switch (func_8002F368(play)) {
+            switch (Actor_GetPlayerExchangeItemId(play)) {
                 case EXCH_ITEM_BOTTLE_BLUE_FIRE:
                     this->actor.textId = 0x70F0;
                     break;

--- a/src/overlays/actors/ovl_En_Ko/z_en_ko.c
+++ b/src/overlays/actors/ovl_En_Ko/z_en_ko.c
@@ -991,7 +991,7 @@ void func_80A9877C(EnKo* this, PlayState* play) {
         ENKO_TYPE == ENKO_TYPE_CHILD_FADO && play->sceneId == SCENE_LOST_WOODS) {
         this->actor.textId = INV_CONTENT(ITEM_TRADE_ADULT) > ITEM_ODD_POTION ? 0x10B9 : 0x10DF;
 
-        if (func_8002F368(play) == EXCH_ITEM_ODD_POTION) {
+        if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_ODD_POTION) {
 #if OOT_VERSION < NTSC_1_1
             this->actor.textId = GET_INFTABLE(INFTABLE_B6) ? 0x10B8 : 0x10B7;
 #else

--- a/src/overlays/actors/ovl_En_Kz/z_en_kz.c
+++ b/src/overlays/actors/ovl_En_Kz/z_en_kz.c
@@ -292,7 +292,7 @@ void func_80A9CB18(EnKz* this, PlayState* play) {
     if (EnKz_UpdateTalking(play, &this->actor, &this->interactInfo.talkState, 340.0f, EnKz_GetTextId,
                            EnKz_UpdateTalkState)) {
         if ((this->actor.textId == 0x401A) && !GET_EVENTCHKINF(EVENTCHKINF_GAVE_LETTER_TO_KING_ZORA)) {
-            if (func_8002F368(play) == EXCH_ITEM_BOTTLE_RUTOS_LETTER) {
+            if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_BOTTLE_RUTOS_LETTER) {
                 this->actor.textId = 0x401B;
                 this->sfxPlayed = false;
             } else {
@@ -304,7 +304,7 @@ void func_80A9CB18(EnKz* this, PlayState* play) {
 
         if (LINK_IS_ADULT) {
             if ((INV_CONTENT(ITEM_TRADE_ADULT) == ITEM_PRESCRIPTION) &&
-                (func_8002F368(play) == EXCH_ITEM_PRESCRIPTION)) {
+                (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_PRESCRIPTION)) {
                 this->actor.textId = 0x4014;
                 this->sfxPlayed = false;
                 player->actor.textId = this->actor.textId;
@@ -494,7 +494,7 @@ void EnKz_SetupGetItem(EnKz* this, PlayState* play) {
         this->actionFunc = EnKz_StartTimer;
     } else {
 #if OOT_VERSION < PAL_1_0
-        getItemId = func_8002F368(play) == EXCH_ITEM_PRESCRIPTION ? GI_EYEBALL_FROG : GI_TUNIC_ZORA;
+        getItemId = Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_PRESCRIPTION ? GI_EYEBALL_FROG : GI_TUNIC_ZORA;
 #else
         getItemId = this->isTrading == true ? GI_EYEBALL_FROG : GI_TUNIC_ZORA;
 #endif

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -216,7 +216,7 @@ void EnMk_Wait(EnMk* this, PlayState* play) {
     s32 playerExchangeItem;
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        playerExchangeItem = func_8002F368(play);
+        playerExchangeItem = Actor_GetPlayerExchangeItemId(play);
 
         if (this->actor.textId != 0x4018) {
             player->actor.textId = this->actor.textId;

--- a/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
+++ b/src/overlays/actors/ovl_En_Niw_Lady/z_en_niw_lady.c
@@ -374,7 +374,7 @@ void func_80ABA878(EnNiwLady* this, PlayState* play) {
         this->unk_26E = 11;
     }
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        s8 playerExchangeItemId = func_8002F368(play);
+        s8 playerExchangeItemId = Actor_GetPlayerExchangeItemId(play);
 
         if ((playerExchangeItemId == EXCH_ITEM_POCKET_CUCCO) && GET_EVENTCHKINF(EVENTCHKINF_TALON_WOKEN_IN_KAKARIKO)) {
             Sfx_PlaySfxCentered(NA_SE_SY_TRE_BOX_APPEAR);

--- a/src/overlays/actors/ovl_En_Ta/z_en_ta.c
+++ b/src/overlays/actors/ovl_En_Ta/z_en_ta.c
@@ -368,7 +368,7 @@ void EnTa_IdleAsleepInCastle(EnTa* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        s32 exchangeItemId = func_8002F368(play);
+        s32 exchangeItemId = Actor_GetPlayerExchangeItemId(play);
 
         switch (exchangeItemId) {
             case EXCH_ITEM_CHICKEN:
@@ -403,7 +403,7 @@ void EnTa_IdleAsleepInKakariko(EnTa* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     if (Actor_TalkOfferAccepted(&this->actor, play)) {
-        s32 exchangeItemId = func_8002F368(play);
+        s32 exchangeItemId = Actor_GetPlayerExchangeItemId(play);
 
         switch (exchangeItemId) {
             case EXCH_ITEM_POCKET_CUCCO:

--- a/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
+++ b/src/overlays/actors/ovl_En_Toryo/z_en_toryo.c
@@ -318,7 +318,7 @@ void EnToryo_HandleTalking(EnToryo* this, PlayState* play) {
 
     if (this->messageState == 0) {
         if (Actor_TalkOfferAccepted(&this->actor, play)) {
-            this->exchangeItemId = func_8002F368(play);
+            this->exchangeItemId = Actor_GetPlayerExchangeItemId(play);
             if (this->exchangeItemId != EXCH_ITEM_NONE) {
                 player->actor.textId = EnToryo_ReactToExchangeItem(this, play);
                 this->actor.textId = player->actor.textId;

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -537,7 +537,7 @@ void ObjBean_SetupWaitForBean(ObjBean* this) {
 
 void ObjBean_WaitForBean(ObjBean* this, PlayState* play) {
     if (Actor_TalkOfferAccepted(&this->dyna.actor, play)) {
-        if (func_8002F368(play) == EXCH_ITEM_MAGIC_BEAN) {
+        if (Actor_GetPlayerExchangeItemId(play) == EXCH_ITEM_MAGIC_BEAN) {
             func_80B8FE00(this);
             Flags_SetSwitch(play, PARAMS_GET_U(this->dyna.actor.params, 0, 6));
         }


### PR DESCRIPTION
this PR invites anyone to discuss and decide on the name

my initial thought was to name it simply `Player_GetExchangeItemId`. I've reconsidered to settle for `Actor_GetPlayerExchangeItemId` now, though. arguably, the former might be not the best name, as discussed with @fig02 @ https://github.com/zeldaret/oot/pull/2295#discussion_r1884153020


## reasoning
all in all it seems that the general consensus is:
- prefix indicates a caller
  - `Actor_` for common functions
  - `%EntityName%_` for entity-specific ones
- the rest descibes its purpose, obviously
  - it shouldn't necesarily be a getter

so, following this rule, `Actor_GetPlayerExchangeItemId` seems to fit:
- multiple different entities request exchange info
- player is still being mentioned here, because the state is completely encapsulated inside its data


## P.S.
existing functions considered:
- `Actor_FindNearby`: an actor looks up another one
- `BgDyYoseizo_Vanish`: Great Fairy looks up an ocarina spot, besides the main purpose
- `Actor_GetProjectileActor`: an actor looks up a projectile
- `BgGanonOtyuka_WaitToFall`: Ganon looks up a falling platform
- `ObjBean_CheckForHorseTrample`: Bean plant looks up a horse proximity