### PR TITLE
Rename gMtx(F)Clear to gIdentityMtx(F)

### DIFF
--- a/baseroms/gc-eu-mq-dbg/config.yml
+++ b/baseroms/gc-eu-mq-dbg/config.yml
@@ -50,7 +50,7 @@ incbins:
     vram: 0x80157D30
     size: 0x60
 variables:
-  gMtxClear: 0x8012DB20
+  gIdentityMtx: 0x8012DB20
   sNesMessageEntryTable: 0x8014B320
   sGerMessageEntryTable: 0x8014F548
   sFraMessageEntryTable: 0x80151658

--- a/baseroms/gc-eu-mq/config.yml
+++ b/baseroms/gc-eu-mq/config.yml
@@ -42,7 +42,7 @@ incbins:
     vram: 0x801130D0
     size: 0x60
 variables:
-  gMtxClear: 0x800FBC00
+  gIdentityMtx: 0x800FBC00
   sNesMessageEntryTable: 0x801077F0
   sGerMessageEntryTable: 0x8010BA18
   sFraMessageEntryTable: 0x8010DB28

--- a/baseroms/gc-eu/config.yml
+++ b/baseroms/gc-eu/config.yml
@@ -42,7 +42,7 @@ incbins:
     vram: 0x801130F0
     size: 0x60
 variables:
-  gMtxClear: 0x800FBC20
+  gIdentityMtx: 0x800FBC20
   sNesMessageEntryTable: 0x80107810
   sGerMessageEntryTable: 0x8010BA38
   sFraMessageEntryTable: 0x8010DB48

--- a/baseroms/gc-jp-ce/config.yml
+++ b/baseroms/gc-jp-ce/config.yml
@@ -42,7 +42,7 @@ incbins:
     vram: 0x801158E0
     size: 0x60
 variables:
-  gMtxClear: 0x800FE2A0
+  gIdentityMtx: 0x800FE2A0
   sJpnMessageEntryTable: 0x80109E8C
   sNesMessageEntryTable: 0x8010DFCC
   sStaffMessageEntryTable: 0x801121EC

--- a/baseroms/gc-jp-mq/config.yml
+++ b/baseroms/gc-jp-mq/config.yml
@@ -42,7 +42,7 @@ incbins:
     vram: 0x801158E0
     size: 0x60
 variables:
-  gMtxClear: 0x800FE2A0
+  gIdentityMtx: 0x800FE2A0
   sJpnMessageEntryTable: 0x80109E8C
   sNesMessageEntryTable: 0x8010DFCC
   sStaffMessageEntryTable: 0x801121EC

--- a/baseroms/gc-jp/config.yml
+++ b/baseroms/gc-jp/config.yml
@@ -42,7 +42,7 @@ incbins:
     vram: 0x80115900
     size: 0x60
 variables:
-  gMtxClear: 0x800FE2C0
+  gIdentityMtx: 0x800FE2C0
   sJpnMessageEntryTable: 0x80109EAC
   sNesMessageEntryTable: 0x8010DFEC
   sStaffMessageEntryTable: 0x8011220C

--- a/baseroms/gc-us-mq/config.yml
+++ b/baseroms/gc-us-mq/config.yml
@@ -42,7 +42,7 @@ incbins:
     vram: 0x801158C0
     size: 0x60
 variables:
-  gMtxClear: 0x800FE280
+  gIdentityMtx: 0x800FE280
   sJpnMessageEntryTable: 0x80109E6C
   sNesMessageEntryTable: 0x8010DFAC
   sStaffMessageEntryTable: 0x801121CC

--- a/baseroms/gc-us/config.yml
+++ b/baseroms/gc-us/config.yml
@@ -42,7 +42,7 @@ incbins:
     vram: 0x801158E0
     size: 0x60
 variables:
-  gMtxClear: 0x800FE2A0
+  gIdentityMtx: 0x800FE2A0
   sJpnMessageEntryTable: 0x80109E8C
   sNesMessageEntryTable: 0x8010DFCC
   sStaffMessageEntryTable: 0x801121EC

--- a/baseroms/ique-cn/config.yml
+++ b/baseroms/ique-cn/config.yml
@@ -42,7 +42,7 @@ incbins:
     vram: 0x80121EE0
     size: 0x60
 variables:
