### PR TITLE
Fix circular Makefile dependency with assets/text/*.o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,8 +489,7 @@ ASSET_BIN_DIRS := $(ASSET_BIN_DIRS_EXTRACTED) $(ASSET_BIN_DIRS_COMMITTED)
 ASSET_FILES_BIN_EXTRACTED := $(foreach dir,$(ASSET_BIN_DIRS_EXTRACTED),$(wildcard $(dir)/*.bin))
 ASSET_FILES_BIN_COMMITTED := $(foreach dir,$(ASSET_BIN_DIRS_COMMITTED),$(wildcard $(dir)/*.bin))
 ASSET_FILES_OUT := $(foreach f,$(ASSET_FILES_BIN_EXTRACTED:.bin=.bin.inc.c),$(f:$(EXTRACTED_DIR)/%=$(BUILD_DIR)/%)) \
-                   $(foreach f,$(ASSET_FILES_BIN_COMMITTED:.bin=.bin.inc.c),$(BUILD_DIR)/$f) \
-                   $(foreach f,$(wildcard assets/text/*.c),$(BUILD_DIR)/$(f:.c=.o))
+                   $(foreach f,$(ASSET_FILES_BIN_COMMITTED:.bin=.bin.inc.c),$(BUILD_DIR)/$f)
 
 # Find all .o files included in the spec
 SPEC_O_FILES := $(shell $(CPP) $(CPPFLAGS) $(SPEC) | $(BUILD_DIR_REPLACE) | sed -n -E 's/^[ \t]*include[ \t]*"([a-zA-Z0-9/_.-]+\.o)"/\1/p')


### PR DESCRIPTION
After #2410, make now complains with
```
make: Circular asset_files <- build/ique-cn/assets/text/jpn_message_data_static.o dependency dropped.
make: Circular build/ique-cn/assets/text/nes_message_data_static.o <- asset_files dependency dropped.
make: Circular build/ique-cn/assets/text/staff_message_data_static.o <- asset_files dependency dropped.
```
There's no need for these .o files to be built as part of `asset_files` though. Now `asset_files` consists of only .inc.c files which must be generated before building any C files.