### PR TITLE
Fix editing PATH in macOS build instructions

### DIFF
--- a/docs/BUILDING_MACOS.md
+++ b/docs/BUILDING_MACOS.md
@@ -67,7 +67,7 @@ sudo make install
 
 Edit your `~/.bash_profile`/`~/.zprofile` (or whichever shell you use) to add the new binutils binaries to the system PATH
 ```bash
-echo 'export PATH=$PATH:/opt/cross/bin' >> ~/.bash_profile
+echo 'export PATH="$PATH:/opt/cross/bin"' >> ~/.bash_profile
 ```
 
 Reload `~/.bash_profile` (or just launch a new terminal tab)

--- a/docs/BUILDING_MACOS.md
+++ b/docs/BUILDING_MACOS.md
@@ -65,9 +65,9 @@ make -j
 sudo make install
 ```
 
-Edit your `~/.bash_profile`/`~/.zsh_profile` (or whichever shell you use) to add the new binutils binaries to the system PATH
+Edit your `~/.bash_profile`/`~/.zprofile` (or whichever shell you use) to add the new binutils binaries to the system PATH
 ```bash
-echo "export PATH=$PATH:/opt/cross/bin" >> ~/.bash_profile
+echo 'export PATH=$PATH:/opt/cross/bin' >> ~/.bash_profile
 ```
 
 Reload `~/.bash_profile` (or just launch a new terminal tab)


### PR DESCRIPTION
Problems pointed out by Aroenai on Discord:

* $PATH was expanded in the command, so the current value of the path is written instead of literally `$PATH`
* The correct config file for zsh is `.zprofile`, not `.zsh_profile`