### PR TITLE
[iQue] Build some C files with EGCS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ CPPFLAGS += -P -xc -fno-dollars-in-identifiers $(CPP_DEFINES)
 ASFLAGS += -march=vr4300 -32 -no-pad-sections -Iinclude -I$(EXTRACTED_DIR)
 
 ifeq ($(COMPILER),gcc)
-  CFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -mdivide-breaks -fno-PIC -fno-common -ffreestanding -funsigned-char -fbuiltin -fno-builtin-bzero -fno-builtin-bcmp -fno-builtin-bcopy -fno-builtin-sinf -fno-builtin-cosf $(CHECK_WARNINGS)
+  CFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -mdivide-breaks -fno-PIC -fno-common -ffreestanding -funsigned-char -fbuiltin -fno-builtin-sinf -fno-builtin-cosf $(CHECK_WARNINGS)
   CCASFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -fno-PIC -fno-common -Wa,-no-pad-sections
   MIPS_VERSION := -mips3
 else

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,6 @@ N64_EMULATOR ?=
 # This may also be used to disable debug features on debug ROMs by setting DEBUG_FEATURES to 0
 # DEBUG_FEATURES ?= 1
 
-CFLAGS ?=
-CCASFLAGS ?=
-CPPFLAGS ?=
-CPP_DEFINES ?=
-
 # Version-specific settings
 REGIONAL_CHECKSUM := 0
 ifeq ($(VERSION),ntsc-1.0)
@@ -209,7 +204,6 @@ EXTRACTED_DIR := extracted/$(VERSION)
 VENV := .venv
 
 MAKE = make
-CPPFLAGS += -P -xc -fno-dollars-in-identifiers
 
 ifeq ($(PLATFORM),N64)
   CPP_DEFINES += -DPLATFORM_N64=1 -DPLATFORM_GC=0 -DPLATFORM_IQUE=0
@@ -287,6 +281,9 @@ ifeq ($(ORIG_COMPILER),1)
   CCAS     := $(CC)
 endif
 
+EGCS_PREFIX := tools/egcs/$(DETECTED_OS)/
+EGCS_CC := $(EGCS_PREFIX)gcc -B $(EGCS_PREFIX)
+
 AS      := $(MIPS_BINUTILS_PREFIX)as
 LD      := $(MIPS_BINUTILS_PREFIX)ld
 OBJCOPY := $(MIPS_BINUTILS_PREFIX)objcopy
@@ -335,10 +332,6 @@ SEQ_CPPFLAGS  := -D_LANGUAGE_ASEQ -DMML_VERSION=MML_VERSION_OOT $(CPP_DEFINES) -
 SBCFLAGS := --matching
 SFCFLAGS := --matching
 
-CFLAGS += $(CPP_DEFINES)
-CCASFLAGS := $(CPP_DEFINES)
-CPPFLAGS += $(CPP_DEFINES)
-
 # Extra debugging steps
 ifeq ($(DEBUG_OBJECTS),1)
   OBJDUMP_CMD = @$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > $(@:.o=.s)
@@ -360,20 +353,20 @@ ifeq ($(DEBUG_FEATURES),1)
   GBI_DEFINES += -DGBI_DEBUG
 endif
 
-CFLAGS += $(GBI_DEFINES)
-
-ASFLAGS := -march=vr4300 -32 -no-pad-sections -Iinclude -I$(EXTRACTED_DIR)
+CPPFLAGS += -P -xc -fno-dollars-in-identifiers $(CPP_DEFINES)
+ASFLAGS += -march=vr4300 -32 -no-pad-sections -Iinclude -I$(EXTRACTED_DIR)
 
 ifeq ($(COMPILER),gcc)
