### PR TITLE
Cleanup colliders 3

### DIFF
--- a/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
+++ b/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.c
@@ -140,12 +140,12 @@ void BgDodoago_Init(Actor* thisx, PlayState* play) {
         return;
     }
 
-    Collider_InitCylinder(play, &this->colliderMain);
-    Collider_InitCylinder(play, &this->colliderLeft);
-    Collider_InitCylinder(play, &this->colliderRight);
-    Collider_SetCylinder(play, &this->colliderMain, &this->dyna.actor, &sColCylinderInitMain);
-    Collider_SetCylinder(play, &this->colliderLeft, &this->dyna.actor, &sColCylinderInitLeftRight);
-    Collider_SetCylinder(play, &this->colliderRight, &this->dyna.actor, &sColCylinderInitLeftRight);
+    Collider_InitCylinder(play, &this->mainCollider);
+    Collider_InitCylinder(play, &this->leftCollider);
+    Collider_InitCylinder(play, &this->rightCollider);
+    Collider_SetCylinder(play, &this->mainCollider, &this->dyna.actor, &sColCylinderInitMain);
+    Collider_SetCylinder(play, &this->leftCollider, &this->dyna.actor, &sColCylinderInitLeftRight);
+    Collider_SetCylinder(play, &this->rightCollider, &this->dyna.actor, &sColCylinderInitLeftRight);
 
     BgDodoago_SetupAction(this, BgDodoago_WaitExplosives);
     sDisableBombCatcher = false;
@@ -155,13 +155,13 @@ void BgDodoago_Destroy(Actor* thisx, PlayState* play) {
     BgDodoago* this = (BgDodoago*)thisx;
 
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
-    Collider_DestroyCylinder(play, &this->colliderMain);
-    Collider_DestroyCylinder(play, &this->colliderLeft);
-    Collider_DestroyCylinder(play, &this->colliderRight);
+    Collider_DestroyCylinder(play, &this->mainCollider);
+    Collider_DestroyCylinder(play, &this->leftCollider);
+    Collider_DestroyCylinder(play, &this->rightCollider);
 }
 
 void BgDodoago_WaitExplosives(BgDodoago* this, PlayState* play) {
-    Actor* explosive = Actor_GetCollidedExplosive(play, &this->colliderMain.base);
+    Actor* explosive = Actor_GetCollidedExplosive(play, &this->mainCollider.base);
 
     if (explosive != NULL) {
         this->state =
@@ -198,21 +198,21 @@ void BgDodoago_WaitExplosives(BgDodoago* this, PlayState* play) {
             sTimer = 50;
         }
     } else if (Flags_GetEventChkInf(EVENTCHKINF_B0)) {
-        Collider_UpdateCylinder(&this->dyna.actor, &this->colliderMain);
-        Collider_UpdateCylinder(&this->dyna.actor, &this->colliderLeft);
-        Collider_UpdateCylinder(&this->dyna.actor, &this->colliderRight);
+        Collider_UpdateCylinder(&this->dyna.actor, &this->mainCollider);
+        Collider_UpdateCylinder(&this->dyna.actor, &this->leftCollider);
+        Collider_UpdateCylinder(&this->dyna.actor, &this->rightCollider);
 
-        this->colliderMain.dim.pos.z += 200;
+        this->mainCollider.dim.pos.z += 200;
 
-        this->colliderLeft.dim.pos.z += 215;
-        this->colliderLeft.dim.pos.x += 90;
+        this->leftCollider.dim.pos.z += 215;
+        this->leftCollider.dim.pos.x += 90;
 
-        this->colliderRight.dim.pos.z += 215;
-        this->colliderRight.dim.pos.x -= 90;
+        this->rightCollider.dim.pos.z += 215;
+        this->rightCollider.dim.pos.x -= 90;
 
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderMain.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderLeft.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderRight.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->mainCollider.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->leftCollider.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->rightCollider.base);
     }
 }
 
