### PR TITLE
[iQue] Match z_fishing

### DIFF
--- a/include/z64player.h
+++ b/include/z64player.h
@@ -931,7 +931,7 @@ typedef struct Player {
 
     /* 0x0854 */ f32 unk_854;
     /* 0x0858 */ f32 unk_858;
-    /* 0x085C */ f32 unk_85C; // stick length among other things
+    /* 0x085C */ f32 unk_85C; // stick length among other things (TODO: probably part of an "fwork" array)
     /* 0x0860 */ s16 unk_860; // stick flame timer among other things
     /* 0x0862 */ s8 unk_862; // get item draw ID + 1
     /* 0x0864 */ f32 unk_864;

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -514,7 +514,7 @@ void Fishing_SpawnRipple(Vec3f* projectedPos, FishingEffect* effect, Vec3f* pos,
         return;
     }
 
-    for (i = 0; i < countLimit; i++) {
+    for (i = 0; i < countLimit; i++, effect++) {
         if (effect->type == FS_EFF_NONE) {
             effect->type = FS_EFF_RIPPLE;
             effect->pos = *pos;
@@ -535,8 +535,6 @@ void Fishing_SpawnRipple(Vec3f* projectedPos, FishingEffect* effect, Vec3f* pos,
             }
             break;
         }
-
-        effect++;
     }
 }
 
@@ -548,7 +546,7 @@ void Fishing_SpawnDustSplash(Vec3f* projectedPos, FishingEffect* effect, Vec3f* 
         return;
     }
 
-    for (i = 0; i < 100; i++) {
+    for (i = 0; i < 100; i++, effect++) {
         if ((effect->type == FS_EFF_NONE) || (effect->type == FS_EFF_RAIN_DROP) ||
             (effect->type == FS_EFF_RAIN_RIPPLE) || (effect->type == FS_EFF_RAIN_SPLASH)) {
             effect->type = FS_EFF_DUST_SPLASH;
@@ -559,8 +557,6 @@ void Fishing_SpawnDustSplash(Vec3f* projectedPos, FishingEffect* effect, Vec3f* 
             effect->scale = scale;
             break;
         }
-
-        effect++;
     }
 }
 
@@ -572,7 +568,7 @@ void Fishing_SpawnWaterDust(Vec3f* projectedPos, FishingEffect* effect, Vec3f* p
         return;
     }
 
-    for (i = 0; i < 90; i++) {
+    for (i = 0; i < 90; i++, effect++) {
         if (effect->type == FS_EFF_NONE) {
             effect->type = FS_EFF_WATER_DUST;
             effect->pos = *pos;
@@ -584,8 +580,6 @@ void Fishing_SpawnWaterDust(Vec3f* projectedPos, FishingEffect* effect, Vec3f* p
             effect->rot.x = 2.0f * scale;
             break;
         }
-
-        effect++;
     }
 }
 
@@ -597,7 +591,7 @@ void Fishing_SpawnBubble(Vec3f* projectedPos, FishingEffect* effect, Vec3f* pos,
         return;
     }
 
-    for (i = 0; i < 90; i++) {
+    for (i = 0; i < 90; i++, effect++) {
         if (effect->type == FS_EFF_NONE) {
             effect->type = FS_EFF_BUBBLE;
             effect->pos = *pos;
@@ -608,8 +602,6 @@ void Fishing_SpawnBubble(Vec3f* projectedPos, FishingEffect* effect, Vec3f* pos,
             effect->state = state;
             break;
         }
-
-        effect++;
     }
 }
 
@@ -623,7 +615,7 @@ void Fishing_SpawnRainDrop(FishingEffect* effect, Vec3f* pos, Vec3f* rot) {
 
     effect += 30;
 
-    for (i = 30; i < FISHING_EFFECT_COUNT; i++) {
+    for (i = 30; i < FISHING_EFFECT_COUNT; i++, effect++) {
         if (effect->type == FS_EFF_NONE) {
             effect->type = FS_EFF_RAIN_DROP;
             effect->pos = *pos;
@@ -636,8 +628,6 @@ void Fishing_SpawnRainDrop(FishingEffect* effect, Vec3f* pos, Vec3f* rot) {
             Matrix_MultVec3f(&velSrc, &effect->vel);
             break;
         }
-
-        effect++;
     }
 }
 
@@ -792,7 +782,7 @@ void Fishing_InitPondProps(Fishing* this, PlayState* play) {
 
     Fishing_SeedRand(1, 29100, 9786);
 
-    for (i = 0; i < POND_PROP_COUNT; i++) {
+    for (i = 0; i < POND_PROP_COUNT; i++, prop++) {
         if (sPondPropInits[i].type == FS_PROP_INIT_STOP) {
             break;
         }
@@ -801,8 +791,7 @@ void Fishing_InitPondProps(Fishing* this, PlayState* play) {
         prop->pos.x = sPondPropInits[i].pos.x;
         prop->pos.y = sPondPropInits[i].pos.y;
         prop->pos.z = sPondPropInits[i].pos.z;
-        prop->rotX = 0.0f;
-        prop->reedAngle = 0.0f;
+        prop->rotX = prop->reedAngle = 0.0f;
 
         prop->timer = Rand_ZeroFloat(100.0f);
         prop->drawDistance = 800.0f;
@@ -836,8 +825,6 @@ void Fishing_InitPondProps(Fishing* this, PlayState* play) {
             prop->drawDistance = 1000.0f;
             Fishing_SetColliderElement(i, &sFishingMain->collider, &prop->pos, prop->scale);
         }
-
-        prop++;
     }
 }
 
@@ -875,7 +862,7 @@ void Fishing_Init(Actor* thisx, PlayState* play2) {
 #endif
 
     if (thisx->params < EN_FISH_PARAM) {
-        FishingGroupFish* fish;
+        s32 pad;
 
 #if PLATFORM_N64
         // Anti-piracy check, if the check fails the line can't be reeled in if
@@ -980,32 +967,30 @@ void Fishing_Init(Actor* thisx, PlayState* play2) {
         sFishGroupAngle3 = 4.6f;
 
         for (i = 0; i < GROUP_FISH_COUNT; i++) {
-            fish = &sGroupFishes[i];
-
-            fish->type = FS_GROUP_FISH_NORMAL;
+            sGroupFishes[i].type = FS_GROUP_FISH_NORMAL;
 
             if (i <= 20) {
-                fish->homePos.x = fish->pos.x = sinf(sFishGroupAngle1) * 720.0f;
-                fish->homePos.z = fish->pos.z = cosf(sFishGroupAngle1) * 720.0f;
+                sGroupFishes[i].homePos.x = sGroupFishes[i].pos.x = sinf(sFishGroupAngle1) * 720.0f;
+                sGroupFishes[i].homePos.z = sGroupFishes[i].pos.z = cosf(sFishGroupAngle1) * 720.0f;
             } else if (i <= 40) {
-                fish->homePos.x = fish->pos.x = sinf(sFishGroupAngle2) * 720.0f;
-                fish->homePos.z = fish->pos.z = cosf(sFishGroupAngle2) * 720.0f;
+                sGroupFishes[i].homePos.x = sGroupFishes[i].pos.x = sinf(sFishGroupAngle2) * 720.0f;
+                sGroupFishes[i].homePos.z = sGroupFishes[i].pos.z = cosf(sFishGroupAngle2) * 720.0f;
             } else {
-                fish->homePos.x = fish->pos.x = sinf(sFishGroupAngle3) * 720.0f;
-                fish->homePos.z = fish->pos.z = cosf(sFishGroupAngle3) * 720.0f;
+                sGroupFishes[i].homePos.x = sGroupFishes[i].pos.x = sinf(sFishGroupAngle3) * 720.0f;
+                sGroupFishes[i].homePos.z = sGroupFishes[i].pos.z = cosf(sFishGroupAngle3) * 720.0f;
             }
 
-            fish->homePos.y = fish->pos.y = -35.0f;
+            sGroupFishes[i].homePos.y = sGroupFishes[i].pos.y = -35.0f;
 
-            fish->timer = Rand_ZeroFloat(100.0f);
+            sGroupFishes[i].timer = Rand_ZeroFloat(100.0f);
 
-            fish->unk_3C = 0;
-            fish->unk_3E = 0;
-            fish->unk_40 = 0;
+            sGroupFishes[i].unk_3C = 0;
+            sGroupFishes[i].unk_3E = 0;
+            sGroupFishes[i].unk_40 = 0;
 
             if (sLinkAge != LINK_AGE_CHILD) {
                 if (((i >= 15) && (i < 20)) || ((i >= 35) && (i < 40)) || ((i >= 55) && (i < 60))) {
-                    fish->type = FS_GROUP_FISH_NONE;
+                    sGroupFishes[i].type = FS_GROUP_FISH_NONE;
                 }
             }
         }
@@ -1053,7 +1038,7 @@ void Fishing_Init(Actor* thisx, PlayState* play2) {
         Actor_ChangeCategory(play, &play->actorCtx, thisx, ACTORCAT_PROP);
         thisx->attentionRangeType = ATTENTION_RANGE_0;
         thisx->flags |= ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY;
-        this->lightNode = LightContext_InsertLight(play, &play->lightCtx, &this->lightInfo);
+        this->lightNode = LightContext_InsertLight(play2, &play->lightCtx, &this->lightInfo);
     } else {
         this->fishState = 10;
         this->fishStateNext = 10;
@@ -1099,7 +1084,7 @@ void Fishing_UpdateEffects(FishingEffect* effect, PlayState* play) {
     f32 rippleY;
     s16 i;
 
-    for (i = 0; i < FISHING_EFFECT_COUNT; i++) {
+    for (i = 0; i < FISHING_EFFECT_COUNT; i++, effect++) {
         if (effect->type) {
             effect->timer++;
             effect->pos.x += effect->vel.x;
@@ -1129,8 +1114,7 @@ void Fishing_UpdateEffects(FishingEffect* effect, PlayState* play) {
                 effect->alpha -= 10;
 
                 if (effect->pos.y > (WATER_SURFACE_Y(play) - 5.0f)) {
-                    effect->accel.y = 0.0f;
-                    effect->vel.y = 0.0f;
+                    effect->vel.y = effect->accel.y = 0.0f;
                     effect->alpha -= 5;
                 }
 
@@ -1236,16 +1220,14 @@ void Fishing_UpdateEffects(FishingEffect* effect, PlayState* play) {
                 }
             }
         }
-
-        effect++;
     }
 }
 
-void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
+void Fishing_DrawEffects(FishingEffect* effect, PlayState* play2) {
     u8 materialFlag = 0;
     f32 rotY;
     s16 i;
-    s32 pad;
+    PlayState* play = (PlayState*)play2;
     FishingEffect* firstEffect = effect;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_fishing.c", 2271);
@@ -1254,7 +1236,7 @@ void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
 
     gDPPipeSync(POLY_XLU_DISP++);
 
-    for (i = 0; i < 100; i++) {
+    for (i = 0; i < 100; i++, effect++) {
         if (effect->type == FS_EFF_RIPPLE) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_XLU_DISP++, gFishingRippleMaterialDL);
@@ -1271,12 +1253,11 @@ void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
 
             gSPDisplayList(POLY_XLU_DISP++, gFishingRippleModelDL);
         }
-        effect++;
     }
 
-    effect = firstEffect;
     materialFlag = 0;
-    for (i = 0; i < 100; i++) {
+    effect = firstEffect;
+    for (i = 0; i < 100; i++, effect++) {
         if (effect->type == FS_EFF_DUST_SPLASH) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_XLU_DISP++, gFishingDustSplashMaterialDL);
@@ -1287,19 +1268,18 @@ void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
             gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 180, 180, 180, effect->alpha);
 
             Matrix_Translate(effect->pos.x, effect->pos.y, effect->pos.z, MTXMODE_NEW);
-            Matrix_ReplaceRotation(&play->billboardMtxF);
+            Matrix_ReplaceRotation(&play2->billboardMtxF);
             Matrix_Scale(effect->scale, effect->scale, 1.0f, MTXMODE_APPLY);
 
             MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, play->state.gfxCtx, "../z_fishing.c", 2346);
 
             gSPDisplayList(POLY_XLU_DISP++, gFishingDustSplashModelDL);
         }
-        effect++;
     }
 
-    effect = firstEffect;
     materialFlag = 0;
-    for (i = 0; i < 100; i++) {
+    effect = firstEffect;
+    for (i = 0; i < 100; i++, effect++) {
         if (effect->type == FS_EFF_WATER_DUST) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_OPA_DISP++, gFishingWaterDustMaterialDL);
@@ -1314,19 +1294,18 @@ void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
                                         (effect->timer + (i * 3)) * 5, 32, 64, 1, 0, 0, 32, 32));
 
             Matrix_Translate(effect->pos.x, effect->pos.y, effect->pos.z, MTXMODE_NEW);
-            Matrix_ReplaceRotation(&play->billboardMtxF);
+            Matrix_ReplaceRotation(&play2->billboardMtxF);
             Matrix_Scale(effect->scale, effect->scale, 1.0f, MTXMODE_APPLY);
 
             MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_fishing.c", 2394);
 
             gSPDisplayList(POLY_OPA_DISP++, gFishingWaterDustModelDL);
         }
-        effect++;
     }
 
-    effect = firstEffect;
     materialFlag = 0;
-    for (i = 0; i < 100; i++) {
+    effect = firstEffect;
+    for (i = 0; i < 100; i++, effect++) {
         if (effect->type == FS_EFF_BUBBLE) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_XLU_DISP++, gFishingBubbleMaterialDL);
@@ -1336,19 +1315,19 @@ void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
             }
 
             Matrix_Translate(effect->pos.x, effect->pos.y, effect->pos.z, MTXMODE_NEW);
-            Matrix_ReplaceRotation(&play->billboardMtxF);
+            Matrix_ReplaceRotation(&play2->billboardMtxF);
             Matrix_Scale(effect->scale, effect->scale, 1.0f, MTXMODE_APPLY);
 
             MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, play->state.gfxCtx, "../z_fishing.c", 2423);
 
             gSPDisplayList(POLY_XLU_DISP++, gFishingBubbleModelDL);
         }
-        effect++;
     }
 
-    effect = firstEffect + 30;
     materialFlag = 0;
-    for (i = 30; i < FISHING_EFFECT_COUNT; i++) {
+    effect = firstEffect;
+    effect += 30;
+    for (i = 30; i < FISHING_EFFECT_COUNT; i++, effect++) {
         if (effect->type == FS_EFF_RAIN_DROP) {
             if (materialFlag == 0) {
                 POLY_XLU_DISP = Gfx_SetupDL(POLY_XLU_DISP, SETUPDL_20);
@@ -1367,14 +1346,14 @@ void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
 
             gSPDisplayList(POLY_XLU_DISP++, gFishingRainDropModelDL);
         }
-        effect++;
     }
 
     Gfx_SetupDL_25Xlu(play->state.gfxCtx);
 
-    effect = firstEffect + 30;
     materialFlag = 0;
-    for (i = 30; i < FISHING_EFFECT_COUNT; i++) {
+    effect = firstEffect;
+    effect += 30;
+    for (i = 30; i < FISHING_EFFECT_COUNT; i++, effect++) {
         if (effect->type == FS_EFF_RAIN_RIPPLE) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_XLU_DISP++, gFishingRippleMaterialDL);
@@ -1390,12 +1369,12 @@ void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
 
             gSPDisplayList(POLY_XLU_DISP++, gFishingRippleModelDL);
         }
-        effect++;
     }
 
-    effect = firstEffect + 30;
     materialFlag = 0;
-    for (i = 30; i < FISHING_EFFECT_COUNT; i++) {
+    effect = firstEffect;
+    effect += 30;
+    for (i = 30; i < FISHING_EFFECT_COUNT; i++, effect++) {
         if (effect->type == FS_EFF_RAIN_SPLASH) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_XLU_DISP++, gFishingRainSplashMaterialDL);
@@ -1410,7 +1389,7 @@ void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
             }
 
             Matrix_Translate(effect->pos.x, effect->pos.y, effect->pos.z, MTXMODE_NEW);
-            Matrix_ReplaceRotation(&play->billboardMtxF);
+            Matrix_ReplaceRotation(&play2->billboardMtxF);
             Matrix_RotateY(rotY, MTXMODE_APPLY);
             Matrix_Scale(effect->scale, effect->scale, 1.0f, MTXMODE_APPLY);
 
@@ -1418,7 +1397,6 @@ void Fishing_DrawEffects(FishingEffect* effect, PlayState* play) {
 
             gSPDisplayList(POLY_XLU_DISP++, gFishingRainSplashModelDL);
         }
-        effect++;
     }
 
     effect = firstEffect;
@@ -1483,7 +1461,7 @@ void Fishing_UpdateLine(PlayState* play, Vec3f* basePos, Vec3f* pos, Vec3f* rot,
     f32 dist;
     f32 spD8;
     s16 spooled;
-    s32 pad;
+    f32 segDist;
     f32 temp_f20;
     Vec3f posSrc = { 0.0f, 0.0f, 0.0f };
     Vec3f posStep;
@@ -1504,12 +1482,12 @@ void Fishing_UpdateLine(PlayState* play, Vec3f* basePos, Vec3f* pos, Vec3f* rot,
         sp90 = segPos.y - tempPos.y;
         sp8C = segPos.z - tempPos.z;
 
-        temp_f20 = sqrtf(SQ(sp94) + SQ(sp90) + SQ(sp8C)) * 0.97f;
-        if (temp_f20 > 1000.0f) {
-            temp_f20 = 1000.0f;
+        segDist = sqrtf(SQ(sp94) + SQ(sp90) + SQ(sp8C)) * 0.97f;
+        if (segDist > 1000.0f) {
+            segDist = 1000.0f;
         }
 
-        sRodLineSpooled = 200.0f - (temp_f20 * 200.0f * 0.001f);
+        sRodLineSpooled = 200.0f - (segDist * 200.0f * 0.001f);
     }
 
     spooled = sRodLineSpooled;
@@ -1520,22 +1498,22 @@ void Fishing_UpdateLine(PlayState* play, Vec3f* basePos, Vec3f* pos, Vec3f* rot,
             pos[i] = *basePos;
         } else if (D_80B7A6A4 != 0) {
             temp_f20 = (f32)(i - spooled) / (f32)(LINE_SEG_COUNT - spooled + 1);
-            Math_ApproachF(&pos[i].x, (sp94 * temp_f20) + tempPos.x, 1.0f, 20.0f);
-            Math_ApproachF(&pos[i].y, (sp90 * temp_f20) + tempPos.y, 1.0f, 20.0f);
-            Math_ApproachF(&pos[i].z, (sp8C * temp_f20) + tempPos.z, 1.0f, 20.0f);
+            Math_ApproachF(&pos[i].x, tempPos.x + (sp94 * temp_f20), 1.0f, 20.0f);
+            Math_ApproachF(&pos[i].y, tempPos.y + (sp90 * temp_f20), 1.0f, 20.0f);
+            Math_ApproachF(&pos[i].z, tempPos.z + (sp8C * temp_f20), 1.0f, 20.0f);
         }
     }
 
     for (i = spooled + 1, k = 0; i < LINE_SEG_COUNT; i++, k++) {
-        temp_f18 = 2.0f * D_80B7E148;
-
         dx = (pos + i)->x - (pos + i - 1)->x;
         spD8 = (pos + i)->y;
+
+        temp_f18 = 2.0f * D_80B7E148;
 
         sqDistXZ = SQ((pos + i)->x) + SQ((pos + i)->z);
 
         if (sqDistXZ > SQ(920.0f)) {
-            phi_f12 = ((sqrtf(sqDistXZ) - 920.0f) * 0.11f) + WATER_SURFACE_Y(play);
+            phi_f12 = WATER_SURFACE_Y(play) + ((sqrtf(sqDistXZ) - 920.0f) * 0.11f);
         } else {
             phi_f12 = WATER_SURFACE_Y(play);
         }
@@ -1544,7 +1522,7 @@ void Fishing_UpdateLine(PlayState* play, Vec3f* basePos, Vec3f* pos, Vec3f* rot,
             s32 pad;
 
             if (spD8 < phi_f12) {
-                phi_f12 = ((sqrtf(sqDistXZ) - 920.0f) * 0.147f) + WATER_SURFACE_Y(play);
+                phi_f12 = WATER_SURFACE_Y(play) + ((sqrtf(sqDistXZ) - 920.0f) * 0.147f);
                 if (spD8 > phi_f12) {
                     f32 phi_f2 = (spD8 - phi_f12) * 0.05f;
 
@@ -1740,8 +1718,7 @@ void Fishing_UpdateSinkingLure(PlayState* play) {
     Vec3f posStep;
     Vec3f sp94;
     Vec3f sp88;
-    f32 offsetX;
-    f32 offsetZ;
+    Vec3f offset;
     Player* player = GET_PLAYER(play);
     Vec3f* pos;
 
@@ -1769,15 +1746,15 @@ void Fishing_UpdateSinkingLure(PlayState* play) {
         pos = sSinkingLurePos;
 
         if ((i < 10) && (sRodCastState == 5)) {
-            offsetX = (10 - i) * sp88.x * 0.1f;
-            offsetZ = (10 - i) * sp88.z * 0.1f;
+            offset.x = sp88.x * (10 - i) * 0.1f;
+            offset.z = sp88.z * (10 - i) * 0.1f;
         } else {
-            offsetX = offsetZ = 0.0f;
+            offset.x = offset.z = 0.0f;
         }
 
-        dx = (pos + i)->x - (pos + i - 1)->x + offsetX;
+        dx = (pos + i)->x - (pos + i - 1)->x + offset.x;
         dy = (pos + i)->y - (pos + i - 1)->y + offsetY;
-        dz = (pos + i)->z - (pos + i - 1)->z + offsetZ;
+        dz = (pos + i)->z - (pos + i - 1)->z + offset.z;
 
         ry = Math_Atan2F(dz, dx);
         dist = sqrtf(SQ(dx) + SQ(dz));
@@ -1798,15 +1775,15 @@ static f32 sSinkingLureSizes[] = {
     0.9f, 0.85f, 0.8f, 0.7f, 0.8f, 1.0f, 1.2f, 1.1f, 1.0f, 0.8f,
 };
 
-void Fishing_DrawSinkingLure(PlayState* play) {
+void Fishing_DrawSinkingLure(PlayState* play2) {
+    PlayState* play = (PlayState*)play2;
     s16 i;
-    f32 scale;
 
     OPEN_DISPS(play->state.gfxCtx, "../z_fishing.c", 3209);
 
-    Fishing_UpdateSinkingLure(play);
+    Fishing_UpdateSinkingLure(play2);
 
-    if (sLurePos.y < WATER_SURFACE_Y(play)) {
+    if (sLurePos.y < WATER_SURFACE_Y(play2)) {
         Gfx_SetupDL_25Opa(play->state.gfxCtx);
 
         gSPDisplayList(POLY_OPA_DISP++, gFishingSinkingLureSegmentMaterialDL);
@@ -1814,9 +1791,10 @@ void Fishing_DrawSinkingLure(PlayState* play) {
         for (i = SINKING_LURE_SEG_COUNT - 1; i >= 0; i--) {
             if ((i + sSinkingLureSegmentIndex) < SINKING_LURE_SEG_COUNT) {
                 Matrix_Translate(sSinkingLurePos[i].x, sSinkingLurePos[i].y, sSinkingLurePos[i].z, MTXMODE_NEW);
-                scale = sSinkingLureSizes[i + sSinkingLureSegmentIndex] * 0.04f;
-                Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
-                Matrix_ReplaceRotation(&play->billboardMtxF);
+                Matrix_Scale(sSinkingLureSizes[i + sSinkingLureSegmentIndex] * 0.04f,
+                             sSinkingLureSizes[i + sSinkingLureSegmentIndex] * 0.04f,
+                             sSinkingLureSizes[i + sSinkingLureSegmentIndex] * 0.04f, MTXMODE_APPLY);
+                Matrix_ReplaceRotation(&play2->billboardMtxF);
 
                 MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_fishing.c", 3239);
                 gSPDisplayList(POLY_OPA_DISP++, gFishingSinkingLureSegmentModelDL);
@@ -1830,9 +1808,10 @@ void Fishing_DrawSinkingLure(PlayState* play) {
         for (i = SINKING_LURE_SEG_COUNT - 1; i >= 0; i--) {
             if ((i + sSinkingLureSegmentIndex) < SINKING_LURE_SEG_COUNT) {
                 Matrix_Translate(sSinkingLurePos[i].x, sSinkingLurePos[i].y, sSinkingLurePos[i].z, MTXMODE_NEW);
-                scale = sSinkingLureSizes[i + sSinkingLureSegmentIndex] * 0.04f;
-                Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
-                Matrix_ReplaceRotation(&play->billboardMtxF);
+                Matrix_Scale(sSinkingLureSizes[i + sSinkingLureSegmentIndex] * 0.04f,
+                             sSinkingLureSizes[i + sSinkingLureSegmentIndex] * 0.04f,
+                             sSinkingLureSizes[i + sSinkingLureSegmentIndex] * 0.04f, MTXMODE_APPLY);
+                Matrix_ReplaceRotation(&play2->billboardMtxF);
 
                 MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, play->state.gfxCtx, "../z_fishing.c", 3265);
                 gSPDisplayList(POLY_XLU_DISP++, gFishingSinkingLureSegmentModelDL);
@@ -2006,14 +1985,14 @@ static f32 sRodBendRatios[22] = {
 
 static Vec3f sRodTipOffset = { 0.0f, 0.0f, 0.0f };
 
-void Fishing_DrawRod(PlayState* play) {
+void Fishing_DrawRod(PlayState* play2) {
     s16 i;
     f32 lureXZLen;
     f32 spC4;
     f32 spC0;
-    Input* input = &play->state.input[0];
+    PlayState* play = (PlayState*)play2;
     Player* player = GET_PLAYER(play);
-    s32 pad;
+    Input* input = &play->state.input[0];
 
     OPEN_DISPS(play->state.gfxCtx, "../z_fishing.c", 3600);
 
@@ -2108,13 +2087,13 @@ void Fishing_DrawRod(PlayState* play) {
     Matrix_RotateX((D_80B7A6C0 + 20.0f) * 0.01f * M_PI, MTXMODE_APPLY);
     Matrix_Scale(0.70000005f, 0.70000005f, 0.70000005f, MTXMODE_APPLY);
 
-    spC0 = (D_80B7A6BC * (((player->unk_85C - 1.0f) * -0.25f) + 0.5f)) + (D_80B7A6AC + D_80B7A6B8);
+    spC0 = D_80B7A6AC + D_80B7A6B8 + (D_80B7A6BC * ((((*player).unk_85C - 1.0f) * -0.25f) + 0.5f));
 
     Matrix_Translate(0.0f, 0.0f, -1300.0f, MTXMODE_APPLY);
 
     for (i = 0; i < 22; i++) {
-        Matrix_RotateY(sRodBendRatios[i] * sRodBendRotY * 0.5f, MTXMODE_APPLY);
-        Matrix_RotateX(sRodBendRatios[i] * spC0 * 0.5f, MTXMODE_APPLY);
+        Matrix_RotateY(sRodBendRotY * sRodBendRatios[i] * 0.5f, MTXMODE_APPLY);
+        Matrix_RotateX(spC0 * sRodBendRatios[i] * 0.5f, MTXMODE_APPLY);
 
         Matrix_Push();
         Matrix_Scale(sRodScales[i], sRodScales[i], 0.52f, MTXMODE_APPLY);
@@ -2350,7 +2329,7 @@ void Fishing_UpdateLure(Fishing* this, PlayState* play) {
                     }
                 }
 
-                spE4 = ((sqrtf(lureXZLen) - 920.0f) * 0.11f) + WATER_SURFACE_Y(play);
+                spE4 = WATER_SURFACE_Y(play) + ((sqrtf(lureXZLen) - 920.0f) * 0.11f);
                 if (sLurePos.y <= spE4) {
                     sLurePos.y = spE4;
                     sLurePosDelta.x = sLurePosDelta.y = sLurePosDelta.z = 0.0f;
@@ -2383,7 +2362,6 @@ void Fishing_UpdateLure(Fishing* this, PlayState* play) {
                         for (i = 0; i < 50; i++) {
                             f32 sp7C = Rand_ZeroFloat(1.5f) + 0.5f;
                             f32 sp78 = Rand_ZeroFloat(6.28f);
-                            s32 pad;
 
                             sp9C.x = sinf(sp78) * sp7C;
                             sp9C.z = cosf(sp78) * sp7C;
@@ -2445,8 +2423,8 @@ void Fishing_UpdateLure(Fishing* this, PlayState* play) {
             player->unk_860 = 2;
 
             if (sLureWigglePosY < 3.0f) {
-                spD0 = sLureRotXTarget * Math_SinS(sLureTimer * 0x1060);
-                Math_ApproachF(&sLureRot.x, -M_PI / 6.0f + spD0, 0.3f, sLureRotXStep);
+                lureXZLen = Math_SinS(sLureTimer * 0x1060) * sLureRotXTarget;
+                Math_ApproachF(&sLureRot.x, -M_PI / 6.0f + lureXZLen, 0.3f, sLureRotXStep);
                 Math_ApproachF(&sLureRotXStep, 0.5f, 1.0f, 0.02f);
                 Math_ApproachZeroF(&sLureRotXTarget, 1.0f, 0.02f);
             } else {
@@ -2459,20 +2437,21 @@ void Fishing_UpdateLure(Fishing* this, PlayState* play) {
             lureXZLen = SQ(sLurePos.x) + SQ(sLurePos.z);
             if (lureXZLen < SQ(920.0f)) {
                 if (sLurePos.y <= spE4 + 4) {
+                    Input* input2 = &play->state.input[0];
                     f32 wiggle = 0.0f;
 
                     if (D_80B7E150 == 0) {
-                        if (fabsf(input->rel.stick_x) > 30.0f) {
-                            wiggle = fabsf((input->rel.stick_x - sStickAdjXPrev) * (1.0f / 60.0f));
-                        } else if (fabsf(input->rel.stick_y) > 30.0f) {
-                            wiggle = fabsf((input->rel.stick_y - sStickAdjYPrev) * (1.0f / 60.0f));
+                        if (fabsf(input2->rel.stick_x) > 30.0f) {
+                            wiggle = fabsf((input2->rel.stick_x - sStickAdjXPrev) * (1.0f / 60.0f));
+                        } else if (fabsf(input2->rel.stick_y) > 30.0f) {
+                            wiggle = fabsf((input2->rel.stick_y - sStickAdjYPrev) * (1.0f / 60.0f));
                         }
                     }
 
                     if (wiggle > 1.0f) {
                         wiggle = 1.0f;
                     }
-                    if (CHECK_BTN_ALL(input->press.button, BTN_B)) {
+                    if (CHECK_BTN_ALL(input2->press.button, BTN_B)) {
                         wiggle = 0.5f;
                     }
 
@@ -2495,7 +2474,7 @@ void Fishing_UpdateLure(Fishing* this, PlayState* play) {
                         sp90.z = player->actor.world.pos.z - sLurePos.z;
                         sp90.y = Math_Atan2F(sp90.z, sp90.x);
 
-                        sLureWiggleRotYTarget = (wiggle * sLureWiggleSign) + sp90.y;
+                        sLureWiggleRotYTarget = sp90.y + (wiggle * sLureWiggleSign);
                         sLureWiggleSign *= -1.0f;
                         sLureWigglePosY = fabsf(wiggle) * 6.0f;
                         sLureRot.x = 0.0f;
@@ -2509,7 +2488,7 @@ void Fishing_UpdateLure(Fishing* this, PlayState* play) {
                             sReelLinePos[LINE_SEG_COUNT - 1].y += sLureLineSegPosDelta.y;
                             sLurePos.y += sLureLineSegPosDelta.y;
                         }
-                    } else if (CHECK_BTN_ALL(input->cur.button, BTN_A)) {
+                    } else if (CHECK_BTN_ALL(input2->cur.button, BTN_A)) {
                         spDC = 0x500;
                         sLureWiggleRotYTarget = sReelLineRot[LINE_SEG_COUNT - 2].y + M_PI;
                         sLureRot.x = 0.0f;
@@ -2528,7 +2507,7 @@ void Fishing_UpdateLure(Fishing* this, PlayState* play) {
                     }
                 }
             } else {
-                spE4 = ((sqrtf(lureXZLen) - 920.0f) * 0.11f) + WATER_SURFACE_Y(play);
+                spE4 = WATER_SURFACE_Y(play) + ((sqrtf(lureXZLen) - 920.0f) * 0.11f);
                 if (sLurePos.y <= spE4) {
                     sLurePos.y = spE4;
                     spDC = 0x500;
@@ -2718,9 +2697,20 @@ s32 Fishing_SplashBySize(Fishing* this, PlayState* play, u8 ignorePosCheck) {
         return false;
     }
 
-    // Necessary to match
-    if (this->fishLength) {}
+    if (this->fishLength >= 60.0f) {
+        // Unknown optimized-out code
+        count = 0;
+        scale = 0.0f;
+    }
 
+    //! @bug Probably intended to be an else-if.
+    if (this->fishLength >= 50.0f) {
+        // Unknown optimized-out code
+        count = 0;
+        scale = 0.0f;
+    }
+
+    //! @bug Probably intended to be an else-if.
     if (this->fishLength >= 40.0f) {
         count = 40;
         scale = 1.2f;
@@ -2765,9 +2755,13 @@ void Fishing_SplashBySize2(Fishing* this, PlayState* play) {
     f32 speedXZ;
     f32 angle;
 
-    // Necessary to match
-    if (this->fishLength) {}
+    if (this->fishLength >= 60.0f) {
+        // Unknown optimized-out code
+        count = 0;
+        scale = 0.0f;
+    }
 
+    //! @bug Probably intended to be an else-if.
     if (this->fishLength >= 45.0f) {
         count = 30;
         scale = 0.5f;
@@ -2957,10 +2951,6 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
     f32 phi_f0;
     f32 phi_f2;
     Vec3f bubblePos;
-    Vec3f spB8;
-    f32 temp_f0;
-    f32 temp;
-    f32 rumbleStrength;
 
     this->actor.cullingVolumeDistance = 700.0f;
     this->actor.cullingVolumeScale = 50.0f;
@@ -3033,11 +3023,10 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
 
         this->fishLimbRotPhase += this->fishLimbRotPhaseStep;
 
-        temp = cosf(this->fishLimbRotPhase);
-        this->fishLimb23RotYDelta = this->unk_16E + (s16)(temp * this->fishLimbRotPhaseMag);
+        this->fishLimb23RotYDelta = (s16)(cosf(this->fishLimbRotPhase) * this->fishLimbRotPhaseMag) + (*this).unk_16E;
 
-        temp = cosf(this->fishLimbRotPhase + -1.2f);
-        this->fishLimb4RotYDelta = this->unk_16E + (s16)(temp * this->fishLimbRotPhaseMag * 1.6f);
+        this->fishLimb4RotYDelta =
+            (s16)(cosf(this->fishLimbRotPhase + -1.2f) * this->fishLimbRotPhaseMag * 1.6f) + (*this).unk_16E;
     } else {
         Actor_SetScale(&this->actor, this->fishLength * 65.0f * 0.000001f);
 
@@ -3047,12 +3036,11 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
         this->fishLimbRotPhase += this->fishLimbRotPhaseStep * 0.8f;
 
         for (i = 0; i < 3; i++) {
-            temp = cosf(this->fishLimbRotPhase + (i * 2.1f));
-            this->loachRotYDelta[i] = this->unk_16E + (s16)(temp * this->fishLimbRotPhaseMag * 2.0f);
+            this->loachRotYDelta[i] =
+                (s16)(cosf(this->fishLimbRotPhase + (i * 2.1f)) * this->fishLimbRotPhaseMag * 2.0f) + (*this).unk_16E;
         }
 
-        temp = cosf(this->fishLimbRotPhase + 0.4f);
-        this->fishLimb23RotYDelta = (this->fishLimbRotPhaseMag * temp * 2.0f) * 0.6f;
+        this->fishLimb23RotYDelta = (cosf(this->fishLimbRotPhase + 0.4f) * (*this).fishLimbRotPhaseMag * 2.0f) * 0.6f;
     }
 
     distX = this->fishTargetPos.x - this->actor.world.pos.x;
@@ -3299,6 +3287,8 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                     Math_ApproachZeroF(&this->actor.speed, 1.0f, 0.01f);
 
                     if ((this->actor.speed == 0.0f) || (this->actor.world.pos.y > (WATER_SURFACE_Y(play) - 5.0f))) {
+                        Vec3f spB8;
+
                         this->fishTargetPos.x = Rand_ZeroFloat(300.0f);
                         this->fishTargetPos.z = Rand_ZeroFloat(300.0f);
                         this->fishTargetPos.y = this->actor.floorHeight + 10.0f;
@@ -3355,7 +3345,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             this->fishTargetPos.z = sLurePos.z + targetPosOffset.z;
 
             if (sLureEquipped == FS_LURE_SINKING) {
-                this->fishTargetPos.y = sLurePos.y;
+                this->fishTargetPos.y = sLurePos.y + 0.0f;
             } else if (this->isLoach == 0) {
                 this->fishTargetPos.y = sLurePos.y - 15.0f;
             } else {
@@ -3366,7 +3356,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                 this->fishTargetPos.y = this->actor.floorHeight + 3.0f;
             }
 
-            if ((sLureEquipped != FS_LURE_SINKING) && (this->fishTargetPos.y < this->actor.world.pos.y)) {
+            if ((sLureEquipped != FS_LURE_SINKING) && (this->actor.world.pos.y > this->fishTargetPos.y)) {
                 Math_ApproachF(&this->actor.world.pos.y, this->fishTargetPos.y, 0.1f,
                                (this->actor.world.pos.y - this->fishTargetPos.y) * 0.1f);
             }
@@ -3591,8 +3581,8 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                 (sqrtf(SQ(sLurePos.x) + SQ(sLurePos.z)) > 800.0f)) {
 
                 this->timerArray[0] = 0;
-                this->unk_190 = 1.0f;
                 this->fishState = this->fishStateNext;
+                this->unk_190 = 1.0f;
                 this->unk_194 = 2000.0f;
             } else if (distToTarget < 10.0f) {
                 if (sLurePos.y > (WATER_SURFACE_Y(play) - 10.0f)) {
@@ -3648,6 +3638,10 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             if ((sLureBitTimer != 0) && (sLineHooked == 0)) { // pull the line to hook it
                 if (((input->rel.stick_y < -50) && (sStickAdjYPrev > -40)) ||
                     CHECK_BTN_ALL(input->press.button, BTN_A)) {
+                    f32 temp_f0;
+                    s32 pad;
+                    f32 rumbleStrength;
+
                     if (input->rel.stick_y < -50) {
                         temp_f0 = 40.0f - ((this->fishLength - 30.0f) * 1.333333f);
                         if (temp_f0 > 0.0f) {
@@ -3918,7 +3912,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
             Math_ApproachS(&this->fishLimbDRotZDelta, 11000, 2, 4000);
             Math_ApproachF(&sCatchCamX, 15.0f, 0.05f, 0.75f);
 
-            multiVecSrc.x = sCatchCamX;
+            multiVecSrc.x = sCatchCamX + 0.0f;
             if (sLinkAge != LINK_AGE_CHILD) {
                 multiVecSrc.y = 30.0f;
                 multiVecSrc.z = 55.0f;
@@ -3993,7 +3987,7 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                                         sLureCaughtWith = sLureEquipped;
                                         Actor_Kill(&this->actor);
                                     } else if ((this->isLoach == 0) && (sFishOnHandIsLoach == 0) &&
-                                               ((s16)this->fishLength < (s16)sFishOnHandLength)) {
+                                               ((s16)sFishOnHandLength > (s16)this->fishLength)) {
                                         this->keepState = 1;
                                         this->timerArray[0] = 0x3C;
 
@@ -4203,11 +4197,13 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
         }
 
         if ((this->actor.world.pos.y < WATER_SURFACE_Y(play)) &&
-            (this->actor.world.pos.y > (WATER_SURFACE_Y(play) - 10.0f)) && ((this->stateAndTimer & 1) == 0) &&
-            (this->actor.speed > 0.0f)) {
-            Vec3f pos = this->actor.world.pos;
-            pos.y = WATER_SURFACE_Y(play);
-            Fishing_SpawnRipple(&this->actor.projectedPos, play->specialEffects, &pos, 80.0f, 500.0f, 150, 90);
+            (this->actor.world.pos.y > (WATER_SURFACE_Y(play) - 10.0f))) {
+            if (((this->stateAndTimer & 1) == 0) && (this->actor.speed > 0.0f)) {
+                Vec3f pos = this->actor.world.pos;
+
+                pos.y = WATER_SURFACE_Y(play);
+                Fishing_SpawnRipple(&this->actor.projectedPos, play->specialEffects, &pos, 80.0f, 500.0f, 150, 90);
+            }
         }
 
         if ((this->actor.speed > 0.0f) || (this->fishState == 5)) {
@@ -4260,8 +4256,8 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
                     if ((this->fishState == 5) && ((this->stateAndTimer & 1) == 0)) {
                         Vec3f pos;
 
-                        pos.x = Rand_CenteredFloat(10.0f) + this->actor.world.pos.x;
-                        pos.z = Rand_CenteredFloat(10.0f) + this->actor.world.pos.z;
+                        pos.x = this->actor.world.pos.x + Rand_CenteredFloat(10.0f);
+                        pos.z = this->actor.world.pos.z + Rand_CenteredFloat(10.0f);
                         pos.y = this->actor.floorHeight + 5.0f;
                         Fishing_SpawnWaterDust(&this->actor.projectedPos, play->specialEffects, &pos,
                                                (this->fishLength * 0.005f) + 0.15f);
@@ -4279,9 +4275,9 @@ void Fishing_UpdateFish(Actor* thisx, PlayState* play2) {
         this->bubbleTime--;
 
         for (i = 0; i < 2; i++) {
-            pos.x = Rand_CenteredFloat(range) + this->actor.world.pos.x;
-            pos.y = Rand_CenteredFloat(range) + this->actor.world.pos.y;
-            pos.z = Rand_CenteredFloat(range) + this->actor.world.pos.z;
+            pos.x = this->actor.world.pos.x + Rand_CenteredFloat(range);
+            pos.y = this->actor.world.pos.y + Rand_CenteredFloat(range);
+            pos.z = this->actor.world.pos.z + Rand_CenteredFloat(range);
             Fishing_SpawnBubble(&this->actor.projectedPos, play->specialEffects, &pos, Rand_ZeroFloat(0.035f) + 0.04f,
                                 0);
         }
@@ -4347,9 +4343,9 @@ void Fishing_DrawFish(Actor* thisx, PlayState* play) {
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
 
     Matrix_Translate(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z, MTXMODE_NEW);
-    Matrix_RotateY(BINANG_TO_RAD_ALT(this->unk_162 + this->actor.shape.rot.y), MTXMODE_APPLY);
-    Matrix_RotateX(BINANG_TO_RAD_ALT(this->unk_160 + this->actor.shape.rot.x), MTXMODE_APPLY);
-    Matrix_RotateZ(BINANG_TO_RAD_ALT(this->unk_164 + this->actor.shape.rot.z), MTXMODE_APPLY);
+    Matrix_RotateY(BINANG_TO_RAD_ALT(this->actor.shape.rot.y + (*this).unk_162), MTXMODE_APPLY);
+    Matrix_RotateX(BINANG_TO_RAD_ALT(this->actor.shape.rot.x + (*this).unk_160), MTXMODE_APPLY);
+    Matrix_RotateZ(BINANG_TO_RAD_ALT(this->actor.shape.rot.z + (*this).unk_164), MTXMODE_APPLY);
     Matrix_Scale(this->actor.scale.x, this->actor.scale.y, this->actor.scale.z, MTXMODE_APPLY);
 
     if (this->isLoach == 0) {
@@ -4407,7 +4403,7 @@ void Fishing_UpdatePondProps(PlayState* play) {
     Actor* actor;
     s16 i;
 
-    for (i = 0; i < POND_PROP_COUNT; i++) {
+    for (i = 0; i < POND_PROP_COUNT; i++, prop++) {
         if (prop->type != FS_PROP_NONE) {
             prop->shouldDraw = false;
             prop->timer++;
@@ -4449,13 +4445,11 @@ void Fishing_UpdatePondProps(PlayState* play) {
 
                     Math_ApproachS(&prop->lilyPadAngle, 0, 20, 80);
                     prop->pos.y =
-                        (Math_SinS(prop->timer * 0x1000) * prop->lilyPadOffset) + (WATER_SURFACE_Y(play) + 2.0f);
+                        WATER_SURFACE_Y(play) + 2.0f + (Math_SinS(prop->timer * 0x1000) * prop->lilyPadOffset);
                     Math_ApproachZeroF(&prop->lilyPadOffset, 0.1f, 0.02f);
                 }
             }
         }
-
-        prop++;
     }
 
     if (sSubCamId == SUB_CAM_ID_DONE) {
@@ -4473,7 +4467,7 @@ void Fishing_DrawPondProps(PlayState* play) {
 
     Matrix_Push();
 
-    for (i = 0; i < POND_PROP_COUNT; i++) {
+    for (i = 0; i < POND_PROP_COUNT; i++, prop++) {
         if (prop->type == FS_PROP_REED) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_XLU_DISP++, gFishingReedMaterialDL);
@@ -4491,13 +4485,11 @@ void Fishing_DrawPondProps(PlayState* play) {
                 gSPDisplayList(POLY_XLU_DISP++, gFishingReedModelDL);
             }
         }
-
-        prop++;
     }
 
-    prop = &sPondProps[0];
     materialFlag = 0;
-    for (i = 0; i < POND_PROP_COUNT; i++) {
+    prop = &sPondProps[0];
+    for (i = 0; i < POND_PROP_COUNT; i++, prop++) {
         if (prop->type == FS_PROP_WOOD_POST) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_OPA_DISP++, gFishingWoodPostMaterialDL);
@@ -4512,13 +4504,11 @@ void Fishing_DrawPondProps(PlayState* play) {
                 gSPDisplayList(POLY_OPA_DISP++, gFishingWoodPostModelDL);
             }
         }
-
-        prop++;
     }
 
-    prop = &sPondProps[0];
     materialFlag = 0;
-    for (i = 0; i < POND_PROP_COUNT; i++) {
+    prop = &sPondProps[0];
+    for (i = 0; i < POND_PROP_COUNT; i++, prop++) {
         if (prop->type == FS_PROP_LILY_PAD) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_XLU_DISP++, gFishingLilyPadMaterialDL);
@@ -4536,13 +4526,11 @@ void Fishing_DrawPondProps(PlayState* play) {
                 gSPDisplayList(POLY_XLU_DISP++, gFishingLilyPadModelDL);
             }
         }
-
-        prop++;
     }
 
-    prop = &sPondProps[0];
     materialFlag = 0;
-    for (i = 0; i < POND_PROP_COUNT; i++) {
+    prop = &sPondProps[0];
+    for (i = 0; i < POND_PROP_COUNT; i++, prop++) {
         if (prop->type == FS_PROP_ROCK) {
             if (materialFlag == 0) {
                 gSPDisplayList(POLY_OPA_DISP++, gFishingRockMaterialDL);
@@ -4558,8 +4546,6 @@ void Fishing_DrawPondProps(PlayState* play) {
                 gSPDisplayList(POLY_OPA_DISP++, gFishingRockModelDL);
             }
         }
-
-        prop++;
     }
 
     Matrix_Pop();
@@ -4599,10 +4585,10 @@ void Fishing_UpdateGroupFishes(PlayState* play) {
     basePos[0].y = -35.0f;
     basePos[0].z = cosf(sFishGroupAngle1) * 720.0f;
 
-    temp1 = refPos->x - basePos[0].x;
-    temp2 = refPos->z - basePos[0].z;
+    dx = refPos->x - basePos[0].x;
+    dz = refPos->z - basePos[0].z;
 
-    if ((SQ(temp1) + SQ(temp2)) < SQ(50.0f)) {
+    if ((SQ(dx) + SQ(dz)) < SQ(50.0f)) {
         sFishGroupAngle1 += 0.3f;
         groupContactFlags |= 1;
     } else if (sFishGroupVar != 0.0f) {
@@ -4616,10 +4602,10 @@ void Fishing_UpdateGroupFishes(PlayState* play) {
     basePos[1].y = -35.0f;
     basePos[1].z = cosf(sFishGroupAngle2) * 720.0f;
 
-    temp1 = refPos->x - basePos[1].x;
-    temp2 = refPos->z - basePos[1].z;
+    dx = refPos->x - basePos[1].x;
+    dz = refPos->z - basePos[1].z;
 
-    if ((SQ(temp1) + SQ(temp2)) < SQ(50.0f)) {
+    if ((SQ(dx) + SQ(dz)) < SQ(50.0f)) {
         sFishGroupAngle2 -= 0.3f;
         groupContactFlags |= 2;
     } else if (sFishGroupVar != 0.0f) {
@@ -4633,10 +4619,10 @@ void Fishing_UpdateGroupFishes(PlayState* play) {
     basePos[2].y = -35.0f;
     basePos[2].z = cosf(sFishGroupAngle3) * 720.0f;
 
-    temp1 = refPos->x - basePos[2].x;
-    temp2 = refPos->z - basePos[2].z;
+    dx = refPos->x - basePos[2].x;
+    dz = refPos->z - basePos[2].z;
 
-    if ((SQ(temp1) + SQ(temp2)) < SQ(50.0f)) {
+    if ((SQ(dx) + SQ(dz)) < SQ(50.0f)) {
         sFishGroupAngle3 -= 0.3f;
         groupContactFlags |= 4;
     } else if (sFishGroupVar != 0.0f) {
@@ -4652,7 +4638,7 @@ void Fishing_UpdateGroupFishes(PlayState* play) {
         spD8 = 1.0f;
     }
 
-    for (i = 0; i < GROUP_FISH_COUNT; i++) {
+    for (i = 0; i < GROUP_FISH_COUNT; i++, fish++) {
         if (fish->type != FS_GROUP_FISH_NONE) {
             fish->timer++;
 
@@ -4733,7 +4719,7 @@ void Fishing_UpdateGroupFishes(PlayState* play) {
             Math_ApproachF(&fish->velY, 0.75f, 1.0f, 0.05f);
 
             temp1 = fish->velY * spD8;
-            temp2 = Math_CosS(fish->unk_3C) * temp1;
+            temp2 = temp1 * Math_CosS(fish->unk_3C);
 
             fish->pos.x += temp2 * Math_SinS(fish->unk_3E);
             fish->pos.y += temp1 * Math_SinS(fish->unk_3C);
@@ -4746,8 +4732,6 @@ void Fishing_UpdateGroupFishes(PlayState* play) {
                 fish->scaleX = (cosf(fish->unk_30) * fish->unk_38) + offset;
             }
         }
-
-        fish++;
     }
 
     sFishGroupVar = 0.0f;
@@ -4780,7 +4764,7 @@ void Fishing_DrawGroupFishes(PlayState* play) {
                 Matrix_Translate(fish->pos.x, fish->pos.y, fish->pos.z, MTXMODE_NEW);
                 Matrix_RotateY(BINANG_TO_RAD_ALT2((f32)fish->unk_3E), MTXMODE_APPLY);
                 Matrix_RotateX(BINANG_TO_RAD_ALT2(-(f32)fish->unk_3C), MTXMODE_APPLY);
-                Matrix_Scale(fish->scaleX * scale, scale, scale, MTXMODE_APPLY);
+                Matrix_Scale(scale * fish->scaleX, scale, scale, MTXMODE_APPLY);
 
                 MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_fishing.c", 8093);
                 gSPDisplayList(POLY_OPA_DISP++, gFishingGroupFishModelDL);
@@ -5066,8 +5050,8 @@ void Fishing_HandleOwnerDialog(Fishing* this, PlayState* play) {
                         }
                     }
                 } else {
-                    getItemId = GI_RUPEE_PURPLE;
                     sFishOnHandLength = 0.0f; // doesn't record loach
+                    getItemId = GI_RUPEE_PURPLE;
                 }
 
                 this->actor.parent = NULL;
@@ -5360,6 +5344,7 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
             Math_ApproachF(&sSubCamAt.y, sLurePos.y, subCamAtMaxVelFrac, 50.0f * sSubCamVelFactor);
             Math_ApproachF(&sSubCamAt.z, sLurePos.z, subCamAtMaxVelFrac, fabsf(lureDist.z) * sSubCamVelFactor);
 
+            multiVecSrc.x = -30.0f;
             multiVecSrc.x = 0.0f - D_80B7FED0;
             if (sLinkAge != LINK_AGE_CHILD) {
                 multiVecSrc.y = 80.0f;
@@ -5541,7 +5526,7 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
 
             Math_ApproachF(&sCatchCamX, 15.0f, 0.1f, 0.75f);
 
-            multiVecSrc.x = sCatchCamX - 15.0f;
+            multiVecSrc.x = sCatchCamX + 0.0f - 15.0f;
 
             if (sLinkAge != LINK_AGE_CHILD) {
                 multiVecSrc.y = 60.0f;
@@ -5621,8 +5606,8 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
         ((play->gameplayFrames % 2) == 0)) {
         Vec3f pos;
 
-        pos.x = Rand_CenteredFloat(20.0f) + player->actor.world.pos.x;
-        pos.z = Rand_CenteredFloat(20.0f) + player->actor.world.pos.z;
+        pos.x = player->actor.world.pos.x + Rand_CenteredFloat(20.0f);
+        pos.z = player->actor.world.pos.z + Rand_CenteredFloat(20.0f);
         pos.y = player->actor.floorHeight + 5.0f;
         Fishing_SpawnWaterDust(NULL, play->specialEffects, &pos, 0.5f);
     }
@@ -5674,11 +5659,11 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
     }
 
     sREG(14) = 0;
-#endif
 
     PRINTF_COLOR_GREEN();
     PRINTF("zelda_time %x\n", ((void)0, gSaveContext.save.dayTime));
     PRINTF_RST();
+#endif
 
     if (sStormChanceTimer >= 2) {
         sStormChanceTimer--;
@@ -5743,9 +5728,9 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
         rot.z = (Camera_GetInputDirYaw(mainCam) * -(M_PI / 0x8000)) + rot.y;
 
         for (i = 0; i < (u8)sStormStrength; i++) {
-            pos.x = Rand_CenteredFloat(700.0f) + play->view.eye.x;
+            pos.x = play->view.eye.x + Rand_CenteredFloat(700.0f);
             pos.y = (Rand_ZeroFloat(100.0f) + 150.0f) - 170.0f;
-            pos.z = Rand_CenteredFloat(700.0f) + play->view.eye.z;
+            pos.z = play->view.eye.z + Rand_CenteredFloat(700.0f);
 
             if (pos.z < 1160.0f) {
                 SkinMatrix_Vec3fMtxFMultXYZW(&play->viewProjectionMtxF, &pos, &projectedPos, &sProjectedW);
@@ -5780,9 +5765,9 @@ void Fishing_UpdateOwner(Actor* thisx, PlayState* play2) {
         BREG(26) = 0;
         Message_StartTextbox(play, 0x407B + BREG(27), NULL);
     }
-#endif
 
     PRINTF("HI_SCORE = %x\n", HIGH_SCORE(HS_FISHING));
+#endif
 }
 
 s32 Fishing_OwnerOverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {
@@ -5817,7 +5802,7 @@ static void* sFishingOwnerEyeTexs[] = {
 };
 
 void Fishing_DrawOwner(Actor* thisx, PlayState* play) {
-    s32 pad;
+    PlayState* play2 = (PlayState*)play;
     Fishing* this = (Fishing*)thisx;
     Input* input = &play->state.input[0];
 
@@ -5833,10 +5818,10 @@ void Fishing_DrawOwner(Actor* thisx, PlayState* play) {
                               Fishing_OwnerOverrideLimbDraw, Fishing_OwnerPostLimbDraw, this);
     }
 
-    Fishing_DrawPondProps(play);
-    Fishing_DrawEffects(play->specialEffects, play);
-    Fishing_DrawGroupFishes(play);
-    Fishing_DrawStreamSplash(play);
+    Fishing_DrawPondProps(play2);
+    Fishing_DrawEffects(play2->specialEffects, play2);
+    Fishing_DrawGroupFishes(play2);
+    Fishing_DrawStreamSplash(play2);
 
     if (sFishingMusicDelay != 0) {
         sFishingMusicDelay--;
@@ -5857,10 +5842,10 @@ void Fishing_DrawOwner(Actor* thisx, PlayState* play) {
     }
 
     if ((sFishingPlayingState != 0) && sIsRodVisible) {
-        Fishing_DrawRod(play);
+        Fishing_DrawRod(play2);
         Fishing_UpdateLinePos(sReelLinePos);
-        Fishing_UpdateLine(play, &sRodTipPos, sReelLinePos, sReelLineRot, sReelLineUnk);
-        Fishing_DrawLureAndLine(play, sReelLinePos, sReelLineRot);
+        Fishing_UpdateLine(play2, &sRodTipPos, sReelLinePos, sReelLineRot, sReelLineUnk);
+        Fishing_DrawLureAndLine(play2, sReelLinePos, sReelLineRot);
 
         sStickAdjXPrev = input->rel.stick_x;
         sStickAdjYPrev = input->rel.stick_y;
@@ -5878,7 +5863,7 @@ void Fishing_DrawOwner(Actor* thisx, PlayState* play) {
     gSPDisplayList(POLY_XLU_DISP++, gFishingAquariumContainerDL);
 
     if ((sFishingPlayingState != 0) && (sLureEquipped == FS_LURE_SINKING)) {
-        Fishing_DrawSinkingLure(play);
+        Fishing_DrawSinkingLure(play2);
     }
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_fishing.c", 9305);

--- a/src/overlays/actors/ovl_Fishing/z_fishing.h
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.h
@@ -20,12 +20,12 @@ typedef struct Fishing {
     /* 0x015A */ s16 fishStateNext;
     /* 0x015C */ s16 stateAndTimer; // fish use as timer that's AND'd, owner as talking state
     /* 0x015E */ s16 unk_15E;
-    /* 0x0160 */ s16 unk_160; // fish use as rotateX, owner as index of eye texture
-    /* 0x0162 */ s16 unk_162; // fish use as rotateY, owner as index of eye texture
-    /* 0x0164 */ s16 unk_164; // fish use as rotateZ, owner as rotation of head
+    /* 0x0160 */ s16 unk_160; // fish use as rotateX, owner as index of eye texture (TODO: probably part of a "work" array)
+    /* 0x0162 */ s16 unk_162; // fish use as rotateY, owner as index of eye texture (TODO: probably part of a "work" array)
+    /* 0x0164 */ s16 unk_164; // fish use as rotateZ, owner as rotation of head (TODO: probably part of a "work" array)
     /* 0x0166 */ Vec3s rotationTarget;
     /* 0x016C */ s16 fishLimb23RotYDelta;
-    /* 0x016E */ s16 unk_16E;
+    /* 0x016E */ s16 unk_16E; // (TODO: probably part of a "work" array)
     /* 0x0170 */ s16 fishLimbDRotZDelta;
     /* 0x0172 */ s16 fishLimbEFRotYDelta;
     /* 0x0174 */ s16 fishLimb89RotYDelta;
@@ -38,7 +38,7 @@ typedef struct Fishing {
     /* 0x0190 */ f32 unk_190; // fishLimbRotPhaseStep target
     /* 0x0194 */ f32 unk_194; // fishLimbRotPhaseMag target
     /* 0x0198 */ f32 fishLimbRotPhaseStep;
-    /* 0x019C */ f32 fishLimbRotPhaseMag;
+    /* 0x019C */ f32 fishLimbRotPhaseMag; // (TODO: probably part of an "fwork" array)
     /* 0x01A0 */ s16 bumpTimer; // set when hitting a wall.
     /* 0x01A2 */ s16 unk_1A2; // "scared" timer?
     /* 0x01A4 */ s16 unk_1A4; // "scared" timer? set at same time as above


### PR DESCRIPTION
Notes:
* I could only match some arithmetic expressions for both compilers by using `(*this).foo` for a few fields, namely `unk_160`, `unk_162`, `unk_164`, `unk_16E`, `fishLimbRotPhaseMag`, and player `unk_85C`. From discord this probably means the fields were part of an array, and that Morita liked to use these, so I guess it makes sense. I left TODOs for future cleanups. I'm not very sure about `fishLimbRotPhaseMag`, it can match without an array by keeping `f32 temp` around in `Fishing_UpdateFish`, but I could only match the stack by eliminating `temp`.
* EGCS optimizes less in `Fishing_SplashBySize` and `Fishing_SplashBySize2`, revealing some buggy cases. It seems that bigger fish were meant to splash more than they actually do in-game.