-  CFLAGS += -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -mdivide-breaks -fno-PIC -fno-common -ffreestanding -fbuiltin -fno-builtin-sinf -fno-builtin-cosf $(CHECK_WARNINGS) -funsigned-char
-  CCASFLAGS += -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -fno-PIC -fno-common -Wa,-no-pad-sections
+  CFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -mdivide-breaks -fno-PIC -fno-common -ffreestanding -funsigned-char -fbuiltin -fno-builtin-bzero -fno-builtin-bcmp -fno-builtin-bcopy -fno-builtin-sinf -fno-builtin-cosf $(CHECK_WARNINGS)
+  CCASFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -nostdinc $(INC) -march=vr4300 -mfix4300 -mabi=32 -mno-abicalls -fno-PIC -fno-common -Wa,-no-pad-sections
   MIPS_VERSION := -mips3
 else
   # Suppress warnings for wrong number of macro arguments (to fake variadic
   # macros) and Microsoft extensions such as anonymous structs (which the
   # compiler does support but warns for their usage).
-  CFLAGS += -G 0 -non_shared -fullwarn -verbose -Xcpluscomm $(INC) -Wab,-r4300_mul -woff 516,609,649,838,712,807
-  CCASFLAGS += -G 0 -non_shared -fullwarn -verbose -Xcpluscomm $(INC) -Wab,-r4300_mul -woff 516,609,649,838,712,807 -o32
+  CFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -non_shared -fullwarn -verbose -Xcpluscomm $(INC) -Wab,-r4300_mul -woff 516,609,649,838,712,807
+  CCASFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -non_shared -fullwarn -verbose -Xcpluscomm $(INC) -Wab,-r4300_mul -woff 516,609,649,838,712,807 -o32
+  EGCS_CFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -nostdinc $(INC) -mcpu=vr4300 -mabi=32 -mgp32 -mfp32 -fno-PIC
   MIPS_VERSION := -mips2
 endif
 
@@ -503,7 +496,7 @@ O_FILES       := $(foreach f,$(S_FILES:.s=.o),$(BUILD_DIR)/$f) \
                  $(foreach f,$(ASSET_C_FILES_COMMITTED:.c=.o),$(BUILD_DIR)/$f) \
                  $(foreach f,$(BASEROM_BIN_FILES),$(BUILD_DIR)/baserom/$(notdir $f).o) \
                  $(BUILD_DIR)/src/code/z_message_z_game_over.o \
-				 $(BUILD_DIR)/src/makerom/ipl3.o
+                 $(BUILD_DIR)/src/makerom/ipl3.o
 
 OVL_RELOC_FILES := $(shell $(CPP) $(CPPFLAGS) $(SPEC) | $(BUILD_DIR_REPLACE) | grep -o '[^"]*_reloc.o' )
 
@@ -564,6 +557,34 @@ endif
 $(BUILD_DIR)/src/code/jpegutils.o: CC := $(CC_OLD)
 $(BUILD_DIR)/src/code/jpegdecoder.o: CC := $(CC_OLD)
 
+ifeq ($(PLATFORM),IQUE)
+# Some files are compiled with EGCS on iQue
+EGCS_O_FILES += $(BUILD_DIR)/src/boot/boot_main.o
+EGCS_O_FILES += $(BUILD_DIR)/src/boot/idle.o
+EGCS_O_FILES += $(BUILD_DIR)/src/boot/z_locale.o
+EGCS_O_FILES += $(BUILD_DIR)/src/boot/z_std_dma.o
+EGCS_O_FILES += $(BUILD_DIR)/src/boot/zlib.o
+# EGCS_O_FILES += (BUILD_DIR)/src/code/z_actor.o
+EGCS_O_FILES += $(BUILD_DIR)/src/code/z_common_data.o
+EGCS_O_FILES += $(BUILD_DIR)/src/code/z_construct.o
+# EGCS_O_FILES += (BUILD_DIR)/src/code/z_kanfont.o
+# EGCS_O_FILES += (BUILD_DIR)/src/code/z_message.o
+EGCS_O_FILES += $(BUILD_DIR)/src/code/z_parameter.o
+# EGCS_O_FILES += (BUILD_DIR)/src/code/z_sram.o
+EGCS_O_FILES += $(BUILD_DIR)/src/overlays/actors/ovl_En_Mag/z_en_mag.o
+EGCS_O_FILES += $(BUILD_DIR)/src/overlays/actors/ovl_End_Title/z_end_title.o
+EGCS_O_FILES += $(BUILD_DIR)/src/overlays/actors/ovl_Fishing/z_fishing.o
+# EGCS_O_FILES += (BUILD_DIR)/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.o
+EGCS_O_FILES += $(BUILD_DIR)/src/overlays/gamestates/ovl_opening/z_opening.o
+EGCS_O_FILES += $(BUILD_DIR)/src/overlays/gamestates/ovl_title/z_title.o
+EGCS_O_FILES += $(BUILD_DIR)/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map.o
+EGCS_O_FILES += $(BUILD_DIR)/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.o
+
+$(EGCS_O_FILES): CC := $(EGCS_CC)
+$(EGCS_O_FILES): CFLAGS := $(EGCS_CFLAGS) -mno-abicalls
+$(EGCS_O_FILES): MIPS_VERSION := -mips3
+endif
+
 ifeq ($(DEBUG_FEATURES),1)
 $(BUILD_DIR)/src/libc/%.o: OPTFLAGS := -g
 $(BUILD_DIR)/src/libc/%.o: ASOPTFLAGS := -g
