### PR TITLE
Only build .o files listed in the spec

### DIFF
--- a/src/code/db_camera.c
+++ b/src/code/db_camera.c
@@ -1,7 +1,5 @@
 #include "global.h"
 
-#if DEBUG_FEATURES
-
 #define DEBUG_CAM_CONTROLLER_PORT 2
 
 static PlayState* sPlay;
@@ -2368,5 +2366,3 @@ void func_800BB060(void) {
 int func_800BB06C(void) {
     return sDebugCamPtr->unk_00 == 2 && sDebugCamAnim.unk_0A != 0;
 }
-
-#endif

--- a/src/code/fault_gc.c
+++ b/src/code/fault_gc.c
@@ -40,8 +40,6 @@
  * DPad-Up may be pressed to enable sending fault pages over osSyncPrintf as well as displaying them on-screen.
  * DPad-Down disables sending fault pages over osSyncPrintf.
  */
-#if !PLATFORM_N64
-
 #pragma increment_block_number "gc-eu:160 gc-eu-mq:160 gc-eu-mq-dbg:160 gc-jp:176 gc-jp-ce:176 gc-jp-mq:176 gc-us:176" \
                                "gc-us-mq:176"
 
@@ -1340,5 +1338,3 @@ NORETURN void Fault_AddHungupAndCrash(const char* file, int line) {
     sprintf(msg, "HungUp %s:%d", file, line);
     Fault_AddHungupAndCrashImpl(msg, NULL);
 }
-
-#endif

--- a/src/code/fault_gc_drawer.c
+++ b/src/code/fault_gc_drawer.c
@@ -9,8 +9,6 @@
 #include "terminal.h"
 #pragma increment_block_number "gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
 
-#if !PLATFORM_N64
-
 typedef struct FaultDrawer {
     /* 0x00 */ u16* fb;
     /* 0x04 */ u16 w;
@@ -344,5 +342,3 @@ void Fault_InitDrawer(void) {
     bcopy(&sFaultDrawerDefault, &sFaultDrawer, sizeof(FaultDrawer));
     sFaultDrawer.fb = (u16*)(PHYS_TO_K0(osMemSize) - sizeof(u16[SCREEN_HEIGHT][SCREEN_WIDTH]));
 }
-
-#endif

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -1,5 +1,3 @@
-#if PLATFORM_N64
-
 #pragma increment_block_number "ntsc-1.0:0 ntsc-1.1:0 ntsc-1.2:0 pal-1.0:0 pal-1.1:0"
 
 #include "global.h"
@@ -849,5 +847,3 @@ NORETURN void Fault_AddHungupAndCrash(const char* file, int line) {
     sprintf(msg, "HungUp %s:%d", file, line);
     Fault_AddHungupAndCrashImpl(msg, NULL);
 }
-
-#endif

--- a/src/libc64/__osMalloc_gc.c
+++ b/src/libc64/__osMalloc_gc.c
@@ -3,8 +3,6 @@
 #include "libc64/os_malloc.h"
 #include "terminal.h"
 
-#if !PLATFORM_N64
-
 #define FILL_ALLOC_BLOCK_FLAG (1 << 0)
 #define FILL_FREE_BLOCK_FLAG (1 << 1)
 #define CHECK_FREE_BLOCK_FLAG (1 << 2)
@@ -890,6 +888,4 @@ s32 __osCheckArena(Arena* arena) {
 u8 ArenaImpl_GetAllocFailures(Arena* arena) {
     return arena->allocFailures;
 }
-#endif
-
 #endif

--- a/src/libc64/__osMalloc_n64.c
+++ b/src/libc64/__osMalloc_n64.c
@@ -2,8 +2,6 @@
 #include "fault.h"
 #include "libc64/os_malloc.h"
 
-#if PLATFORM_N64
-
 #define NODE_MAGIC 0x7373
 
 #define NODE_IS_VALID(node) ((node)->magic == NODE_MAGIC)
@@ -470,5 +468,3 @@ s32 __osCheckArena(Arena* arena) {
 u8 ArenaImpl_GetAllocFailures(Arena* arena) {
     return arena->allocFailures;
 }
-
-#endif

--- a/src/n64dd/n64dd_error_textures.c
+++ b/src/n64dd/n64dd_error_textures.c
@@ -1,7 +1,5 @@
 #include "ultra64.h"
 
-#if PLATFORM_N64
-
 u64 gN64DDError41Texs[2][0x600 / sizeof(u64)] = {
     {
 #include "assets/n64dd/error_textures/n64dd_error_41_jpn.i4.inc.c"
@@ -19,5 +17,3 @@ u64 gN64DDPleaseReadManualTexs[2][0x2800 / sizeof(u64)] = {
 #include "assets/n64dd/error_textures/n64dd_please_read_manual_eng.i4.inc.c"
     },
 };
-
-#endif


### PR DESCRIPTION
Currently we build all files no matter what. Now we build only files that in the spec (extracted via `sed`), which should speed up compile times a little and allows us to remove some CPP guards. However, this change might be surprising for users if they add a new .c file and wonder why it isn't compiling when running `make`.