### PR TITLE
Use enums for settings in SRAM header

### DIFF
--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -68,6 +68,13 @@ typedef void (*AudioCustomUpdateFunction)(void);
 
 #define AUDIO_RELOCATED_ADDRESS_START K0BASE
 
+typedef enum SoundSetting {
+    /* 0 */ SOUND_SETTING_STEREO,
+    /* 1 */ SOUND_SETTING_MONO,
+    /* 2 */ SOUND_SETTING_HEADSET,
+    /* 3 */ SOUND_SETTING_SURROUND
+} SoundSetting;
+
 typedef enum SoundMode {
     /* 0 */ SOUNDMODE_STEREO,
     /* 1 */ SOUNDMODE_HEADSET,
@@ -1197,7 +1204,7 @@ void func_800F64E0(u8 arg0);
 void Audio_ToggleMalonSinging(u8 malonSingingDisabled);
 void Audio_SetEnvReverb(s8 reverb);
 void Audio_SetCodeReverb(s8 reverb);
-void func_800F6700(s8 audioSetting);
+void Audio_SetSoundMode(s8 soundSetting);
 void Audio_SetBaseFilter(u8);
 void Audio_SetExtraFilter(u8);
 void Audio_SetCutsceneFlag(s8 flag);

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -6,6 +6,11 @@
 #include "z64inventory.h"
 #include "z64math.h"
 
+typedef enum ZTargetSetting {
+    /* 0 */ Z_TARGET_SETTING_SWITCH,
+    /* 1 */ Z_TARGET_SETTING_HOLD
+} ZTargetSetting;
+
 typedef enum Language {
 #if OOT_NTSC
     /* 0 */ LANGUAGE_JPN,
@@ -315,10 +320,10 @@ typedef struct SaveContext {
     /* 0x1404 */ u16 minigameState;
     /* 0x1406 */ u16 minigameScore; // "yabusame_total"
     /* 0x1408 */ char unk_1408[0x0001];
-    /* 0x1409 */ u8 language; // NTSC 0: Japanese; 1: English | PAL 0: English; 1: German; 2: French
-    /* 0x140A */ u8 audioSetting;
+    /* 0x1409 */ u8 language; // NTSC 0: Japanese; 1: English | PAL 0: English; 1: German; 2: French (see enum `Language`)
+    /* 0x140A */ u8 soundSetting; // 0: Stereo; 1: Mono; 2: Headset; 3: Surround (see enum `SoundSetting`)
     /* 0x140B */ char unk_140B[0x0001];
-    /* 0x140C */ u8 zTargetSetting; // 0: Switch; 1: Hold
+    /* 0x140C */ u8 zTargetSetting; // 0: Switch; 1: Hold (see enum `ZTargetSetting`)
     /* 0x140E */ u16 forcedSeqId; // immediately start playing the sequence if set
     /* 0x1410 */ u8 cutsceneTransitionControl; // context dependent usage: can either trigger a delayed fade or control fill alpha
     /* 0x1411 */ char unk_1411[0x0001];

--- a/include/z64sram.h
+++ b/include/z64sram.h
@@ -12,7 +12,7 @@ typedef struct SramContext {
 
 typedef enum SramHeaderField {
     /* 0x00 */ SRAM_HEADER_SOUND,
-    /* 0x01 */ SRAM_HEADER_ZTARGET,
+    /* 0x01 */ SRAM_HEADER_Z_TARGET,
     /* 0x02 */ SRAM_HEADER_LANGUAGE,
     /* 0x03 */ SRAM_HEADER_MAGIC // must be the value in `sSramDefaultHeader` for save to be considered valid
 } SramHeaderField;

--- a/src/audio/debug.inc.c
+++ b/src/audio/debug.inc.c
@@ -847,7 +847,7 @@ void AudioDebug_ProcessInput_SndCont(void) {
                                      &gSfxDefaultReverb);
                 break;
             case 4:
-                func_800F6700(sAudioSndContWork[sAudioSndContSel]);
+                Audio_SetSoundMode(sAudioSndContWork[sAudioSndContSel]);
                 break;
             case 5:
                 SEQCMD_DISABLE_PLAY_SEQUENCES(sAudioSndContWork[sAudioSndContSel]);

--- a/src/audio/general.c
+++ b/src/audio/general.c
@@ -3766,26 +3766,26 @@ void Audio_SetCodeReverb(s8 reverb) {
     }
 }
 
-void func_800F6700(s8 audioSetting) {
+void Audio_SetSoundMode(s8 soundSetting) {
     s8 soundModeIndex;
 
-    switch (audioSetting) {
-        case 0:
+    switch (soundSetting) {
+        case SOUND_SETTING_STEREO:
             soundModeIndex = SOUNDMODE_STEREO;
             sSoundMode = SOUNDMODE_STEREO;
             break;
 
-        case 1:
+        case SOUND_SETTING_MONO:
             soundModeIndex = SOUNDMODE_MONO;
             sSoundMode = SOUNDMODE_MONO;
             break;
 
-        case 2:
+        case SOUND_SETTING_HEADSET:
             soundModeIndex = SOUNDMODE_HEADSET;
             sSoundMode = SOUNDMODE_HEADSET;
             break;
 
-        case 3:
+        case SOUND_SETTING_SURROUND:
             soundModeIndex = SOUNDMODE_STEREO;
             sSoundMode = SOUNDMODE_SURROUND;
             break;

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -29,7 +29,7 @@
 #include "z64thread.h"
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ntsc-1.2:78 pal-1.0:76 pal-1.1:76"
+                               "ntsc-1.2:72 pal-1.0:70 pal-1.1:70"
 
 StackEntry sDmaMgrStackInfo;
 OSMesgQueue sDmaMgrMsgQueue;

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -25,7 +25,7 @@ extern struct IrqMgr gIrqMgr;
 #include "z64thread.h"
 
 #pragma increment_block_number "gc-eu:144 gc-eu-mq:144 gc-jp:144 gc-jp-ce:144 gc-jp-mq:144 gc-us:144 gc-us-mq:144" \
-                               "ique-cn:160 ntsc-1.0:139 ntsc-1.1:139 ntsc-1.2:139 pal-1.0:137 pal-1.1:137"
+                               "ique-cn:160 ntsc-1.0:133 ntsc-1.1:133 ntsc-1.2:133 pal-1.0:131 pal-1.1:131"
 
 extern u8 _buffersSegmentEnd[];
 

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -5,8 +5,8 @@
 #include "z64olib.h"
 #include "overlays/actors/ovl_En_Horse/z_en_horse.h"
 
-#pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192 gc-us-mq:192" \
-                               "ique-cn:192 ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
+#pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
+                               "ique-cn:128 ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
 
 s16 Camera_RequestSettingImpl(Camera* camera, s16 requestedSetting, s16 flags);
 s32 Camera_RequestModeImpl(Camera* camera, s16 requestedMode, u8 forceModeChange);
@@ -3640,7 +3640,7 @@ s32 Camera_KeepOn3(Camera* camera) {
 }
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ique-cn:128 ntsc-1.0:140 ntsc-1.1:140 ntsc-1.2:140 pal-1.0:138 pal-1.1:138"
+                               "ique-cn:128 ntsc-1.0:134 ntsc-1.1:134 ntsc-1.2:134 pal-1.0:132 pal-1.1:132"
 
 s32 Camera_KeepOn4(Camera* camera) {
     static Vec3f D_8015BD50;

--- a/src/code/z_common_data.c
+++ b/src/code/z_common_data.c
@@ -3,7 +3,7 @@
 #include "versions.h"
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ntsc-1.0:176 ntsc-1.1:176 ntsc-1.2:176 pal-1.0:192 pal-1.1:192"
+                               "ntsc-1.0:176 ntsc-1.1:176 ntsc-1.2:176 pal-1.0:176 pal-1.1:176"
 
 ALIGNED(16) SaveContext gSaveContext;
 #if PLATFORM_IQUE

--- a/src/code/z_kankyo.c
+++ b/src/code/z_kankyo.c
@@ -1,5 +1,5 @@
-#pragma increment_block_number "gc-eu:228 gc-eu-mq:228 gc-jp:208 gc-jp-ce:208 gc-jp-mq:208 gc-us:208 gc-us-mq:208" \
-                               "ique-cn:208 ntsc-1.0:224 ntsc-1.1:224 ntsc-1.2:224 pal-1.0:236 pal-1.1:236"
+#pragma increment_block_number "gc-eu:224 gc-eu-mq:224 gc-jp:208 gc-jp-ce:208 gc-jp-mq:208 gc-us:208 gc-us-mq:208" \
+                               "ique-cn:208 ntsc-1.0:224 ntsc-1.1:224 ntsc-1.2:224 pal-1.0:232 pal-1.1:232"
 
 #include "global.h"
 #include "ultra64.h"

--- a/src/code/z_sram.c
+++ b/src/code/z_sram.c
@@ -52,10 +52,13 @@ u16 gSramSlotOffsets[] = {
 };
 
 static u8 sSramDefaultHeader[] = {
-    // TODO: use enums for these
-    0, // SRAM_HEADER_SOUND
-    0, // SRAM_HEADER_ZTARGET
-    0, // SRAM_HEADER_LANGUAGE
+    SOUND_SETTING_STEREO,    // SRAM_HEADER_SOUND
+    Z_TARGET_SETTING_SWITCH, // SRAM_HEADER_Z_TARGET
+#if OOT_NTSC
+    LANGUAGE_JPN, // SRAM_HEADER_LANGUAGE
+#else
+    LANGUAGE_ENG, // SRAM_HEADER_LANGUAGE
+#endif
 
     // SRAM_HEADER_MAGIC
     0x98,
@@ -1016,8 +1019,8 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
         }
     }
 
-    gSaveContext.audioSetting = sramCtx->readBuff[SRAM_HEADER_SOUND] & 3;
-    gSaveContext.zTargetSetting = sramCtx->readBuff[SRAM_HEADER_ZTARGET] & 1;
+    gSaveContext.soundSetting = sramCtx->readBuff[SRAM_HEADER_SOUND] & 3;
+    gSaveContext.zTargetSetting = sramCtx->readBuff[SRAM_HEADER_Z_TARGET] & 1;
 
 #if OOT_PAL
     gSaveContext.language = sramCtx->readBuff[SRAM_HEADER_LANGUAGE];
@@ -1042,11 +1045,11 @@ void Sram_InitSram(GameState* gameState, SramContext* sramCtx) {
     PRINTF(T("ＧＯＯＤ！ＧＯＯＤ！ サイズ＝%d + %d ＝ %d\n", "GOOD! GOOD! Size = %d + %d = %d\n"), sizeof(SaveInfo), 4,
            sizeof(SaveInfo) + 4);
     PRINTF_COLOR_BLUE();
-    PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.audioSetting);
-    PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.audioSetting);
-    PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.audioSetting);
+    PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.soundSetting);
+    PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.soundSetting);
+    PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.soundSetting);
     PRINTF_RST();
-    func_800F6700(gSaveContext.audioSetting);
+    Audio_SetSoundMode(gSaveContext.soundSetting);
 }
 
 void Sram_Alloc(GameState* gameState, SramContext* sramCtx) {

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -31,7 +31,7 @@
 #include "assets/objects/object_sst/object_sst.h"
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 
-#pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
+#pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
                                "pal-1.0:128 pal-1.1:128"
 
 #define FLAGS                                                                                 \

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -69,8 +69,7 @@ void EnMag_ResetSram(void) {
     SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8007000), buffer, 0x800, 1);
     SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8007800), buffer, 0x800, 1);
 
