### PR TITLE
format.py: Allow empty files

### DIFF
--- a/format.py
+++ b/format.py
@@ -97,8 +97,7 @@ def run_clang_apply_replacements(tmp_dir: str):
 
 def cleanup_whitespace(file: str):
     """
-    Remove whitespace at the end of lines,
-    ensure the file ends with an empty line.
+    Remove whitespace at the end of lines, and ensure all lines end with a newline.
     """
     file_p = Path(file)
     contents = file_p.read_text(encoding="UTF-8")
@@ -108,7 +107,7 @@ def cleanup_whitespace(file: str):
     if n_subst != 0:
         modified = True
 
-    if not contents.endswith("\n"):
+    if contents and not contents.endswith("\n"):
         contents += "\n"
         modified = True
 


### PR DESCRIPTION
Tiny thing, but currently format.py insists that every file has at least one line, which is slightly annoying (it causes diffs/blame in #2433 to match an empty line up to the "old" file, which should have had 0 lines instead of 1). Now we instead insist that every line ends in a newline.