### PR TITLE
Removing Docker Compose Version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   oot:
     volumes:


### PR DESCRIPTION
This is deprecated. When you build using it, you get error: "the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion".