### PR TITLE
Download EGCS binutils and gcc for iQue

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -10,3 +10,4 @@ vtxdis
 yaz0
 
 ido_recomp/
+egcs/

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -69,13 +69,13 @@ $(foreach p,$(PROGRAMS),$(eval $(call COMPILE,$(p))))
 
 $(IDO_RECOMP_5_3_DIR):
 	mkdir -p $@
-	curl -L https://github.com/decompals/ido-static-recomp/releases/download/$(IDO_RECOMP_VERSION)/ido-5.3-recomp-$(DETECTED_OS).tar.gz | tar xz -C $@
+	curl -sL https://github.com/decompals/ido-static-recomp/releases/download/$(IDO_RECOMP_VERSION)/ido-5.3-recomp-$(DETECTED_OS).tar.gz | tar xz -C $@
 
 $(IDO_RECOMP_7_1_DIR):
 	mkdir -p $@
-	curl -L https://github.com/decompals/ido-static-recomp/releases/download/$(IDO_RECOMP_VERSION)/ido-7.1-recomp-$(DETECTED_OS).tar.gz | tar xz -C $@
+	curl -sL https://github.com/decompals/ido-static-recomp/releases/download/$(IDO_RECOMP_VERSION)/ido-7.1-recomp-$(DETECTED_OS).tar.gz | tar xz -C $@
 
 $(EGCS_DIR):
 	mkdir -p $@
-	curl -L https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/$(EGCS_BINUTILS_VERSION)/mips-binutils-egcs-2.9.5-$(DETECTED_OS).tar.gz | tar xz -C $@
-	curl -L https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/$(EGCS_GCC_VERSION)/mips-gcc-egcs-2.91.66-$(DETECTED_OS).tar.gz | tar xz -C $@
+	curl -sL https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/$(EGCS_BINUTILS_VERSION)/mips-binutils-egcs-2.9.5-$(DETECTED_OS).tar.gz | tar xz -C $@
+	curl -sL https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/$(EGCS_GCC_VERSION)/mips-gcc-egcs-2.91.66-$(DETECTED_OS).tar.gz | tar xz -C $@

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -14,6 +14,10 @@ IDO_RECOMP_VERSION := v1.2
 IDO_RECOMP_5_3_DIR := ido_recomp/$(DETECTED_OS)/5.3
 IDO_RECOMP_7_1_DIR := ido_recomp/$(DETECTED_OS)/7.1
 
+EGCS_BINUTILS_VERSION := 0.6
+EGCS_GCC_VERSION := 0.5
+EGCS_DIR := egcs/$(DETECTED_OS)
+
 ifeq ($(shell command -v clang >/dev/null 2>&1; echo $$?),0)
   CC := clang
 else
@@ -30,14 +34,14 @@ ifneq ($(LLD),0)
   CFLAGS += -fuse-ld=lld
 endif
 
-all: $(PROGRAMS) $(IDO_RECOMP_5_3_DIR) $(IDO_RECOMP_7_1_DIR)
+all: $(PROGRAMS) $(IDO_RECOMP_5_3_DIR) $(IDO_RECOMP_7_1_DIR) $(EGCS_DIR)
 	$(MAKE) -C ZAPD
 	$(MAKE) -C fado
 	$(MAKE) -C audio
 
 clean:
 	$(RM) $(PROGRAMS) $(addsuffix .exe,$(PROGRAMS))
-	$(RM) -r ido_recomp
+	$(RM) -r ido_recomp egcs
 	$(MAKE) -C ZAPD clean
 	$(MAKE) -C fado clean
 	$(MAKE) -C audio clean
@@ -70,3 +74,8 @@ $(IDO_RECOMP_5_3_DIR):
 $(IDO_RECOMP_7_1_DIR):
 	mkdir -p $@
 	curl -L https://github.com/decompals/ido-static-recomp/releases/download/$(IDO_RECOMP_VERSION)/ido-7.1-recomp-$(DETECTED_OS).tar.gz | tar xz -C $@
+
+$(EGCS_DIR):
+	mkdir -p $@
+	curl -L https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/$(EGCS_BINUTILS_VERSION)/mips-binutils-egcs-2.9.5-$(DETECTED_OS).tar.gz | tar xz -C $@
+	curl -L https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/$(EGCS_GCC_VERSION)/mips-gcc-egcs-2.91.66-$(DETECTED_OS).tar.gz | tar xz -C $@


### PR DESCRIPTION
I don't personally plan to wire these up immediately, but at least it's possible now.

```bash
$ tree tools/egcs
tools/egcs
└── macos
    ├── addr2line
    ├── ar
    ├── as
    ├── cc1
    ├── cc1plus
    ├── cccp
    ├── cpp
    ├── cxxfilt
    ├── g++
    ├── gcc
    ├── ld
    ├── nm
    ├── objcopy
    ├── objdump
    ├── ranlib
    ├── readelf
    ├── strings
    └── strip
```