### PR TITLE
[iQue] Unify file select actionButtonAlpha and confirmButtonAlpha

### DIFF
--- a/include/z64.h
+++ b/include/z64.h
@@ -259,7 +259,7 @@ typedef struct FileSelectState {
     /* 0x1CA80 */ s16 nameAlpha[3];
     /* 0x1CA86 */ s16 connectorAlpha[3];
     /* 0x1CA8C */ s16 fileInfoAlpha[3];
-    /* 0x1CA92 */ s16 actionButtonAlpha[4];
+    /* 0x1CA92 */ s16 actionButtonAlpha[4]; // also contains the alphas for the confirm buttons
     /* 0x1CA9A */ s16 optionButtonAlpha;
     /* 0x1CA9C */ s16 nameEntryBoxAlpha;
     /* 0x1CA9E */ s16 controlsAlpha;

--- a/include/z64.h
+++ b/include/z64.h
@@ -259,8 +259,7 @@ typedef struct FileSelectState {
     /* 0x1CA80 */ s16 nameAlpha[3];
     /* 0x1CA86 */ s16 connectorAlpha[3];
     /* 0x1CA8C */ s16 fileInfoAlpha[3];
-    /* 0x1CA92 */ s16 actionButtonAlpha[2];
-    /* 0x1CA96 */ s16 confirmButtonAlpha[2];
+    /* 0x1CA92 */ s16 actionButtonAlpha[4];
     /* 0x1CA9A */ s16 optionButtonAlpha;
     /* 0x1CA9C */ s16 nameEntryBoxAlpha;
     /* 0x1CA9E */ s16 controlsAlpha;

--- a/src/overlays/gamestates/ovl_file_choose/file_select.h
+++ b/src/overlays/gamestates/ovl_file_choose/file_select.h
@@ -133,14 +133,11 @@ typedef enum SelectMenuButtonIndex {
     /* 4 */ FS_BTN_SELECT_QUIT
 } SelectMenuButtonIndex;
 
-typedef enum ConfirmButtonIndex {
-    /* 0 */ FS_BTN_CONFIRM_YES,
-    /* 1 */ FS_BTN_CONFIRM_QUIT
-} ConfirmButtonIndex;
-
 typedef enum ActionButtonIndex {
     /* 0 */ FS_BTN_ACTION_COPY,
-    /* 1 */ FS_BTN_ACTION_ERASE
+    /* 1 */ FS_BTN_ACTION_ERASE,
+    /* 2 */ FS_BTN_ACTION_YES,
+    /* 3 */ FS_BTN_ACTION_QUIT
 } ActionButtonIndex;
 
 typedef enum SettingIndex {

--- a/src/overlays/gamestates/ovl_file_choose/file_select.h
+++ b/src/overlays/gamestates/ovl_file_choose/file_select.h
@@ -133,6 +133,11 @@ typedef enum SelectMenuButtonIndex {
     /* 4 */ FS_BTN_SELECT_QUIT
 } SelectMenuButtonIndex;
 
+typedef enum ConfirmButtonIndex {
+    /* 0 */ FS_BTN_CONFIRM_YES,
+    /* 1 */ FS_BTN_CONFIRM_QUIT
+} ConfirmButtonIndex;
+
 typedef enum ActionButtonIndex {
     /* 0 */ FS_BTN_ACTION_COPY,
     /* 1 */ FS_BTN_ACTION_ERASE,

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1671,7 +1671,7 @@ void FileSelect_FadeMainToSelect(GameState* thisx) {
     if (this->actionTimer == 0) {
         this->actionTimer = 8;
         this->selectMode++;
-        this->confirmButtonIndex = 0;
+        this->confirmButtonIndex = FS_BTN_CONFIRM_YES;
     }
 }
 
@@ -1730,7 +1730,7 @@ void FileSelect_ConfirmFile(GameState* thisx) {
     Input* input = &this->state.input[0];
 
     if (CHECK_BTN_ALL(input->press.button, BTN_START) || (CHECK_BTN_ALL(input->press.button, BTN_A))) {
-        if (this->confirmButtonIndex == 0) {
+        if (this->confirmButtonIndex == FS_BTN_CONFIRM_YES) {
             Rumble_Request(300.0f, 180, 20, 100);
             Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_L, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1772,7 +1772,8 @@ void FileSelect_FadeOutFileInfo(GameState* thisx) {
         this->selectMode++;
     }
 
-    this->confirmButtonAlpha[0] = this->confirmButtonAlpha[1] = this->fileInfoAlpha[this->buttonIndex];
+    this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] = this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] =
+        this->fileInfoAlpha[this->buttonIndex];
 }
 
 /**

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1475,7 +1475,7 @@ void FileSelect_DrawWindowContents(GameState* thisx) {
         temp = this->confirmButtonTexIndices[i];
 
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
-                        this->confirmButtonAlpha[i]);
+                        this->actionButtonAlpha[i + 2]);
         gDPLoadTextureBlock(POLY_OPA_DISP++, sActionButtonTextures[gSaveContext.language][temp], G_IM_FMT_IA,
                             G_IM_SIZ_16b, 64, 16, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                             G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
@@ -1671,7 +1671,7 @@ void FileSelect_FadeMainToSelect(GameState* thisx) {
     if (this->actionTimer == 0) {
         this->actionTimer = 8;
         this->selectMode++;
-        this->confirmButtonIndex = FS_BTN_CONFIRM_YES;
+        this->confirmButtonIndex = 0;
     }
 }
 
@@ -1717,7 +1717,7 @@ void FileSelect_FadeInFileInfo(GameState* thisx) {
         this->selectMode++;
     }
 
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] = this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] =
+    this->actionButtonAlpha[FS_BTN_ACTION_YES] = this->actionButtonAlpha[FS_BTN_ACTION_QUIT] =
         this->fileInfoAlpha[this->buttonIndex];
 }
 
@@ -1730,7 +1730,7 @@ void FileSelect_ConfirmFile(GameState* thisx) {
     Input* input = &this->state.input[0];
 
     if (CHECK_BTN_ALL(input->press.button, BTN_START) || (CHECK_BTN_ALL(input->press.button, BTN_A))) {
-        if (this->confirmButtonIndex == FS_BTN_CONFIRM_YES) {
+        if (this->confirmButtonIndex == 0) {
             Rumble_Request(300.0f, 180, 20, 100);
             Audio_PlaySfxGeneral(NA_SE_SY_FSEL_DECIDE_L, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                  &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
@@ -1772,7 +1772,7 @@ void FileSelect_FadeOutFileInfo(GameState* thisx) {
         this->selectMode++;
     }
 
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] = this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] =
+    this->actionButtonAlpha[FS_BTN_ACTION_YES] = this->actionButtonAlpha[FS_BTN_ACTION_QUIT] =
         this->fileInfoAlpha[this->buttonIndex];
 }
 
@@ -2240,8 +2240,8 @@ void FileSelect_InitContext(GameState* thisx) {
             this->nameBoxAlpha[2] = this->nameAlpha[0] = this->nameAlpha[1] = this->nameAlpha[2] =
                 this->connectorAlpha[0] = this->connectorAlpha[1] = this->connectorAlpha[2] = this->fileInfoAlpha[0] =
                     this->fileInfoAlpha[1] = this->fileInfoAlpha[2] = this->actionButtonAlpha[FS_BTN_ACTION_COPY] =
-                        this->actionButtonAlpha[FS_BTN_ACTION_ERASE] = this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] =
-                            this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = this->optionButtonAlpha =
+                        this->actionButtonAlpha[FS_BTN_ACTION_ERASE] = this->actionButtonAlpha[FS_BTN_ACTION_YES] =
+                            this->actionButtonAlpha[FS_BTN_ACTION_QUIT] = this->optionButtonAlpha =
                                 this->nameEntryBoxAlpha = this->controlsAlpha = this->emptyFileTextAlpha = 0;
 
     this->windowPosX = 6;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
@@ -354,7 +354,7 @@ void FileSelect_SetupCopyConfirm2(GameState* thisx) {
 
     if (this->actionTimer == 0) {
         this->configMode = CM_COPY_CONFIRM;
-        this->buttonIndex = 1;
+        this->buttonIndex = FS_BTN_CONFIRM_QUIT;
     }
 }
 
@@ -369,7 +369,7 @@ void FileSelect_CopyConfirm(GameState* thisx) {
     Input* input = &this->state.input[0];
     u16 dayTime;
 
-    if (((this->buttonIndex != 0) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
+    if (((this->buttonIndex != FS_BTN_CONFIRM_YES) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
         CHECK_BTN_ALL(input->press.button, BTN_B)) {
         this->actionTimer = 8;
         this->nextTitleLabel = FS_TITLE_COPY_TO;
@@ -822,7 +822,7 @@ void FileSelect_SetupEraseConfirm2(GameState* thisx) {
         this->fileInfoAlpha[this->buttonIndex] = this->titleAlpha[0] = 255;
         this->titleAlpha[1] = 0;
         this->actionButtonAlpha[FS_BTN_ACTION_YES] = 200;
-        this->buttonIndex = 1;
+        this->buttonIndex = FS_BTN_CONFIRM_QUIT;
         this->configMode = CM_ERASE_CONFIRM;
     }
 }
@@ -835,7 +835,7 @@ void FileSelect_EraseConfirm(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
     Input* input = &this->state.input[0];
 
-    if (((this->buttonIndex != 0) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
+    if (((this->buttonIndex != FS_BTN_CONFIRM_YES) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
         CHECK_BTN_ALL(input->press.button, BTN_B)) {
         this->buttonIndex = this->selectedFileIndex;
         this->nextTitleLabel = FS_TITLE_ERASE_FILE;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
@@ -33,7 +33,7 @@ void FileSelect_SetupCopySource(GameState* thisx) {
     this->actionButtonAlpha[FS_BTN_ACTION_COPY] -= 25;
     this->actionButtonAlpha[FS_BTN_ACTION_ERASE] -= 25;
     this->optionButtonAlpha -= 25;
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] += 25;
+    this->actionButtonAlpha[FS_BTN_ACTION_QUIT] += 25;
     this->titleAlpha[0] -= 31;
     this->titleAlpha[1] += 31;
     this->actionTimer--;
@@ -44,7 +44,7 @@ void FileSelect_SetupCopySource(GameState* thisx) {
         this->actionButtonAlpha[FS_BTN_ACTION_COPY] = this->actionButtonAlpha[FS_BTN_ACTION_ERASE] =
             this->optionButtonAlpha = 0;
 
-        this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 200;
+        this->actionButtonAlpha[FS_BTN_ACTION_QUIT] = 200;
         this->titleLabel = this->nextTitleLabel;
 
         this->titleAlpha[0] = 255;
@@ -292,7 +292,7 @@ void FileSelect_ExitToCopySource2(GameState* thisx) {
         this->titleLabel = this->nextTitleLabel;
         this->titleAlpha[0] = 255;
         this->titleAlpha[1] = 0;
-        this->buttonIndex = 3;
+        this->buttonIndex = FS_BTN_COPY_QUIT;
         this->configMode = CM_SELECT_COPY_SOURCE;
     }
 }
@@ -349,12 +349,12 @@ void FileSelect_SetupCopyConfirm1(GameState* thisx) {
 void FileSelect_SetupCopyConfirm2(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
 
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] += 25;
+    this->actionButtonAlpha[FS_BTN_ACTION_YES] += 25;
     this->actionTimer--;
 
     if (this->actionTimer == 0) {
         this->configMode = CM_COPY_CONFIRM;
-        this->buttonIndex = FS_BTN_CONFIRM_QUIT;
+        this->buttonIndex = 1;
     }
 }
 
@@ -369,7 +369,7 @@ void FileSelect_CopyConfirm(GameState* thisx) {
     Input* input = &this->state.input[0];
     u16 dayTime;
 
-    if (((this->buttonIndex != FS_BTN_CONFIRM_YES) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
+    if (((this->buttonIndex != 0) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
         CHECK_BTN_ALL(input->press.button, BTN_B)) {
         this->actionTimer = 8;
         this->nextTitleLabel = FS_TITLE_COPY_TO;
@@ -406,7 +406,7 @@ void FileSelect_ReturnToCopyDest(GameState* thisx) {
 
     this->titleAlpha[0] -= 31;
     this->titleAlpha[1] += 31;
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] -= 25;
+    this->actionButtonAlpha[FS_BTN_ACTION_YES] -= 25;
 
     for (i = 0; i < 3; i++) {
         if ((i != this->copyDestFileIndex) && (i != this->selectedFileIndex)) {
@@ -447,8 +447,8 @@ void FileSelect_CopyAnim1(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
 
     this->titleAlpha[0] -= 31;
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] -= 25;
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] -= 25;
+    this->actionButtonAlpha[FS_BTN_ACTION_YES] -= 25;
+    this->actionButtonAlpha[FS_BTN_ACTION_QUIT] -= 25;
     this->actionTimer--;
 
     if (this->actionTimer == 0) {
@@ -619,14 +619,14 @@ void FileSelect_ExitCopyToMain(GameState* thisx) {
     }
 
     this->actionButtonAlpha[FS_BTN_ACTION_COPY] += 25;
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] -= 25;
+    this->actionButtonAlpha[FS_BTN_ACTION_QUIT] -= 25;
     this->titleAlpha[0] -= 31;
     this->titleAlpha[1] += 31;
     this->actionTimer--;
 
     if (this->actionTimer == 0) {
         this->actionButtonAlpha[FS_BTN_ACTION_COPY] = 200;
-        this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 0;
+        this->actionButtonAlpha[FS_BTN_ACTION_QUIT] = 0;
         this->titleLabel = this->nextTitleLabel;
         this->titleAlpha[0] = 255;
         this->titleAlpha[1] = 0;
@@ -659,7 +659,7 @@ void FileSelect_SetupEraseSelect(GameState* thisx) {
     this->actionButtonAlpha[FS_BTN_ACTION_COPY] -= 50;
     this->actionButtonAlpha[FS_BTN_ACTION_ERASE] -= 50;
     this->optionButtonAlpha -= 50;
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] += 25;
+    this->actionButtonAlpha[FS_BTN_ACTION_QUIT] += 25;
 
     if (this->actionButtonAlpha[FS_BTN_ACTION_COPY] <= 0) {
         this->actionButtonAlpha[FS_BTN_ACTION_COPY] = this->actionButtonAlpha[FS_BTN_ACTION_ERASE] =
@@ -676,7 +676,7 @@ void FileSelect_SetupEraseSelect(GameState* thisx) {
         XREG(35) = XREG(36);
         this->actionButtonAlpha[FS_BTN_ACTION_COPY] = this->actionButtonAlpha[FS_BTN_ACTION_ERASE] =
             this->optionButtonAlpha = 0;
-        this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 200;
+        this->actionButtonAlpha[FS_BTN_ACTION_QUIT] = 200;
         this->titleLabel = this->nextTitleLabel;
         this->titleAlpha[0] = 255;
         this->titleAlpha[1] = 0;
@@ -810,7 +810,7 @@ void FileSelect_SetupEraseConfirm1(GameState* thisx) {
 void FileSelect_SetupEraseConfirm2(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
 
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] += 25;
+    this->actionButtonAlpha[FS_BTN_ACTION_YES] += 25;
     this->titleAlpha[0] -= 15;
     this->titleAlpha[1] += 15;
     this->fileInfoAlpha[this->buttonIndex] += 25;
@@ -821,8 +821,8 @@ void FileSelect_SetupEraseConfirm2(GameState* thisx) {
         this->titleLabel = this->nextTitleLabel;
         this->fileInfoAlpha[this->buttonIndex] = this->titleAlpha[0] = 255;
         this->titleAlpha[1] = 0;
-        this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] = 200;
-        this->buttonIndex = FS_BTN_ERASE_FILE_2;
+        this->actionButtonAlpha[FS_BTN_ACTION_YES] = 200;
+        this->buttonIndex = 1;
         this->configMode = CM_ERASE_CONFIRM;
     }
 }
@@ -835,7 +835,7 @@ void FileSelect_EraseConfirm(GameState* thisx) {
     FileSelectState* this = (FileSelectState*)thisx;
     Input* input = &this->state.input[0];
 
-    if (((this->buttonIndex != FS_BTN_CONFIRM_YES) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
+    if (((this->buttonIndex != 0) && CHECK_BTN_ANY(input->press.button, BTN_A | BTN_START)) ||
         CHECK_BTN_ALL(input->press.button, BTN_B)) {
         this->buttonIndex = this->selectedFileIndex;
         this->nextTitleLabel = FS_TITLE_ERASE_FILE;
@@ -868,7 +868,7 @@ void FileSelect_ExitToEraseSelect1(GameState* thisx) {
 
     this->fileInfoAlpha[this->buttonIndex] -= 25;
     this->nameBoxAlpha[this->buttonIndex] += 25;
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] -= 25;
+    this->actionButtonAlpha[FS_BTN_ACTION_YES] -= 25;
     this->actionTimer--;
 
     if (this->actionTimer == 0) {
@@ -941,8 +941,8 @@ void FileSelect_EraseAnim1(GameState* thisx) {
             this->titleAlpha[0] -= 31;
             this->titleAlpha[1] += 31;
             this->fileInfoAlpha[this->selectedFileIndex] -= 25;
-            this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] -= 25;
-            this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] -= 25;
+            this->actionButtonAlpha[FS_BTN_ACTION_YES] -= 25;
+            this->actionButtonAlpha[FS_BTN_ACTION_QUIT] -= 25;
         }
 
         this->fileNamesY[this->selectedFileIndex] -= D_80813800;
@@ -956,7 +956,7 @@ void FileSelect_EraseAnim1(GameState* thisx) {
             this->titleAlpha[1] = this->connectorAlpha[this->selectedFileIndex] = 0;
 
             this->fileInfoAlpha[this->selectedFileIndex] = this->nameBoxAlpha[this->selectedFileIndex] =
-                this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] = this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 0;
+                this->actionButtonAlpha[FS_BTN_ACTION_YES] = this->actionButtonAlpha[FS_BTN_ACTION_QUIT] = 0;
 
             this->configMode++;
             this->actionTimer = 90;
@@ -1032,7 +1032,7 @@ void FileSelect_EraseAnim3(GameState* thisx) {
         this->highlightPulseDir = 1;
         XREG(35) = XREG(36);
         this->actionButtonAlpha[FS_BTN_ACTION_COPY] = 200;
-        this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] = this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 0;
+        this->actionButtonAlpha[FS_BTN_ACTION_YES] = this->actionButtonAlpha[FS_BTN_ACTION_QUIT] = 0;
         this->titleLabel = this->nextTitleLabel;
         this->titleAlpha[0] = 255;
         this->titleAlpha[1] = 0;
@@ -1065,10 +1065,10 @@ void FileSelect_ExitEraseToMain(GameState* thisx) {
     this->actionButtonAlpha[FS_BTN_ACTION_COPY] += 25;
     this->actionButtonAlpha[FS_BTN_ACTION_ERASE] += 25;
     this->optionButtonAlpha += 25;
-    this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] -= 50;
+    this->actionButtonAlpha[FS_BTN_ACTION_QUIT] -= 50;
 
-    if (this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] <= 0) {
-        this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 0;
+    if (this->actionButtonAlpha[FS_BTN_ACTION_QUIT] <= 0) {
+        this->actionButtonAlpha[FS_BTN_ACTION_QUIT] = 0;
     }
 
     this->titleAlpha[0] -= 31;
@@ -1080,7 +1080,7 @@ void FileSelect_ExitEraseToMain(GameState* thisx) {
         this->highlightPulseDir = 1;
         XREG(35) = XREG(36);
         this->actionButtonAlpha[FS_BTN_ACTION_COPY] = 200;
-        this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 0;
+        this->actionButtonAlpha[FS_BTN_ACTION_QUIT] = 0;
         this->titleLabel = this->nextTitleLabel;
         this->titleAlpha[0] = 255;
         this->titleAlpha[1] = 0;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
@@ -676,7 +676,7 @@ void FileSelect_SetupEraseSelect(GameState* thisx) {
         XREG(35) = XREG(36);
         this->actionButtonAlpha[FS_BTN_ACTION_COPY] = this->actionButtonAlpha[FS_BTN_ACTION_ERASE] =
             this->optionButtonAlpha = 0;
-        this->confirmButtonAlpha[1] = 200;
+        this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 200;
         this->titleLabel = this->nextTitleLabel;
         this->titleAlpha[0] = 255;
         this->titleAlpha[1] = 0;
@@ -955,11 +955,8 @@ void FileSelect_EraseAnim1(GameState* thisx) {
             this->titleAlpha[0] = 255;
             this->titleAlpha[1] = this->connectorAlpha[this->selectedFileIndex] = 0;
 
-            // probably a fake match, there should be a better chained assignment
-            this->confirmButtonAlpha[0] = this->confirmButtonAlpha[1] = 0;
-            if (1) {}
             this->fileInfoAlpha[this->selectedFileIndex] = this->nameBoxAlpha[this->selectedFileIndex] =
-                this->confirmButtonAlpha[1];
+                this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] = this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 0;
 
             this->configMode++;
             this->actionTimer = 90;
@@ -1035,7 +1032,7 @@ void FileSelect_EraseAnim3(GameState* thisx) {
         this->highlightPulseDir = 1;
         XREG(35) = XREG(36);
         this->actionButtonAlpha[FS_BTN_ACTION_COPY] = 200;
-        this->confirmButtonAlpha[0] = this->confirmButtonAlpha[1] = 0;
+        this->confirmButtonAlpha[FS_BTN_CONFIRM_YES] = this->confirmButtonAlpha[FS_BTN_CONFIRM_QUIT] = 0;
         this->titleLabel = this->nextTitleLabel;
         this->titleAlpha[0] = 255;
         this->titleAlpha[1] = 0;


### PR DESCRIPTION
Currently the `FileSelect` struct has `actionButtonAlpha` and `confirmButtonAlpha` arrays, but I think they should be combined. For example in https://decomp.me/scratch/zUTSO, instead of `confirmButtonAlpha[0]`, the code seems to access `actionButtonAlpha[2]` which would be OOB otherwise.

~~I also got rid of `ConfirmButtonIndex` and replaced it with hardcoded `0`/`1` in the few places it was used, but I'm not sure about this. I think having both `FS_BTN_CONFIRM_YES` and `FS_BTN_ACTION_YES` would be confusing, and the code seems to treat it as 0/1 instead of an enum anyway (e.g. using `^= 1` to flip the value).~~