-  gMtxClear: 0x80106980
+  gIdentityMtx: 0x80106980
   sJpnMessageEntryTable: 0x80115838
   sNesMessageEntryTable: 0x80119978
   sStaffMessageEntryTable: 0x8011DB98

--- a/baseroms/ntsc-1.0/config.yml
+++ b/baseroms/ntsc-1.0/config.yml
@@ -45,7 +45,7 @@ incbins:
     vram: 0x80114D70
     size: 0x60
 variables:
-  gMtxClear: 0x800FEDB0
+  gIdentityMtx: 0x800FEDB0
   sJpnMessageEntryTable: 0x8010A94C
   sNesMessageEntryTable: 0x8010EA8C
   sStaffMessageEntryTable: 0x80112CAC

--- a/baseroms/ntsc-1.1/config.yml
+++ b/baseroms/ntsc-1.1/config.yml
@@ -45,7 +45,7 @@ incbins:
     vram: 0x80114F30
     size: 0x60
 variables:
-  gMtxClear: 0x800FEF70
+  gIdentityMtx: 0x800FEF70
   sJpnMessageEntryTable: 0x8010AB0C
   sNesMessageEntryTable: 0x8010EC4C
   sStaffMessageEntryTable: 0x80112E6C

--- a/baseroms/ntsc-1.2/config.yml
+++ b/baseroms/ntsc-1.2/config.yml
@@ -45,7 +45,7 @@ incbins:
     vram: 0x80115420
     size: 0x60
 variables:
-  gMtxClear: 0x800FF3F0
+  gIdentityMtx: 0x800FF3F0
   sJpnMessageEntryTable: 0x8010AFFC
   sNesMessageEntryTable: 0x8010F13C
   sStaffMessageEntryTable: 0x8011335C

--- a/baseroms/pal-1.0/config.yml
+++ b/baseroms/pal-1.0/config.yml
@@ -50,7 +50,7 @@ incbins:
     vram: 0x80112B70
     size: 0x60
 variables:
-  gMtxClear: 0x800FCD00
+  gIdentityMtx: 0x800FCD00
   sNesMessageEntryTable: 0x801088BC
   sGerMessageEntryTable: 0x8010CAE4
   sFraMessageEntryTable: 0x8010EBF4

--- a/baseroms/pal-1.1/config.yml
+++ b/baseroms/pal-1.1/config.yml
@@ -50,7 +50,7 @@ incbins:
     vram: 0x80112BB0
     size: 0x60
 variables:
-  gMtxClear: 0x800FCD40
+  gIdentityMtx: 0x800FCD40
   sNesMessageEntryTable: 0x801088FC
   sGerMessageEntryTable: 0x8010CB24
   sFraMessageEntryTable: 0x8010EC34

--- a/include/sys_matrix.h
+++ b/include/sys_matrix.h
@@ -11,8 +11,8 @@ typedef enum MatrixMode {
     /* 1 */ MTXMODE_APPLY // applies transformation to the current matrix
 } MatrixMode;
 
-extern Mtx gMtxClear;
-extern MtxF gMtxFClear;
+extern Mtx gIdentityMtx;
+extern MtxF gIdentityMtxF;
 
 /* Stack operations */
 

--- a/src/code/sys_matrix.c
+++ b/src/code/sys_matrix.c
@@ -4,14 +4,14 @@
 #endif
 
 // clang-format off
