### PR TITLE
Use iconv from Homebrew on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,13 @@ OBJCOPY := $(MIPS_BINUTILS_PREFIX)objcopy
 OBJDUMP := $(MIPS_BINUTILS_PREFIX)objdump
 NM      := $(MIPS_BINUTILS_PREFIX)nm
 
+# The default iconv on macOS has some differences from GNU iconv, so we use the Homebrew version instead
+ifeq ($(UNAME_S),Darwin)
+  ICONV := /usr/local/opt/libiconv/bin/iconv
+else
+  ICONV := iconv
+endif
+
 INC := -Iinclude -Iinclude/libc -Isrc -I$(BUILD_DIR) -I. -I$(EXTRACTED_DIR)
 
 # Check code syntax with host compiler
@@ -598,7 +605,7 @@ $(BUILD_DIR)/assets/misc/z_select_static/%.o: GBI_DEFINES := -DF3DEX_GBI
 
 ifeq ($(PERMUTER),)  # permuter + preprocess.py misbehaves, permuter doesn't care about rodata diffs or bss ordering so just don't use it in that case
 # Handle encoding (UTF-8 -> EUC-JP) and custom pragmas
-$(BUILD_DIR)/src/%.o: CC := ./tools/preprocess.sh -v $(VERSION) -- $(CC)
+$(BUILD_DIR)/src/%.o: CC := ./tools/preprocess.sh -v $(VERSION) -i $(ICONV) -- $(CC)
 endif
 
 else

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ NM      := $(MIPS_BINUTILS_PREFIX)nm
 
 # The default iconv on macOS has some differences from GNU iconv, so we use the Homebrew version instead
 ifeq ($(UNAME_S),Darwin)
-  ICONV := /usr/local/opt/libiconv/bin/iconv
+  ICONV := $(shell brew --prefix)/opt/libiconv/bin/iconv
 else
   ICONV := iconv
 endif

--- a/docs/BUILDING_MACOS.md
+++ b/docs/BUILDING_MACOS.md
@@ -19,7 +19,7 @@ You can install them with the following commands:
 
 ```bash
 brew update
-brew install coreutils make python3 libpng bash clang-format libxml2
+brew install coreutils make python3 libpng bash clang-format libxml2 libiconv
 ```
 
 (The repository expects Homebrew-installed programs to be either linked correctly in `$PATH` etc. or in their default locations.)

--- a/tools/preprocess.sh
+++ b/tools/preprocess.sh
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: CC0-1.0
 
 # Usage: preprocess [flags] -- [compile command minus input file...] [single input file]
-# Flags: -v OOT_VERSION (required)
+# Flags:
+#   -v OOT_VERSION (required)
+#   -i ICONV_PATH (optional, default: iconv)
 # Preprocess a C file to:
 # * Re-encode from UTF-8 to EUC-JP
 #   (the repo uses UTF-8 for text encoding, but the strings in the ROM are encoded in EUC-JP)
@@ -39,11 +41,16 @@ then
     echo srcfile="$srcfile"
 fi
 
-while getopts "v:" opt "${flags[@]}"
+ICONV=iconv
+
+while getopts "v:i:" opt "${flags[@]}"
 do
     case $opt in
         v)
             OOT_VERSION=$OPTARG
+            ;;
+        i)
+            ICONV=$OPTARG
             ;;
         ?)
             echo "Error: Bad flags"
@@ -76,7 +83,7 @@ trap "rm -rf $tempdir" EXIT
 {
     printf '#line 1 "%s"\n' "$srcfile"  # linemarker
     ./tools/preprocess_pragmas $OOT_VERSION "$srcfile" < "$srcfile"
-} | iconv -f UTF-8 -t EUC-JP > "$tempfile"
+} | "${ICONV}" -f UTF-8 -t EUC-JP > "$tempfile"
 
 # Also include the source file's directory to have the include path as if we compiled the original source.
 # Pass the processed temporary file for compilation.


### PR DESCRIPTION
Apparently the implementation of `iconv` changed in macOS 14.0 Sonoma and it no longer handles backslashes in the way we want. Now we make users install GNU iconv from homebrew instead and plumb it through to preprocess.sh.