### PR TITLE
Use CIC 6102 for iQue decompressed ROMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -811,9 +811,6 @@ endif
 
 #### Various Recipes ####
 
-$(ROM): $(ELF)
-	$(ELF2ROM) -cic 6105 $< $@
-
 ifeq ($(PLATFORM),IQUE)
   COMPRESS_ARGS := --format gzip --pad-to 0x4000
   CIC = 6102
@@ -821,6 +818,9 @@ else
   COMPRESS_ARGS := --format yaz0 --pad-to 0x800000 --fill-padding-bytes
   CIC = 6105
 endif
+
+$(ROM): $(ELF)
+	$(ELF2ROM) -cic $(CIC) $< $@
 
 $(ROMC): $(ROM) $(ELF) $(BUILD_DIR)/compress_ranges.txt
 	$(PYTHON) tools/compress.py --in $(ROM) --out $@ --dmadata-start `./tools/dmadata_start.sh $(NM) $(ELF)` --compress `cat $(BUILD_DIR)/compress_ranges.txt` --threads $(N_THREADS) $(COMPRESS_ARGS)

--- a/baseroms/ique-cn/checksum.md5
+++ b/baseroms/ique-cn/checksum.md5
@@ -1,1 +1,1 @@
-17a9f30d722c29e6912bd4b66713d2b0  build/ique-cn/oot-ique-cn.z64
+0238288a8e7c53b558b818865daf6ef3  build/ique-cn/oot-ique-cn.z64

--- a/tools/decompress_baserom.py
+++ b/tools/decompress_baserom.py
@@ -33,7 +33,8 @@ def decompress_zlib(data: bytes) -> bytes:
 def decompress(data: bytes, is_ique: bool) -> bytes:
     if is_ique:
         return decompress_zlib(data)
-    return crunch64.yaz0.decompress(data)
+    else:
+        return crunch64.yaz0.decompress(data)
 
 
 def round_up(n, shift):
@@ -43,9 +44,10 @@ def round_up(n, shift):
 
 def update_crc(decompressed: io.BytesIO, is_ique: bool) -> io.BytesIO:
     print("Recalculating crc...")
-    cic_kind = (
-        ipl3checksum.CICKind.CIC_6102_7101 if is_ique else ipl3checksum.CICKind.CIC_X105
-    )
+    if is_ique:
+        cic_kind = ipl3checksum.CICKind.CIC_6102_7101
+    else:
+        cic_kind = ipl3checksum.CICKind.CIC_X105
     calculated_checksum = cic_kind.calculateChecksum(bytes(decompressed.getbuffer()))
     new_crc = struct.pack(f">II", calculated_checksum[0], calculated_checksum[1])
 

--- a/tools/decompress_baserom.py
+++ b/tools/decompress_baserom.py
@@ -30,8 +30,8 @@ def decompress_zlib(data: bytes) -> bytes:
     return bytes(output)
 
 
-def decompress(data: bytes, is_zlib_compressed: bool) -> bytes:
-    if is_zlib_compressed:
+def decompress(data: bytes, is_ique: bool) -> bytes:
+    if is_ique:
         return decompress_zlib(data)
     return crunch64.yaz0.decompress(data)
 
@@ -41,11 +41,12 @@ def round_up(n, shift):
     return (n + mod - 1) >> shift << shift
 
 
-def update_crc(decompressed: io.BytesIO) -> io.BytesIO:
+def update_crc(decompressed: io.BytesIO, is_ique: bool) -> io.BytesIO:
     print("Recalculating crc...")
-    calculated_checksum = ipl3checksum.CICKind.CIC_X105.calculateChecksum(
-        bytes(decompressed.getbuffer())
+    cic_kind = (
+        ipl3checksum.CICKind.CIC_6102_7101 if is_ique else ipl3checksum.CICKind.CIC_X105
     )
+    calculated_checksum = cic_kind.calculateChecksum(bytes(decompressed.getbuffer()))
     new_crc = struct.pack(f">II", calculated_checksum[0], calculated_checksum[1])
 
     decompressed.seek(0x10)
@@ -57,7 +58,7 @@ def decompress_rom(
     file_content: bytearray,
     dmadata_start: int,
     dma_entries: list[dmadata.DmaEntry],
-    is_zlib_compressed: bool,
+    is_ique: bool,
 ) -> bytearray:
     rom_segments = {}  # vrom start : data s.t. len(data) == vrom_end - vrom_start
     new_dmadata = []  # new dmadata: list[dmadata.Entry]
@@ -73,7 +74,7 @@ def decompress_rom(
             new_dmadata.append(dma_entry)
             continue
         if dma_entry.is_compressed():
-            new_contents = decompress(file_content[p_start:p_end], is_zlib_compressed)
+            new_contents = decompress(file_content[p_start:p_end], is_ique)
             rom_segments[v_start] = new_contents
         else:
             rom_segments[v_start] = file_content[p_start : p_start + v_end - v_start]
@@ -95,7 +96,7 @@ def decompress_rom(
     decompressed.seek(padding_start)
     decompressed.write(b"\x00" * (padding_end - padding_start))
     # re-calculate crc
-    return bytearray(update_crc(decompressed).getbuffer())
+    return bytearray(update_crc(decompressed, is_ique).getbuffer())
 
 
 def get_str_hash(byte_array):
@@ -246,10 +247,8 @@ def main():
     # Decompress
     if any(dma_entry.is_compressed() for dma_entry in dma_entries):
         print("Decompressing rom...")
-        is_zlib_compressed = version in {"ique-cn", "ique-zh"}
-        file_content = decompress_rom(
-            file_content, dmadata_start, dma_entries, is_zlib_compressed
-        )
+        is_ique = version in {"ique-cn", "ique-zh"}
+        file_content = decompress_rom(file_content, dmadata_start, dma_entries, is_ique)
 
     # Double check the hash
     str_hash = get_str_hash(file_content)

--- a/tools/decompress_baserom.py
+++ b/tools/decompress_baserom.py
@@ -247,7 +247,7 @@ def main():
     # Decompress
     if any(dma_entry.is_compressed() for dma_entry in dma_entries):
         print("Decompressing rom...")
-        is_ique = version in {"ique-cn", "ique-zh"}
+        is_ique = version.startswith("ique-")
         file_content = decompress_rom(file_content, dmadata_start, dma_entries, is_ique)
 
     # Double check the hash


### PR DESCRIPTION
Now it uses the same checksum type as the compressed/released ROM. This probably doesn't matter for anything but it annoyed @MrCheeze