### PR TITLE
Fixup includes

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -131,7 +131,7 @@ ListAlloc* ListAlloc_Init(ListAlloc* this);
 void* ListAlloc_Alloc(ListAlloc* this, u32 size);
 void ListAlloc_Free(ListAlloc* this, void* data);
 void ListAlloc_FreeAll(ListAlloc* this);
-void Main(void* arg);
+
 void SysCfb_Init(s32 n64dd);
 void* SysCfb_GetFbPtr(s32 idx);
 void* SysCfb_GetFbEnd(void);

--- a/include/ultra64.h
+++ b/include/ultra64.h
@@ -189,7 +189,6 @@ void osViSetEvent(OSMesgQueue* mq, OSMesg msg, u32 retraceCount);
 s32 osPfsIsPlug(OSMesgQueue* mq, u8* pattern);
 void __osPfsRequestData(u8 cmd);
 void __osPfsGetInitData(u8* pattern, OSContStatus* contData);
-void guS2DInitBg(union uObjBg* bg);
 s32 __osPfsSelectBank(OSPfs* pfs, u8 bank);
 s32 osContSetCh(u8 ch);
 s32 osPfsFileState(OSPfs* pfs, s32 fileNo, OSPfsState* state);

--- a/src/code/sys_math_atan.c
+++ b/src/code/sys_math_atan.c
@@ -1,3 +1,4 @@
+#include "sys_math.h"
 #include "z64math.h"
 #include "macros.h"
 

--- a/src/code/sys_ucode.c
+++ b/src/code/sys_ucode.c
@@ -1,4 +1,5 @@
 #include "ultra64.h"
+#include "sys_ucode.h"
 
 u64* sDefaultGSPUCodeText = gspF3DZEX2_NoN_PosLight_fifoTextStart;
 u64* sDefaultGSPUCodeData = gspF3DZEX2_NoN_PosLight_fifoDataStart;

--- a/src/code/z_elf_message.c
+++ b/src/code/z_elf_message.c
@@ -2,6 +2,7 @@
 #include "rand.h"
 #include "z64play.h"
 #include "z64player.h"
+#include "z64quest_hint.h"
 #include "z64quest_hint_commands.h"
 #include "z64save.h"
 

--- a/src/code/z_olib.c
+++ b/src/code/z_olib.c
@@ -1,5 +1,6 @@
 #include "z64math.h"
 #include "libc64/math64.h"
+#include "z64olib.h"
 #include "z_lib.h"
 
 /**

--- a/src/code/z_ss_sram.c
+++ b/src/code/z_ss_sram.c
@@ -1,4 +1,5 @@
 #include "ultra64.h"
+#include "z64ss_sram.h"
 
 #include "macros.h"
 #include "global.h"

--- a/src/libc64/math64.c
+++ b/src/libc64/math64.c
@@ -1,3 +1,4 @@
+#include "libc64/math64.h"
 #include "z64math.h"
 #include "macros.h"
 

--- a/src/libu64/padsetup.c
+++ b/src/libu64/padsetup.c
@@ -1,4 +1,5 @@
 #include "ultra64.h"
+#include "libu64/padsetup.h"
 
 s32 PadSetup_Init(OSMesgQueue* mq, u8* outMask, OSContStatus* status) {
     s32 ret;


### PR DESCRIPTION
- Remove two duplicate declarations
- Add some missing includes so that function definitions (with bodys) are seen together with their declaration (prototype) at some point during compilation, allowing the compiler to error if they don't match
  - there are more such cases but it's all functions from functions.h so I'll wait for functions.h to disappear

I found these out using a jank tool I made based on libclang https://gist.github.com/Dragorn421/bdb270515156493efa845b8040e7b6c5