### PR TITLE
[iQue] Don't use -funsigned-char for z_std_dma

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -594,8 +594,6 @@ EGCS_O_FILES += $(BUILD_DIR)/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope
 $(EGCS_O_FILES): CC := $(EGCS_CC)
 $(EGCS_O_FILES): CFLAGS := $(EGCS_CFLAGS) -mno-abicalls
 $(EGCS_O_FILES): MIPS_VERSION :=
-
-$(BUILD_DIR)/src/boot/z_std_dma.o: CFLAGS += -funsigned-char
 endif
 
 ifeq ($(PLATFORM),IQUE)

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -75,7 +75,7 @@ const char* sDmaMgrFileNames[] = {
  *  -1 if the first character that does not match has a smaller value in str1 than str2,
  *  +1 if the first character that does not match has a greater value in str1 than str2
  */
-s32 DmaMgr_StrCmp(const char* str1, const char* str2) {
+s32 DmaMgr_StrCmp(const u8* str1, const u8* str2) {
     while (*str1 != '\0') {
         if (*str1 > *str2) {
             return 1;
@@ -338,7 +338,8 @@ const char* DmaMgr_GetFileName(uintptr_t vrom) {
         return "(unknown)";
     }
 
-    if (DmaMgr_StrCmp(ret, "kanji") == 0 || DmaMgr_StrCmp(ret, "link_animetion") == 0) {
+    if (DmaMgr_StrCmp((const u8*)ret, (const u8*)"kanji") == 0 ||
+        DmaMgr_StrCmp((const u8*)ret, (const u8*)"link_animetion") == 0) {
         // This check may be related to these files being too large to be loaded all at once, however a NULL filename
         // does not prevent them from being loaded.
         return NULL;
@@ -379,7 +380,8 @@ void DmaMgr_ProcessRequest(DmaRequest* req) {
             if (0) {
 #if !PLATFORM_GC
                 // Based on the MM Debug ROM, these strings are part of the condition for the empty if statement below
-                if (DmaMgr_StrCmp("", "kanji") != 0 && DmaMgr_StrCmp("", "link_animetion") != 0)
+                if (DmaMgr_StrCmp((const u8*)"", (const u8*)"kanji") != 0 &&
+                    DmaMgr_StrCmp((const u8*)"", (const u8*)"link_animetion") != 0)
 #endif
                 {
                     // The string is defined in .rodata of debug builds but not used, suggesting a debug print is here


### PR DESCRIPTION
Based on other files it seems like char is signed, and I find it more ugly that z_std_dma has different flags than using `u8` here. Note the casts aren't strictly necessary, they just squash some CC_CHECK warnings