### PR TITLE
Split some data from src/audio/session_config.c into src/audio/session_init.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -788,6 +788,14 @@ endif
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
 	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > $(@:.o=.s)
 
+$(BUILD_DIR)/src/audio/session_init.o: src/audio/session_init.c $(BUILD_DIR)/assets/audio/soundfont_sizes.h $(BUILD_DIR)/assets/audio/sequence_sizes.h
+ifneq ($(RUN_CC_CHECK),0)
+	$(CC_CHECK) $<
+endif
+	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $(@:.o=.tmp) $<
+	$(LD) -r -T linker_scripts/data_with_rodata.ld -o $@ $(@:.o=.tmp)
+	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > $(@:.o=.s)
+
 $(BUILD_DIR)/src/libultra/libc/ll.o: src/libultra/libc/ll.c
 ifneq ($(RUN_CC_CHECK),0)
 	$(CC_CHECK) $<
@@ -966,8 +974,6 @@ $(BUILD_DIR)/assets/audio/sequence_font_table.o: $(BUILD_DIR)/assets/audio/seque
 	$(AS) $(ASFLAGS) $< -o $@
 
 # make headers with file sizes and amounts
-
-$(BUILD_DIR)/src/audio/session_config.o: $(BUILD_DIR)/assets/audio/soundfont_sizes.h $(BUILD_DIR)/assets/audio/sequence_sizes.h
 
 $(BUILD_DIR)/assets/audio/soundfont_sizes.h: $(SOUNDFONT_O_FILES)
 	$(AFILE_SIZES) $@ NUM_SOUNDFONTS SOUNDFONT_SIZES .rodata $^

--- a/include/variables.h
+++ b/include/variables.h
@@ -133,8 +133,8 @@ extern s32 gSystemArenaLogSeverity;
 extern u8 __osPfsInodeCacheBank;
 extern s32 __osPfsLastChannel;
 
-extern const TempoData gTempoData;
-extern const AudioHeapInitSizes gAudioHeapInitSizes;
+extern TempoData gTempoData;
+extern AudioHeapInitSizes gAudioHeapInitSizes;
 extern s16 gOcarinaSongItemMap[];
 extern AudioTable gSoundFontTable;
 extern u8 gSequenceFontTable[];

--- a/spec
+++ b/spec
@@ -740,6 +740,7 @@ beginseg
     include "$(BUILD_DIR)/src/audio/sequence.o"
     include "$(BUILD_DIR)/src/audio/data.o"
     include "$(BUILD_DIR)/src/audio/session_config.o"
+    include "$(BUILD_DIR)/src/audio/session_init.o"
 #if PLATFORM_N64
     include "$(BUILD_DIR)/src/libu64/gfxprint.o"
     include "$(BUILD_DIR)/src/libu64/rcp_utils.o"

--- a/src/audio/lib/load.c
+++ b/src/audio/lib/load.c
@@ -1250,8 +1250,7 @@ void AudioLoad_Init(void* heap, u32 heapSize) {
 
     ramAddr = AudioHeap_Alloc(&gAudioCtx.initPool, gAudioHeapInitSizes.permanentPoolSize);
     if (ramAddr == NULL) {
-        // cast away const from gAudioHeapInitSizes
-        *((u32*)&gAudioHeapInitSizes.permanentPoolSize) = 0;
+        gAudioHeapInitSizes.permanentPoolSize = 0;
     }
 
     AudioHeap_InitPool(&gAudioCtx.permanentPool, ramAddr, gAudioHeapInitSizes.permanentPoolSize);

--- a/src/audio/session_config.c
+++ b/src/audio/session_config.c
@@ -1,32 +1,8 @@
 #include "global.h"
-#include "assets/audio/sequence_sizes.h"
-#include "assets/audio/soundfont_sizes.h"
-#define SFX_SEQ_SIZE Sequence_0_SIZE
-#define SFX_SOUNDFONTS_SIZE (Soundfont_0_SIZE + Soundfont_1_SIZE)
 
 AudioContext gAudioCtx;
 AudioCustomUpdateFunction gAudioCustomUpdateFunction;
 s32 D_801755D8[3]; // unused
-
-const TempoData gTempoData = {
-    0x1C00,            // unk_00
-    SEQTICKS_PER_BEAT, // seqTicksPerBeat
-};
-
-// Sizes of everything on the init pool
-#define AI_BUFFERS_SIZE (AIBUF_SIZE * ARRAY_COUNT(gAudioCtx.aiBuffers))
-#define SOUNDFONT_LIST_SIZE (NUM_SOUNDFONTS * sizeof(SoundFont))
-#if OOT_VERSION < PAL_1_0 || PLATFORM_GC
-#define PERMANENT_POOL_SIZE (SFX_SEQ_SIZE + SFX_SOUNDFONTS_SIZE)
-#else
-#define PERMANENT_POOL_SIZE (SFX_SEQ_SIZE + SFX_SOUNDFONTS_SIZE + 0x10)
-#endif
-
-const AudioHeapInitSizes gAudioHeapInitSizes = {
-    ALIGN16(sizeof(gAudioHeap) - 0x100),                                  // audio heap size
-    ALIGN16(PERMANENT_POOL_SIZE + AI_BUFFERS_SIZE + SOUNDFONT_LIST_SIZE), // init pool size
-    ALIGN16(PERMANENT_POOL_SIZE),                                         // permanent pool size
-};
 
 #define DEFAULT_REVERB_SETTINGS \
     { 1, 0x30, 0x3000, 0, 0, 0x7FFF, 0x0000, 0x0000, 0xFF, 0x3000, 0x0, 0x0 }

--- a/src/audio/session_init.c
+++ b/src/audio/session_init.c
@@ -1,0 +1,26 @@
+#include "global.h"
+#include "assets/audio/sequence_sizes.h"
+#include "assets/audio/soundfont_sizes.h"
+
+#define SFX_SEQ_SIZE Sequence_0_SIZE
+#define SFX_SOUNDFONTS_SIZE (Soundfont_0_SIZE + Soundfont_1_SIZE)
+
+TempoData gTempoData = {
+    0x1C00,            // unk_00
+    SEQTICKS_PER_BEAT, // seqTicksPerBeat
+};
+
+// Sizes of everything on the init pool
+#define AI_BUFFERS_SIZE (AIBUF_SIZE * ARRAY_COUNT(gAudioCtx.aiBuffers))
+#define SOUNDFONT_LIST_SIZE (NUM_SOUNDFONTS * sizeof(SoundFont))
+#if OOT_VERSION < PAL_1_0 || PLATFORM_GC
+#define PERMANENT_POOL_SIZE (SFX_SEQ_SIZE + SFX_SOUNDFONTS_SIZE)
+#else
+#define PERMANENT_POOL_SIZE (SFX_SEQ_SIZE + SFX_SOUNDFONTS_SIZE + 0x10)
+#endif
+
+AudioHeapInitSizes gAudioHeapInitSizes = {
+    ALIGN16(sizeof(gAudioHeap) - 0x100),                                  // audio heap size
+    ALIGN16(PERMANENT_POOL_SIZE + AI_BUFFERS_SIZE + SOUNDFONT_LIST_SIZE), // init pool size
+    ALIGN16(PERMANENT_POOL_SIZE),                                         // permanent pool size
+};


### PR DESCRIPTION
Some of the data in `session_config.c` had to be const-qualified in order to end up rodata, however some of this data is written to. This PR splits that data into a new file, `session_init.c`, and removes the const qualifiers, instead incrementally linking data -> rodata. This avoids having to cast away const.
