### PR TITLE
Fix /bin/bash -> /usr/bin/env bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &
         python3-pip \
         python3-venv \
         git \
+        curl \
         wget \
         unzip \
         clang-tidy \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --no-builtin-rules
 
 # Ensure the build fails if a piped command fails
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 .SHELLFLAGS = -o pipefail -c
 
 #### Build options ####

--- a/tools/disasm/do_disasm.sh
+++ b/tools/disasm/do_disasm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu -o pipefail
 
 if [ "${VERBOSE-}" ]

--- a/tools/generate_patch_from_jenkins.sh
+++ b/tools/generate_patch_from_jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 PATCH=$(git diff | base64 -w 0)


### PR DESCRIPTION
Bash is not guaranteed to be at `/bin/bash` so the build process fails on Linux distributions where this is not the case. This PR fixes that by replacing `/bin/bash` with `/usr/bin/env bash` which correctly resolves the path to bash.

Also, the build process seems to now require `curl` so I added it to the docker container since it will fail to build from clean.