-Mtx gMtxClear = gdSPDefMtx(
+Mtx gIdentityMtx = gdSPDefMtx(
     1.0f, 0.0f, 0.0f, 0.0f,
     0.0f, 1.0f, 0.0f, 0.0f,
     0.0f, 0.0f, 1.0f, 0.0f,
     0.0f, 0.0f, 0.0f, 1.0f
 );
 
-MtxF gMtxFClear = {
+MtxF gIdentityMtxF = {
     1.0f, 0.0f, 0.0f, 0.0f,
     0.0f, 1.0f, 0.0f, 0.0f,
     0.0f, 0.0f, 1.0f, 0.0f,

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2314,8 +2314,8 @@ void Actor_InitContext(PlayState* play, ActorContext* actorCtx, ActorEntry* play
     bzero(actorCtx, sizeof(ActorContext));
 
     ActorOverlayTable_Init();
-    Matrix_MtxFCopy(&play->billboardMtxF, &gMtxFClear);
-    Matrix_MtxFCopy(&play->viewProjectionMtxF, &gMtxFClear);
+    Matrix_MtxFCopy(&play->billboardMtxF, &gIdentityMtxF);
+    Matrix_MtxFCopy(&play->viewProjectionMtxF, &gIdentityMtxF);
 
     overlayEntry = &gActorOverlayTable[0];
     for (i = 0; i < ARRAY_COUNT(gActorOverlayTable); i++) {

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -46,7 +46,7 @@ void Collider_DrawPoly(GraphicsContext* gfxCtx, Vec3f* vA, Vec3f* vB, Vec3f* vC,
 
     OPEN_DISPS(gfxCtx, "../z_collision_check.c", 713);
 
-    gSPMatrix(POLY_OPA_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(POLY_OPA_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gDPSetPrimColor(POLY_OPA_DISP++, 0x00, 0xFF, r, g, b, 50);
     gDPPipeSync(POLY_OPA_DISP++);
     gDPSetRenderMode(POLY_OPA_DISP++, G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2);

--- a/src/code/z_eff_blure.c
+++ b/src/code/z_eff_blure.c
@@ -805,7 +805,7 @@ void EffectBlure_DrawSimpleVertices(GraphicsContext* gfxCtx, EffectBlure* this, 
                     gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
                     gSPVertex(POLY_XLU_DISP++, &vtx[4 * i], 4, 0);
                     gSP2Triangles(POLY_XLU_DISP++, 0, 1, 3, 0, 0, 3, 2, 0);
-                    gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+                    gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
                 }
             }
         }
@@ -932,7 +932,7 @@ void EffectBlure_Draw(void* thisx, GraphicsContext* gfxCtx) {
 
     OPEN_DISPS(gfxCtx, "../z_eff_blure.c", 1596);
 
-    gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     if (this->numElements != 0) {
         if (this->flags == 0) {

--- a/src/code/z_eff_spark.c
+++ b/src/code/z_eff_spark.c
@@ -154,7 +154,7 @@ void EffectSpark_Draw(void* thisx, GraphicsContext* gfxCtx) {
     OPEN_DISPS(gfxCtx, "../z_eff_spark.c", 293);
 
     if (this != NULL) {
-        gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
         POLY_XLU_DISP = Gfx_SetupDL(POLY_XLU_DISP, SETUPDL_38);
         gDPSetCycleType(POLY_XLU_DISP++, G_CYC_2CYCLE);

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -356,7 +356,7 @@ void Minimap_DrawCompassIcons(PlayState* play) {
     if (play->interfaceCtx.minimapAlpha >= 0xAA) {
         Gfx_SetupDL_42Overlay(play->state.gfxCtx);
 
-        gSPMatrix(OVERLAY_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(OVERLAY_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
         gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -3429,7 +3429,7 @@ void Interface_Draw(PlayState* play) {
             gSPSegment(OVERLAY_DISP++, 0x08, pauseCtx->iconItemSegment);
             Gfx_SetupDL_42Overlay(play->state.gfxCtx);
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATERGBA_PRIM, G_CC_MODULATERGBA_PRIM);
-            gSPMatrix(OVERLAY_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            gSPMatrix(OVERLAY_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
             // PAUSE_CURSOR_QUAD_4
             pauseCtx->cursorVtx[16].v.ob[0] = pauseCtx->cursorVtx[18].v.ob[0] = pauseCtx->equipAnimX / 10;

--- a/src/code/z_room.c
+++ b/src/code/z_room.c
@@ -48,14 +48,14 @@ void Room_DrawNormal(PlayState* play, Room* room, u32 flags) {
         func_800342EC(&D_801270A0, play);
         gSPSegment(POLY_OPA_DISP++, 0x03, room->segment);
         func_80093C80(play);
-        gSPMatrix(POLY_OPA_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_OPA_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     }
 
     if (flags & ROOM_DRAW_XLU) {
         func_8003435C(&D_801270A0, play);
         gSPSegment(POLY_XLU_DISP++, 0x03, room->segment);
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
-        gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     }
 
     roomShape = &room->roomShape->normal;
@@ -122,7 +122,7 @@ void Room_DrawCullable(PlayState* play, Room* room, u32 flags) {
         func_800342EC(&D_801270A0, play);
         gSPSegment(POLY_OPA_DISP++, 0x03, room->segment);
         func_80093C80(play);
-        gSPMatrix(POLY_OPA_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_OPA_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     }
 
     if (1) {}
@@ -131,7 +131,7 @@ void Room_DrawCullable(PlayState* play, Room* room, u32 flags) {
         func_8003435C(&D_801270A0, play);
         gSPSegment(POLY_XLU_DISP++, 0x03, room->segment);
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
-        gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     }
 
     roomShape = &room->roomShape->cullable;
@@ -390,7 +390,7 @@ void Room_DrawImageSingle(PlayState* play, Room* room, u32 flags) {
 
         if (drawOpa) {
             Gfx_SetupDL_25Opa(play->state.gfxCtx);
-            gSPMatrix(POLY_OPA_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            gSPMatrix(POLY_OPA_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_OPA_DISP++, entry->opa);
         }
 
@@ -421,7 +421,7 @@ void Room_DrawImageSingle(PlayState* play, Room* room, u32 flags) {
     if (drawXlu) {
         gSPSegment(POLY_XLU_DISP++, 0x03, room->segment);
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
-        gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, entry->xlu);
     }
 
@@ -499,7 +499,7 @@ void Room_DrawImageMulti(PlayState* play, Room* room, u32 flags) {
 
         if (drawOpa) {
             Gfx_SetupDL_25Opa(play->state.gfxCtx);
-            gSPMatrix(POLY_OPA_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            gSPMatrix(POLY_OPA_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_OPA_DISP++, dListsEntry->opa);
         }
 
@@ -530,7 +530,7 @@ void Room_DrawImageMulti(PlayState* play, Room* room, u32 flags) {
     if (drawXlu) {
         gSPSegment(POLY_XLU_DISP++, 0x03, room->segment);
         Gfx_SetupDL_25Xlu(play->state.gfxCtx);
-        gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(POLY_XLU_DISP++, dListsEntry->xlu);
     }
 

--- a/src/code/z_skin.c
+++ b/src/code/z_skin.c
@@ -207,7 +207,7 @@ void Skin_DrawImpl(Actor* actor, PlayState* play, Skin* skin, SkinPostDraw postD
     skeleton = SEGMENTED_TO_VIRTUAL(skin->skeletonHeader->segment);
 
     if (!(drawFlags & SKIN_DRAW_FLAG_CUSTOM_MATRIX)) {
-        gSPMatrix(POLY_OPA_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_OPA_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         mtx = SkinMatrix_MtxFToNewMtx(gfxCtx, &skin->mtx);
 
         if (mtx == NULL) {

--- a/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
@@ -244,7 +244,7 @@ void BgHidanRsekizou_Draw(Actor* thisx, PlayState* play) {
 
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx, "../z_bg_hidan_rsekizou.c", 568);
     gSPDisplayList(POLY_OPA_DISP++, gFireTempleSpinningFlamethrowerDL);
-    Matrix_MtxFCopy(&mf, &gMtxFClear);
+    Matrix_MtxFCopy(&mf, &gIdentityMtxF);
 
     POLY_XLU_DISP = Gfx_SetupDL(POLY_XLU_DISP, SETUPDL_20);
 

--- a/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
@@ -360,7 +360,7 @@ Gfx* func_8088DC50(PlayState* play, BgHidanSekizou* this, s16 arg2, s16 arg3, Gf
     }
     temp_f20 = Math_SinS(arg2);
     temp_f22 = Math_CosS(arg2);
-    Matrix_MtxFCopy(&sp68, &gMtxFClear);
+    Matrix_MtxFCopy(&sp68, &gIdentityMtxF);
     temp_v1 = Camera_GetCamDirYaw(GET_ACTIVE_CAM(play)) - arg2;
 
     if (ABS(temp_v1) < 0x4000) {

--- a/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
@@ -233,7 +233,7 @@ Gfx* func_8088EB54(PlayState* play, BgHidanSima* this, Gfx* gfx) {
     f32 sin;
     s32 pad[2];
 
-    Matrix_MtxFCopy(&mtxF, &gMtxFClear);
+    Matrix_MtxFCopy(&mtxF, &gIdentityMtxF);
     cos = Math_CosS(this->dyna.actor.world.rot.y + 0x8000);
     sin = Math_SinS(this->dyna.actor.world.rot.y + 0x8000);
 

--- a/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
+++ b/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
@@ -706,7 +706,7 @@ void EnHorseNormal_Draw(Actor* thisx, PlayState* play2) {
         if (mtx == NULL) {
             return;
         }
-        gSPMatrix(POLY_OPA_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_OPA_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPMatrix(POLY_OPA_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         func_800A63CC(&this->actor, play, &this->skin, NULL, NULL, true, 0,
                       SKIN_DRAW_FLAG_CUSTOM_TRANSFORMS | SKIN_DRAW_FLAG_CUSTOM_MATRIX);

--- a/src/overlays/effects/ovl_Effect_Ss_Bomb/z_eff_ss_bomb.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Bomb/z_eff_ss_bomb.c
@@ -67,7 +67,7 @@ void EffectSsBomb_Draw(PlayState* play, u32 index, EffectSs* this) {
     SkinMatrix_MtxFMtxFMult(&mfTrans, &play->billboardMtxF, &mfTransBillboard);
     SkinMatrix_MtxFMtxFMult(&mfTransBillboard, &mfScale, &mfResult);
 
-    gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     mtx = SkinMatrix_MtxFToNewMtx(gfxCtx, &mfResult);
 

--- a/src/overlays/effects/ovl_Effect_Ss_Dust/z_eff_ss_dust.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Dust/z_eff_ss_dust.c
@@ -96,7 +96,7 @@ void EffectSsDust_Draw(PlayState* play, u32 index, EffectSs* this) {
     SkinMatrix_SetScale(&mfScale, scale, scale, 1.0f);
     SkinMatrix_MtxFMtxFMult(&mfTrans, &play->billboardMtxF, &mfTransBillboard);
     SkinMatrix_MtxFMtxFMult(&mfTransBillboard, &mfScale, &mfResult);
-    gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     mtx = SkinMatrix_MtxFToNewMtx(gfxCtx, &mfResult);
 

--- a/src/overlays/effects/ovl_Effect_Ss_HitMark/z_eff_ss_hitmark.c
+++ b/src/overlays/effects/ovl_Effect_Ss_HitMark/z_eff_ss_hitmark.c
@@ -87,7 +87,7 @@ void EffectSsHitMark_Draw(PlayState* play, u32 index, EffectSs* this) {
     SkinMatrix_SetScale(&mfScale, scale, scale, 1.0f);
     SkinMatrix_MtxFMtxFMult(&mfTrans, &play->billboardMtxF, &mfTransBillboard);
     SkinMatrix_MtxFMtxFMult(&mfTransBillboard, &mfScale, &mfResult);
-    gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     mtx = SkinMatrix_MtxFToNewMtx(gfxCtx, &mfResult);
 

--- a/src/overlays/effects/ovl_Effect_Ss_KiraKira/z_eff_ss_kirakira.c
+++ b/src/overlays/effects/ovl_Effect_Ss_KiraKira/z_eff_ss_kirakira.c
@@ -97,7 +97,7 @@ void EffectSsKiraKira_Draw(PlayState* play, u32 index, EffectSs* this) {
     SkinMatrix_MtxFMtxFMult(&mfTrans, &play->billboardMtxF, &mfTransBillboard);
     SkinMatrix_MtxFMtxFMult(&mfTransBillboard, &mfRotY, &mfTransBillboardRotY);
     SkinMatrix_MtxFMtxFMult(&mfTransBillboardRotY, &mfScale, &mfResult);
-    gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     mtx = SkinMatrix_MtxFToNewMtx(gfxCtx, &mfResult);
 

--- a/src/overlays/effects/ovl_Effect_Ss_Lightning/z_eff_ss_lightning.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Lightning/z_eff_ss_lightning.c
@@ -100,7 +100,7 @@ void EffectSsLightning_Draw(PlayState* play, u32 index, EffectSs* this) {
     SkinMatrix_MtxFMtxFMult(&mfTransBillboard, &mfRotate, &mfTransBillboardRotate);
     SkinMatrix_MtxFMtxFMult(&mfTransBillboardRotate, &mfScale, &mfResult);
 
-    gSPMatrix(POLY_XLU_DISP++, &gMtxClear, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(POLY_XLU_DISP++, &gIdentityMtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     mtx = SkinMatrix_MtxFToNewMtx(gfxCtx, &mfResult);
 

--- a/tools/ZAPDConfigs/gc-eu-mq-dbg/SymbolMap.txt
+++ b/tools/ZAPDConfigs/gc-eu-mq-dbg/SymbolMap.txt
@@ -1,2 +1,2 @@
-8012DB20 gMtxClear
+8012DB20 gIdentityMtx
 80A8E610 sShadowTex

--- a/tools/ZAPDConfigs/gc-eu-mq/SymbolMap.txt
+++ b/tools/ZAPDConfigs/gc-eu-mq/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FBC00 gMtxClear
+800FBC00 gIdentityMtx
 80A72FA0 sShadowTex

--- a/tools/ZAPDConfigs/gc-eu/SymbolMap.txt
+++ b/tools/ZAPDConfigs/gc-eu/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FBC20 gMtxClear
+800FBC20 gIdentityMtx
 80A73020 sShadowTex

--- a/tools/ZAPDConfigs/gc-jp-ce/SymbolMap.txt
+++ b/tools/ZAPDConfigs/gc-jp-ce/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FE2A0 gMtxClear
+800FE2A0 gIdentityMtx
 80A74120 sShadowTex

--- a/tools/ZAPDConfigs/gc-jp-mq/SymbolMap.txt
+++ b/tools/ZAPDConfigs/gc-jp-mq/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FE2A0 gMtxClear
+800FE2A0 gIdentityMtx
 80A740D0 sShadowTex

--- a/tools/ZAPDConfigs/gc-jp/SymbolMap.txt
+++ b/tools/ZAPDConfigs/gc-jp/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FE2C0 gMtxClear
+800FE2C0 gIdentityMtx
 80A74150 sShadowTex

--- a/tools/ZAPDConfigs/gc-us-mq/SymbolMap.txt
+++ b/tools/ZAPDConfigs/gc-us-mq/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FE280 gMtxClear
+800FE280 gIdentityMtx
 80A740B0 sShadowTex

--- a/tools/ZAPDConfigs/gc-us/SymbolMap.txt
+++ b/tools/ZAPDConfigs/gc-us/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FE2A0 gMtxClear
+800FE2A0 gIdentityMtx
 80A74130 sShadowTex

--- a/tools/ZAPDConfigs/ique-cn/SymbolMap.txt
+++ b/tools/ZAPDConfigs/ique-cn/SymbolMap.txt
@@ -1,2 +1,2 @@
-80106980 gMtxClear
+80106980 gIdentityMtx
 80AE0B10 sShadowTex

--- a/tools/ZAPDConfigs/ntsc-1.0/SymbolMap.txt
+++ b/tools/ZAPDConfigs/ntsc-1.0/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FEDB0 gMtxClear
+800FEDB0 gIdentityMtx
 80AE0AE0 sShadowTex

--- a/tools/ZAPDConfigs/ntsc-1.1/SymbolMap.txt
+++ b/tools/ZAPDConfigs/ntsc-1.1/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FEF70 gMtxClear
+800FEF70 gIdentityMtx
 80AE0C80 sShadowTex

--- a/tools/ZAPDConfigs/ntsc-1.2/SymbolMap.txt
+++ b/tools/ZAPDConfigs/ntsc-1.2/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FF3F0 gMtxClear
+800FF3F0 gIdentityMtx
 80AE0FE0 sShadowTex

--- a/tools/ZAPDConfigs/pal-1.0/SymbolMap.txt
+++ b/tools/ZAPDConfigs/pal-1.0/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FCD00 gMtxClear
+800FCD00 gIdentityMtx
 80AE19F0 sShadowTex

--- a/tools/ZAPDConfigs/pal-1.1/SymbolMap.txt
+++ b/tools/ZAPDConfigs/pal-1.1/SymbolMap.txt
@@ -1,2 +1,2 @@
-800FCD40 gMtxClear
+800FCD40 gIdentityMtx
 80AE1B80 sShadowTex


### PR DESCRIPTION
Contributions made in this pr are licensed under CC0

This aligns with the name used in MM decomp.