### PR TITLE
Preserve NULL/true/false macros in permuter/decomp.me import

### DIFF
--- a/tools/permuter_settings.toml
+++ b/tools/permuter_settings.toml
@@ -2,6 +2,9 @@ build_system = "make"
 compiler_type = "ido"  # adjusts default weights for permuting
 
 [preserve_macros]
+NULL = "void"
+true = "int"
+false = "int"
 "g[DS]P.*" = "void"
 "gDma.*" = "void"
 "a[A-Z].*" = "void"


### PR DESCRIPTION
this bugs me all the time so I'm finally doing something about it