-    gSaveContext.soundSetting = SOUND_SETTING_STEREO;
-    gSaveContext.zTargetSetting = Z_TARGET_SETTING_SWITCH;
+    gSaveContext.soundSetting = gSaveContext.zTargetSetting = 0; // SOUND_SETTING_STEREO/Z_TARGET_SETTING_SWITCH
     Audio_SetSoundMode(gSaveContext.soundSetting);
 }
 #endif

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -69,8 +69,9 @@ void EnMag_ResetSram(void) {
     SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8007000), buffer, 0x800, 1);
     SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8007800), buffer, 0x800, 1);
 
-    gSaveContext.audioSetting = gSaveContext.zTargetSetting = 0;
-    func_800F6700(gSaveContext.audioSetting);
+    gSaveContext.soundSetting = SOUND_SETTING_STEREO;
+    gSaveContext.zTargetSetting = Z_TARGET_SETTING_SWITCH;
+    Audio_SetSoundMode(gSaveContext.soundSetting);
 }
 #endif
 

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -1411,8 +1411,8 @@ void func_80B3F3D8(void) {
     Sfx_PlaySfxCentered2(NA_SE_PL_SKIP);
 }
 
-#pragma increment_block_number "gc-eu:64 gc-eu-mq:64 gc-jp:64 gc-jp-ce:64 gc-jp-mq:64 gc-us:64 gc-us-mq:64" \
-                               "ique-cn:128 ntsc-1.0:64 ntsc-1.1:64 ntsc-1.2:64 pal-1.0:64 pal-1.1:64"
+#pragma increment_block_number "gc-eu:64 gc-eu-mq:64 gc-jp:64 gc-jp-ce:64 gc-jp-mq:64 gc-us:64 gc-us-mq:64 ique-cn:64" \
+                               "ntsc-1.0:64 ntsc-1.1:64 ntsc-1.2:64 pal-1.0:64 pal-1.1:64"
 
 void EnXc_PlayDiveSFX(Vec3f* src, PlayState* play) {
     static Vec3f D_80B42DA0;

--- a/src/overlays/gamestates/ovl_file_choose/file_select.h
+++ b/src/overlays/gamestates/ovl_file_choose/file_select.h
@@ -155,13 +155,6 @@ typedef enum SettingIndex {
     /*   */ FS_SETTING_MAX
 } SettingIndex;
 
-typedef enum AudioOption {
-    /* 0 */ FS_AUDIO_STEREO,
-    /* 1 */ FS_AUDIO_MONO,
-    /* 2 */ FS_AUDIO_HEADSET,
-    /* 3 */ FS_AUDIO_SURROUND
-} AudioOption;
-
 typedef enum CharPage {
     /* 0 */ FS_CHAR_PAGE_HIRA,
     /* 1 */ FS_CHAR_PAGE_KATA,

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -741,12 +741,12 @@ void FileSelect_PulsateCursor(GameState* thisx) {
 
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, 3, OS_WRITE);
         PRINTF("1:read_buff[]=%x, %x, %x, %x\n", sramCtx->readBuff[SRAM_HEADER_SOUND],
-               sramCtx->readBuff[SRAM_HEADER_ZTARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
+               sramCtx->readBuff[SRAM_HEADER_Z_TARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
                sramCtx->readBuff[SRAM_HEADER_MAGIC]);
 
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, SRAM_SIZE, OS_READ);
         PRINTF("read_buff[]=%x, %x, %x, %x\n", sramCtx->readBuff[SRAM_HEADER_SOUND],
-               sramCtx->readBuff[SRAM_HEADER_ZTARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
+               sramCtx->readBuff[SRAM_HEADER_Z_TARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
                sramCtx->readBuff[SRAM_HEADER_MAGIC]);
     } else if (CHECK_BTN_ALL(debugInput->press.button, BTN_DUP)) {
         sramCtx->readBuff[SRAM_HEADER_LANGUAGE] = gSaveContext.language = LANGUAGE_GER;
@@ -754,11 +754,11 @@ void FileSelect_PulsateCursor(GameState* thisx) {
 
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, 3, OS_WRITE);
         PRINTF("1:read_buff[]=%x, %x, %x, %x\n", sramCtx->readBuff[SRAM_HEADER_SOUND],
-               sramCtx->readBuff[SRAM_HEADER_ZTARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
+               sramCtx->readBuff[SRAM_HEADER_Z_TARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
                sramCtx->readBuff[SRAM_HEADER_MAGIC]);
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, SRAM_SIZE, OS_READ);
         PRINTF("read_buff[]=%x, %x, %x, %x\n", sramCtx->readBuff[SRAM_HEADER_SOUND],
-               sramCtx->readBuff[SRAM_HEADER_ZTARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
+               sramCtx->readBuff[SRAM_HEADER_Z_TARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
                sramCtx->readBuff[SRAM_HEADER_MAGIC]);
     } else if (CHECK_BTN_ALL(debugInput->press.button, BTN_DRIGHT)) {
         sramCtx->readBuff[SRAM_HEADER_LANGUAGE] = gSaveContext.language = LANGUAGE_FRA;
@@ -766,12 +766,12 @@ void FileSelect_PulsateCursor(GameState* thisx) {
 
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, 3, OS_WRITE);
         PRINTF("1:read_buff[]=%x, %x, %x, %x\n", sramCtx->readBuff[SRAM_HEADER_SOUND],
-               sramCtx->readBuff[SRAM_HEADER_ZTARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
+               sramCtx->readBuff[SRAM_HEADER_Z_TARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
                sramCtx->readBuff[SRAM_HEADER_MAGIC]);
 
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, SRAM_SIZE, OS_READ);
         PRINTF("read_buff[]=%x, %x, %x, %x\n", sramCtx->readBuff[SRAM_HEADER_SOUND],
-               sramCtx->readBuff[SRAM_HEADER_ZTARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
+               sramCtx->readBuff[SRAM_HEADER_Z_TARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
                sramCtx->readBuff[SRAM_HEADER_MAGIC]);
     }
 #endif

--- a/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
@@ -1353,7 +1353,7 @@ void FileSelect_UpdateOptionsMenu(GameState* thisx) {
         Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_L, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
         this->configMode = CM_OPTIONS_TO_MAIN;
-        sramCtx->readBuff[0] = gSaveContext.audioSetting;
+        sramCtx->readBuff[0] = gSaveContext.soundSetting;
         sramCtx->readBuff[1] = gSaveContext.zTargetSetting;
 #if OOT_PAL_N64
         sramCtx->readBuff[2] = gSaveContext.language;
@@ -1363,11 +1363,11 @@ void FileSelect_UpdateOptionsMenu(GameState* thisx) {
         PRINTF_COLOR_YELLOW();
         PRINTF("sram->read_buff[2] = J_N = %x\n", sramCtx->readBuff[2]);
         PRINTF("sram->read_buff[2] = J_N = %x\n", &sramCtx->readBuff[2]);
-        PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.audioSetting);
-        PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.audioSetting);
-        PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.audioSetting);
+        PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.soundSetting);
+        PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.soundSetting);
+        PRINTF("Na_SetSoundOutputMode = %d\n", gSaveContext.soundSetting);
         PRINTF_RST();
-        func_800F6700(gSaveContext.audioSetting);
+        Audio_SetSoundMode(gSaveContext.soundSetting);
         PRINTF("終了\n");
         return;
     }
@@ -1377,11 +1377,11 @@ void FileSelect_UpdateOptionsMenu(GameState* thisx) {
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
 
         if (sSelectedSetting == FS_SETTING_AUDIO) {
-            gSaveContext.audioSetting--;
+            gSaveContext.soundSetting--;
 
             // because audio setting is unsigned, can't check for < 0
-            if (gSaveContext.audioSetting > 0xF0) {
-                gSaveContext.audioSetting = FS_AUDIO_SURROUND;
+            if (gSaveContext.soundSetting > 0xF0) {
+                gSaveContext.soundSetting = SOUND_SETTING_SURROUND;
             }
         } else {
 #if !OOT_PAL_N64
@@ -1402,10 +1402,10 @@ void FileSelect_UpdateOptionsMenu(GameState* thisx) {
                              &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
 
         if (sSelectedSetting == FS_SETTING_AUDIO) {
-            gSaveContext.audioSetting++;
+            gSaveContext.soundSetting++;
 
-            if (gSaveContext.audioSetting > FS_AUDIO_SURROUND) {
-                gSaveContext.audioSetting = FS_AUDIO_STEREO;
+            if (gSaveContext.soundSetting > SOUND_SETTING_SURROUND) {
+                gSaveContext.soundSetting = SOUND_SETTING_STEREO;
             }
         } else {
 #if !OOT_PAL_N64
@@ -1719,7 +1719,7 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
 
     for (i = 0, vtx = 0; i < 4; i++, vtx += 4) {
         gDPPipeSync(POLY_OPA_DISP++);
-        if (i == gSaveContext.audioSetting) {
+        if (i == gSaveContext.soundSetting) {
             if (sSelectedSetting == FS_SETTING_AUDIO) {
                 gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, cursorPrimRed, cursorPrimGreen, cursorPrimBlue,
                                 this->titleAlpha[0]);


### PR DESCRIPTION
I put the `AudioSetting` enum in z64audio.h since it's used in audio code, but confusingly there's also the `SoundMode` enum which is almost the same but isn't. I named the function that translates between them as `Audio_SetAudioSetting` but this name feels doubly redundant. Suggestions welcome