### PR TITLE
[iQue] Define EGCS macro instead of relying on `__GNUC__`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,10 +376,10 @@ else
   # compiler does support but warns for their usage).
   CFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -non_shared -fullwarn -verbose -Xcpluscomm $(INC) -Wab,-r4300_mul -woff 516,609,649,838,712,807
   CCASFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -non_shared -fullwarn -verbose -Xcpluscomm $(INC) -Wab,-r4300_mul -woff 516,609,649,838,712,807 -o32
-  EGCS_CFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -G 0 -nostdinc $(INC) -mcpu=vr4300 -mabi=32 -mgp32 -mfp32 -fno-PIC
   MIPS_VERSION := -mips2
 
-  EGCS_CCASFLAGS := -Wall -nostdinc $(CPP_DEFINES) $(INC) -c -G 0 -Wa,-irix-symtab -D_ABIO32=1 -D_ABI64=3 -D_MIPS_SIM_ABI64=_ABI64 -D_MIPS_SIM_ABI32=_ABIO32 -DMIPSEB -D_LANGUAGE_ASSEMBLY -mabi=32 -fno-PIC -non_shared -mcpu=4300 -mfix4300
+  EGCS_CFLAGS += $(CPP_DEFINES) $(GBI_DEFINES) -DEGCS -G 0 -nostdinc $(INC) -mcpu=vr4300 -mabi=32 -mgp32 -mfp32 -fno-PIC
+  EGCS_CCASFLAGS := -Wall -nostdinc $(CPP_DEFINES) -DEGCS $(INC) -c -G 0 -Wa,-irix-symtab -D_ABIO32=1 -D_ABI64=3 -D_MIPS_SIM_ABI64=_ABI64 -D_MIPS_SIM_ABI32=_ABIO32 -DMIPSEB -D_LANGUAGE_ASSEMBLY -mabi=32 -fno-PIC -non_shared -mcpu=4300 -mfix4300
   EGCS_ASOPTFLAGS :=
 endif
 

--- a/include/libc/stdarg.h
+++ b/include/libc/stdarg.h
@@ -1,16 +1,7 @@
 #ifndef STDARG_H
 #define STDARG_H
 
-// When building with modern GCC, use the official vaarg macros to avoid warnings and possibly bad codegen.
-
-#if __GNUC__ >= 3
-
-#define va_list  __builtin_va_list
-#define va_start __builtin_va_start
-#define va_arg   __builtin_va_arg
-#define va_end   __builtin_va_end
-
-#elif defined(__sgi) /* IDO */
+#if defined(__sgi) /* IDO */
 
 #ifndef _VA_LIST_
 # define _VA_LIST_
@@ -52,7 +43,7 @@ typedef char* va_list;
 /* No cleanup processing is required for the end of a varargs list: */
 #define va_end(__list)
 
-#else /* EGCS */
+#elif defined(EGCS) /* EGCS */
 
 typedef char * __gnuc_va_list;
 
@@ -74,6 +65,14 @@ typedef char * __gnuc_va_list;
                                 *(__type *) (void *) (__AP - __va_rounded_size (__type)))
 
 typedef __gnuc_va_list va_list;
+
+#else /* Modern GCC */
+
+// When building with modern GCC, use the official vaarg macros to avoid warnings and possibly bad codegen.
+#define va_list  __builtin_va_list
+#define va_start __builtin_va_start
+#define va_arg   __builtin_va_arg
+#define va_end   __builtin_va_end
 
 #endif
 

--- a/include/macros.h
+++ b/include/macros.h
@@ -52,10 +52,10 @@
 
 #if DEBUG_FEATURES
 #define PRINTF osSyncPrintf
+#elif defined(EGCS)
+#define PRINTF(format, args...) while (0) osSyncPrintf(format, ##args)
 #elif IDO_PRINTF_WORKAROUND
 #define PRINTF(args) (void)0
-#elif defined(__GNUC__) && __GNUC__ < 3
-#define PRINTF(format, args...) while (0) osSyncPrintf(format, ##args)
 #else
 #define PRINTF(format, ...) (void)0
 #endif

--- a/src/audio/general.c
+++ b/src/audio/general.c
@@ -8,8 +8,6 @@
 #define AUDIO_PRINTF osSyncPrintf
 #elif IDO_PRINTF_WORKAROUND
 #define AUDIO_PRINTF(args) (void)0
-#elif defined(__GNUC__) && __GNUC__ < 3
-#define AUDIO_PRINTF(format, args...) (void)0
 #else
 #define AUDIO_PRINTF(format, ...) (void)0
 #endif

--- a/src/code/sched.c
+++ b/src/code/sched.c
@@ -62,8 +62,6 @@ vs32 sSchedDebugPrintfEnabled = false;
     PRINTF
 #elif IDO_PRINTF_WORKAROUND
 #define SCHED_DEBUG_PRINTF(args) (void)0
-#elif defined(__GNUC__) && __GNUC__ < 3
-#define SCHED_DEBUG_PRINTF(format, args...) (void)0
 #else
 #define SCHED_DEBUG_PRINTF(format, ...) (void)0
 #endif

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -24,8 +24,6 @@ static s32 sCurCeilingBgId;
     PRINTF
 #elif IDO_PRINTF_WORKAROUND
 #define ACTOR_DEBUG_PRINTF(args) (void)0
-#elif defined(__GNUC__) && __GNUC__ < 3
-#define ACTOR_DEBUG_PRINTF(format, args...) (void)0
 #else
 #define ACTOR_DEBUG_PRINTF(format, ...) (void)0
 #endif

--- a/src/libgcc/longlong.h
+++ b/src/libgcc/longlong.h
@@ -83,7 +83,7 @@
         (sl) = __x;                        \
     } while (0)
 
-#if __GNUC__ < 3
+#ifdef EGCS
 #define umul_ppmm(w1, w0, u, v) \
     __asm__("multu %2,%3" : "=l"((USItype)(w0)), "=h"((USItype)(w1)) : "d"((USItype)(u)), "d"((USItype)(v)))
 #else

--- a/src/libgcc/longlong.h
+++ b/src/libgcc/longlong.h
@@ -83,10 +83,11 @@
         (sl) = __x;                        \
     } while (0)
 
-#ifdef EGCS
+#if __GNUC__ < 3
 #define umul_ppmm(w1, w0, u, v) \
     __asm__("multu %2,%3" : "=l"((USItype)(w0)), "=h"((USItype)(w1)) : "d"((USItype)(u)), "d"((USItype)(v)))
 #else
+/* Non-matching version for modern GCC  */
 #define umul_ppmm(w1, w0, u, v)  \
     __asm__("multu %2,%3\n\t"    \
             "mflo %0\n\t"        \


### PR DESCRIPTION
For EGCS-specific changes that are important for matching, this seems clearer than relying on `__GNUC__ < 3`. This also fixes the permuter import for the iQue PRINTF macro.