### PR TITLE
Cleanup colliders struct members 2

### DIFF
--- a/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.c
@@ -77,7 +77,7 @@ void BgJyaBombchuiwa_SetupCollider(BgJyaBombchuiwa* this, PlayState* play) {
     s32 pad;
 
     Collider_InitJntSph(play, &this->collider);
-    Collider_SetJntSph(play, &this->collider, &this->actor, &sJntSphInit, &this->colliderItems);
+    Collider_SetJntSph(play, &this->collider, &this->actor, &sJntSphInit, this->colliderElements);
 }
 
 void BgJyaBombchuiwa_SetDrawFlags(BgJyaBombchuiwa* this, u8 drawFlags) {

--- a/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.h
@@ -12,7 +12,7 @@ typedef struct BgJyaBombchuiwa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ BgJyaBombchuiwaActionFunc actionFunc;
     /* 0x0150 */ ColliderJntSph collider;
-    /* 0x0170 */ ColliderJntSphElement colliderItems;
+    /* 0x0170 */ ColliderJntSphElement colliderElements[1];
     /* 0x01B0 */ f32 lightRayIntensity;
     /* 0x01B4 */ s16 timer;
     /* 0x01B6 */ u8 drawFlags; // Used to determine how the actor is drawn.

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.c
@@ -90,7 +90,7 @@ void BgJyaGoroiwa_InitCollider(BgJyaGoroiwa* this, PlayState* play) {
     s32 pad;
 
     Collider_InitJntSph(play, &this->collider);
-    Collider_SetJntSph(play, &this->collider, &this->actor, &sJntSphInit, &this->colliderItem);
+    Collider_SetJntSph(play, &this->collider, &this->actor, &sJntSphInit, this->colliderElements);
     BgJyaGoroiwa_UpdateCollider(this);
     this->collider.elements[0].dim.worldSphere.radius = 58;
 }

--- a/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Goroiwa/z_bg_jya_goroiwa.h
@@ -12,7 +12,7 @@ typedef struct BgJyaGoroiwa {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ BgJyaGoroiwaFunc actionFunc;
     /* 0x0150 */ ColliderJntSph collider;
-    /* 0x0170 */ ColliderJntSphElement colliderItem;
+    /* 0x0170 */ ColliderJntSphElement colliderElements[1];
     /* 0x01B0 */ f32 speedFactor;
     /* 0x01B4 */ s16 hasHit;
     /* 0x01B6 */ s16 waitTimer;

--- a/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.c
@@ -136,7 +136,7 @@ void BgJyaMegami_InitCollider(BgJyaMegami* this, PlayState* play) {
     s32 pad;
 
     Collider_InitJntSph(play, &this->collider);
-    Collider_SetJntSph(play, &this->collider, &this->dyna.actor, &sJntSphInit, &this->colliderItem);
+    Collider_SetJntSph(play, &this->collider, &this->dyna.actor, &sJntSphInit, this->colliderElements);
 }
 
 void BgJyaMegami_SpawnEffect(PlayState* play, Vec3f* pos, Vec3f* velocity, s32 num, s32 arg4) {

--- a/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Megami/z_bg_jya_megami.h
@@ -19,7 +19,7 @@ typedef struct BgJyaMegami {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ BgJyaMegamiActionFunc actionFunc;
     /* 0x0168 */ ColliderJntSph collider;
-    /* 0x0188 */ ColliderJntSphElement colliderItem;
+    /* 0x0188 */ ColliderJntSphElement colliderElements[1];
     /* 0x01C8 */ s16 lightTimer;
     /* 0x01CA */ s16 explosionTimer;
     /* 0x01CC */ s16 crumbleIndex;

--- a/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.c
+++ b/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.c
@@ -152,7 +152,7 @@ void func_808B4C4C(BgSpot16Bombstone* this, PlayState* play) {
     s32 pad;
 
     Collider_InitJntSph(play, &this->colliderJntSph);
-    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderElements);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
     this->colliderJntSph.elements[0].dim.worldSphere.center.x = this->actor.world.pos.x;
     this->colliderJntSph.elements[0].dim.worldSphere.center.y = this->actor.world.pos.y + 50.0f;
     this->colliderJntSph.elements[0].dim.worldSphere.center.z = this->actor.world.pos.z;

--- a/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.h
+++ b/src/overlays/actors/ovl_Bg_Spot16_Bombstone/z_bg_spot16_bombstone.h
@@ -18,7 +18,7 @@ typedef struct BgSpot16Bombstone {
     /* 0x015C */ f32 sinRotation;
     /* 0x0160 */ f32 cosRotation;
     /* 0x0164 */ ColliderJntSph colliderJntSph;
-    /* 0x0184 */ ColliderJntSphElement colliderElements[1];
+    /* 0x0184 */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x01C4 */ ColliderCylinder colliderCylinder;
     /* 0x0210 */ s16 unk_210;
     /* 0x0212 */ s16 unk_212;

--- a/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
@@ -90,7 +90,7 @@ void func_808B7710(Actor* thisx, PlayState* play) {
     BgSpot18Basket* this = (BgSpot18Basket*)thisx;
 
     Collider_InitJntSph(play, &this->colliderJntSph);
-    Collider_SetJntSph(play, &this->colliderJntSph, &this->dyna.actor, &sJntSphInit, this->ColliderJntSphElements);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->dyna.actor, &sJntSphInit, this->colliderJntSphElements);
     this->dyna.actor.colChkInfo.mass = MASS_IMMOVABLE;
 }
 

--- a/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.h
+++ b/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.h
@@ -11,7 +11,7 @@ typedef void (*BgSpot18BasketActionFunc)(struct BgSpot18Basket*, struct PlayStat
 typedef struct BgSpot18Basket {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ ColliderJntSph colliderJntSph;
-    /* 0x0184 */ ColliderJntSphElement ColliderJntSphElements[2];
+    /* 0x0184 */ ColliderJntSphElement colliderJntSphElements[2];
     /* 0x0204 */ BgSpot18BasketActionFunc actionFunc;
     /* 0x0208 */ f32 unk_208;
     /* 0x020C */ s16 unk_20C;

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -389,7 +389,7 @@ void BossMo_Init(Actor* thisx, PlayState* play2) {
         this->actor.world.pos.y = MO_WATER_LEVEL(play);
         this->actor.prevPos = this->targetPos = this->actor.world.pos;
         Collider_InitJntSph(play, &this->tentCollider);
-        Collider_SetJntSph(play, &this->tentCollider, &this->actor, &sJntSphInit, this->tentElements);
+        Collider_SetJntSph(play, &this->tentCollider, &this->actor, &sJntSphInit, this->tentColliderElements);
         this->tentMaxAngle = 1.0f;
     }
 }
@@ -1151,7 +1151,7 @@ void BossMo_TentCollisionCheck(BossMo* this, PlayState* play) {
     s16 i2;
     ColliderElement* acHitElem;
 
-    for (i1 = 0; i1 < ARRAY_COUNT(this->tentElements); i1++) {
+    for (i1 = 0; i1 < ARRAY_COUNT(this->tentColliderElements); i1++) {
         if (this->tentCollider.elements[i1].base.acElemFlags & ACELEM_HIT) {
 
             for (i2 = 0; i2 < 19; i2++) {

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.h
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.h
@@ -124,7 +124,7 @@ typedef struct BossMo {
     /* 0x100C */ f32 subCamYawShake;
     /* 0x1010 */ Vec3f tentTipPos;
     /* 0x101C */ ColliderJntSph tentCollider;
-    /* 0x103C */ ColliderJntSphElement tentElements[19];
+    /* 0x103C */ ColliderJntSphElement tentColliderElements[19];
     /* 0x14FC */ ColliderCylinder coreCollider;
     /* 0x1548 */ char unk_1548[0x44];
 } BossMo; // size = 0x158C

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -306,7 +306,7 @@ void BossSst_Init(Actor* thisx, PlayState* play2) {
         SkelAnime_InitFlex(play, &this->skelAnime, &gBongoHeadSkel, &gBongoHeadEyeOpenIdleAnim, this->jointTable,
                            this->morphTable, 45);
         ActorShape_Init(&this->actor.shape, 70000.0f, ActorShadow_DrawCircle, 95.0f);
-        Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitHead, this->colliderItems);
+        Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitHead, this->colliderJntSphElements);
         Collider_SetCylinder(play, &this->colliderCyl, &this->actor, &sCylinderInitHead);
         sHead = this;
         this->actor.world.pos.x = ROOM_CENTER_X + 50.0f;
@@ -339,7 +339,7 @@ void BossSst_Init(Actor* thisx, PlayState* play2) {
             Actor_ChangeCategory(play, &play->actorCtx, &this->actor, ACTORCAT_BOSS);
         }
     } else {
-        Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitHand, this->colliderItems);
+        Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitHand, this->colliderJntSphElements);
         Collider_SetCylinder(play, &this->colliderCyl, &this->actor, &sCylinderInitHand);
         if (this->actor.params == BONGO_LEFT_HAND) {
             SkelAnime_InitFlex(play, &this->skelAnime, &gBongoLeftHandSkel, &gBongoLeftHandIdleAnim, this->jointTable,

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
@@ -46,7 +46,7 @@ typedef struct BossSst {
     /* 0x03C4 */ f32 radius;
     /* 0x03C8 */ Vec3f center;
     /* 0x03D4 */ ColliderJntSph colliderJntSph;
-    /* 0x03F4 */ ColliderJntSphElement colliderItems[11];
+    /* 0x03F4 */ ColliderJntSphElement colliderJntSphElements[11];
     /* 0x06B4 */ ColliderCylinder colliderCyl;
     /* 0x0700 */ BossSstEffect effects[BOSS_SST_EFFECT_COUNT];
     /* 0x09D0 */ s16 trailIndex;

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -703,7 +703,8 @@ void BossVa_Init(Actor* thisx, PlayState* play2) {
         case BOSSVA_SUPPORT_2:
         case BOSSVA_SUPPORT_3:
             Collider_InitJntSph(play, &this->colliderJntSph);
-            Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitSupport, this->colliderJntSphElements);
+            Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitSupport,
+                               this->colliderJntSphElements);
             if (sCsState < BOSSVA_BATTLE) {
                 BossVa_SetupSupportIntro(this, play);
             } else {
@@ -732,7 +733,8 @@ void BossVa_Init(Actor* thisx, PlayState* play2) {
             break;
         default:
             Collider_InitJntSph(play, &this->colliderJntSph);
-            Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitBari, this->colliderJntSphElements);
+            Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitBari,
+                               this->colliderJntSphElements);
             Collider_InitQuad(play, &this->colliderLightning);
             Collider_SetQuad(play, &this->colliderLightning, &this->actor, &sQuadInit);
             this->unk_1D8.x = 1.0f;

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -702,8 +702,8 @@ void BossVa_Init(Actor* thisx, PlayState* play2) {
         case BOSSVA_SUPPORT_1:
         case BOSSVA_SUPPORT_2:
         case BOSSVA_SUPPORT_3:
-            Collider_InitJntSph(play, &this->colliderSph);
-            Collider_SetJntSph(play, &this->colliderSph, &this->actor, &sJntSphInitSupport, this->elements);
+            Collider_InitJntSph(play, &this->colliderJntSph);
+            Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitSupport, this->colliderJntSphElements);
             if (sCsState < BOSSVA_BATTLE) {
                 BossVa_SetupSupportIntro(this, play);
             } else {
@@ -731,8 +731,8 @@ void BossVa_Init(Actor* thisx, PlayState* play2) {
             BossVa_SetupDoor(this, play);
             break;
         default:
-            Collider_InitJntSph(play, &this->colliderSph);
-            Collider_SetJntSph(play, &this->colliderSph, &this->actor, &sJntSphInitBari, this->elements);
+            Collider_InitJntSph(play, &this->colliderJntSph);
+            Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitBari, this->colliderJntSphElements);
             Collider_InitQuad(play, &this->colliderLightning);
             Collider_SetQuad(play, &this->colliderLightning, &this->actor, &sQuadInit);
             this->unk_1D8.x = 1.0f;
@@ -752,7 +752,7 @@ void BossVa_Destroy(Actor* thisx, PlayState* play) {
     BossVa* this = (BossVa*)thisx;
 
     SkelAnime_Free(&this->skelAnime, play);
-    Collider_DestroyJntSph(play, &this->colliderSph);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
     Collider_DestroyCylinder(play, &this->colliderBody);
 }
 
@@ -1745,11 +1745,11 @@ void BossVa_SupportAttached(BossVa* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
-    if (this->colliderSph.base.acFlags & AC_HIT) {
+    if (this->colliderJntSph.base.acFlags & AC_HIT) {
         BossVa_SetupSupportCut(this, play);
     } else {
         if (this->actor.colorFilterTimer == 0) {
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderSph.base);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
         }
 
         if ((this->timer % 2) == 0) {
@@ -2548,23 +2548,23 @@ void BossVa_BariPhase3Attack(BossVa* this, PlayState* play) {
 
     Math_SmoothStepToS(&this->vaBariUnused.z, this->vaBariUnused.x, 1, 0x1E, 0);
     this->vaBariUnused.y += this->vaBariUnused.z;
-    if ((this->colliderLightning.base.atFlags & AT_HIT) || (this->colliderSph.base.atFlags & AT_HIT)) {
-        if ((this->colliderLightning.base.at == &player->actor) || (this->colliderSph.base.at == &player->actor)) {
+    if ((this->colliderLightning.base.atFlags & AT_HIT) || (this->colliderJntSph.base.atFlags & AT_HIT)) {
+        if ((this->colliderLightning.base.at == &player->actor) || (this->colliderJntSph.base.at == &player->actor)) {
             Actor_SetPlayerKnockbackLargeNoDamage(play, &this->actor, 8.0f, GET_BODY(this)->actor.yawTowardsPlayer,
                                                   8.0f);
             Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
-            this->colliderSph.base.at = NULL;
+            this->colliderJntSph.base.at = NULL;
             this->colliderLightning.base.at = NULL;
         }
 
         this->colliderLightning.base.atFlags &= ~AT_HIT;
-        this->colliderSph.base.atFlags &= ~AT_HIT;
+        this->colliderJntSph.base.atFlags &= ~AT_HIT;
     }
 
-    if (this->colliderSph.base.acFlags & AC_HIT) {
-        this->colliderSph.base.acFlags &= ~AC_HIT;
-        if ((this->colliderSph.base.ac->id == ACTOR_EN_BOOM) && (sp52 >= 128)) {
-            boomerang = (EnBoom*)this->colliderSph.base.ac;
+    if (this->colliderJntSph.base.acFlags & AC_HIT) {
+        this->colliderJntSph.base.acFlags &= ~AC_HIT;
+        if ((this->colliderJntSph.base.ac->id == ACTOR_EN_BOOM) && (sp52 >= 128)) {
+            boomerang = (EnBoom*)this->colliderJntSph.base.ac;
             boomerang->returnTimer = 0;
             boomerang->moveTo = &player->actor;
             boomerang->actor.world.rot.y = boomerang->actor.yawTowardsPlayer;
@@ -2587,14 +2587,14 @@ void BossVa_BariPhase3Attack(BossVa* this, PlayState* play) {
 
     if (sp52 >= 128) {
         BossVa_Spark(play, this, 1, 75, 15.0f, 7.0f, SPARK_TETHER, 1.0f, true);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderSph.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
         sPhase3StopMoving = false;
     } else {
         sPhase3StopMoving = true;
     }
 
     CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderLightning.base);
-    CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderSph.base);
+    CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderJntSph.base);
     if ((play->gameplayFrames % 4) == 0) {
         Math_SmoothStepToS(&this->unk_1F0, 0x78, 1, 0xA, 0);
     }
@@ -2644,17 +2644,17 @@ void BossVa_BariPhase2Attack(BossVa* this, PlayState* play) {
         return;
     }
 
-    if ((this->colliderLightning.base.atFlags & AT_HIT) || (this->colliderSph.base.atFlags & AT_HIT)) {
-        if ((this->colliderLightning.base.at == &player->actor) || (this->colliderSph.base.at == &player->actor)) {
+    if ((this->colliderLightning.base.atFlags & AT_HIT) || (this->colliderJntSph.base.atFlags & AT_HIT)) {
+        if ((this->colliderLightning.base.at == &player->actor) || (this->colliderJntSph.base.at == &player->actor)) {
             Actor_SetPlayerKnockbackLargeNoDamage(play, &this->actor, 8.0f, GET_BODY(this)->actor.yawTowardsPlayer,
                                                   8.0f);
             Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
-            this->colliderSph.base.at = NULL;
+            this->colliderJntSph.base.at = NULL;
             this->colliderLightning.base.at = NULL;
         }
 
         this->colliderLightning.base.atFlags &= ~AT_HIT;
-        this->colliderSph.base.atFlags &= ~AT_HIT;
+        this->colliderJntSph.base.atFlags &= ~AT_HIT;
     }
 
     Math_SmoothStepToF(&this->actor.world.pos.y, 4.0f, 1.0f, 2.0f, 0.0f);
@@ -2675,11 +2675,11 @@ void BossVa_BariPhase2Attack(BossVa* this, PlayState* play) {
         Math_SmoothStepToF(&this->unk_1A0, (Math_SinS(sPhase2Timer * 0x190) * sp4C) + 320.0f, 1.0f, 10.0f, 0.0f);
         Math_SmoothStepToS(&this->unk_1AC, sp50 + 0x1F4, 1, 0x3C, 0);
         this->actor.world.pos.y += 2.0f * Math_SinF(this->unk_1A4);
-        if (this->colliderSph.base.acFlags & AC_HIT) {
-            this->colliderSph.base.acFlags &= ~AC_HIT;
+        if (this->colliderJntSph.base.acFlags & AC_HIT) {
+            this->colliderJntSph.base.acFlags &= ~AC_HIT;
 
-            if ((this->colliderSph.base.ac->id == ACTOR_EN_BOOM) && (sp52 >= 64)) {
-                boomerang = (EnBoom*)this->colliderSph.base.ac;
+            if ((this->colliderJntSph.base.ac->id == ACTOR_EN_BOOM) && (sp52 >= 64)) {
+                boomerang = (EnBoom*)this->colliderJntSph.base.ac;
                 boomerang->returnTimer = 0;
                 boomerang->moveTo = &player->actor;
                 boomerang->actor.world.rot.y = boomerang->actor.yawTowardsPlayer;
@@ -2688,7 +2688,7 @@ void BossVa_BariPhase2Attack(BossVa* this, PlayState* play) {
         }
 
         CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderLightning.base);
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderSph.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderJntSph.base);
     } else {
         this->actor.flags |= ACTOR_FLAG_ATTENTION_ENABLED;
         Math_SmoothStepToS(&this->unk_1AC, sp50 + 150, 1, 0x3C, 0);
@@ -2703,13 +2703,13 @@ void BossVa_BariPhase2Attack(BossVa* this, PlayState* play) {
         }
 
         this->actor.world.pos.y += Math_SinF(this->unk_1A4) * 4.0f;
-        if (this->colliderSph.base.acFlags & AC_HIT) {
+        if (this->colliderJntSph.base.acFlags & AC_HIT) {
             BossVa_KillBari(this, play);
         }
     }
 
     Math_SmoothStepToS(&this->actor.shape.rot.x, 0, 1, 0x5DC, 0);
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderSph.base);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
     if ((play->gameplayFrames % 4) == 0) {
         Math_SmoothStepToS(&this->unk_1F0, 0x78, 1, 0xA, 0);
     }
@@ -2742,7 +2742,7 @@ void BossVa_BariPhase3Stunned(BossVa* this, PlayState* play) {
     Vec3f sp40 = GET_BODY(this)->unk_1D8;
 
     this->actor.world.rot.x = Math_Vec3f_Pitch(&GET_BODY(this)->actor.world.pos, &this->actor.world.pos);
-    if (this->colliderSph.base.acFlags & AC_HIT) {
+    if (this->colliderJntSph.base.acFlags & AC_HIT) {
         BossVa_KillBari(this, play);
         return;
     }
@@ -2750,7 +2750,7 @@ void BossVa_BariPhase3Stunned(BossVa* this, PlayState* play) {
     this->unk_1A4 += Rand_ZeroOne() * 0.5f;
     Math_SmoothStepToF(&this->actor.world.pos.y, 4.0f, 1.0f, 2.0f, 0.0f);
     this->actor.world.pos.y += Math_SinF(this->unk_1A4) * 3.0f;
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderSph.base);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
     if ((play->gameplayFrames % 4) == 0) {
         Math_SmoothStepToS(&this->unk_1F0, 0x28, 1, 0xA, 0);
         BossVa_Spark(play, this, 1, this->unk_1F0, 25.0f, 20.0f, SPARK_BARI, 2.0f, true);
@@ -2972,7 +2972,7 @@ void BossVa_SupportPostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec
         switch (limbIndex) {
             case 4:
                 Matrix_MultVec3f(&sZeroVec, &this->actor.focus.pos);
-                Collider_UpdateSpheres(0, &this->colliderSph);
+                Collider_UpdateSpheres(0, &this->colliderJntSph);
                 break;
             case 7:
                 Matrix_MultVec3f(&sZeroVec, &this->armTip);
@@ -3228,7 +3228,7 @@ void BossVa_Draw(Actor* thisx, PlayState* play) {
             if (!this->isDead) {
                 SkelAnime_DrawOpa(play, this->skelAnime.skeleton, this->skelAnime.jointTable,
                                   BossVa_BariOverrideLimbDraw, BossVa_BariPostLimbDraw, this);
-                Collider_UpdateSpheres(0, &this->colliderSph);
+                Collider_UpdateSpheres(0, &this->colliderJntSph);
                 if (sCsState < BOSSVA_BATTLE) {
                     spBC = GET_BODY(this)->actor.world.pos;
                 } else {

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
@@ -42,8 +42,8 @@ typedef struct BossVa {
     /* 0x0274 */ Vec3f unk_274; // Unused body position
     /* 0x0280 */ Vec3f unk_280; // Unused body position
     /* 0x028C */ ColliderCylinder colliderBody;
-    /* 0x02D8 */ ColliderJntSph colliderSph;
-    /* 0x02F8 */ ColliderJntSphElement elements[1];
+    /* 0x02D8 */ ColliderJntSph colliderJntSph;
+    /* 0x02F8 */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x0338 */ ColliderQuad colliderLightning;
 } BossVa; // size = 0x03B8
 

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -137,7 +137,7 @@ void DoorKiller_Init(Actor* thisx, PlayState* play2) {
             Collider_InitCylinder(play, &this->colliderCylinder);
             Collider_SetCylinder(play, &this->colliderCylinder, &this->actor, &sCylinderInit);
             Collider_InitJntSph(play, &this->colliderJntSph);
-            Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphItems);
+            Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
             this->colliderJntSph.elements[0].dim.worldSphere.radius = 80;
             this->colliderJntSph.elements[0].dim.worldSphere.center.x = (s16)this->actor.world.pos.x;
             this->colliderJntSph.elements[0].dim.worldSphere.center.y = (s16)this->actor.world.pos.y + 50;

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.h
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.h
@@ -28,7 +28,7 @@ typedef struct DoorKiller {
     /* 0x021C */ u8 requiredObjectSlot;
     /* 0x021D */ u8 textureEntryIndex;
     /* 0x0220 */ ColliderJntSph colliderJntSph;
-    /* 0x0240 */ ColliderJntSphElement colliderJntSphItems[1];
+    /* 0x0240 */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x0280 */ DoorKillerActionFunc actionFunc;
 } DoorKiller; // size = 0x0284
 

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -184,7 +184,7 @@ void EnBigokuta_Init(Actor* thisx, PlayState* play) {
                        this->jointTable, this->morphTable, 20);
 
     Collider_InitJntSph(play, &this->collider);
-    Collider_SetJntSph(play, &this->collider, &this->actor, &sJntSphInit, this->elements);
+    Collider_SetJntSph(play, &this->collider, &this->actor, &sJntSphInit, this->colliderElements);
 
     this->collider.elements[0].dim.worldSphere.radius = this->collider.elements[0].dim.modelSphere.radius;
 

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -184,7 +184,7 @@ void EnBigokuta_Init(Actor* thisx, PlayState* play) {
                        this->jointTable, this->morphTable, 20);
 
     Collider_InitJntSph(play, &this->collider);
-    Collider_SetJntSph(play, &this->collider, &this->actor, &sJntSphInit, &this->element);
+    Collider_SetJntSph(play, &this->collider, &this->actor, &sJntSphInit, this->elements);
 
     this->collider.elements[0].dim.worldSphere.radius = this->collider.elements[0].dim.modelSphere.radius;
 

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
@@ -20,7 +20,7 @@ typedef struct EnBigokuta {
     /* 0x019C */ Vec3s jointTable[20];
     /* 0x0214 */ Vec3s morphTable[20];
     /* 0x028C */ ColliderJntSph collider;
-    /* 0x02AC */ ColliderJntSphElement elements[1];
+    /* 0x02AC */ ColliderJntSphElement colliderElements[1];
     /* 0x02EC */ ColliderCylinder cylinder[2];
 } EnBigokuta; // size = 0x0384
 

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
@@ -20,7 +20,7 @@ typedef struct EnBigokuta {
     /* 0x019C */ Vec3s jointTable[20];
     /* 0x0214 */ Vec3s morphTable[20];
     /* 0x028C */ ColliderJntSph collider;
-    /* 0x02AC */ ColliderJntSphElement element;
+    /* 0x02AC */ ColliderJntSphElement elements[1];
     /* 0x02EC */ ColliderCylinder cylinder[2];
 } EnBigokuta; // size = 0x0384
 

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -112,8 +112,8 @@ void EnBom_Init(Actor* thisx, PlayState* play) {
     Collider_InitCylinder(play, &this->bombCollider);
     Collider_InitJntSph(play, &this->explosionCollider);
     Collider_SetCylinder(play, &this->bombCollider, thisx, &sCylinderInit);
-    Collider_SetJntSph(play, &this->explosionCollider, thisx, &sJntSphInit, &this->explosionColliderItems[0]);
-    this->explosionColliderItems[0].base.atDmgInfo.damage += (thisx->shape.rot.z & 0xFF00) >> 8;
+    Collider_SetJntSph(play, &this->explosionCollider, thisx, &sJntSphInit, &this->explosionColliderElements[0]);
+    this->explosionColliderElements[0].base.atDmgInfo.damage += (thisx->shape.rot.z & 0xFF00) >> 8;
 
     thisx->shape.rot.z &= 0xFF;
     if (thisx->shape.rot.z & 0x80) {

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.h
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.h
@@ -12,7 +12,7 @@ typedef struct EnBom {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ ColliderCylinder bombCollider;
     /* 0x0198 */ ColliderJntSph explosionCollider;
-    /* 0x01B8 */ ColliderJntSphElement explosionColliderItems[1];
+    /* 0x01B8 */ ColliderJntSphElement explosionColliderElements[1];
     /* 0x01F8 */ s16 timer;
     /* 0x01FA */ s16 flashSpeedScale;
     /* 0x01FC */ f32 flashIntensity;

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -107,7 +107,7 @@ void EnBombf_Init(Actor* thisx, PlayState* play) {
     Collider_InitCylinder(play, &this->bombCollider);
     Collider_InitJntSph(play, &this->explosionCollider);
     Collider_SetCylinder(play, &this->bombCollider, thisx, &sCylinderInit);
-    Collider_SetJntSph(play, &this->explosionCollider, thisx, &sJntSphInit, &this->explosionColliderItems[0]);
+    Collider_SetJntSph(play, &this->explosionCollider, thisx, &sJntSphInit, &this->explosionColliderElements[0]);
 
     if (thisx->params == BOMBFLOWER_BODY) {
         shapeUnk10 = 1000.0f;

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.h
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.h
@@ -12,7 +12,7 @@ typedef struct EnBombf {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ ColliderCylinder bombCollider;
     /* 0x0198 */ ColliderJntSph explosionCollider;
-    /* 0x01B8 */ ColliderJntSphElement explosionColliderItems[1];
+    /* 0x01B8 */ ColliderJntSphElement explosionColliderElements[1];
     /* 0x01F8 */ s16 timer;
     /* 0x01FC */ EnBombfActionFunc actionFunc;
     /* 0x0200 */ s32 isFuseEnabled; // enables the ability to ignite and tick down to explode

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -107,7 +107,7 @@ void EnBubble_SetDimensions(EnBubble* this, f32 dim) {
 }
 
 u32 func_809CBCBC(EnBubble* this) {
-    ColliderElement* elem = &this->colliderSphere.elements[0].base;
+    ColliderElement* elem = &this->colliderJntSph.elements[0].base;
 
     elem->atDmgInfo.dmgFlags = DMG_EXPLOSIVE;
     elem->atDmgInfo.effect = 0;
@@ -124,7 +124,7 @@ u32 func_809CBCEC(EnBubble* this) {
 }
 
 void EnBubble_DamagePlayer(EnBubble* this, PlayState* play) {
-    s32 damage = -this->colliderSphere.elements[0].base.atDmgInfo.damage;
+    s32 damage = -this->colliderJntSph.elements[0].base.atDmgInfo.damage;
 
     play->damagePlayer(play, damage);
     Actor_SetPlayerKnockbackSmallNoDamage(play, &this->actor, 6.0f, this->actor.yawTowardsPlayer, 6.0f);
@@ -218,8 +218,8 @@ void EnBubble_Fly(EnBubble* this, PlayState* play) {
     s32 bgId;
     u8 bounceCount;
 
-    if (this->colliderSphere.elements[1].base.acElemFlags & ACELEM_HIT) {
-        attackerActor = this->colliderSphere.base.ac;
+    if (this->colliderJntSph.elements[1].base.acElemFlags & ACELEM_HIT) {
+        attackerActor = this->colliderJntSph.base.ac;
         this->normalizedAttackerVelocity = attackerActor->velocity;
         EnBubble_Vec3fNormalize(&this->normalizedAttackerVelocity);
         this->velocityFromAttack.x += (this->normalizedAttackerVelocity.x * 3.0f);
@@ -292,14 +292,14 @@ void EnBubble_Fly(EnBubble* this, PlayState* play) {
 }
 
 u32 func_809CC648(EnBubble* this) {
-    if (((this->colliderSphere.base.acFlags & AC_HIT) != 0) == false) {
+    if (((this->colliderJntSph.base.acFlags & AC_HIT) != 0) == false) {
         return false;
     }
-    this->colliderSphere.base.acFlags &= ~AC_HIT;
-    if (this->colliderSphere.elements[1].base.acElemFlags & ACELEM_HIT) {
-        this->unk_1F0.x = this->colliderSphere.base.ac->velocity.x / 10.0f;
-        this->unk_1F0.y = this->colliderSphere.base.ac->velocity.y / 10.0f;
-        this->unk_1F0.z = this->colliderSphere.base.ac->velocity.z / 10.0f;
+    this->colliderJntSph.base.acFlags &= ~AC_HIT;
+    if (this->colliderJntSph.elements[1].base.acElemFlags & ACELEM_HIT) {
+        this->unk_1F0.x = this->colliderJntSph.base.ac->velocity.x / 10.0f;
+        this->unk_1F0.y = this->colliderJntSph.base.ac->velocity.y / 10.0f;
+        this->unk_1F0.z = this->colliderJntSph.base.ac->velocity.z / 10.0f;
         this->graphicRotSpeed = 128.0f;
         this->graphicEccentricity = 0.48f;
         return false;
@@ -312,8 +312,8 @@ u32 EnBubble_DetectPop(EnBubble* this, PlayState* play) {
     if (DECR(this->unk_208) != 0 || this->actionFunc == EnBubble_Pop) {
         return false;
     }
-    if (this->colliderSphere.base.ocFlags2 & OC2_HIT_PLAYER) {
-        this->colliderSphere.base.ocFlags2 &= ~OC2_HIT_PLAYER;
+    if (this->colliderJntSph.base.ocFlags2 & OC2_HIT_PLAYER) {
+        this->colliderJntSph.base.ocFlags2 &= ~OC2_HIT_PLAYER;
         EnBubble_DamagePlayer(this, play);
         this->unk_208 = 8;
         return true;
@@ -326,7 +326,7 @@ void func_809CC774(EnBubble* this) {
     Vec3f src;
     Vec3f dest;
 
-    dim = &this->colliderSphere.elements[0].dim;
+    dim = &this->colliderJntSph.elements[0].dim;
     src.x = dim->modelSphere.center.x;
     src.y = dim->modelSphere.center.y;
     src.z = dim->modelSphere.center.z;
@@ -336,7 +336,7 @@ void func_809CC774(EnBubble* this) {
     dim->worldSphere.center.y = dest.y;
     dim->worldSphere.center.z = dest.z;
     dim->worldSphere.radius = dim->modelSphere.radius * (1.0f + this->expansionWidth);
-    this->colliderSphere.elements[1].dim = *dim;
+    this->colliderJntSph.elements[1].dim = *dim;
 }
 
 void EnBubble_Init(Actor* thisx, PlayState* play) {
@@ -344,8 +344,8 @@ void EnBubble_Init(Actor* thisx, PlayState* play) {
     u32 pad;
 
     ActorShape_Init(&this->actor.shape, 16.0f, ActorShadow_DrawCircle, 0.2f);
-    Collider_InitJntSph(play, &this->colliderSphere);
-    Collider_SetJntSph(play, &this->colliderSphere, &this->actor, &sJntSphInit, this->colliderSphereItems);
+    Collider_InitJntSph(play, &this->colliderJntSph);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, DamageTable_Get(9), &sColChkInfoInit2);
     this->actor.naviEnemyId = NAVI_ENEMY_SHABOM;
     this->bounceDirection.x = Rand_ZeroOne();
@@ -362,7 +362,7 @@ void EnBubble_Init(Actor* thisx, PlayState* play) {
 void EnBubble_Destroy(Actor* thisx, PlayState* play) {
     EnBubble* this = (EnBubble*)thisx;
 
-    Collider_DestroyJntSph(play, &this->colliderSphere);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
 }
 
 void EnBubble_Wait(EnBubble* this, PlayState* play) {
@@ -372,8 +372,8 @@ void EnBubble_Wait(EnBubble* this, PlayState* play) {
     } else {
         EnBubble_Fly(this, play);
         this->actor.shape.yOffset = ((this->expansionHeight + 1.0f) * 16.0f);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderSphere.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderSphere.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
     }
 }
 
@@ -401,8 +401,8 @@ void EnBubble_Regrow(EnBubble* this, PlayState* play) {
     if (func_809CC020(this)) {
         this->actionFunc = EnBubble_Wait;
     }
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderSphere.base);
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderSphere.base);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
 }
 
 void EnBubble_Update(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.h
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.h
@@ -11,8 +11,8 @@ typedef void (*EnBubbleActionFunc)(struct EnBubble*, struct PlayState*);
 typedef struct EnBubble {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ EnBubbleActionFunc actionFunc;
-    /* 0x0150 */ ColliderJntSph colliderSphere;
-    /* 0x0170 */ ColliderJntSphElement colliderSphereItems[2];
+    /* 0x0150 */ ColliderJntSph colliderJntSph;
+    /* 0x0170 */ ColliderJntSphElement colliderJntSphElements[2];
     /* 0x01F0 */ Vec3f unk_1F0; // set but never used
     /* 0x01FC */ Vec3f unk_1FC; // randomly generated, set but never used
     /* 0x0208 */ s16 unk_208;   // set to 8 when about to pop

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.c
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.c
@@ -330,8 +330,10 @@ void EnDh_Attack(EnDh* this, PlayState* play) {
         Animation_Change(&this->skelAnime, &object_dh_Anim_004658, -1.0f, this->skelAnime.curFrame, 0.0f, ANIMMODE_ONCE,
                          -4.0f);
         this->actionState = 4;
-        this->colliderJntSph.base.atFlags = this->colliderJntSph.elements[0].base.atElemFlags = AT_NONE; // also ATELEM_NONE
-        this->colliderJntSph.elements[0].base.atDmgInfo.dmgFlags = this->colliderJntSph.elements[0].base.atDmgInfo.damage = 0;
+        this->colliderJntSph.base.atFlags = this->colliderJntSph.elements[0].base.atElemFlags =
+            AT_NONE; // also ATELEM_NONE
+        this->colliderJntSph.elements[0].base.atDmgInfo.dmgFlags =
+            this->colliderJntSph.elements[0].base.atDmgInfo.damage = 0;
     }
     switch (this->actionState) {
         case 1:
@@ -507,8 +509,10 @@ void EnDh_CollisionCheck(EnDh* this, PlayState* play) {
     if ((this->colliderJntSph.base.acFlags & AC_HIT) && !this->retreat) {
         this->colliderJntSph.base.acFlags &= ~AC_HIT;
         if ((this->actor.colChkInfo.damageEffect != 0) && (this->actor.colChkInfo.damageEffect != 6)) {
-            this->colliderJntSph.base.atFlags = this->colliderJntSph.elements[0].base.atElemFlags = AT_NONE; // also ATELEM_NONE
-            this->colliderJntSph.elements[0].base.atDmgInfo.dmgFlags = this->colliderJntSph.elements[0].base.atDmgInfo.damage = 0;
+            this->colliderJntSph.base.atFlags = this->colliderJntSph.elements[0].base.atElemFlags =
+                AT_NONE; // also ATELEM_NONE
+            this->colliderJntSph.elements[0].base.atDmgInfo.dmgFlags =
+                this->colliderJntSph.elements[0].base.atDmgInfo.damage = 0;
             if (player->unk_844 != 0) {
                 this->unk_258 = player->unk_845;
             }

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.c
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.c
@@ -179,8 +179,8 @@ void EnDh_Init(Actor* thisx, PlayState* play) {
     this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
     Collider_InitCylinder(play, &this->collider1);
     Collider_SetCylinder(play, &this->collider1, &this->actor, &sCylinderInit);
-    Collider_InitJntSph(play, &this->collider2);
-    Collider_SetJntSph(play, &this->collider2, &this->actor, &sJntSphInit, this->elements);
+    Collider_InitJntSph(play, &this->colliderJntSph);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
     EnDh_SetupWait(this);
 }
 
@@ -190,7 +190,7 @@ void EnDh_Destroy(Actor* thisx, PlayState* play) {
 
     func_800F5B58();
     Collider_DestroyCylinder(play, &this->collider1);
-    Collider_DestroyJntSph(play, &this->collider2);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
 }
 
 void EnDh_SpawnDebris(PlayState* play, EnDh* this, Vec3f* spawnPos, f32 spread, s32 arg4, f32 accelXZ, f32 scale) {
@@ -330,8 +330,8 @@ void EnDh_Attack(EnDh* this, PlayState* play) {
         Animation_Change(&this->skelAnime, &object_dh_Anim_004658, -1.0f, this->skelAnime.curFrame, 0.0f, ANIMMODE_ONCE,
                          -4.0f);
         this->actionState = 4;
-        this->collider2.base.atFlags = this->collider2.elements[0].base.atElemFlags = AT_NONE; // also ATELEM_NONE
-        this->collider2.elements[0].base.atDmgInfo.dmgFlags = this->collider2.elements[0].base.atDmgInfo.damage = 0;
+        this->colliderJntSph.base.atFlags = this->colliderJntSph.elements[0].base.atElemFlags = AT_NONE; // also ATELEM_NONE
+        this->colliderJntSph.elements[0].base.atDmgInfo.dmgFlags = this->colliderJntSph.elements[0].base.atDmgInfo.damage = 0;
     }
     switch (this->actionState) {
         case 1:
@@ -344,20 +344,20 @@ void EnDh_Attack(EnDh* this, PlayState* play) {
             break;
         case 2:
             if (this->skelAnime.curFrame >= 4.0f) {
-                this->collider2.base.atFlags = this->collider2.elements[0].base.atElemFlags =
+                this->colliderJntSph.base.atFlags = this->colliderJntSph.elements[0].base.atElemFlags =
                     AT_ON | AT_TYPE_ENEMY; // also ATELEM_ON | ATELEM_SFX_WOOD
-                this->collider2.elements[0].base.atDmgInfo.dmgFlags = DMG_DEFAULT;
-                this->collider2.elements[0].base.atDmgInfo.damage = 8;
+                this->colliderJntSph.elements[0].base.atDmgInfo.dmgFlags = DMG_DEFAULT;
+                this->colliderJntSph.elements[0].base.atDmgInfo.damage = 8;
             }
-            if (this->collider2.base.atFlags & AT_BOUNCED) {
-                this->collider2.base.atFlags &= ~(AT_HIT | AT_BOUNCED);
-                this->collider2.base.atFlags = this->collider2.elements[0].base.atElemFlags =
+            if (this->colliderJntSph.base.atFlags & AT_BOUNCED) {
+                this->colliderJntSph.base.atFlags &= ~(AT_HIT | AT_BOUNCED);
+                this->colliderJntSph.base.atFlags = this->colliderJntSph.elements[0].base.atElemFlags =
                     AT_NONE; // also ATELEM_NONE
-                this->collider2.elements[0].base.atDmgInfo.dmgFlags =
-                    this->collider2.elements[0].base.atDmgInfo.damage = 0;
+                this->colliderJntSph.elements[0].base.atDmgInfo.dmgFlags =
+                    this->colliderJntSph.elements[0].base.atDmgInfo.damage = 0;
                 this->actionState++;
-            } else if (this->collider2.base.atFlags & AT_HIT) {
-                this->collider2.base.atFlags &= ~AT_HIT;
+            } else if (this->colliderJntSph.base.atFlags & AT_HIT) {
+                this->colliderJntSph.base.atFlags &= ~AT_HIT;
                 Actor_SetPlayerKnockbackLargeNoDamage(play, &this->actor, 8.0f, this->actor.shape.rot.y, 8.0f);
             }
             break;
@@ -372,10 +372,10 @@ void EnDh_Attack(EnDh* this, PlayState* play) {
                 Animation_Change(&this->skelAnime, &object_dh_Anim_004658, -1.0f,
                                  Animation_GetLastFrame(&object_dh_Anim_004658), 0.0f, ANIMMODE_ONCE, -4.0f);
                 this->actionState++;
-                this->collider2.base.atFlags = this->collider2.elements[0].base.atElemFlags =
+                this->colliderJntSph.base.atFlags = this->colliderJntSph.elements[0].base.atElemFlags =
                     AT_NONE; // also ATELEM_NONE
-                this->collider2.elements[0].base.atDmgInfo.dmgFlags =
-                    this->collider2.elements[0].base.atDmgInfo.damage = 0;
+                this->colliderJntSph.elements[0].base.atDmgInfo.dmgFlags =
+                    this->colliderJntSph.elements[0].base.atDmgInfo.damage = 0;
             }
             break;
         case 5:
@@ -504,11 +504,11 @@ void EnDh_CollisionCheck(EnDh* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 lastHealth;
 
-    if ((this->collider2.base.acFlags & AC_HIT) && !this->retreat) {
-        this->collider2.base.acFlags &= ~AC_HIT;
+    if ((this->colliderJntSph.base.acFlags & AC_HIT) && !this->retreat) {
+        this->colliderJntSph.base.acFlags &= ~AC_HIT;
         if ((this->actor.colChkInfo.damageEffect != 0) && (this->actor.colChkInfo.damageEffect != 6)) {
-            this->collider2.base.atFlags = this->collider2.elements[0].base.atElemFlags = AT_NONE; // also ATELEM_NONE
-            this->collider2.elements[0].base.atDmgInfo.dmgFlags = this->collider2.elements[0].base.atDmgInfo.damage = 0;
+            this->colliderJntSph.base.atFlags = this->colliderJntSph.elements[0].base.atElemFlags = AT_NONE; // also ATELEM_NONE
+            this->colliderJntSph.elements[0].base.atDmgInfo.dmgFlags = this->colliderJntSph.elements[0].base.atDmgInfo.damage = 0;
             if (player->unk_844 != 0) {
                 this->unk_258 = player->unk_845;
             }
@@ -553,13 +553,13 @@ void EnDh_Update(Actor* thisx, PlayState* play) {
         if (((this->curAction != DH_DAMAGE) && (this->actor.shape.yOffset == 0.0f)) ||
             ((player->unk_844 != 0) && (player->unk_845 != this->unk_258))) {
 
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider2.base);
-            CollisionCheck_SetAT(play, &play->colChkCtx, &this->collider2.base);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
+            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderJntSph.base);
             CollisionCheck_SetAT(play, &play->colChkCtx, &this->collider1.base);
         }
     } else {
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider1.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider2.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
     }
 }
 
@@ -571,7 +571,7 @@ void EnDh_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, 
         Matrix_MultVec3f(&headOffset, &this->headPos);
         Matrix_Push();
         Matrix_Translate(headOffset.x, headOffset.y, headOffset.z, MTXMODE_APPLY);
-        Collider_UpdateSpheres(1, &this->collider2);
+        Collider_UpdateSpheres(1, &this->colliderJntSph);
         Matrix_Pop();
     }
 }

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.h
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.h
@@ -24,8 +24,8 @@ typedef struct EnDh {
     /* 0x025C */ s16 timer;
     /* 0x025E */ s16 dirtWavePhase;
     /* 0x0260 */ ColliderCylinder collider1;
-    /* 0x02AC */ ColliderJntSph collider2;
-    /* 0x02CC */ ColliderJntSphElement elements[1];
+    /* 0x02AC */ ColliderJntSph colliderJntSph;
+    /* 0x02CC */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x030C */ Vec3f headPos;
     /* 0x0318 */ f32 dirtWaveSpread;
     /* 0x031C */ f32 dirtWaveHeight;

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -644,9 +644,12 @@ void EnDodongo_SweepTail(EnDodongo* this, PlayState* play) {
             Animation_PlayOnceSetSpeed(&this->skelAnime, animation, 2.0f);
             this->timer = 18;
             this->bodyCollider.base.atFlags = this->bodyColliderElements[1].base.atElemFlags =
-                this->bodyColliderElements[2].base.atElemFlags = AT_ON | AT_TYPE_ENEMY; // also ATELEM_ON | ATELEM_SFX_WOOD
-            this->bodyColliderElements[1].base.atDmgInfo.dmgFlags = this->bodyColliderElements[2].base.atDmgInfo.dmgFlags = DMG_DEFAULT;
-            this->bodyColliderElements[1].base.atDmgInfo.damage = this->bodyColliderElements[2].base.atDmgInfo.damage = 8;
+                this->bodyColliderElements[2].base.atElemFlags =
+                    AT_ON | AT_TYPE_ENEMY; // also ATELEM_ON | ATELEM_SFX_WOOD
+            this->bodyColliderElements[1].base.atDmgInfo.dmgFlags =
+                this->bodyColliderElements[2].base.atDmgInfo.dmgFlags = DMG_DEFAULT;
+            this->bodyColliderElements[1].base.atDmgInfo.damage = this->bodyColliderElements[2].base.atDmgInfo.damage =
+                8;
         }
     } else if (this->timer > 1) {
         Vec3f tailPos;

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -337,10 +337,10 @@ void EnDodongo_Init(Actor* thisx, PlayState* play) {
     this->actor.colChkInfo.damageTable = &sDamageTable;
     Collider_InitQuad(play, &this->colliderAT);
     Collider_InitTris(play, &this->colliderHard);
-    Collider_InitJntSph(play, &this->colliderBody);
+    Collider_InitJntSph(play, &this->bodyCollider);
     Collider_SetQuad(play, &this->colliderAT, &this->actor, &sAttackQuadInit);
     Collider_SetTris(play, &this->colliderHard, &this->actor, &sHardTrisInit, this->trisElements);
-    Collider_SetJntSph(play, &this->colliderBody, &this->actor, &sBodyJntSphInit, this->sphElements);
+    Collider_SetJntSph(play, &this->bodyCollider, &this->actor, &sBodyJntSphInit, this->bodyColliderElements);
 
     blureInit.p1StartColor[0] = blureInit.p1StartColor[1] = blureInit.p1StartColor[2] = blureInit.p1StartColor[3] =
         blureInit.p2StartColor[0] = blureInit.p2StartColor[1] = blureInit.p2StartColor[2] = blureInit.p1EndColor[0] =
@@ -366,7 +366,7 @@ void EnDodongo_Destroy(Actor* thisx, PlayState* play) {
 
     Effect_Delete(play, this->blureIdx);
     Collider_DestroyTris(play, &this->colliderHard);
-    Collider_DestroyJntSph(play, &this->colliderBody);
+    Collider_DestroyJntSph(play, &this->bodyCollider);
     Collider_DestroyQuad(play, &this->colliderAT);
 }
 
@@ -505,9 +505,9 @@ void EnDodongo_SwallowBomb(EnDodongo* this, PlayState* play) {
                     deathFireAccel.x = deathFireVel.x * -0.1f;
                     deathFireAccel.y = deathFireVel.y * -0.1f;
                     deathFireAccel.z = deathFireVel.z * -0.1f;
-                    pos.x = this->sphElements[0].dim.worldSphere.center.x + deathFireVel.x;
-                    pos.y = this->sphElements[0].dim.worldSphere.center.y + deathFireVel.y;
-                    pos.z = this->sphElements[0].dim.worldSphere.center.z + deathFireVel.z;
+                    pos.x = this->bodyColliderElements[0].dim.worldSphere.center.x + deathFireVel.x;
+                    pos.y = this->bodyColliderElements[0].dim.worldSphere.center.y + deathFireVel.y;
+                    pos.z = this->bodyColliderElements[0].dim.worldSphere.center.z + deathFireVel.z;
                     func_8002836C(play, &pos, &deathFireVel, &deathFireAccel, &this->bombSmokePrimColor,
                                   &this->bombSmokeEnvColor, 400, 10, 10);
                 }
@@ -620,13 +620,13 @@ void EnDodongo_SweepTail(EnDodongo* this, PlayState* play) {
 
     if (SkelAnime_Update(&this->skelAnime)) {
         if ((this->timer != 0) || (ABS(yawDiff1) < 0x4000)) {
-            this->sphElements[2].base.atElemFlags = ATELEM_NONE;
-            this->sphElements[1].base.atElemFlags = ATELEM_NONE;
-            this->colliderBody.base.atFlags = AT_NONE;
-            this->sphElements[2].base.atDmgInfo.dmgFlags = 0;
-            this->sphElements[1].base.atDmgInfo.dmgFlags = 0;
-            this->sphElements[2].base.atDmgInfo.damage = 0;
-            this->sphElements[1].base.atDmgInfo.damage = 0;
+            this->bodyColliderElements[2].base.atElemFlags = ATELEM_NONE;
+            this->bodyColliderElements[1].base.atElemFlags = ATELEM_NONE;
+            this->bodyCollider.base.atFlags = AT_NONE;
+            this->bodyColliderElements[2].base.atDmgInfo.dmgFlags = 0;
+            this->bodyColliderElements[1].base.atDmgInfo.dmgFlags = 0;
+            this->bodyColliderElements[2].base.atDmgInfo.damage = 0;
+            this->bodyColliderElements[1].base.atDmgInfo.damage = 0;
             EnDodongo_SetupBreatheFire(this);
             this->timer = Rand_S16Offset(5, 10);
         } else {
@@ -643,33 +643,33 @@ void EnDodongo_SweepTail(EnDodongo* this, PlayState* play) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_DODO_J_TAIL);
             Animation_PlayOnceSetSpeed(&this->skelAnime, animation, 2.0f);
             this->timer = 18;
-            this->colliderBody.base.atFlags = this->sphElements[1].base.atElemFlags =
-                this->sphElements[2].base.atElemFlags = AT_ON | AT_TYPE_ENEMY; // also ATELEM_ON | ATELEM_SFX_WOOD
-            this->sphElements[1].base.atDmgInfo.dmgFlags = this->sphElements[2].base.atDmgInfo.dmgFlags = DMG_DEFAULT;
-            this->sphElements[1].base.atDmgInfo.damage = this->sphElements[2].base.atDmgInfo.damage = 8;
+            this->bodyCollider.base.atFlags = this->bodyColliderElements[1].base.atElemFlags =
+                this->bodyColliderElements[2].base.atElemFlags = AT_ON | AT_TYPE_ENEMY; // also ATELEM_ON | ATELEM_SFX_WOOD
+            this->bodyColliderElements[1].base.atDmgInfo.dmgFlags = this->bodyColliderElements[2].base.atDmgInfo.dmgFlags = DMG_DEFAULT;
+            this->bodyColliderElements[1].base.atDmgInfo.damage = this->bodyColliderElements[2].base.atDmgInfo.damage = 8;
         }
     } else if (this->timer > 1) {
         Vec3f tailPos;
 
         this->timer--;
         this->actor.shape.rot.y = this->actor.world.rot.y += this->tailSwipeSpeed;
-        tailPos.x = this->sphElements[1].dim.worldSphere.center.x;
-        tailPos.y = this->sphElements[1].dim.worldSphere.center.y;
-        tailPos.z = this->sphElements[1].dim.worldSphere.center.z;
+        tailPos.x = this->bodyColliderElements[1].dim.worldSphere.center.x;
+        tailPos.y = this->bodyColliderElements[1].dim.worldSphere.center.y;
+        tailPos.z = this->bodyColliderElements[1].dim.worldSphere.center.z;
         Actor_SpawnFloorDustRing(play, &this->actor, &tailPos, 5.0f, 2, 2.0f, 100, 15, false);
-        tailPos.x = this->sphElements[2].dim.worldSphere.center.x;
-        tailPos.y = this->sphElements[2].dim.worldSphere.center.y;
-        tailPos.z = this->sphElements[2].dim.worldSphere.center.z;
+        tailPos.x = this->bodyColliderElements[2].dim.worldSphere.center.x;
+        tailPos.y = this->bodyColliderElements[2].dim.worldSphere.center.y;
+        tailPos.z = this->bodyColliderElements[2].dim.worldSphere.center.z;
         Actor_SpawnFloorDustRing(play, &this->actor, &tailPos, 5.0f, 2, 2.0f, 100, 15, false);
 
-        if (this->colliderBody.base.atFlags & AT_HIT) {
+        if (this->bodyCollider.base.atFlags & AT_HIT) {
             Player* player = GET_PLAYER(play);
 
-            if (this->colliderBody.base.at == &player->actor) {
+            if (this->bodyCollider.base.at == &player->actor) {
                 Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
             }
         }
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->bodyCollider.base);
     }
 }
 
@@ -726,10 +726,10 @@ void EnDodongo_Stunned(EnDodongo* this, PlayState* play) {
 void EnDodongo_CollisionCheck(EnDodongo* this, PlayState* play) {
     if (this->colliderHard.base.acFlags & AC_BOUNCED) {
         this->colliderHard.base.acFlags &= ~AC_BOUNCED;
-        this->colliderBody.base.acFlags &= ~AC_HIT;
-    } else if ((this->colliderBody.base.acFlags & AC_HIT) && (this->actionState > DODONGO_DEATH)) {
-        this->colliderBody.base.acFlags &= ~AC_HIT;
-        Actor_SetDropFlagJntSph(&this->actor, &this->colliderBody, false);
+        this->bodyCollider.base.acFlags &= ~AC_HIT;
+    } else if ((this->bodyCollider.base.acFlags & AC_HIT) && (this->actionState > DODONGO_DEATH)) {
+        this->bodyCollider.base.acFlags &= ~AC_HIT;
+        Actor_SetDropFlagJntSph(&this->actor, &this->bodyCollider, false);
         if (this->actor.colChkInfo.damageEffect != 0xE) {
             this->damageEffect = this->actor.colChkInfo.damageEffect;
             if ((this->actor.colChkInfo.damageEffect == 1) || (this->actor.colChkInfo.damageEffect == 0xF)) {
@@ -790,12 +790,12 @@ void EnDodongo_Update(Actor* thisx, PlayState* play) {
             Actor_PlaySfx(&this->actor, NA_SE_EN_RIZA_DOWN);
         }
     }
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderBody.base);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyCollider.base);
     if (this->actionState != DODONGO_DEATH) {
         CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderHard.base);
     }
     if (this->actionState > DODONGO_DEATH) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->bodyCollider.base);
     }
     if ((this->actionState >= DODONGO_IDLE) && EnDodongo_AteBomb(this, play)) {
         EnDodongo_SetupSwallowBomb(this);
@@ -852,7 +852,7 @@ void EnDodongo_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* 
     Vec3f mouthOffset = { 1800.0f, 1200.0f, 0.0f };
     Vec3f headOffset = { 1500.0f, 300.0f, 0.0f };
 
-    Collider_UpdateSpheres(limbIndex, &this->colliderBody);
+    Collider_UpdateSpheres(limbIndex, &this->bodyCollider);
 
     switch (limbIndex) {
         case 2:

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.h
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.h
@@ -35,8 +35,8 @@ typedef struct EnDodongo {
     /* 0x03D4 */ ColliderQuad colliderAT;
     /* 0x0454 */ ColliderTris colliderHard;
     /* 0x0474 */ ColliderTrisElement trisElements[3];
-    /* 0x0588 */ ColliderJntSph colliderBody;
-    /* 0x05A8 */ ColliderJntSphElement sphElements[6];
+    /* 0x0588 */ ColliderJntSph bodyCollider;
+    /* 0x05A8 */ ColliderJntSphElement bodyColliderElements[6];
 } EnDodongo; // size = 0x0728
 
 typedef enum EnDodongoParam {

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -583,7 +583,7 @@ void EnHorse_UpdateIngoRaceInfo(EnHorse* this, PlayState* play, RaceInfo* raceIn
     EnHorse_RotateToPoint(this, play, &curWaypointPos, 400);
 
     if (distSq < SQ(300.0f)) {
-        if (this->actor.xzDistToPlayer < 130.0f || this->jntSph.elements[0].base.ocElemFlags & OCELEM_HIT) {
+        if (this->actor.xzDistToPlayer < 130.0f || this->colliderJntSph.elements[0].base.ocElemFlags & OCELEM_HIT) {
             s32 pad;
 
             if (Math_SinS(this->actor.yawTowardsPlayer - this->actor.world.rot.y) > 0.0f) {
@@ -844,8 +844,8 @@ void EnHorse_Init(Actor* thisx, PlayState* play2) {
     Collider_SetCylinder(play, &this->cyl1, &this->actor, &sCylinderInit1);
     Collider_InitCylinder(play, &this->cyl2);
     Collider_SetCylinder(play, &this->cyl2, &this->actor, &sCylinderInit2);
-    Collider_InitJntSph(play, &this->jntSph);
-    Collider_SetJntSph(play, &this->jntSph, &this->actor, &sJntSphInit, &this->jntSphList);
+    Collider_InitJntSph(play, &this->colliderJntSph);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
     CollisionCheck_SetInfo(&this->actor.colChkInfo, DamageTable_Get(0xB), &D_80A65F38);
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.focus.pos.y += 70.0f;
@@ -930,7 +930,7 @@ void EnHorse_Destroy(Actor* thisx, PlayState* play) {
     Skin_Free(play, &this->skin);
     Collider_DestroyCylinder(play, &this->cyl1);
     Collider_DestroyCylinder(play, &this->cyl2);
-    Collider_DestroyJntSph(play, &this->jntSph);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
 }
 
 void EnHorse_RotateToPlayer(EnHorse* this, PlayState* play) {
@@ -951,7 +951,7 @@ void EnHorse_Freeze(EnHorse* this) {
         this->action = ENHORSE_ACT_FROZEN;
         this->cyl1.base.ocFlags1 &= ~OC1_ON;
         this->cyl2.base.ocFlags1 &= ~OC1_ON;
-        this->jntSph.base.ocFlags1 &= ~OC1_ON;
+        this->colliderJntSph.base.ocFlags1 &= ~OC1_ON;
         this->animationIdx = ENHORSE_ANIM_IDLE;
     }
 }
@@ -967,7 +967,7 @@ void EnHorse_Frozen(EnHorse* this, PlayState* play) {
     if (this->noInputTimer < 0) {
         this->cyl1.base.ocFlags1 |= OC1_ON;
         this->cyl2.base.ocFlags1 |= OC1_ON;
-        this->jntSph.base.ocFlags1 |= OC1_ON;
+        this->colliderJntSph.base.ocFlags1 |= OC1_ON;
         if (this->playerControlled == true) {
             this->stateFlags &= ~ENHORSE_FLAG_7;
             if (this->actor.params == HORSE_PTYPE_4) {
@@ -1752,7 +1752,7 @@ void EnHorse_HighJump(EnHorse* this, PlayState* play) {
 void EnHorse_InitInactive(EnHorse* this) {
     this->cyl1.base.ocFlags1 &= ~OC1_ON;
     this->cyl2.base.ocFlags1 &= ~OC1_ON;
-    this->jntSph.base.ocFlags1 &= ~OC1_ON;
+    this->colliderJntSph.base.ocFlags1 &= ~OC1_ON;
     this->action = ENHORSE_ACT_INACTIVE;
     this->animationIdx = ENHORSE_ANIM_WALK;
     this->stateFlags |= ENHORSE_INACTIVE;
@@ -1786,7 +1786,7 @@ void EnHorse_Inactive(EnHorse* this, PlayState* play2) {
         this->actor.params = HORSE_PTYPE_0;
         this->cyl1.base.ocFlags1 |= OC1_ON;
         this->cyl2.base.ocFlags1 |= OC1_ON;
-        this->jntSph.base.ocFlags1 |= OC1_ON;
+        this->colliderJntSph.base.ocFlags1 |= OC1_ON;
     }
 }
 
@@ -3570,12 +3570,12 @@ void EnHorse_Update(Actor* thisx, PlayState* play2) {
                 this->rider->shape.rot.y = thisx->shape.rot.y;
             }
         }
-        if (this->jntSph.elements[0].base.ocElemFlags & OCELEM_HIT) {
+        if (this->colliderJntSph.elements[0].base.ocElemFlags & OCELEM_HIT) {
             if (thisx->speed > 6.0f) {
                 thisx->speed -= 1.0f;
             }
         }
-        if (this->jntSph.base.acFlags & AC_HIT) {
+        if (this->colliderJntSph.base.acFlags & AC_HIT) {
             this->unk_21C = this->unk_228;
             if (this->stateFlags & ENHORSE_DRAW) {
                 Audio_PlaySfxGeneral(NA_SE_EV_HORSE_NEIGH, &this->unk_21C, 4, &gSfxDefaultFreqAndVolScale,
@@ -3836,17 +3836,17 @@ void EnHorse_PostDraw(Actor* thisx, PlayState* play, Skin* skin) {
         }
     }
 
-    for (i = 0; i < this->jntSph.count; i++) {
-        center.x = this->jntSph.elements[i].dim.modelSphere.center.x;
-        center.y = this->jntSph.elements[i].dim.modelSphere.center.y;
-        center.z = this->jntSph.elements[i].dim.modelSphere.center.z;
+    for (i = 0; i < this->colliderJntSph.count; i++) {
+        center.x = this->colliderJntSph.elements[i].dim.modelSphere.center.x;
+        center.y = this->colliderJntSph.elements[i].dim.modelSphere.center.y;
+        center.z = this->colliderJntSph.elements[i].dim.modelSphere.center.z;
 
-        Skin_GetLimbPos(skin, this->jntSph.elements[i].dim.limb, &center, &newCenter);
-        this->jntSph.elements[i].dim.worldSphere.center.x = newCenter.x;
-        this->jntSph.elements[i].dim.worldSphere.center.y = newCenter.y;
-        this->jntSph.elements[i].dim.worldSphere.center.z = newCenter.z;
-        this->jntSph.elements[i].dim.worldSphere.radius =
-            this->jntSph.elements[i].dim.modelSphere.radius * this->jntSph.elements[i].dim.scale;
+        Skin_GetLimbPos(skin, this->colliderJntSph.elements[i].dim.limb, &center, &newCenter);
+        this->colliderJntSph.elements[i].dim.worldSphere.center.x = newCenter.x;
+        this->colliderJntSph.elements[i].dim.worldSphere.center.y = newCenter.y;
+        this->colliderJntSph.elements[i].dim.worldSphere.center.z = newCenter.z;
+        this->colliderJntSph.elements[i].dim.worldSphere.radius =
+            this->colliderJntSph.elements[i].dim.modelSphere.radius * this->colliderJntSph.elements[i].dim.scale;
     }
 
     //! @bug Setting colliders in a draw function allows for duplicate entries to be added to their respective lists
@@ -3854,8 +3854,8 @@ void EnHorse_PostDraw(Actor* thisx, PlayState* play, Skin* skin) {
     //! Actors will draw for a couple of frames between the pauses, but some important logic updates will not occur.
     //! In the case of OC, this can cause unwanted effects such as a very large amount of displacement being applied to
     //! a colliding actor.
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->jntSph.base);
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->jntSph.base);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
 }
 
 // unused

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.h
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.h
@@ -142,8 +142,8 @@ typedef struct EnHorse {
     /* 0x0274 */ f32 jumpStartY;
     /* 0x0278 */ ColliderCylinder cyl1;
     /* 0x02C4 */ ColliderCylinder cyl2;
-    /* 0x0310 */ ColliderJntSph jntSph;
-    /* 0x0330 */ ColliderJntSphElement jntSphList;
+    /* 0x0310 */ ColliderJntSph colliderJntSph;
+    /* 0x0330 */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x0370 */ u32 playerDir;
     /* 0x0374 */ s16 unk_374;
     /* 0x0376 */ s16 angleToPlayer;

--- a/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
+++ b/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.c
@@ -181,10 +181,10 @@ void EnHorseGanon_Init(Actor* thisx, PlayState* play) {
     this->currentAnimation = 0;
     Animation_PlayOnce(&this->skin.skelAnime, sAnimations[0]);
 
-    Collider_InitCylinder(play, &this->colliderBody);
-    Collider_SetCylinder(play, &this->colliderBody, &this->actor, &sCylinderInit);
-    Collider_InitJntSph(play, &this->colliderHead);
-    Collider_SetJntSph(play, &this->colliderHead, &this->actor, &sJntSphInit, this->headElements);
+    Collider_InitCylinder(play, &this->bodyCollider);
+    Collider_SetCylinder(play, &this->bodyCollider, &this->actor, &sCylinderInit);
+    Collider_InitJntSph(play, &this->headCollider);
+    Collider_SetJntSph(play, &this->headCollider, &this->actor, &sJntSphInit, this->headColliderElements);
 
     CollisionCheck_SetInfo(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
     func_80A68AC4(this);
@@ -194,8 +194,8 @@ void EnHorseGanon_Destroy(Actor* thisx, PlayState* play) {
     EnHorseGanon* this = (EnHorseGanon*)thisx;
 
     Skin_Free(play, &this->skin);
-    Collider_DestroyCylinder(play, &this->colliderBody);
-    Collider_DestroyJntSph(play, &this->colliderHead);
+    Collider_DestroyCylinder(play, &this->bodyCollider);
+    Collider_DestroyJntSph(play, &this->headCollider);
 }
 
 void func_80A68AC4(EnHorseGanon* this) {
@@ -293,8 +293,8 @@ void EnHorseGanon_Update(Actor* thisx, PlayState* play) {
                                 UPDBGCHECKINFO_FLAG_4);
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.focus.pos.y += 70.0f;
-    Collider_UpdateCylinder(&this->actor, &this->colliderBody);
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderBody.base);
+    Collider_UpdateCylinder(&this->actor, &this->bodyCollider);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyCollider.base);
 }
 
 void EnHorseGanon_PostDraw(Actor* thisx, PlayState* play, Skin* skin) {
@@ -303,23 +303,23 @@ void EnHorseGanon_PostDraw(Actor* thisx, PlayState* play, Skin* skin) {
     EnHorseGanon* this = (EnHorseGanon*)thisx;
     s32 index;
 
-    for (index = 0; index < this->colliderHead.count; index++) {
-        sp4C.x = this->colliderHead.elements[index].dim.modelSphere.center.x;
-        sp4C.y = this->colliderHead.elements[index].dim.modelSphere.center.y;
-        sp4C.z = this->colliderHead.elements[index].dim.modelSphere.center.z;
+    for (index = 0; index < this->headCollider.count; index++) {
+        sp4C.x = this->headCollider.elements[index].dim.modelSphere.center.x;
+        sp4C.y = this->headCollider.elements[index].dim.modelSphere.center.y;
+        sp4C.z = this->headCollider.elements[index].dim.modelSphere.center.z;
 
-        Skin_GetLimbPos(skin, this->colliderHead.elements[index].dim.limb, &sp4C, &sp40);
+        Skin_GetLimbPos(skin, this->headCollider.elements[index].dim.limb, &sp4C, &sp40);
 
-        this->colliderHead.elements[index].dim.worldSphere.center.x = sp40.x;
-        this->colliderHead.elements[index].dim.worldSphere.center.y = sp40.y;
-        this->colliderHead.elements[index].dim.worldSphere.center.z = sp40.z;
+        this->headCollider.elements[index].dim.worldSphere.center.x = sp40.x;
+        this->headCollider.elements[index].dim.worldSphere.center.y = sp40.y;
+        this->headCollider.elements[index].dim.worldSphere.center.z = sp40.z;
 
-        this->colliderHead.elements[index].dim.worldSphere.radius =
-            this->colliderHead.elements[index].dim.modelSphere.radius * this->colliderHead.elements[index].dim.scale;
+        this->headCollider.elements[index].dim.worldSphere.radius =
+            this->headCollider.elements[index].dim.modelSphere.radius * this->headCollider.elements[index].dim.scale;
     }
 
     //! @bug see relevant comment in `EnHorse_SkinCallback1`
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderHead.base);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->headCollider.base);
 }
 
 void EnHorseGanon_Draw(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.h
+++ b/src/overlays/actors/ovl_En_Horse_Ganon/z_en_horse_ganon.h
@@ -19,9 +19,9 @@ typedef struct EnHorseGanon {
     /* 0x01F0 */ u8 unk_1F0[0x04];
     /* 0x01F4 */ f32 unk_1F4;
     /* 0x01F8 */ u8 unk_1F8[0x04];
-    /* 0x01FC */ ColliderCylinder colliderBody;
-    /* 0x0248 */ ColliderJntSph colliderHead;
-    /* 0x0268 */ ColliderJntSphElement headElements[1];
+    /* 0x01FC */ ColliderCylinder bodyCollider;
+    /* 0x0248 */ ColliderJntSph headCollider;
+    /* 0x0268 */ ColliderJntSphElement headColliderElements[1];
 } EnHorseGanon; // size = 0x02A8
 
 #endif

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
@@ -168,7 +168,7 @@ void EnHorseLinkChild_Init(Actor* thisx, PlayState* play) {
     Collider_InitCylinder(play, &this->bodyCollider);
     Collider_SetCylinderType1(play, &this->bodyCollider, &this->actor, &sCylinderInit);
     Collider_InitJntSph(play, &this->headCollider);
-    Collider_SetJntSph(play, &this->headCollider, &this->actor, &sJntSphInit, this->headElements);
+    Collider_SetJntSph(play, &this->headCollider, &this->actor, &sJntSphInit, this->headColliderElements);
     CollisionCheck_SetInfo(&this->actor.colChkInfo, NULL, &sColCheckInfoInit);
     this->unk_1F0 = 0;
     this->eyeTexIndex = 0;

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.h
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.h
@@ -20,7 +20,7 @@ typedef struct EnHorseLinkChild {
     /* 0x01F0 */ s32 unk_1F0;
     /* 0x01F4 */ ColliderCylinder bodyCollider;
     /* 0x0240 */ ColliderJntSph headCollider;
-    /* 0x0260 */ ColliderJntSphElement headElements[1];
+    /* 0x0260 */ ColliderJntSphElement headColliderElements[1];
     /* 0x02A0 */ s32 unk_2A0;
 } EnHorseLinkChild; // size = 0x02A4
 

--- a/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
+++ b/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.c
@@ -197,7 +197,7 @@ void EnHorseNormal_Init(Actor* thisx, PlayState* play) {
     Collider_InitCylinder(play, &this->bodyCollider);
     Collider_SetCylinder(play, &this->bodyCollider, &this->actor, &sCylinderInit1);
     Collider_InitJntSph(play, &this->headCollider);
-    Collider_SetJntSph(play, &this->headCollider, &this->actor, &sJntSphInit, this->headElements);
+    Collider_SetJntSph(play, &this->headCollider, &this->actor, &sJntSphInit, this->headColliderElements);
     Collider_InitCylinder(play, &this->cloneCollider);
     Collider_SetCylinder(play, &this->cloneCollider, &this->actor, &sCylinderInit2);
     CollisionCheck_SetInfo(&this->actor.colChkInfo, NULL, &sColChkInfoInit);

--- a/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.h
+++ b/src/overlays/actors/ovl_En_Horse_Normal/z_en_horse_normal.h
@@ -26,7 +26,7 @@ typedef struct EnHorseNormal {
     /* 0x0224 */ char unk_224[0x04];
     /* 0x0228 */ ColliderCylinder bodyCollider;
     /* 0x0274 */ ColliderJntSph headCollider;
-    /* 0x0294 */ ColliderJntSphElement headElements[1];
+    /* 0x0294 */ ColliderJntSphElement headColliderElements[1];
     /* 0x02D4 */ ColliderCylinder cloneCollider;
     /* 0x0320 */ char unk_320[0x04];
     /* 0x0324 */ s32 waypoint;

--- a/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
+++ b/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
@@ -163,8 +163,8 @@ void EnHorseZelda_Init(Actor* thisx, PlayState* play) {
     Animation_PlayOnce(&this->skin.skelAnime, sAnimationHeaders[0]);
     Collider_InitCylinder(play, &this->colliderCylinder);
     Collider_SetCylinderType1(play, &this->colliderCylinder, &this->actor, &sCylinderInit);
-    Collider_InitJntSph(play, &this->colliderSphere);
-    Collider_SetJntSph(play, &this->colliderSphere, &this->actor, &sJntSphInit, &this->colliderSphereItem);
+    Collider_InitJntSph(play, &this->colliderJntSph);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
     CollisionCheck_SetInfo(&this->actor.colChkInfo, NULL, &sColChkInfoInit);
     this->animationIndex = 0;
     EnHorseZelda_SetupStop(this);
@@ -174,7 +174,7 @@ void EnHorseZelda_Destroy(Actor* thisx, PlayState* play) {
     EnHorseZelda* this = (EnHorseZelda*)thisx;
 
     Collider_DestroyCylinder(play, &this->colliderCylinder);
-    Collider_DestroyJntSph(play, &this->colliderSphere);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
     Skin_Free(play, &this->skin);
 }
 
@@ -250,23 +250,23 @@ void EnHorseZelda_PostDraw(Actor* thisx, PlayState* play, Skin* skin) {
     EnHorseZelda* this = (EnHorseZelda*)thisx;
     s32 i;
 
-    for (i = 0; i < this->colliderSphere.count; i++) {
-        offset.x = this->colliderSphere.elements[i].dim.modelSphere.center.x;
-        offset.y = this->colliderSphere.elements[i].dim.modelSphere.center.y;
-        offset.z = this->colliderSphere.elements[i].dim.modelSphere.center.z;
+    for (i = 0; i < this->colliderJntSph.count; i++) {
+        offset.x = this->colliderJntSph.elements[i].dim.modelSphere.center.x;
+        offset.y = this->colliderJntSph.elements[i].dim.modelSphere.center.y;
+        offset.z = this->colliderJntSph.elements[i].dim.modelSphere.center.z;
 
-        Skin_GetLimbPos(skin, this->colliderSphere.elements[i].dim.limb, &offset, &dst);
+        Skin_GetLimbPos(skin, this->colliderJntSph.elements[i].dim.limb, &offset, &dst);
 
-        this->colliderSphere.elements[i].dim.worldSphere.center.x = dst.x;
-        this->colliderSphere.elements[i].dim.worldSphere.center.y = dst.y;
-        this->colliderSphere.elements[i].dim.worldSphere.center.z = dst.z;
+        this->colliderJntSph.elements[i].dim.worldSphere.center.x = dst.x;
+        this->colliderJntSph.elements[i].dim.worldSphere.center.y = dst.y;
+        this->colliderJntSph.elements[i].dim.worldSphere.center.z = dst.z;
 
-        this->colliderSphere.elements[i].dim.worldSphere.radius =
-            this->colliderSphere.elements[i].dim.modelSphere.radius * this->colliderSphere.elements[i].dim.scale;
+        this->colliderJntSph.elements[i].dim.worldSphere.radius =
+            this->colliderJntSph.elements[i].dim.modelSphere.radius * this->colliderJntSph.elements[i].dim.scale;
     }
 
     //! @bug see relevant comment in `EnHorse_SkinCallback1`
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderSphere.base);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
 }
 
 void EnHorseZelda_Draw(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.h
+++ b/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.h
@@ -19,8 +19,8 @@ typedef struct EnHorseZelda {
     /* 0x01F4 */ f32 floorYForwards;
     /* 0x01F8 */ char unk_1F8[0x4];
     /* 0x01FC */ ColliderCylinder colliderCylinder;
-    /* 0x0248 */ ColliderJntSph colliderSphere;
-    /* 0x0268 */ ColliderJntSphElement colliderSphereItem;
+    /* 0x0248 */ ColliderJntSph colliderJntSph;
+    /* 0x0268 */ ColliderJntSphElement colliderJntSphElements[1];
 } EnHorseZelda; // size = 0x02A8
 
 #endif

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -204,7 +204,7 @@ void EnInsect_Init(Actor* thisx, PlayState* play2) {
 
     SkelAnime_Init(play, &this->skelAnime, &gBugSkel, &gBugCrawlAnim, this->jointTable, this->morphTable, 24);
     Collider_InitJntSph(play, &this->collider);
-    Collider_SetJntSph(play, &this->collider, &this->actor, &sColliderInit, &this->colliderItem);
+    Collider_SetJntSph(play, &this->collider, &this->actor, &sColliderInit, this->colliderElements);
 
     this->actor.colChkInfo.mass = 30;
 

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.h
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.h
@@ -21,7 +21,7 @@ typedef void (*EnInsectActionFunc)(struct EnInsect*, struct PlayState*);
 typedef struct EnInsect {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ ColliderJntSph collider;
-    /* 0x016C */ ColliderJntSphElement colliderItem;
+    /* 0x016C */ ColliderJntSphElement colliderElements[1];
     /* 0x01AC */ SkelAnime skelAnime;
     /* 0x01F0 */ Vec3s jointTable[24];
     /* 0x0280 */ Vec3s morphTable[24];

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -218,12 +218,12 @@ void EnPeehat_Init(Actor* thisx, PlayState* play) {
     this->actor.colChkInfo.health = 6;
     this->actor.colChkInfo.damageTable = &sDamageTable;
     this->actor.floorHeight = this->actor.world.pos.y;
-    Collider_InitCylinder(play, &this->colCylinder);
-    Collider_SetCylinder(play, &this->colCylinder, &this->actor, &sCylinderInit);
-    Collider_InitQuad(play, &this->colQuad);
-    Collider_SetQuad(play, &this->colQuad, &this->actor, &sQuadInit);
-    Collider_InitJntSph(play, &this->colJntSph);
-    Collider_SetJntSph(play, &this->colJntSph, &this->actor, &sJntSphInit, this->colJntSphItemList);
+    Collider_InitCylinder(play, &this->colliderCylinder);
+    Collider_SetCylinder(play, &this->colliderCylinder, &this->actor, &sCylinderInit);
+    Collider_InitQuad(play, &this->colliderQuad);
+    Collider_SetQuad(play, &this->colliderQuad, &this->actor, &sQuadInit);
+    Collider_InitJntSph(play, &this->colliderJntSph);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
 
     this->actor.naviEnemyId = NAVI_ENEMY_PEAHAT;
     this->xzDistToRise = 740.0f;
@@ -245,12 +245,12 @@ void EnPeehat_Init(Actor* thisx, PlayState* play) {
         case PEAHAT_TYPE_LARVA:
             this->actor.scale.x = this->actor.scale.z = 0.006f;
             this->actor.scale.y = 0.003f;
-            this->colCylinder.dim.radius = 25;
-            this->colCylinder.dim.height = 15;
-            this->colCylinder.dim.yShift = -5;
-            this->colCylinder.elem.acDmgInfo.dmgFlags = DMG_ARROW | DMG_SLINGSHOT;
-            this->colQuad.base.atFlags = AT_ON | AT_TYPE_ENEMY;
-            this->colQuad.base.acFlags = AC_ON | AC_TYPE_PLAYER;
+            this->colliderCylinder.dim.radius = 25;
+            this->colliderCylinder.dim.height = 15;
+            this->colliderCylinder.dim.yShift = -5;
+            this->colliderCylinder.elem.acDmgInfo.dmgFlags = DMG_ARROW | DMG_SLINGSHOT;
+            this->colliderQuad.base.atFlags = AT_ON | AT_TYPE_ENEMY;
+            this->colliderQuad.base.acFlags = AC_ON | AC_TYPE_PLAYER;
             this->actor.naviEnemyId = NAVI_ENEMY_PEAHAT_LARVA;
             EnPeehat_Larva_SetStateSeekPlayer(this);
             break;
@@ -261,8 +261,8 @@ void EnPeehat_Destroy(Actor* thisx, PlayState* play) {
     EnPeehat* this = (EnPeehat*)thisx;
     EnPeehat* parent;
 
-    Collider_DestroyCylinder(play, &this->colCylinder);
-    Collider_DestroyJntSph(play, &this->colJntSph);
+    Collider_DestroyCylinder(play, &this->colliderCylinder);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
 
     // If PEAHAT_TYPE_LARVA, decrement total larva spawned
     if (this->actor.params > 0) {
@@ -295,7 +295,7 @@ void EnPeehat_SpawnDust(PlayState* play, EnPeehat* this, Vec3f* pos, f32 arg3, s
  * Handles being hit when on the ground
  */
 void EnPeehat_HitWhenGrounded(EnPeehat* this, PlayState* play) {
-    this->colCylinder.base.acFlags &= ~AC_HIT;
+    this->colliderCylinder.base.acFlags &= ~AC_HIT;
     if ((play->gameplayFrames & 0xF) == 0) {
         Vec3f itemDropPos = this->actor.world.pos;
 
@@ -307,7 +307,7 @@ void EnPeehat_HitWhenGrounded(EnPeehat* this, PlayState* play) {
     } else {
         s32 i;
 
-        this->colCylinder.base.acFlags &= ~AC_HIT;
+        this->colliderCylinder.base.acFlags &= ~AC_HIT;
         for (i = MAX_LARVA - this->unk_2FA; i > 0; i--) {
             Actor* larva =
                 Actor_SpawnAsChild(&play->actorCtx, &this->actor, play, ACTOR_EN_PEEHAT,
@@ -333,7 +333,7 @@ void EnPeehat_Ground_SetStateGround(EnPeehat* this) {
     this->unk_2D4 = 0;
     this->unk_2FA = 0;
     this->state = PEAHAT_STATE_3;
-    this->colCylinder.base.acFlags &= ~AC_HIT;
+    this->colliderCylinder.base.acFlags &= ~AC_HIT;
     EnPeehat_SetupAction(this, EnPeehat_Ground_StateGround);
 }
 
@@ -358,7 +358,7 @@ void EnPeehat_Ground_StateGround(EnPeehat* this, PlayState* play) {
             } else {
                 Math_SmoothStepToF(&this->scaleShift, 0.0f, 1.0f, 0.005f, 0.0f);
             }
-        } else if (this->colCylinder.base.acFlags & AC_HIT) {
+        } else if (this->colliderCylinder.base.acFlags & AC_HIT) {
             EnPeehat_HitWhenGrounded(this, play);
         }
     }
@@ -388,7 +388,7 @@ void EnPeehat_Flying_StateGrounded(EnPeehat* this, PlayState* play) {
             } else {
                 Math_SmoothStepToF(&this->scaleShift, 0.0f, 1.0f, 0.005f, 0.0f);
             }
-        } else if (this->colCylinder.base.acFlags & AC_HIT) {
+        } else if (this->colliderCylinder.base.acFlags & AC_HIT) {
             EnPeehat_HitWhenGrounded(this, play);
         }
     }
@@ -575,22 +575,22 @@ void EnPeehat_Larva_StateSeekPlayer(EnPeehat* this, PlayState* play) {
     this->bladeRot += this->bladeRotVel;
     Math_SmoothStepToF(&this->scaleShift, 0.075f, 1.0f, 0.005f, 0.0f);
     Actor_PlaySfx(&this->actor, NA_SE_EN_PIHAT_SM_FLY - SFX_FLAG);
-    if (this->colQuad.base.atFlags & AT_BOUNCED) {
+    if (this->colliderQuad.base.atFlags & AT_BOUNCED) {
         this->actor.colChkInfo.health = 0;
-        this->colQuad.base.acFlags &= ~AC_BOUNCED;
+        this->colliderQuad.base.acFlags &= ~AC_BOUNCED;
         EnPeehat_SetStateAttackRecoil(this);
-    } else if ((this->colQuad.base.atFlags & AT_HIT) || (this->colCylinder.base.acFlags & AC_HIT) ||
+    } else if ((this->colliderQuad.base.atFlags & AT_HIT) || (this->colliderCylinder.base.acFlags & AC_HIT) ||
                (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         Player* player = GET_PLAYER(play);
-        this->colQuad.base.atFlags &= ~AT_HIT;
-        if (!(this->colCylinder.base.acFlags & AC_HIT) && &player->actor == this->colQuad.base.at) {
+        this->colliderQuad.base.atFlags &= ~AT_HIT;
+        if (!(this->colliderCylinder.base.acFlags & AC_HIT) && &player->actor == this->colliderQuad.base.at) {
             if (Rand_ZeroOne() > 0.5f) {
                 this->actor.world.rot.y += 0x2000;
             } else {
                 this->actor.world.rot.y -= 0x2000;
             }
             this->unk_2D4 = 40;
-        } else if (this->colCylinder.base.acFlags & AC_HIT || this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
+        } else if (this->colliderCylinder.base.acFlags & AC_HIT || this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
             Vec3f zeroVec = { 0, 0, 0 };
             s32 i;
             for (i = 4; i >= 0; i--) {
@@ -601,7 +601,7 @@ void EnPeehat_Larva_StateSeekPlayer(EnPeehat* this, PlayState* play) {
                 EffectSsDeadDb_Spawn(play, &pos, &zeroVec, &zeroVec, 40, 7, 255, 255, 255, 255, 255, 0, 0, 1, 9, 1);
             }
         }
-        if (&player->actor != this->colQuad.base.at || this->colCylinder.base.acFlags & AC_HIT) {
+        if (&player->actor != this->colliderQuad.base.at || this->colliderCylinder.base.acFlags & AC_HIT) {
             if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
                 EffectSsDeadSound_SpawnStationary(play, &this->actor.projectedPos, NA_SE_EN_PIHAT_SM_DEAD, 1, 1, 40);
             }
@@ -894,13 +894,13 @@ void EnPeehat_StateExplode(EnPeehat* this, PlayState* play) {
 }
 
 void EnPeehat_Adult_CollisionCheck(EnPeehat* this, PlayState* play) {
-    if ((this->colCylinder.base.acFlags & AC_BOUNCED) || (this->colQuad.base.acFlags & AC_BOUNCED)) {
-        this->colQuad.base.acFlags &= ~AC_BOUNCED;
-        this->colCylinder.base.acFlags &= ~AC_BOUNCED;
-        this->colJntSph.base.acFlags &= ~AC_HIT;
-    } else if (this->colJntSph.base.acFlags & AC_HIT) {
-        this->colJntSph.base.acFlags &= ~AC_HIT;
-        Actor_SetDropFlagJntSph(&this->actor, &this->colJntSph, true);
+    if ((this->colliderCylinder.base.acFlags & AC_BOUNCED) || (this->colliderQuad.base.acFlags & AC_BOUNCED)) {
+        this->colliderQuad.base.acFlags &= ~AC_BOUNCED;
+        this->colliderCylinder.base.acFlags &= ~AC_BOUNCED;
+        this->colliderJntSph.base.acFlags &= ~AC_HIT;
+    } else if (this->colliderJntSph.base.acFlags & AC_HIT) {
+        this->colliderJntSph.base.acFlags &= ~AC_HIT;
+        Actor_SetDropFlagJntSph(&this->actor, &this->colliderJntSph, true);
         if (this->actor.colChkInfo.damageEffect == PEAHAT_DMG_EFF_NUT ||
             this->actor.colChkInfo.damageEffect == PEAHAT_DMG_EFF_LIGHT_ICE_ARROW) {
             return;
@@ -963,9 +963,9 @@ void EnPeehat_Update(Actor* thisx, PlayState* play) {
     // if PEAHAT_TYPE_GROUNDED
     if (thisx->params < 0) {
         // Set the Z-Target point on the Peahat's weak point
-        thisx->focus.pos.x = this->colJntSph.elements[0].dim.worldSphere.center.x;
-        thisx->focus.pos.y = this->colJntSph.elements[0].dim.worldSphere.center.y;
-        thisx->focus.pos.z = this->colJntSph.elements[0].dim.worldSphere.center.z;
+        thisx->focus.pos.x = this->colliderJntSph.elements[0].dim.worldSphere.center.x;
+        thisx->focus.pos.y = this->colliderJntSph.elements[0].dim.worldSphere.center.y;
+        thisx->focus.pos.z = this->colliderJntSph.elements[0].dim.worldSphere.center.z;
         if (this->state == PEAHAT_STATE_SEEK_PLAYER) {
             Math_SmoothStepToS(&thisx->shape.rot.x, 6000, 1, 300, 0);
         } else {
@@ -974,21 +974,21 @@ void EnPeehat_Update(Actor* thisx, PlayState* play) {
     } else {
         thisx->focus.pos = thisx->world.pos;
     }
-    Collider_UpdateCylinder(thisx, &this->colCylinder);
+    Collider_UpdateCylinder(thisx, &this->colliderCylinder);
     if (thisx->colChkInfo.health > 0) {
         // If Adult Peahat
         if (thisx->params <= 0) {
-            CollisionCheck_SetOC(play, &play->colChkCtx, &this->colCylinder.base);
-            CollisionCheck_SetOC(play, &play->colChkCtx, &this->colJntSph.base);
+            CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder.base);
+            CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
             if (thisx->colorFilterTimer == 0 || !(thisx->colorFilterParams & 0x4000)) {
                 if (this->state != PEAHAT_STATE_EXPLODE) {
-                    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colJntSph.base);
+                    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
                 }
             }
         }
-        if (thisx->params != PEAHAT_TYPE_FLYING && this->colQuad.base.atFlags & AT_HIT) {
-            this->colQuad.base.atFlags &= ~AT_HIT;
-            if (&player->actor == this->colQuad.base.at) {
+        if (thisx->params != PEAHAT_TYPE_FLYING && this->colliderQuad.base.atFlags & AT_HIT) {
+            this->colliderQuad.base.atFlags &= ~AT_HIT;
+            if (&player->actor == this->colliderQuad.base.at) {
                 EnPeehat_SetStateAttackRecoil(this);
             }
         }
@@ -996,8 +996,8 @@ void EnPeehat_Update(Actor* thisx, PlayState* play) {
     if (this->state == PEAHAT_STATE_15 || this->state == PEAHAT_STATE_SEEK_PLAYER || this->state == PEAHAT_STATE_FLY ||
         this->state == PEAHAT_STATE_RETURN_HOME || this->state == PEAHAT_STATE_EXPLODE) {
         if (thisx->params != PEAHAT_TYPE_FLYING) {
-            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colQuad.base);
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colQuad.base);
+            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderQuad.base);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderQuad.base);
         }
         // if PEAHAT_TYPE_GROUNDED
         if (thisx->params < 0 && (thisx->flags & ACTOR_FLAG_INSIDE_CULLING_VOLUME)) {
@@ -1012,10 +1012,10 @@ void EnPeehat_Update(Actor* thisx, PlayState* play) {
                 }
             }
         } else if (thisx->params != PEAHAT_TYPE_FLYING) {
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCylinder.base);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder.base);
         }
     } else {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCylinder.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder.base);
     }
     Math_SmoothStepToF(&this->scaleShift, 0.0f, 1.0f, 0.001f, 0.0f);
 }
@@ -1064,7 +1064,7 @@ void EnPeehat_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* r
         OPEN_DISPS(play->state.gfxCtx, "../z_en_peehat.c", 1981);
         Matrix_Push();
         Matrix_Translate(-1000.0f, 0.0f, 0.0f, MTXMODE_APPLY);
-        Collider_UpdateSpheres(0, &this->colJntSph);
+        Collider_UpdateSpheres(0, &this->colliderJntSph);
         Matrix_Translate(500.0f, 0.0f, 0.0f, MTXMODE_APPLY);
         if (this->actor.colorFilterTimer != 0 && (this->actor.colorFilterParams & 0x4000)) {
             damageYRot = Math_SinS(this->actor.colorFilterTimer * 0x4E20) * 0.35f;
@@ -1088,11 +1088,11 @@ void EnPeehat_Draw(Actor* thisx, PlayState* play) {
     SkelAnime_DrawOpa(play, this->skelAnime.skeleton, this->skelAnime.jointTable, EnPeehat_OverrideLimbDraw,
                       EnPeehat_PostLimbDraw, this);
     if (this->actor.speed != 0.0f || this->actor.velocity.y != 0.0f) {
-        Matrix_MultVec3f(&D_80AD285C[0], &this->colQuad.dim.quad[1]);
-        Matrix_MultVec3f(&D_80AD285C[1], &this->colQuad.dim.quad[0]);
-        Matrix_MultVec3f(&D_80AD285C[2], &this->colQuad.dim.quad[3]);
-        Matrix_MultVec3f(&D_80AD285C[3], &this->colQuad.dim.quad[2]);
-        Collider_SetQuadVertices(&this->colQuad, &this->colQuad.dim.quad[0], &this->colQuad.dim.quad[1],
-                                 &this->colQuad.dim.quad[2], &this->colQuad.dim.quad[3]);
+        Matrix_MultVec3f(&D_80AD285C[0], &this->colliderQuad.dim.quad[1]);
+        Matrix_MultVec3f(&D_80AD285C[1], &this->colliderQuad.dim.quad[0]);
+        Matrix_MultVec3f(&D_80AD285C[2], &this->colliderQuad.dim.quad[3]);
+        Matrix_MultVec3f(&D_80AD285C[3], &this->colliderQuad.dim.quad[2]);
+        Collider_SetQuadVertices(&this->colliderQuad, &this->colliderQuad.dim.quad[0], &this->colliderQuad.dim.quad[1],
+                                 &this->colliderQuad.dim.quad[2], &this->colliderQuad.dim.quad[3]);
     }
 }

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
@@ -38,10 +38,10 @@ typedef struct EnPeehat {
     /* 0x02FA */ s16 unk_2FA;          // larva count (PEAHAT_TYPE_FLYING, PEAHAT_TYPE_GROUNDED),
                                       // shape rotation direction (PEAHAT_TYPE_GROUNDED)
     /* 0x02FC */ s16 animTimer;
-    /* 0x0300 */ ColliderCylinder colCylinder;
-    /* 0x034C */ ColliderJntSph colJntSph;
-    /* 0x036C */ ColliderJntSphElement colJntSphItemList[1];
-    /* 0x03AC */ ColliderQuad colQuad;
+    /* 0x0300 */ ColliderCylinder colliderCylinder;
+    /* 0x034C */ ColliderJntSph colliderJntSph;
+    /* 0x036C */ ColliderJntSphElement colliderJntSphElements[1];
+    /* 0x03AC */ ColliderQuad colliderQuad;
 } EnPeehat; // size = 0x042C
 
 #endif

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -205,14 +205,14 @@ void EnPoh_Init(Actor* thisx, PlayState* play) {
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 30.0f);
-    Collider_InitJntSph(play, &this->colliderSph);
-    Collider_SetJntSph(play, &this->colliderSph, &this->actor, &sJntSphInit, &this->colliderSphItem);
-    this->colliderSph.elements[0].dim.worldSphere.radius = 0;
-    this->colliderSph.elements[0].dim.worldSphere.center.x = this->actor.world.pos.x;
-    this->colliderSph.elements[0].dim.worldSphere.center.y = this->actor.world.pos.y;
-    this->colliderSph.elements[0].dim.worldSphere.center.z = this->actor.world.pos.z;
-    Collider_InitCylinder(play, &this->colliderCyl);
-    Collider_SetCylinder(play, &this->colliderCyl, &this->actor, &sCylinderInit);
+    Collider_InitJntSph(play, &this->colliderJntSph);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
+    this->colliderJntSph.elements[0].dim.worldSphere.radius = 0;
+    this->colliderJntSph.elements[0].dim.worldSphere.center.x = this->actor.world.pos.x;
+    this->colliderJntSph.elements[0].dim.worldSphere.center.y = this->actor.world.pos.y;
+    this->colliderJntSph.elements[0].dim.worldSphere.center.z = this->actor.world.pos.z;
+    Collider_InitCylinder(play, &this->colliderCylinder);
+    Collider_SetCylinder(play, &this->colliderCylinder, &this->actor, &sCylinderInit);
     CollisionCheck_SetInfo(&this->actor.colChkInfo, &sDamageTable, &sColChkInfoInit);
     this->unk_194 = 0;
     this->unk_195 = 32;
@@ -265,8 +265,8 @@ void EnPoh_Destroy(Actor* thisx, PlayState* play) {
     EnPoh* this = (EnPoh*)thisx;
 
     LightContext_RemoveLight(play, &play->lightCtx, this->lightNode);
-    Collider_DestroyJntSph(play, &this->colliderSph);
-    Collider_DestroyCylinder(play, &this->colliderCyl);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
+    Collider_DestroyCylinder(play, &this->colliderCylinder);
     if (this->actor.params == EN_POH_RUPEE) {
         D_80AE1A50--;
     }
@@ -310,12 +310,12 @@ void func_80ADE28C(EnPoh* this) {
     } else {
         Animation_PlayOnce(&this->skelAnime, &gPoeComposerDamagedAnim);
     }
-    if (this->colliderCyl.elem.acHitElem->atDmgInfo.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
-        this->actor.world.rot.y = this->colliderCyl.base.ac->world.rot.y;
+    if (this->colliderCylinder.elem.acHitElem->atDmgInfo.dmgFlags & (DMG_ARROW | DMG_SLINGSHOT)) {
+        this->actor.world.rot.y = this->colliderCylinder.base.ac->world.rot.y;
     } else {
-        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->colliderCyl.base.ac) + 0x8000;
+        this->actor.world.rot.y = Actor_WorldYawTowardActor(&this->actor, this->colliderCylinder.base.ac) + 0x8000;
     }
-    this->colliderCyl.base.acFlags &= ~AC_ON;
+    this->colliderCylinder.base.acFlags &= ~AC_ON;
     this->actor.speed = 5.0f;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 16);
     this->actionFunc = func_80ADEECC;
@@ -325,7 +325,7 @@ void func_80ADE368(EnPoh* this) {
     Animation_MorphToLoop(&this->skelAnime, this->info->fleeAnim, -5.0f);
     this->actor.speed = 5.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y + 0x8000;
-    this->colliderCyl.base.acFlags |= AC_ON;
+    this->colliderCylinder.base.acFlags |= AC_ON;
     this->unk_198 = 200;
     this->actionFunc = func_80ADF894;
 }
@@ -429,13 +429,13 @@ void func_80ADE6D4(EnPoh* this) {
 void EnPoh_Talk(EnPoh* this, PlayState* play) {
     this->actor.home.pos.y = this->actor.world.pos.y;
     Actor_SetFocus(&this->actor, -10.0f);
-    this->colliderCyl.dim.radius = 13;
-    this->colliderCyl.dim.height = 30;
-    this->colliderCyl.dim.yShift = 0;
-    this->colliderCyl.dim.pos.x = this->actor.world.pos.x;
-    this->colliderCyl.dim.pos.y = this->actor.world.pos.y - 20.0f;
-    this->colliderCyl.dim.pos.z = this->actor.world.pos.z;
-    this->colliderCyl.base.ocFlags1 = OC1_ON | OC1_TYPE_PLAYER;
+    this->colliderCylinder.dim.radius = 13;
+    this->colliderCylinder.dim.height = 30;
+    this->colliderCylinder.dim.yShift = 0;
+    this->colliderCylinder.dim.pos.x = this->actor.world.pos.x;
+    this->colliderCylinder.dim.pos.y = this->actor.world.pos.y - 20.0f;
+    this->colliderCylinder.dim.pos.z = this->actor.world.pos.z;
+    this->colliderCylinder.base.ocFlags1 = OC1_ON | OC1_TYPE_PLAYER;
     if (this->actor.params == EN_POH_FLAT || this->actor.params == EN_POH_SHARP) {
         if (CHECK_QUEST_ITEM(QUEST_SONG_SUN)) {
             this->actor.textId = 0x5000;
@@ -793,12 +793,12 @@ void func_80ADFE80(EnPoh* this, PlayState* play) {
         this->actor.flags &= ~ACTOR_FLAG_TALK_OFFER_AUTO_ACCEPTED;
         return;
     }
-    if (this->colliderCyl.base.ocFlags1 & OC1_HIT) {
+    if (this->colliderCylinder.base.ocFlags1 & OC1_HIT) {
         this->actor.flags |= ACTOR_FLAG_TALK_OFFER_AUTO_ACCEPTED;
         Actor_OfferTalkNearColChkInfoCylinder(&this->actor, play);
     } else {
         this->actor.flags &= ~ACTOR_FLAG_TALK_OFFER_AUTO_ACCEPTED;
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCyl.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder.base);
     }
     this->actor.world.pos.y = Math_SinS(this->unk_195 * 0x800) * 5.0f + this->actor.home.pos.y;
     if (this->unk_195 != 0) {
@@ -807,7 +807,7 @@ void func_80ADFE80(EnPoh* this, PlayState* play) {
     if (this->unk_195 == 0) {
         this->unk_195 = 32;
     }
-    this->colliderCyl.dim.pos.y = this->actor.world.pos.y - 20.0f;
+    this->colliderCylinder.dim.pos.y = this->actor.world.pos.y - 20.0f;
     Actor_SetFocus(&this->actor, -10.0f);
     Lights_PointNoGlowSetInfo(&this->lightInfo, this->actor.world.pos.x, this->actor.world.pos.y,
                               this->actor.world.pos.z, this->info->lightColor.r, this->info->lightColor.g,
@@ -879,8 +879,8 @@ void EnPoh_TalkComposer(EnPoh* this, PlayState* play) {
 }
 
 void func_80AE032C(EnPoh* this, PlayState* play) {
-    if (this->colliderCyl.base.acFlags & AC_HIT) {
-        this->colliderCyl.base.acFlags &= ~AC_HIT;
+    if (this->colliderCylinder.base.acFlags & AC_HIT) {
+        this->colliderCylinder.base.acFlags &= ~AC_HIT;
         if (this->actor.colChkInfo.damageEffect != 0 || this->actor.colChkInfo.damage != 0) {
             if (Actor_ApplyDamage(&this->actor) == 0) {
                 Enemy_StartFinishingBlow(play, &this->actor);
@@ -934,12 +934,12 @@ void EnPoh_Update(Actor* thisx, PlayState* play) {
             SkelAnime_InitFlex(play, &this->skelAnime, &gPoeComposerSkel, &gPoeComposerFloatAnim, this->jointTable,
                                this->morphTable, 12);
             this->actor.draw = EnPoh_DrawComposer;
-            this->colliderSph.elements[0].dim.limb = 9;
-            this->colliderSph.elements[0].dim.modelSphere.center.y *= -1;
+            this->colliderJntSph.elements[0].dim.limb = 9;
+            this->colliderJntSph.elements[0].dim.modelSphere.center.y *= -1;
             this->actor.shape.rot.y = this->actor.world.rot.y = -0x4000;
-            this->colliderCyl.dim.radius = 20;
-            this->colliderCyl.dim.height = 55;
-            this->colliderCyl.dim.yShift = 15;
+            this->colliderCylinder.dim.radius = 20;
+            this->colliderCylinder.dim.height = 55;
+            this->colliderCylinder.dim.yShift = 15;
         }
         this->actor.flags &= ~ACTOR_FLAG_UPDATE_CULLING_DISABLED;
         EnPoh_SetupInitialAction(this);
@@ -1004,8 +1004,8 @@ void EnPoh_UpdateLiving(Actor* thisx, PlayState* play) {
     Vec3f checkPos;
     s32 bgId;
 
-    if (this->colliderSph.base.atFlags & AT_HIT) {
-        this->colliderSph.base.atFlags &= ~AT_HIT;
+    if (this->colliderJntSph.base.atFlags & AT_HIT) {
+        this->colliderJntSph.base.atFlags &= ~AT_HIT;
         func_80ADE4C8(this);
     }
     func_80AE032C(this, play);
@@ -1014,14 +1014,14 @@ void EnPoh_UpdateLiving(Actor* thisx, PlayState* play) {
     Actor_MoveXZGravity(&this->actor);
     if (this->actionFunc == EnPoh_Attack && this->unk_198 < 10) {
         this->actor.flags |= ACTOR_FLAG_SFX_FOR_PLAYER_BODY_HIT;
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderSph.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderJntSph.base);
     }
-    Collider_UpdateCylinder(&this->actor, &this->colliderCyl);
-    if ((this->colliderCyl.base.acFlags & AC_ON) && this->lightColor.a == 255) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCyl.base);
+    Collider_UpdateCylinder(&this->actor, &this->colliderCylinder);
+    if ((this->colliderCylinder.base.acFlags & AC_ON) && this->lightColor.a == 255) {
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder.base);
     }
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCyl.base);
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderSph.base);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder.base);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
     Actor_SetFocus(&this->actor, 42.0f);
     if (this->actionFunc != func_80ADEECC && this->actionFunc != func_80ADF574) {
         if (this->actionFunc == func_80ADF894) {
@@ -1060,7 +1060,7 @@ s32 EnPoh_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* p
 void EnPoh_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx, Gfx** gfxP) {
     EnPoh* this = (EnPoh*)thisx;
 
-    Collider_UpdateSpheres(limbIndex, &this->colliderSph);
+    Collider_UpdateSpheres(limbIndex, &this->colliderJntSph);
     if (this->actionFunc == func_80ADF15C && this->unk_198 >= 2 && limbIndex == this->info->unk_7) {
         MATRIX_FINALIZE_AND_LOAD((*gfxP)++, play->state.gfxCtx, "../z_en_poh.c", 2460);
         gSPDisplayList((*gfxP)++, this->info->burnDisplayList);
@@ -1076,9 +1076,9 @@ void EnPoh_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot,
             this->actor.world.pos.y = this->unk_368.yw;
             this->actor.world.pos.z = this->unk_368.zw;
         }
-        Lights_PointGlowSetInfo(&this->lightInfo, this->colliderSph.elements[0].dim.worldSphere.center.x,
-                                this->colliderSph.elements[0].dim.worldSphere.center.y,
-                                this->colliderSph.elements[0].dim.worldSphere.center.z, this->envColor.r,
+        Lights_PointGlowSetInfo(&this->lightInfo, this->colliderJntSph.elements[0].dim.worldSphere.center.x,
+                                this->colliderJntSph.elements[0].dim.worldSphere.center.y,
+                                this->colliderJntSph.elements[0].dim.worldSphere.center.z, this->envColor.r,
                                 this->envColor.g, this->envColor.b, this->envColor.a * (200.0f / 255));
     }
 }

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.h
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.h
@@ -54,9 +54,9 @@ typedef struct EnPoh {
     /* 0x02A4 */ EnPohInfo* info;
     /* 0x02A8 */ LightNode* lightNode;
     /* 0x02AC */ LightInfo lightInfo;
-    /* 0x02BC */ ColliderCylinder colliderCyl;
-    /* 0x0308 */ ColliderJntSph colliderSph;
-    /* 0x0328 */ ColliderJntSphElement colliderSphItem;
+    /* 0x02BC */ ColliderCylinder colliderCylinder;
+    /* 0x0308 */ ColliderJntSph colliderJntSph;
+    /* 0x0328 */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x0368 */ MtxF unk_368;
 } EnPoh; // size = 0x03A8
 

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -198,25 +198,25 @@ void EnSsh_InitColliders(EnSsh* this, PlayState* play) {
     s32 pad;
 
     for (i = 0; i < ARRAY_COUNT(cylinders); i++) {
-        Collider_InitCylinder(play, &this->colCylinder[i]);
-        Collider_SetCylinder(play, &this->colCylinder[i], &this->actor, cylinders[i]);
+        Collider_InitCylinder(play, &this->collidersCylinder[i]);
+        Collider_SetCylinder(play, &this->collidersCylinder[i], &this->actor, cylinders[i]);
     }
 
-    this->colCylinder[0].elem.acDmgInfo.dmgFlags =
+    this->collidersCylinder[0].elem.acDmgInfo.dmgFlags =
         DMG_ARROW | DMG_MAGIC_FIRE | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_EXPLOSIVE | DMG_DEKU_NUT;
-    this->colCylinder[1].elem.acDmgInfo.dmgFlags =
+    this->collidersCylinder[1].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT & ~(DMG_ARROW | DMG_MAGIC_FIRE | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_EXPLOSIVE | DMG_DEKU_NUT) &
         ~(DMG_MAGIC_LIGHT | DMG_MAGIC_ICE);
-    this->colCylinder[2].base.colMaterial = COL_MATERIAL_METAL;
-    this->colCylinder[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
-    this->colCylinder[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
-    this->colCylinder[2].elem.acDmgInfo.dmgFlags =
+    this->collidersCylinder[2].base.colMaterial = COL_MATERIAL_METAL;
+    this->collidersCylinder[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
+    this->collidersCylinder[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
+    this->collidersCylinder[2].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT & ~(DMG_ARROW | DMG_MAGIC_FIRE | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_EXPLOSIVE | DMG_DEKU_NUT);
 
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, DamageTable_Get(2), &sColChkInfoInit);
 
-    Collider_InitJntSph(play, &this->colSph);
-    Collider_SetJntSph(play, &this->colSph, &this->actor, &sJntSphInit, this->colSphElements);
+    Collider_InitJntSph(play, &this->colJntSph);
+    Collider_SetJntSph(play, &this->colJntSph, &this->actor, &sJntSphInit, this->colJntSphElements);
 }
 
 f32 EnSsh_SetAnimation(EnSsh* this, s32 animIndex) {
@@ -270,21 +270,21 @@ void EnSsh_SetColliderScale(EnSsh* this, f32 scale, f32 radiusMod) {
     f32 yShift;
     s32 i;
 
-    radius = this->colSph.elements[0].dim.modelSphere.radius;
+    radius = this->colJntSph.elements[0].dim.modelSphere.radius;
     radius *= scale;
-    this->colSph.elements[0].dim.modelSphere.radius = radius;
+    this->colJntSph.elements[0].dim.modelSphere.radius = radius;
 
     for (i = 0; i < 6; i++) {
-        yShift = this->colCylinder[i].dim.yShift;
-        radius = this->colCylinder[i].dim.radius;
-        height = this->colCylinder[i].dim.height;
+        yShift = this->collidersCylinder[i].dim.yShift;
+        radius = this->collidersCylinder[i].dim.radius;
+        height = this->collidersCylinder[i].dim.height;
         yShift *= scale;
         radius *= scale * radiusMod;
         height *= scale;
 
-        this->colCylinder[i].dim.yShift = yShift;
-        this->colCylinder[i].dim.radius = radius;
-        this->colCylinder[i].dim.height = height;
+        this->collidersCylinder[i].dim.yShift = yShift;
+        this->collidersCylinder[i].dim.radius = radius;
+        this->collidersCylinder[i].dim.height = height;
     }
     Actor_SetScale(&this->actor, 0.04f * scale);
     this->floorHeightOffset = 40.0f * scale;
@@ -436,17 +436,17 @@ void EnSsh_Sway(EnSsh* this) {
 }
 
 void EnSsh_CheckBodyStickHit(EnSsh* this, PlayState* play) {
-    ColliderElement* elem = &this->colCylinder[0].elem;
+    ColliderElement* elem = &this->collidersCylinder[0].elem;
     Player* player = GET_PLAYER(play);
 
     if (player->unk_860 != 0) {
         elem->acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->colCylinder[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->colCylinder[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->collidersCylinder[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->collidersCylinder[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
     } else {
         elem->acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->colCylinder[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->colCylinder[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->collidersCylinder[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->collidersCylinder[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
     }
 }
 
@@ -458,8 +458,8 @@ s32 EnSsh_CheckHitPlayer(EnSsh* this, PlayState* play) {
         return false;
     }
     for (i = 0; i < 3; i++) {
-        if (this->colCylinder[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) {
-            this->colCylinder[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
+        if (this->collidersCylinder[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) {
+            this->collidersCylinder[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
             hit = true;
         }
     }
@@ -481,13 +481,13 @@ s32 EnSsh_CheckHitPlayer(EnSsh* this, PlayState* play) {
 s32 EnSsh_CheckHitFront(EnSsh* this) {
     u32 acFlags;
 
-    if (this->colCylinder[2].base.acFlags) {} // Needed for matching
-    acFlags = this->colCylinder[2].base.acFlags;
+    if (this->collidersCylinder[2].base.acFlags) {} // Needed for matching
+    acFlags = this->collidersCylinder[2].base.acFlags;
 
     if (!!(acFlags & AC_HIT) == 0) {
         return 0;
     } else {
-        this->colCylinder[2].base.acFlags &= ~AC_HIT;
+        this->collidersCylinder[2].base.acFlags &= ~AC_HIT;
         this->invincibilityTimer = 8;
         if ((this->swayTimer == 0) && (this->hitTimer == 0) && (this->stunTimer == 0)) {
             this->swayTimer = 60;
@@ -497,14 +497,14 @@ s32 EnSsh_CheckHitFront(EnSsh* this) {
 }
 
 s32 EnSsh_CheckHitBack(EnSsh* this, PlayState* play) {
-    ColliderCylinder* cyl = &this->colCylinder[0];
+    ColliderCylinder* cyl = &this->collidersCylinder[0];
     s32 hit = false;
 
     if (cyl->base.acFlags & AC_HIT) {
         cyl->base.acFlags &= ~AC_HIT;
         hit = true;
     }
-    cyl = &this->colCylinder[1];
+    cyl = &this->collidersCylinder[1];
     if (cyl->base.acFlags & AC_HIT) {
         cyl->base.acFlags &= ~AC_HIT;
         hit = true;
@@ -547,19 +547,19 @@ s32 EnSsh_CollisionCheck(EnSsh* this, PlayState* play) {
 }
 
 void EnSsh_SetBodyCylinderAC(EnSsh* this, PlayState* play) {
-    Collider_UpdateCylinder(&this->actor, &this->colCylinder[0]);
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCylinder[0].base);
+    Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[0]);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[0].base);
 }
 
 void EnSsh_SetLegsCylinderAC(EnSsh* this, PlayState* play) {
     s16 angleTowardsLink = ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y));
 
     if (angleTowardsLink < 90 * (0x10000 / 360)) {
-        Collider_UpdateCylinder(&this->actor, &this->colCylinder[2]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCylinder[2].base);
+        Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[2]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[2].base);
     } else {
-        Collider_UpdateCylinder(&this->actor, &this->colCylinder[1]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCylinder[1].base);
+        Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[1]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[1].base);
     }
 }
 
@@ -582,18 +582,18 @@ s32 EnSsh_SetCylinderOC(EnSsh* this, PlayState* play) {
         Matrix_RotateY(BINANG_TO_RAD_ALT(this->initialYaw), MTXMODE_APPLY);
         Matrix_MultVec3f(&cyloffsets[i], &cylPos);
         Matrix_Pop();
-        this->colCylinder[i + 3].dim.pos.x = cylPos.x;
-        this->colCylinder[i + 3].dim.pos.y = cylPos.y;
-        this->colCylinder[i + 3].dim.pos.z = cylPos.z;
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colCylinder[i + 3].base);
+        this->collidersCylinder[i + 3].dim.pos.x = cylPos.x;
+        this->collidersCylinder[i + 3].dim.pos.y = cylPos.y;
+        this->collidersCylinder[i + 3].dim.pos.z = cylPos.z;
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->collidersCylinder[i + 3].base);
     }
     return 1;
 }
 
 void EnSsh_SetColliders(EnSsh* this, PlayState* play) {
     if (this->actor.colChkInfo.health == 0) {
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colSph.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colSph.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colJntSph.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colJntSph.base);
     } else {
         if (this->hitTimer == 0) {
             EnSsh_SetCylinderOC(this, play);
@@ -645,9 +645,9 @@ void EnSsh_Destroy(Actor* thisx, PlayState* play) {
 
     Effect_Delete(play, this->blureIdx);
     for (i = 0; i < 6; i++) {
-        Collider_DestroyCylinder(play, &this->colCylinder[i]);
+        Collider_DestroyCylinder(play, &this->collidersCylinder[i]);
     }
-    Collider_DestroyJntSph(play, &this->colSph);
+    Collider_DestroyJntSph(play, &this->colJntSph);
 }
 
 void EnSsh_Wait(EnSsh* this, PlayState* play) {
@@ -869,7 +869,7 @@ s32 EnSsh_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* p
 void EnSsh_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx) {
     EnSsh* this = (EnSsh*)thisx;
 
-    Collider_UpdateSpheres(limbIndex, &this->colSph);
+    Collider_UpdateSpheres(limbIndex, &this->colJntSph);
 }
 
 void EnSsh_Draw(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -215,8 +215,8 @@ void EnSsh_InitColliders(EnSsh* this, PlayState* play) {
 
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, DamageTable_Get(2), &sColChkInfoInit);
 
-    Collider_InitJntSph(play, &this->colJntSph);
-    Collider_SetJntSph(play, &this->colJntSph, &this->actor, &sJntSphInit, this->colJntSphElements);
+    Collider_InitJntSph(play, &this->colliderJntSph);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
 }
 
 f32 EnSsh_SetAnimation(EnSsh* this, s32 animIndex) {
@@ -270,9 +270,9 @@ void EnSsh_SetColliderScale(EnSsh* this, f32 scale, f32 radiusMod) {
     f32 yShift;
     s32 i;
 
-    radius = this->colJntSph.elements[0].dim.modelSphere.radius;
+    radius = this->colliderJntSph.elements[0].dim.modelSphere.radius;
     radius *= scale;
-    this->colJntSph.elements[0].dim.modelSphere.radius = radius;
+    this->colliderJntSph.elements[0].dim.modelSphere.radius = radius;
 
     for (i = 0; i < 6; i++) {
         yShift = this->collidersCylinder[i].dim.yShift;
@@ -592,8 +592,8 @@ s32 EnSsh_SetCylinderOC(EnSsh* this, PlayState* play) {
 
 void EnSsh_SetColliders(EnSsh* this, PlayState* play) {
     if (this->actor.colChkInfo.health == 0) {
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colJntSph.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colJntSph.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderJntSph.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
     } else {
         if (this->hitTimer == 0) {
             EnSsh_SetCylinderOC(this, play);
@@ -647,7 +647,7 @@ void EnSsh_Destroy(Actor* thisx, PlayState* play) {
     for (i = 0; i < 6; i++) {
         Collider_DestroyCylinder(play, &this->collidersCylinder[i]);
     }
-    Collider_DestroyJntSph(play, &this->colJntSph);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
 }
 
 void EnSsh_Wait(EnSsh* this, PlayState* play) {
@@ -869,7 +869,7 @@ s32 EnSsh_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* p
 void EnSsh_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx) {
     EnSsh* this = (EnSsh*)thisx;
 
-    Collider_UpdateSpheres(limbIndex, &this->colJntSph);
+    Collider_UpdateSpheres(limbIndex, &this->colliderJntSph);
 }
 
 void EnSsh_Draw(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
@@ -14,9 +14,9 @@ typedef struct EnSsh {
     /* 0x0190 */ Vec3s jointTable[30];
     /* 0x0244 */ Vec3s morphTable[30];
     /* 0x02F8 */ EnSshActionFunc actionFunc;
-    /* 0x02FC */ ColliderCylinder colCylinder[6];
-    /* 0x04C4 */ ColliderJntSph colSph;
-    /* 0x04E4 */ ColliderJntSphElement colSphElements[1];
+    /* 0x02FC */ ColliderCylinder collidersCylinder[6];
+    /* 0x04C4 */ ColliderJntSph colliderJntSph;
+    /* 0x04E4 */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x0524 */ s16 initialYaw;
     /* 0x0526 */ s16 maxTurnRate;
     /* 0x0528 */ s16 unkTimer;

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -295,58 +295,58 @@ void EnSt_InitColliders(EnSt* this, PlayState* play) {
     s32 pad;
 
     for (i = 0; i < ARRAY_COUNT(cylinders); i++) {
-        Collider_InitCylinder(play, &this->colCylinder[i]);
-        Collider_SetCylinder(play, &this->colCylinder[i], &this->actor, cylinders[i]);
+        Collider_InitCylinder(play, &this->colliderCylinder[i]);
+        Collider_SetCylinder(play, &this->colliderCylinder[i], &this->actor, cylinders[i]);
     }
 
-    this->colCylinder[0].elem.acDmgInfo.dmgFlags =
+    this->colliderCylinder[0].elem.acDmgInfo.dmgFlags =
         DMG_MAGIC_FIRE | DMG_ARROW | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT;
-    this->colCylinder[1].elem.acDmgInfo.dmgFlags =
+    this->colliderCylinder[1].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT &
         ~(DMG_MAGIC_FIRE | DMG_ARROW | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT) &
         ~(DMG_MAGIC_LIGHT | DMG_MAGIC_ICE);
-    this->colCylinder[2].base.colMaterial = COL_MATERIAL_METAL;
-    this->colCylinder[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
-    this->colCylinder[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
-    this->colCylinder[2].elem.acDmgInfo.dmgFlags =
+    this->colliderCylinder[2].base.colMaterial = COL_MATERIAL_METAL;
+    this->colliderCylinder[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
+    this->colliderCylinder[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
+    this->colliderCylinder[2].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT &
         ~(DMG_MAGIC_FIRE | DMG_ARROW | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT);
 
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, DamageTable_Get(2), &sColChkInit);
 
-    Collider_InitJntSph(play, &this->colSph);
-    Collider_SetJntSph(play, &this->colSph, &this->actor, &sJntSphInit, this->colSphItems);
+    Collider_InitJntSph(play, &this->colliderJntSph);
+    Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
 }
 
 void EnSt_CheckBodyStickHit(EnSt* this, PlayState* play) {
-    ColliderElement* bodyElem = &this->colCylinder[0].elem;
+    ColliderElement* bodyElem = &this->colliderCylinder[0].elem;
     Player* player = GET_PLAYER(play);
 
     if (player->unk_860 != 0) {
         bodyElem->acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->colCylinder[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->colCylinder[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->colliderCylinder[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->colliderCylinder[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
     } else {
         bodyElem->acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->colCylinder[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->colCylinder[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->colliderCylinder[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->colliderCylinder[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
     }
 }
 
 void EnSt_SetBodyCylinderAC(EnSt* this, PlayState* play) {
-    Collider_UpdateCylinder(&this->actor, &this->colCylinder[0]);
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCylinder[0].base);
+    Collider_UpdateCylinder(&this->actor, &this->colliderCylinder[0]);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder[0].base);
 }
 
 void EnSt_SetLegsCylinderAC(EnSt* this, PlayState* play) {
     s16 angleTowardsLink = ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y));
 
     if (angleTowardsLink < 0x3FFC) {
-        Collider_UpdateCylinder(&this->actor, &this->colCylinder[2]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCylinder[2].base);
+        Collider_UpdateCylinder(&this->actor, &this->colliderCylinder[2]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder[2].base);
     } else {
-        Collider_UpdateCylinder(&this->actor, &this->colCylinder[1]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCylinder[1].base);
+        Collider_UpdateCylinder(&this->actor, &this->colliderCylinder[1]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder[1].base);
     }
 }
 
@@ -369,10 +369,10 @@ s32 EnSt_SetCylinderOC(EnSt* this, PlayState* play) {
         Matrix_RotateY(BINANG_TO_RAD_ALT(this->initialYaw), MTXMODE_APPLY);
         Matrix_MultVec3f(&cyloffsets[i], &cylPos);
         Matrix_Pop();
-        this->colCylinder[i + 3].dim.pos.x = cylPos.x;
-        this->colCylinder[i + 3].dim.pos.y = cylPos.y;
-        this->colCylinder[i + 3].dim.pos.z = cylPos.z;
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colCylinder[i + 3].base);
+        this->colliderCylinder[i + 3].dim.pos.x = cylPos.x;
+        this->colliderCylinder[i + 3].dim.pos.y = cylPos.y;
+        this->colliderCylinder[i + 3].dim.pos.z = cylPos.z;
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder[i + 3].base);
     }
 
     return true;
@@ -400,10 +400,10 @@ s32 EnSt_CheckHitPlayer(EnSt* this, PlayState* play) {
     s32 i;
 
     for (i = 0, hit = 0; i < 3; i++) {
-        if (((this->colCylinder[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) != 0) == 0) {
+        if (((this->colliderCylinder[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) != 0) == 0) {
             continue;
         }
-        this->colCylinder[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
+        this->colliderCylinder[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
         hit = true;
     }
 
@@ -423,13 +423,13 @@ s32 EnSt_CheckHitPlayer(EnSt* this, PlayState* play) {
 }
 
 s32 EnSt_CheckHitFrontside(EnSt* this) {
-    u8 acFlags = this->colCylinder[2].base.acFlags;
+    u8 acFlags = this->colliderCylinder[2].base.acFlags;
 
     if (!!(acFlags & AC_HIT) == 0) {
         // not hit
         return false;
     } else {
-        this->colCylinder[2].base.acFlags &= ~AC_HIT;
+        this->colliderCylinder[2].base.acFlags &= ~AC_HIT;
         this->invulnerableTimer = 8;
         this->playSwayFlag = 0;
         this->swayTimer = 60;
@@ -438,7 +438,7 @@ s32 EnSt_CheckHitFrontside(EnSt* this) {
 }
 
 s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
-    ColliderCylinder* cyl = &this->colCylinder[0];
+    ColliderCylinder* cyl = &this->colliderCylinder[0];
     s32 flags = 0; // damage flags from colliders 0 and 1
     s32 hit = false;
 
@@ -448,7 +448,7 @@ s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
         flags |= cyl->elem.acHitElem->atDmgInfo.dmgFlags;
     }
 
-    cyl = &this->colCylinder[1];
+    cyl = &this->colliderCylinder[1];
     if (cyl->base.acFlags & AC_HIT) {
         cyl->base.acFlags &= ~AC_HIT;
         hit = true;
@@ -533,21 +533,21 @@ void EnSt_SetColliderScale(EnSt* this) {
         scaleAmount = 1.4f;
     }
 
-    radius = this->colSph.elements[0].dim.modelSphere.radius;
+    radius = this->colliderJntSph.elements[0].dim.modelSphere.radius;
     radius *= scaleAmount;
-    this->colSph.elements[0].dim.modelSphere.radius = radius;
+    this->colliderJntSph.elements[0].dim.modelSphere.radius = radius;
 
     for (i = 0; i < 6; i++) {
-        yShift = this->colCylinder[i].dim.yShift;
-        radius = this->colCylinder[i].dim.radius;
-        height = this->colCylinder[i].dim.height;
+        yShift = this->colliderCylinder[i].dim.yShift;
+        radius = this->colliderCylinder[i].dim.radius;
+        height = this->colliderCylinder[i].dim.height;
         yShift *= scaleAmount;
         radius *= scaleAmount;
         height *= scaleAmount;
 
-        this->colCylinder[i].dim.yShift = yShift;
-        this->colCylinder[i].dim.radius = radius;
-        this->colCylinder[i].dim.height = height;
+        this->colliderCylinder[i].dim.yShift = yShift;
+        this->colliderCylinder[i].dim.radius = radius;
+        this->colliderCylinder[i].dim.height = height;
     }
     Actor_SetScale(&this->actor, 0.04f * scaleAmount);
     this->colliderScale = scaleAmount;
@@ -828,9 +828,9 @@ void EnSt_Destroy(Actor* thisx, PlayState* play) {
 
     Effect_Delete(play, this->blureIdx);
     for (i = 0; i < 6; i++) {
-        Collider_DestroyCylinder(play, &this->colCylinder[i]);
+        Collider_DestroyCylinder(play, &this->colliderCylinder[i]);
     }
-    Collider_DestroyJntSph(play, &this->colSph);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
 }
 
 void EnSt_WaitOnCeiling(EnSt* this, PlayState* play) {
@@ -1097,7 +1097,7 @@ s32 EnSt_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dListP, Vec3f* p
 void EnSt_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dListP, Vec3s* rot, void* thisx) {
     EnSt* this = (EnSt*)thisx;
 
-    Collider_UpdateSpheres(limbIndex, &this->colSph);
+    Collider_UpdateSpheres(limbIndex, &this->colliderJntSph);
 }
 
 void EnSt_Draw(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_St/z_en_st.h
+++ b/src/overlays/actors/ovl_En_St/z_en_st.h
@@ -12,9 +12,9 @@ typedef struct EnSt {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ EnStActionFunc actionFunc;
-    /* 0x0194 */ ColliderCylinder colCylinder[6];
-    /* 0x035C */ ColliderJntSph colSph;
-    /* 0x037C */ ColliderJntSphElement colSphItems[1];
+    /* 0x0194 */ ColliderCylinder colliderCylinder[6];
+    /* 0x035C */ ColliderJntSph colliderJntSph;
+    /* 0x037C */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x03BC */ s16 initialYaw;
     /* 0x03BE */ s16 deathYawTarget;
     /* 0x03C0 */ s16 groundBounces;

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -205,7 +205,7 @@ void EnTite_Init(Actor* thisx, PlayState* play) {
     thisx->colChkInfo.health = 2;
     thisx->colChkInfo.mass = MASS_HEAVY;
     Collider_InitJntSph(play, &this->collider);
-    Collider_SetJntSph(play, &this->collider, thisx, &sJntSphInit, &this->colliderItem);
+    Collider_SetJntSph(play, &this->collider, thisx, &sJntSphInit, this->colliderElements);
     this->unk_2DC = UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2 | UPDBGCHECKINFO_FLAG_3 | UPDBGCHECKINFO_FLAG_4;
     if (this->actor.params == TEKTITE_BLUE) {
         this->unk_2DC |= UPDBGCHECKINFO_FLAG_6; // Don't use the actor engine's ripple spawning code

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.h
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.h
@@ -28,7 +28,7 @@ typedef struct EnTite {
     /* 0x02E3 */ u8 spawnIceTimer;
     /* 0x02E4 */ u8 damageEffect;
     /* 0x02E8 */ ColliderJntSph collider;
-    /* 0x0308 */ ColliderJntSphElement colliderItem;
+    /* 0x0308 */ ColliderJntSphElement colliderElements[1];
     /* 0x0348 */ Vec3f frontLeftFootPos;
     /* 0x0354 */ Vec3f frontRightFootPos;
     /* 0x0360 */ Vec3f backRightFootPos;

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -242,12 +242,12 @@ void EnWf_Init(Actor* thisx, PlayState* play) {
     this->eyeIndex = 0;
     this->unk_2F4 = 10.0f; // Set and not used
 
-    Collider_InitJntSph(play, &this->colliderSpheres);
-    Collider_SetJntSph(play, &this->colliderSpheres, thisx, &sJntSphInit, this->colliderSpheresElements);
-    Collider_InitCylinder(play, &this->colliderCylinderBody);
-    Collider_SetCylinder(play, &this->colliderCylinderBody, thisx, &sBodyCylinderInit);
-    Collider_InitCylinder(play, &this->colliderCylinderTail);
-    Collider_SetCylinder(play, &this->colliderCylinderTail, thisx, &sTailCylinderInit);
+    Collider_InitJntSph(play, &this->colliderJntSph);
+    Collider_SetJntSph(play, &this->colliderJntSph, thisx, &sJntSphInit, this->colliderJntSphElements);
+    Collider_InitCylinder(play, &this->bodyColliderCylinder);
+    Collider_SetCylinder(play, &this->bodyColliderCylinder, thisx, &sBodyCylinderInit);
+    Collider_InitCylinder(play, &this->tailColliderCylinder);
+    Collider_SetCylinder(play, &this->tailColliderCylinder, thisx, &sTailCylinderInit);
 
     if (thisx->params == WOLFOS_NORMAL) {
         SkelAnime_InitFlex(play, &this->skelAnime, &gWolfosNormalSkel, &gWolfosWaitingAnim, this->jointTable,
@@ -258,8 +258,8 @@ void EnWf_Init(Actor* thisx, PlayState* play) {
         SkelAnime_InitFlex(play, &this->skelAnime, &gWolfosWhiteSkel, &gWolfosWaitingAnim, this->jointTable,
                            this->morphTable, WOLFOS_LIMB_MAX);
         Actor_SetScale(thisx, 0.01f);
-        this->colliderSpheres.elements[0].base.atDmgInfo.damage =
-            this->colliderSpheres.elements[1].base.atDmgInfo.damage = 8;
+        this->colliderJntSph.elements[0].base.atDmgInfo.damage =
+            this->colliderJntSph.elements[1].base.atDmgInfo.damage = 8;
         thisx->naviEnemyId = NAVI_ENEMY_WHITE_WOLFOS;
     }
 
@@ -273,9 +273,9 @@ void EnWf_Init(Actor* thisx, PlayState* play) {
 void EnWf_Destroy(Actor* thisx, PlayState* play) {
     EnWf* this = (EnWf*)thisx;
 
-    Collider_DestroyJntSph(play, &this->colliderSpheres);
-    Collider_DestroyCylinder(play, &this->colliderCylinderBody);
-    Collider_DestroyCylinder(play, &this->colliderCylinderTail);
+    Collider_DestroyJntSph(play, &this->colliderJntSph);
+    Collider_DestroyCylinder(play, &this->bodyColliderCylinder);
+    Collider_DestroyCylinder(play, &this->tailColliderCylinder);
 
     if ((this->actor.params != WOLFOS_NORMAL) && (this->switchFlag != 0xFF)) {
         func_800F5B58();
@@ -733,7 +733,7 @@ void EnWf_RunAroundPlayer(EnWf* this, PlayState* play) {
 
 void EnWf_SetupSlash(EnWf* this) {
     Animation_PlayOnce(&this->skelAnime, &gWolfosSlashingAnim);
-    this->colliderSpheres.base.atFlags &= ~AT_BOUNCED;
+    this->colliderJntSph.base.atFlags &= ~AT_BOUNCED;
     this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
     this->action = WOLFOS_ACTION_SLASH;
     this->unk_2FA = 0; // Set and not used
@@ -1263,27 +1263,27 @@ void func_80B36F40(EnWf* this, PlayState* play) {
 }
 
 void EnWf_UpdateDamage(EnWf* this, PlayState* play) {
-    if (this->colliderSpheres.base.acFlags & AC_BOUNCED) {
-        this->colliderSpheres.base.acFlags &= ~(AC_HIT | AC_BOUNCED);
-        this->colliderCylinderBody.base.acFlags &= ~AC_HIT;
-        this->colliderCylinderTail.base.acFlags &= ~AC_HIT;
-    } else if ((this->colliderCylinderBody.base.acFlags & AC_HIT) ||
-               (this->colliderCylinderTail.base.acFlags & AC_HIT)) {
+    if (this->colliderJntSph.base.acFlags & AC_BOUNCED) {
+        this->colliderJntSph.base.acFlags &= ~(AC_HIT | AC_BOUNCED);
+        this->bodyColliderCylinder.base.acFlags &= ~AC_HIT;
+        this->tailColliderCylinder.base.acFlags &= ~AC_HIT;
+    } else if ((this->bodyColliderCylinder.base.acFlags & AC_HIT) ||
+               (this->tailColliderCylinder.base.acFlags & AC_HIT)) {
         if (this->action >= WOLFOS_ACTION_WAIT) {
             s16 yawDiff = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
 
-            if ((!(this->colliderCylinderBody.base.acFlags & AC_HIT) &&
-                 (this->colliderCylinderTail.base.acFlags & AC_HIT)) ||
+            if ((!(this->bodyColliderCylinder.base.acFlags & AC_HIT) &&
+                 (this->tailColliderCylinder.base.acFlags & AC_HIT)) ||
                 (ABS(yawDiff) > 19000)) {
                 this->actor.colChkInfo.damage *= 4;
             }
 
-            this->colliderCylinderBody.base.acFlags &= ~AC_HIT;
-            this->colliderCylinderTail.base.acFlags &= ~AC_HIT;
+            this->bodyColliderCylinder.base.acFlags &= ~AC_HIT;
+            this->tailColliderCylinder.base.acFlags &= ~AC_HIT;
 
             if (this->actor.colChkInfo.damageEffect != ENWF_DMGEFF_ICE_MAGIC) {
                 this->damageEffect = this->actor.colChkInfo.damageEffect;
-                Actor_SetDropFlag(&this->actor, &this->colliderCylinderBody.elem, true);
+                Actor_SetDropFlag(&this->actor, &this->bodyColliderCylinder.elem, true);
 #if OOT_VERSION >= PAL_1_0
                 this->slashStatus = 0;
 #endif
@@ -1337,23 +1337,23 @@ void EnWf_Update(Actor* thisx, PlayState* play) {
         Math_SmoothStepToS(&this->actor.shape.rot.z, 0, 1, 1000, 0);
     }
 
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderSpheres.base);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
 
     if (this->action >= WOLFOS_ACTION_WAIT) {
         if ((this->actor.colorFilterTimer == 0) || !(this->actor.colorFilterParams & 0x4000)) {
-            Collider_UpdateCylinder(&this->actor, &this->colliderCylinderBody);
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinderTail.base);
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinderBody.base);
+            Collider_UpdateCylinder(&this->actor, &this->bodyColliderCylinder);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->tailColliderCylinder.base);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->bodyColliderCylinder.base);
         }
     }
 
     if (this->action == WOLFOS_ACTION_BLOCKING) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderSpheres.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
     }
 
     if (this->slashStatus > 0) {
-        if (!(this->colliderSpheres.base.atFlags & AT_BOUNCED)) {
-            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderSpheres.base);
+        if (!(this->colliderJntSph.base.atFlags & AT_BOUNCED)) {
+            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderJntSph.base);
         } else {
             EnWf_SetupRecoilFromBlockedSlash(this);
         }
@@ -1387,16 +1387,16 @@ void EnWf_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, 
     EnWf* this = (EnWf*)thisx;
     s32 bodyPartIndex = -1;
 
-    Collider_UpdateSpheres(limbIndex, &this->colliderSpheres);
+    Collider_UpdateSpheres(limbIndex, &this->colliderJntSph);
 
     if (limbIndex == WOLFOS_LIMB_TAIL) {
         Vec3f colliderPos;
 
         bodyPartIndex = -1;
         Matrix_MultVec3f(&colliderVec, &colliderPos);
-        this->colliderCylinderTail.dim.pos.x = colliderPos.x;
-        this->colliderCylinderTail.dim.pos.y = colliderPos.y;
-        this->colliderCylinderTail.dim.pos.z = colliderPos.z;
+        this->tailColliderCylinder.dim.pos.x = colliderPos.x;
+        this->tailColliderCylinder.dim.pos.y = colliderPos.y;
+        this->tailColliderCylinder.dim.pos.z = colliderPos.z;
     }
 
     if ((this->fireTimer != 0) || ((this->actor.colorFilterTimer != 0) && (this->actor.colorFilterParams & 0x4000))) {

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.h
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.h
@@ -74,10 +74,10 @@ typedef struct EnWf {
     /* 0x02FE */ s16 runAngle;
     /* 0x0300 */ s16 unk_300; // Set, but ineffectual (see comment in Draw)
     /* 0x0302 */ u8 eyeIndex;
-    /* 0x0304 */ ColliderJntSph colliderSpheres;
-    /* 0x0324 */ ColliderJntSphElement colliderSpheresElements[4];
-    /* 0x0424 */ ColliderCylinder colliderCylinderBody;
-    /* 0x0470 */ ColliderCylinder colliderCylinderTail;
+    /* 0x0304 */ ColliderJntSph colliderJntSph;
+    /* 0x0324 */ ColliderJntSphElement colliderJntSphElements[4];
+    /* 0x0424 */ ColliderCylinder bodyColliderCylinder;
+    /* 0x0470 */ ColliderCylinder tailColliderCylinder;
     /* 0x04BC */ Vec3f unk_4BC;
     /* 0x04C8 */ Vec3f unk_4C8;
     /* 0x04D4 */ Vec3s unk_4D4;

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
@@ -131,10 +131,10 @@ void MirRay_SetupCollider(MirRay* this) {
     colliderOffset.x = (this->poolPt.x - this->sourcePt.x) * dataEntry->unk_10;
     colliderOffset.y = (this->poolPt.y - this->sourcePt.y) * dataEntry->unk_10;
     colliderOffset.z = (this->poolPt.z - this->sourcePt.z) * dataEntry->unk_10;
-    this->colliderSph.elements[0].dim.worldSphere.center.x = colliderOffset.x + this->sourcePt.x;
-    this->colliderSph.elements[0].dim.worldSphere.center.y = colliderOffset.y + this->sourcePt.y;
-    this->colliderSph.elements[0].dim.worldSphere.center.z = colliderOffset.z + this->sourcePt.z;
-    this->colliderSph.elements[0].dim.worldSphere.radius = dataEntry->unk_14 * this->colliderSph.elements->dim.scale;
+    this->colliderJntSph.elements[0].dim.worldSphere.center.x = colliderOffset.x + this->sourcePt.x;
+    this->colliderJntSph.elements[0].dim.worldSphere.center.y = colliderOffset.y + this->sourcePt.y;
+    this->colliderJntSph.elements[0].dim.worldSphere.center.z = colliderOffset.z + this->sourcePt.z;
+    this->colliderJntSph.elements[0].dim.worldSphere.radius = dataEntry->unk_14 * this->colliderJntSph.elements->dim.scale;
 }
 
 // Set up a light point between source point and reflection point. Reflection point is the pool point (for windows) or
@@ -221,8 +221,8 @@ void MirRay_Init(Actor* thisx, PlayState* play) {
     this->shieldCorners[5].y = -800.0f;
 
     if (PARAMS_GET_NOSHIFT(dataEntry->params, 1, 1)) {
-        Collider_InitJntSph(play, &this->colliderSph);
-        Collider_SetJntSph(play, &this->colliderSph, &this->actor, &sJntSphInit, &this->colliderSphItem);
+        Collider_InitJntSph(play, &this->colliderJntSph);
+        Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
         if (!PARAMS_GET_NOSHIFT(dataEntry->params, 2, 1)) { // Beams not from mirrors
             MirRay_SetupCollider(this);
         }
@@ -243,7 +243,7 @@ void MirRay_Destroy(Actor* thisx, PlayState* play) {
     LightContext_RemoveLight(play, &play->lightCtx, this->lightNode);
 
     if (sMirRayData[this->actor.params].params & 2) {
-        Collider_DestroyJntSph(play, &this->colliderSph);
+        Collider_DestroyJntSph(play, &this->colliderJntSph);
     }
 
     Collider_DestroyQuad(play, &this->shieldRay);
@@ -261,7 +261,7 @@ void MirRay_Update(Actor* thisx, PlayState* play) {
             if (sMirRayData[this->actor.params].params & 4) { // Beams from mirrors
                 MirRay_SetupCollider(this);
             }
-            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderSph.base);
+            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderJntSph.base);
         }
         if (this->reflectIntensity > 0.0f) {
             CollisionCheck_SetAT(play, &play->colChkCtx, &this->shieldRay.base);

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
@@ -134,7 +134,8 @@ void MirRay_SetupCollider(MirRay* this) {
     this->colliderJntSph.elements[0].dim.worldSphere.center.x = colliderOffset.x + this->sourcePt.x;
     this->colliderJntSph.elements[0].dim.worldSphere.center.y = colliderOffset.y + this->sourcePt.y;
     this->colliderJntSph.elements[0].dim.worldSphere.center.z = colliderOffset.z + this->sourcePt.z;
-    this->colliderJntSph.elements[0].dim.worldSphere.radius = dataEntry->unk_14 * this->colliderJntSph.elements->dim.scale;
+    this->colliderJntSph.elements[0].dim.worldSphere.radius =
+        dataEntry->unk_14 * this->colliderJntSph.elements->dim.scale;
 }
 
 // Set up a light point between source point and reflection point. Reflection point is the pool point (for windows) or

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.h
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.h
@@ -29,8 +29,8 @@ typedef struct MirRayShieldReflection {
 
 typedef struct MirRay {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ColliderJntSph colliderSph;
-    /* 0x016C */ ColliderJntSphElement colliderSphItem;
+    /* 0x014C */ ColliderJntSph colliderJntSph;
+    /* 0x016C */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x01AC */ ColliderQuad shieldRay;
     /* 0x022C */ f32 reflectIntensity; // Reflection occurs if it is positive, brightness depends on it
     /* 0x0230 */ Vec3f shieldCorners[6];

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -210,10 +210,10 @@ void ObjSwitch_InitDynaPoly(ObjSwitch* this, PlayState* play, CollisionHeader* c
 }
 
 void ObjSwitch_InitJntSphCollider(ObjSwitch* this, PlayState* play, ColliderJntSphInit* colliderJntSphInit) {
-    ColliderJntSph* colliderJntSph = &this->jntSph.col;
+    ColliderJntSph* colliderJntSph = &this->jntSph.collider;
 
     Collider_InitJntSph(play, colliderJntSph);
-    Collider_SetJntSph(play, colliderJntSph, &this->dyna.actor, colliderJntSphInit, this->jntSph.elements);
+    Collider_SetJntSph(play, colliderJntSph, &this->dyna.actor, colliderJntSphInit, this->jntSph.colliderElements);
     Matrix_SetTranslateRotateYXZ(this->dyna.actor.world.pos.x,
                                  this->dyna.actor.world.pos.y +
                                      this->dyna.actor.shape.yOffset * this->dyna.actor.scale.y,
@@ -223,13 +223,13 @@ void ObjSwitch_InitJntSphCollider(ObjSwitch* this, PlayState* play, ColliderJntS
 }
 
 void ObjSwitch_InitTrisCollider(ObjSwitch* this, PlayState* play, ColliderTrisInit* colliderTrisInit) {
-    ColliderTris* colliderTris = &this->tris.col;
+    ColliderTris* colliderTris = &this->tris.collider;
     s32 i;
     s32 j;
     Vec3f pos[3];
 
     Collider_InitTris(play, colliderTris);
-    Collider_SetTris(play, colliderTris, &this->dyna.actor, colliderTrisInit, this->tris.elements);
+    Collider_SetTris(play, colliderTris, &this->dyna.actor, colliderTrisInit, this->tris.colliderElements);
 
     for (i = 0; i < 2; i++) {
         for (j = 0; j < 3; j++) {
@@ -368,12 +368,12 @@ void ObjSwitch_Destroy(Actor* thisx, PlayState* play) {
     switch (OBJSWITCH_TYPE(&this->dyna.actor)) {
         case OBJSWITCH_TYPE_FLOOR_RUSTY:
         case OBJSWITCH_TYPE_EYE:
-            Collider_DestroyTris(play, &this->tris.col);
+            Collider_DestroyTris(play, &this->tris.collider);
             break;
 
         case OBJSWITCH_TYPE_CRYSTAL:
         case OBJSWITCH_TYPE_CRYSTAL_TARGETABLE:
-            Collider_DestroyJntSph(play, &this->jntSph.col);
+            Collider_DestroyJntSph(play, &this->jntSph.collider);
             break;
     }
 }
@@ -385,12 +385,12 @@ void ObjSwitch_FloorUpInit(ObjSwitch* this) {
 
 void ObjSwitch_FloorUp(ObjSwitch* this, PlayState* play) {
     if (OBJSWITCH_TYPE(&this->dyna.actor) == OBJSWITCH_TYPE_FLOOR_RUSTY) {
-        if (this->tris.col.base.acFlags & AC_HIT) {
+        if (this->tris.collider.base.acFlags & AC_HIT) {
             ObjSwitch_FloorPressInit(this);
             ObjSwitch_SetOn(this, play);
-            this->tris.col.base.acFlags &= ~AC_HIT;
+            this->tris.collider.base.acFlags &= ~AC_HIT;
         } else {
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->tris.col.base);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->tris.collider.base);
         }
     } else {
         switch (OBJSWITCH_SUBTYPE(&this->dyna.actor)) {
@@ -509,8 +509,8 @@ s32 ObjSwitch_EyeIsHit(ObjSwitch* this) {
     Actor* collidingActor;
     s16 yawDiff;
 
-    if ((this->tris.col.base.acFlags & AC_HIT) && !(this->prevColFlags & AC_HIT)) {
-        collidingActor = this->tris.col.base.ac;
+    if ((this->tris.collider.base.acFlags & AC_HIT) && !(this->prevColFlags & AC_HIT)) {
+        collidingActor = this->tris.collider.base.ac;
         if (collidingActor != NULL) {
             yawDiff = collidingActor->world.rot.y - this->dyna.actor.shape.rot.y;
             if (ABS(yawDiff) > 0x5000) {
@@ -613,7 +613,7 @@ void ObjSwitch_CrystalOffInit(ObjSwitch* this) {
 void ObjSwitch_CrystalOff(ObjSwitch* this, PlayState* play) {
     switch (OBJSWITCH_SUBTYPE(&this->dyna.actor)) {
         case OBJSWITCH_SUBTYPE_ONCE:
-            if ((this->jntSph.col.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) {
+            if ((this->jntSph.collider.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 ObjSwitch_SetOn(this, play);
                 ObjSwitch_CrystalTurnOnInit(this);
@@ -621,7 +621,7 @@ void ObjSwitch_CrystalOff(ObjSwitch* this, PlayState* play) {
             break;
 
         case OBJSWITCH_SUBTYPE_SYNC:
-            if (((this->jntSph.col.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) ||
+            if (((this->jntSph.collider.base.acFlags & AC_HIT) && this->disableAcTimer <= 0) ||
                 Flags_GetSwitch(play, OBJSWITCH_SWITCH_FLAG(&this->dyna.actor))) {
 
                 this->disableAcTimer = 10;
@@ -631,7 +631,7 @@ void ObjSwitch_CrystalOff(ObjSwitch* this, PlayState* play) {
             break;
 
         case OBJSWITCH_SUBTYPE_TOGGLE:
-            if ((this->jntSph.col.base.acFlags & AC_HIT) && !(this->prevColFlags & AC_HIT) &&
+            if ((this->jntSph.collider.base.acFlags & AC_HIT) && !(this->prevColFlags & AC_HIT) &&
                 this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 ObjSwitch_SetOn(this, play);
@@ -675,7 +675,7 @@ void ObjSwitch_CrystalOn(ObjSwitch* this, PlayState* play) {
             break;
 
         case OBJSWITCH_SUBTYPE_TOGGLE:
-            if ((this->jntSph.col.base.acFlags & AC_HIT) && !(this->prevColFlags & AC_HIT) &&
+            if ((this->jntSph.collider.base.acFlags & AC_HIT) && !(this->prevColFlags & AC_HIT) &&
                 this->disableAcTimer <= 0) {
                 this->disableAcTimer = 10;
                 ObjSwitch_CrystalTurnOffInit(this);
@@ -719,9 +719,9 @@ void ObjSwitch_Update(Actor* thisx, PlayState* play) {
             break;
 
         case OBJSWITCH_TYPE_EYE:
-            this->prevColFlags = this->tris.col.base.acFlags;
-            this->tris.col.base.acFlags &= ~AC_HIT;
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->tris.col.base);
+            this->prevColFlags = this->tris.collider.base.acFlags;
+            this->tris.collider.base.acFlags &= ~AC_HIT;
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->tris.collider.base);
             break;
 
         case OBJSWITCH_TYPE_CRYSTAL:
@@ -729,12 +729,12 @@ void ObjSwitch_Update(Actor* thisx, PlayState* play) {
             if (!Player_InCsMode(play) && this->disableAcTimer > 0) {
                 this->disableAcTimer--;
             }
-            this->prevColFlags = this->jntSph.col.base.acFlags;
-            this->jntSph.col.base.acFlags &= ~AC_HIT;
+            this->prevColFlags = this->jntSph.collider.base.acFlags;
+            this->jntSph.collider.base.acFlags &= ~AC_HIT;
             if (this->disableAcTimer <= 0) {
-                CollisionCheck_SetAC(play, &play->colChkCtx, &this->jntSph.col.base);
+                CollisionCheck_SetAC(play, &play->colChkCtx, &this->jntSph.collider.base);
             }
-            CollisionCheck_SetOC(play, &play->colChkCtx, &this->jntSph.col.base);
+            CollisionCheck_SetOC(play, &play->colChkCtx, &this->jntSph.collider.base);
             break;
     }
 }

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -26,13 +26,13 @@ typedef enum ObjSwitchSubType {
 } ObjSwitchSubType;
 
 typedef struct ObjSwitchJntSph {
-    /* 0x00 */ ColliderJntSph col;
-    /* 0x20 */ ColliderJntSphElement elements[1];
+    /* 0x00 */ ColliderJntSph collider;
+    /* 0x20 */ ColliderJntSphElement colliderElements[1];
 } ObjSwitchJntSph;
 
 typedef struct ObjSwitchTris {
-    /* 0x00 */ ColliderTris col;
-    /* 0x20 */ ColliderTrisElement elements[2];
+    /* 0x00 */ ColliderTris collider;
+    /* 0x20 */ ColliderTrisElement colliderElements[2];
 } ObjSwitchTris;
 
 typedef struct ObjSwitch {


### PR DESCRIPTION
Continuation of #2462

This focuses mostly on `JntSph` colliders, standardizing on either `collider`+`colliderElements` (sometimes used if it's the actor's sole collider) or `colliderJntSph`+`colliderJntSphElements`
Some colliders are also named, like "head" in `headCollider`+`headColliderElements`: then the name is a prefix

Also `ColliderJntSphElement[]` buffers in actor structs are now always arrays, even when it's a single element