@@ -290,15 +290,15 @@ void BgDodoago_Update(Actor* thisx, PlayState* play) {
     if (this->dyna.actor.parent == NULL) {
         // this is a "bomb catcher", it kills the XZ speed and sets the timer for bombs that are dropped through the
         // holes in the bridge above the skull
-        if ((this->colliderLeft.base.ocFlags1 & OC1_HIT) || (this->colliderRight.base.ocFlags1 & OC1_HIT)) {
+        if ((this->leftCollider.base.ocFlags1 & OC1_HIT) || (this->rightCollider.base.ocFlags1 & OC1_HIT)) {
 
-            if (this->colliderLeft.base.ocFlags1 & OC1_HIT) {
-                actor = this->colliderLeft.base.oc;
+            if (this->leftCollider.base.ocFlags1 & OC1_HIT) {
+                actor = this->leftCollider.base.oc;
             } else {
-                actor = this->colliderRight.base.oc;
+                actor = this->rightCollider.base.oc;
             }
-            this->colliderLeft.base.ocFlags1 &= ~OC1_HIT;
-            this->colliderRight.base.ocFlags1 &= ~OC1_HIT;
+            this->leftCollider.base.ocFlags1 &= ~OC1_HIT;
+            this->rightCollider.base.ocFlags1 &= ~OC1_HIT;
 
             if (actor->category == ACTORCAT_EXPLOSIVE && actor->id == ACTOR_EN_BOM && actor->params == 0) {
                 bomb = (EnBom*)actor;

--- a/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.h
+++ b/src/overlays/actors/ovl_Bg_Dodoago/z_bg_dodoago.h
@@ -16,9 +16,9 @@ typedef void (*BgDodoagoActionFunc)(struct BgDodoago*, struct PlayState*);
 typedef struct BgDodoago {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ s16 state; // BgDodoagoEye or a timer-like value
-    /* 0x0168 */ ColliderCylinder colliderMain;  // Used to detect explosions for lighting the eyes
-    /* 0x01B4 */ ColliderCylinder colliderLeft;  // OC-colliding bombs have their xz speed cleared and timer set
-    /* 0x0200 */ ColliderCylinder colliderRight; // same as colliderLeft
+    /* 0x0168 */ ColliderCylinder mainCollider;  // Used to detect explosions for lighting the eyes
+    /* 0x01B4 */ ColliderCylinder leftCollider;  // OC-colliding bombs have their xz speed cleared and timer set
+    /* 0x0200 */ ColliderCylinder rightCollider; // same as colliderLeft
     /* 0x024C */ BgDodoagoActionFunc actionFunc;
 } BgDodoago; // size = 0x0250
 

--- a/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.c
@@ -155,12 +155,12 @@ void BgHakaSgami_Init(Actor* thisx, PlayState* play) {
 
     Collider_InitTris(play, colliderScythe);
     Collider_SetTris(play, colliderScythe, thisx, &sTrisInit, this->colliderScytheItems);
-    Collider_InitCylinder(play, &this->colliderScytheCenter);
-    Collider_SetCylinder(play, &this->colliderScytheCenter, thisx, &sCylinderInit);
+    Collider_InitCylinder(play, &this->scytheCenterCollider);
+    Collider_SetCylinder(play, &this->scytheCenterCollider, thisx, &sCylinderInit);
 
-    this->colliderScytheCenter.dim.pos.x = thisx->world.pos.x;
-    this->colliderScytheCenter.dim.pos.y = thisx->world.pos.y;
-    this->colliderScytheCenter.dim.pos.z = thisx->world.pos.z;
+    this->scytheCenterCollider.dim.pos.x = thisx->world.pos.x;
+    this->scytheCenterCollider.dim.pos.y = thisx->world.pos.y;
+    this->scytheCenterCollider.dim.pos.z = thisx->world.pos.z;
 
     CollisionCheck_SetInfo(&thisx->colChkInfo, NULL, &sColChkInfoInit);
 
@@ -181,8 +181,8 @@ void BgHakaSgami_Init(Actor* thisx, PlayState* play) {
         thisx->flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
     } else {
         this->requiredObjectSlot = Object_GetSlot(&play->objectCtx, OBJECT_ICE_OBJECTS);
-        this->colliderScytheCenter.dim.radius = 30;
-        this->colliderScytheCenter.dim.height = 70;
+        this->scytheCenterCollider.dim.radius = 30;
+        this->scytheCenterCollider.dim.height = 70;
         Actor_SetFocus(thisx, 40.0f);
     }
 
@@ -200,7 +200,7 @@ void BgHakaSgami_Destroy(Actor* thisx, PlayState* play) {
     Effect_Delete(play, this->blureEffectIndex[0]);
     Effect_Delete(play, this->blureEffectIndex[1]);
     Collider_DestroyTris(play, &this->colliderScythe);
-    Collider_DestroyCylinder(play, &this->colliderScytheCenter);
+    Collider_DestroyCylinder(play, &this->scytheCenterCollider);
 }
 
 void BgHakaSgami_SetupSpin(BgHakaSgami* this, PlayState* play) {
@@ -289,7 +289,7 @@ void BgHakaSgami_Spin(BgHakaSgami* this, PlayState* play) {
     }
 
     CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderScythe.base);
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderScytheCenter.base);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->scytheCenterCollider.base);
     Actor_PlaySfx_Flagged(&this->actor, NA_SE_EV_ROLLCUTTER_MOTOR - SFX_FLAG);
 }
 

--- a/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.h
@@ -15,7 +15,7 @@ typedef struct BgHakaSgami {
     /* 0x0151 */ s8 unk_151;
     /* 0x0152 */ s16 timer;
     /* 0x0154 */ s32 blureEffectIndex[2];
-    /* 0x015C */ ColliderCylinder colliderScytheCenter;
+    /* 0x015C */ ColliderCylinder scytheCenterCollider;
     /* 0x01A8 */ ColliderTris colliderScythe;
     /* 0x01C8 */ ColliderTrisElement colliderScytheItems[4];
 } BgHakaSgami; // size = 0x0338

--- a/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.c
@@ -89,13 +89,13 @@ static InitChainEntry sInitChain[] = {
 static CollisionHeader* sCollisionHeaders[] = { &gPillarCol, &gThroneCol };
 
 void BgJyaIronobj_InitCylinder(BgJyaIronobj* this, PlayState* play) {
-    ColliderCylinder* colCylinder = &this->colCylinder;
+    ColliderCylinder* colCylinder = &this->colliderCylinder;
 
     Collider_InitCylinder(play, colCylinder);
     Collider_SetCylinder(play, colCylinder, &this->dyna.actor, &sCylinderInit);
     if (PARAMS_GET_U(this->dyna.actor.params, 0, 1) == 1) {
-        this->colCylinder.dim.radius = 40;
-        this->colCylinder.dim.height = 100;
+        this->colliderCylinder.dim.radius = 40;
+        this->colliderCylinder.dim.height = 100;
     }
     Collider_UpdateCylinder(&this->dyna.actor, colCylinder);
 }
@@ -244,7 +244,7 @@ void BgJyaIronobj_Init(Actor* thisx, PlayState* play) {
 void BgJyaIronobj_Destroy(Actor* thisx, PlayState* play) {
     BgJyaIronobj* this = (BgJyaIronobj*)thisx;
 
-    Collider_DestroyCylinder(play, &this->colCylinder);
+    Collider_DestroyCylinder(play, &this->colliderCylinder);
     DynaPoly_DeleteBgActor(play, &play->colCtx.dyna, this->dyna.bgId);
 }
 
@@ -258,9 +258,9 @@ void func_808992E8(BgJyaIronobj* this, PlayState* play) {
     Vec3f dropPos;
     s32 i;
 
-    if (this->colCylinder.base.acFlags & AC_HIT) {
-        actor = this->colCylinder.base.ac;
-        this->colCylinder.base.acFlags &= ~AC_HIT;
+    if (this->colliderCylinder.base.acFlags & AC_HIT) {
+        actor = this->colliderCylinder.base.ac;
+        this->colliderCylinder.base.acFlags &= ~AC_HIT;
         if (actor != NULL && actor->id == ACTOR_EN_IK) {
             particleFunc[PARAMS_GET_U(this->dyna.actor.params, 0, 1)](this, play, (EnIk*)actor);
             SfxSource_PlaySfxAtFixedWorldPos(play, &this->dyna.actor.world.pos, 80, NA_SE_EN_IRONNACK_BREAK_PILLAR);
@@ -275,7 +275,7 @@ void func_808992E8(BgJyaIronobj* this, PlayState* play) {
             return;
         }
     } else {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCylinder.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder.base);
     }
 }
 

--- a/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.h
+++ b/src/overlays/actors/ovl_Bg_Jya_Ironobj/z_bg_jya_ironobj.h
@@ -11,7 +11,7 @@ typedef void (*BgJyaIronobjActionFunc)(struct BgJyaIronobj*, struct PlayState*);
 typedef struct BgJyaIronobj {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x0164 */ BgJyaIronobjActionFunc actionFunc;
-    /* 0x0168 */ ColliderCylinder colCylinder;
+    /* 0x0168 */ ColliderCylinder colliderCylinder;
 } BgJyaIronobj; // size = 0x01B4
 
 #endif

--- a/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
+++ b/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
@@ -68,7 +68,7 @@ ActorProfile Bg_Spot06_Objects_Profile = {
     /**/ BgSpot06Objects_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphItemsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -92,7 +92,7 @@ static ColliderJntSphInit sJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     1,
-    sJntSphItemsInit,
+    sJntSphElementsInit,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd_colchk.inc.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd_colchk.inc.c
@@ -1,6 +1,6 @@
 #include "z64collision_check.h"
 
-static ColliderJntSphElementInit sJntSphItemsInit[19] = {
+static ColliderJntSphElementInit sJntSphElementsInit[19] = {
     {
         {
             ELEM_MATERIAL_UNK3,
@@ -222,5 +222,5 @@ static ColliderJntSphInit sJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     19,
-    sJntSphItemsInit,
+    sJntSphElementsInit,
 };

--- a/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -87,7 +87,7 @@ static Vec3f D_80906D6C = { 0.0f, 0.0f, 500.0f };
 
 static u8 D_80906D78 = 0;
 
-static ColliderJntSphElementInit sJntSphItemsInit1[] = {
+static ColliderJntSphElementInit sJntSphElementsInit1[] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -275,11 +275,11 @@ static ColliderJntSphInit sJntSphInit1 = {
         OC2_FIRST_ONLY | OC2_TYPE_1,
         COLSHAPE_JNTSPH,
     },
-    ARRAY_COUNT(sJntSphItemsInit1),
-    sJntSphItemsInit1,
+    ARRAY_COUNT(sJntSphElementsInit1),
+    sJntSphElementsInit1,
 };
 
-static ColliderJntSphElementInit sJntSphItemsInit2[] = {
+static ColliderJntSphElementInit sJntSphElementsInit2[] = {
     {
         {
             ELEM_MATERIAL_UNK2,
@@ -313,8 +313,8 @@ static ColliderJntSphInit sJntSphInit2 = {
         OC2_TYPE_1,
         COLSHAPE_JNTSPH,
     },
-    ARRAY_COUNT(sJntSphItemsInit2),
-    sJntSphItemsInit2,
+    ARRAY_COUNT(sJntSphElementsInit2),
+    sJntSphElementsInit2,
 };
 
 static Vec3f D_8090EB20;

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -313,10 +313,10 @@ void BossGanondrof_Init(Actor* thisx, PlayState* play) {
         BossGanondrof_SetupPaintings(this);
     }
 
-    Collider_InitCylinder(play, &this->colliderBody);
-    Collider_InitCylinder(play, &this->colliderSpear);
-    Collider_SetCylinder(play, &this->colliderBody, &this->actor, &sCylinderInitBody);
-    Collider_SetCylinder(play, &this->colliderSpear, &this->actor, &sCylinderInitSpear);
+    Collider_InitCylinder(play, &this->bodyCollider);
+    Collider_InitCylinder(play, &this->spearCollider);
+    Collider_SetCylinder(play, &this->bodyCollider, &this->actor, &sCylinderInitBody);
+    Collider_SetCylinder(play, &this->spearCollider, &this->actor, &sCylinderInitSpear);
     this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
     if (Flags_GetClear(play, play->roomCtx.curRoom.num)) {
         Actor_Kill(&this->actor);
@@ -336,8 +336,8 @@ void BossGanondrof_Destroy(Actor* thisx, PlayState* play) {
 
     PRINTF("DT1\n");
     SkelAnime_Free(&this->skelAnime, play);
-    Collider_DestroyCylinder(play, &this->colliderBody);
-    Collider_DestroyCylinder(play, &this->colliderSpear);
+    Collider_DestroyCylinder(play, &this->bodyCollider);
+    Collider_DestroyCylinder(play, &this->spearCollider);
     if (this->actor.params == GND_REAL_BOSS) {
         LightContext_RemoveLight(play, &play->lightCtx, this->lightNode);
     }
@@ -480,9 +480,9 @@ void BossGanondrof_Paintings(BossGanondrof* this, PlayState* play) {
     if (this->flyMode != GND_FLY_PAINTING) {
         BossGanondrof_SetupNeutral(this, -20.0f);
         this->timers[0] = 100;
-        this->colliderBody.dim.radius = 20;
-        this->colliderBody.dim.height = 60;
-        this->colliderBody.dim.yShift = -33;
+        this->bodyCollider.dim.radius = 20;
+        this->bodyCollider.dim.height = 60;
+        this->bodyCollider.dim.yShift = -33;
         Actor_PlaySfx(&this->actor, NA_SE_EN_FANTOM_LAUGH);
         this->actor.naviEnemyId = NAVI_ENEMY_PHANTOM_GANON_PHASE_2;
     } else {
@@ -794,7 +794,7 @@ void BossGanondrof_SetupBlock(BossGanondrof* this, PlayState* play) {
 }
 
 void BossGanondrof_Block(BossGanondrof* this, PlayState* play) {
-    this->colliderBody.base.colMaterial = COL_MATERIAL_METAL;
+    this->bodyCollider.base.colMaterial = COL_MATERIAL_METAL;
     SkelAnime_Update(&this->skelAnime);
     this->actor.world.pos.x += this->actor.velocity.x;
     this->actor.world.pos.z += this->actor.velocity.z;
@@ -823,7 +823,7 @@ void BossGanondrof_Charge(BossGanondrof* this, PlayState* play) {
     f32 dxCenter = thisx->world.pos.x - GND_BOSSROOM_CENTER_X;
     f32 dzCenter = thisx->world.pos.z - GND_BOSSROOM_CENTER_Z;
 
-    this->colliderBody.base.colMaterial = COL_MATERIAL_METAL;
+    this->bodyCollider.base.colMaterial = COL_MATERIAL_METAL;
     SkelAnime_Update(&this->skelAnime);
     switch (this->work[GND_ACTION_STATE]) {
         case CHARGE_WINDUP:
@@ -1250,13 +1250,13 @@ void BossGanondrof_CollisionCheck(BossGanondrof* this, PlayState* play) {
     if (this->work[GND_INVINC_TIMER] != 0) {
         this->work[GND_INVINC_TIMER]--;
         this->returnCount = 0;
-        this->colliderBody.base.acFlags &= ~AC_HIT;
+        this->bodyCollider.base.acFlags &= ~AC_HIT;
     } else {
-        acHit = this->colliderBody.base.acFlags & AC_HIT;
+        acHit = this->bodyCollider.base.acFlags & AC_HIT;
         if ((acHit && ((s8)this->actor.colChkInfo.health > 0)) || (this->returnCount != 0)) {
             if (acHit) {
-                this->colliderBody.base.acFlags &= ~AC_HIT;
-                acHitElem = this->colliderBody.elem.acHitElem;
+                this->bodyCollider.base.acFlags &= ~AC_HIT;
+                acHitElem = this->bodyCollider.elem.acHitElem;
             }
             if (this->flyMode != GND_FLY_PAINTING) {
                 if (acHit && (this->actionFunc != BossGanondrof_Stunned) &&
@@ -1319,7 +1319,7 @@ void BossGanondrof_Update(Actor* thisx, PlayState* play) {
 
     PRINTF("MOVE START %d\n", this->actor.params);
     this->actor.flags &= ~ACTOR_FLAG_HOOKSHOT_PULLS_PLAYER;
-    this->colliderBody.base.colMaterial = COL_MATERIAL_HIT3;
+    this->bodyCollider.base.colMaterial = COL_MATERIAL_HIT3;
     if (this->killActor) {
         Actor_Kill(&this->actor);
         return;
@@ -1347,20 +1347,20 @@ void BossGanondrof_Update(Actor* thisx, PlayState* play) {
     }
 
     PRINTF("MOVE END\n");
-    BossGanondrof_SetColliderPos(&this->targetPos, &this->colliderBody);
-    BossGanondrof_SetColliderPos(&this->spearTip, &this->colliderSpear);
+    BossGanondrof_SetColliderPos(&this->targetPos, &this->bodyCollider);
+    BossGanondrof_SetColliderPos(&this->spearTip, &this->spearCollider);
     if ((this->flyMode == GND_FLY_PAINTING) && !horse->bossGndInPainting) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->bodyCollider.base);
     }
     if ((this->actionFunc == BossGanondrof_Stunned) && (this->timers[0] > 1)) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderBody.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->bodyCollider.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyCollider.base);
     } else if (this->actionFunc == BossGanondrof_Block) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->bodyCollider.base);
     } else if (this->actionFunc == BossGanondrof_Charge) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderBody.base);
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderBody.base);
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderSpear.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->bodyCollider.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->bodyCollider.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->spearCollider.base);
     }
 
     this->actor.focus.pos = this->targetPos;

--- a/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
+++ b/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.h
@@ -98,8 +98,8 @@ typedef struct BossGanondrof {
     /* 0x0454 */ f32 rideRotY[30]; // possibly only 25 used
     /* 0x04CC */ LightNode* lightNode;
     /* 0x04D0 */ LightInfo lightInfo;
-    /* 0x04E0 */ ColliderCylinder colliderBody;
-    /* 0x052C */ ColliderCylinder colliderSpear;
+    /* 0x04E0 */ ColliderCylinder bodyCollider;
+    /* 0x052C */ ColliderCylinder spearCollider;
 } BossGanondrof; // size = 0x0578
 
 #endif

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -89,7 +89,7 @@ ActorProfile Boss_Goma_Profile = {
     /**/ BossGoma_Draw,
 };
 
-static ColliderJntSphElementInit sColliderJntSphElementInit[13] = {
+static ColliderJntSphElementInit sColliderJntSphElementsInit[13] = {
     {
         {
             ELEM_MATERIAL_UNK3,
@@ -245,7 +245,7 @@ static ColliderJntSphInit sColliderJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     13,
-    sColliderJntSphElementInit,
+    sColliderJntSphElementsInit,
 };
 
 static u8 sClearPixelTableFirstPass[16 * 16] = {

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -296,7 +296,7 @@ void BossSst_Init(Actor* thisx, PlayState* play2) {
     BossSst* this = (BossSst*)thisx;
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
-    Collider_InitCylinder(play, &this->colliderCyl);
+    Collider_InitCylinder(play, &this->colliderCylinder);
     Collider_InitJntSph(play, &this->colliderJntSph);
     CollisionCheck_SetInfo(&this->actor.colChkInfo, &sDamageTable, &sColChkInfoInit);
     Flags_SetSwitch(play, 0x14);
@@ -307,7 +307,7 @@ void BossSst_Init(Actor* thisx, PlayState* play2) {
                            this->morphTable, 45);
         ActorShape_Init(&this->actor.shape, 70000.0f, ActorShadow_DrawCircle, 95.0f);
         Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitHead, this->colliderJntSphElements);
-        Collider_SetCylinder(play, &this->colliderCyl, &this->actor, &sCylinderInitHead);
+        Collider_SetCylinder(play, &this->colliderCylinder, &this->actor, &sCylinderInitHead);
         sHead = this;
         this->actor.world.pos.x = ROOM_CENTER_X + 50.0f;
         this->actor.world.pos.y = ROOM_CENTER_Y + 0.0f;
@@ -340,7 +340,7 @@ void BossSst_Init(Actor* thisx, PlayState* play2) {
         }
     } else {
         Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInitHand, this->colliderJntSphElements);
-        Collider_SetCylinder(play, &this->colliderCyl, &this->actor, &sCylinderInitHand);
+        Collider_SetCylinder(play, &this->colliderCylinder, &this->actor, &sCylinderInitHand);
         if (this->actor.params == BONGO_LEFT_HAND) {
             SkelAnime_InitFlex(play, &this->skelAnime, &gBongoLeftHandSkel, &gBongoLeftHandIdleAnim, this->jointTable,
                                this->morphTable, 27);
@@ -365,7 +365,7 @@ void BossSst_Destroy(Actor* thisx, PlayState* play) {
     BossSst* this = (BossSst*)thisx;
 
     Collider_DestroyJntSph(play, &this->colliderJntSph);
-    Collider_DestroyCylinder(play, &this->colliderCyl);
+    Collider_DestroyCylinder(play, &this->colliderCylinder);
     Audio_StopSfxByPos(&this->center);
 }
 
@@ -727,7 +727,7 @@ void BossSst_HeadDamagedHand(BossSst* this, PlayState* play) {
 void BossSst_HeadSetupReadyCharge(BossSst* this) {
     Animation_MorphToLoop(&this->skelAnime, &gBongoHeadEyeOpenIdleAnim, -5.0f);
     this->actor.speed = 0.0f;
-    this->colliderCyl.base.acFlags |= AC_ON;
+    this->colliderCylinder.base.acFlags |= AC_ON;
     this->actionFunc = BossSst_HeadReadyCharge;
 }
 
@@ -803,7 +803,7 @@ void BossSst_HeadSetupEndCharge(BossSst* this) {
     Animation_MorphToLoop(&this->skelAnime, &gBongoHeadEyeCloseIdleAnim, -20.0f);
     this->targetYaw = Actor_WorldYawTowardPoint(&this->actor, &sRoomCenter);
     this->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
-    this->colliderCyl.base.acFlags &= ~AC_ON;
+    this->colliderCylinder.base.acFlags &= ~AC_ON;
     this->radius *= -1.0f;
     this->actionFunc = BossSst_HeadEndCharge;
 }
@@ -820,7 +820,7 @@ void BossSst_HeadEndCharge(BossSst* this, PlayState* play) {
 void BossSst_HeadSetupFrozenHand(BossSst* this) {
     Animation_MorphToLoop(&this->skelAnime, &gBongoHeadEyeOpenIdleAnim, -5.0f);
     this->ready = false;
-    this->colliderCyl.base.acFlags |= AC_ON;
+    this->colliderCylinder.base.acFlags |= AC_ON;
     this->actionFunc = BossSst_HeadFrozenHand;
 }
 
@@ -833,7 +833,7 @@ void BossSst_HeadFrozenHand(BossSst* this, PlayState* play) {
 
 void BossSst_HeadSetupUnfreezeHand(BossSst* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gBongoHeadEyeCloseAnim, -5.0f);
-    this->colliderCyl.base.acFlags &= ~AC_ON;
+    this->colliderCylinder.base.acFlags &= ~AC_ON;
     this->actionFunc = BossSst_HeadUnfreezeHand;
 }
 
@@ -848,7 +848,7 @@ void BossSst_HeadSetupStunned(BossSst* this) {
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA,
                          Animation_GetLastFrame(&gBongoHeadKnockoutAnim));
     this->colliderJntSph.base.atFlags &= ~(AT_ON | AT_HIT);
-    this->colliderCyl.base.acFlags &= ~AC_ON;
+    this->colliderCylinder.base.acFlags &= ~AC_ON;
     this->vVanish = false;
     this->actor.flags &= ~ACTOR_FLAG_REACT_TO_LENS;
     BossSst_HeadSfx(this, NA_SE_EN_SHADEST_FREEZE);
@@ -900,8 +900,8 @@ void BossSst_HeadStunned(BossSst* this, PlayState* play) {
 
 void BossSst_HeadSetupVulnerable(BossSst* this) {
     Animation_MorphToLoop(&this->skelAnime, &gBongoHeadStunnedAnim, -5.0f);
-    this->colliderCyl.base.acFlags |= AC_ON;
-    this->colliderCyl.elem.acDmgInfo.dmgFlags = DMG_SWORD | DMG_DEKU_STICK;
+    this->colliderCylinder.base.acFlags |= AC_ON;
+    this->colliderCylinder.elem.acDmgInfo.dmgFlags = DMG_SWORD | DMG_DEKU_STICK;
     this->actor.speed = 0.0f;
     this->colliderJntSph.elements[10].base.acElemFlags |= (ACELEM_ON | ACELEM_HOOKABLE);
     this->colliderJntSph.elements[0].base.acElemFlags &= ~ACELEM_ON;
@@ -942,7 +942,7 @@ void BossSst_HeadSetupDamage(BossSst* this) {
                          Animation_GetLastFrame(&gBongoHeadDamageAnim));
     Actor_SetColorFilter(&sHands[RIGHT]->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA,
                          Animation_GetLastFrame(&gBongoHeadDamageAnim));
-    this->colliderCyl.base.acFlags &= ~AC_ON;
+    this->colliderCylinder.base.acFlags &= ~AC_ON;
     BossSst_HeadSfx(this, NA_SE_EN_SHADEST_DAMAGE);
     this->actionFunc = BossSst_HeadDamage;
 }
@@ -959,8 +959,8 @@ void BossSst_HeadDamage(BossSst* this, PlayState* play) {
 
 void BossSst_HeadSetupRecover(BossSst* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &gBongoHeadRecoverAnim, -5.0f);
-    this->colliderCyl.base.acFlags &= ~AC_ON;
-    this->colliderCyl.elem.acDmgInfo.dmgFlags = DMG_DEFAULT;
+    this->colliderCylinder.base.acFlags &= ~AC_ON;
+    this->colliderCylinder.elem.acDmgInfo.dmgFlags = DMG_DEFAULT;
     this->colliderJntSph.elements[10].base.acElemFlags &= ~(ACELEM_ON | ACELEM_HOOKABLE);
     this->colliderJntSph.elements[0].base.acElemFlags |= ACELEM_ON;
     this->vVanish = true;
@@ -1046,7 +1046,7 @@ void BossSst_HeadSetupDeath(BossSst* this, PlayState* play) {
     Actor_SetColorFilter(&sHands[LEFT]->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 60);
     Actor_SetColorFilter(&sHands[RIGHT]->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 60);
     this->timer = 60;
-    this->colliderCyl.base.acFlags &= ~AC_ON;
+    this->colliderCylinder.base.acFlags &= ~AC_ON;
     this->colliderJntSph.base.ocFlags1 &= ~OC1_ON;
     sHands[LEFT]->colliderJntSph.base.ocFlags1 &= ~OC1_ON;
     sHands[RIGHT]->colliderJntSph.base.ocFlags1 &= ~OC1_ON;
@@ -1536,9 +1536,9 @@ void BossSst_HandSlam(BossSst* this, PlayState* play) {
                 this->ready = true;
                 Actor_PlaySfx(&this->actor, NA_SE_EN_SHADEST_TAIKO_LOW);
                 BossSst_SpawnShockwave(this);
-                this->colliderCyl.base.atFlags |= AT_ON;
-                Collider_UpdateCylinder(&this->actor, &this->colliderCyl);
-                this->colliderCyl.dim.radius = sCylinderInitHand.dim.radius;
+                this->colliderCylinder.base.atFlags |= AT_ON;
+                Collider_UpdateCylinder(&this->actor, &this->colliderCylinder);
+                this->colliderCylinder.dim.radius = sCylinderInitHand.dim.radius;
             }
         }
 
@@ -2582,8 +2582,8 @@ void BossSst_HandCollisionCheck(BossSst* this, PlayState* play) {
 }
 
 void BossSst_HeadCollisionCheck(BossSst* this, PlayState* play) {
-    if (this->colliderCyl.base.acFlags & AC_HIT) {
-        this->colliderCyl.base.acFlags &= ~AC_HIT;
+    if (this->colliderCylinder.base.acFlags & AC_HIT) {
+        this->colliderCylinder.base.acFlags &= ~AC_HIT;
         if ((this->actor.colChkInfo.damageEffect != 0) || (this->actor.colChkInfo.damage != 0)) {
             if (this->actionFunc == BossSst_HeadVulnerable) {
                 if (Actor_ApplyDamage(&this->actor) == 0) {
@@ -2615,13 +2615,13 @@ void BossSst_UpdateHand(Actor* thisx, PlayState* play) {
     BossSst* this = (BossSst*)thisx;
     BossSstHandTrail* trail;
 
-    if (this->colliderCyl.base.atFlags & AT_ON) {
+    if (this->colliderCylinder.base.atFlags & AT_ON) {
         if ((this->effects[0].move < 5) ||
             (this->actor.xzDistToPlayer < ((this->effects[2].scale * 0.01f) * sCylinderInitHand.dim.radius)) ||
-            (this->colliderCyl.base.atFlags & AT_HIT)) {
-            this->colliderCyl.base.atFlags &= ~(AT_ON | AT_HIT);
+            (this->colliderCylinder.base.atFlags & AT_HIT)) {
+            this->colliderCylinder.base.atFlags &= ~(AT_ON | AT_HIT);
         } else {
-            this->colliderCyl.dim.radius = (this->effects[0].scale * 0.01f) * sCylinderInitHand.dim.radius;
+            this->colliderCylinder.dim.radius = (this->effects[0].scale * 0.01f) * sCylinderInitHand.dim.radius;
         }
     }
 
@@ -2648,8 +2648,8 @@ void BossSst_UpdateHand(Actor* thisx, PlayState* play) {
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderJntSph.base);
     }
 
-    if (this->colliderCyl.base.atFlags & AT_ON) {
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderCyl.base);
+    if (this->colliderCylinder.base.atFlags & AT_ON) {
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderCylinder.base);
     }
 
     if ((HAND_STATE(this) != HAND_DEATH) && (HAND_STATE(this) != HAND_WAIT) && (HAND_STATE(this) != HAND_BEAT) &&
@@ -2702,8 +2702,8 @@ void BossSst_UpdateHead(Actor* thisx, PlayState* play2) {
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
 #else
     if ((this->actionFunc != BossSst_HeadLurk) && (this->actionFunc != BossSst_HeadIntro)) {
-        if (this->colliderCyl.base.acFlags & AC_ON) {
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCyl.base);
+        if (this->colliderCylinder.base.acFlags & AC_ON) {
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder.base);
         }
         CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
     }
@@ -2884,9 +2884,9 @@ void BossSst_PostHeadDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* ro
     if (limbIndex == 8) {
         Matrix_MultVec3f(&zeroVec, &this->actor.focus.pos);
         Matrix_MultVec3f(&headVec, &headPos);
-        this->colliderCyl.dim.pos.x = headPos.x;
-        this->colliderCyl.dim.pos.y = headPos.y;
-        this->colliderCyl.dim.pos.z = headPos.z;
+        this->colliderCylinder.dim.pos.x = headPos.x;
+        this->colliderCylinder.dim.pos.y = headPos.y;
+        this->colliderCylinder.dim.pos.z = headPos.z;
     }
 
     Collider_UpdateSpheres(limbIndex, &this->colliderJntSph);

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -2696,8 +2696,8 @@ void BossSst_UpdateHead(Actor* thisx, PlayState* play2) {
     }
 
 #if OOT_VERSION < NTSC_1_2
-    if (this->colliderCyl.base.acFlags & AC_ON) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCyl.base);
+    if (this->colliderCylinder.base.acFlags & AC_ON) {
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder.base);
     }
     CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderJntSph.base);
 #else

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.h
@@ -47,7 +47,7 @@ typedef struct BossSst {
     /* 0x03C8 */ Vec3f center;
     /* 0x03D4 */ ColliderJntSph colliderJntSph;
     /* 0x03F4 */ ColliderJntSphElement colliderJntSphElements[11];
-    /* 0x06B4 */ ColliderCylinder colliderCyl;
+    /* 0x06B4 */ ColliderCylinder colliderCylinder;
     /* 0x0700 */ BossSstEffect effects[BOSS_SST_EFFECT_COUNT];
     /* 0x09D0 */ s16 trailIndex;
     /* 0x09D2 */ s16 trailCount;

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst_colchk.inc.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst_colchk.inc.c
@@ -1,6 +1,6 @@
 #include "z64collision_check.h"
 
-static ColliderJntSphElementInit sJntSphItemsInitHand[11] = {
+static ColliderJntSphElementInit sJntSphElementsInitHand[11] = {
     {
         {
             ELEM_MATERIAL_UNK1,
@@ -134,10 +134,10 @@ static ColliderJntSphInit sJntSphInitHand = {
         COLSHAPE_JNTSPH,
     },
     11,
-    sJntSphItemsInitHand,
+    sJntSphElementsInitHand,
 };
 
-static ColliderJntSphElementInit sJntSphItemsInitHead[11] = {
+static ColliderJntSphElementInit sJntSphElementsInitHead[11] = {
     {
         {
             ELEM_MATERIAL_UNK1,
@@ -271,7 +271,7 @@ static ColliderJntSphInit sJntSphInitHead = {
         COLSHAPE_JNTSPH,
     },
     11,
-    sJntSphItemsInitHead,
+    sJntSphElementsInitHead,
 };
 
 static ColliderCylinderInit sCylinderInitHead = {

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -698,8 +698,8 @@ void BossVa_Init(Actor* thisx, PlayState* play2) {
                 }
 
                 this->zapHeadPos.x = 1.0f;
-                Collider_InitCylinder(play, &this->colliderBody);
-                Collider_SetCylinder(play, &this->colliderBody, &this->actor, &sCylinderInit);
+                Collider_InitCylinder(play, &this->bodyCollider);
+                Collider_SetCylinder(play, &this->bodyCollider, &this->actor, &sCylinderInit);
 
                 for (i = BOSSVA_ZAPPER_3; i >= BOSSVA_SUPPORT_1; i--) {
                     Actor_SpawnAsChild(
@@ -773,7 +773,7 @@ void BossVa_Destroy(Actor* thisx, PlayState* play) {
 
     SkelAnime_Free(&this->skelAnime, play);
     Collider_DestroyJntSph(play, &this->colliderJntSph);
-    Collider_DestroyCylinder(play, &this->colliderBody);
+    Collider_DestroyCylinder(play, &this->bodyCollider);
 }
 
 void BossVa_SetupIntro(BossVa* this) {
@@ -1091,9 +1091,9 @@ void BossVa_BodyPhase1(BossVa* this, PlayState* play) {
         }
     }
 
-    if (this->colliderBody.base.atFlags & AT_HIT) {
-        this->colliderBody.base.atFlags &= ~AT_HIT;
-        if (this->colliderBody.base.at == &player->actor) {
+    if (this->bodyCollider.base.atFlags & AT_HIT) {
+        this->bodyCollider.base.atFlags &= ~AT_HIT;
+        if (this->bodyCollider.base.at == &player->actor) {
             Actor_SetPlayerKnockbackLargeNoDamage(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
         }
     }
@@ -1121,9 +1121,9 @@ void BossVa_BodyPhase1(BossVa* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
-    Collider_UpdateCylinder(&this->actor, &this->colliderBody);
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderBody.base);
-    CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderBody.base);
+    Collider_UpdateCylinder(&this->actor, &this->bodyCollider);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyCollider.base);
+    CollisionCheck_SetAT(play, &play->colChkCtx, &this->bodyCollider.base);
     func_800F436C(&this->actor.projectedPos, NA_SE_EN_BALINADE_LEVEL - SFX_FLAG, 1.0f);
 }
 
@@ -1153,17 +1153,17 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
             Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 160);
             this->actor.colorFilterTimer = this->invincibilityTimer;
         } else {
-            this->colliderBody.elem.acDmgInfo.dmgFlags = DMG_BOOMERANG;
+            this->bodyCollider.elem.acDmgInfo.dmgFlags = DMG_BOOMERANG;
         }
     }
 
-    if (this->colliderBody.base.acFlags & AC_HIT) {
-        this->colliderBody.base.acFlags &= ~AC_HIT;
+    if (this->bodyCollider.base.acFlags & AC_HIT) {
+        this->bodyCollider.base.acFlags &= ~AC_HIT;
 
-        if (this->colliderBody.base.ac->id == ACTOR_EN_BOOM) {
+        if (this->bodyCollider.base.ac->id == ACTOR_EN_BOOM) {
             sPhase2Timer &= 0xFE00;
             Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 160);
-            this->colliderBody.elem.acDmgInfo.dmgFlags = DMG_SWORD | DMG_BOOMERANG | DMG_DEKU_STICK;
+            this->bodyCollider.elem.acDmgInfo.dmgFlags = DMG_SWORD | DMG_BOOMERANG | DMG_DEKU_STICK;
         } else {
             sKillBari++;
             if ((this->actor.colorFilterTimer != 0) && !(this->actor.colorFilterParams & 0x4000)) {
@@ -1181,11 +1181,11 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_FAINT);
     }
 
-    if (this->colliderBody.base.atFlags & AT_HIT) {
-        this->colliderBody.base.atFlags &= ~AT_HIT;
+    if (this->bodyCollider.base.atFlags & AT_HIT) {
+        this->bodyCollider.base.atFlags &= ~AT_HIT;
 
         sPhase2Timer = (sPhase2Timer + 0x18) & 0xFFF0;
-        if (this->colliderBody.base.at == &player->actor) {
+        if (this->bodyCollider.base.at == &player->actor) {
             Actor_SetPlayerKnockbackLargeNoDamage(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
         }
@@ -1229,14 +1229,14 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
     this->actor.focus.pos = this->actor.world.pos;
     this->actor.focus.pos.y += 45.0f;
 
-    Collider_UpdateCylinder(&this->actor, &this->colliderBody);
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderBody.base);
+    Collider_UpdateCylinder(&this->actor, &this->bodyCollider);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyCollider.base);
     if (this->actor.colorFilterTimer == 0) {
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->bodyCollider.base);
     }
 
     if ((this->actor.colorFilterTimer == 0) || !(this->actor.colorFilterParams & 0x4000)) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->bodyCollider.base);
     }
 
     func_800F436C(&this->actor.projectedPos, NA_SE_EN_BALINADE_LEVEL - SFX_FLAG,
@@ -1244,7 +1244,7 @@ void BossVa_BodyPhase2(BossVa* this, PlayState* play) {
 }
 
 void BossVa_SetupBodyPhase3(BossVa* this) {
-    this->colliderBody.elem.acDmgInfo.dmgFlags = DMG_BOOMERANG;
+    this->bodyCollider.elem.acDmgInfo.dmgFlags = DMG_BOOMERANG;
     this->actor.speed = 0.0f;
     sPhase3StopMoving = false;
     BossVa_SetupAction(this, BossVa_BodyPhase3);
@@ -1259,16 +1259,16 @@ void BossVa_BodyPhase3(BossVa* this, PlayState* play) {
     sp62 = Math_Vec3f_Yaw(&this->actor.world.pos, &this->actor.home.pos);
     this->unk_1B0 += 0xCE4;
     this->bodyGlow = (s16)(Math_SinS(this->unk_1B0) * 50.0f) + 150;
-    if (this->colliderBody.base.atFlags & AT_HIT) {
-        this->colliderBody.base.atFlags &= ~AT_HIT;
-        if (this->colliderBody.base.at == &player->actor) {
+    if (this->bodyCollider.base.atFlags & AT_HIT) {
+        this->bodyCollider.base.atFlags &= ~AT_HIT;
+        if (this->bodyCollider.base.at == &player->actor) {
             Actor_SetPlayerKnockbackLargeNoDamage(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             this->actor.world.rot.y += (s16)Rand_CenteredFloat(0x2EE0) + 0x8000;
             Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
         }
     }
 
-    if (this->colliderBody.base.acFlags & AC_HIT) {
+    if (this->bodyCollider.base.acFlags & AC_HIT) {
         this->skelAnime.curFrame = 0.0f;
         Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_BLUE, 255, COLORFILTER_BUFFLAG_OPA, 12);
         Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_FAINT);
@@ -1346,11 +1346,11 @@ void BossVa_BodyPhase3(BossVa* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
-    Collider_UpdateCylinder(&this->actor, &this->colliderBody);
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderBody.base);
-    CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderBody.base);
+    Collider_UpdateCylinder(&this->actor, &this->bodyCollider);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyCollider.base);
+    CollisionCheck_SetAT(play, &play->colChkCtx, &this->bodyCollider.base);
     if (this->timer == 0) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->bodyCollider.base);
     }
 
     func_800F436C(&this->actor.projectedPos, NA_SE_EN_BALINADE_LEVEL - SFX_FLAG,
@@ -1369,7 +1369,7 @@ void BossVa_SetupBodyPhase4(BossVa* this, PlayState* play) {
         this->timer = -30;
     }
 
-    this->colliderBody.dim.radius = 55;
+    this->bodyCollider.dim.radius = 55;
     BossVa_SetupAction(this, BossVa_BodyPhase4);
 }
 
@@ -1380,9 +1380,9 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
 
     this->unk_1B0 = (this->unk_1B0 + (s16)((sFightPhase - PHASE_4 + 1) * 1000.0f)) + 0xCE4;
     this->bodyGlow = (s16)(Math_SinS(this->unk_1B0) * 50.0f) + 150;
-    if (this->colliderBody.base.atFlags & AT_HIT) {
-        this->colliderBody.base.atFlags &= ~AT_HIT;
-        if (this->colliderBody.base.at == &player->actor) {
+    if (this->bodyCollider.base.atFlags & AT_HIT) {
+        this->bodyCollider.base.atFlags &= ~AT_HIT;
+        if (this->bodyCollider.base.at == &player->actor) {
             Actor_SetPlayerKnockbackLargeNoDamage(play, &this->actor, 8.0f, this->actor.yawTowardsPlayer, 8.0f);
             this->actor.world.rot.y += (s16)Rand_CenteredFloat(0x2EE0) + 0x8000;
             Actor_PlaySfx(&player->actor, NA_SE_PL_BODY_HIT);
@@ -1392,8 +1392,8 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_BL_SPARK - SFX_FLAG);
     }
 
-    if (this->colliderBody.base.acFlags & AC_HIT) {
-        this->colliderBody.base.acFlags &= ~AC_HIT;
+    if (this->bodyCollider.base.acFlags & AC_HIT) {
+        this->bodyCollider.base.acFlags &= ~AC_HIT;
         this->skelAnime.curFrame = 0.0f;
         if (this->timer >= 0) {
             if (this->invincibilityTimer == 0) {
@@ -1423,8 +1423,8 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
                     Actor_PlaySfx(&this->actor, NA_SE_EN_BALINADE_FAINT);
                 }
             }
-        } else if (this->colliderBody.base.ac->id == ACTOR_EN_BOOM) {
-            boomerang = (EnBoom*)this->colliderBody.base.ac;
+        } else if (this->bodyCollider.base.ac->id == ACTOR_EN_BOOM) {
+            boomerang = (EnBoom*)this->bodyCollider.base.ac;
             boomerang->returnTimer = 0;
             boomerang->moveTo = &player->actor;
             boomerang->actor.world.rot.y = boomerang->actor.yawTowardsPlayer;
@@ -1448,7 +1448,7 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
             }
             Math_SmoothStepToF(&this->actor.speed, ((sFightPhase - PHASE_4 + 1) * 1.5f) + 4.0f, 1.0f, 0.25f, 0.0f);
         }
-        this->colliderBody.elem.acDmgInfo.dmgFlags = DMG_BOOMERANG;
+        this->bodyCollider.elem.acDmgInfo.dmgFlags = DMG_BOOMERANG;
     } else {
         Math_SmoothStepToS(&this->vaBodySpinRate, 0, 1, 0x96, 0);
         if (this->timer > 0) {
@@ -1456,7 +1456,7 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
                 this->timer = 35;
             }
             Math_SmoothStepToF(&this->actor.shape.yOffset, -480.0f, 1.0f, 30.0f, 0.0f);
-            this->colliderBody.elem.acDmgInfo.dmgFlags = DMG_SWORD | DMG_BOOMERANG | DMG_DEKU_STICK;
+            this->bodyCollider.elem.acDmgInfo.dmgFlags = DMG_SWORD | DMG_BOOMERANG | DMG_DEKU_STICK;
             this->timer--;
         } else {
             if ((player->stateFlags1 & PLAYER_STATE1_26) && (this->timer < -60)) {
@@ -1518,13 +1518,13 @@ void BossVa_BodyPhase4(BossVa* this, PlayState* play) {
     }
 
     Actor_UpdateBgCheckInfo(play, &this->actor, 30.0f, 70.0f, 0.0f, UPDBGCHECKINFO_FLAG_0);
-    Collider_UpdateCylinder(&this->actor, &this->colliderBody);
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderBody.base);
+    Collider_UpdateCylinder(&this->actor, &this->bodyCollider);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyCollider.base);
     if (this->invincibilityTimer == 0) {
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->bodyCollider.base);
     }
     if ((this->vaBodySpinRate > 0x3E8) || (this->actor.shape.yOffset < -1200.0f)) {
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderBody.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->bodyCollider.base);
     }
     func_800F436C(&this->actor.projectedPos, NA_SE_EN_BALINADE_LEVEL - SFX_FLAG,
                   (this->vaBodySpinRate * 0.00025f) + 1.0f);
@@ -2839,10 +2839,10 @@ void BossVa_Update(Actor* thisx, PlayState* play2) {
 
     switch (this->actor.params) {
         case BOSSVA_BODY:
-            if (this->colliderBody.base.acFlags & AC_HIT) {
-                this->colliderBody.base.acFlags &= ~AC_HIT;
-                if (this->colliderBody.base.ac->id == ACTOR_EN_BOOM) {
-                    boomerang = (EnBoom*)this->colliderBody.base.ac;
+            if (this->bodyCollider.base.acFlags & AC_HIT) {
+                this->bodyCollider.base.acFlags &= ~AC_HIT;
+                if (this->bodyCollider.base.ac->id == ACTOR_EN_BOOM) {
+                    boomerang = (EnBoom*)this->bodyCollider.base.ac;
                     boomerang->returnTimer = 0;
                 }
             }

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.h
@@ -41,7 +41,7 @@ typedef struct BossVa {
     /* 0x01FC */ Vec3f effectPos[10];
     /* 0x0274 */ Vec3f unk_274; // Unused body position
     /* 0x0280 */ Vec3f unk_280; // Unused body position
-    /* 0x028C */ ColliderCylinder colliderBody;
+    /* 0x028C */ ColliderCylinder bodyCollider;
     /* 0x02D8 */ ColliderJntSph colliderJntSph;
     /* 0x02F8 */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x0338 */ ColliderQuad colliderLightning;

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
@@ -128,19 +128,19 @@ s32 DemoGj_HitByExplosion(DemoGj* this, PlayState* play, ColliderCylinder* cylin
 void DemoGj_DestroyCylinder(DemoGj* this, PlayState* play) {
     switch (DemoGj_GetType(this)) {
         case DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_1:
-            Collider_DestroyCylinder(play, &this->cylinders[0]);
-            Collider_DestroyCylinder(play, &this->cylinders[1]);
-            Collider_DestroyCylinder(play, &this->cylinders[2]);
+            Collider_DestroyCylinder(play, &this->collidersCylinder[0]);
+            Collider_DestroyCylinder(play, &this->collidersCylinder[1]);
+            Collider_DestroyCylinder(play, &this->collidersCylinder[2]);
             break;
 
         case DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_2:
-            Collider_DestroyCylinder(play, &this->cylinders[0]);
-            Collider_DestroyCylinder(play, &this->cylinders[1]);
-            Collider_DestroyCylinder(play, &this->cylinders[2]);
+            Collider_DestroyCylinder(play, &this->collidersCylinder[0]);
+            Collider_DestroyCylinder(play, &this->collidersCylinder[1]);
+            Collider_DestroyCylinder(play, &this->collidersCylinder[2]);
             break;
 
         case DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_TALL:
-            Collider_DestroyCylinder(play, &this->cylinders[0]);
+            Collider_DestroyCylinder(play, &this->collidersCylinder[0]);
             break;
     }
 }
@@ -987,9 +987,9 @@ void DemoGj_DrawRubbleAroundArena(DemoGj* this, PlayState* play) {
 // Inits the three cylinders with `sCylinderInit1`
 void DemoGj_InitDestructableRubble1(DemoGj* this, PlayState* play) {
     DemoGj_InitSetIndices(this, play, 15, 0, NULL);
-    DemoGj_InitCylinder(this, play, &this->cylinders[0], &sCylinderInit1);
-    DemoGj_InitCylinder(this, play, &this->cylinders[1], &sCylinderInit1);
-    DemoGj_InitCylinder(this, play, &this->cylinders[2], &sCylinderInit1);
+    DemoGj_InitCylinder(this, play, &this->collidersCylinder[0], &sCylinderInit1);
+    DemoGj_InitCylinder(this, play, &this->collidersCylinder[1], &sCylinderInit1);
+    DemoGj_InitCylinder(this, play, &this->collidersCylinder[2], &sCylinderInit1);
 }
 
 #if DEBUG_FEATURES
@@ -1002,9 +1002,9 @@ void DemoGj_DoNothing1(DemoGj* this, PlayState* play) {
  * Used by DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_1
  */
 void func_8097AEE8(DemoGj* this, PlayState* play) {
-    ColliderCylinder* cylinder0 = &this->cylinders[0];
-    ColliderCylinder* cylinder1 = &this->cylinders[1];
-    ColliderCylinder* cylinder2 = &this->cylinders[2];
+    ColliderCylinder* cylinder0 = &this->collidersCylinder[0];
+    ColliderCylinder* cylinder1 = &this->collidersCylinder[1];
+    ColliderCylinder* cylinder2 = &this->collidersCylinder[2];
     Vec3f* actorPos = &this->dyna.actor.world.pos;
     s32 pad;
     s16 theta = this->dyna.actor.world.rot.y;
@@ -1026,9 +1026,9 @@ void func_8097AEE8(DemoGj* this, PlayState* play) {
 
 void DemoGj_SetCylindersAsAC(DemoGj* this, PlayState* play) {
     s32 pad[2];
-    Collider* cylinder0 = &this->cylinders[0].base;
-    Collider* cylinder1 = &this->cylinders[1].base;
-    Collider* cylinder2 = &this->cylinders[2].base;
+    Collider* cylinder0 = &this->collidersCylinder[0].base;
+    Collider* cylinder1 = &this->collidersCylinder[1].base;
+    Collider* cylinder2 = &this->collidersCylinder[2].base;
     s32 pad2[3];
 
     CollisionCheck_SetAC(play, &play->colChkCtx, cylinder0);
@@ -1060,13 +1060,13 @@ void func_8097B128(DemoGj* this, PlayState* play) {
 }
 
 s32 DemoGj_HasCylinderAnyExploded(DemoGj* this, PlayState* play) {
-    if (DemoGj_HitByExplosion(this, play, &this->cylinders[0])) {
+    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[0])) {
         return true;
     }
-    if (DemoGj_HitByExplosion(this, play, &this->cylinders[1])) {
+    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[1])) {
         return true;
     }
-    if (DemoGj_HitByExplosion(this, play, &this->cylinders[2])) {
+    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[2])) {
         return true;
     }
     return false;
@@ -1124,9 +1124,9 @@ void DemoGj_DrawDestructableRubble1(DemoGj* this, PlayState* play) {
 // Inits the three cylinders with `sCylinderInit2`
 void DemoGj_InitDestructableRubble2(DemoGj* this, PlayState* play) {
     DemoGj_InitSetIndices(this, play, 16, 0, NULL);
-    DemoGj_InitCylinder(this, play, &this->cylinders[0], &sCylinderInit2);
-    DemoGj_InitCylinder(this, play, &this->cylinders[1], &sCylinderInit2);
-    DemoGj_InitCylinder(this, play, &this->cylinders[2], &sCylinderInit2);
+    DemoGj_InitCylinder(this, play, &this->collidersCylinder[0], &sCylinderInit2);
+    DemoGj_InitCylinder(this, play, &this->collidersCylinder[1], &sCylinderInit2);
+    DemoGj_InitCylinder(this, play, &this->collidersCylinder[2], &sCylinderInit2);
 }
 
 #if DEBUG_FEATURES
@@ -1136,9 +1136,9 @@ void DemoGj_DoNothing2(DemoGj* this, PlayState* play) {
 
 // Moves the ColliderCylinder's relative to the actor's position.
 void func_8097B450(DemoGj* this, PlayState* play) {
-    ColliderCylinder* cylinder0 = &this->cylinders[0];
-    ColliderCylinder* cylinder1 = &this->cylinders[1];
-    ColliderCylinder* cylinder2 = &this->cylinders[2];
+    ColliderCylinder* cylinder0 = &this->collidersCylinder[0];
+    ColliderCylinder* cylinder1 = &this->collidersCylinder[1];
+    ColliderCylinder* cylinder2 = &this->collidersCylinder[2];
     Vec3f* actorPos = &this->dyna.actor.world.pos;
     s32 pad;
     s16 theta = this->dyna.actor.world.rot.y;
@@ -1160,9 +1160,9 @@ void func_8097B450(DemoGj* this, PlayState* play) {
 
 void DemoGj_SetCylindersAsAC2(DemoGj* this, PlayState* play) {
     s32 pad[2];
-    Collider* cylinder0 = &this->cylinders[0].base;
-    Collider* cylinder1 = &this->cylinders[1].base;
-    Collider* cylinder2 = &this->cylinders[2].base;
+    Collider* cylinder0 = &this->collidersCylinder[0].base;
+    Collider* cylinder1 = &this->collidersCylinder[1].base;
+    Collider* cylinder2 = &this->collidersCylinder[2].base;
     s32 pad2[3];
 
     CollisionCheck_SetAC(play, &play->colChkCtx, cylinder0);
@@ -1172,13 +1172,13 @@ void DemoGj_SetCylindersAsAC2(DemoGj* this, PlayState* play) {
 
 // Does the same as `DemoGj_HasCylinderAnyExploded`
 s32 DemoGj_HasCylinderAnyExploded2(DemoGj* this, PlayState* play) {
-    if (DemoGj_HitByExplosion(this, play, &this->cylinders[0])) {
+    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[0])) {
         return true;
     }
-    if (DemoGj_HitByExplosion(this, play, &this->cylinders[1])) {
+    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[1])) {
         return true;
     }
-    if (DemoGj_HitByExplosion(this, play, &this->cylinders[2])) {
+    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[2])) {
         return true;
     }
     return false;
@@ -1259,7 +1259,7 @@ void DemoGj_DemoGj_InitDestructableRubble2(DemoGj* this, PlayState* play) {
 // Inits the first cylinder (only that one) with `sCylinderInit3`
 void DemoGj_InitDestructableRubbleTall(DemoGj* this, PlayState* play) {
     DemoGj_InitSetIndices(this, play, 17, 0, NULL);
-    DemoGj_InitCylinder(this, play, &this->cylinders[0], &sCylinderInit3);
+    DemoGj_InitCylinder(this, play, &this->collidersCylinder[0], &sCylinderInit3);
 }
 
 #if DEBUG_FEATURES
@@ -1301,7 +1301,7 @@ void func_8097B9BC(DemoGj* this, PlayState* play) {
  */
 void func_8097BA48(DemoGj* this, PlayState* play) {
     Actor* thisx = &this->dyna.actor;
-    ColliderCylinder* cylinder = &this->cylinders[0];
+    ColliderCylinder* cylinder = &this->collidersCylinder[0];
     s32 pad[2];
 
     if (func_809797E4(this, 4)) {

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.c
@@ -128,19 +128,19 @@ s32 DemoGj_HitByExplosion(DemoGj* this, PlayState* play, ColliderCylinder* cylin
 void DemoGj_DestroyCylinder(DemoGj* this, PlayState* play) {
     switch (DemoGj_GetType(this)) {
         case DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_1:
-            Collider_DestroyCylinder(play, &this->collidersCylinder[0]);
-            Collider_DestroyCylinder(play, &this->collidersCylinder[1]);
-            Collider_DestroyCylinder(play, &this->collidersCylinder[2]);
+            Collider_DestroyCylinder(play, &this->colliderCylinders[0]);
+            Collider_DestroyCylinder(play, &this->colliderCylinders[1]);
+            Collider_DestroyCylinder(play, &this->colliderCylinders[2]);
             break;
 
         case DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_2:
-            Collider_DestroyCylinder(play, &this->collidersCylinder[0]);
-            Collider_DestroyCylinder(play, &this->collidersCylinder[1]);
-            Collider_DestroyCylinder(play, &this->collidersCylinder[2]);
+            Collider_DestroyCylinder(play, &this->colliderCylinders[0]);
+            Collider_DestroyCylinder(play, &this->colliderCylinders[1]);
+            Collider_DestroyCylinder(play, &this->colliderCylinders[2]);
             break;
 
         case DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_TALL:
-            Collider_DestroyCylinder(play, &this->collidersCylinder[0]);
+            Collider_DestroyCylinder(play, &this->colliderCylinders[0]);
             break;
     }
 }
@@ -987,9 +987,9 @@ void DemoGj_DrawRubbleAroundArena(DemoGj* this, PlayState* play) {
 // Inits the three cylinders with `sCylinderInit1`
 void DemoGj_InitDestructableRubble1(DemoGj* this, PlayState* play) {
     DemoGj_InitSetIndices(this, play, 15, 0, NULL);
-    DemoGj_InitCylinder(this, play, &this->collidersCylinder[0], &sCylinderInit1);
-    DemoGj_InitCylinder(this, play, &this->collidersCylinder[1], &sCylinderInit1);
-    DemoGj_InitCylinder(this, play, &this->collidersCylinder[2], &sCylinderInit1);
+    DemoGj_InitCylinder(this, play, &this->colliderCylinders[0], &sCylinderInit1);
+    DemoGj_InitCylinder(this, play, &this->colliderCylinders[1], &sCylinderInit1);
+    DemoGj_InitCylinder(this, play, &this->colliderCylinders[2], &sCylinderInit1);
 }
 
 #if DEBUG_FEATURES
@@ -1002,9 +1002,9 @@ void DemoGj_DoNothing1(DemoGj* this, PlayState* play) {
  * Used by DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_1
  */
 void func_8097AEE8(DemoGj* this, PlayState* play) {
-    ColliderCylinder* cylinder0 = &this->collidersCylinder[0];
-    ColliderCylinder* cylinder1 = &this->collidersCylinder[1];
-    ColliderCylinder* cylinder2 = &this->collidersCylinder[2];
+    ColliderCylinder* cylinder0 = &this->colliderCylinders[0];
+    ColliderCylinder* cylinder1 = &this->colliderCylinders[1];
+    ColliderCylinder* cylinder2 = &this->colliderCylinders[2];
     Vec3f* actorPos = &this->dyna.actor.world.pos;
     s32 pad;
     s16 theta = this->dyna.actor.world.rot.y;
@@ -1026,9 +1026,9 @@ void func_8097AEE8(DemoGj* this, PlayState* play) {
 
 void DemoGj_SetCylindersAsAC(DemoGj* this, PlayState* play) {
     s32 pad[2];
-    Collider* cylinder0 = &this->collidersCylinder[0].base;
-    Collider* cylinder1 = &this->collidersCylinder[1].base;
-    Collider* cylinder2 = &this->collidersCylinder[2].base;
+    Collider* cylinder0 = &this->colliderCylinders[0].base;
+    Collider* cylinder1 = &this->colliderCylinders[1].base;
+    Collider* cylinder2 = &this->colliderCylinders[2].base;
     s32 pad2[3];
 
     CollisionCheck_SetAC(play, &play->colChkCtx, cylinder0);
@@ -1060,13 +1060,13 @@ void func_8097B128(DemoGj* this, PlayState* play) {
 }
 
 s32 DemoGj_HasCylinderAnyExploded(DemoGj* this, PlayState* play) {
-    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[0])) {
+    if (DemoGj_HitByExplosion(this, play, &this->colliderCylinders[0])) {
         return true;
     }
-    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[1])) {
+    if (DemoGj_HitByExplosion(this, play, &this->colliderCylinders[1])) {
         return true;
     }
-    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[2])) {
+    if (DemoGj_HitByExplosion(this, play, &this->colliderCylinders[2])) {
         return true;
     }
     return false;
@@ -1124,9 +1124,9 @@ void DemoGj_DrawDestructableRubble1(DemoGj* this, PlayState* play) {
 // Inits the three cylinders with `sCylinderInit2`
 void DemoGj_InitDestructableRubble2(DemoGj* this, PlayState* play) {
     DemoGj_InitSetIndices(this, play, 16, 0, NULL);
-    DemoGj_InitCylinder(this, play, &this->collidersCylinder[0], &sCylinderInit2);
-    DemoGj_InitCylinder(this, play, &this->collidersCylinder[1], &sCylinderInit2);
-    DemoGj_InitCylinder(this, play, &this->collidersCylinder[2], &sCylinderInit2);
+    DemoGj_InitCylinder(this, play, &this->colliderCylinders[0], &sCylinderInit2);
+    DemoGj_InitCylinder(this, play, &this->colliderCylinders[1], &sCylinderInit2);
+    DemoGj_InitCylinder(this, play, &this->colliderCylinders[2], &sCylinderInit2);
 }
 
 #if DEBUG_FEATURES
@@ -1136,9 +1136,9 @@ void DemoGj_DoNothing2(DemoGj* this, PlayState* play) {
 
 // Moves the ColliderCylinder's relative to the actor's position.
 void func_8097B450(DemoGj* this, PlayState* play) {
-    ColliderCylinder* cylinder0 = &this->collidersCylinder[0];
-    ColliderCylinder* cylinder1 = &this->collidersCylinder[1];
-    ColliderCylinder* cylinder2 = &this->collidersCylinder[2];
+    ColliderCylinder* cylinder0 = &this->colliderCylinders[0];
+    ColliderCylinder* cylinder1 = &this->colliderCylinders[1];
+    ColliderCylinder* cylinder2 = &this->colliderCylinders[2];
     Vec3f* actorPos = &this->dyna.actor.world.pos;
     s32 pad;
     s16 theta = this->dyna.actor.world.rot.y;
@@ -1160,9 +1160,9 @@ void func_8097B450(DemoGj* this, PlayState* play) {
 
 void DemoGj_SetCylindersAsAC2(DemoGj* this, PlayState* play) {
     s32 pad[2];
-    Collider* cylinder0 = &this->collidersCylinder[0].base;
-    Collider* cylinder1 = &this->collidersCylinder[1].base;
-    Collider* cylinder2 = &this->collidersCylinder[2].base;
+    Collider* cylinder0 = &this->colliderCylinders[0].base;
+    Collider* cylinder1 = &this->colliderCylinders[1].base;
+    Collider* cylinder2 = &this->colliderCylinders[2].base;
     s32 pad2[3];
 
     CollisionCheck_SetAC(play, &play->colChkCtx, cylinder0);
@@ -1172,13 +1172,13 @@ void DemoGj_SetCylindersAsAC2(DemoGj* this, PlayState* play) {
 
 // Does the same as `DemoGj_HasCylinderAnyExploded`
 s32 DemoGj_HasCylinderAnyExploded2(DemoGj* this, PlayState* play) {
-    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[0])) {
+    if (DemoGj_HitByExplosion(this, play, &this->colliderCylinders[0])) {
         return true;
     }
-    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[1])) {
+    if (DemoGj_HitByExplosion(this, play, &this->colliderCylinders[1])) {
         return true;
     }
-    if (DemoGj_HitByExplosion(this, play, &this->collidersCylinder[2])) {
+    if (DemoGj_HitByExplosion(this, play, &this->colliderCylinders[2])) {
         return true;
     }
     return false;
@@ -1259,7 +1259,7 @@ void DemoGj_DemoGj_InitDestructableRubble2(DemoGj* this, PlayState* play) {
 // Inits the first cylinder (only that one) with `sCylinderInit3`
 void DemoGj_InitDestructableRubbleTall(DemoGj* this, PlayState* play) {
     DemoGj_InitSetIndices(this, play, 17, 0, NULL);
-    DemoGj_InitCylinder(this, play, &this->collidersCylinder[0], &sCylinderInit3);
+    DemoGj_InitCylinder(this, play, &this->colliderCylinders[0], &sCylinderInit3);
 }
 
 #if DEBUG_FEATURES
@@ -1301,7 +1301,7 @@ void func_8097B9BC(DemoGj* this, PlayState* play) {
  */
 void func_8097BA48(DemoGj* this, PlayState* play) {
     Actor* thisx = &this->dyna.actor;
-    ColliderCylinder* cylinder = &this->collidersCylinder[0];
+    ColliderCylinder* cylinder = &this->colliderCylinders[0];
     s32 pad[2];
 
     if (func_809797E4(this, 4)) {

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.h
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.h
@@ -17,7 +17,7 @@ typedef struct DemoGj {
     /* 0x0178 */ BossGanon2* ganon;
     /* 0x017C */ s32 isTransformedIntoGanon; // flag
     /* 0x0180 */ s32 isRotated; // flag
-    /* 0x0184 */ ColliderCylinder cylinders[3];
+    /* 0x0184 */ ColliderCylinder collidersCylinder[3];
     /* 0x0268 */ s32 killFlag; // This actor never sets this flag, but it reads it. If set to `true` and the actor type is DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_1, DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_2 or DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_TALL, then the actor will be killed and will drop the specified amount of collectibles.
     /* 0x026C */ Vec3f unk_26C; // This actor never sets this. Specifies which direction will this actor explode when killed using `killFlag`.
 } DemoGj; // size = 0x0278

--- a/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.h
+++ b/src/overlays/actors/ovl_Demo_Gj/z_demo_gj.h
@@ -17,7 +17,7 @@ typedef struct DemoGj {
     /* 0x0178 */ BossGanon2* ganon;
     /* 0x017C */ s32 isTransformedIntoGanon; // flag
     /* 0x0180 */ s32 isRotated; // flag
-    /* 0x0184 */ ColliderCylinder collidersCylinder[3];
+    /* 0x0184 */ ColliderCylinder colliderCylinders[3];
     /* 0x0268 */ s32 killFlag; // This actor never sets this flag, but it reads it. If set to `true` and the actor type is DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_1, DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_2 or DEMOGJ_TYPE_DESTRUCTABLE_RUBBLE_TALL, then the actor will be killed and will drop the specified amount of collectibles.
     /* 0x026C */ Vec3f unk_26C; // This actor never sets this. Specifies which direction will this actor explode when killed using `killFlag`.
 } DemoGj; // size = 0x0278

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -72,7 +72,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 20, 100, 0, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphItemsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -96,7 +96,7 @@ static ColliderJntSphInit sJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     1,
-    sJntSphItemsInit,
+    sJntSphElementsInit,
 };
 
 static DoorKillerTextureEntry sDoorTextures[4] = {

--- a/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
+++ b/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.c
@@ -68,8 +68,8 @@ void EnAnubiceFire_Init(Actor* thisx, PlayState* play) {
     EnAnubiceFire* this = (EnAnubiceFire*)thisx;
     s32 i;
 
-    Collider_InitCylinder(play, &this->cylinder);
-    Collider_SetCylinder(play, &this->cylinder, &this->actor, &sCylinderInit);
+    Collider_InitCylinder(play, &this->colliderCylinder);
+    Collider_SetCylinder(play, &this->colliderCylinder, &this->actor, &sCylinderInit);
 
     this->unk_15A = 30;
     this->unk_154 = 2.0f;
@@ -86,7 +86,7 @@ void EnAnubiceFire_Init(Actor* thisx, PlayState* play) {
 void EnAnubiceFire_Destroy(Actor* thisx, PlayState* play) {
     EnAnubiceFire* this = (EnAnubiceFire*)thisx;
 
-    Collider_DestroyCylinder(play, &this->cylinder);
+    Collider_DestroyCylinder(play, &this->colliderCylinder);
 }
 
 void func_809B26EC(EnAnubiceFire* this, PlayState* play) {
@@ -121,12 +121,12 @@ void func_809B27D8(EnAnubiceFire* this, PlayState* play) {
     Math_ApproachF(&this->scale, this->unk_154, 0.2f, 0.4f);
     if ((this->unk_15A == 0) && (this->scale < 0.1f)) {
         Actor_Kill(&this->actor);
-    } else if ((this->actor.params == 0) && (this->cylinder.base.atFlags & AT_BOUNCED)) {
+    } else if ((this->actor.params == 0) && (this->colliderCylinder.base.atFlags & AT_BOUNCED)) {
         if (Player_HasMirrorShieldEquipped(play)) {
             Actor_PlaySfx(&this->actor, NA_SE_IT_SHIELD_REFLECT_SW);
-            this->cylinder.base.atFlags &= ~(AT_HIT | AT_BOUNCED | AT_TYPE_ENEMY);
-            this->cylinder.base.atFlags |= AT_TYPE_PLAYER;
-            this->cylinder.elem.atDmgInfo.dmgFlags = DMG_DEKU_STICK;
+            this->colliderCylinder.base.atFlags &= ~(AT_HIT | AT_BOUNCED | AT_TYPE_ENEMY);
+            this->colliderCylinder.base.atFlags |= AT_TYPE_PLAYER;
+            this->colliderCylinder.elem.atDmgInfo.dmgFlags = DMG_DEKU_STICK;
             this->unk_15A = 30;
             this->actor.params = 1;
             this->actor.velocity.x *= -1.0f;
@@ -208,14 +208,14 @@ void EnAnubiceFire_Update(Actor* thisx, PlayState* play) {
                             UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2 | UPDBGCHECKINFO_FLAG_3 |
                                 UPDBGCHECKINFO_FLAG_4);
     if (!(this->scale < 0.6f || this->actionFunc == func_809B2B48)) {
-        this->cylinder.dim.radius = this->scale * 15.0f + 5.0f;
-        this->cylinder.dim.height = this->scale * 15.0f + 5.0f;
-        this->cylinder.dim.yShift = this->scale * -0.75f + -15.0f;
+        this->colliderCylinder.dim.radius = this->scale * 15.0f + 5.0f;
+        this->colliderCylinder.dim.height = this->scale * 15.0f + 5.0f;
+        this->colliderCylinder.dim.yShift = this->scale * -0.75f + -15.0f;
 
         if (this->unk_15A != 0) {
-            Collider_UpdateCylinder(&this->actor, &this->cylinder);
-            CollisionCheck_SetAT(play, &play->colChkCtx, &this->cylinder.base);
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->cylinder.base);
+            Collider_UpdateCylinder(&this->actor, &this->colliderCylinder);
+            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderCylinder.base);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder.base);
         }
 
         if (BgCheck_SphVsFirstPoly(&play->colCtx, &this->actor.world.pos, 30.0f)) {

--- a/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.h
+++ b/src/overlays/actors/ovl_En_Anubice_Fire/z_en_anubice_fire.h
@@ -18,7 +18,7 @@ typedef struct EnAnubiceFire {
     /* 0x015C */ s16 unk_15C;
     /* 0x015E */ s16 unk_15E;
     /* 0x0178 */ Vec3f unk_160[6];
-    /* 0x01A8 */ ColliderCylinder cylinder;
+    /* 0x01A8 */ ColliderCylinder colliderCylinder;
 } EnAnubiceFire; // size = 0x01F4
 
 #endif

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.c
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.c
@@ -51,7 +51,7 @@ ActorProfile En_Ba_Profile = {
 
 static Vec3f D_809B8080 = { 0.0f, 0.0f, 32.0f };
 
-static ColliderJntSphElementInit sJntSphElementInit[2] = {
+static ColliderJntSphElementInit sJntSphElementsInit[2] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -86,7 +86,7 @@ static ColliderJntSphInit sJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     2,
-    sJntSphElementInit,
+    sJntSphElementsInit,
 };
 
 void EnBa_SetupAction(EnBa* this, EnBaActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -225,7 +225,7 @@ ActorProfile En_Bb_Profile = {
     /**/ EnBb_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -249,7 +249,7 @@ static ColliderJntSphInit sJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     1,
-    sJntSphElementInit,
+    sJntSphElementsInit,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -63,7 +63,7 @@ ActorProfile En_Bigokuta_Profile = {
     /**/ EnBigokuta_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK1,
@@ -86,8 +86,8 @@ static ColliderJntSphInit sJntSphInit = {
         OC2_TYPE_1,
         COLSHAPE_JNTSPH,
     },
-    ARRAY_COUNT(sJntSphElementInit),
-    sJntSphElementInit,
+    ARRAY_COUNT(sJntSphElementsInit),
+    sJntSphElementsInit,
 };
 
 static ColliderCylinderInit sCylinderInit[] = {

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -189,8 +189,8 @@ void EnBigokuta_Init(Actor* thisx, PlayState* play) {
     this->collider.elements[0].dim.worldSphere.radius = this->collider.elements[0].dim.modelSphere.radius;
 
     for (i = 0; i < ARRAY_COUNT(sCylinderInit); i++) {
-        Collider_InitCylinder(play, &this->collidersCylinder[i]);
-        Collider_SetCylinder(play, &this->collidersCylinder[i], &this->actor, &sCylinderInit[i]);
+        Collider_InitCylinder(play, &this->colliderCylinders[i]);
+        Collider_SetCylinder(play, &this->colliderCylinders[i], &this->actor, &sCylinderInit[i]);
     }
 
     CollisionCheck_SetInfo(&this->actor.colChkInfo, &sDamageTable, sColChkInfoInit);
@@ -213,8 +213,8 @@ void EnBigokuta_Destroy(Actor* thisx, PlayState* play) {
     s32 i;
 
     Collider_DestroyJntSph(play, &this->collider);
-    for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
-        Collider_DestroyCylinder(play, &this->collidersCylinder[i]);
+    for (i = 0; i < ARRAY_COUNT(this->colliderCylinders); i++) {
+        Collider_DestroyCylinder(play, &this->colliderCylinders[i]);
     }
 }
 
@@ -326,7 +326,7 @@ void func_809BD3F8(EnBigokuta* this) {
     this->unk_198 = 80;
     this->unk_19A = this->unk_194 * -0x200;
     func_809BCE3C(this);
-    this->collidersCylinder[0].base.atFlags |= AT_ON;
+    this->colliderCylinders[0].base.atFlags |= AT_ON;
     this->collider.base.acFlags |= AC_ON;
     this->actionFunc = func_809BDC08;
 }
@@ -344,7 +344,7 @@ void func_809BD4A4(EnBigokuta* this) {
     this->actor.world.rot.x = this->actor.shape.rot.y + 0x8000;
     this->unk_19A = this->unk_194 * 0x200;
     this->collider.base.acFlags &= ~AC_ON;
-    this->collidersCylinder[0].base.atFlags |= AT_ON;
+    this->colliderCylinders[0].base.atFlags |= AT_ON;
     this->actionFunc = func_809BDFC8;
 }
 
@@ -352,7 +352,7 @@ void func_809BD524(EnBigokuta* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &object_bigokuta_Anim_000D1C, -5.0f);
     this->unk_196 = 80;
     this->unk_19A = 0;
-    this->collidersCylinder[0].base.atFlags |= AT_ON;
+    this->colliderCylinders[0].base.atFlags |= AT_ON;
     Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_MAHI);
     if (this->collider.elements[0].base.acHitElem->atDmgInfo.dmgFlags & DMG_DEKU_NUT) {
         this->unk_195 = true;
@@ -369,7 +369,7 @@ void func_809BD5E0(EnBigokuta* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &object_bigokuta_Anim_000444, -5.0f);
     this->unk_196 = 24;
     this->unk_19A = 0;
-    this->collidersCylinder[0].base.atFlags &= ~AT_ON;
+    this->colliderCylinders[0].base.atFlags &= ~AT_ON;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 24);
     this->actionFunc = func_809BE180;
 }
@@ -405,7 +405,7 @@ void func_809BD768(EnBigokuta* this) {
     this->unk_194 = Rand_ZeroOne() < 0.5f ? -1 : 1;
     this->unk_19A = 0;
     this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
-    this->collidersCylinder[0].base.atFlags &= ~AT_ON;
+    this->colliderCylinders[0].base.atFlags &= ~AT_ON;
     Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_SINK);
     this->actionFunc = func_809BE4A4;
 }
@@ -601,12 +601,12 @@ void func_809BE058(EnBigokuta* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
 
-    if ((this->collider.base.ocFlags1 & OC1_HIT) || (this->collidersCylinder[0].base.ocFlags1 & OC1_HIT) ||
-        (this->collidersCylinder[1].base.ocFlags1 & OC1_HIT)) {
+    if ((this->collider.base.ocFlags1 & OC1_HIT) || (this->colliderCylinders[0].base.ocFlags1 & OC1_HIT) ||
+        (this->colliderCylinders[1].base.ocFlags1 & OC1_HIT)) {
         speedXZ = CLAMP_MIN(player->actor.speed, 1.0f);
         if (!(this->collider.base.ocFlags1 & OC1_HIT)) {
-            this->collidersCylinder[0].base.ocFlags1 &= ~OC1_HIT;
-            this->collidersCylinder[1].base.ocFlags1 &= ~OC1_HIT;
+            this->colliderCylinders[0].base.ocFlags1 &= ~OC1_HIT;
+            this->colliderCylinders[1].base.ocFlags1 &= ~OC1_HIT;
             speedXZ *= -1.0f;
         }
         player->actor.world.pos.x -= speedXZ * Math_SinS(this->actor.shape.rot.y);
@@ -724,12 +724,12 @@ void func_809BE568(EnBigokuta* this) {
     this->collider.elements[0].dim.worldSphere.center.y =
         this->actor.world.pos.y + this->collider.elements[0].dim.modelSphere.center.y;
 
-    for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
-        this->collidersCylinder[i].dim.pos.x =
+    for (i = 0; i < ARRAY_COUNT(this->colliderCylinders); i++) {
+        this->colliderCylinders[i].dim.pos.x =
             this->actor.world.pos.x + sCylinderInit[i].dim.pos.z * sin + sCylinderInit[i].dim.pos.x * cos;
-        this->collidersCylinder[i].dim.pos.z =
+        this->colliderCylinders[i].dim.pos.z =
             this->actor.world.pos.z + sCylinderInit[i].dim.pos.z * cos - sCylinderInit[i].dim.pos.x * sin;
-        this->collidersCylinder[i].dim.pos.y = this->actor.world.pos.y;
+        this->colliderCylinders[i].dim.pos.y = this->actor.world.pos.y;
     }
 }
 
@@ -737,10 +737,10 @@ void func_809BE798(EnBigokuta* this, PlayState* play) {
     s16 effectRot;
     s16 yawDiff;
 
-    if ((this->collidersCylinder[0].base.atFlags & AT_HIT) || (this->collidersCylinder[1].base.atFlags & AT_HIT) ||
+    if ((this->colliderCylinders[0].base.atFlags & AT_HIT) || (this->colliderCylinders[1].base.atFlags & AT_HIT) ||
         (this->collider.base.atFlags & AT_HIT)) {
-        this->collidersCylinder[0].base.atFlags &= ~AT_HIT;
-        this->collidersCylinder[1].base.atFlags &= ~AT_HIT;
+        this->colliderCylinders[0].base.atFlags &= ~AT_HIT;
+        this->colliderCylinders[1].base.atFlags &= ~AT_HIT;
         this->collider.base.atFlags &= ~AT_HIT;
         yawDiff = this->actor.yawTowardsPlayer - this->actor.world.rot.y;
         if (yawDiff > 0x4000) {
@@ -801,19 +801,19 @@ void EnBigokuta_Update(Actor* thisx, PlayState* play2) {
     Camera_RequestSetting(play->cameraPtrs[CAM_ID_MAIN], CAM_SET_BIG_OCTO);
     Camera_UnsetStateFlag(play->cameraPtrs[CAM_ID_MAIN], CAM_STATE_CHECK_BG);
 
-    if (this->collidersCylinder[0].base.atFlags & AT_ON) {
+    if (this->colliderCylinders[0].base.atFlags & AT_ON) {
         if (this->actionFunc != func_809BE058) {
-            for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
-                CollisionCheck_SetAT(play, &play->colChkCtx, &this->collidersCylinder[i].base);
+            for (i = 0; i < ARRAY_COUNT(this->colliderCylinders); i++) {
+                CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderCylinders[i].base);
             }
             this->actor.flags |= ACTOR_FLAG_SFX_FOR_PLAYER_BODY_HIT;
         } else {
-            for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
-                CollisionCheck_SetOC(play, &play->colChkCtx, &this->collidersCylinder[i].base);
+            for (i = 0; i < ARRAY_COUNT(this->colliderCylinders); i++) {
+                CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinders[i].base);
             }
         }
-        for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[i].base);
+        for (i = 0; i < ARRAY_COUNT(this->colliderCylinders); i++) {
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinders[i].base);
         }
         if (this->collider.base.acFlags & AC_ON) {
             CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -189,8 +189,8 @@ void EnBigokuta_Init(Actor* thisx, PlayState* play) {
     this->collider.elements[0].dim.worldSphere.radius = this->collider.elements[0].dim.modelSphere.radius;
 
     for (i = 0; i < ARRAY_COUNT(sCylinderInit); i++) {
-        Collider_InitCylinder(play, &this->cylinder[i]);
-        Collider_SetCylinder(play, &this->cylinder[i], &this->actor, &sCylinderInit[i]);
+        Collider_InitCylinder(play, &this->collidersCylinder[i]);
+        Collider_SetCylinder(play, &this->collidersCylinder[i], &this->actor, &sCylinderInit[i]);
     }
 
     CollisionCheck_SetInfo(&this->actor.colChkInfo, &sDamageTable, sColChkInfoInit);
@@ -213,8 +213,8 @@ void EnBigokuta_Destroy(Actor* thisx, PlayState* play) {
     s32 i;
 
     Collider_DestroyJntSph(play, &this->collider);
-    for (i = 0; i < ARRAY_COUNT(this->cylinder); i++) {
-        Collider_DestroyCylinder(play, &this->cylinder[i]);
+    for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
+        Collider_DestroyCylinder(play, &this->collidersCylinder[i]);
     }
 }
 
@@ -326,7 +326,7 @@ void func_809BD3F8(EnBigokuta* this) {
     this->unk_198 = 80;
     this->unk_19A = this->unk_194 * -0x200;
     func_809BCE3C(this);
-    this->cylinder[0].base.atFlags |= AT_ON;
+    this->collidersCylinder[0].base.atFlags |= AT_ON;
     this->collider.base.acFlags |= AC_ON;
     this->actionFunc = func_809BDC08;
 }
@@ -344,7 +344,7 @@ void func_809BD4A4(EnBigokuta* this) {
     this->actor.world.rot.x = this->actor.shape.rot.y + 0x8000;
     this->unk_19A = this->unk_194 * 0x200;
     this->collider.base.acFlags &= ~AC_ON;
-    this->cylinder[0].base.atFlags |= AT_ON;
+    this->collidersCylinder[0].base.atFlags |= AT_ON;
     this->actionFunc = func_809BDFC8;
 }
 
@@ -352,7 +352,7 @@ void func_809BD524(EnBigokuta* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &object_bigokuta_Anim_000D1C, -5.0f);
     this->unk_196 = 80;
     this->unk_19A = 0;
-    this->cylinder[0].base.atFlags |= AT_ON;
+    this->collidersCylinder[0].base.atFlags |= AT_ON;
     Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_MAHI);
     if (this->collider.elements[0].base.acHitElem->atDmgInfo.dmgFlags & DMG_DEKU_NUT) {
         this->unk_195 = true;
@@ -369,7 +369,7 @@ void func_809BD5E0(EnBigokuta* this) {
     Animation_MorphToPlayOnce(&this->skelAnime, &object_bigokuta_Anim_000444, -5.0f);
     this->unk_196 = 24;
     this->unk_19A = 0;
-    this->cylinder[0].base.atFlags &= ~AT_ON;
+    this->collidersCylinder[0].base.atFlags &= ~AT_ON;
     Actor_SetColorFilter(&this->actor, COLORFILTER_COLORFLAG_RED, 255, COLORFILTER_BUFFLAG_OPA, 24);
     this->actionFunc = func_809BE180;
 }
@@ -405,7 +405,7 @@ void func_809BD768(EnBigokuta* this) {
     this->unk_194 = Rand_ZeroOne() < 0.5f ? -1 : 1;
     this->unk_19A = 0;
     this->actor.flags &= ~ACTOR_FLAG_ATTENTION_ENABLED;
-    this->cylinder[0].base.atFlags &= ~AT_ON;
+    this->collidersCylinder[0].base.atFlags &= ~AT_ON;
     Actor_PlaySfx(&this->actor, NA_SE_EN_DAIOCTA_SINK);
     this->actionFunc = func_809BE4A4;
 }
@@ -601,12 +601,12 @@ void func_809BE058(EnBigokuta* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
 
-    if ((this->collider.base.ocFlags1 & OC1_HIT) || (this->cylinder[0].base.ocFlags1 & OC1_HIT) ||
-        (this->cylinder[1].base.ocFlags1 & OC1_HIT)) {
+    if ((this->collider.base.ocFlags1 & OC1_HIT) || (this->collidersCylinder[0].base.ocFlags1 & OC1_HIT) ||
+        (this->collidersCylinder[1].base.ocFlags1 & OC1_HIT)) {
         speedXZ = CLAMP_MIN(player->actor.speed, 1.0f);
         if (!(this->collider.base.ocFlags1 & OC1_HIT)) {
-            this->cylinder[0].base.ocFlags1 &= ~OC1_HIT;
-            this->cylinder[1].base.ocFlags1 &= ~OC1_HIT;
+            this->collidersCylinder[0].base.ocFlags1 &= ~OC1_HIT;
+            this->collidersCylinder[1].base.ocFlags1 &= ~OC1_HIT;
             speedXZ *= -1.0f;
         }
         player->actor.world.pos.x -= speedXZ * Math_SinS(this->actor.shape.rot.y);
@@ -724,12 +724,12 @@ void func_809BE568(EnBigokuta* this) {
     this->collider.elements[0].dim.worldSphere.center.y =
         this->actor.world.pos.y + this->collider.elements[0].dim.modelSphere.center.y;
 
-    for (i = 0; i < ARRAY_COUNT(this->cylinder); i++) {
-        this->cylinder[i].dim.pos.x =
+    for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
+        this->collidersCylinder[i].dim.pos.x =
             this->actor.world.pos.x + sCylinderInit[i].dim.pos.z * sin + sCylinderInit[i].dim.pos.x * cos;
-        this->cylinder[i].dim.pos.z =
+        this->collidersCylinder[i].dim.pos.z =
             this->actor.world.pos.z + sCylinderInit[i].dim.pos.z * cos - sCylinderInit[i].dim.pos.x * sin;
-        this->cylinder[i].dim.pos.y = this->actor.world.pos.y;
+        this->collidersCylinder[i].dim.pos.y = this->actor.world.pos.y;
     }
 }
 
@@ -737,10 +737,10 @@ void func_809BE798(EnBigokuta* this, PlayState* play) {
     s16 effectRot;
     s16 yawDiff;
 
-    if ((this->cylinder[0].base.atFlags & AT_HIT) || (this->cylinder[1].base.atFlags & AT_HIT) ||
+    if ((this->collidersCylinder[0].base.atFlags & AT_HIT) || (this->collidersCylinder[1].base.atFlags & AT_HIT) ||
         (this->collider.base.atFlags & AT_HIT)) {
-        this->cylinder[0].base.atFlags &= ~AT_HIT;
-        this->cylinder[1].base.atFlags &= ~AT_HIT;
+        this->collidersCylinder[0].base.atFlags &= ~AT_HIT;
+        this->collidersCylinder[1].base.atFlags &= ~AT_HIT;
         this->collider.base.atFlags &= ~AT_HIT;
         yawDiff = this->actor.yawTowardsPlayer - this->actor.world.rot.y;
         if (yawDiff > 0x4000) {
@@ -801,19 +801,19 @@ void EnBigokuta_Update(Actor* thisx, PlayState* play2) {
     Camera_RequestSetting(play->cameraPtrs[CAM_ID_MAIN], CAM_SET_BIG_OCTO);
     Camera_UnsetStateFlag(play->cameraPtrs[CAM_ID_MAIN], CAM_STATE_CHECK_BG);
 
-    if (this->cylinder[0].base.atFlags & AT_ON) {
+    if (this->collidersCylinder[0].base.atFlags & AT_ON) {
         if (this->actionFunc != func_809BE058) {
-            for (i = 0; i < ARRAY_COUNT(this->cylinder); i++) {
-                CollisionCheck_SetAT(play, &play->colChkCtx, &this->cylinder[i].base);
+            for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
+                CollisionCheck_SetAT(play, &play->colChkCtx, &this->collidersCylinder[i].base);
             }
             this->actor.flags |= ACTOR_FLAG_SFX_FOR_PLAYER_BODY_HIT;
         } else {
-            for (i = 0; i < ARRAY_COUNT(this->cylinder); i++) {
-                CollisionCheck_SetOC(play, &play->colChkCtx, &this->cylinder[i].base);
+            for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
+                CollisionCheck_SetOC(play, &play->colChkCtx, &this->collidersCylinder[i].base);
             }
         }
-        for (i = 0; i < ARRAY_COUNT(this->cylinder); i++) {
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->cylinder[i].base);
+        for (i = 0; i < ARRAY_COUNT(this->collidersCylinder); i++) {
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[i].base);
         }
         if (this->collider.base.acFlags & AC_ON) {
             CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
@@ -21,7 +21,7 @@ typedef struct EnBigokuta {
     /* 0x0214 */ Vec3s morphTable[20];
     /* 0x028C */ ColliderJntSph collider;
     /* 0x02AC */ ColliderJntSphElement colliderElements[1];
-    /* 0x02EC */ ColliderCylinder cylinder[2];
+    /* 0x02EC */ ColliderCylinder collidersCylinder[2];
 } EnBigokuta; // size = 0x0384
 
 #endif

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
@@ -21,7 +21,7 @@ typedef struct EnBigokuta {
     /* 0x0214 */ Vec3s morphTable[20];
     /* 0x028C */ ColliderJntSph collider;
     /* 0x02AC */ ColliderJntSphElement colliderElements[1];
-    /* 0x02EC */ ColliderCylinder collidersCylinder[2];
+    /* 0x02EC */ ColliderCylinder colliderCylinders[2];
 } EnBigokuta; // size = 0x0384
 
 #endif

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
@@ -41,7 +41,7 @@ ActorProfile En_Bom_Chu_Profile = {
     /**/ EnBomChu_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElemInit[] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -64,8 +64,8 @@ static ColliderJntSphInit sJntSphInit = {
         OC2_TYPE_2,
         COLSHAPE_JNTSPH,
     },
-    ARRAY_COUNT(sJntSphElemInit),
-    sJntSphElemInit,
+    ARRAY_COUNT(sJntSphElementsInit),
+    sJntSphElementsInit,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -256,7 +256,7 @@ void EnDntNomal_TargetWait(EnDntNomal* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
 #if OOT_VERSION < PAL_1_0
-    if (this->targetQuad.base.acFlags & AC_HIT)
+    if (this->targetColliderQuad.base.acFlags & AC_HIT)
 #else
     if ((this->targetColliderQuad.base.acFlags & AC_HIT) || BREG(0))
 #endif

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -149,16 +149,16 @@ void EnDntNomal_Init(Actor* thisx, PlayState* play) {
         PRINTF("\n\n");
         // "Deku Scrub target"
         PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ デグナッツ的当て ☆☆☆☆☆ \n" VT_RST);
-        Collider_InitQuad(play, &this->targetQuad);
-        Collider_SetQuad(play, &this->targetQuad, &this->actor, &sTargetQuadInit);
+        Collider_InitQuad(play, &this->targetColliderQuad);
+        Collider_SetQuad(play, &this->targetColliderQuad, &this->actor, &sTargetQuadInit);
         this->actor.world.rot.y = this->actor.shape.rot.y = this->actor.yawTowardsPlayer;
         this->objectId = OBJECT_HINTNUTS;
     } else {
         PRINTF("\n\n");
         // "Deku Scrub mask show audience"
         PRINTF(VT_FGCOL(GREEN) "☆☆☆☆☆ デグナッツお面品評会一般人 ☆☆☆☆☆ \n" VT_RST);
-        Collider_InitCylinder(play, &this->bodyCyl);
-        Collider_SetCylinder(play, &this->bodyCyl, &this->actor, &sBodyCylinderInit);
+        Collider_InitCylinder(play, &this->bodyColliderCylinder);
+        Collider_SetCylinder(play, &this->bodyColliderCylinder, &this->actor, &sBodyCylinderInit);
         this->objectId = OBJECT_DNK;
     }
     if (this->objectId >= 0) {
@@ -182,9 +182,9 @@ void EnDntNomal_Destroy(Actor* thisx, PlayState* play) {
     EnDntNomal* this = (EnDntNomal*)thisx;
 
     if (this->type == ENDNTNOMAL_TARGET) {
-        Collider_DestroyQuad(play, &this->targetQuad);
+        Collider_DestroyQuad(play, &this->targetColliderQuad);
     } else {
-        Collider_DestroyCylinder(play, &this->bodyCyl);
+        Collider_DestroyCylinder(play, &this->bodyColliderCylinder);
     }
 }
 
@@ -258,14 +258,14 @@ void EnDntNomal_TargetWait(EnDntNomal* this, PlayState* play) {
 #if OOT_VERSION < PAL_1_0
     if (this->targetQuad.base.acFlags & AC_HIT)
 #else
-    if ((this->targetQuad.base.acFlags & AC_HIT) || BREG(0))
+    if ((this->targetColliderQuad.base.acFlags & AC_HIT) || BREG(0))
 #endif
     {
-        this->targetQuad.base.acFlags &= ~AC_HIT;
+        this->targetColliderQuad.base.acFlags &= ~AC_HIT;
 
-        dx = fabsf(targetX - this->targetQuad.elem.acDmgInfo.hitPos.x);
-        dy = fabsf(targetY - this->targetQuad.elem.acDmgInfo.hitPos.y);
-        dz = fabsf(targetZ - this->targetQuad.elem.acDmgInfo.hitPos.z);
+        dx = fabsf(targetX - this->targetColliderQuad.elem.acDmgInfo.hitPos.x);
+        dy = fabsf(targetY - this->targetColliderQuad.elem.acDmgInfo.hitPos.y);
+        dz = fabsf(targetZ - this->targetColliderQuad.elem.acDmgInfo.hitPos.z);
 
         scoreVel.y = 5.0f;
 
@@ -854,13 +854,13 @@ void EnDntNomal_Update(Actor* thisx, PlayState* play) {
                             UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2 | UPDBGCHECKINFO_FLAG_3 |
                                 UPDBGCHECKINFO_FLAG_4);
     if (this->type == ENDNTNOMAL_TARGET) {
-        Collider_SetQuadVertices(&this->targetQuad, &this->targetVtx[0], &this->targetVtx[1], &this->targetVtx[2],
+        Collider_SetQuadVertices(&this->targetColliderQuad, &this->targetVtx[0], &this->targetVtx[1], &this->targetVtx[2],
                                  &this->targetVtx[3]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->targetQuad.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->targetColliderQuad.base);
     } else {
-        Collider_UpdateCylinder(&this->actor, &this->bodyCyl);
+        Collider_UpdateCylinder(&this->actor, &this->bodyColliderCylinder);
         if (this->isSolid) {
-            CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyCyl.base);
+            CollisionCheck_SetOC(play, &play->colChkCtx, &this->bodyColliderCylinder.base);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.c
@@ -854,8 +854,8 @@ void EnDntNomal_Update(Actor* thisx, PlayState* play) {
                             UPDBGCHECKINFO_FLAG_0 | UPDBGCHECKINFO_FLAG_2 | UPDBGCHECKINFO_FLAG_3 |
                                 UPDBGCHECKINFO_FLAG_4);
     if (this->type == ENDNTNOMAL_TARGET) {
-        Collider_SetQuadVertices(&this->targetColliderQuad, &this->targetVtx[0], &this->targetVtx[1], &this->targetVtx[2],
-                                 &this->targetVtx[3]);
+        Collider_SetQuadVertices(&this->targetColliderQuad, &this->targetVtx[0], &this->targetVtx[1],
+                                 &this->targetVtx[2], &this->targetVtx[3]);
         CollisionCheck_SetAC(play, &play->colChkCtx, &this->targetColliderQuad.base);
     } else {
         Collider_UpdateCylinder(&this->actor, &this->bodyColliderCylinder);

--- a/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.h
+++ b/src/overlays/actors/ovl_En_Dnt_Nomal/z_en_dnt_nomal.h
@@ -38,8 +38,8 @@ typedef struct EnDntNomal {
     /* 0x0279 */ s8 requiredObjectSlot;
     /* 0x027C */ Vec3f mouthPos;
     /* 0x0288 */ Vec3f targetPos;
-    /* 0x0294 */ ColliderQuad targetQuad;
-    /* 0x0314 */ ColliderCylinder bodyCyl;
+    /* 0x0294 */ ColliderQuad targetColliderQuad;
+    /* 0x0314 */ ColliderCylinder bodyColliderCylinder;
 } EnDntNomal; // size = 0x0360
 
 #define ENDNTNOMAL_TARGET 0

--- a/src/overlays/actors/ovl_En_Goma/z_en_goma.c
+++ b/src/overlays/actors/ovl_En_Goma/z_en_goma.c
@@ -185,10 +185,10 @@ void EnGoma_Init(Actor* thisx, PlayState* play) {
         this->eggScale = 1.0f;
         this->eggSquishAngle = Rand_ZeroOne() * 1000.0f;
         this->actionTimer = 50;
-        Collider_InitCylinder(play, &this->colCyl1);
-        Collider_SetCylinder(play, &this->colCyl1, &this->actor, &D_80A4B7A0);
-        Collider_InitCylinder(play, &this->colCyl2);
-        Collider_SetCylinder(play, &this->colCyl2, &this->actor, &D_80A4B7CC);
+        Collider_InitCylinder(play, &this->colliderCylinder1);
+        Collider_SetCylinder(play, &this->colliderCylinder1, &this->actor, &D_80A4B7A0);
+        Collider_InitCylinder(play, &this->colliderCylinder2);
+        Collider_SetCylinder(play, &this->colliderCylinder2, &this->actor, &D_80A4B7CC);
     }
 }
 
@@ -196,8 +196,8 @@ void EnGoma_Destroy(Actor* thisx, PlayState* play) {
     EnGoma* this = (EnGoma*)thisx;
 
     if (this->actor.params < 10) {
-        Collider_DestroyCylinder(play, &this->colCyl1);
-        Collider_DestroyCylinder(play, &this->colCyl2);
+        Collider_DestroyCylinder(play, &this->colliderCylinder1);
+        Collider_DestroyCylinder(play, &this->colliderCylinder2);
     }
 }
 
@@ -635,15 +635,15 @@ void EnGoma_UpdateHit(EnGoma* this, PlayState* play) {
         ColliderElement* acHitElem;
         u8 swordDamage;
 
-        if ((this->colCyl1.base.atFlags & AT_HIT) && this->actionFunc == EnGoma_Jump) {
+        if ((this->colliderCylinder1.base.atFlags & AT_HIT) && this->actionFunc == EnGoma_Jump) {
             EnGoma_SetupLand(this);
             this->actor.speed = 0.0f;
             this->actor.velocity.y = 0.0f;
         }
 
-        if ((this->colCyl2.base.acFlags & AC_HIT) && (s8)this->actor.colChkInfo.health > 0) {
-            acHitElem = this->colCyl2.elem.acHitElem;
-            this->colCyl2.base.acFlags &= ~AC_HIT;
+        if ((this->colliderCylinder2.base.acFlags & AC_HIT) && (s8)this->actor.colChkInfo.health > 0) {
+            acHitElem = this->colliderCylinder2.elem.acHitElem;
+            this->colliderCylinder2.base.acFlags &= ~AC_HIT;
 
             if (this->gomaType == ENGOMA_NORMAL) {
                 u32 dmgFlags = acHitElem->atDmgInfo.dmgFlags;
@@ -753,20 +753,20 @@ void EnGoma_Update(Actor* thisx, PlayState* play) {
         EnGoma_UpdateEyeEnvColor(this);
         this->visualState = 1;
         if (player->meleeWeaponState != 0) {
-            this->colCyl2.dim.radius = 35;
-            this->colCyl2.dim.height = 35;
-            this->colCyl2.dim.yShift = 0;
+            this->colliderCylinder2.dim.radius = 35;
+            this->colliderCylinder2.dim.height = 35;
+            this->colliderCylinder2.dim.yShift = 0;
         } else {
-            this->colCyl2.dim.radius = 15;
-            this->colCyl2.dim.height = 30;
-            this->colCyl2.dim.yShift = 10;
+            this->colliderCylinder2.dim.radius = 15;
+            this->colliderCylinder2.dim.height = 30;
+            this->colliderCylinder2.dim.yShift = 10;
         }
         if (this->invincibilityTimer == 0) {
-            Collider_UpdateCylinder(&this->actor, &this->colCyl1);
-            Collider_UpdateCylinder(&this->actor, &this->colCyl2);
-            CollisionCheck_SetOC(play, &play->colChkCtx, &this->colCyl1.base);
-            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colCyl2.base);
-            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colCyl1.base);
+            Collider_UpdateCylinder(&this->actor, &this->colliderCylinder1);
+            Collider_UpdateCylinder(&this->actor, &this->colliderCylinder2);
+            CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder1.base);
+            CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder2.base);
+            CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderCylinder1.base);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Goma/z_en_goma.h
+++ b/src/overlays/actors/ovl_En_Goma/z_en_goma.h
@@ -73,8 +73,8 @@ typedef struct EnGoma {
     /* 0x2F8 */ s16 stunTimer;
     /* 0x2FC */ Vec3f shieldKnockbackVel;
     /* 0x308 */ Gfx* bossLimbDL; // set by z_boss_goma
-    /* 0x30C */ ColliderCylinder colCyl1;
-    /* 0x358 */ ColliderCylinder colCyl2;
+    /* 0x30C */ ColliderCylinder colliderCylinder1;
+    /* 0x358 */ ColliderCylinder colliderCylinder2;
 } EnGoma; // size = 0x03A4
 
 #endif

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -143,7 +143,7 @@ static ColliderCylinderInit sCylinderInit2 = {
     { 20, 70, 0, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphItemsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -167,7 +167,7 @@ static ColliderJntSphInit sJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     1,
-    sJntSphItemsInit,
+    sJntSphElementsInit,
 };
 
 static CollisionCheckInfoInit D_80A65F38 = { 10, 35, 100, MASS_HEAVY };

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -840,10 +840,10 @@ void EnHorse_Init(Actor* thisx, PlayState* play2) {
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawHorse, 20.0f);
     this->action = ENHORSE_ACT_IDLE;
     this->actor.speed = 0.0f;
-    Collider_InitCylinder(play, &this->cyl1);
-    Collider_SetCylinder(play, &this->cyl1, &this->actor, &sCylinderInit1);
-    Collider_InitCylinder(play, &this->cyl2);
-    Collider_SetCylinder(play, &this->cyl2, &this->actor, &sCylinderInit2);
+    Collider_InitCylinder(play, &this->colliderCylinder1);
+    Collider_SetCylinder(play, &this->colliderCylinder1, &this->actor, &sCylinderInit1);
+    Collider_InitCylinder(play, &this->colliderCylinder2);
+    Collider_SetCylinder(play, &this->colliderCylinder2, &this->actor, &sCylinderInit2);
     Collider_InitJntSph(play, &this->colliderJntSph);
     Collider_SetJntSph(play, &this->colliderJntSph, &this->actor, &sJntSphInit, this->colliderJntSphElements);
     CollisionCheck_SetInfo(&this->actor.colChkInfo, DamageTable_Get(0xB), &D_80A65F38);
@@ -928,8 +928,8 @@ void EnHorse_Destroy(Actor* thisx, PlayState* play) {
         Audio_StopSfxByPos(&this->unk_21C);
     }
     Skin_Free(play, &this->skin);
-    Collider_DestroyCylinder(play, &this->cyl1);
-    Collider_DestroyCylinder(play, &this->cyl2);
+    Collider_DestroyCylinder(play, &this->colliderCylinder1);
+    Collider_DestroyCylinder(play, &this->colliderCylinder2);
     Collider_DestroyJntSph(play, &this->colliderJntSph);
 }
 
@@ -949,8 +949,8 @@ void EnHorse_Freeze(EnHorse* this) {
         }
         this->prevAction = this->action;
         this->action = ENHORSE_ACT_FROZEN;
-        this->cyl1.base.ocFlags1 &= ~OC1_ON;
-        this->cyl2.base.ocFlags1 &= ~OC1_ON;
+        this->colliderCylinder1.base.ocFlags1 &= ~OC1_ON;
+        this->colliderCylinder2.base.ocFlags1 &= ~OC1_ON;
         this->colliderJntSph.base.ocFlags1 &= ~OC1_ON;
         this->animationIdx = ENHORSE_ANIM_IDLE;
     }
@@ -965,8 +965,8 @@ void EnHorse_Frozen(EnHorse* this, PlayState* play) {
     this->actor.speed = 0.0f;
     this->noInputTimer--;
     if (this->noInputTimer < 0) {
-        this->cyl1.base.ocFlags1 |= OC1_ON;
-        this->cyl2.base.ocFlags1 |= OC1_ON;
+        this->colliderCylinder1.base.ocFlags1 |= OC1_ON;
+        this->colliderCylinder2.base.ocFlags1 |= OC1_ON;
         this->colliderJntSph.base.ocFlags1 |= OC1_ON;
         if (this->playerControlled == true) {
             this->stateFlags &= ~ENHORSE_FLAG_7;
@@ -1750,8 +1750,8 @@ void EnHorse_HighJump(EnHorse* this, PlayState* play) {
 }
 
 void EnHorse_InitInactive(EnHorse* this) {
-    this->cyl1.base.ocFlags1 &= ~OC1_ON;
-    this->cyl2.base.ocFlags1 &= ~OC1_ON;
+    this->colliderCylinder1.base.ocFlags1 &= ~OC1_ON;
+    this->colliderCylinder2.base.ocFlags1 &= ~OC1_ON;
     this->colliderJntSph.base.ocFlags1 &= ~OC1_ON;
     this->action = ENHORSE_ACT_INACTIVE;
     this->animationIdx = ENHORSE_ANIM_WALK;
@@ -1784,8 +1784,8 @@ void EnHorse_Inactive(EnHorse* this, PlayState* play2) {
         this->followTimer = 0;
         EnHorse_SetFollowAnimation(this, play);
         this->actor.params = HORSE_PTYPE_0;
-        this->cyl1.base.ocFlags1 |= OC1_ON;
-        this->cyl2.base.ocFlags1 |= OC1_ON;
+        this->colliderCylinder1.base.ocFlags1 |= OC1_ON;
+        this->colliderCylinder2.base.ocFlags1 |= OC1_ON;
         this->colliderJntSph.base.ocFlags1 |= OC1_ON;
     }
 }
@@ -3585,17 +3585,17 @@ void EnHorse_Update(Actor* thisx, PlayState* play2) {
         if (this->action != ENHORSE_ACT_INGO_RACE) {
             EnHorse_TiltBody(this, play);
         }
-        Collider_UpdateCylinder(thisx, &this->cyl1);
-        Collider_UpdateCylinder(thisx, &this->cyl2);
+        Collider_UpdateCylinder(thisx, &this->colliderCylinder1);
+        Collider_UpdateCylinder(thisx, &this->colliderCylinder2);
 
         // Required to match
-        this->cyl1.dim.pos.x = this->cyl1.dim.pos.x + (s16)(Math_SinS(thisx->shape.rot.y) * 11.0f);
-        this->cyl1.dim.pos.z = this->cyl1.dim.pos.z + (s16)(Math_CosS(thisx->shape.rot.y) * 11.0f);
-        this->cyl2.dim.pos.x = this->cyl2.dim.pos.x + (s16)(Math_SinS(thisx->shape.rot.y) * -18.0f);
-        this->cyl2.dim.pos.z = this->cyl2.dim.pos.z + (s16)(Math_CosS(thisx->shape.rot.y) * -18.0f);
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->cyl1.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->cyl1.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->cyl2.base);
+        this->colliderCylinder1.dim.pos.x = this->colliderCylinder1.dim.pos.x + (s16)(Math_SinS(thisx->shape.rot.y) * 11.0f);
+        this->colliderCylinder1.dim.pos.z = this->colliderCylinder1.dim.pos.z + (s16)(Math_CosS(thisx->shape.rot.y) * 11.0f);
+        this->colliderCylinder2.dim.pos.x = this->colliderCylinder2.dim.pos.x + (s16)(Math_SinS(thisx->shape.rot.y) * -18.0f);
+        this->colliderCylinder2.dim.pos.z = this->colliderCylinder2.dim.pos.z + (s16)(Math_CosS(thisx->shape.rot.y) * -18.0f);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderCylinder1.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder1.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder2.base);
         if ((player->stateFlags1 & PLAYER_STATE1_0) && player->rideActor != NULL) {
             if (play->sceneId != SCENE_LON_LON_RANCH ||
                 (play->sceneId == SCENE_LON_LON_RANCH && (thisx->world.pos.z < -2400.0f))) {
@@ -3639,9 +3639,9 @@ void EnHorse_Update(Actor* thisx, PlayState* play2) {
         }
 
         if (thisx->speed >= 5.0f) {
-            this->cyl1.base.atFlags |= AT_ON;
+            this->colliderCylinder1.base.atFlags |= AT_ON;
         } else {
-            this->cyl1.base.atFlags &= ~AT_ON;
+            this->colliderCylinder1.base.atFlags &= ~AT_ON;
         }
 
         if (gSaveContext.save.entranceIndex != ENTR_LON_LON_RANCH_0 || gSaveContext.sceneLayer != 9) {

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -3589,10 +3589,14 @@ void EnHorse_Update(Actor* thisx, PlayState* play2) {
         Collider_UpdateCylinder(thisx, &this->colliderCylinder2);
 
         // Required to match
-        this->colliderCylinder1.dim.pos.x = this->colliderCylinder1.dim.pos.x + (s16)(Math_SinS(thisx->shape.rot.y) * 11.0f);
-        this->colliderCylinder1.dim.pos.z = this->colliderCylinder1.dim.pos.z + (s16)(Math_CosS(thisx->shape.rot.y) * 11.0f);
-        this->colliderCylinder2.dim.pos.x = this->colliderCylinder2.dim.pos.x + (s16)(Math_SinS(thisx->shape.rot.y) * -18.0f);
-        this->colliderCylinder2.dim.pos.z = this->colliderCylinder2.dim.pos.z + (s16)(Math_CosS(thisx->shape.rot.y) * -18.0f);
+        this->colliderCylinder1.dim.pos.x =
+            this->colliderCylinder1.dim.pos.x + (s16)(Math_SinS(thisx->shape.rot.y) * 11.0f);
+        this->colliderCylinder1.dim.pos.z =
+            this->colliderCylinder1.dim.pos.z + (s16)(Math_CosS(thisx->shape.rot.y) * 11.0f);
+        this->colliderCylinder2.dim.pos.x =
+            this->colliderCylinder2.dim.pos.x + (s16)(Math_SinS(thisx->shape.rot.y) * -18.0f);
+        this->colliderCylinder2.dim.pos.z =
+            this->colliderCylinder2.dim.pos.z + (s16)(Math_CosS(thisx->shape.rot.y) * -18.0f);
         CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderCylinder1.base);
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder1.base);
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder2.base);

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.h
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.h
@@ -140,8 +140,8 @@ typedef struct EnHorse {
     /* 0x0264 */ Vec2f curStick;
     /* 0x026C */ Vec2f lastStick;
     /* 0x0274 */ f32 jumpStartY;
-    /* 0x0278 */ ColliderCylinder cyl1;
-    /* 0x02C4 */ ColliderCylinder cyl2;
+    /* 0x0278 */ ColliderCylinder colliderCylinder1;
+    /* 0x02C4 */ ColliderCylinder colliderCylinder2;
     /* 0x0310 */ ColliderJntSph colliderJntSph;
     /* 0x0330 */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x0370 */ u32 playerDir;

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
@@ -66,7 +66,7 @@ static ColliderCylinderInitType1 sCylinderInit = {
     { 20, 100, 0, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -90,7 +90,7 @@ static ColliderJntSphInit sJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     1,
-    sJntSphElementInit,
+    sJntSphElementsInit,
 };
 
 static CollisionCheckInfoInit sColCheckInfoInit = { 10, 35, 100, MASS_HEAVY };

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -67,7 +67,7 @@ ActorProfile En_Insect_Profile = {
     /**/ EnInsect_Draw,
 };
 
-static ColliderJntSphElementInit sColliderItemInit[1] = {
+static ColliderJntSphElementInit sColliderElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -91,7 +91,7 @@ static ColliderJntSphInit sColliderInit = {
         COLSHAPE_JNTSPH,
     },
     1,
-    sColliderItemInit,
+    sColliderElementsInit,
 };
 
 /**

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -89,7 +89,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 50, 160, -70, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElemInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -113,7 +113,7 @@ static ColliderJntSphInit sJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     1,
-    sJntSphElemInit,
+    sJntSphElementsInit,
 };
 
 static ColliderQuadInit sQuadInit = {

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -91,7 +91,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 20, 40, 20, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit D_80AE1AA0[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -115,7 +115,7 @@ static ColliderJntSphInit sJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     1,
-    D_80AE1AA0,
+    sJntSphElementsInit,
 };
 
 static CollisionCheckInfoInit sColChkInfoInit = { 4, 25, 50, 40 };

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -210,19 +210,19 @@ void EnSsh_InitColliders(EnSsh* this, PlayState* play) {
     s32 pad;
 
     for (i = 0; i < ARRAY_COUNT(cylinders); i++) {
-        Collider_InitCylinder(play, &this->collidersCylinder[i]);
-        Collider_SetCylinder(play, &this->collidersCylinder[i], &this->actor, cylinders[i]);
+        Collider_InitCylinder(play, &this->colliderCylinders[i]);
+        Collider_SetCylinder(play, &this->colliderCylinders[i], &this->actor, cylinders[i]);
     }
 
-    this->collidersCylinder[0].elem.acDmgInfo.dmgFlags =
+    this->colliderCylinders[0].elem.acDmgInfo.dmgFlags =
         DMG_ARROW | DMG_MAGIC_FIRE | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_EXPLOSIVE | DMG_DEKU_NUT;
-    this->collidersCylinder[1].elem.acDmgInfo.dmgFlags =
+    this->colliderCylinders[1].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT & ~(DMG_ARROW | DMG_MAGIC_FIRE | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_EXPLOSIVE | DMG_DEKU_NUT) &
         ~(DMG_MAGIC_LIGHT | DMG_MAGIC_ICE);
-    this->collidersCylinder[2].base.colMaterial = COL_MATERIAL_METAL;
-    this->collidersCylinder[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
-    this->collidersCylinder[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
-    this->collidersCylinder[2].elem.acDmgInfo.dmgFlags =
+    this->colliderCylinders[2].base.colMaterial = COL_MATERIAL_METAL;
+    this->colliderCylinders[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
+    this->colliderCylinders[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
+    this->colliderCylinders[2].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT & ~(DMG_ARROW | DMG_MAGIC_FIRE | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_EXPLOSIVE | DMG_DEKU_NUT);
 
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, DamageTable_Get(2), &sColChkInfoInit);
@@ -287,16 +287,16 @@ void EnSsh_SetColliderScale(EnSsh* this, f32 scale, f32 radiusMod) {
     this->colliderJntSph.elements[0].dim.modelSphere.radius = radius;
 
     for (i = 0; i < 6; i++) {
-        yShift = this->collidersCylinder[i].dim.yShift;
-        radius = this->collidersCylinder[i].dim.radius;
-        height = this->collidersCylinder[i].dim.height;
+        yShift = this->colliderCylinders[i].dim.yShift;
+        radius = this->colliderCylinders[i].dim.radius;
+        height = this->colliderCylinders[i].dim.height;
         yShift *= scale;
         radius *= scale * radiusMod;
         height *= scale;
 
-        this->collidersCylinder[i].dim.yShift = yShift;
-        this->collidersCylinder[i].dim.radius = radius;
-        this->collidersCylinder[i].dim.height = height;
+        this->colliderCylinders[i].dim.yShift = yShift;
+        this->colliderCylinders[i].dim.radius = radius;
+        this->colliderCylinders[i].dim.height = height;
     }
     Actor_SetScale(&this->actor, 0.04f * scale);
     this->floorHeightOffset = 40.0f * scale;
@@ -448,17 +448,17 @@ void EnSsh_Sway(EnSsh* this) {
 }
 
 void EnSsh_CheckBodyStickHit(EnSsh* this, PlayState* play) {
-    ColliderElement* elem = &this->collidersCylinder[0].elem;
+    ColliderElement* elem = &this->colliderCylinders[0].elem;
     Player* player = GET_PLAYER(play);
 
     if (player->unk_860 != 0) {
         elem->acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->collidersCylinder[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->collidersCylinder[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->colliderCylinders[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->colliderCylinders[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
     } else {
         elem->acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->collidersCylinder[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->collidersCylinder[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->colliderCylinders[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->colliderCylinders[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
     }
 }
 
@@ -470,8 +470,8 @@ s32 EnSsh_CheckHitPlayer(EnSsh* this, PlayState* play) {
         return false;
     }
     for (i = 0; i < 3; i++) {
-        if (this->collidersCylinder[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) {
-            this->collidersCylinder[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
+        if (this->colliderCylinders[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) {
+            this->colliderCylinders[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
             hit = true;
         }
     }
@@ -493,13 +493,13 @@ s32 EnSsh_CheckHitPlayer(EnSsh* this, PlayState* play) {
 s32 EnSsh_CheckHitFront(EnSsh* this) {
     u32 acFlags;
 
-    if (this->collidersCylinder[2].base.acFlags) {} // Needed for matching
-    acFlags = this->collidersCylinder[2].base.acFlags;
+    if (this->colliderCylinders[2].base.acFlags) {} // Needed for matching
+    acFlags = this->colliderCylinders[2].base.acFlags;
 
     if (!!(acFlags & AC_HIT) == 0) {
         return 0;
     } else {
-        this->collidersCylinder[2].base.acFlags &= ~AC_HIT;
+        this->colliderCylinders[2].base.acFlags &= ~AC_HIT;
         this->invincibilityTimer = 8;
         if ((this->swayTimer == 0) && (this->hitTimer == 0) && (this->stunTimer == 0)) {
             this->swayTimer = 60;
@@ -509,14 +509,14 @@ s32 EnSsh_CheckHitFront(EnSsh* this) {
 }
 
 s32 EnSsh_CheckHitBack(EnSsh* this, PlayState* play) {
-    ColliderCylinder* cyl = &this->collidersCylinder[0];
+    ColliderCylinder* cyl = &this->colliderCylinders[0];
     s32 hit = false;
 
     if (cyl->base.acFlags & AC_HIT) {
         cyl->base.acFlags &= ~AC_HIT;
         hit = true;
     }
-    cyl = &this->collidersCylinder[1];
+    cyl = &this->colliderCylinders[1];
     if (cyl->base.acFlags & AC_HIT) {
         cyl->base.acFlags &= ~AC_HIT;
         hit = true;
@@ -559,19 +559,19 @@ s32 EnSsh_CollisionCheck(EnSsh* this, PlayState* play) {
 }
 
 void EnSsh_SetBodyCylinderAC(EnSsh* this, PlayState* play) {
-    Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[0]);
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[0].base);
+    Collider_UpdateCylinder(&this->actor, &this->colliderCylinders[0]);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinders[0].base);
 }
 
 void EnSsh_SetLegsCylinderAC(EnSsh* this, PlayState* play) {
     s16 angleTowardsLink = ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y));
 
     if (angleTowardsLink < 90 * (0x10000 / 360)) {
-        Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[2]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[2].base);
+        Collider_UpdateCylinder(&this->actor, &this->colliderCylinders[2]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinders[2].base);
     } else {
-        Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[1]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[1].base);
+        Collider_UpdateCylinder(&this->actor, &this->colliderCylinders[1]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinders[1].base);
     }
 }
 
@@ -594,10 +594,10 @@ s32 EnSsh_SetCylinderOC(EnSsh* this, PlayState* play) {
         Matrix_RotateY(BINANG_TO_RAD_ALT(this->initialYaw), MTXMODE_APPLY);
         Matrix_MultVec3f(&cyloffsets[i], &cylPos);
         Matrix_Pop();
-        this->collidersCylinder[i + 3].dim.pos.x = cylPos.x;
-        this->collidersCylinder[i + 3].dim.pos.y = cylPos.y;
-        this->collidersCylinder[i + 3].dim.pos.z = cylPos.z;
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->collidersCylinder[i + 3].base);
+        this->colliderCylinders[i + 3].dim.pos.x = cylPos.x;
+        this->colliderCylinders[i + 3].dim.pos.y = cylPos.y;
+        this->colliderCylinders[i + 3].dim.pos.z = cylPos.z;
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinders[i + 3].base);
     }
     return 1;
 }
@@ -657,7 +657,7 @@ void EnSsh_Destroy(Actor* thisx, PlayState* play) {
 
     Effect_Delete(play, this->blureIdx);
     for (i = 0; i < 6; i++) {
-        Collider_DestroyCylinder(play, &this->collidersCylinder[i]);
+        Collider_DestroyCylinder(play, &this->colliderCylinders[i]);
     }
     Collider_DestroyJntSph(play, &this->colliderJntSph);
 }

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
@@ -14,7 +14,7 @@ typedef struct EnSsh {
     /* 0x0190 */ Vec3s jointTable[30];
     /* 0x0244 */ Vec3s morphTable[30];
     /* 0x02F8 */ EnSshActionFunc actionFunc;
-    /* 0x02FC */ ColliderCylinder collidersCylinder[6];
+    /* 0x02FC */ ColliderCylinder colliderCylinders[6];
     /* 0x04C4 */ ColliderJntSph colliderJntSph;
     /* 0x04E4 */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x0524 */ s16 initialYaw;

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -295,20 +295,20 @@ void EnSt_InitColliders(EnSt* this, PlayState* play) {
     s32 pad;
 
     for (i = 0; i < ARRAY_COUNT(cylinders); i++) {
-        Collider_InitCylinder(play, &this->collidersCylinder[i]);
-        Collider_SetCylinder(play, &this->collidersCylinder[i], &this->actor, cylinders[i]);
+        Collider_InitCylinder(play, &this->colliderCylinders[i]);
+        Collider_SetCylinder(play, &this->colliderCylinders[i], &this->actor, cylinders[i]);
     }
 
-    this->collidersCylinder[0].elem.acDmgInfo.dmgFlags =
+    this->colliderCylinders[0].elem.acDmgInfo.dmgFlags =
         DMG_MAGIC_FIRE | DMG_ARROW | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT;
-    this->collidersCylinder[1].elem.acDmgInfo.dmgFlags =
+    this->colliderCylinders[1].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT &
         ~(DMG_MAGIC_FIRE | DMG_ARROW | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT) &
         ~(DMG_MAGIC_LIGHT | DMG_MAGIC_ICE);
-    this->collidersCylinder[2].base.colMaterial = COL_MATERIAL_METAL;
-    this->collidersCylinder[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
-    this->collidersCylinder[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
-    this->collidersCylinder[2].elem.acDmgInfo.dmgFlags =
+    this->colliderCylinders[2].base.colMaterial = COL_MATERIAL_METAL;
+    this->colliderCylinders[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
+    this->colliderCylinders[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
+    this->colliderCylinders[2].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT &
         ~(DMG_MAGIC_FIRE | DMG_ARROW | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT);
 
@@ -319,34 +319,34 @@ void EnSt_InitColliders(EnSt* this, PlayState* play) {
 }
 
 void EnSt_CheckBodyStickHit(EnSt* this, PlayState* play) {
-    ColliderElement* bodyElem = &this->collidersCylinder[0].elem;
+    ColliderElement* bodyElem = &this->colliderCylinders[0].elem;
     Player* player = GET_PLAYER(play);
 
     if (player->unk_860 != 0) {
         bodyElem->acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->collidersCylinder[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->collidersCylinder[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->colliderCylinders[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->colliderCylinders[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
     } else {
         bodyElem->acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->collidersCylinder[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->collidersCylinder[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->colliderCylinders[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->colliderCylinders[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
     }
 }
 
 void EnSt_SetBodyCylinderAC(EnSt* this, PlayState* play) {
-    Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[0]);
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[0].base);
+    Collider_UpdateCylinder(&this->actor, &this->colliderCylinders[0]);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinders[0].base);
 }
 
 void EnSt_SetLegsCylinderAC(EnSt* this, PlayState* play) {
     s16 angleTowardsLink = ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y));
 
     if (angleTowardsLink < 0x3FFC) {
-        Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[2]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[2].base);
+        Collider_UpdateCylinder(&this->actor, &this->colliderCylinders[2]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinders[2].base);
     } else {
-        Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[1]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[1].base);
+        Collider_UpdateCylinder(&this->actor, &this->colliderCylinders[1]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinders[1].base);
     }
 }
 
@@ -369,10 +369,10 @@ s32 EnSt_SetCylinderOC(EnSt* this, PlayState* play) {
         Matrix_RotateY(BINANG_TO_RAD_ALT(this->initialYaw), MTXMODE_APPLY);
         Matrix_MultVec3f(&cyloffsets[i], &cylPos);
         Matrix_Pop();
-        this->collidersCylinder[i + 3].dim.pos.x = cylPos.x;
-        this->collidersCylinder[i + 3].dim.pos.y = cylPos.y;
-        this->collidersCylinder[i + 3].dim.pos.z = cylPos.z;
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->collidersCylinder[i + 3].base);
+        this->colliderCylinders[i + 3].dim.pos.x = cylPos.x;
+        this->colliderCylinders[i + 3].dim.pos.y = cylPos.y;
+        this->colliderCylinders[i + 3].dim.pos.z = cylPos.z;
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinders[i + 3].base);
     }
 
     return true;
@@ -400,10 +400,10 @@ s32 EnSt_CheckHitPlayer(EnSt* this, PlayState* play) {
     s32 i;
 
     for (i = 0, hit = 0; i < 3; i++) {
-        if (((this->collidersCylinder[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) != 0) == 0) {
+        if (((this->colliderCylinders[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) != 0) == 0) {
             continue;
         }
-        this->collidersCylinder[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
+        this->colliderCylinders[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
         hit = true;
     }
 
@@ -423,13 +423,13 @@ s32 EnSt_CheckHitPlayer(EnSt* this, PlayState* play) {
 }
 
 s32 EnSt_CheckHitFrontside(EnSt* this) {
-    u8 acFlags = this->collidersCylinder[2].base.acFlags;
+    u8 acFlags = this->colliderCylinders[2].base.acFlags;
 
     if (!!(acFlags & AC_HIT) == 0) {
         // not hit
         return false;
     } else {
-        this->collidersCylinder[2].base.acFlags &= ~AC_HIT;
+        this->colliderCylinders[2].base.acFlags &= ~AC_HIT;
         this->invulnerableTimer = 8;
         this->playSwayFlag = 0;
         this->swayTimer = 60;
@@ -438,7 +438,7 @@ s32 EnSt_CheckHitFrontside(EnSt* this) {
 }
 
 s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
-    ColliderCylinder* cyl = &this->collidersCylinder[0];
+    ColliderCylinder* cyl = &this->colliderCylinders[0];
     s32 flags = 0; // damage flags from colliders 0 and 1
     s32 hit = false;
 
@@ -448,7 +448,7 @@ s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
         flags |= cyl->elem.acHitElem->atDmgInfo.dmgFlags;
     }
 
-    cyl = &this->collidersCylinder[1];
+    cyl = &this->colliderCylinders[1];
     if (cyl->base.acFlags & AC_HIT) {
         cyl->base.acFlags &= ~AC_HIT;
         hit = true;
@@ -538,16 +538,16 @@ void EnSt_SetColliderScale(EnSt* this) {
     this->colliderJntSph.elements[0].dim.modelSphere.radius = radius;
 
     for (i = 0; i < 6; i++) {
-        yShift = this->collidersCylinder[i].dim.yShift;
-        radius = this->collidersCylinder[i].dim.radius;
-        height = this->collidersCylinder[i].dim.height;
+        yShift = this->colliderCylinders[i].dim.yShift;
+        radius = this->colliderCylinders[i].dim.radius;
+        height = this->colliderCylinders[i].dim.height;
         yShift *= scaleAmount;
         radius *= scaleAmount;
         height *= scaleAmount;
 
-        this->collidersCylinder[i].dim.yShift = yShift;
-        this->collidersCylinder[i].dim.radius = radius;
-        this->collidersCylinder[i].dim.height = height;
+        this->colliderCylinders[i].dim.yShift = yShift;
+        this->colliderCylinders[i].dim.radius = radius;
+        this->colliderCylinders[i].dim.height = height;
     }
     Actor_SetScale(&this->actor, 0.04f * scaleAmount);
     this->colliderScale = scaleAmount;
@@ -828,7 +828,7 @@ void EnSt_Destroy(Actor* thisx, PlayState* play) {
 
     Effect_Delete(play, this->blureIdx);
     for (i = 0; i < 6; i++) {
-        Collider_DestroyCylinder(play, &this->collidersCylinder[i]);
+        Collider_DestroyCylinder(play, &this->colliderCylinders[i]);
     }
     Collider_DestroyJntSph(play, &this->colliderJntSph);
 }

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -295,20 +295,20 @@ void EnSt_InitColliders(EnSt* this, PlayState* play) {
     s32 pad;
 
     for (i = 0; i < ARRAY_COUNT(cylinders); i++) {
-        Collider_InitCylinder(play, &this->colliderCylinder[i]);
-        Collider_SetCylinder(play, &this->colliderCylinder[i], &this->actor, cylinders[i]);
+        Collider_InitCylinder(play, &this->collidersCylinder[i]);
+        Collider_SetCylinder(play, &this->collidersCylinder[i], &this->actor, cylinders[i]);
     }
 
-    this->colliderCylinder[0].elem.acDmgInfo.dmgFlags =
+    this->collidersCylinder[0].elem.acDmgInfo.dmgFlags =
         DMG_MAGIC_FIRE | DMG_ARROW | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT;
-    this->colliderCylinder[1].elem.acDmgInfo.dmgFlags =
+    this->collidersCylinder[1].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT &
         ~(DMG_MAGIC_FIRE | DMG_ARROW | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT) &
         ~(DMG_MAGIC_LIGHT | DMG_MAGIC_ICE);
-    this->colliderCylinder[2].base.colMaterial = COL_MATERIAL_METAL;
-    this->colliderCylinder[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
-    this->colliderCylinder[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
-    this->colliderCylinder[2].elem.acDmgInfo.dmgFlags =
+    this->collidersCylinder[2].base.colMaterial = COL_MATERIAL_METAL;
+    this->collidersCylinder[2].elem.acElemFlags = ACELEM_ON | ACELEM_HOOKABLE | ACELEM_NO_AT_INFO;
+    this->collidersCylinder[2].elem.elemMaterial = ELEM_MATERIAL_UNK2;
+    this->collidersCylinder[2].elem.acDmgInfo.dmgFlags =
         DMG_DEFAULT &
         ~(DMG_MAGIC_FIRE | DMG_ARROW | DMG_HOOKSHOT | DMG_HAMMER_SWING | DMG_BOOMERANG | DMG_EXPLOSIVE | DMG_DEKU_NUT);
 
@@ -319,34 +319,34 @@ void EnSt_InitColliders(EnSt* this, PlayState* play) {
 }
 
 void EnSt_CheckBodyStickHit(EnSt* this, PlayState* play) {
-    ColliderElement* bodyElem = &this->colliderCylinder[0].elem;
+    ColliderElement* bodyElem = &this->collidersCylinder[0].elem;
     Player* player = GET_PLAYER(play);
 
     if (player->unk_860 != 0) {
         bodyElem->acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->colliderCylinder[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->colliderCylinder[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->collidersCylinder[1].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
+        this->collidersCylinder[2].elem.acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
     } else {
         bodyElem->acDmgInfo.dmgFlags &= ~DMG_DEKU_STICK;
-        this->colliderCylinder[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
-        this->colliderCylinder[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->collidersCylinder[1].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
+        this->collidersCylinder[2].elem.acDmgInfo.dmgFlags |= DMG_DEKU_STICK;
     }
 }
 
 void EnSt_SetBodyCylinderAC(EnSt* this, PlayState* play) {
-    Collider_UpdateCylinder(&this->actor, &this->colliderCylinder[0]);
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder[0].base);
+    Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[0]);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[0].base);
 }
 
 void EnSt_SetLegsCylinderAC(EnSt* this, PlayState* play) {
     s16 angleTowardsLink = ABS((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y));
 
     if (angleTowardsLink < 0x3FFC) {
-        Collider_UpdateCylinder(&this->actor, &this->colliderCylinder[2]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder[2].base);
+        Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[2]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[2].base);
     } else {
-        Collider_UpdateCylinder(&this->actor, &this->colliderCylinder[1]);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderCylinder[1].base);
+        Collider_UpdateCylinder(&this->actor, &this->collidersCylinder[1]);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->collidersCylinder[1].base);
     }
 }
 
@@ -369,10 +369,10 @@ s32 EnSt_SetCylinderOC(EnSt* this, PlayState* play) {
         Matrix_RotateY(BINANG_TO_RAD_ALT(this->initialYaw), MTXMODE_APPLY);
         Matrix_MultVec3f(&cyloffsets[i], &cylPos);
         Matrix_Pop();
-        this->colliderCylinder[i + 3].dim.pos.x = cylPos.x;
-        this->colliderCylinder[i + 3].dim.pos.y = cylPos.y;
-        this->colliderCylinder[i + 3].dim.pos.z = cylPos.z;
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderCylinder[i + 3].base);
+        this->collidersCylinder[i + 3].dim.pos.x = cylPos.x;
+        this->collidersCylinder[i + 3].dim.pos.y = cylPos.y;
+        this->collidersCylinder[i + 3].dim.pos.z = cylPos.z;
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->collidersCylinder[i + 3].base);
     }
 
     return true;
@@ -400,10 +400,10 @@ s32 EnSt_CheckHitPlayer(EnSt* this, PlayState* play) {
     s32 i;
 
     for (i = 0, hit = 0; i < 3; i++) {
-        if (((this->colliderCylinder[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) != 0) == 0) {
+        if (((this->collidersCylinder[i + 3].base.ocFlags2 & OC2_HIT_PLAYER) != 0) == 0) {
             continue;
         }
-        this->colliderCylinder[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
+        this->collidersCylinder[i + 3].base.ocFlags2 &= ~OC2_HIT_PLAYER;
         hit = true;
     }
 
@@ -423,13 +423,13 @@ s32 EnSt_CheckHitPlayer(EnSt* this, PlayState* play) {
 }
 
 s32 EnSt_CheckHitFrontside(EnSt* this) {
-    u8 acFlags = this->colliderCylinder[2].base.acFlags;
+    u8 acFlags = this->collidersCylinder[2].base.acFlags;
 
     if (!!(acFlags & AC_HIT) == 0) {
         // not hit
         return false;
     } else {
-        this->colliderCylinder[2].base.acFlags &= ~AC_HIT;
+        this->collidersCylinder[2].base.acFlags &= ~AC_HIT;
         this->invulnerableTimer = 8;
         this->playSwayFlag = 0;
         this->swayTimer = 60;
@@ -438,7 +438,7 @@ s32 EnSt_CheckHitFrontside(EnSt* this) {
 }
 
 s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
-    ColliderCylinder* cyl = &this->colliderCylinder[0];
+    ColliderCylinder* cyl = &this->collidersCylinder[0];
     s32 flags = 0; // damage flags from colliders 0 and 1
     s32 hit = false;
 
@@ -448,7 +448,7 @@ s32 EnSt_CheckHitBackside(EnSt* this, PlayState* play) {
         flags |= cyl->elem.acHitElem->atDmgInfo.dmgFlags;
     }
 
-    cyl = &this->colliderCylinder[1];
+    cyl = &this->collidersCylinder[1];
     if (cyl->base.acFlags & AC_HIT) {
         cyl->base.acFlags &= ~AC_HIT;
         hit = true;
@@ -538,16 +538,16 @@ void EnSt_SetColliderScale(EnSt* this) {
     this->colliderJntSph.elements[0].dim.modelSphere.radius = radius;
 
     for (i = 0; i < 6; i++) {
-        yShift = this->colliderCylinder[i].dim.yShift;
-        radius = this->colliderCylinder[i].dim.radius;
-        height = this->colliderCylinder[i].dim.height;
+        yShift = this->collidersCylinder[i].dim.yShift;
+        radius = this->collidersCylinder[i].dim.radius;
+        height = this->collidersCylinder[i].dim.height;
         yShift *= scaleAmount;
         radius *= scaleAmount;
         height *= scaleAmount;
 
-        this->colliderCylinder[i].dim.yShift = yShift;
-        this->colliderCylinder[i].dim.radius = radius;
-        this->colliderCylinder[i].dim.height = height;
+        this->collidersCylinder[i].dim.yShift = yShift;
+        this->collidersCylinder[i].dim.radius = radius;
+        this->collidersCylinder[i].dim.height = height;
     }
     Actor_SetScale(&this->actor, 0.04f * scaleAmount);
     this->colliderScale = scaleAmount;
@@ -828,7 +828,7 @@ void EnSt_Destroy(Actor* thisx, PlayState* play) {
 
     Effect_Delete(play, this->blureIdx);
     for (i = 0; i < 6; i++) {
-        Collider_DestroyCylinder(play, &this->colliderCylinder[i]);
+        Collider_DestroyCylinder(play, &this->collidersCylinder[i]);
     }
     Collider_DestroyJntSph(play, &this->colliderJntSph);
 }

--- a/src/overlays/actors/ovl_En_St/z_en_st.h
+++ b/src/overlays/actors/ovl_En_St/z_en_st.h
@@ -12,7 +12,7 @@ typedef struct EnSt {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ EnStActionFunc actionFunc;
-    /* 0x0194 */ ColliderCylinder colliderCylinder[6];
+    /* 0x0194 */ ColliderCylinder collidersCylinder[6];
     /* 0x035C */ ColliderJntSph colliderJntSph;
     /* 0x037C */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x03BC */ s16 initialYaw;

--- a/src/overlays/actors/ovl_En_St/z_en_st.h
+++ b/src/overlays/actors/ovl_En_St/z_en_st.h
@@ -12,7 +12,7 @@ typedef struct EnSt {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
     /* 0x0190 */ EnStActionFunc actionFunc;
-    /* 0x0194 */ ColliderCylinder collidersCylinder[6];
+    /* 0x0194 */ ColliderCylinder colliderCylinders[6];
     /* 0x035C */ ColliderJntSph colliderJntSph;
     /* 0x037C */ ColliderJntSphElement colliderJntSphElements[1];
     /* 0x03BC */ s16 initialYaw;

--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -47,7 +47,7 @@ ActorProfile En_Sw_Profile = {
     /**/ EnSw_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphItemsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[1] = {
     {
         { ELEM_MATERIAL_UNK0, { 0xFFCFFFFF, 0x00, 0x08 }, { 0xFFC3FFFE, 0x00, 0x00 }, 0x01, 0x05, 0x01 },
         { 2, { { 0, -300, 0 }, 21 }, 100 },
@@ -57,7 +57,7 @@ static ColliderJntSphElementInit sJntSphItemsInit[1] = {
 static ColliderJntSphInit sJntSphInit = {
     { COL_MATERIAL_HIT6, 0x11, 0x09, 0x39, 0x10, COLSHAPE_JNTSPH },
     1,
-    sJntSphItemsInit,
+    sJntSphElementsInit,
 };
 
 static CollisionCheckInfoInit2 D_80B0F074 = { 1, 2, 25, 25, MASS_IMMOVABLE };

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -60,7 +60,7 @@ void EnWf_SetupDie(EnWf* this);
 void EnWf_Die(EnWf* this, PlayState* play);
 s32 EnWf_DodgeRanged(PlayState* play, EnWf* this);
 
-static ColliderJntSphElementInit sJntSphItemsInit[4] = {
+static ColliderJntSphElementInit sJntSphElementsInit[4] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -116,8 +116,8 @@ static ColliderJntSphInit sJntSphInit = {
         OC2_TYPE_1,
         COLSHAPE_JNTSPH,
     },
-    ARRAY_COUNT(sJntSphItemsInit),
-    sJntSphItemsInit,
+    ARRAY_COUNT(sJntSphElementsInit),
+    sJntSphElementsInit,
 };
 
 static ColliderCylinderInit sBodyCylinderInit = {

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
@@ -96,18 +96,18 @@ void ObjIcePoly_Init(Actor* thisx, PlayState* play) {
     }
     Actor_SetScale(thisx, sScale[thisx->params]);
     thisx->world.pos.y = sOffsetY[thisx->params] + thisx->home.pos.y;
-    Collider_InitCylinder(play, &this->colliderIce);
-    Collider_SetCylinder(play, &this->colliderIce, thisx, &sCylinderInitIce);
-    Collider_InitCylinder(play, &this->colliderHard);
-    Collider_SetCylinder(play, &this->colliderHard, thisx, &sCylinderInitHard);
-    Collider_UpdateCylinder(thisx, &this->colliderIce);
-    Collider_UpdateCylinder(thisx, &this->colliderHard);
+    Collider_InitCylinder(play, &this->iceCollider);
+    Collider_SetCylinder(play, &this->iceCollider, thisx, &sCylinderInitIce);
+    Collider_InitCylinder(play, &this->hardCollider);
+    Collider_SetCylinder(play, &this->hardCollider, thisx, &sCylinderInitHard);
+    Collider_UpdateCylinder(thisx, &this->iceCollider);
+    Collider_UpdateCylinder(thisx, &this->hardCollider);
     thisx->colChkInfo.mass = MASS_IMMOVABLE;
     this->alpha = 255;
-    this->colliderIce.dim.radius *= thisx->scale.x;
-    this->colliderIce.dim.height *= thisx->scale.y;
-    this->colliderHard.dim.radius *= thisx->scale.x;
-    this->colliderHard.dim.height *= thisx->scale.y;
+    this->iceCollider.dim.radius *= thisx->scale.x;
+    this->iceCollider.dim.height *= thisx->scale.y;
+    this->hardCollider.dim.radius *= thisx->scale.x;
+    this->hardCollider.dim.height *= thisx->scale.y;
     Actor_SetFocus(thisx, thisx->scale.y * 30.0f);
     this->actionFunc = ObjIcePoly_Idle;
 }
@@ -117,8 +117,8 @@ void ObjIcePoly_Destroy(Actor* thisx, PlayState* play) {
     ObjIcePoly* this = (ObjIcePoly*)thisx;
 
     if ((this->actor.params >= 0) && (this->actor.params < 3)) {
-        Collider_DestroyCylinder(play, &this->colliderIce);
-        Collider_DestroyCylinder(play, &this->colliderHard);
+        Collider_DestroyCylinder(play, &this->iceCollider);
+        Collider_DestroyCylinder(play, &this->hardCollider);
     }
 }
 
@@ -127,17 +127,17 @@ void ObjIcePoly_Idle(ObjIcePoly* this, PlayState* play) {
     s32 pad;
     Vec3f pos;
 
-    if (this->colliderIce.base.acFlags & AC_HIT) {
-        this->meltTimer = -this->colliderIce.elem.acHitElem->atDmgInfo.damage;
+    if (this->iceCollider.base.acFlags & AC_HIT) {
+        this->meltTimer = -this->iceCollider.elem.acHitElem->atDmgInfo.damage;
         this->actor.focus.rot.y = this->actor.yawTowardsPlayer;
         OnePointCutscene_Init(play, 5120, 40, &this->actor, CAM_ID_MAIN);
         this->actionFunc = ObjIcePoly_Melt;
     } else if (this->actor.parent != NULL) {
         this->actor.parent->freezeTimer = 40;
-        CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderIce.base);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderIce.base);
-        CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderIce.base);
-        CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderHard.base);
+        CollisionCheck_SetAT(play, &play->colChkCtx, &this->iceCollider.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->iceCollider.base);
+        CollisionCheck_SetOC(play, &play->colChkCtx, &this->iceCollider.base);
+        CollisionCheck_SetAC(play, &play->colChkCtx, &this->hardCollider.base);
     } else {
         Actor_Kill(&this->actor);
     }

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.h
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.h
@@ -14,8 +14,8 @@ typedef struct ObjIcePoly {
     /* 0x0150 */ u8 alpha;
     /* 0x0151 */ u8 unk_151; // Unused. Probably intended to be a switch flag.
     /* 0x0152 */ s16 meltTimer;
-    /* 0x0154 */ ColliderCylinder colliderIce;
-    /* 0x01A0 */ ColliderCylinder colliderHard;
+    /* 0x0154 */ ColliderCylinder iceCollider;
+    /* 0x01A0 */ ColliderCylinder hardCollider;
 } ObjIcePoly; // size = 0x01EC
 
 #endif

--- a/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
+++ b/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
@@ -60,7 +60,7 @@ ActorProfile Obj_Lightswitch_Profile = {
     /**/ ObjLightswitch_Draw,
 };
 
-static ColliderJntSphElementInit sColliderJntSphElementInit[] = {
+static ColliderJntSphElementInit sColliderJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -83,7 +83,7 @@ static ColliderJntSphInit sColliderJntSphInit = {
         COLSHAPE_JNTSPH,
     },
     1,
-    sColliderJntSphElementInit,
+    sColliderJntSphElementsInit,
 };
 
 static CollisionCheckInfoInit sColChkInfoInit = { 0, 12, 60, MASS_IMMOVABLE };

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -160,7 +160,7 @@ static ColliderTrisInit sEyeTrisInit = {
     sEyeTrisElementsInit,
 };
 
-static ColliderJntSphElementInit sCrystalJntSphElementInit[1] = {
+static ColliderJntSphElementInit sCrystalJntSphElementsInit[1] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -183,8 +183,8 @@ static ColliderJntSphInit sCrystalJntSphInit = {
         OC2_TYPE_2,
         COLSHAPE_JNTSPH,
     },
-    ARRAY_COUNT(sCrystalJntSphElementInit),
-    sCrystalJntSphElementInit,
+    ARRAY_COUNT(sCrystalJntSphElementsInit),
+    sCrystalJntSphElementsInit,
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
+++ b/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.c
@@ -97,12 +97,12 @@ void ObjSyokudai_Init(Actor* thisx, PlayState* play) {
     Actor_ProcessInitChain(&this->actor, sInitChain);
     ActorShape_Init(&this->actor.shape, 0.0f, NULL, 0.0f);
 
-    Collider_InitCylinder(play, &this->colliderStand);
-    Collider_SetCylinder(play, &this->colliderStand, &this->actor, &sCylInitStand);
-    this->colliderStand.base.colMaterial = sColMaterialsStand[PARAMS_GET_NOMASK(this->actor.params, 12)];
+    Collider_InitCylinder(play, &this->standCollider);
+    Collider_SetCylinder(play, &this->standCollider, &this->actor, &sCylInitStand);
+    this->standCollider.base.colMaterial = sColMaterialsStand[PARAMS_GET_NOMASK(this->actor.params, 12)];
 
-    Collider_InitCylinder(play, &this->colliderFlame);
-    Collider_SetCylinder(play, &this->colliderFlame, &this->actor, &sCylInitFlame);
+    Collider_InitCylinder(play, &this->flameCollider);
+    Collider_SetCylinder(play, &this->flameCollider, &this->actor, &sCylInitFlame);
 
     this->actor.colChkInfo.mass = MASS_IMMOVABLE;
 
@@ -124,8 +124,8 @@ void ObjSyokudai_Destroy(Actor* thisx, PlayState* play) {
     s32 pad;
     ObjSyokudai* this = (ObjSyokudai*)thisx;
 
-    Collider_DestroyCylinder(play, &this->colliderStand);
-    Collider_DestroyCylinder(play, &this->colliderFlame);
+    Collider_DestroyCylinder(play, &this->standCollider);
+    Collider_DestroyCylinder(play, &this->flameCollider);
     LightContext_RemoveLight(play, &play->lightCtx, this->lightNode);
 }
 
@@ -182,8 +182,8 @@ void ObjSyokudai_Update(Actor* thisx, PlayState* play2) {
                 this->litTimer = 20;
             }
         }
-        if (this->colliderFlame.base.acFlags & AC_HIT) {
-            dmgFlags = this->colliderFlame.elem.acHitElem->atDmgInfo.dmgFlags;
+        if (this->flameCollider.base.acFlags & AC_HIT) {
+            dmgFlags = this->flameCollider.elem.acHitElem->atDmgInfo.dmgFlags;
             if (dmgFlags & (DMG_FIRE | DMG_ARROW_NORMAL)) {
                 interactionType = 1;
             }
@@ -206,7 +206,7 @@ void ObjSyokudai_Update(Actor* thisx, PlayState* play2) {
                         player->unk_860 = 200;
                     }
                 } else if (dmgFlags & DMG_ARROW_NORMAL) {
-                    arrow = (EnArrow*)this->colliderFlame.base.ac;
+                    arrow = (EnArrow*)this->flameCollider.base.ac;
                     if ((arrow->actor.update != NULL) && (arrow->actor.id == ACTOR_EN_ARROW)) {
                         arrow->actor.params = 0;
                         arrow->collider.elem.atDmgInfo.dmgFlags = DMG_ARROW_FIRE;
@@ -243,12 +243,12 @@ void ObjSyokudai_Update(Actor* thisx, PlayState* play2) {
         }
     }
 
-    Collider_UpdateCylinder(&this->actor, &this->colliderStand);
-    CollisionCheck_SetOC(play, &play->colChkCtx, &this->colliderStand.base);
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderStand.base);
+    Collider_UpdateCylinder(&this->actor, &this->standCollider);
+    CollisionCheck_SetOC(play, &play->colChkCtx, &this->standCollider.base);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->standCollider.base);
 
-    Collider_UpdateCylinder(&this->actor, &this->colliderFlame);
-    CollisionCheck_SetAC(play, &play->colChkCtx, &this->colliderFlame.base);
+    Collider_UpdateCylinder(&this->actor, &this->flameCollider);
+    CollisionCheck_SetAC(play, &play->colChkCtx, &this->flameCollider.base);
 
     if (this->litTimer > 0) {
         this->litTimer--;

--- a/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h
+++ b/src/overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h
@@ -9,8 +9,8 @@ struct ObjSyokudai;
 
 typedef struct ObjSyokudai {
     /* 0x0000 */ Actor actor;
-    /* 0x014C */ ColliderCylinder colliderStand;
-    /* 0x0198 */ ColliderCylinder colliderFlame;
+    /* 0x014C */ ColliderCylinder standCollider;
+    /* 0x0198 */ ColliderCylinder flameCollider;
     /* 0x01E4 */ s16 litTimer;
     /* 0x01E6 */ u8 flameTexScroll;
     /* 0x01E8 */ LightNode* lightNode;


### PR DESCRIPTION
#2465 continued

- standardize `ColliderJntSphElementInit` data names on `s[Name][Collider]JntSphElementsInit[Name]` (for now, in the future `s[Name][Collider]JntSphElementsInit`)
- standardize `ColliderCylinder` struct members names on `[name]collider[Cylinder][s]` (`[s]` if it's an array of colliders)