@@ -589,7 +610,12 @@ endif
 $(BUILD_DIR)/src/audio/sfx.o: CFLAGS += -use_readwrite_const
 $(BUILD_DIR)/src/audio/sequence.o: CFLAGS += -use_readwrite_const
 
+ifeq ($(PLATFORM),IQUE)
+$(BUILD_DIR)/src/libultra/%.o: CC := $(EGCS_CC)
+$(BUILD_DIR)/src/libultra/%.o: CFLAGS := $(EGCS_CFLAGS) -mno-abicalls
+else
 $(BUILD_DIR)/src/libultra/%.o: CC := $(CC_OLD)
+endif
 
 $(BUILD_DIR)/src/libultra/libc/ll.o: OPTFLAGS := -O1
 $(BUILD_DIR)/src/libultra/libc/ll.o: MIPS_VERSION := -mips3 -32
@@ -647,6 +673,11 @@ endif
 
 $(BUILD_DIR)/src/libleo/%.o: CC := $(CC_OLD)
 $(BUILD_DIR)/src/libleo/%.o: OPTFLAGS := -O2
+
+ifeq ($(PLATFORM),IQUE)
+$(BUILD_DIR)/src/libgcc/%.o: CC := $(EGCS_CC)
+$(BUILD_DIR)/src/libgcc/%.o: CFLAGS := $(EGCS_CFLAGS)
+endif
 
 $(BUILD_DIR)/assets/misc/z_select_static/%.o: GBI_DEFINES := -DF3DEX_GBI
 

--- a/include/attributes.h
+++ b/include/attributes.h
@@ -8,12 +8,22 @@
 #endif
 
 #define UNUSED       __attribute__((unused))
-#define FALLTHROUGH  __attribute__((fallthrough))
-#define NORETURN     __attribute__((noreturn))
 #define NO_REORDER   __attribute__((no_reorder))
 #define SECTION_DATA __attribute__((section(".data")))
 
-#ifdef __GNUC__
+#if __GNUC__ >= 7
+#define FALLTHROUGH  __attribute__((fallthrough))
+#else
+#define FALLTHROUGH
+#endif
+
+#if defined(__GNUC__) && defined(NON_MATCHING)
+#define NORETURN     __attribute__((noreturn))
+#else
+#define NORETURN
+#endif
+
+#if defined(__GNUC__) && defined(NON_MATCHING)
 #define UNREACHABLE() __builtin_unreachable()
 #else
 #define UNREACHABLE()

