### PR TITLE
Name cutscenes from dungeons (Spirit Boss Room, Jabu-Jabu's Belly and Ganon)

### DIFF
--- a/assets/xml/scenes/dungeons/bdan.xml
+++ b/assets/xml/scenes/dungeons/bdan.xml
@@ -1,6 +1,7 @@
 <Root>
     <File Name="bdan_scene" Segment="2">
         <Cutscene Name="gJabuJabuIntroCs" Offset="0x155E0"/>
+        <Cutscene Name="gJabuJabuSapphireRetrieveUnusedCs" Offset="0x13080"/>
         <Scene Name="bdan_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_room_0" Segment="3">

--- a/assets/xml/scenes/dungeons/bdan.xml
+++ b/assets/xml/scenes/dungeons/bdan.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="bdan_scene" Segment="2">
-        <Cutscene Name="gJabuJabuIntroCs" Offset="0x155E0"/>
-        <Cutscene Name="gJabuJabuSapphireRetrieveUnusedCs" Offset="0x13080"/>
+        <Cutscene Name="gJabuIntroCs" Offset="0x155E0"/>
+        <Cutscene Name="gJabuSapphireRetrieveUnusedCs" Offset="0x13080"/>
         <Scene Name="bdan_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_room_0" Segment="3">

--- a/assets/xml/scenes/dungeons/bdan_mq.xml
+++ b/assets/xml/scenes/dungeons/bdan_mq.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="bdan_scene" Segment="2">
-        <Cutscene Name="gJabuJabuIntroCs" Offset="0x15600"/>
-        <Cutscene Name="gJabuJabuSapphireRetrieveUnusedCs" Offset="0x130A0"/>
+        <Cutscene Name="gJabuIntroCs" Offset="0x15600"/>
+        <Cutscene Name="gJabuSapphireRetrieveUnusedCs" Offset="0x130A0"/>
         <Scene Name="bdan_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_room_0" Segment="3">

--- a/assets/xml/scenes/dungeons/bdan_mq.xml
+++ b/assets/xml/scenes/dungeons/bdan_mq.xml
@@ -1,6 +1,7 @@
 <Root>
     <File Name="bdan_scene" Segment="2">
         <Cutscene Name="gJabuJabuIntroCs" Offset="0x15600"/>
+        <Cutscene Name="gJabuJabuSapphireRetrieveUnusedCs" Offset="0x130A0"/>
         <Scene Name="bdan_scene" Offset="0x0"/>
     </File>
     <File Name="bdan_room_0" Segment="3">

--- a/assets/xml/scenes/dungeons/ganon_demo.xml
+++ b/assets/xml/scenes/dungeons/ganon_demo.xml
@@ -1,6 +1,7 @@
 <Root>
     <File Name="ganon_demo_scene" Segment="2">
         <Scene Name="ganon_demo_scene" Offset="0x0"/>
+        <Cutscene Name="gGanonBossCastleCollapseCs" Offset="0x01B0"/>
     </File>
     <File Name="ganon_demo_room_0" Segment="3">
         <Room Name="ganon_demo_room_0" Offset="0x0"/>

--- a/assets/xml/scenes/dungeons/ganon_demo.xml
+++ b/assets/xml/scenes/dungeons/ganon_demo.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="ganon_demo_scene" Segment="2">
         <Scene Name="ganon_demo_scene" Offset="0x0"/>
-        <Cutscene Name="gGanonBossCastleCollapseCs" Offset="0x01B0"/>
+        <Cutscene Name="gGanonCastleCollapseCs" Offset="0x01B0"/>
     </File>
     <File Name="ganon_demo_room_0" Segment="3">
         <Room Name="ganon_demo_room_0" Offset="0x0"/>

--- a/assets/xml/scenes/dungeons/jyasinboss.xml
+++ b/assets/xml/scenes/dungeons/jyasinboss.xml
@@ -2,6 +2,7 @@
     <File Name="jyasinboss_scene" Segment="2">
         <Cutscene Name="gSpiritBossNabooruKnuckleIntroCs" Offset="0x2BB0"/>
         <Cutscene Name="gSpiritBossNabooruKnuckleDefeatCs" Offset="0x3F80"/>
+        <Cutscene Name="gSpiritBossTitleCs" Offset="0x5850"/>
         <Scene Name="jyasinboss_scene" Offset="0x0"/>
     </File>
     <File Name="jyasinboss_room_0" Segment="3">

--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -95,7 +95,7 @@ EntranceCutscene sEntranceCutsceneTable[] = {
     { ENTR_GERUDO_VALLEY_0, 2, EVENTCHKINF_B2, gGerudoValleyIntroCs },
     { ENTR_GERUDOS_FORTRESS_0, 2, EVENTCHKINF_B3, gGerudoFortressIntroCs },
     { ENTR_LON_LON_RANCH_0, 2, EVENTCHKINF_B4, gLonLonRanchIntroCs },
-    { ENTR_JABU_JABU_0, 2, EVENTCHKINF_B5, gJabuJabuIntroCs },
+    { ENTR_JABU_JABU_0, 2, EVENTCHKINF_B5, gJabuIntroCs },
     { ENTR_GRAVEYARD_0, 2, EVENTCHKINF_B6, gGraveyardIntroCs },
     { ENTR_ZORAS_FOUNTAIN_2, 2, EVENTCHKINF_B7, gZorasFountainIntroCs },
     { ENTR_DESERT_COLOSSUS_0, 2, EVENTCHKINF_B8, gDesertColossusIntroCs },
@@ -115,7 +115,7 @@ EntranceCutscene sEntranceCutsceneTable[] = {
 };
 
 void* sCutscenesUnknownList[] = {
-    gDekuTreeIntroCs,     gJabuJabuIntroCs, gDcOpeningCs, gSpiritBossNabooruKnuckleDefeatCs,
+    gDekuTreeIntroCs,     gJabuIntroCs,    gDcOpeningCs, gSpiritBossNabooruKnuckleDefeatCs,
     gIceCavernSerenadeCs, gTowerBarrierCs,
 };
 


### PR DESCRIPTION
`gJabuJabuSapphireRetrieveUnusedCs` seems the same as `D_80AF10A4` afaict, the main differences is missing text enum usage in the actor file and float values

now it's only "indoors" cutscenes, which will be the next PR (except for temple of time which will be separate because it contains a lot of cutscenes), then it's cutscenes from actors