### PR TITLE
fix_bss.py: Try to handle one-past-the-end pointers

### DIFF
--- a/tools/fix_bss.py
+++ b/tools/fix_bss.py
@@ -170,9 +170,9 @@ def get_file_pointers(
 
         # For relocations against a global symbol, subtract the addend so that the pointer
         # is for the start of the symbol. This can help deal with things like STACK_TOP
-        # (where the pointer is past the end of the symbol) or negative addends. If the
-        # relocation is against a section however, it's not useful to subtract the addend,
-        # so we keep it as-is and hope for the best.
+        # (where the pointer is past the end of the symbol) or negative addends. We can't do
+        # this for relocations against a section though, since we need the added to distinguish
+        # between different static variables.
         if reloc.name.startswith("."):  # section
             addend = reloc.addend
         else:  # symbol
@@ -446,13 +446,13 @@ def determine_base_bss_ordering(
         new_symbol = None
         new_offset = 0
         for symbol in build_bss_symbols:
-            if (
-                symbol.offset <= build_offset
-                and build_offset < symbol.offset + symbol.size
-            ):
+            # To handle one-past-the-end pointers, we check <= instead of < for the symbol end.
+            # This won't work if there is another symbol right after this one, since we'll
+            # attribute this pointer to that symbol instead. This could prevent us from solving
+            # BSS ording, but often the two symbols are adjacent in the baserom so it works anyway.
+            if symbol.offset <= build_offset <= symbol.offset + symbol.size:
                 new_symbol = symbol
                 new_offset = base_offset - (build_offset - symbol.offset)
-                break
 
         if new_symbol is None:
             if p.addend > 0:

--- a/tools/fix_bss.py
+++ b/tools/fix_bss.py
@@ -170,9 +170,9 @@ def get_file_pointers(
 
         # For relocations against a global symbol, subtract the addend so that the pointer
         # is for the start of the symbol. This can help deal with things like STACK_TOP
-        # (where the pointer is past the end of the symbol) or negative addends. We can't do
-        # this for relocations against a section though, since we need the added to distinguish
-        # between different static variables.
+        # (where the pointer is past the end of the symbol) or negative addends. We can't
+        # do this for relocations against a section though, since we need the addend to
+        # distinguish between different static variables.
         if reloc.name.startswith("."):  # section
             addend = reloc.addend
         else:  # symbol
@@ -449,7 +449,7 @@ def determine_base_bss_ordering(
             # To handle one-past-the-end pointers, we check <= instead of < for the symbol end.
             # This won't work if there is another symbol right after this one, since we'll
             # attribute this pointer to that symbol instead. This could prevent us from solving
-            # BSS ording, but often the two symbols are adjacent in the baserom so it works anyway.
+            # BSS ordering, but often the two symbols are adjacent in the baserom too so it works anyway.
             if symbol.offset <= build_offset <= symbol.offset + symbol.size:
                 new_symbol = symbol
                 new_offset = base_offset - (build_offset - symbol.offset)


### PR DESCRIPTION
Sometimes fix_bss.py can fail to fix z_collision_check, e.g. https://discord.com/channels/688807550715560050/688851337085190255/1308193502265606264. And I ran into this with z_boss_sst in #2429 too.

This is because these files contain a pointer to the end of an array (`acTris` and `atTris` in z_collision_check, or `sHandYawOffsets` in z_boss_sst) and fix_bss.py attributes it to the next symbol instead. Mostly this works out fine anyway, but sometimes array is at the end of the bss section (or followed by padding) where there's no next symbol to attribute this pointer to. Previously fix_bss.py would error here but now it doesn't.