### PR TITLE
Match iQue compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -707,8 +707,13 @@ $(ROM): $(ELF)
 	$(ELF2ROM) -cic 6105 $< $@
 
 $(ROMC): $(ROM) $(ELF) $(BUILD_DIR)/compress_ranges.txt
-	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dmadata-start `./tools/dmadata_start.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` --threads $(N_THREADS)
+ifeq ($(PLATFORM),IQUE)
+	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dmadata-start `./tools/dmadata_start.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` --format gzip --threads $(N_THREADS)
+	$(PYTHON) -m ipl3checksum sum --cic 6102 --update $@
+else
+	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dmadata-start `./tools/dmadata_start.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` --format yaz0 --pad-rom --threads $(N_THREADS)
 	$(PYTHON) -m ipl3checksum sum --cic 6105 --update $@
+endif
 
 $(ELF): $(TEXTURE_FILES_OUT) $(ASSET_FILES_OUT) $(O_FILES) $(OVL_RELOC_FILES) $(LDSCRIPT) $(BUILD_DIR)/undefined_syms.txt \
         $(SAMPLEBANK_O_FILES) $(SOUNDFONT_O_FILES) $(SEQUENCE_O_FILES) \

--- a/Makefile
+++ b/Makefile
@@ -707,10 +707,10 @@ $(ROM): $(ELF)
 	$(ELF2ROM) -cic 6105 $< $@
 
 ifeq ($(PLATFORM),IQUE)
-  COMPRESS_ARGS := --format gzip
+  COMPRESS_ARGS := --format gzip --pad-to 0x4000
   CIC = 6102
 else
-  COMPRESS_ARGS := --format yaz0 --pad-rom
+  COMPRESS_ARGS := --format yaz0 --pad-to 0x800000 --fill-padding-bytes
   CIC = 6105
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -715,7 +715,7 @@ else
 endif
 
 $(ROMC): $(ROM) $(ELF) $(BUILD_DIR)/compress_ranges.txt
-	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dmadata-start `./tools/dmadata_start.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` $(COMPRESS_ARGS) --threads $(N_THREADS)
+	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dmadata-start `./tools/dmadata_start.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` --threads $(N_THREADS) $(COMPRESS_ARGS)
 	$(PYTHON) -m ipl3checksum sum --cic $(CIC) --update $@
 
 $(ELF): $(TEXTURE_FILES_OUT) $(ASSET_FILES_OUT) $(O_FILES) $(OVL_RELOC_FILES) $(LDSCRIPT) $(BUILD_DIR)/undefined_syms.txt \

--- a/Makefile
+++ b/Makefile
@@ -706,14 +706,17 @@ endif
 $(ROM): $(ELF)
 	$(ELF2ROM) -cic 6105 $< $@
 
-$(ROMC): $(ROM) $(ELF) $(BUILD_DIR)/compress_ranges.txt
 ifeq ($(PLATFORM),IQUE)
-	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dmadata-start `./tools/dmadata_start.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` --format gzip --threads $(N_THREADS)
-	$(PYTHON) -m ipl3checksum sum --cic 6102 --update $@
+  COMPRESS_ARGS := --format gzip
+  CIC = 6102
 else
-	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dmadata-start `./tools/dmadata_start.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` --format yaz0 --pad-rom --threads $(N_THREADS)
-	$(PYTHON) -m ipl3checksum sum --cic 6105 --update $@
+  COMPRESS_ARGS := --format yaz0 --pad-rom
+  CIC = 6105
 endif
+
+$(ROMC): $(ROM) $(ELF) $(BUILD_DIR)/compress_ranges.txt
+	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dmadata-start `./tools/dmadata_start.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` $(COMPRESS_ARGS) --threads $(N_THREADS)
+	$(PYTHON) -m ipl3checksum sum --cic $(CIC) --update $@
 
 $(ELF): $(TEXTURE_FILES_OUT) $(ASSET_FILES_OUT) $(O_FILES) $(OVL_RELOC_FILES) $(LDSCRIPT) $(BUILD_DIR)/undefined_syms.txt \
         $(SAMPLEBANK_O_FILES) $(SOUNDFONT_O_FILES) $(SEQUENCE_O_FILES) \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Setup and compression
-crunch64>=0.3.1,<1.0.0
+crunch64>=0.5.1,<1.0.0
 ipl3checksum>=1.2.0,<2.0.0
 pyyaml>=6.0.1,<7.0.0
 

--- a/tools/compress.py
+++ b/tools/compress.py
@@ -17,6 +17,12 @@ import crunch64
 import dmadata
 
 
+COMPRESSION_METHODS = {
+    "yaz0": crunch64.yaz0.compress,
+    "gzip": crunch64.gzip.compress,
+}
+
+
 def align(v: int):
     v += 0xF
     return v // 0x10 * 0x10
@@ -62,12 +68,7 @@ def compress_rom(
     """
 
     # Compression function
-    if compression_format == "yaz0":
-        compress = crunch64.yaz0.compress
-    elif compression_format == "gzip":
-        compress = crunch64.gzip.compress
-    else:
-        raise ValueError(f"Unknown compression format: {compression_format}")
+    compress = COMPRESSION_METHODS[compression_format]
 
     # Segments of the compressed rom (not all are compressed)
     compressed_rom_segments: list[RomSegment] = []
@@ -252,7 +253,7 @@ def main():
     parser.add_argument(
         "--format",
         dest="format",
-        choices=["yaz0", "gzip"],
+        choices=COMPRESSION_METHODS.keys(),
         default="yaz0",
         help="compression format to use (default: yaz0)",
     )

--- a/tools/compress.py
+++ b/tools/compress.py
@@ -65,7 +65,7 @@ def compress_rom(
     compress_entries_indices: the indices in the dmadata of the segments that should be compressed
     compression_format: the compression format to use
     pad_to_multiple_of: pad the compressed rom to a multiple of this size, in bytes
-    fill_padding_bytes: fill the padding with a 0x00 0x01 0x02 ... pattern
+    fill_padding_bytes: fill the padding bytes with a 0x00 0x01 0x02 ... pattern instead of zeros
     n_threads: how many cores to use for compression
     """
 
@@ -265,7 +265,7 @@ def main():
         "--fill-padding-bytes",
         dest="fill_padding_bytes",
         action="store_true",
-        help="fill the padding with a 0x00 0x01 0x02 ... pattern",
+        help="fill the padding bytes with a 0x00 0x01 0x02 ... pattern instead of zeros",
     )
     parser.add_argument(
         "--threads",

--- a/tools/compress.py
+++ b/tools/compress.py
@@ -165,7 +165,7 @@ def compress_rom(
     if pad_rom:
         pad_to_multiple_of = 8 * 2**20  # 8 MiB
     else:
-        pad_to_multiple_of = 4 * 2**10  # 4 KiB
+        pad_to_multiple_of = 16 * 2**10  # 16 KiB
     compressed_rom_size_padded = (
         (compressed_rom_size + pad_to_multiple_of - 1)
         // pad_to_multiple_of


### PR DESCRIPTION
Besides using gzip compression, it seems like iQue ROMs also have different padding and checksum methods from N64 ROMs.

Tested with:
```
$ tools/compress.py --in baseroms/ique-cn/baserom-decompressed.z64 --out build/ique-cn/oot-ique-cn-compressed.z64 --dmadata-start 0xB7A0 --compress $(cat build/ique-cn/compress_ranges.txt) --format gzip --threads 8
$ python3 -m ipl3checksum sum --cic 6102 --update build/ique-cn/oot-ique-cn-compressed.z64
$ md5sum -c baseroms/ique-cn/checksum-compressed.md5
```