### PR TITLE
[iQue] Match ovl_kaleido_scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -589,8 +589,10 @@ EGCS_O_FILES += $(BUILD_DIR)/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map.o
 EGCS_O_FILES += $(BUILD_DIR)/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.o
 
 $(EGCS_O_FILES): CC := $(EGCS_CC)
-$(EGCS_O_FILES): CFLAGS := $(EGCS_CFLAGS) -mno-abicalls -funsigned-char
+$(EGCS_O_FILES): CFLAGS := $(EGCS_CFLAGS) -mno-abicalls
 $(EGCS_O_FILES): MIPS_VERSION :=
+
+$(BUILD_DIR)/src/boot/z_std_dma.o: CFLAGS += -funsigned-char
 endif
 
 ifeq ($(PLATFORM),IQUE)

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -421,7 +421,7 @@ typedef enum LinkAge {
 #define OWNED_EQUIP_FLAG(equip, value) (gBitFlags[value] << gEquipShifts[equip])
 #define OWNED_EQUIP_FLAG_ALT(equip, value) ((1 << (value)) << gEquipShifts[equip])
 #define CHECK_OWNED_EQUIP(equip, value) (gSaveContext.save.info.inventory.equipment & OWNED_EQUIP_FLAG(equip, value))
-#define CHECK_OWNED_EQUIP_ALT(equip, value) (gBitFlags[(value) + (equip) * 4] & gSaveContext.save.info.inventory.equipment)
+#define CHECK_OWNED_EQUIP_ALT(equip, value) (gSaveContext.save.info.inventory.equipment & gBitFlags[(value) + (equip) * 4])
 
 #define SWORD_EQUIP_TO_PLAYER(swordEquip) (swordEquip)
 #define SHIELD_EQUIP_TO_PLAYER(shieldEquip) (shieldEquip)

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -420,7 +420,7 @@ typedef enum LinkAge {
 #define CUR_EQUIP_VALUE(equip) ((s32)(gSaveContext.save.info.equips.equipment & gEquipMasks[equip]) >> gEquipShifts[equip])
 #define OWNED_EQUIP_FLAG(equip, value) (gBitFlags[value] << gEquipShifts[equip])
 #define OWNED_EQUIP_FLAG_ALT(equip, value) ((1 << (value)) << gEquipShifts[equip])
-#define CHECK_OWNED_EQUIP(equip, value) (OWNED_EQUIP_FLAG(equip, value) & gSaveContext.save.info.inventory.equipment)
+#define CHECK_OWNED_EQUIP(equip, value) (gSaveContext.save.info.inventory.equipment & OWNED_EQUIP_FLAG(equip, value))
 #define CHECK_OWNED_EQUIP_ALT(equip, value) (gBitFlags[(value) + (equip) * 4] & gSaveContext.save.info.inventory.equipment)
 
 #define SWORD_EQUIP_TO_PLAYER(swordEquip) (swordEquip)
@@ -432,7 +432,7 @@ typedef enum LinkAge {
 #define CAPACITY(upg, value) gUpgradeCapacities[upg][value]
 #define CUR_CAPACITY(upg) CAPACITY(upg, CUR_UPG_VALUE(upg))
 
-#define CHECK_QUEST_ITEM(item) (gBitFlags[item] & gSaveContext.save.info.inventory.questItems)
+#define CHECK_QUEST_ITEM(item) (gSaveContext.save.info.inventory.questItems & gBitFlags[item])
 #define CHECK_DUNGEON_ITEM(item, dungeonIndex) (gSaveContext.save.info.inventory.dungeonItems[dungeonIndex] & gBitFlags[item])
 
 #define GET_GS_FLAGS(index) \

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map.c
@@ -150,7 +150,7 @@ void KaleidoScope_DrawDungeonMap(PlayState* play, GraphicsContext* gfxCtx) {
                 pauseCtx->cursorSpecialPos = 0;
                 pauseCtx->cursorSlot[PAUSE_MAP] = pauseCtx->cursorPoint[PAUSE_MAP] = pauseCtx->dungeonMapSlot;
                 pauseCtx->cursorX[PAUSE_MAP] = 0;
-                j = 72 + (pauseCtx->cursorSlot[PAUSE_MAP] * 4);
+                j = (pauseCtx->cursorSlot[PAUSE_MAP] + 18) * 4;
                 KaleidoScope_SetCursorPos(pauseCtx, j, pauseCtx->mapPageVtx);
                 Audio_PlaySfxGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
@@ -181,7 +181,7 @@ void KaleidoScope_DrawDungeonMap(PlayState* play, GraphicsContext* gfxCtx) {
                 }
 
                 PRINTF("kscope->cursor_point====%d\n", pauseCtx->cursorPoint[PAUSE_MAP]);
-                j = 72 + (pauseCtx->cursorSlot[PAUSE_MAP] * 4);
+                j = (pauseCtx->cursorSlot[PAUSE_MAP] + 18) * 4;
                 KaleidoScope_SetCursorPos(pauseCtx, j, pauseCtx->mapPageVtx);
                 Audio_PlaySfxGeneral(NA_SE_SY_CURSOR, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                      &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
@@ -203,7 +203,7 @@ void KaleidoScope_DrawDungeonMap(PlayState* play, GraphicsContext* gfxCtx) {
 
         pauseCtx->cursorSlot[PAUSE_MAP] = pauseCtx->cursorPoint[PAUSE_MAP];
 
-        j = 72 + (pauseCtx->cursorSlot[PAUSE_MAP] * 4);
+        j = (pauseCtx->cursorSlot[PAUSE_MAP] + 18) * 4;
         KaleidoScope_SetCursorPos(pauseCtx, j, pauseCtx->mapPageVtx);
 
         if (pauseCtx->cursorX[PAUSE_MAP] == 0) {
@@ -285,7 +285,7 @@ void KaleidoScope_DrawDungeonMap(PlayState* play, GraphicsContext* gfxCtx) {
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, pauseCtx->alpha);
 
     pauseCtx->mapPageVtx[116].v.ob[1] = pauseCtx->mapPageVtx[117].v.ob[1] =
-        pauseCtx->pagesYOrigin1 - (VREG(30) * 14) + 49;
+        pauseCtx->pagesYOrigin1 + 50 - (VREG(30) * 14) - 1;
     pauseCtx->mapPageVtx[118].v.ob[1] = pauseCtx->mapPageVtx[119].v.ob[1] = pauseCtx->mapPageVtx[116].v.ob[1] - 16;
 
     gDPLoadTextureBlock(POLY_OPA_DISP++, gDungeonMapLinkHeadTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, 16, 16, 0,
@@ -550,9 +550,8 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
 
         if (pauseCtx->cursorSpecialPos == 0) {
             if (pauseCtx->stickAdjX > 30) {
-                D_8082A6D4 = 0;
-
                 do {
+                    D_8082A6D4 = 0;
                     pauseCtx->cursorPoint[PAUSE_WORLD_MAP]++;
                     if (pauseCtx->cursorPoint[PAUSE_WORLD_MAP] >= WORLD_MAP_POINT_MAX) {
                         pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = WORLD_MAP_POINT_MAX - 1;
@@ -562,9 +561,8 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
                 } while (pauseCtx->worldMapPoints[pauseCtx->cursorPoint[PAUSE_WORLD_MAP]] ==
                          WORLD_MAP_POINT_STATE_HIDE);
             } else if (pauseCtx->stickAdjX < -30) {
-                D_8082A6D4 = 0;
-
                 do {
+                    D_8082A6D4 = 0;
                     pauseCtx->cursorPoint[PAUSE_WORLD_MAP]--;
                     if (pauseCtx->cursorPoint[PAUSE_WORLD_MAP] < 0) {
                         pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = 0;
@@ -585,8 +583,8 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
             pauseCtx->cursorItem[PAUSE_MAP] = gSaveContext.worldMapArea + 0x18;
             if (pauseCtx->cursorSpecialPos == PAUSE_CURSOR_PAGE_LEFT) {
                 if (pauseCtx->stickAdjX > 30) {
-                    pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = 0;
                     pauseCtx->cursorSpecialPos = 0;
+                    pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = 0;
 
                     while (pauseCtx->worldMapPoints[pauseCtx->cursorPoint[PAUSE_WORLD_MAP]] ==
                            WORLD_MAP_POINT_STATE_HIDE) {
@@ -603,8 +601,8 @@ void KaleidoScope_DrawWorldMap(PlayState* play, GraphicsContext* gfxCtx) {
                 }
             } else {
                 if (pauseCtx->stickAdjX < -30) {
-                    pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = WORLD_MAP_POINT_MAX - 1;
                     pauseCtx->cursorSpecialPos = 0;
+                    pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = WORLD_MAP_POINT_MAX - 1;
 
                     while (pauseCtx->worldMapPoints[pauseCtx->cursorPoint[PAUSE_WORLD_MAP]] ==
                            WORLD_MAP_POINT_STATE_HIDE) {

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -721,7 +721,7 @@ static u16 sPageSwitchNextPageIndex[] = {
     PAUSE_QUEST, // PAUSE_EQUIP left
 };
 
-u8 gSlotAgeReqs[] = {
+char gSlotAgeReqs[] = {
     AGE_REQ_CHILD, // SLOT_DEKU_STICK
     AGE_REQ_NONE,  // SLOT_DEKU_NUT
     AGE_REQ_NONE,  // SLOT_BOMB
@@ -748,7 +748,7 @@ u8 gSlotAgeReqs[] = {
     AGE_REQ_CHILD, // SLOT_TRADE_CHILD
 };
 
-u8 gEquipAgeReqs[4][4] = {
+char gEquipAgeReqs[4][4] = {
     {
         AGE_REQ_ADULT, // 0 UPG_QUIVER
         AGE_REQ_CHILD, // EQUIP_TYPE_SWORD EQUIP_VALUE_SWORD_KOKIRI
@@ -775,7 +775,7 @@ u8 gEquipAgeReqs[4][4] = {
     },
 };
 
-u8 gItemAgeReqs[] = {
+char gItemAgeReqs[] = {
     AGE_REQ_CHILD, // ITEM_DEKU_STICK
     AGE_REQ_NONE,  // ITEM_DEKU_NUT
     AGE_REQ_NONE,  // ITEM_BOMB
@@ -954,7 +954,7 @@ Gfx* KaleidoScope_QuadTextureIA8(Gfx* gfx, void* texture, s16 width, s16 height,
     return gfx;
 }
 
-void KaleidoScope_OverridePalIndexCI4(u8* texture, s32 size, s32 targetIndex, s32 newIndex) {
+void KaleidoScope_OverridePalIndexCI4(char* texture, s32 size, s32 targetIndex, s32 newIndex) {
     s32 i;
     s32 index1;
     s32 index2;
@@ -1015,7 +1015,7 @@ void KaleidoScope_SetDefaultCursor(PlayState* play) {
             s = pauseCtx->cursorSlot[PAUSE_ITEM];
             if (gSaveContext.save.info.inventory.items[s] == ITEM_NONE) {
                 i = s + 1;
-                while (true) {
+                for (;;) {
                     if (gSaveContext.save.info.inventory.items[i] != ITEM_NONE) {
                         break;
                     }
@@ -1268,11 +1268,12 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             } else if (pauseCtx->stickAdjX > 30) {
                 if (sStickXRepeatState == 1) {
                     sStickXRepeatTimer--;
-                    if (sStickXRepeatTimer < 0) {
+                    // NOLINTBEGIN
+                    if (sStickXRepeatTimer < 0)
                         sStickXRepeatTimer = R_PAUSE_STICK_REPEAT_DELAY;
-                    } else {
+                    else
                         pauseCtx->stickAdjX = 0;
-                    }
+                    // NOLINTEND
                 } else {
                     sStickXRepeatTimer = R_PAUSE_STICK_REPEAT_DELAY_FIRST;
                     sStickXRepeatState = 1;
@@ -1296,11 +1297,12 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
             } else if (pauseCtx->stickAdjY > 30) {
                 if (sStickYRepeatState == 1) {
                     sStickYRepeatTimer--;
-                    if (sStickYRepeatTimer < 0) {
+                    // NOLINTBEGIN
+                    if (sStickYRepeatTimer < 0)
                         sStickYRepeatTimer = R_PAUSE_STICK_REPEAT_DELAY;
-                    } else {
+                    else
                         pauseCtx->stickAdjY = 0;
-                    }
+                    // NOLINTEND
                 } else {
                     sStickYRepeatTimer = R_PAUSE_STICK_REPEAT_DELAY_FIRST;
                     sStickYRepeatState = 1;
@@ -1573,7 +1575,7 @@ void KaleidoScope_DrawPages(PlayState* play, GraphicsContext* gfxCtx) {
         } else if (((pauseCtx->state == PAUSE_STATE_SAVE_PROMPT) &&
                     (pauseCtx->savePromptState >= PAUSE_SAVE_PROMPT_STATE_SAVED)) ||
                    pauseCtx->state == PAUSE_STATE_GAME_OVER_SAVED) {
-#if PLATFORM_N64
+#if !PLATFORM_GC
             POLY_OPA_DISP = KaleidoScope_QuadTextureIA8(POLY_OPA_DISP, sSaveConfirmationTexs[gSaveContext.language],
                                                         152, 16, PROMPT_QUAD_MESSAGE * 4);
 #endif
@@ -1823,7 +1825,7 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
     gSPDisplayList(POLY_OPA_DISP++, gRButtonIconDL);
 
     if (pauseCtx->cursorSpecialPos != 0) {
-        j = (pauseCtx->cursorSpecialPos * 4) - 32;
+        j = (pauseCtx->cursorSpecialPos - 8) * 4;
         pauseCtx->cursorVtx[0].v.ob[0] = pauseCtx->infoPanelVtx[j].v.ob[0];
         pauseCtx->cursorVtx[0].v.ob[1] = pauseCtx->infoPanelVtx[j].v.ob[1];
         KaleidoScope_DrawCursor(play, pauseCtx->pageIndex);
@@ -2002,8 +2004,8 @@ void KaleidoScope_DrawInfoPanel(PlayState* play) {
                                                             D_8082ADD8[gSaveContext.language], 16, 4);
             } else if ((pauseCtx->pageIndex == PAUSE_MAP) && sInDungeonScene) {
 
-            } else if ((pauseCtx->pageIndex == PAUSE_QUEST) && (pauseCtx->cursorSlot[PAUSE_QUEST] >= 6) &&
-                       (pauseCtx->cursorSlot[PAUSE_QUEST] <= 0x11)) {
+            } else if ((pauseCtx->pageIndex == PAUSE_QUEST) &&
+                       ((pauseCtx->cursorSlot[PAUSE_QUEST] >= 6) && (pauseCtx->cursorSlot[PAUSE_QUEST] <= 0x11))) {
                 if (pauseCtx->namedItem != PAUSE_ITEM_NONE) {
                     pauseCtx->infoPanelVtx[16].v.ob[0] = pauseCtx->infoPanelVtx[18].v.ob[0] =
                         R_KALEIDO_UNK3(gSaveContext.language);
@@ -2121,8 +2123,8 @@ void KaleidoScope_UpdateNamePanel(PlayState* play) {
             pauseCtx->nameDisplayTimer = 0;
         }
     } else if (pauseCtx->nameColorSet == 0) {
-        if (((pauseCtx->pageIndex == PAUSE_QUEST) && (pauseCtx->cursorSlot[PAUSE_QUEST] >= 6) &&
-             (pauseCtx->cursorSlot[PAUSE_QUEST] <= 0x11) &&
+        if (((pauseCtx->pageIndex == PAUSE_QUEST) &&
+             ((pauseCtx->cursorSlot[PAUSE_QUEST] >= 6) && (pauseCtx->cursorSlot[PAUSE_QUEST] <= 0x11)) &&
              (pauseCtx->mainState == PAUSE_MAIN_STATE_IDLE_CURSOR_ON_SONG)) ||
             (pauseCtx->pageIndex == PAUSE_ITEM) ||
             ((pauseCtx->pageIndex == PAUSE_EQUIP) && (pauseCtx->cursorX[PAUSE_EQUIP] != 0))) {
@@ -2143,16 +2145,16 @@ void KaleidoScope_UpdateNamePanel(PlayState* play) {
 void KaleidoScope_UpdatePageSwitch(PlayState* play, Input* input) {
     PauseContext* pauseCtx = &play->pauseCtx;
     s32 frameAdvanceFreeze = false;
-    s32 nextPageMode;
 
     if (R_PAUSE_PAGE_SWITCH_FRAME_ADVANCE_ON && !CHECK_BTN_ALL(input->press.button, BTN_L)) {
         frameAdvanceFreeze = true;
     }
 
     if (!frameAdvanceFreeze) {
-        nextPageMode = pauseCtx->nextPageMode;
-        pauseCtx->eye.x += sPageSwitchEyeDx[nextPageMode];
-        pauseCtx->eye.z += sPageSwitchEyeDz[nextPageMode];
+        pauseCtx->eye.x += sPageSwitchEyeDx[pauseCtx->nextPageMode];
+        pauseCtx->eye.z += sPageSwitchEyeDz[pauseCtx->nextPageMode];
+
+        if (pauseCtx->nextPageMode) {}
 
         if (pauseCtx->pageSwitchTimer < ((4 * PAGE_SWITCH_NSTEPS) / 2)) {
             WREG(16) -= WREG(25) / WREG(6);
@@ -2398,7 +2400,6 @@ static s16 sVtxMapWorldAreaX[] = {
     20,   // WORLD_MAP_AREA_GORON_CITY
     -34,  // WORLD_MAP_AREA_LON_LON_RANCH
     -300, // WORLD_MAP_AREA_QUESTION_MARK
-    0,    // WORLD_MAP_AREA_GANONS_CASTLE
 };
 
 static s16 sVtxMapWorldAreaWidth[] = {
@@ -2423,7 +2424,6 @@ static s16 sVtxMapWorldAreaWidth[] = {
     16, // WORLD_MAP_AREA_GORON_CITY
     20, // WORLD_MAP_AREA_LON_LON_RANCH
     -1, // WORLD_MAP_AREA_QUESTION_MARK
-    0,  // WORLD_MAP_AREA_GANONS_CASTLE
 };
 
 static s16 sVtxMapWorldAreaY[] = {
@@ -2448,7 +2448,6 @@ static s16 sVtxMapWorldAreaY[] = {
     37,   // WORLD_MAP_AREA_GORON_CITY
     -13,  // WORLD_MAP_AREA_LON_LON_RANCH
     -300, // WORLD_MAP_AREA_QUESTION_MARK
-    0,    // WORLD_MAP_AREA_GANONS_CASTLE
 };
 
 static s16 sVtxMapWorldAreaHeight[] = {
@@ -2473,7 +2472,6 @@ static s16 sVtxMapWorldAreaHeight[] = {
     13, // WORLD_MAP_AREA_GORON_CITY
     12, // WORLD_MAP_AREA_LON_LON_RANCH
     1,  // WORLD_MAP_AREA_QUESTION_MARK
-    0,  // WORLD_MAP_AREA_GANONS_CASTLE
 };
 
 s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 numQuads) {
@@ -2481,16 +2479,16 @@ s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 num
     static s16 sTradeQuestMarkerBobTimer = 1;
     static s16 sTradeQuestMarkerBobState = 0;
     PauseContext* pauseCtx = &play->pauseCtx;
+    s16 i;
+    s16 j;
+    s16 bufI;
+    s16 bufIAfterPageSections;
+    s16 pageBgQuadX;
+    s16 pageBgQuadY;
     s16* quadsX;
     s16* quadsWidth;
     s16* quadsY;
     s16* quadsHeight;
-    s16 bufIAfterPageSections;
-    s16 pageBgQuadX;
-    s16 pageBgQuadY;
-    s16 i;
-    s16 j;
-    s16 bufI;
 
     // Vertices for KaleidoScope_DrawPageSections
 
@@ -2502,7 +2500,7 @@ s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 num
 
         // For each row
         for (pageBgQuadY = (PAGE_BG_ROWS * PAGE_BG_QUAD_HEIGHT) / 2, i = 0; i < PAGE_BG_ROWS;
-             i++, bufI += 4, pageBgQuadY -= PAGE_BG_QUAD_HEIGHT) {
+             bufI += 4, i++, pageBgQuadY -= PAGE_BG_QUAD_HEIGHT) {
             vtx[bufI + 0].v.ob[0] = vtx[bufI + 2].v.ob[0] = pageBgQuadX;
 
             vtx[bufI + 1].v.ob[0] = vtx[bufI + 3].v.ob[0] = vtx[bufI + 0].v.ob[0] + PAGE_BG_QUAD_WIDTH;
@@ -2513,10 +2511,7 @@ s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 num
 
             vtx[bufI + 0].v.ob[2] = vtx[bufI + 1].v.ob[2] = vtx[bufI + 2].v.ob[2] = vtx[bufI + 3].v.ob[2] = 0;
 
-            vtx[bufI + 0].v.flag = 0;
-            vtx[bufI + 1].v.flag = 0;
-            vtx[bufI + 2].v.flag = 0;
-            vtx[bufI + 3].v.flag = 0;
+            vtx[bufI + 0].v.flag = vtx[bufI + 1].v.flag = vtx[bufI + 2].v.flag = vtx[bufI + 3].v.flag = 0;
 
             vtx[bufI + 0].v.tc[0] = vtx[bufI + 0].v.tc[1] = vtx[bufI + 1].v.tc[1] = vtx[bufI + 2].v.tc[0] = 0;
 
@@ -2552,7 +2547,7 @@ s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 num
         quadsHeight = sVtxPageQuadsHeight[vtxPage];
 
         for (j = 0; j < numQuads; j++, bufI += 4) {
-            vtx[bufI + 2].v.ob[0] = vtx[bufI + 0].v.ob[0] = quadsX[j];
+            vtx[bufI + 0].v.ob[0] = vtx[bufI + 2].v.ob[0] = quadsX[j];
 
             vtx[bufI + 1].v.ob[0] = vtx[bufI + 3].v.ob[0] = vtx[bufI + 0].v.ob[0] + quadsWidth[j];
 
@@ -2610,9 +2605,9 @@ s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 num
                             sTradeQuestMarkerBobTimer = 8;
                             break;
                         case 2:
+                            sTradeQuestMarkerBobState = 0;
                             sTradeQuestMarkerBobY = 0;
                             sTradeQuestMarkerBobTimer = 6;
-                            sTradeQuestMarkerBobState = 0;
                             break;
                     }
                 } else {
@@ -2626,11 +2621,11 @@ s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 num
 
                 vtx[i + 1].v.ob[0] = vtx[i + 3].v.ob[0] = vtx[i + 0].v.ob[0] + 8;
 
-                vtx[i + 0].v.ob[1] = vtx[i + 1].v.ob[1] = vtx[j + 0].v.ob[1] - sTradeQuestMarkerBobY + 10;
-
-                vtx[i + 0].v.ob[2] = vtx[i + 1].v.ob[2] = vtx[i + 2].v.ob[2] = vtx[i + 3].v.ob[2] = 0;
+                vtx[i + 0].v.ob[1] = vtx[i + 1].v.ob[1] = vtx[j + 0].v.ob[1] + 10 - sTradeQuestMarkerBobY;
 
                 vtx[i + 2].v.ob[1] = vtx[i + 3].v.ob[1] = vtx[i + 0].v.ob[1] - 8;
+
+                vtx[i + 0].v.ob[2] = vtx[i + 1].v.ob[2] = vtx[i + 2].v.ob[2] = vtx[i + 3].v.ob[2] = 0;
 
                 vtx[i + 0].v.flag = vtx[i + 1].v.flag = vtx[i + 2].v.flag = vtx[i + 3].v.flag = 0;
 
@@ -2970,7 +2965,7 @@ void KaleidoScope_SetVertices(PlayState* play, GraphicsContext* gfxCtx) {
 
     // ITEM_QUAD_GRID_SELECTED_C_LEFT, ITEM_QUAD_GRID_SELECTED_C_DOWN, ITEM_QUAD_GRID_SELECTED_C_RIGHT
 
-    for (j = 1; j < 4; j++, i += 4) {
+    for (j = 1; j < 4; i += 4, j++) {
         if (gSaveContext.save.info.equips.cButtonSlots[j - 1] != ITEM_NONE) {
             k = gSaveContext.save.info.equips.cButtonSlots[j - 1] * 4;
 
@@ -3118,7 +3113,7 @@ void KaleidoScope_SetVertices(PlayState* play, GraphicsContext* gfxCtx) {
         }
     }
 
-    for (j = 0; j < 4; j++, k += 4) {
+    for (j = 0; j < 4; k += 4, j++) {
         if (CUR_EQUIP_VALUE(j) != 0) {
             i = (CUR_EQUIP_VALUE(j) + D_8082B134[j] - 1) * 4;
 
@@ -3158,7 +3153,7 @@ void KaleidoScope_SetVertices(PlayState* play, GraphicsContext* gfxCtx) {
 
     x = 112;
     y = 50;
-    while (true) {
+    for (;;) {
         pauseCtx->equipVtx[k + 0].v.ob[0] = pauseCtx->equipVtx[k + 2].v.ob[0] = -64;
 
         pauseCtx->equipVtx[k + 1].v.ob[0] = pauseCtx->equipVtx[k + 3].v.ob[0] = pauseCtx->equipVtx[k + 0].v.ob[0] + 64;
@@ -3190,7 +3185,6 @@ void KaleidoScope_SetVertices(PlayState* play, GraphicsContext* gfxCtx) {
             pauseCtx->equipVtx[k + 3].v.cn[3] = pauseCtx->alpha;
 
         x -= 32;
-        y -= 32;
         if (x < 0) {
             pauseCtx->equipVtx[k + 2].v.ob[1] = pauseCtx->equipVtx[k + 3].v.ob[1] =
                 pauseCtx->equipVtx[k + 0].v.ob[1] - 0x10;
@@ -3199,6 +3193,7 @@ void KaleidoScope_SetVertices(PlayState* play, GraphicsContext* gfxCtx) {
             break;
         }
 
+        y -= 32;
         k += 4;
     }
 
@@ -3239,13 +3234,13 @@ void KaleidoScope_SetVertices(PlayState* play, GraphicsContext* gfxCtx) {
             pauseCtx->questVtx[k + 0].v.ob[0] = pauseCtx->questVtx[k + 2].v.ob[0] = sQuestQuadsX[j] + 2;
 
             pauseCtx->questVtx[k + 1].v.ob[0] = pauseCtx->questVtx[k + 3].v.ob[0] =
-                pauseCtx->questVtx[k + 0].v.ob[0] + quadWidth - 4;
+                pauseCtx->questVtx[k + 0].v.ob[0] + (quadWidth - 4);
 
             pauseCtx->questVtx[k + 0].v.ob[1] = pauseCtx->questVtx[k + 1].v.ob[1] =
                 sQuestQuadsY[j] + pauseCtx->pagesYOrigin1 - 2;
 
             pauseCtx->questVtx[k + 2].v.ob[1] = pauseCtx->questVtx[k + 3].v.ob[1] =
-                pauseCtx->questVtx[k + 0].v.ob[1] - sQuestQuadsSize[j] + 4;
+                pauseCtx->questVtx[k + 0].v.ob[1] - (sQuestQuadsSize[j] - 4);
         }
 
         pauseCtx->questVtx[k + 0].v.ob[2] = pauseCtx->questVtx[k + 1].v.ob[2] = pauseCtx->questVtx[k + 2].v.ob[2] =
@@ -3417,16 +3412,16 @@ void KaleidoScope_UpdateOpening(PlayState* play) {
     } else if (pauseCtx->pageSwitchTimer == (4 * PAGE_SWITCH_NSTEPS * 1)) {
         // `ZREG(47)` is always 1 so this normally never happens
         pauseCtx->pageIndex = sPageSwitchNextPageIndex[pauseCtx->nextPageMode];
-        pauseCtx->nextPageMode = (u16)(pauseCtx->pageIndex * 2) + 1;
+        pauseCtx->nextPageMode = (u16)(pauseCtx->pageIndex << 1) + 1;
     }
 }
 
 void KaleidoScope_UpdateCursorVtx(PlayState* play) {
     PauseContext* pauseCtx = &play->pauseCtx;
-    s32 tlOffsetX;
-    s32 tlOffsetY;
-    s32 rightOffsetX;
-    s32 bottomOffsetY;
+    s16 tlOffsetX;
+    s16 tlOffsetY;
+    s16 bottomOffsetY;
+    s16 rightOffsetX;
 
     if (pauseCtx->cursorSpecialPos == 0) {
         tlOffsetX = -1;
@@ -3530,8 +3525,8 @@ void KaleidoScope_LoadDungeonMap(PlayState* play) {
 }
 
 void KaleidoScope_UpdateDungeonMap(PlayState* play) {
-    PauseContext* pauseCtx = &play->pauseCtx;
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
+    PauseContext* pauseCtx = &play->pauseCtx;
 
     PRINTF("ＭＡＰ ＤＭＡ = %d\n", play->interfaceCtx.mapPaletteIndex);
 
@@ -3548,16 +3543,16 @@ void KaleidoScope_UpdateDungeonMap(PlayState* play) {
     Map_SetFloorPalettesData(play, pauseCtx->dungeonMapSlot - 3);
 
     if ((play->sceneId >= SCENE_DEKU_TREE) && (play->sceneId <= SCENE_TREASURE_BOX_SHOP)) {
-        if ((VREG(30) + 3) == pauseCtx->cursorPoint[PAUSE_MAP]) {
-            KaleidoScope_OverridePalIndexCI4(interfaceCtx->mapSegment, MAP_48x85_TEX_SIZE,
+        if (VREG(30) == pauseCtx->cursorPoint[PAUSE_MAP] - 3) {
+            KaleidoScope_OverridePalIndexCI4((char*)interfaceCtx->mapSegment, MAP_48x85_TEX_SIZE,
                                              interfaceCtx->mapPaletteIndex, 14);
         }
     }
 
     if ((play->sceneId >= SCENE_DEKU_TREE) && (play->sceneId <= SCENE_TREASURE_BOX_SHOP)) {
-        if ((VREG(30) + 3) == pauseCtx->cursorPoint[PAUSE_MAP]) {
-            KaleidoScope_OverridePalIndexCI4(interfaceCtx->mapSegment + ALIGN16(MAP_48x85_TEX_SIZE), MAP_48x85_TEX_SIZE,
-                                             interfaceCtx->mapPaletteIndex, 14);
+        if (VREG(30) == pauseCtx->cursorPoint[PAUSE_MAP] - 3) {
+            KaleidoScope_OverridePalIndexCI4((char*)interfaceCtx->mapSegment + ALIGN16(MAP_48x85_TEX_SIZE),
+                                             MAP_48x85_TEX_SIZE, interfaceCtx->mapPaletteIndex, 14);
         }
     }
 }
@@ -3627,9 +3622,9 @@ void KaleidoScope_Update(PlayState* play) {
             size1 = Player_InitPauseDrawData(play, pauseCtx->playerSegment, &pauseCtx->playerSkelAnime);
             PRINTF("プレイヤー size1＝%x\n", size1);
 
+            size0 = (uintptr_t)_icon_item_staticSegmentRomEnd - (uintptr_t)_icon_item_staticSegmentRomStart;
             pauseCtx->iconItemSegment = (void*)ALIGN16((uintptr_t)pauseCtx->playerSegment + size1);
 
-            size0 = (uintptr_t)_icon_item_staticSegmentRomEnd - (uintptr_t)_icon_item_staticSegmentRomStart;
             PRINTF("icon_item size0=%x\n", size0);
             DMA_REQUEST_SYNC(pauseCtx->iconItemSegment, (uintptr_t)_icon_item_staticSegmentRomStart, size0,
                              "../z_kaleido_scope_PAL.c", 3662);
@@ -3698,10 +3693,12 @@ void KaleidoScope_Update(PlayState* play) {
 #if OOT_NTSC
             if (gSaveContext.language == LANGUAGE_JPN) {
                 size = (uintptr_t)_icon_item_jpn_staticSegmentRomEnd - (uintptr_t)_icon_item_jpn_staticSegmentRomStart;
+                PRINTF("icon_item_jpn dungeon-size=%x\n", size);
                 DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_jpn_staticSegmentRomStart, size,
                                  "../z_kaleido_scope_PAL.c", UNK_LINE);
             } else {
                 size = (uintptr_t)_icon_item_nes_staticSegmentRomEnd - (uintptr_t)_icon_item_nes_staticSegmentRomStart;
+                PRINTF("icon_item_dungeon dungeon-size=%x\n", size);
                 DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_nes_staticSegmentRomStart, size,
                                  "../z_kaleido_scope_PAL.c", UNK_LINE);
             }
@@ -3734,37 +3731,42 @@ void KaleidoScope_Update(PlayState* play) {
             if (((void)0, gSaveContext.worldMapArea) < WORLD_MAP_AREA_MAX) {
 #if OOT_NTSC
                 if (gSaveContext.language == LANGUAGE_JPN) {
-                    DMA_REQUEST_SYNC(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
-                                     (uintptr_t)_map_name_staticSegmentRomStart +
-                                         (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
-                                         24 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_JPN * MAP_NAME_TEX2_SIZE,
-                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", UNK_LINE);
+                    DMA_REQUEST_SYNC(
+                        pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
+                        (uintptr_t)_map_name_staticSegmentRomStart +
+                            ((((void)0, gSaveContext.worldMapArea) + 22 * LANGUAGE_JPN) * MAP_NAME_TEX2_SIZE) +
+                            24 * MAP_NAME_TEX1_SIZE,
+                        MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", UNK_LINE);
                 } else {
-                    DMA_REQUEST_SYNC(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
-                                     (uintptr_t)_map_name_staticSegmentRomStart +
-                                         (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
-                                         24 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_ENG * MAP_NAME_TEX2_SIZE,
-                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", UNK_LINE);
+                    DMA_REQUEST_SYNC(
+                        pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
+                        (uintptr_t)_map_name_staticSegmentRomStart +
+                            ((((void)0, gSaveContext.worldMapArea) + 22 * LANGUAGE_ENG) * MAP_NAME_TEX2_SIZE) +
+                            24 * MAP_NAME_TEX1_SIZE,
+                        MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", UNK_LINE);
                 }
 #else
                 if (gSaveContext.language == LANGUAGE_ENG) {
-                    DMA_REQUEST_SYNC(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
-                                     (uintptr_t)_map_name_staticSegmentRomStart +
-                                         (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
-                                         36 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_ENG * MAP_NAME_TEX2_SIZE,
-                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 3776);
+                    DMA_REQUEST_SYNC(
+                        pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
+                        (uintptr_t)_map_name_staticSegmentRomStart +
+                            ((((void)0, gSaveContext.worldMapArea) + 22 * LANGUAGE_ENG) * MAP_NAME_TEX2_SIZE) +
+                            36 * MAP_NAME_TEX1_SIZE,
+                        MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 3776);
                 } else if (gSaveContext.language == LANGUAGE_GER) {
-                    DMA_REQUEST_SYNC(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
-                                     (uintptr_t)_map_name_staticSegmentRomStart +
-                                         (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
-                                         36 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_GER * MAP_NAME_TEX2_SIZE,
-                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 3780);
+                    DMA_REQUEST_SYNC(
+                        pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
+                        (uintptr_t)_map_name_staticSegmentRomStart +
+                            ((((void)0, gSaveContext.worldMapArea) + 22 * LANGUAGE_GER) * MAP_NAME_TEX2_SIZE) +
+                            36 * MAP_NAME_TEX1_SIZE,
+                        MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 3780);
                 } else {
-                    DMA_REQUEST_SYNC(pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
-                                     (uintptr_t)_map_name_staticSegmentRomStart +
-                                         (((void)0, gSaveContext.worldMapArea) * MAP_NAME_TEX2_SIZE) +
-                                         36 * MAP_NAME_TEX1_SIZE + 22 * LANGUAGE_FRA * MAP_NAME_TEX2_SIZE,
-                                     MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 3784);
+                    DMA_REQUEST_SYNC(
+                        pauseCtx->nameSegment + MAX(MAP_NAME_TEX1_SIZE, ITEM_NAME_TEX_SIZE),
+                        (uintptr_t)_map_name_staticSegmentRomStart +
+                            ((((void)0, gSaveContext.worldMapArea) + 22 * LANGUAGE_FRA) * MAP_NAME_TEX2_SIZE) +
+                            36 * MAP_NAME_TEX1_SIZE,
+                        MAP_NAME_TEX2_SIZE, "../z_kaleido_scope_PAL.c", 3784);
                 }
 #endif
             }
@@ -3868,7 +3870,7 @@ void KaleidoScope_Update(PlayState* play) {
                 pauseCtx->worldMapPoints[WORLD_MAP_POINT_DEATH_MOUNTAIN] = WORLD_MAP_POINT_STATE_SHOW;
             }
 
-            if (gBitFlags[WORLD_MAP_AREA_KAKARIKO_VILLAGE] & gSaveContext.save.info.worldMapAreaData) {
+            if (gSaveContext.save.info.worldMapAreaData & gBitFlags[WORLD_MAP_AREA_KAKARIKO_VILLAGE]) {
                 pauseCtx->worldMapPoints[WORLD_MAP_POINT_KAKARIKO_VILLAGE] = WORLD_MAP_POINT_STATE_SHOW;
             }
             if (CHECK_QUEST_ITEM(QUEST_SONG_LULLABY)) {
@@ -3896,7 +3898,7 @@ void KaleidoScope_Update(PlayState* play) {
                 pauseCtx->worldMapPoints[WORLD_MAP_POINT_KAKARIKO_VILLAGE] = WORLD_MAP_POINT_STATE_SHOW;
             }
 
-            if (gBitFlags[WORLD_MAP_AREA_LOST_WOODS] & gSaveContext.save.info.worldMapAreaData) {
+            if (gSaveContext.save.info.worldMapAreaData & gBitFlags[WORLD_MAP_AREA_LOST_WOODS]) {
                 pauseCtx->worldMapPoints[WORLD_MAP_POINT_LOST_WOODS] = WORLD_MAP_POINT_STATE_SHOW;
             }
             if (GET_EVENTCHKINF(EVENTCHKINF_0F)) {
@@ -4016,7 +4018,7 @@ void KaleidoScope_Update(PlayState* play) {
                         pauseCtx->state = PAUSE_STATE_CLOSING;
                         R_PAUSE_PAGES_Y_ORIGIN_2 = PAUSE_PAGES_Y_ORIGIN_2_LOWER;
                         func_800F64E0(0);
-#if !PLATFORM_N64 && OOT_NTSC
+#if PLATFORM_GC && OOT_NTSC
                         AudioOcarina_SetInstrument(OCARINA_INSTRUMENT_OFF);
 #endif
                     } else if (CHECK_BTN_ALL(input->press.button, BTN_B)) {
@@ -4169,7 +4171,7 @@ void KaleidoScope_Update(PlayState* play) {
                             R_PAUSE_PAGES_Y_ORIGIN_2 = PAUSE_PAGES_Y_ORIGIN_2_LOWER;
                             YREG(8) = pauseCtx->promptPitch;
                             func_800F64E0(0);
-#if !PLATFORM_N64 && OOT_NTSC
+#if PLATFORM_GC && OOT_NTSC
                             AudioOcarina_SetInstrument(OCARINA_INSTRUMENT_OFF);
 #endif
                         } else {
@@ -4180,7 +4182,7 @@ void KaleidoScope_Update(PlayState* play) {
                             gSaveContext.save.info.playerData.savedSceneId = play->sceneId;
                             Sram_WriteSave(&play->sramCtx);
                             pauseCtx->savePromptState = PAUSE_SAVE_PROMPT_STATE_SAVED;
-#if PLATFORM_N64
+#if !PLATFORM_GC
                             sDelayTimer = 90;
 #else
                             sDelayTimer = 3;
@@ -4197,7 +4199,7 @@ void KaleidoScope_Update(PlayState* play) {
                             gSaveContext.buttonStatus[3] = BTN_ENABLED;
                         gSaveContext.hudVisibilityMode = HUD_VISIBILITY_NO_CHANGE;
                         Interface_ChangeHudVisibilityMode(HUD_VISIBILITY_ALL);
-#if !PLATFORM_N64 && OOT_NTSC
+#if PLATFORM_GC && OOT_NTSC
                         AudioOcarina_SetInstrument(OCARINA_INSTRUMENT_OFF);
 #endif
                     }
@@ -4295,10 +4297,12 @@ void KaleidoScope_Update(PlayState* play) {
 #if OOT_NTSC
             if (gSaveContext.language == LANGUAGE_JPN) {
                 size = (uintptr_t)_icon_item_jpn_staticSegmentRomEnd - (uintptr_t)_icon_item_jpn_staticSegmentRomStart;
+                PRINTF("icon_item_jpn dungeon-size=%x\n", size);
                 DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_jpn_staticSegmentRomStart, size,
                                  "../z_kaleido_scope_PAL.c", UNK_LINE);
             } else {
                 size = (uintptr_t)_icon_item_nes_staticSegmentRomEnd - (uintptr_t)_icon_item_nes_staticSegmentRomStart;
+                PRINTF("icon_item_dungeon dungeon-size=%x\n", size);
                 DMA_REQUEST_SYNC(pauseCtx->iconItemLangSegment, (uintptr_t)_icon_item_nes_staticSegmentRomStart, size,
                                  "../z_kaleido_scope_PAL.c", UNK_LINE);
             }
@@ -4389,9 +4393,9 @@ void KaleidoScope_Update(PlayState* play) {
                 D_8082AB9C = 255;
                 D_8082ABA0 = 130;
                 D_8082ABA4 = 0;
+                D_8082B260 = 40;
 
                 pauseCtx->state++; // PAUSE_STATE_GAME_OVER_WINDOW_DELAY
-                D_8082B260 = 40;
             }
             break;
 
@@ -4443,7 +4447,7 @@ void KaleidoScope_Update(PlayState* play) {
                     gSaveContext.save.info.playerData.savedSceneId = play->sceneId;
                     Sram_WriteSave(&play->sramCtx);
                     pauseCtx->state = PAUSE_STATE_GAME_OVER_SAVED;
-#if PLATFORM_N64
+#if !PLATFORM_GC
                     sDelayTimer = 90;
 #else
                     sDelayTimer = 3;
@@ -4595,7 +4599,7 @@ void KaleidoScope_Update(PlayState* play) {
                 pauseCtx->equipPagePitch = 160.0f;
                 pauseCtx->itemPagePitch = 160.0f;
                 pauseCtx->namedItem = PAUSE_ITEM_NONE;
-                play->interfaceCtx.startAlpha = 0;
+                interfaceCtx->startAlpha = 0;
             }
             break;
 
@@ -4626,7 +4630,7 @@ void KaleidoScope_Update(PlayState* play) {
                 case SCENE_WATER_TEMPLE_BOSS:
                 case SCENE_SPIRIT_TEMPLE_BOSS:
                 case SCENE_SHADOW_TEMPLE_BOSS:
-                    Map_InitData(play, play->interfaceCtx.mapRoomNum);
+                    Map_InitData(play, interfaceCtx->mapRoomNum);
                     break;
             }
 

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -2582,6 +2582,11 @@ s16 KaleidoScope_SetPageVertices(PlayState* play, Vtx* vtx, s16 vtxPage, s16 num
 
             bufI -= ((VTX_PAGE_MAP_WORLD_QUADS - WORLD_MAP_QUAD_TRADE_QUEST_MARKER) * 4);
 
+            //! @bug If worldMapArea is WORLD_MAP_AREA_GANONS_CASTLE or WORLD_MAP_AREA_MAX, this will read past the end
+            //! of the sVtxMapWorldArea arrays and generate garbage vertex data. This is harmless though:
+            //! if pauseCtx->tradeQuestMarker != TRADE_QUEST_MARKER_NONE then the vertices are immediately overwritten,
+            //! and if pauseCtx->tradeQuestMarker == TRADE_QUEST_MARKER_NONE then KaleidoScope_DrawWorldMap will not
+            //! draw anything with these vertices.
             j = gSaveContext.worldMapArea;
 
             vtx[bufI + 0].v.ob[0] = vtx[bufI + 2].v.ob[0] = sVtxMapWorldAreaX[j];

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
@@ -7,9 +7,9 @@
 extern u8 gAmmoItems[];
 extern s16 gVtxPageMapWorldQuadsWidth[];
 extern s16 gVtxPageMapWorldQuadsHeight[];
-extern u8 gSlotAgeReqs[];
-extern u8 gEquipAgeReqs[EQUIP_TYPE_MAX][4];
-extern u8 gItemAgeReqs[];
+extern char gSlotAgeReqs[];
+extern char gEquipAgeReqs[EQUIP_TYPE_MAX][4];
+extern char gItemAgeReqs[];
 extern u8 gAreaGsFlags[];
 
 #define AGE_REQ_ADULT LINK_AGE_ADULT

--- a/tools/disasm/ique-cn/files_ovl_kaleido_scope.csv
+++ b/tools/disasm/ique-cn/files_ovl_kaleido_scope.csv
@@ -32,4 +32,4 @@ offset,vram,.ovl
 
 offset,vram,.bss
 1C030,80830220,src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope
-1C040,80830230,.end
+1C0A0,80830290,.end


### PR DESCRIPTION
Notes:
* Some bytes are unsigned for IDO but signed for EGCS, (in particular `gItemAgeReqs` and the first argument to `KaleidoScope_OverridePalIndexCI4`) and I've represented with `char`. This means we can't use `-funsigned-char` here, and I suspect our usage of it in z_std_dma is fake. An alternative could be to make a type which is `u8` for IDO and `s8` for EGCS but idk what to call that
* Apparently removing braces from if-else statements can matter. I've wrapped these in `NOLINTBEGIN/NOLINTEND` so clang-tidy doesn't add them back. An alternative could be a ternary like `(sStickXRepeatTimer < 0) ? (sStickXRepeatTimer = R_PAUSE_STICK_REPEAT_DELAY) : (pauseCtx->stickAdjX = 0);`.
* For `KaleidoScope_UpdatePageSwitch`, I couldn't find anything that worked for both iQue and N64, so I fake-matched it for N64 since I thought it looked better than an ifdef
* `sVtxMapWorldAreaHeight` is definitely too long. The other arrays could have a trailing 0, but I removed it from all of them for consistency. I'm not sure if this reads OOB for `WORLD_MAP_AREA_GANONS_CASTLE` or `WORLD_MAP_AREA_MAX` because tbh I don't understand the code