### PR TITLE
Error on invalid OOT_REGION

### DIFF
--- a/src/makerom/rom_header.s
+++ b/src/makerom/rom_header.s
@@ -27,6 +27,8 @@
 /* 0x3E */ REGION(JP)
 #elif OOT_REGION == REGION_EU
 /* 0x3E */ REGION(PAL)
+#else
+#error "Unknown OOT_REGION"
 #endif
 /* 0x3F */ GAME_REVISION(OOT_REVISION)
 


### PR DESCRIPTION
Previously e.g. `make REGION=us` would silently produce an invalid ROM. Now at least it fails with
```
src/makerom/rom_header.s:31:2: error: "Unknown OOT_REGION"
#error "Unknown OOT_REGION"
 ^
```