--- a/include/libc/assert.h
+++ b/include/libc/assert.h
@@ -29,7 +29,7 @@ __attribute__((noreturn)) void __assert(const char* assertion, const char* file,
 
 // Static/compile-time assertions
 
-#if !defined(__sgi) && (defined(__GNUC__) || (__STDC_VERSION__ >= 201112L))
+#if !defined(__sgi) && (__GNUC__ >= 5 || __STDC_VERSION__ >= 201112L)
 # define static_assert(cond, msg) _Static_assert(cond, msg)
 #else
 # ifndef GLUE

--- a/include/libc/stdarg.h
+++ b/include/libc/stdarg.h
@@ -1,16 +1,16 @@
 #ifndef STDARG_H
 #define STDARG_H
 
-// When building with GCC, use the official vaarg macros to avoid warnings and possibly bad codegen.
+// When building with modern GCC, use the official vaarg macros to avoid warnings and possibly bad codegen.
 
-#ifdef __GNUC__
+#if __GNUC__ >= 3
 
 #define va_list  __builtin_va_list
 #define va_start __builtin_va_start
 #define va_arg   __builtin_va_arg
 #define va_end   __builtin_va_end
 
-#else
+#elif defined(__sgi) /* IDO */
 
 #ifndef _VA_LIST_
 # define _VA_LIST_
@@ -52,6 +52,28 @@ typedef char* va_list;
 /* No cleanup processing is required for the end of a varargs list: */
 #define va_end(__list)
 
-#endif /* __GNUC__ */
+#else /* EGCS */
+
+typedef char * __gnuc_va_list;
+
+#define __va_rounded_size(__TYPE)  \
+  (((sizeof (__TYPE) + sizeof (int) - 1) / sizeof (int)) * sizeof (int))
+
+#define va_start(__AP, __LASTARG) \
+  (__AP = (__gnuc_va_list) __builtin_next_arg (__LASTARG))
+
+#define va_end(__AP)    ((void)0)
+
+/* We cast to void * and then to TYPE * because this avoids
+   a warning about increasing the alignment requirement.  */
+#define va_arg(__AP, __type)                                                \
+  ((__type *) (void *) (__AP = (char *) ((__alignof__(__type) > 4           \
+                                ? ((__PTRDIFF_TYPE__)__AP + 8 - 1) & -8     \
+                                : ((__PTRDIFF_TYPE__)__AP + 4 - 1) & -4)    \
+                                         + __va_rounded_size(__type))))[-1]
+
+typedef __gnuc_va_list va_list;
+
+#endif
 
 #endif

--- a/include/libc/stddef.h
+++ b/include/libc/stddef.h
@@ -15,7 +15,7 @@ typedef unsigned long   size_t;
 
 #endif
 
-#ifdef __GNUC__
+#if __GNUC__ >= 4
 #define offsetof(structure, member) __builtin_offsetof (structure, member)
 #else
 #define offsetof(structure, member) ((size_t)&(((structure*)0)->member))

--- a/include/macros.h
+++ b/include/macros.h
@@ -53,6 +53,8 @@
 #define PRINTF osSyncPrintf
 #elif IDO_PRINTF_WORKAROUND
 #define PRINTF(args) (void)0
+#elif defined(__GNUC__) && __GNUC__ < 3
+#define PRINTF(format, args...) (void)0
 #else
 #define PRINTF(format, ...) (void)0
 #endif

--- a/include/ultra64/libc.h
+++ b/include/ultra64/libc.h
@@ -5,14 +5,8 @@
 
 void osSyncPrintf(const char* fmt, ...);
 
-#ifdef __GNUC__
-void bzero(void* __s, unsigned int __n);
-int bcmp(const void* __sl, const void* __s2, unsigned int __n);
-void bcopy(const void* __src, void* __dest, unsigned int __n);
-#else
 void bzero(void* __s, int __n);
 int bcmp(const void* __sl, const void* __s2, int __n);
 void bcopy(const void* __src, void* __dest, int __n);
-#endif
 
 #endif

--- a/include/ultra64/libc.h
+++ b/include/ultra64/libc.h
@@ -5,8 +5,14 @@
 
 void osSyncPrintf(const char* fmt, ...);
 
+#if defined(__GNUC__) && defined(NON_MATCHING)
+void bzero(void* __s, unsigned int __n);
+int bcmp(const void* __sl, const void* __s2, unsigned int __n);
+void bcopy(const void* __src, void* __dest, unsigned int __n);
+#else
 void bzero(void* __s, int __n);
 int bcmp(const void* __sl, const void* __s2, int __n);
 void bcopy(const void* __src, void* __dest, int __n);
+#endif
 
 #endif

--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -205,7 +205,7 @@ typedef s16 AdpcmBookData[];
 
 typedef struct AdpcmBook {
     /* 0x00 */ AdpcmBookHeader header;
-    /* 0x08 */ AdpcmBookData book; // size 8 * order * numPredictors. 8-byte aligned
+    /* 0x08 */ s16 book[1]; // size 8 * order * numPredictors. 8-byte aligned
 } AdpcmBook; // size >= 0x8
 
 typedef struct Sample {

--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -201,8 +201,6 @@ typedef struct AdpcmBookHeader {
  * The procedure used to design the codeBook is based on an adaptive clustering algorithm.
  * The size of the codeBook is (8 * order * numPredictors) and is 8-byte aligned
  */
-typedef s16 AdpcmBookData[];
-
 typedef struct AdpcmBook {
     /* 0x00 */ AdpcmBookHeader header;
     /* 0x08 */ s16 book[1]; // size 8 * order * numPredictors. 8-byte aligned

--- a/src/audio/general.c
+++ b/src/audio/general.c
@@ -8,6 +8,8 @@
 #define AUDIO_PRINTF osSyncPrintf
 #elif IDO_PRINTF_WORKAROUND
 #define AUDIO_PRINTF(args) (void)0
+#elif defined(__GNUC__) && __GNUC__ < 3
+#define AUDIO_PRINTF(format, args...) (void)0
 #else
 #define AUDIO_PRINTF(format, ...) (void)0
 #endif

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -24,7 +24,7 @@ extern struct IrqMgr gIrqMgr;
 #endif
 
 #pragma increment_block_number "gc-eu:160 gc-eu-mq:160 gc-jp:160 gc-jp-ce:160 gc-jp-mq:160 gc-us:160 gc-us-mq:160" \
-                               "ntsc-1.0:141 ntsc-1.1:141 ntsc-1.2:141 pal-1.0:139 pal-1.1:139"
+                               "ntsc-1.0:142 ntsc-1.1:142 ntsc-1.2:142 pal-1.0:140 pal-1.1:140"
 
 extern u8 _buffersSegmentEnd[];
 

--- a/src/code/sched.c
+++ b/src/code/sched.c
@@ -62,6 +62,8 @@ vs32 sSchedDebugPrintfEnabled = false;
     PRINTF
 #elif IDO_PRINTF_WORKAROUND
 #define SCHED_DEBUG_PRINTF(args) (void)0
+#elif defined(__GNUC__) && __GNUC__ < 3
+#define SCHED_DEBUG_PRINTF(format, args...) (void)0
 #else
 #define SCHED_DEBUG_PRINTF(format, ...) (void)0
 #endif

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -24,6 +24,8 @@ static s32 sCurCeilingBgId;
     PRINTF
 #elif IDO_PRINTF_WORKAROUND
 #define ACTOR_DEBUG_PRINTF(args) (void)0
+#elif defined(__GNUC__) && __GNUC__ < 3
+#define ACTOR_DEBUG_PRINTF(format, args...) (void)0
 #else
 #define ACTOR_DEBUG_PRINTF(format, ...) (void)0
 #endif

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -3639,7 +3639,7 @@ s32 Camera_KeepOn3(Camera* camera) {
 }
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ntsc-1.0:144 ntsc-1.1:144 ntsc-1.2:144 pal-1.0:142 pal-1.1:142"
+                               "ntsc-1.0:145 ntsc-1.1:145 ntsc-1.2:145 pal-1.0:143 pal-1.1:143"
 
 s32 Camera_KeepOn4(Camera* camera) {
     static Vec3f D_8015BD50;

--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -3,7 +3,7 @@
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include "overlays/effects/ovl_Effect_Ss_Dead_Sound/z_eff_ss_dead_sound.h"
 
-#pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-eu-mq-dbg:0 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128" \
+#pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-eu-mq-dbg:0 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128" \
                                "gc-us-mq:128 ntsc-1.2:128"
 
 #define FLAGS 0

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -35,7 +35,7 @@
 #include "cic6105.h"
 #endif
 
-#pragma increment_block_number "gc-eu:166 gc-eu-mq:166 gc-jp:166 gc-jp-ce:166 gc-jp-mq:166 gc-us:166 gc-us-mq:166" \
+#pragma increment_block_number "gc-eu:167 gc-eu-mq:167 gc-jp:167 gc-jp-ce:167 gc-jp-mq:167 gc-us:167 gc-us-mq:167" \
                                "ntsc-1.0:121 ntsc-1.1:121 ntsc-1.2:121 pal-1.0:121 pal-1.1:121"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -15,7 +15,7 @@ IDO_RECOMP_5_3_DIR := ido_recomp/$(DETECTED_OS)/5.3
 IDO_RECOMP_7_1_DIR := ido_recomp/$(DETECTED_OS)/7.1
 
 EGCS_BINUTILS_VERSION := 0.6
-EGCS_GCC_VERSION := 0.5
+EGCS_GCC_VERSION := 0.6
 EGCS_DIR := egcs/$(DETECTED_OS)
 
 ifeq ($(shell command -v clang >/dev/null 2>&1; echo $$?),0)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -15,7 +15,7 @@ IDO_RECOMP_5_3_DIR := ido_recomp/$(DETECTED_OS)/5.3
 IDO_RECOMP_7_1_DIR := ido_recomp/$(DETECTED_OS)/7.1
 
 EGCS_BINUTILS_VERSION := 0.6
-EGCS_GCC_VERSION := 0.6
+EGCS_GCC_VERSION := 0.7
 EGCS_DIR := egcs/$(DETECTED_OS)
 
 ifeq ($(shell command -v clang >/dev/null 2>&1; echo $$?),0)

--- a/tools/audio/soundfont_compiler.c
+++ b/tools/audio/soundfont_compiler.c
@@ -1076,7 +1076,7 @@ emit_c_samples(FILE *out, soundfont *sf)
                    "NO_REORDER SECTION_DATA ALIGNED(16) AdpcmBookHeader SF%d_%s_BOOK_HEADER = {"    "\n"
                    "    %d, %d,"                                                                    "\n"
                    "};"                                                                             "\n"
-                   "NO_REORDER SECTION_DATA AdpcmBookData SF%d_%s_BOOK_DATA = {"                    "\n",
+                   "NO_REORDER SECTION_DATA s16 SF%d_%s_BOOK_DATA[] = {"                            "\n",
                     // clang-format on
                     sf->info.index, bookname, sample->aifc.book.order, sample->aifc.book.npredictors, sf->info.index,
                     bookname);

--- a/tools/permuter_settings.toml
+++ b/tools/permuter_settings.toml
@@ -33,3 +33,4 @@ ACTOR_DEBUG_PRINTF = "void"
 [decompme.compilers]
 "tools/ido_recomp/*/7.1/cc" = "ido7.1"
 "tools/ido_recomp/*/5.3/cc" = "ido5.3"
+"tools/egcs/*/gcc" = "egcs_1.1.2-4"

--- a/undefined_syms.txt
+++ b/undefined_syms.txt
@@ -9,3 +9,17 @@ D_0F000000 = 0x0F000000;
 
 // z_bg_mjin
 D_06000000 = 0x06000000;
+
+#if PLATFORM_IQUE
+__divdi3 = 0x80008010;
+__moddi3 = 0x800085F0;
+__udivdi3 = 0x80008B80;
+__umoddi3 = 0x800090F0;
+__cmpdi2 = 0x80009600;
+__floatdidf = 0x80009650;
+__floatdisf = 0x800096A0;
+__fixunsdfdi = 0x80009760;
+__fixdfdi = 0x80009960;
+__fixunssfdi = 0x800099D0;
+__fixsfdi = 0x80009BD0;
+#endif


### PR DESCRIPTION
This prepares both the Makefile and headers for matching EGCS-compiled iQue files.

Makefile notes:
* I refactored things so that `EGCS_CFLAGS` looks similar to `CFLAGS` so we can swap it out for the files we need. It's a little weird but I think it looks okay
* Some files current can't be built right now because they trigger and internal compiler error (like this: https://decomp.me/scratch/yvoJT). It seems to be triggered by accessing an array which is at a large offset in a struct, but it's sensitive to optimizations and such. I guess we'll have to work around it somehow, I'm not really sure.

Header notes:
* Most "modern GCC" features (including C99 stuff) are now guarded with `__GNUC__ >= N`. I copied the stdarg.h macros from the egcs repo (but simplified to assume the N64 ABI).
* For some things we assumed `__GNUC__` meant `NON_MATCHING`, so that's now more explicit.