### PR TITLE
Macroify MML opcodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,8 @@ endif
 
 $(BUILD_DIR)/src/boot/build.o: CPP_DEFINES += -DBUILD_CREATOR="\"$(BUILD_CREATOR)\"" -DBUILD_DATE="\"$(BUILD_DATE)\"" -DBUILD_TIME="\"$(BUILD_TIME)\""
 
+$(BUILD_DIR)/src/audio/lib/seqplayer.o: CPP_DEFINES += -DMML_VERSION=MML_VERSION_OOT
+
 ifeq ($(COMPILER),ido)
 $(BUILD_DIR)/src/boot/driverominit.o: OPTFLAGS := -O2
 

--- a/assets/audio/sequences/seq_0.prg.seq
+++ b/assets/audio/sequences/seq_0.prg.seq
@@ -1302,7 +1302,7 @@ CHAN_08EC:
 /* 0x08EE [0xC7 0x02 0x09 0x04     ] */ stseq       2, LAYER_0903 + STSEQ_NOTEDV_DELAY_HI
 /* 0x08F2 [0xC7 0x02 0x08 0xFD     ] */ stseq       2, CHAN_08FC + STSEQ_LDI_IMM
 /* 0x08F6 [0xB8 0x0C               ] */ rand        12
-/* 0x08F8 [0xC7 0x5C 0x09 0x03     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_DF3), LAYER_0903 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x08F8 [0xC7 0x5C 0x09 0x03     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF3), LAYER_0903 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_08FC:
 /* 0x08FC [0xCC 0x01               ] */ ldi         1
 /* 0x08FE [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -4978,7 +4978,7 @@ CHAN_2274:
 /* 0x2284 [0x56                    ] */ subio       IO_PORT_6
 /* 0x2285 [0xC9 0x07               ] */ and         7
 CHAN_2287:
-/* 0x2287 [0xC7 0x60 0x22 0x98     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_F3), LAYER_2298 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x2287 [0xC7 0x60 0x22 0x98     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_F3), LAYER_2298 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x228B [0x66                    ] */ ldio        IO_PORT_6
 /* 0x228C [0xC8 0xFC               ] */ sub         252
 /* 0x228E [0xC9 0x04               ] */ and         4
@@ -6529,7 +6529,7 @@ LAYER_2C4E:
 
 .channel CHAN_2C54
 /* 0x2C54 [0x89 0x2C 0x62          ] */ ldlayer     1, LAYER_2C62
-/* 0x2C57 [0xCC 0x58               ] */ ldi         (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A2)
+/* 0x2C57 [0xCC 0x58               ] */ ldi         (ASEQ_OPC_LAYER_NOTEDV | PITCH_A2)
 /* 0x2C59 [0xC7 0x00 0x22 0x88     ] */ stseq       0, CHAN_2287 + STSEQ_STSEQ_IMM
 /* 0x2C5D [0xFB 0x22 0x67          ] */ jump        CHAN_2267
 
@@ -6649,7 +6649,7 @@ CHAN_2D01:
 .channel CHAN_2D13
 /* 0x2D13 [0x89 0x2D 0x25          ] */ ldlayer     1, LAYER_2D25
 /* 0x2D16 [0x8A 0x2D 0x23          ] */ ldlayer     2, LAYER_2D23
-/* 0x2D19 [0xCC 0x66               ] */ ldi         (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_B3)
+/* 0x2D19 [0xCC 0x66               ] */ ldi         (ASEQ_OPC_LAYER_NOTEDV | PITCH_B3)
 /* 0x2D1B [0xC7 0x00 0x22 0x88     ] */ stseq       0, CHAN_2287 + STSEQ_STSEQ_IMM
 /* 0x2D1F [0xFB 0x22 0x67          ] */ jump        CHAN_2267
 /* 0x2D22 [0xFF                    ] */ end
@@ -9201,7 +9201,7 @@ CHAN_4162:
 /* 0x4164 [0xC7 0x03 0x41 0x7A     ] */ stseq       3, LAYER_4179 + STSEQ_NOTEDV_DELAY_HI
 /* 0x4168 [0xC7 0x03 0x41 0x73     ] */ stseq       3, CHAN_4172 + STSEQ_LDI_IMM
 /* 0x416C [0xB8 0x08               ] */ rand        8
-/* 0x416E [0xC7 0x5B 0x41 0x79     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_C3), LAYER_4179 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x416E [0xC7 0x5B 0x41 0x79     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C3), LAYER_4179 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_4172:
 /* 0x4172 [0xCC 0x01               ] */ ldi         1
 /* 0x4174 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -9763,7 +9763,7 @@ LAYER_4245:
 /* 0x44C9 [0x88 0x44 0xD7          ] */ ldlayer     0, LAYER_44D7
 /* 0x44CC [0xED 0x14               ] */ gain        20
 /* 0x44CE [0xB8 0x04               ] */ rand        4
-/* 0x44D0 [0xC7 0x6B 0x44 0xD7     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_E4), LAYER_44D7 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x44D0 [0xC7 0x6B 0x44 0xD7     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_E4), LAYER_44D7 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x44D4 [0xD9 0xE8               ] */ releaserate 232
 /* 0x44D6 [0xFF                    ] */ end
 
@@ -10353,7 +10353,7 @@ LAYER_47B3:
 /* 0x4860 [0x88 0x48 0x70          ] */ ldlayer     0, LAYER_4870
 CHAN_4863:
 /* 0x4863 [0xB8 0x04               ] */ rand        4
-/* 0x4865 [0xC7 0x60 0x48 0x70     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_F3), LAYER_4870 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x4865 [0xC7 0x60 0x48 0x70     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_F3), LAYER_4870 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x4869 [0xCC 0x12               ] */ ldi         18
 /* 0x486B [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x486E [0xF4 0xF3               ] */ rjump       CHAN_4863
@@ -12266,7 +12266,7 @@ LAYER_53FD:
 /* 0x5403 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x5405 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x5406 [0xC8 0xB0               ] */ sub         176
-/* 0x5408 [0xC7 0x00 0x54 0x17     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDVG | PITCH_A0), LAYER_5417 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x5408 [0xC7 0x00 0x54 0x17     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | PITCH_A0), LAYER_5417 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x540C [0xCB 0x54 0x1C          ] */ ldseq       UNK_541C
 /* 0x540F [0xC7 0x00 0x54 0x19     ] */ stseq       0, LAYER_5417 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x5413 [0x88 0x54 0x17          ] */ ldlayer     0, LAYER_5417
@@ -12640,7 +12640,7 @@ CHAN_565E:
 /* 0x5660 [0xC7 0x28 0x56 0x76     ] */ stseq       40, LAYER_5675 + STSEQ_NOTEDV_DELAY_HI
 /* 0x5664 [0xC7 0x28 0x56 0x6F     ] */ stseq       40, CHAN_566E + STSEQ_LDI_IMM
 /* 0x5668 [0xB8 0x06               ] */ rand        6
-/* 0x566A [0xC7 0x64 0x56 0x75     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A3), LAYER_5675 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x566A [0xC7 0x64 0x56 0x75     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A3), LAYER_5675 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_566E:
 /* 0x566E [0xCC 0x01               ] */ ldi         1
 /* 0x5670 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -14045,7 +14045,7 @@ CHAN_6116:
 /* 0x6118 [0x3F 0x06               ] */ stcio       15, IO_PORT_6
 CHAN_611A:
 /* 0x611A [0xCB 0x61 0x6D          ] */ ldseq       UNK_616D
-/* 0x611D [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x611D [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x6121 [0x66                    ] */ ldio        IO_PORT_6
 CHAN_6122:
 /* 0x6122 [0xCB 0x61 0x71          ] */ ldseq       UNK_6171
@@ -14079,8 +14079,8 @@ CHAN_613E:
 /* 0x6145 [0xCC 0x00               ] */ ldi         0
                                         // Reads the byte at (PTR + 0) into TR (the note)
 /* 0x6147 [0xB6                    ] */ dyntblv
-                                        // Store ASEQ_OPC_LAYER_STEP3_NOTEDV + TR into the pitch
-/* 0x6148 [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
+                                        // Store ASEQ_OPC_LAYER_NOTEDV + TR into the pitch
+/* 0x6148 [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
                                         // Load 1 into TR
 /* 0x614C [0xCC 0x01               ] */ ldi         1
                                         // Reads the byte at (PTR + 1) into TR (the velocity)
@@ -14355,7 +14355,7 @@ UNK_62CC:
 /* 0x62D1 [0x76                    ] */ stio        IO_PORT_6
 /* 0x62D2 [0xC9 0x01               ] */ and         1
 /* 0x62D4 [0xCB 0x62 0xE8          ] */ ldseq       UNK_62E8
-/* 0x62D7 [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x62D7 [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x62DB [0xB8 0x02               ] */ rand        2
 /* 0x62DD [0xCB 0x62 0xEA          ] */ ldseq       UNK_62EA
 /* 0x62E0 [0xC7 0x00 0x64 0xC1     ] */ stseq       0, LAYER_64BF + STSEQ_NOTEDV_VELOCITY_2
@@ -14482,7 +14482,7 @@ UNK_6374:
 /* 0x6379 [0x76                    ] */ stio        IO_PORT_6
 /* 0x637A [0xC9 0x01               ] */ and         1
 /* 0x637C [0xCB 0x63 0x96          ] */ ldseq       UNK_6396
-/* 0x637F [0xC7 0x40 0x63 0x90     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_6390 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x637F [0xC7 0x40 0x63 0x90     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_6390 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x6383 [0xB8 0x02               ] */ rand        2
 /* 0x6385 [0xCB 0x63 0x98          ] */ ldseq       UNK_6398
 /* 0x6388 [0xC7 0x00 0x63 0x92     ] */ stseq       0, LAYER_6390 + STSEQ_NOTEDV_VELOCITY_2
@@ -14688,7 +14688,7 @@ UNK_6499:
 /* 0x64A8 [0x76                    ] */ stio        IO_PORT_6
 /* 0x64A9 [0xC9 0x01               ] */ and         1
 /* 0x64AB [0xCB 0x64 0xC5          ] */ ldseq       UNK_64C5
-/* 0x64AE [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x64AE [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x64B2 [0xB8 0x02               ] */ rand        2
 /* 0x64B4 [0xCB 0x64 0xC7          ] */ ldseq       UNK_64C7
 /* 0x64B7 [0xC7 0x00 0x64 0xC1     ] */ stseq       0, LAYER_64BF + STSEQ_NOTEDV_VELOCITY_2
@@ -14785,7 +14785,7 @@ UNK_6511:
 .channel CHAN_6520
 /* 0x6520 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x6521 [0xC8 0x50               ] */ sub         80
-/* 0x6523 [0xC7 0x19 0x65 0x36     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDVG | PITCH_BF2), LAYER_6536 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x6523 [0xC7 0x19 0x65 0x36     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | PITCH_BF2), LAYER_6536 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x6527 [0xCB 0x65 0x3B          ] */ ldseq       UNK_653B
 /* 0x652A [0xC7 0x00 0x65 0x38     ] */ stseq       0, LAYER_6536 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x652E [0x88 0x65 0x34          ] */ ldlayer     0, LAYER_6534
@@ -14806,7 +14806,7 @@ UNK_653B:
 .channel CHAN_6562
 /* 0x6562 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x6563 [0xC8 0x77               ] */ sub         119
-/* 0x6565 [0xC7 0x00 0x65 0x76     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDVG | PITCH_A0), LAYER_6576 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x6565 [0xC7 0x00 0x65 0x76     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | PITCH_A0), LAYER_6576 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x6569 [0xCB 0x65 0x7B          ] */ ldseq       UNK_657B
 /* 0x656C [0xC7 0x00 0x65 0x78     ] */ stseq       0, LAYER_6576 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x6570 [0x88 0x65 0x74          ] */ ldlayer     0, LAYER_6574

--- a/assets/audio/sequences/seq_0.prg.seq
+++ b/assets/audio/sequences/seq_0.prg.seq
@@ -1302,7 +1302,7 @@ CHAN_08EC:
 /* 0x08EE [0xC7 0x02 0x09 0x04     ] */ stseq       2, LAYER_0903 + STSEQ_NOTEDV_DELAY_HI
 /* 0x08F2 [0xC7 0x02 0x08 0xFD     ] */ stseq       2, CHAN_08FC + STSEQ_LDI_IMM
 /* 0x08F6 [0xB8 0x0C               ] */ rand        12
-/* 0x08F8 [0xC7 0x5C 0x09 0x03     ] */ stseq       (NOTEDV_OPCODE | PITCH_DF3), LAYER_0903 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x08F8 [0xC7 0x5C 0x09 0x03     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_DF3), LAYER_0903 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_08FC:
 /* 0x08FC [0xCC 0x01               ] */ ldi         1
 /* 0x08FE [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -4978,7 +4978,7 @@ CHAN_2274:
 /* 0x2284 [0x56                    ] */ subio       IO_PORT_6
 /* 0x2285 [0xC9 0x07               ] */ and         7
 CHAN_2287:
-/* 0x2287 [0xC7 0x60 0x22 0x98     ] */ stseq       (NOTEDV_OPCODE | PITCH_F3), LAYER_2298 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x2287 [0xC7 0x60 0x22 0x98     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_F3), LAYER_2298 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x228B [0x66                    ] */ ldio        IO_PORT_6
 /* 0x228C [0xC8 0xFC               ] */ sub         252
 /* 0x228E [0xC9 0x04               ] */ and         4
@@ -6529,7 +6529,7 @@ LAYER_2C4E:
 
 .channel CHAN_2C54
 /* 0x2C54 [0x89 0x2C 0x62          ] */ ldlayer     1, LAYER_2C62
-/* 0x2C57 [0xCC 0x58               ] */ ldi         (NOTEDV_OPCODE | PITCH_A2)
+/* 0x2C57 [0xCC 0x58               ] */ ldi         (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A2)
 /* 0x2C59 [0xC7 0x00 0x22 0x88     ] */ stseq       0, CHAN_2287 + STSEQ_STSEQ_IMM
 /* 0x2C5D [0xFB 0x22 0x67          ] */ jump        CHAN_2267
 
@@ -6649,7 +6649,7 @@ CHAN_2D01:
 .channel CHAN_2D13
 /* 0x2D13 [0x89 0x2D 0x25          ] */ ldlayer     1, LAYER_2D25
 /* 0x2D16 [0x8A 0x2D 0x23          ] */ ldlayer     2, LAYER_2D23
-/* 0x2D19 [0xCC 0x66               ] */ ldi         (NOTEDV_OPCODE | PITCH_B3)
+/* 0x2D19 [0xCC 0x66               ] */ ldi         (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_B3)
 /* 0x2D1B [0xC7 0x00 0x22 0x88     ] */ stseq       0, CHAN_2287 + STSEQ_STSEQ_IMM
 /* 0x2D1F [0xFB 0x22 0x67          ] */ jump        CHAN_2267
 /* 0x2D22 [0xFF                    ] */ end
@@ -9201,7 +9201,7 @@ CHAN_4162:
 /* 0x4164 [0xC7 0x03 0x41 0x7A     ] */ stseq       3, LAYER_4179 + STSEQ_NOTEDV_DELAY_HI
 /* 0x4168 [0xC7 0x03 0x41 0x73     ] */ stseq       3, CHAN_4172 + STSEQ_LDI_IMM
 /* 0x416C [0xB8 0x08               ] */ rand        8
-/* 0x416E [0xC7 0x5B 0x41 0x79     ] */ stseq       (NOTEDV_OPCODE | PITCH_C3), LAYER_4179 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x416E [0xC7 0x5B 0x41 0x79     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_C3), LAYER_4179 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_4172:
 /* 0x4172 [0xCC 0x01               ] */ ldi         1
 /* 0x4174 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -9763,7 +9763,7 @@ LAYER_4245:
 /* 0x44C9 [0x88 0x44 0xD7          ] */ ldlayer     0, LAYER_44D7
 /* 0x44CC [0xED 0x14               ] */ gain        20
 /* 0x44CE [0xB8 0x04               ] */ rand        4
-/* 0x44D0 [0xC7 0x6B 0x44 0xD7     ] */ stseq       (NOTEDV_OPCODE | PITCH_E4), LAYER_44D7 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x44D0 [0xC7 0x6B 0x44 0xD7     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_E4), LAYER_44D7 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x44D4 [0xD9 0xE8               ] */ releaserate 232
 /* 0x44D6 [0xFF                    ] */ end
 
@@ -10353,7 +10353,7 @@ LAYER_47B3:
 /* 0x4860 [0x88 0x48 0x70          ] */ ldlayer     0, LAYER_4870
 CHAN_4863:
 /* 0x4863 [0xB8 0x04               ] */ rand        4
-/* 0x4865 [0xC7 0x60 0x48 0x70     ] */ stseq       (NOTEDV_OPCODE | PITCH_F3), LAYER_4870 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x4865 [0xC7 0x60 0x48 0x70     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_F3), LAYER_4870 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x4869 [0xCC 0x12               ] */ ldi         18
 /* 0x486B [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x486E [0xF4 0xF3               ] */ rjump       CHAN_4863
@@ -12266,7 +12266,7 @@ LAYER_53FD:
 /* 0x5403 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x5405 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x5406 [0xC8 0xB0               ] */ sub         176
-/* 0x5408 [0xC7 0x00 0x54 0x17     ] */ stseq       (NOTEDVG_OPCODE | PITCH_A0), LAYER_5417 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x5408 [0xC7 0x00 0x54 0x17     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDVG | PITCH_A0), LAYER_5417 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x540C [0xCB 0x54 0x1C          ] */ ldseq       UNK_541C
 /* 0x540F [0xC7 0x00 0x54 0x19     ] */ stseq       0, LAYER_5417 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x5413 [0x88 0x54 0x17          ] */ ldlayer     0, LAYER_5417
@@ -12640,7 +12640,7 @@ CHAN_565E:
 /* 0x5660 [0xC7 0x28 0x56 0x76     ] */ stseq       40, LAYER_5675 + STSEQ_NOTEDV_DELAY_HI
 /* 0x5664 [0xC7 0x28 0x56 0x6F     ] */ stseq       40, CHAN_566E + STSEQ_LDI_IMM
 /* 0x5668 [0xB8 0x06               ] */ rand        6
-/* 0x566A [0xC7 0x64 0x56 0x75     ] */ stseq       (NOTEDV_OPCODE | PITCH_A3), LAYER_5675 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x566A [0xC7 0x64 0x56 0x75     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A3), LAYER_5675 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_566E:
 /* 0x566E [0xCC 0x01               ] */ ldi         1
 /* 0x5670 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -14045,7 +14045,7 @@ CHAN_6116:
 /* 0x6118 [0x3F 0x06               ] */ stcio       15, IO_PORT_6
 CHAN_611A:
 /* 0x611A [0xCB 0x61 0x6D          ] */ ldseq       UNK_616D
-/* 0x611D [0xC7 0x40 0x61 0x2D     ] */ stseq       (NOTEDV_OPCODE | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x611D [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x6121 [0x66                    ] */ ldio        IO_PORT_6
 CHAN_6122:
 /* 0x6122 [0xCB 0x61 0x71          ] */ ldseq       UNK_6171
@@ -14079,8 +14079,8 @@ CHAN_613E:
 /* 0x6145 [0xCC 0x00               ] */ ldi         0
                                         // Reads the byte at (PTR + 0) into TR (the note)
 /* 0x6147 [0xB6                    ] */ dyntblv
-                                        // Store NOTEDV_OPCODE + TR into the pitch
-/* 0x6148 [0xC7 0x40 0x61 0x2D     ] */ stseq       (NOTEDV_OPCODE | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
+                                        // Store ASEQ_OPC_LAYER_STEP3_NOTEDV + TR into the pitch
+/* 0x6148 [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
                                         // Load 1 into TR
 /* 0x614C [0xCC 0x01               ] */ ldi         1
                                         // Reads the byte at (PTR + 1) into TR (the velocity)
@@ -14355,7 +14355,7 @@ UNK_62CC:
 /* 0x62D1 [0x76                    ] */ stio        IO_PORT_6
 /* 0x62D2 [0xC9 0x01               ] */ and         1
 /* 0x62D4 [0xCB 0x62 0xE8          ] */ ldseq       UNK_62E8
-/* 0x62D7 [0xC7 0x40 0x64 0xBF     ] */ stseq       (NOTEDV_OPCODE | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x62D7 [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x62DB [0xB8 0x02               ] */ rand        2
 /* 0x62DD [0xCB 0x62 0xEA          ] */ ldseq       UNK_62EA
 /* 0x62E0 [0xC7 0x00 0x64 0xC1     ] */ stseq       0, LAYER_64BF + STSEQ_NOTEDV_VELOCITY_2
@@ -14482,7 +14482,7 @@ UNK_6374:
 /* 0x6379 [0x76                    ] */ stio        IO_PORT_6
 /* 0x637A [0xC9 0x01               ] */ and         1
 /* 0x637C [0xCB 0x63 0x96          ] */ ldseq       UNK_6396
-/* 0x637F [0xC7 0x40 0x63 0x90     ] */ stseq       (NOTEDV_OPCODE | PITCH_A0), LAYER_6390 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x637F [0xC7 0x40 0x63 0x90     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_6390 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x6383 [0xB8 0x02               ] */ rand        2
 /* 0x6385 [0xCB 0x63 0x98          ] */ ldseq       UNK_6398
 /* 0x6388 [0xC7 0x00 0x63 0x92     ] */ stseq       0, LAYER_6390 + STSEQ_NOTEDV_VELOCITY_2
@@ -14688,7 +14688,7 @@ UNK_6499:
 /* 0x64A8 [0x76                    ] */ stio        IO_PORT_6
 /* 0x64A9 [0xC9 0x01               ] */ and         1
 /* 0x64AB [0xCB 0x64 0xC5          ] */ ldseq       UNK_64C5
-/* 0x64AE [0xC7 0x40 0x64 0xBF     ] */ stseq       (NOTEDV_OPCODE | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x64AE [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x64B2 [0xB8 0x02               ] */ rand        2
 /* 0x64B4 [0xCB 0x64 0xC7          ] */ ldseq       UNK_64C7
 /* 0x64B7 [0xC7 0x00 0x64 0xC1     ] */ stseq       0, LAYER_64BF + STSEQ_NOTEDV_VELOCITY_2
@@ -14785,7 +14785,7 @@ UNK_6511:
 .channel CHAN_6520
 /* 0x6520 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x6521 [0xC8 0x50               ] */ sub         80
-/* 0x6523 [0xC7 0x19 0x65 0x36     ] */ stseq       (NOTEDVG_OPCODE | PITCH_BF2), LAYER_6536 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x6523 [0xC7 0x19 0x65 0x36     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDVG | PITCH_BF2), LAYER_6536 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x6527 [0xCB 0x65 0x3B          ] */ ldseq       UNK_653B
 /* 0x652A [0xC7 0x00 0x65 0x38     ] */ stseq       0, LAYER_6536 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x652E [0x88 0x65 0x34          ] */ ldlayer     0, LAYER_6534
@@ -14806,7 +14806,7 @@ UNK_653B:
 .channel CHAN_6562
 /* 0x6562 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x6563 [0xC8 0x77               ] */ sub         119
-/* 0x6565 [0xC7 0x00 0x65 0x76     ] */ stseq       (NOTEDVG_OPCODE | PITCH_A0), LAYER_6576 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x6565 [0xC7 0x00 0x65 0x76     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDVG | PITCH_A0), LAYER_6576 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x6569 [0xCB 0x65 0x7B          ] */ ldseq       UNK_657B
 /* 0x656C [0xC7 0x00 0x65 0x78     ] */ stseq       0, LAYER_6576 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x6570 [0x88 0x65 0x74          ] */ ldlayer     0, LAYER_6574

--- a/assets/audio/sequences/seq_0.prg.seq
+++ b/assets/audio/sequences/seq_0.prg.seq
@@ -1302,7 +1302,7 @@ CHAN_08EC:
 /* 0x08EE [0xC7 0x02 0x09 0x04     ] */ stseq       2, LAYER_0903 + STSEQ_NOTEDV_DELAY_HI
 /* 0x08F2 [0xC7 0x02 0x08 0xFD     ] */ stseq       2, CHAN_08FC + STSEQ_LDI_IMM
 /* 0x08F6 [0xB8 0x0C               ] */ rand        12
-/* 0x08F8 [0xC7 0x5C 0x09 0x03     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF3), LAYER_0903 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x08F8 [0xC7 0x5C 0x09 0x03     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_DF3), LAYER_0903 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_08FC:
 /* 0x08FC [0xCC 0x01               ] */ ldi         1
 /* 0x08FE [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -4978,7 +4978,7 @@ CHAN_2274:
 /* 0x2284 [0x56                    ] */ subio       IO_PORT_6
 /* 0x2285 [0xC9 0x07               ] */ and         7
 CHAN_2287:
-/* 0x2287 [0xC7 0x60 0x22 0x98     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_F3), LAYER_2298 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x2287 [0xC7 0x60 0x22 0x98     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_F3), LAYER_2298 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x228B [0x66                    ] */ ldio        IO_PORT_6
 /* 0x228C [0xC8 0xFC               ] */ sub         252
 /* 0x228E [0xC9 0x04               ] */ and         4
@@ -6529,7 +6529,7 @@ LAYER_2C4E:
 
 .channel CHAN_2C54
 /* 0x2C54 [0x89 0x2C 0x62          ] */ ldlayer     1, LAYER_2C62
-/* 0x2C57 [0xCC 0x58               ] */ ldi         (ASEQ_OPC_LAYER_NOTEDV | PITCH_A2)
+/* 0x2C57 [0xCC 0x58               ] */ ldi         (ASEQ_OP_LAYER_NOTEDV | PITCH_A2)
 /* 0x2C59 [0xC7 0x00 0x22 0x88     ] */ stseq       0, CHAN_2287 + STSEQ_STSEQ_IMM
 /* 0x2C5D [0xFB 0x22 0x67          ] */ jump        CHAN_2267
 
@@ -6649,7 +6649,7 @@ CHAN_2D01:
 .channel CHAN_2D13
 /* 0x2D13 [0x89 0x2D 0x25          ] */ ldlayer     1, LAYER_2D25
 /* 0x2D16 [0x8A 0x2D 0x23          ] */ ldlayer     2, LAYER_2D23
-/* 0x2D19 [0xCC 0x66               ] */ ldi         (ASEQ_OPC_LAYER_NOTEDV | PITCH_B3)
+/* 0x2D19 [0xCC 0x66               ] */ ldi         (ASEQ_OP_LAYER_NOTEDV | PITCH_B3)
 /* 0x2D1B [0xC7 0x00 0x22 0x88     ] */ stseq       0, CHAN_2287 + STSEQ_STSEQ_IMM
 /* 0x2D1F [0xFB 0x22 0x67          ] */ jump        CHAN_2267
 /* 0x2D22 [0xFF                    ] */ end
@@ -9201,7 +9201,7 @@ CHAN_4162:
 /* 0x4164 [0xC7 0x03 0x41 0x7A     ] */ stseq       3, LAYER_4179 + STSEQ_NOTEDV_DELAY_HI
 /* 0x4168 [0xC7 0x03 0x41 0x73     ] */ stseq       3, CHAN_4172 + STSEQ_LDI_IMM
 /* 0x416C [0xB8 0x08               ] */ rand        8
-/* 0x416E [0xC7 0x5B 0x41 0x79     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C3), LAYER_4179 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x416E [0xC7 0x5B 0x41 0x79     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C3), LAYER_4179 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_4172:
 /* 0x4172 [0xCC 0x01               ] */ ldi         1
 /* 0x4174 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -9763,7 +9763,7 @@ LAYER_4245:
 /* 0x44C9 [0x88 0x44 0xD7          ] */ ldlayer     0, LAYER_44D7
 /* 0x44CC [0xED 0x14               ] */ gain        20
 /* 0x44CE [0xB8 0x04               ] */ rand        4
-/* 0x44D0 [0xC7 0x6B 0x44 0xD7     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_E4), LAYER_44D7 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x44D0 [0xC7 0x6B 0x44 0xD7     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_E4), LAYER_44D7 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x44D4 [0xD9 0xE8               ] */ releaserate 232
 /* 0x44D6 [0xFF                    ] */ end
 
@@ -10353,7 +10353,7 @@ LAYER_47B3:
 /* 0x4860 [0x88 0x48 0x70          ] */ ldlayer     0, LAYER_4870
 CHAN_4863:
 /* 0x4863 [0xB8 0x04               ] */ rand        4
-/* 0x4865 [0xC7 0x60 0x48 0x70     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_F3), LAYER_4870 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x4865 [0xC7 0x60 0x48 0x70     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_F3), LAYER_4870 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x4869 [0xCC 0x12               ] */ ldi         18
 /* 0x486B [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x486E [0xF4 0xF3               ] */ rjump       CHAN_4863
@@ -12266,7 +12266,7 @@ LAYER_53FD:
 /* 0x5403 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x5405 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x5406 [0xC8 0xB0               ] */ sub         176
-/* 0x5408 [0xC7 0x00 0x54 0x17     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | PITCH_A0), LAYER_5417 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x5408 [0xC7 0x00 0x54 0x17     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | PITCH_A0), LAYER_5417 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x540C [0xCB 0x54 0x1C          ] */ ldseq       UNK_541C
 /* 0x540F [0xC7 0x00 0x54 0x19     ] */ stseq       0, LAYER_5417 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x5413 [0x88 0x54 0x17          ] */ ldlayer     0, LAYER_5417
@@ -12640,7 +12640,7 @@ CHAN_565E:
 /* 0x5660 [0xC7 0x28 0x56 0x76     ] */ stseq       40, LAYER_5675 + STSEQ_NOTEDV_DELAY_HI
 /* 0x5664 [0xC7 0x28 0x56 0x6F     ] */ stseq       40, CHAN_566E + STSEQ_LDI_IMM
 /* 0x5668 [0xB8 0x06               ] */ rand        6
-/* 0x566A [0xC7 0x64 0x56 0x75     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A3), LAYER_5675 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x566A [0xC7 0x64 0x56 0x75     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_A3), LAYER_5675 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_566E:
 /* 0x566E [0xCC 0x01               ] */ ldi         1
 /* 0x5670 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -14045,7 +14045,7 @@ CHAN_6116:
 /* 0x6118 [0x3F 0x06               ] */ stcio       15, IO_PORT_6
 CHAN_611A:
 /* 0x611A [0xCB 0x61 0x6D          ] */ ldseq       UNK_616D
-/* 0x611D [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x611D [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x6121 [0x66                    ] */ ldio        IO_PORT_6
 CHAN_6122:
 /* 0x6122 [0xCB 0x61 0x71          ] */ ldseq       UNK_6171
@@ -14079,8 +14079,8 @@ CHAN_613E:
 /* 0x6145 [0xCC 0x00               ] */ ldi         0
                                         // Reads the byte at (PTR + 0) into TR (the note)
 /* 0x6147 [0xB6                    ] */ dyntblv
-                                        // Store ASEQ_OPC_LAYER_NOTEDV + TR into the pitch
-/* 0x6148 [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
+                                        // Store ASEQ_OP_LAYER_NOTEDV + TR into the pitch
+/* 0x6148 [0xC7 0x40 0x61 0x2D     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_A0), LAYER_612D + STSEQ_NOTEDV_OPCODE_PITCH
                                         // Load 1 into TR
 /* 0x614C [0xCC 0x01               ] */ ldi         1
                                         // Reads the byte at (PTR + 1) into TR (the velocity)
@@ -14355,7 +14355,7 @@ UNK_62CC:
 /* 0x62D1 [0x76                    ] */ stio        IO_PORT_6
 /* 0x62D2 [0xC9 0x01               ] */ and         1
 /* 0x62D4 [0xCB 0x62 0xE8          ] */ ldseq       UNK_62E8
-/* 0x62D7 [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x62D7 [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x62DB [0xB8 0x02               ] */ rand        2
 /* 0x62DD [0xCB 0x62 0xEA          ] */ ldseq       UNK_62EA
 /* 0x62E0 [0xC7 0x00 0x64 0xC1     ] */ stseq       0, LAYER_64BF + STSEQ_NOTEDV_VELOCITY_2
@@ -14482,7 +14482,7 @@ UNK_6374:
 /* 0x6379 [0x76                    ] */ stio        IO_PORT_6
 /* 0x637A [0xC9 0x01               ] */ and         1
 /* 0x637C [0xCB 0x63 0x96          ] */ ldseq       UNK_6396
-/* 0x637F [0xC7 0x40 0x63 0x90     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_6390 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x637F [0xC7 0x40 0x63 0x90     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_A0), LAYER_6390 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x6383 [0xB8 0x02               ] */ rand        2
 /* 0x6385 [0xCB 0x63 0x98          ] */ ldseq       UNK_6398
 /* 0x6388 [0xC7 0x00 0x63 0x92     ] */ stseq       0, LAYER_6390 + STSEQ_NOTEDV_VELOCITY_2
@@ -14688,7 +14688,7 @@ UNK_6499:
 /* 0x64A8 [0x76                    ] */ stio        IO_PORT_6
 /* 0x64A9 [0xC9 0x01               ] */ and         1
 /* 0x64AB [0xCB 0x64 0xC5          ] */ ldseq       UNK_64C5
-/* 0x64AE [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x64AE [0xC7 0x40 0x64 0xBF     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_A0), LAYER_64BF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x64B2 [0xB8 0x02               ] */ rand        2
 /* 0x64B4 [0xCB 0x64 0xC7          ] */ ldseq       UNK_64C7
 /* 0x64B7 [0xC7 0x00 0x64 0xC1     ] */ stseq       0, LAYER_64BF + STSEQ_NOTEDV_VELOCITY_2
@@ -14785,7 +14785,7 @@ UNK_6511:
 .channel CHAN_6520
 /* 0x6520 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x6521 [0xC8 0x50               ] */ sub         80
-/* 0x6523 [0xC7 0x19 0x65 0x36     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | PITCH_BF2), LAYER_6536 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x6523 [0xC7 0x19 0x65 0x36     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | PITCH_BF2), LAYER_6536 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x6527 [0xCB 0x65 0x3B          ] */ ldseq       UNK_653B
 /* 0x652A [0xC7 0x00 0x65 0x38     ] */ stseq       0, LAYER_6536 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x652E [0x88 0x65 0x34          ] */ ldlayer     0, LAYER_6534
@@ -14806,7 +14806,7 @@ UNK_653B:
 .channel CHAN_6562
 /* 0x6562 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x6563 [0xC8 0x77               ] */ sub         119
-/* 0x6565 [0xC7 0x00 0x65 0x76     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | PITCH_A0), LAYER_6576 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x6565 [0xC7 0x00 0x65 0x76     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | PITCH_A0), LAYER_6576 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x6569 [0xCB 0x65 0x7B          ] */ ldseq       UNK_657B
 /* 0x656C [0xC7 0x00 0x65 0x78     ] */ stseq       0, LAYER_6576 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x6570 [0x88 0x65 0x74          ] */ ldlayer     0, LAYER_6574

--- a/assets/audio/sequences/seq_1.prg.seq
+++ b/assets/audio/sequences/seq_1.prg.seq
@@ -454,7 +454,7 @@ CHAN_0308:
 /* 0x0319 [0xC7 0x60 0x10 0x00     ] */ stseq       96, ENVELOPE_0FFA + STSEQ_ENVELOPE_POINT(3)
 CHAN_031D:
 /* 0x031D [0xB8 0x18               ] */ rand        24
-/* 0x031F [0xC7 0x62 0x03 0x6F     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G3), LAYER_036F + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x031F [0xC7 0x62 0x03 0x6F     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_G3), LAYER_036F + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0323 [0xCC 0x40               ] */ ldi         64
 /* 0x0325 [0x53                    ] */ subio       IO_PORT_3
 /* 0x0326 [0xC7 0x00 0x03 0x2B     ] */ stseq       0, STSEQ_HERE + STSEQ_RAND
@@ -482,7 +482,7 @@ CHAN_0335:
 /* 0x034B [0xC8 0xFF               ] */ sub         255
 /* 0x034D [0xC7 0x64 0x03 0x87     ] */ stseq       100, LAYER_0385 + STSEQ_NOTEDV_VELOCITY_2
 /* 0x0351 [0xC7 0x64 0x03 0x8A     ] */ stseq       100, LAYER_0388 + STSEQ_NOTEDV_VELOCITY_2
-/* 0x0355 [0xC7 0x67 0x03 0x85     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_0385 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0355 [0xC7 0x67 0x03 0x85     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C4), LAYER_0385 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0359 [0xFF                    ] */ end
 
 UNK_035A:
@@ -1664,7 +1664,7 @@ CHAN_0E72:
 /* 0x0E84 [0xB8 0x02               ] */ rand        2
 /* 0x0E86 [0x73                    ] */ stio        IO_PORT_3
 CHAN_0E87:
-/* 0x0E87 [0xC7 0x67 0x0E 0xCF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_0ECF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0E87 [0xC7 0x67 0x0E 0xCF     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C4), LAYER_0ECF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0E8B [0xB8 0x1E               ] */ rand        30
 /* 0x0E8D [0xC7 0x31 0x0E 0xCC     ] */ stseq       49, LAYER_0ECB + STSEQ_NOTEPAN
 /* 0x0E91 [0x76                    ] */ stio        IO_PORT_6

--- a/assets/audio/sequences/seq_1.prg.seq
+++ b/assets/audio/sequences/seq_1.prg.seq
@@ -454,7 +454,7 @@ CHAN_0308:
 /* 0x0319 [0xC7 0x60 0x10 0x00     ] */ stseq       96, ENVELOPE_0FFA + STSEQ_ENVELOPE_POINT(3)
 CHAN_031D:
 /* 0x031D [0xB8 0x18               ] */ rand        24
-/* 0x031F [0xC7 0x62 0x03 0x6F     ] */ stseq       (NOTEDV_OPCODE | PITCH_G3), LAYER_036F + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x031F [0xC7 0x62 0x03 0x6F     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_G3), LAYER_036F + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0323 [0xCC 0x40               ] */ ldi         64
 /* 0x0325 [0x53                    ] */ subio       IO_PORT_3
 /* 0x0326 [0xC7 0x00 0x03 0x2B     ] */ stseq       0, STSEQ_HERE + STSEQ_RAND
@@ -482,7 +482,7 @@ CHAN_0335:
 /* 0x034B [0xC8 0xFF               ] */ sub         255
 /* 0x034D [0xC7 0x64 0x03 0x87     ] */ stseq       100, LAYER_0385 + STSEQ_NOTEDV_VELOCITY_2
 /* 0x0351 [0xC7 0x64 0x03 0x8A     ] */ stseq       100, LAYER_0388 + STSEQ_NOTEDV_VELOCITY_2
-/* 0x0355 [0xC7 0x67 0x03 0x85     ] */ stseq       (NOTEDV_OPCODE | PITCH_C4), LAYER_0385 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0355 [0xC7 0x67 0x03 0x85     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_C4), LAYER_0385 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0359 [0xFF                    ] */ end
 
 UNK_035A:
@@ -1664,7 +1664,7 @@ CHAN_0E72:
 /* 0x0E84 [0xB8 0x02               ] */ rand        2
 /* 0x0E86 [0x73                    ] */ stio        IO_PORT_3
 CHAN_0E87:
-/* 0x0E87 [0xC7 0x67 0x0E 0xCF     ] */ stseq       (NOTEDV_OPCODE | PITCH_C4), LAYER_0ECF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0E87 [0xC7 0x67 0x0E 0xCF     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_C4), LAYER_0ECF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0E8B [0xB8 0x1E               ] */ rand        30
 /* 0x0E8D [0xC7 0x31 0x0E 0xCC     ] */ stseq       49, LAYER_0ECB + STSEQ_NOTEPAN
 /* 0x0E91 [0x76                    ] */ stio        IO_PORT_6

--- a/assets/audio/sequences/seq_1.prg.seq
+++ b/assets/audio/sequences/seq_1.prg.seq
@@ -454,7 +454,7 @@ CHAN_0308:
 /* 0x0319 [0xC7 0x60 0x10 0x00     ] */ stseq       96, ENVELOPE_0FFA + STSEQ_ENVELOPE_POINT(3)
 CHAN_031D:
 /* 0x031D [0xB8 0x18               ] */ rand        24
-/* 0x031F [0xC7 0x62 0x03 0x6F     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_G3), LAYER_036F + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x031F [0xC7 0x62 0x03 0x6F     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G3), LAYER_036F + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0323 [0xCC 0x40               ] */ ldi         64
 /* 0x0325 [0x53                    ] */ subio       IO_PORT_3
 /* 0x0326 [0xC7 0x00 0x03 0x2B     ] */ stseq       0, STSEQ_HERE + STSEQ_RAND
@@ -482,7 +482,7 @@ CHAN_0335:
 /* 0x034B [0xC8 0xFF               ] */ sub         255
 /* 0x034D [0xC7 0x64 0x03 0x87     ] */ stseq       100, LAYER_0385 + STSEQ_NOTEDV_VELOCITY_2
 /* 0x0351 [0xC7 0x64 0x03 0x8A     ] */ stseq       100, LAYER_0388 + STSEQ_NOTEDV_VELOCITY_2
-/* 0x0355 [0xC7 0x67 0x03 0x85     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_C4), LAYER_0385 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0355 [0xC7 0x67 0x03 0x85     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_0385 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0359 [0xFF                    ] */ end
 
 UNK_035A:
@@ -1664,7 +1664,7 @@ CHAN_0E72:
 /* 0x0E84 [0xB8 0x02               ] */ rand        2
 /* 0x0E86 [0x73                    ] */ stio        IO_PORT_3
 CHAN_0E87:
-/* 0x0E87 [0xC7 0x67 0x0E 0xCF     ] */ stseq       (ASEQ_OPC_LAYER_STEP3_NOTEDV | PITCH_C4), LAYER_0ECF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0E87 [0xC7 0x67 0x0E 0xCF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_0ECF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0E8B [0xB8 0x1E               ] */ rand        30
 /* 0x0E8D [0xC7 0x31 0x0E 0xCC     ] */ stseq       49, LAYER_0ECB + STSEQ_NOTEPAN
 /* 0x0E91 [0x76                    ] */ stio        IO_PORT_6

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -237,20 +237,20 @@
 
 // control flow commands
 #define ASEQ_OP_CONTROL_FLOW_FIRST 0xF2
-#define ASEQ_OP_RBLTZ     0xF2
-#define ASEQ_OP_RBEQZ     0xF3
-#define ASEQ_OP_RJUMP     0xF4
-#define ASEQ_OP_BGEZ      0xF5
-#define ASEQ_OP_BREAK     0xF6
-#define ASEQ_OP_LOOPEND   0xF7
-#define ASEQ_OP_LOOP      0xF8
-#define ASEQ_OP_BLTZ      0xF9
-#define ASEQ_OP_BEQZ      0xFA
-#define ASEQ_OP_JUMP      0xFB
-#define ASEQ_OP_CALL      0xFC
-#define ASEQ_OP_DELAY     0xFD
-#define ASEQ_OP_DELAY1    0xFE
-#define ASEQ_OP_END       0xFF
+#define ASEQ_OP_RBLTZ   0xF2
+#define ASEQ_OP_RBEQZ   0xF3
+#define ASEQ_OP_RJUMP   0xF4
+#define ASEQ_OP_BGEZ    0xF5
+#define ASEQ_OP_BREAK   0xF6
+#define ASEQ_OP_LOOPEND 0xF7
+#define ASEQ_OP_LOOP    0xF8
+#define ASEQ_OP_BLTZ    0xF9
+#define ASEQ_OP_BEQZ    0xFA
+#define ASEQ_OP_JUMP    0xFB
+#define ASEQ_OP_CALL    0xFC
+#define ASEQ_OP_DELAY   0xFD
+#define ASEQ_OP_DELAY1  0xFE
+#define ASEQ_OP_END     0xFF
 
 // sequence commands
 #define ASEQ_OP_SEQUENCE_TESTCHAN          0x00 // low nibble used as argument
@@ -387,30 +387,30 @@
 #define ASEQ_OP_CHANNEL_ALLOCNOTELIST  0xF1
 
 // layer commands
-#define ASEQ_OP_LAYER_NOTEDVG      0x00
-#define ASEQ_OP_LAYER_NOTEDV       0x40
-#define ASEQ_OP_LAYER_NOTEVG       0x80
-#define ASEQ_OP_LAYER_LDELAY       0xC0
-#define ASEQ_OP_LAYER_SHORTVEL     0xC1
-#define ASEQ_OP_LAYER_TRANSPOSE    0xC2
-#define ASEQ_OP_LAYER_SHORTDELAY   0xC3
-#define ASEQ_OP_LAYER_LEGATO       0xC4
-#define ASEQ_OP_LAYER_NOLEGATO     0xC5
-#define ASEQ_OP_LAYER_INSTR        0xC6
-#define ASEQ_OP_LAYER_PORTAMENTO   0xC7
-#define ASEQ_OP_LAYER_NOPORTAMENTO 0xC8
-#define ASEQ_OP_LAYER_SHORTGATE    0xC9
-#define ASEQ_OP_LAYER_NOTEPAN      0xCA
-#define ASEQ_OP_LAYER_ENV          0xCB
-#define ASEQ_OP_LAYER_NODRUMPAN    0xCC
-#define ASEQ_OP_LAYER_STEREO       0xCD
-#define ASEQ_OP_LAYER_BENDFINE     0xCE
-#define ASEQ_OP_LAYER_RELEASERATE  0xCF
-#define ASEQ_OP_LAYER_LDSHORTVEL   0xD0 // low nibble used as an argument
-#define ASEQ_OP_LAYER_LDSHORTGATE  0xE0 // low nibble used as an argument
+#define ASEQ_OP_LAYER_NOTEDVG       0x00
+#define ASEQ_OP_LAYER_NOTEDV        0x40
+#define ASEQ_OP_LAYER_NOTEVG        0x80
+#define ASEQ_OP_LAYER_LDELAY        0xC0
+#define ASEQ_OP_LAYER_SHORTVEL      0xC1
+#define ASEQ_OP_LAYER_TRANSPOSE     0xC2
+#define ASEQ_OP_LAYER_SHORTDELAY    0xC3
+#define ASEQ_OP_LAYER_LEGATO        0xC4
+#define ASEQ_OP_LAYER_NOLEGATO      0xC5
+#define ASEQ_OP_LAYER_INSTR         0xC6
+#define ASEQ_OP_LAYER_PORTAMENTO    0xC7
+#define ASEQ_OP_LAYER_NOPORTAMENTO  0xC8
+#define ASEQ_OP_LAYER_SHORTGATE     0xC9
+#define ASEQ_OP_LAYER_NOTEPAN       0xCA
+#define ASEQ_OP_LAYER_ENV           0xCB
+#define ASEQ_OP_LAYER_NODRUMPAN     0xCC
+#define ASEQ_OP_LAYER_STEREO        0xCD
+#define ASEQ_OP_LAYER_BENDFINE      0xCE
+#define ASEQ_OP_LAYER_RELEASERATE   0xCF
+#define ASEQ_OP_LAYER_LDSHORTVEL    0xD0 // low nibble used as an argument
+#define ASEQ_OP_LAYER_LDSHORTGATE   0xE0 // low nibble used as an argument
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OP_LAYER_F0           0xF0
-#define ASEQ_OP_LAYER_F1           0xF1
+#define ASEQ_OP_LAYER_F0            0xF0
+#define ASEQ_OP_LAYER_F1            0xF1
 #endif
 
 

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -357,27 +357,27 @@
 #define ASEQ_OPC_CHANNEL_ALLOCNOTELIST  0xF1
 
 // layer commands
-#define ASEQ_OPC_LAYER_STEP3_NOTEDVG    0x00
-#define ASEQ_OPC_LAYER_STEP3_NOTEDV     0x40
-#define ASEQ_OPC_LAYER_STEP3_NOTEVG     0x80
-#define ASEQ_OPC_LAYER_STEP3_LDELAY     0xC0
-#define ASEQ_OPC_LAYER_SHORTVEL         0xC1
-#define ASEQ_OPC_LAYER_TRANSPOSE        0xC2
-#define ASEQ_OPC_LAYER_SHORTDELAY       0xC3
-#define ASEQ_OPC_LAYER_LEGATO           0xC4
-#define ASEQ_OPC_LAYER_NOLEGATO         0xC5
-#define ASEQ_OPC_LAYER_INSTR            0xC6
-#define ASEQ_OPC_LAYER_PORTAMENTO       0xC7
-#define ASEQ_OPC_LAYER_NOPORTAMENTO     0xC8
-#define ASEQ_OPC_LAYER_SHORTGATE        0xC9
-#define ASEQ_OPC_LAYER_NOTEPAN          0xCA
-#define ASEQ_OPC_LAYER_ENV              0xCB
-#define ASEQ_OPC_LAYER_NODRUMPAN        0xCC
-#define ASEQ_OPC_LAYER_STEREO           0xCD
-#define ASEQ_OPC_LAYER_BENDFINE         0xCE
-#define ASEQ_OPC_LAYER_RELEASERATE      0xCF
-#define ASEQ_OPC_LAYER_LDSHORTVEL       0xD0 // low nibble used as an argument
-#define ASEQ_OPC_LAYER_LDSHORTGATE      0xE0 // low nibble used as an argument
+#define ASEQ_OPC_LAYER_NOTEDVG      0x00
+#define ASEQ_OPC_LAYER_NOTEDV       0x40
+#define ASEQ_OPC_LAYER_NOTEVG       0x80
+#define ASEQ_OPC_LAYER_LDELAY       0xC0
+#define ASEQ_OPC_LAYER_SHORTVEL     0xC1
+#define ASEQ_OPC_LAYER_TRANSPOSE    0xC2
+#define ASEQ_OPC_LAYER_SHORTDELAY   0xC3
+#define ASEQ_OPC_LAYER_LEGATO       0xC4
+#define ASEQ_OPC_LAYER_NOLEGATO     0xC5
+#define ASEQ_OPC_LAYER_INSTR        0xC6
+#define ASEQ_OPC_LAYER_PORTAMENTO   0xC7
+#define ASEQ_OPC_LAYER_NOPORTAMENTO 0xC8
+#define ASEQ_OPC_LAYER_SHORTGATE    0xC9
+#define ASEQ_OPC_LAYER_NOTEPAN      0xCA
+#define ASEQ_OPC_LAYER_ENV          0xCB
+#define ASEQ_OPC_LAYER_NODRUMPAN    0xCC
+#define ASEQ_OPC_LAYER_STEREO       0xCD
+#define ASEQ_OPC_LAYER_BENDFINE     0xCE
+#define ASEQ_OPC_LAYER_RELEASERATE  0xCF
+#define ASEQ_OPC_LAYER_LDSHORTVEL   0xD0 // low nibble used as an argument
+#define ASEQ_OPC_LAYER_LDSHORTGATE  0xE0 // low nibble used as an argument
 
 
 
@@ -2159,7 +2159,7 @@ $reladdr\@:
  *  Delay for `delay` ticks.
  */
 .macro ldelay delay
-    _wr_cmd_id  ldelay, ,,ASEQ_OPC_LAYER_STEP3_LDELAY,,,,,, 0, 0
+    _wr_cmd_id  ldelay, ,,ASEQ_OPC_LAYER_LDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2170,7 +2170,7 @@ $reladdr\@:
  * Should never be used when not required for matching purposes.
  */
 .macro lldelay delay
-    _wr_cmd_id  lldelay, ,ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_LAYER_STEP3_LDELAY,,,,,, 0, 0
+    _wr_cmd_id  lldelay, ,ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_LAYER_LDELAY,,,,,, 0, 0
     _var_long   \delay
 .endm
 
@@ -2342,7 +2342,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notedvg pitch, delay, velocity, gateTime
-    _wr_cmd_id  notedvg, ,,ASEQ_OPC_LAYER_STEP3_NOTEDVG,,,,,, \pitch, 6
+    _wr_cmd_id  notedvg, ,,ASEQ_OPC_LAYER_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
     _wr_u8      \gateTime
@@ -2356,14 +2356,14 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notedv pitch, delay, velocity
-    _wr_cmd_id  notedv, ,,ASEQ_OPC_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  notedv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
 .endm
 
 /* Workaround for bugs in vanilla sequences, force long encoding for delay. This should not typically be used. */
 .macro noteldv pitch, delay, velocity
-    _wr_cmd_id  noteldv, ,,ASEQ_OPC_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  noteldv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
     _var_long   \delay
     _wr_u8      \velocity
 .endm
@@ -2376,7 +2376,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notevg pitch, velocity, gateTime
-    _wr_cmd_id  notevg, ,,ASEQ_OPC_LAYER_STEP3_NOTEVG,,,,,, \pitch, 6
+    _wr_cmd_id  notevg, ,,ASEQ_OPC_LAYER_NOTEVG,,,,,, \pitch, 6
     _wr_u8      \velocity
     _wr_u8      \gateTime
 .endm
@@ -2390,7 +2390,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdvg pitch, delay
-    _wr_cmd_id  shortdvg, ,,ASEQ_OPC_LAYER_STEP3_NOTEDVG,,,,,, \pitch, 6
+    _wr_cmd_id  shortdvg, ,,ASEQ_OPC_LAYER_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
 .endm
 
@@ -2403,7 +2403,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdv pitch
-    _wr_cmd_id  shortdv, ,,ASEQ_OPC_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  shortdv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
 .endm
 
 /**
@@ -2415,7 +2415,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortvg pitch
-    _wr_cmd_id  shortvg, ,,ASEQ_OPC_LAYER_STEP3_NOTEVG,,,,,, \pitch, 6
+    _wr_cmd_id  shortvg, ,,ASEQ_OPC_LAYER_NOTEVG,,,,,, \pitch, 6
 .endm
 
 /**

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -225,157 +225,159 @@
  */
 
 // control flow commands
-#define ASEQ_CMD_ID_CONTROL_FLOW_FIRST 0xF2
-#define ASEQ_CMD_ID_CTRLFLOW_F2 0xF2
-#define ASEQ_CMD_ID_CTRLFLOW_F3 0xF3
-#define ASEQ_CMD_ID_CTRLFLOW_F4 0xF4
-#define ASEQ_CMD_ID_CTRLFLOW_F5 0xF5
-#define ASEQ_CMD_ID_CTRLFLOW_F6 0xF6
-#define ASEQ_CMD_ID_CTRLFLOW_F7 0xF7
-#define ASEQ_CMD_ID_CTRLFLOW_F8 0xF8
-#define ASEQ_CMD_ID_CTRLFLOW_F9 0xF9
-#define ASEQ_CMD_ID_CTRLFLOW_FA 0xFA
-#define ASEQ_CMD_ID_CTRLFLOW_FB 0xFB
-#define ASEQ_CMD_ID_CTRLFLOW_FC 0xFC
-#define ASEQ_CMD_ID_CTRLFLOW_FD 0xFD
-#define ASEQ_CMD_ID_CTRLFLOW_FE 0xFE
-#define ASEQ_CMD_ID_CTRLFLOW_FF 0xFF
+#define ASEQ_CMD_ID_CONTROL_FLOW_FIRST  0xF2
+#define ASEQ_CMD_ID_CTRLFLOW_RBLTZ      0xF2
+#define ASEQ_CMD_ID_CTRLFLOW_RBEQZ      0xF3
+#define ASEQ_CMD_ID_CTRLFLOW_RJUMP      0xF4
+#define ASEQ_CMD_ID_CTRLFLOW_BGEZ       0xF5
+#define ASEQ_CMD_ID_CTRLFLOW_BREAK      0xF6
+#define ASEQ_CMD_ID_CTRLFLOW_LOOPEND    0xF7
+#define ASEQ_CMD_ID_CTRLFLOW_LOOP       0xF8
+#define ASEQ_CMD_ID_CTRLFLOW_BLTZ       0xF9
+#define ASEQ_CMD_ID_CTRLFLOW_BEQZ       0xFA
+#define ASEQ_CMD_ID_CTRLFLOW_JUMP       0xFB
+#define ASEQ_CMD_ID_CTRLFLOW_CALL       0xFC
+#define ASEQ_CMD_ID_CTRLFLOW_DELAY      0xFD
+#define ASEQ_CMD_ID_CTRLFLOW_DELAY1     0xFE
+#define ASEQ_CMD_ID_CTRLFLOW_END        0xFF
 
 // sequence commands
-#define ASEQ_CMD_ID_SEQUENCE_00 0x00 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_40 0x40 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_50 0x50 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_60 0x60 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_70 0x70 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_80 0x80 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_90 0x90 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_A0 0xA0 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_B0 0xB0 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_C4 0xC4
-#define ASEQ_CMD_ID_SEQUENCE_C5 0xC5
-#define ASEQ_CMD_ID_SEQUENCE_C6 0xC6
-#define ASEQ_CMD_ID_SEQUENCE_C7 0xC7
-#define ASEQ_CMD_ID_SEQUENCE_C8 0xC8
-#define ASEQ_CMD_ID_SEQUENCE_C9 0xC9
-#define ASEQ_CMD_ID_SEQUENCE_CC 0xCC
-#define ASEQ_CMD_ID_SEQUENCE_CD 0xCD
-#define ASEQ_CMD_ID_SEQUENCE_CE 0xCE
-#define ASEQ_CMD_ID_SEQUENCE_D0 0xD0
-#define ASEQ_CMD_ID_SEQUENCE_D1 0xD1
-#define ASEQ_CMD_ID_SEQUENCE_D2 0xD2
-#define ASEQ_CMD_ID_SEQUENCE_D3 0xD3
-#define ASEQ_CMD_ID_SEQUENCE_D4 0xD4
-#define ASEQ_CMD_ID_SEQUENCE_D5 0xD5
-#define ASEQ_CMD_ID_SEQUENCE_D6 0xD6
-#define ASEQ_CMD_ID_SEQUENCE_D7 0xD7
-#define ASEQ_CMD_ID_SEQUENCE_D9 0xD9
-#define ASEQ_CMD_ID_SEQUENCE_DA 0xDA
-#define ASEQ_CMD_ID_SEQUENCE_DB 0xDB
-#define ASEQ_CMD_ID_SEQUENCE_DC 0xDC
-#define ASEQ_CMD_ID_SEQUENCE_DD 0xDD
-#define ASEQ_CMD_ID_SEQUENCE_DE 0xDE
-#define ASEQ_CMD_ID_SEQUENCE_DF 0xDF
-#define ASEQ_CMD_ID_SEQUENCE_EF 0xEF
-#define ASEQ_CMD_ID_SEQUENCE_F0 0xF0
-#define ASEQ_CMD_ID_SEQUENCE_F1 0xF1
+#define ASEQ_CMD_ID_SEQUENCE_TESTCHAN       0x00 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_STOPCHAN       0x40 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_SUBIO          0x50 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_LDRES          0x60 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_STIO           0x70 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_LDIO           0x80 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_LDCHAN         0x90 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_RLDCHAN        0xA0 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_LDSEQ          0xB0 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_RUNSEQ         0xC4
+#define ASEQ_CMD_ID_SEQUENCE_SCRIPTCTR      0xC5
+#define ASEQ_CMD_ID_SEQUENCE_STOP           0xC6
+#define ASEQ_CMD_ID_SEQUENCE_STSEQ          0xC7
+#define ASEQ_CMD_ID_SEQUENCE_SUB            0xC8
+#define ASEQ_CMD_ID_SEQUENCE_AND            0xC9
+#define ASEQ_CMD_ID_SEQUENCE_LDI            0xCC
+#define ASEQ_CMD_ID_SEQUENCE_DYNCALL        0xCD
+#define ASEQ_CMD_ID_SEQUENCE_RAND           0xCE
+#define ASEQ_CMD_ID_SEQUENCE_NOTEALLOC      0xD0
+#define ASEQ_CMD_ID_SEQUENCE_LDSHORTGATEARR 0xD1
+#define ASEQ_CMD_ID_SEQUENCE_LDSHORTVELARR  0xD2
+#define ASEQ_CMD_ID_SEQUENCE_MUTEBHV        0xD3
+#define ASEQ_CMD_ID_SEQUENCE_MUTE           0xD4
+#define ASEQ_CMD_ID_SEQUENCE_MUTESCALE      0xD5
+#define ASEQ_CMD_ID_SEQUENCE_FREECHAN       0xD6
+#define ASEQ_CMD_ID_SEQUENCE_INITCHAN       0xD7
+#define ASEQ_CMD_ID_SEQUENCE_VOLSCALE       0xD9
+#define ASEQ_CMD_ID_SEQUENCE_VOLMODE        0xDA
+#define ASEQ_CMD_ID_SEQUENCE_VOL            0xDB
+#define ASEQ_CMD_ID_SEQUENCE_TEMPOCHG       0xDC
+#define ASEQ_CMD_ID_SEQUENCE_TEMPO          0xDD
+#define ASEQ_CMD_ID_SEQUENCE_RTRANSPOSE     0xDE
+#define ASEQ_CMD_ID_SEQUENCE_TRANSPOSE      0xDF
+#define ASEQ_CMD_ID_SEQUENCE_EF             0xEF
+#define ASEQ_CMD_ID_SEQUENCE_FREENOTELIST   0xF0
+#define ASEQ_CMD_ID_SEQUENCE_ALLOCNOTELIST  0xF1
 
 // channel commands
-#define ASEQ_CMD_ID_CHANNEL_00 0x00 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_10 0x10 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_20 0x20 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_30 0x30 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_40 0x40 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_50 0x50 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_60 0x60 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_70 0x70 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_78 0x78 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_80 0x80 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_88 0x88 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_90 0x90 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_98 0x98 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_B0 0xB0
-#define ASEQ_CMD_ID_CHANNEL_B1 0xB1
-#define ASEQ_CMD_ID_CHANNEL_B2 0xB2
-#define ASEQ_CMD_ID_CHANNEL_B3 0xB3
-#define ASEQ_CMD_ID_CHANNEL_B4 0xB4
-#define ASEQ_CMD_ID_CHANNEL_B5 0xB5
-#define ASEQ_CMD_ID_CHANNEL_B6 0xB6
-#define ASEQ_CMD_ID_CHANNEL_B7 0xB7
-#define ASEQ_CMD_ID_CHANNEL_B8 0xB8
-#define ASEQ_CMD_ID_CHANNEL_B9 0xB9
-#define ASEQ_CMD_ID_CHANNEL_BA 0xBA
-#define ASEQ_CMD_ID_CHANNEL_BB 0xBB
-#define ASEQ_CMD_ID_CHANNEL_BC 0xBC
-#define ASEQ_CMD_ID_CHANNEL_BD 0xBD
-#define ASEQ_CMD_ID_CHANNEL_C1 0xC1
-#define ASEQ_CMD_ID_CHANNEL_C2 0xC2
-#define ASEQ_CMD_ID_CHANNEL_C3 0xC3
-#define ASEQ_CMD_ID_CHANNEL_C4 0xC4
-#define ASEQ_CMD_ID_CHANNEL_C5 0xC5
-#define ASEQ_CMD_ID_CHANNEL_C6 0xC6
-#define ASEQ_CMD_ID_CHANNEL_C7 0xC7
-#define ASEQ_CMD_ID_CHANNEL_C8 0xC8
-#define ASEQ_CMD_ID_CHANNEL_C9 0xC9
-#define ASEQ_CMD_ID_CHANNEL_CA 0xCA
-#define ASEQ_CMD_ID_CHANNEL_CB 0xCB
-#define ASEQ_CMD_ID_CHANNEL_CC 0xCC
-#define ASEQ_CMD_ID_CHANNEL_CD 0xCD
-#define ASEQ_CMD_ID_CHANNEL_CE 0xCE
-#define ASEQ_CMD_ID_CHANNEL_CF 0xCF
-#define ASEQ_CMD_ID_CHANNEL_D0 0xD0
-#define ASEQ_CMD_ID_CHANNEL_D1 0xD1
-#define ASEQ_CMD_ID_CHANNEL_D2 0xD2
-#define ASEQ_CMD_ID_CHANNEL_D3 0xD3
-#define ASEQ_CMD_ID_CHANNEL_D4 0xD4
-#define ASEQ_CMD_ID_CHANNEL_D7 0xD7
-#define ASEQ_CMD_ID_CHANNEL_D8 0xD8
-#define ASEQ_CMD_ID_CHANNEL_D9 0xD9
-#define ASEQ_CMD_ID_CHANNEL_DA 0xDA
-#define ASEQ_CMD_ID_CHANNEL_DB 0xDB
-#define ASEQ_CMD_ID_CHANNEL_DC 0xDC
-#define ASEQ_CMD_ID_CHANNEL_DD 0xDD
-#define ASEQ_CMD_ID_CHANNEL_DE 0xDE
-#define ASEQ_CMD_ID_CHANNEL_DF 0xDF
-#define ASEQ_CMD_ID_CHANNEL_E0 0xE0
-#define ASEQ_CMD_ID_CHANNEL_E1 0xE1
-#define ASEQ_CMD_ID_CHANNEL_E2 0xE2
-#define ASEQ_CMD_ID_CHANNEL_E3 0xE3
-#define ASEQ_CMD_ID_CHANNEL_E4 0xE4
-#define ASEQ_CMD_ID_CHANNEL_E5 0xE5
-#define ASEQ_CMD_ID_CHANNEL_E6 0xE6
-#define ASEQ_CMD_ID_CHANNEL_E7 0xE7
-#define ASEQ_CMD_ID_CHANNEL_E8 0xE8
-#define ASEQ_CMD_ID_CHANNEL_E9 0xE9
-#define ASEQ_CMD_ID_CHANNEL_EA 0xEA
-#define ASEQ_CMD_ID_CHANNEL_EB 0xEB
-#define ASEQ_CMD_ID_CHANNEL_EC 0xEC
-#define ASEQ_CMD_ID_CHANNEL_ED 0xED
-#define ASEQ_CMD_ID_CHANNEL_EE 0xEE
-#define ASEQ_CMD_ID_CHANNEL_F0 0xF0
-#define ASEQ_CMD_ID_CHANNEL_F1 0xF1
+#define ASEQ_CMD_ID_CHANNEL_STOPCHANELAY    0x00 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_LDSAMPLE        0x10 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_LDCHAN          0x20 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_STCIO           0x30 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_LDCIO           0x40 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_SUBIO           0x50 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_LDIO            0x60 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_STIO            0x70 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_RLDLAYER        0x78 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_TESTLAYER       0x80 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_LDLAYER         0x88 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_DELLAYER        0x90 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_DYNLDLAYER      0x98 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_LDFILTER        0xB0
+#define ASEQ_CMD_ID_CHANNEL_FREEFILTER      0xB1
+#define ASEQ_CMD_ID_CHANNEL_LDSEQTOPTR      0xB2
+#define ASEQ_CMD_ID_CHANNEL_FILTER          0xB3
+#define ASEQ_CMD_ID_CHANNEL_PTRTODYNTBL     0xB4
+#define ASEQ_CMD_ID_CHANNEL_DYNTBLTOPTR     0xB5
+#define ASEQ_CMD_ID_CHANNEL_DYNTBLV         0xB6
+#define ASEQ_CMD_ID_CHANNEL_RANDTOPTR       0xB7
+#define ASEQ_CMD_ID_CHANNEL_RAND            0xB8
+#define ASEQ_CMD_ID_CHANNEL_RANDVEL         0xB9
+#define ASEQ_CMD_ID_CHANNEL_RANDGATE        0xBA
+#define ASEQ_CMD_ID_CHANNEL_COMBFILTER      0xBB
+#define ASEQ_CMD_ID_CHANNEL_PTRADD          0xBC
+#if (MML_VERSION == MML_VERSION_OOT)
+#define ASEQ_CMD_ID_CHANNEL_RANDPTR         0xBD
+#endif
+#define ASEQ_CMD_ID_CHANNEL_INSTR           0xC1
+#define ASEQ_CMD_ID_CHANNEL_DYNTBL          0xC2
+#define ASEQ_CMD_ID_CHANNEL_SHORT           0xC3
+#define ASEQ_CMD_ID_CHANNEL_NOSHORT         0xC4
+#define ASEQ_CMD_ID_CHANNEL_DYNTBLLOOKUP    0xC5
+#define ASEQ_CMD_ID_CHANNEL_FONT            0xC6
+#define ASEQ_CMD_ID_CHANNEL_STSEQ           0xC7
+#define ASEQ_CMD_ID_CHANNEL_SUB             0xC8
+#define ASEQ_CMD_ID_CHANNEL_AND             0xC9
+#define ASEQ_CMD_ID_CHANNEL_MUTEBHV         0xCA
+#define ASEQ_CMD_ID_CHANNEL_LDSEQ           0xCB
+#define ASEQ_CMD_ID_CHANNEL_LDI             0xCC
+#define ASEQ_CMD_ID_CHANNEL_STOPCHAN        0xCD
+#define ASEQ_CMD_ID_CHANNEL_LDPTR           0xCE
+#define ASEQ_CMD_ID_CHANNEL_STPTRTOSEQ      0xCF
+#define ASEQ_CMD_ID_CHANNEL_EFFECTS         0xD0
+#define ASEQ_CMD_ID_CHANNEL_NOTEALLOC       0xD1
+#define ASEQ_CMD_ID_CHANNEL_SUSTAIN         0xD2
+#define ASEQ_CMD_ID_CHANNEL_BEND            0xD3
+#define ASEQ_CMD_ID_CHANNEL_REVERB          0xD4
+#define ASEQ_CMD_ID_CHANNEL_VIBFREQ         0xD7
+#define ASEQ_CMD_ID_CHANNEL_VIBDEPTH        0xD8
+#define ASEQ_CMD_ID_CHANNEL_RELEASERATE     0xD9
+#define ASEQ_CMD_ID_CHANNEL_ENV             0xDA
+#define ASEQ_CMD_ID_CHANNEL_TRANSPOSE       0xDB
+#define ASEQ_CMD_ID_CHANNEL_PANWEIGHT       0xDC
+#define ASEQ_CMD_ID_CHANNEL_PAN             0xDD
+#define ASEQ_CMD_ID_CHANNEL_FREQSCALE       0xDE
+#define ASEQ_CMD_ID_CHANNEL_VOL             0xDF
+#define ASEQ_CMD_ID_CHANNEL_VOLEXP          0xE0
+#define ASEQ_CMD_ID_CHANNEL_VIBFREQGRAD     0xE1
+#define ASEQ_CMD_ID_CHANNEL_VIBDEPTHGRAD    0xE2
+#define ASEQ_CMD_ID_CHANNEL_VIBDELAY        0xE3
+#define ASEQ_CMD_ID_CHANNEL_DYNCALL         0xE4
+#define ASEQ_CMD_ID_CHANNEL_REVERBIDX       0xE5
+#define ASEQ_CMD_ID_CHANNEL_SAMPLEBOOK      0xE6
+#define ASEQ_CMD_ID_CHANNEL_LDPARAMS        0xE7
+#define ASEQ_CMD_ID_CHANNEL_PARAMS          0xE8
+#define ASEQ_CMD_ID_CHANNEL_NOTEPRI         0xE9
+#define ASEQ_CMD_ID_CHANNEL_STOP            0xEA
+#define ASEQ_CMD_ID_CHANNEL_FONTINSTR       0xEB
+#define ASEQ_CMD_ID_CHANNEL_VIBRESET        0xEC
+#define ASEQ_CMD_ID_CHANNEL_GAIN            0xED
+#define ASEQ_CMD_ID_CHANNEL_BENDFINE        0xEE
+#define ASEQ_CMD_ID_CHANNEL_FREENOTELIST    0xF0
+#define ASEQ_CMD_ID_CHANNEL_ALLOCNOTELIST   0xF1
 
 // layer commands
-#define ASEQ_CMD_ID_LAYER_STEP3_00 0x00
-#define ASEQ_CMD_ID_LAYER_STEP3_40 0x40
-#define ASEQ_CMD_ID_LAYER_STEP3_80 0x80
-#define ASEQ_CMD_ID_LAYER_STEP3_C0 0xC0
-#define ASEQ_CMD_ID_LAYER_C1 0xC1
-#define ASEQ_CMD_ID_LAYER_C2 0xC2
-#define ASEQ_CMD_ID_LAYER_C3 0xC3
-#define ASEQ_CMD_ID_LAYER_C4 0xC4
-#define ASEQ_CMD_ID_LAYER_C5 0xC5
-#define ASEQ_CMD_ID_LAYER_C6 0xC6
-#define ASEQ_CMD_ID_LAYER_C7 0xC7
-#define ASEQ_CMD_ID_LAYER_C8 0xC8
-#define ASEQ_CMD_ID_LAYER_C9 0xC9
-#define ASEQ_CMD_ID_LAYER_CA 0xCA
-#define ASEQ_CMD_ID_LAYER_CB 0xCB
-#define ASEQ_CMD_ID_LAYER_CC 0xCC
-#define ASEQ_CMD_ID_LAYER_CD 0xCD
-#define ASEQ_CMD_ID_LAYER_CE 0xCE
-#define ASEQ_CMD_ID_LAYER_CF 0xCF
-#define ASEQ_CMD_ID_LAYER_D0 0xD0 // low nibble used as an argument
-#define ASEQ_CMD_ID_LAYER_E0 0xE0 // low nibble used as an argument
+#define ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG 0x00
+#define ASEQ_CMD_ID_LAYER_STEP3_NOTEDV  0x40
+#define ASEQ_CMD_ID_LAYER_STEP3_NOTEVG  0x80
+#define ASEQ_CMD_ID_LAYER_STEP3_LDELAY  0xC0
+#define ASEQ_CMD_ID_LAYER_SHORTVEL      0xC1
+#define ASEQ_CMD_ID_LAYER_TRANSPOSE     0xC2
+#define ASEQ_CMD_ID_LAYER_SHORTDELAY    0xC3
+#define ASEQ_CMD_ID_LAYER_LEGATO        0xC4
+#define ASEQ_CMD_ID_LAYER_NOLEGATO      0xC5
+#define ASEQ_CMD_ID_LAYER_INSTR         0xC6
+#define ASEQ_CMD_ID_LAYER_PORTAMENTO    0xC7
+#define ASEQ_CMD_ID_LAYER_NOPORTAMENTO  0xC8
+#define ASEQ_CMD_ID_LAYER_SHORTGATE     0xC9
+#define ASEQ_CMD_ID_LAYER_NOTEPAN       0xCA
+#define ASEQ_CMD_ID_LAYER_ENV           0xCB
+#define ASEQ_CMD_ID_LAYER_NODRUMPAN     0xCC
+#define ASEQ_CMD_ID_LAYER_STEREO        0xCD
+#define ASEQ_CMD_ID_LAYER_BENDFINE      0xCE
+#define ASEQ_CMD_ID_LAYER_RELEASERATE   0xCF
+#define ASEQ_CMD_ID_LAYER_LDSHORTVEL    0xD0 // low nibble used as an argument
+#define ASEQ_CMD_ID_LAYER_LDSHORTGATE   0xE0 // low nibble used as an argument
 
 
 
@@ -549,7 +551,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq ioPortNum, seqId, label
-        _wr_cmd_id  ldseq, ASEQ_CMD_ID_SEQUENCE_B0,,,,,,,, \ioPortNum, 4
+        _wr_cmd_id  ldseq, ASEQ_CMD_ID_SEQUENCE_LDSEQ,,,,,,,, \ioPortNum, 4
         _wr_u8      \seqId
         _wr_lbl     \label
     .endm
@@ -567,7 +569,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq label
-        _wr_cmd_id  ldseq, ,ASEQ_CMD_ID_CHANNEL_CB,,,,,,, 0, 0
+        _wr_cmd_id  ldseq, ,ASEQ_CMD_ID_CHANNEL_LDSEQ,,,,,,, 0, 0
         _wr_lbl     \label
     .endm
 
@@ -577,14 +579,14 @@ _RESET_SECTION
         _check_arg_bitwidth_u \lowpassCutoff, 4
         _check_arg_bitwidth_u \highpassCutoff, 4
 
-        _wr_cmd_id filter, ,ASEQ_CMD_ID_CHANNEL_B3,,,,,,, 0, 0
+        _wr_cmd_id filter, ,ASEQ_CMD_ID_CHANNEL_FILTER,,,,,,, 0, 0
         _wr_u8 (\lowpassCutoff << 4) | (\highpassCutoff)
     .endm
 
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label
-        _wr_cmd_id env, ,ASEQ_CMD_ID_CHANNEL_DA,,,,,,, 0, 0
+        _wr_cmd_id env, ,ASEQ_CMD_ID_CHANNEL_ENV,,,,,,, 0, 0
         _wr_lbl \label
     .endm
 
@@ -601,7 +603,7 @@ _RESET_SECTION
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label, arg
-        _wr_cmd_id env, ,,ASEQ_CMD_ID_LAYER_CB,,,,,, 0, 0
+        _wr_cmd_id env, ,,ASEQ_CMD_ID_LAYER_ENV,,,,,, 0, 0
         _wr_lbl \label
         _wr_u8 \arg
     .endm
@@ -892,7 +894,7 @@ $reladdr\@:
  *  closed, so are its layers.
  */
 .macro end
-    _wr_cmd_id  end, ASEQ_CMD_ID_CTRLFLOW_FF,ASEQ_CMD_ID_CTRLFLOW_FF,ASEQ_CMD_ID_CTRLFLOW_FF,,,,,, 0, 0
+    _wr_cmd_id  end, ASEQ_CMD_ID_CTRLFLOW_END,ASEQ_CMD_ID_CTRLFLOW_END,ASEQ_CMD_ID_CTRLFLOW_END,,,,,, 0, 0
 .endm
 
 /**
@@ -901,7 +903,7 @@ $reladdr\@:
  *  Delays for one tick.
  */
 .macro delay1
-    _wr_cmd_id  delay1, ASEQ_CMD_ID_CTRLFLOW_FE,ASEQ_CMD_ID_CTRLFLOW_FE,,,,,,, 0, 0
+    _wr_cmd_id  delay1, ASEQ_CMD_ID_CTRLFLOW_DELAY1,ASEQ_CMD_ID_CTRLFLOW_DELAY1,,,,,,, 0, 0
 .endm
 
 /**
@@ -910,7 +912,7 @@ $reladdr\@:
  *  Delays for `delay` ticks.
  */
 .macro delay delay
-    _wr_cmd_id  delay, ASEQ_CMD_ID_CTRLFLOW_FD,ASEQ_CMD_ID_CTRLFLOW_FD,,,,,,, 0, 0
+    _wr_cmd_id  delay, ASEQ_CMD_ID_CTRLFLOW_DELAY,ASEQ_CMD_ID_CTRLFLOW_DELAY,,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -921,7 +923,7 @@ $reladdr\@:
  *  subroutine encounters an `end` instruction.
  */
 .macro call label
-    _wr_cmd_id  call, ASEQ_CMD_ID_CTRLFLOW_FC,ASEQ_CMD_ID_CTRLFLOW_FC,ASEQ_CMD_ID_CTRLFLOW_FC,,,,,, 0, 0
+    _wr_cmd_id  call, ASEQ_CMD_ID_CTRLFLOW_CALL,ASEQ_CMD_ID_CTRLFLOW_CALL,ASEQ_CMD_ID_CTRLFLOW_CALL,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -931,7 +933,7 @@ $reladdr\@:
  *  Branches to `label` unconditionally.
  */
 .macro jump label
-    _wr_cmd_id  jump, ASEQ_CMD_ID_CTRLFLOW_FB,ASEQ_CMD_ID_CTRLFLOW_FB,ASEQ_CMD_ID_CTRLFLOW_FB,,,,,, 0, 0
+    _wr_cmd_id  jump, ASEQ_CMD_ID_CTRLFLOW_JUMP,ASEQ_CMD_ID_CTRLFLOW_JUMP,ASEQ_CMD_ID_CTRLFLOW_JUMP,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -941,7 +943,7 @@ $reladdr\@:
  *  Branches to `label` if TR == 0.
  */
 .macro beqz label
-    _wr_cmd_id  beqz, ASEQ_CMD_ID_CTRLFLOW_FA,ASEQ_CMD_ID_CTRLFLOW_FA,ASEQ_CMD_ID_CTRLFLOW_FA,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_CMD_ID_CTRLFLOW_BEQZ,ASEQ_CMD_ID_CTRLFLOW_BEQZ,ASEQ_CMD_ID_CTRLFLOW_BEQZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -951,7 +953,7 @@ $reladdr\@:
  *  Branches to `label` if TR < 0.
  */
 .macro bltz label
-    _wr_cmd_id  beqz, ASEQ_CMD_ID_CTRLFLOW_F9,ASEQ_CMD_ID_CTRLFLOW_F9,ASEQ_CMD_ID_CTRLFLOW_F9,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_CMD_ID_CTRLFLOW_BLTZ,ASEQ_CMD_ID_CTRLFLOW_BLTZ,ASEQ_CMD_ID_CTRLFLOW_BLTZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -965,7 +967,7 @@ $reladdr\@:
  *  becomes full.
  */
 .macro loop num
-    _wr_cmd_id  loop, ASEQ_CMD_ID_CTRLFLOW_F8,ASEQ_CMD_ID_CTRLFLOW_F8,ASEQ_CMD_ID_CTRLFLOW_F8,,,,,, 0, 0
+    _wr_cmd_id  loop, ASEQ_CMD_ID_CTRLFLOW_LOOP,ASEQ_CMD_ID_CTRLFLOW_LOOP,ASEQ_CMD_ID_CTRLFLOW_LOOP,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -979,7 +981,7 @@ $reladdr\@:
  *  stack is popped.
  */
 .macro loopend
-    _wr_cmd_id  loopend, ASEQ_CMD_ID_CTRLFLOW_F7,ASEQ_CMD_ID_CTRLFLOW_F7,ASEQ_CMD_ID_CTRLFLOW_F7,,,,,, 0, 0
+    _wr_cmd_id  loopend, ASEQ_CMD_ID_CTRLFLOW_LOOPEND,ASEQ_CMD_ID_CTRLFLOW_LOOPEND,ASEQ_CMD_ID_CTRLFLOW_LOOPEND,,,,,, 0, 0
 .endm
 
 /**
@@ -992,7 +994,7 @@ $reladdr\@:
  *  the call stack would be popped twice.
  */
 .macro break
-    _wr_cmd_id  break, ASEQ_CMD_ID_CTRLFLOW_F6,ASEQ_CMD_ID_CTRLFLOW_F6,ASEQ_CMD_ID_CTRLFLOW_F6,,,,,, 0, 0
+    _wr_cmd_id  break, ASEQ_CMD_ID_CTRLFLOW_BREAK,ASEQ_CMD_ID_CTRLFLOW_BREAK,ASEQ_CMD_ID_CTRLFLOW_BREAK,,,,,, 0, 0
 .endm
 
 /**
@@ -1001,7 +1003,7 @@ $reladdr\@:
  *  Branches to `label` if TR >= 0.
  */
 .macro bgez label
-    _wr_cmd_id  bgez, ASEQ_CMD_ID_CTRLFLOW_F5,ASEQ_CMD_ID_CTRLFLOW_F5,ASEQ_CMD_ID_CTRLFLOW_F5,,,,,, 0, 0
+    _wr_cmd_id  bgez, ASEQ_CMD_ID_CTRLFLOW_BGEZ,ASEQ_CMD_ID_CTRLFLOW_BGEZ,ASEQ_CMD_ID_CTRLFLOW_BGEZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1015,7 +1017,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rjump label
-    _wr_cmd_id  rjump, ASEQ_CMD_ID_CTRLFLOW_F4,ASEQ_CMD_ID_CTRLFLOW_F4,ASEQ_CMD_ID_CTRLFLOW_F4,,,,,, 0, 0
+    _wr_cmd_id  rjump, ASEQ_CMD_ID_CTRLFLOW_RJUMP,ASEQ_CMD_ID_CTRLFLOW_RJUMP,ASEQ_CMD_ID_CTRLFLOW_RJUMP,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1029,7 +1031,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbeqz label
-    _wr_cmd_id  rbeqz, ASEQ_CMD_ID_CTRLFLOW_F3,ASEQ_CMD_ID_CTRLFLOW_F3,ASEQ_CMD_ID_CTRLFLOW_F3,,,,,, 0, 0
+    _wr_cmd_id  rbeqz, ASEQ_CMD_ID_CTRLFLOW_RBEQZ,ASEQ_CMD_ID_CTRLFLOW_RBEQZ,ASEQ_CMD_ID_CTRLFLOW_RBEQZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1043,7 +1045,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbltz label
-    _wr_cmd_id  rbltz, ASEQ_CMD_ID_CTRLFLOW_F2,ASEQ_CMD_ID_CTRLFLOW_F2,ASEQ_CMD_ID_CTRLFLOW_F2,,,,,, 0, 0
+    _wr_cmd_id  rbltz, ASEQ_CMD_ID_CTRLFLOW_RBLTZ,ASEQ_CMD_ID_CTRLFLOW_RBLTZ,ASEQ_CMD_ID_CTRLFLOW_RBLTZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1053,7 +1055,7 @@ $reladdr\@:
  *  Clears the channel note pool and reallocates it with space for `num` notes.
  */
 .macro allocnotelist num
-    _wr_cmd_id  allocnotelist, ASEQ_CMD_ID_SEQUENCE_F1,ASEQ_CMD_ID_CHANNEL_F1,,,,,,, 0, 0
+    _wr_cmd_id  allocnotelist, ASEQ_CMD_ID_SEQUENCE_ALLOCNOTELIST,ASEQ_CMD_ID_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -1063,7 +1065,7 @@ $reladdr\@:
  *  Clears the channel note pool.
  */
 .macro freenotelist
-    _wr_cmd_id  freenotelist, ASEQ_CMD_ID_SEQUENCE_F0,ASEQ_CMD_ID_CHANNEL_F0,,,,,,, 0, 0
+    _wr_cmd_id  freenotelist, ASEQ_CMD_ID_SEQUENCE_FREENOTELIST,ASEQ_CMD_ID_CHANNEL_FREENOTELIST,,,,,,, 0, 0
 .endm
 
 /**
@@ -1083,7 +1085,7 @@ $reladdr\@:
  *  Fine-tunes the pitch bend amount for the channel or layer.
  */
 .macro bendfine amt
-    _wr_cmd_id  bendfine, ,ASEQ_CMD_ID_CHANNEL_EE,ASEQ_CMD_ID_LAYER_CE,,,,,, 0, 0
+    _wr_cmd_id  bendfine, ,ASEQ_CMD_ID_CHANNEL_BENDFINE,ASEQ_CMD_ID_LAYER_BENDFINE,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1093,7 +1095,7 @@ $reladdr\@:
  *  Sets the channel gain (multiplicative volume scale factor) to the provided qu4.4 fixed-point value.
  */
 .macro gain value
-    _wr_cmd_id  gain, ,ASEQ_CMD_ID_CHANNEL_ED,,,,,,, 0, 0
+    _wr_cmd_id  gain, ,ASEQ_CMD_ID_CHANNEL_GAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1103,7 +1105,7 @@ $reladdr\@:
  *  Resets channel vibrato, filter, gain, sustain, etc. state.
  */
 .macro vibreset
-    _wr_cmd_id  vibreset, ,ASEQ_CMD_ID_CHANNEL_EC,,,,,,, 0, 0
+    _wr_cmd_id  vibreset, ,ASEQ_CMD_ID_CHANNEL_VIBRESET,,,,,,, 0, 0
 .endm
 
 /**
@@ -1112,7 +1114,7 @@ $reladdr\@:
  *  Updates the soundfont and instrument for the channel simultaneously.
  */
 .macro fontinstr fontId, instId
-    _wr_cmd_id  fontinstr, ,ASEQ_CMD_ID_CHANNEL_EB,,,,,,, 0, 0
+    _wr_cmd_id  fontinstr, ,ASEQ_CMD_ID_CHANNEL_FONTINSTR,,,,,,, 0, 0
     _wr_u8      \fontId
     _wr_u8      \instId
 .endm
@@ -1125,7 +1127,7 @@ $reladdr\@:
 .macro notepri priority1, priority2
     _check_arg_bitwidth_u \priority1, 4
     _check_arg_bitwidth_u \priority2, 4
-    _wr_cmd_id  notepri, ,ASEQ_CMD_ID_CHANNEL_E9,,,,,,, 0, 0
+    _wr_cmd_id  notepri, ,ASEQ_CMD_ID_CHANNEL_NOTEPRI,,,,,,, 0, 0
     _wr_u8      (\priority1 << 4) | \priority2
 .endm
 
@@ -1136,7 +1138,7 @@ $reladdr\@:
  *  Sets various channel parameters.
  */
 .macro params muteBhv, noteAllocPolicy, channelPriority, transposition, pan, panWeight, reverb, reverbIndex
-    _wr_cmd_id  params, ,ASEQ_CMD_ID_CHANNEL_E8,,,,,,, 0, 0
+    _wr_cmd_id  params, ,ASEQ_CMD_ID_CHANNEL_PARAMS,,,,,,, 0, 0
     _wr_u8      \muteBhv
     _wr_u8      \noteAllocPolicy
     _wr_u8      \channelPriority
@@ -1154,7 +1156,7 @@ $reladdr\@:
  *  is ordered in the same way as the arguments in `params`.
  */
 .macro ldparams label
-    _wr_cmd_id  ldparams, ,ASEQ_CMD_ID_CHANNEL_E7,,,,,,, 0, 0
+    _wr_cmd_id  ldparams, ,ASEQ_CMD_ID_CHANNEL_LDPARAMS,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1164,7 +1166,7 @@ $reladdr\@:
  *  Sets the sample book mode.
  */
 .macro samplebook value
-    _wr_cmd_id  samplebook, ,ASEQ_CMD_ID_CHANNEL_E6,,,,,,, 0, 0
+    _wr_cmd_id  samplebook, ,ASEQ_CMD_ID_CHANNEL_SAMPLEBOOK,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1174,7 +1176,7 @@ $reladdr\@:
  *  Sets the channel reverb.
  */
 .macro reverbidx arg
-    _wr_cmd_id  reverbidx, ,ASEQ_CMD_ID_CHANNEL_E5,,,,,,, 0, 0
+    _wr_cmd_id  reverbidx, ,ASEQ_CMD_ID_CHANNEL_REVERBIDX,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1184,7 +1186,7 @@ $reladdr\@:
  *  Sets the channel vibrato delay.
  */
 .macro vibdelay arg
-    _wr_cmd_id  vibdelay, ,ASEQ_CMD_ID_CHANNEL_E3,,,,,,, 0, 0
+    _wr_cmd_id  vibdelay, ,ASEQ_CMD_ID_CHANNEL_VIBDELAY,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1194,7 +1196,7 @@ $reladdr\@:
  *  Sets the vibrato extent.
  */
 .macro vibdepthgrad arg0, arg1, arg2
-    _wr_cmd_id  vibdepthgrad, ,ASEQ_CMD_ID_CHANNEL_E2,,,,,,, 0, 0
+    _wr_cmd_id  vibdepthgrad, ,ASEQ_CMD_ID_CHANNEL_VIBDEPTHGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1206,7 +1208,7 @@ $reladdr\@:
  *  Sets the vibrato rate.
  */
 .macro vibfreqgrad arg0, arg1, arg2
-    _wr_cmd_id  vibfreqgrad, ,ASEQ_CMD_ID_CHANNEL_E1,,,,,,, 0, 0
+    _wr_cmd_id  vibfreqgrad, ,ASEQ_CMD_ID_CHANNEL_VIBFREQGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1218,7 +1220,7 @@ $reladdr\@:
  *  Changes the expression amount for the channel.
  */
 .macro volexp amt
-    _wr_cmd_id  volexp, ,ASEQ_CMD_ID_CHANNEL_E0,,,,,,, 0, 0
+    _wr_cmd_id  volexp, ,ASEQ_CMD_ID_CHANNEL_VOLEXP,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1229,7 +1231,7 @@ $reladdr\@:
  *  provided number of semitones.
  */
 .macro transpose semitones
-    _wr_cmd_id  transpose, ASEQ_CMD_ID_SEQUENCE_DF,ASEQ_CMD_ID_CHANNEL_DB,ASEQ_CMD_ID_LAYER_C2,,,,,, 0, 0
+    _wr_cmd_id  transpose, ASEQ_CMD_ID_SEQUENCE_TRANSPOSE,ASEQ_CMD_ID_CHANNEL_TRANSPOSE,ASEQ_CMD_ID_LAYER_TRANSPOSE,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1239,7 +1241,7 @@ $reladdr\@:
  *  Adjusts the transposition amount. This is only available at the top sequence level.
  */
 .macro rtranspose semitones
-    _wr_cmd_id  rtranspose, ASEQ_CMD_ID_SEQUENCE_DE,,,,,,,, 0, 0
+    _wr_cmd_id  rtranspose, ASEQ_CMD_ID_SEQUENCE_RTRANSPOSE,,,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1249,7 +1251,7 @@ $reladdr\@:
  *  Sets the freqScale for the current channel.
  */
 .macro freqscale arg
-    _wr_cmd_id  freqscale, ,ASEQ_CMD_ID_CHANNEL_DE,,,,,,, 0, 0
+    _wr_cmd_id  freqscale, ,ASEQ_CMD_ID_CHANNEL_FREQSCALE,,,,,,, 0, 0
     _wr_s16     \arg
 .endm
 
@@ -1259,7 +1261,7 @@ $reladdr\@:
  *  Changes the tempo of the sequence.
  */
 .macro tempo bpm
-    _wr_cmd_id  tempo, ASEQ_CMD_ID_SEQUENCE_DD,,,,,,,, 0, 0
+    _wr_cmd_id  tempo, ASEQ_CMD_ID_SEQUENCE_TEMPO,,,,,,,, 0, 0
     _wr_u8      \bpm
 .endm
 
@@ -1269,7 +1271,7 @@ $reladdr\@:
  *  Sets the tempoChange for the sequence.
  */
 .macro tempochg arg
-    _wr_cmd_id  tempochg, ASEQ_CMD_ID_SEQUENCE_DC,,,,,,,, 0, 0
+    _wr_cmd_id  tempochg, ASEQ_CMD_ID_SEQUENCE_TEMPOCHG,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1281,7 +1283,7 @@ $reladdr\@:
 .macro pan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  pan, ,ASEQ_CMD_ID_CHANNEL_DD,,,,,,, 0, 0
+    _wr_cmd_id  pan, ,ASEQ_CMD_ID_CHANNEL_PAN,,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -1297,7 +1299,7 @@ $reladdr\@:
 .macro panweight weight
     /* weight can only take values in 0..127 */
     _check_arg_bitwidth_u \weight, 7
-    _wr_cmd_id  panweight, ,ASEQ_CMD_ID_CHANNEL_DC,,,,,,, 0, 0
+    _wr_cmd_id  panweight, ,ASEQ_CMD_ID_CHANNEL_PANWEIGHT,,,,,,, 0, 0
     _wr_u8      \weight
 .endm
 
@@ -1307,7 +1309,7 @@ $reladdr\@:
  *  Sets the volume amount for this sequence or channel.
  */
 .macro vol amt
-    _wr_cmd_id  vol, ASEQ_CMD_ID_SEQUENCE_DB,ASEQ_CMD_ID_CHANNEL_DF,,,,,,, 0, 0
+    _wr_cmd_id  vol, ASEQ_CMD_ID_SEQUENCE_VOL,ASEQ_CMD_ID_CHANNEL_VOL,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1317,7 +1319,7 @@ $reladdr\@:
  *  TODO DESCRIPTION
  */
 .macro volmode mode, fadeTimer
-    _wr_cmd_id  volmode, ASEQ_CMD_ID_SEQUENCE_DA,,,,,,,, 0, 0
+    _wr_cmd_id  volmode, ASEQ_CMD_ID_SEQUENCE_VOLMODE,,,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u16     \fadeTimer
 .endm
@@ -1328,7 +1330,7 @@ $reladdr\@:
  *  Sets the fadeVolumeScale for the sequence.
  */
 .macro volscale arg
-    _wr_cmd_id  volscale, ASEQ_CMD_ID_SEQUENCE_D9,,,,,,,, 0, 0
+    _wr_cmd_id  volscale, ASEQ_CMD_ID_SEQUENCE_VOLSCALE,,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1338,7 +1340,7 @@ $reladdr\@:
  *  Sets the envelope release rate for this channel or layer.
  */
 .macro releaserate release
-    _wr_cmd_id  releaserate, ,ASEQ_CMD_ID_CHANNEL_D9,ASEQ_CMD_ID_LAYER_CF,,,,,, 0, 0
+    _wr_cmd_id  releaserate, ,ASEQ_CMD_ID_CHANNEL_RELEASERATE,ASEQ_CMD_ID_LAYER_RELEASERATE,,,,,, 0, 0
     _wr_u8      \release
 .endm
 
@@ -1348,7 +1350,7 @@ $reladdr\@:
  *  Sets the vibrato depth for the channel.
  */
 .macro vibdepth arg
-    _wr_cmd_id  vibdepth, ,ASEQ_CMD_ID_CHANNEL_D8,,,,,,, 0, 0
+    _wr_cmd_id  vibdepth, ,ASEQ_CMD_ID_CHANNEL_VIBDEPTH,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1358,7 +1360,7 @@ $reladdr\@:
  *  Sets the vibrato rate for the channel.
  */
 .macro vibfreq arg
-    _wr_cmd_id  vibfreq, ,ASEQ_CMD_ID_CHANNEL_D7,,,,,,, 0, 0
+    _wr_cmd_id  vibfreq, ,ASEQ_CMD_ID_CHANNEL_VIBFREQ,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1371,7 +1373,7 @@ $reladdr\@:
  *       initchan 0b101 initializes channels 0 and 2.
  */
 .macro initchan bitmask
-    _wr_cmd_id  initchan, ASEQ_CMD_ID_SEQUENCE_D7,,,,,,,, 0, 0
+    _wr_cmd_id  initchan, ASEQ_CMD_ID_SEQUENCE_INITCHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1381,7 +1383,7 @@ $reladdr\@:
  *  Frees the channels marked in the provided bitmask.
  */
 .macro freechan bitmask
-    _wr_cmd_id  freechan, ASEQ_CMD_ID_SEQUENCE_D6,,,,,,,, 0, 0
+    _wr_cmd_id  freechan, ASEQ_CMD_ID_SEQUENCE_FREECHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1391,7 +1393,7 @@ $reladdr\@:
  *  Sets the muteVolumeScale for the sequence.
  */
 .macro mutescale arg
-    _wr_cmd_id  mutescale, ASEQ_CMD_ID_SEQUENCE_D5,,,,,,,, 0, 0
+    _wr_cmd_id  mutescale, ASEQ_CMD_ID_SEQUENCE_MUTESCALE,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1401,7 +1403,7 @@ $reladdr\@:
  *  Mutes the sequence player.
  */
 .macro mute
-    _wr_cmd_id  mute, ASEQ_CMD_ID_SEQUENCE_D4,,,,,,,, 0, 0
+    _wr_cmd_id  mute, ASEQ_CMD_ID_SEQUENCE_MUTE,,,,,,,, 0, 0
 .endm
 
 /**
@@ -1410,7 +1412,7 @@ $reladdr\@:
  *  Sets the reverb amount for this channel.
  */
 .macro reverb amt
-    _wr_cmd_id  reverb, ,ASEQ_CMD_ID_CHANNEL_D4,,,,,,, 0, 0
+    _wr_cmd_id  reverb, ,ASEQ_CMD_ID_CHANNEL_REVERB,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1420,7 +1422,7 @@ $reladdr\@:
  *  Sets mute behavior for this sequence or channel.
  */
 .macro mutebhv flags
-    _wr_cmd_id  mutebhv, ASEQ_CMD_ID_SEQUENCE_D3,ASEQ_CMD_ID_CHANNEL_CA,,,,,,, 0, 0
+    _wr_cmd_id  mutebhv, ASEQ_CMD_ID_SEQUENCE_MUTEBHV,ASEQ_CMD_ID_CHANNEL_MUTEBHV,,,,,,, 0, 0
     _wr_u8      \flags
 .endm
 
@@ -1430,7 +1432,7 @@ $reladdr\@:
  *  Sets the pitch bend amount for this channel.
  */
 .macro bend amt
-    _wr_cmd_id  bend, ,ASEQ_CMD_ID_CHANNEL_D3,,,,,,, 0, 0
+    _wr_cmd_id  bend, ,ASEQ_CMD_ID_CHANNEL_BEND,,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1440,7 +1442,7 @@ $reladdr\@:
  *  Sets the location of SHORTVELTBL.
  */
 .macro ldshortvelarr label
-    _wr_cmd_id  ldshortvelarr, ASEQ_CMD_ID_SEQUENCE_D2,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortvelarr, ASEQ_CMD_ID_SEQUENCE_LDSHORTVELARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1450,7 +1452,7 @@ $reladdr\@:
  *  Sets the adsr sustain value for this channel.
  */
 .macro sustain value
-    _wr_cmd_id  sustain, ,ASEQ_CMD_ID_CHANNEL_D2,,,,,,, 0, 0
+    _wr_cmd_id  sustain, ,ASEQ_CMD_ID_CHANNEL_SUSTAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1460,7 +1462,7 @@ $reladdr\@:
  *  Sets the location of SHORTGATETBL.
  */
 .macro ldshortgatearr label
-    _wr_cmd_id  ldshortgatearr, ASEQ_CMD_ID_SEQUENCE_D1,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortgatearr, ASEQ_CMD_ID_SEQUENCE_LDSHORTGATEARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1470,7 +1472,7 @@ $reladdr\@:
  *  Sets the noteAllocPolicy for either the sequence or the current channel.
  */
 .macro notealloc arg
-    _wr_cmd_id  notealloc, ASEQ_CMD_ID_SEQUENCE_D0,ASEQ_CMD_ID_CHANNEL_D1,,,,,,, 0, 0
+    _wr_cmd_id  notealloc, ASEQ_CMD_ID_SEQUENCE_NOTEALLOC,ASEQ_CMD_ID_CHANNEL_NOTEALLOC,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1487,7 +1489,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  effects, ,ASEQ_CMD_ID_CHANNEL_D0,,,,,,, 0, 0
+    _wr_cmd_id  effects, ,ASEQ_CMD_ID_CHANNEL_EFFECTS,,,,,,, 0, 0
     _wr_u8      (\headset << 7) | (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -1497,7 +1499,7 @@ $reladdr\@:
  *  Stores TP -> label
  */
 .macro stptrtoseq label
-    _wr_cmd_id  stptrtoseq, ,ASEQ_CMD_ID_CHANNEL_CF,,,,,,, 0, 0
+    _wr_cmd_id  stptrtoseq, ,ASEQ_CMD_ID_CHANNEL_STPTRTOSEQ,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1507,7 +1509,7 @@ $reladdr\@:
  *  Loads label -> TP
  */
 .macro ldptr label
-    _wr_cmd_id  ldptr, ,ASEQ_CMD_ID_CHANNEL_CE,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_CMD_ID_CHANNEL_LDPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1517,7 +1519,7 @@ $reladdr\@:
  *  Loads imm -> TP
  */
 .macro ldptri imm
-    _wr_cmd_id  ldptr, ,ASEQ_CMD_ID_CHANNEL_CE,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_CMD_ID_CHANNEL_LDPTR,,,,,,, 0, 0
     _wr_u16     \imm
 .endm
 
@@ -1527,7 +1529,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TR. If max is 0 the range is [0, 255]
  */
 .macro rand max
-    _wr_cmd_id  rand, ASEQ_CMD_ID_SEQUENCE_CE,ASEQ_CMD_ID_CHANNEL_B8,,,,,,, 0, 0
+    _wr_cmd_id  rand, ASEQ_CMD_ID_SEQUENCE_RAND,ASEQ_CMD_ID_CHANNEL_RAND,,,,,,, 0, 0
     _wr_u8      \max
 .endm
 
@@ -1542,9 +1544,9 @@ $reladdr\@:
  */
 .macro dyncall table=-1
     .if \table == -1
-        _wr_cmd_id  dyncall, ,ASEQ_CMD_ID_CHANNEL_E4,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ,ASEQ_CMD_ID_CHANNEL_DYNCALL,,,,,,, 0, 0
     .else
-        _wr_cmd_id  dyncall, ASEQ_CMD_ID_SEQUENCE_CD,,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ASEQ_CMD_ID_SEQUENCE_DYNCALL,,,,,,,, 0, 0
         _wr_lbl     \table
     .endif
 .endm
@@ -1555,7 +1557,7 @@ $reladdr\@:
  *  Loads the immediate value `imm` into TR.
  */
 .macro ldi imm
-    _wr_cmd_id  ldi, ASEQ_CMD_ID_SEQUENCE_CC,ASEQ_CMD_ID_CHANNEL_CC,,,,,,, 0, 0
+    _wr_cmd_id  ldi, ASEQ_CMD_ID_SEQUENCE_LDI,ASEQ_CMD_ID_CHANNEL_LDI,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1565,7 +1567,7 @@ $reladdr\@:
  *  Computes TR = TR & imm
  */
 .macro and imm
-    _wr_cmd_id  and, ASEQ_CMD_ID_SEQUENCE_C9,ASEQ_CMD_ID_CHANNEL_C9,,,,,,, 0, 0
+    _wr_cmd_id  and, ASEQ_CMD_ID_SEQUENCE_AND,ASEQ_CMD_ID_CHANNEL_AND,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1575,7 +1577,7 @@ $reladdr\@:
  *  Computes TR = TR - imm
  */
 .macro sub imm
-    _wr_cmd_id  sub, ASEQ_CMD_ID_SEQUENCE_C8,ASEQ_CMD_ID_CHANNEL_C8,,,,,,, 0, 0
+    _wr_cmd_id  sub, ASEQ_CMD_ID_SEQUENCE_SUB,ASEQ_CMD_ID_CHANNEL_SUB,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1585,7 +1587,7 @@ $reladdr\@:
  *  Stores the u8 value `TR + imm` to the location specified by `label`.
  */
 .macro stseq imm, label
-    _wr_cmd_id  stseq, ASEQ_CMD_ID_SEQUENCE_C7,ASEQ_CMD_ID_CHANNEL_C7,,,,,,, 0, 0
+    _wr_cmd_id  stseq, ASEQ_CMD_ID_SEQUENCE_STSEQ,ASEQ_CMD_ID_CHANNEL_STSEQ,,,,,,, 0, 0
     _wr_u8      \imm
     _wr_lbl     \label
 .endm
@@ -1596,7 +1598,7 @@ $reladdr\@:
  *  Immediately stops the sequence or channel.
  */
 .macro stop
-    _wr_cmd_id  stop, ASEQ_CMD_ID_SEQUENCE_C6,ASEQ_CMD_ID_CHANNEL_EA,,,,,,, 0, 0
+    _wr_cmd_id  stop, ASEQ_CMD_ID_SEQUENCE_STOP,ASEQ_CMD_ID_CHANNEL_STOP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1605,7 +1607,7 @@ $reladdr\@:
  *  Set the current soundfont for this channel to `fontId`.
  */
 .macro font fontId
-    _wr_cmd_id  font, ,ASEQ_CMD_ID_CHANNEL_C6,,,,,,, 0, 0
+    _wr_cmd_id  font, ,ASEQ_CMD_ID_CHANNEL_FONT,,,,,,, 0, 0
     _wr_u8      \fontId
 .endm
 
@@ -1618,7 +1620,7 @@ $reladdr\@:
  *  never used, so changing it with this instruction has no useful effects.
  */
 .macro scriptctr arg
-    _wr_cmd_id  scriptctr, ASEQ_CMD_ID_SEQUENCE_C5,,,,,,,, 0, 0
+    _wr_cmd_id  scriptctr, ASEQ_CMD_ID_SEQUENCE_SCRIPTCTR,,,,,,,, 0, 0
     _wr_u16     \arg
 .endm
 
@@ -1629,7 +1631,7 @@ $reladdr\@:
  *  unless TR is -1, in which case nothing happens.
  */
 .macro dyntbllookup
-    _wr_cmd_id  dyntbllookup, ,ASEQ_CMD_ID_CHANNEL_C5,,,,,,, 0, 0
+    _wr_cmd_id  dyntbllookup, ,ASEQ_CMD_ID_CHANNEL_DYNTBLLOOKUP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1638,7 +1640,7 @@ $reladdr\@:
  *  Plays the sequence seqId on seqPlayer.
  */
 .macro runseq seqPlayer, seqId
-    _wr_cmd_id  runseq, ASEQ_CMD_ID_SEQUENCE_C4,,,,,,,, 0, 0
+    _wr_cmd_id  runseq, ASEQ_CMD_ID_SEQUENCE_RUNSEQ,,,,,,,, 0, 0
     _wr_u8      \seqPlayer
     _wr_u8      \seqId
 .endm
@@ -1663,7 +1665,7 @@ $reladdr\@:
  *  Disable short notes encoding.
  */
 .macro noshort
-    _wr_cmd_id  noshort, ,ASEQ_CMD_ID_CHANNEL_C4,,,,,,, 0, 0
+    _wr_cmd_id  noshort, ,ASEQ_CMD_ID_CHANNEL_NOSHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1672,7 +1674,7 @@ $reladdr\@:
  *  Enable short notes encoding.
  */
 .macro short
-    _wr_cmd_id  short, ,ASEQ_CMD_ID_CHANNEL_C3,,,,,,, 0, 0
+    _wr_cmd_id  short, ,ASEQ_CMD_ID_CHANNEL_SHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1681,7 +1683,7 @@ $reladdr\@:
  *  Loads label -> DYNTBL
  */
 .macro dyntbl label
-    _wr_cmd_id  dyntbl, ,ASEQ_CMD_ID_CHANNEL_C2,,,,,,, 0, 0
+    _wr_cmd_id  dyntbl, ,ASEQ_CMD_ID_CHANNEL_DYNTBL,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1691,7 +1693,7 @@ $reladdr\@:
  *  Set instrument `instNum` from the current soundfont as the active instrument for this channel or layer.
  */
 .macro instr instNum
-    _wr_cmd_id  instr, ,ASEQ_CMD_ID_CHANNEL_C1,ASEQ_CMD_ID_LAYER_C6,,,,,, 0, 0
+    _wr_cmd_id  instr, ,ASEQ_CMD_ID_CHANNEL_INSTR,ASEQ_CMD_ID_LAYER_INSTR,,,,,, 0, 0
     _wr_u8      \instNum
 .endm
 
@@ -1718,7 +1720,7 @@ $reladdr\@:
  */
 .macro randptr range, offset
     #if (MML_VERSION == MML_VERSION_OOT)
-        _wr_cmd_id  randptr, ,ASEQ_CMD_ID_CHANNEL_BD,,,,,,, 0, 0
+        _wr_cmd_id  randptr, ,ASEQ_CMD_ID_CHANNEL_RANDPTR,,,,,,, 0, 0
     #else
         _wr_cmd_id  randptr, ,0xA8,,,,,,, 0, 0
     #endif
@@ -1824,7 +1826,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptradd value
-    _wr_cmd_id  ptradd, ,ASEQ_CMD_ID_CHANNEL_BC,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_CMD_ID_CHANNEL_PTRADD,,,,,,, 0, 0
     _wr_lbl     \value
 .endm
 
@@ -1836,7 +1838,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptraddi value
-    _wr_cmd_id  ptradd, ,ASEQ_CMD_ID_CHANNEL_BC,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_CMD_ID_CHANNEL_PTRADD,,,,,,, 0, 0
     _wr_u16     \value
 .endm
 
@@ -1847,7 +1849,7 @@ $reladdr\@:
  *  TODO args? arg0=16,arg1=val<<8 maps well to midi chorus
  */
 .macro combfilter arg0, arg1
-    _wr_cmd_id  combfilter, ,ASEQ_CMD_ID_CHANNEL_BB,,,,,,, 0, 0
+    _wr_cmd_id  combfilter, ,ASEQ_CMD_ID_CHANNEL_COMBFILTER,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u16     \arg1
 .endm
@@ -1860,7 +1862,7 @@ $reladdr\@:
  *  NOTE: This feature is bugged. If this is non-zero it will actually use the range set by randvel.
  */
 .macro randgate range
-    _wr_cmd_id  randgate, ,ASEQ_CMD_ID_CHANNEL_BA,,,,,,, 0, 0
+    _wr_cmd_id  randgate, ,ASEQ_CMD_ID_CHANNEL_RANDGATE,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1870,7 +1872,7 @@ $reladdr\@:
  *  Sets the range for random note velocity fluctuations.
  */
 .macro randvel range
-    _wr_cmd_id  randvel, ,ASEQ_CMD_ID_CHANNEL_B9,,,,,,, 0, 0
+    _wr_cmd_id  randvel, ,ASEQ_CMD_ID_CHANNEL_RANDVEL,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1880,7 +1882,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TP. If max is 0 the range is [0, 65535]
  */
 .macro randtoptr max
-    _wr_cmd_id  randtoptr, ,ASEQ_CMD_ID_CHANNEL_B7,,,,,,, 0, 0
+    _wr_cmd_id  randtoptr, ,ASEQ_CMD_ID_CHANNEL_RANDTOPTR,,,,,,, 0, 0
     _wr_u16     \max
 .endm
 
@@ -1890,7 +1892,7 @@ $reladdr\@:
  *  Loads DYNTBL8[TR] -> TR
  */
 .macro dyntblv
-    _wr_cmd_id  dyntblv, ,ASEQ_CMD_ID_CHANNEL_B6,,,,,,, 0, 0
+    _wr_cmd_id  dyntblv, ,ASEQ_CMD_ID_CHANNEL_DYNTBLV,,,,,,, 0, 0
 .endm
 
 /**
@@ -1899,7 +1901,7 @@ $reladdr\@:
  *  Loads DYNTBL16[TR] -> TP
  */
 .macro dyntbltoptr
-    _wr_cmd_id  dyntbltoptr, ,ASEQ_CMD_ID_CHANNEL_B5,,,,,,, 0, 0
+    _wr_cmd_id  dyntbltoptr, ,ASEQ_CMD_ID_CHANNEL_DYNTBLTOPTR,,,,,,, 0, 0
 .endm
 
 /**
@@ -1908,7 +1910,7 @@ $reladdr\@:
  *  Transfers TP -> DYNTBL
  */
 .macro ptrtodyntbl
-    _wr_cmd_id  ptrtodyntbl, ,ASEQ_CMD_ID_CHANNEL_B4,,,,,,, 0, 0
+    _wr_cmd_id  ptrtodyntbl, ,ASEQ_CMD_ID_CHANNEL_PTRTODYNTBL,,,,,,, 0, 0
 .endm
 
 /**
@@ -1919,7 +1921,7 @@ $reladdr\@:
  *  Note that TR acts as an index into an array of u16 starting at label.
  */
 .macro ldseqtoptr label
-    _wr_cmd_id  ldseqtoptr, ,ASEQ_CMD_ID_CHANNEL_B2,,,,,,, 0, 0
+    _wr_cmd_id  ldseqtoptr, ,ASEQ_CMD_ID_CHANNEL_LDSEQTOPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1929,7 +1931,7 @@ $reladdr\@:
  *  Invalidates the current active filter buffer.
  */
 .macro freefilter
-    _wr_cmd_id  freefilter, ,ASEQ_CMD_ID_CHANNEL_B1,,,,,,, 0, 0
+    _wr_cmd_id  freefilter, ,ASEQ_CMD_ID_CHANNEL_FREEFILTER,,,,,,, 0, 0
 .endm
 
 /**
@@ -1938,7 +1940,7 @@ $reladdr\@:
  *  Sets the active filter buffer to the location specified by `filter`.
  */
 .macro ldfilter filter
-    _wr_cmd_id  ldfilter, ,ASEQ_CMD_ID_CHANNEL_B0,,,,,,, 0, 0
+    _wr_cmd_id  ldfilter, ,ASEQ_CMD_ID_CHANNEL_LDFILTER,,,,,,, 0, 0
     _wr_lbl     \filter
 .endm
 
@@ -1949,7 +1951,7 @@ $reladdr\@:
  *  Delays by `delay` ticks.
  */
 .macro cdelay delay
-    _wr_cmd_id  cdelay, ,ASEQ_CMD_ID_CHANNEL_00,,,,,,, \delay, 4
+    _wr_cmd_id  cdelay, ,ASEQ_CMD_ID_CHANNEL_STOPCHANELAY,,,,,,, \delay, 4
 .endm
 
 /**
@@ -1963,9 +1965,9 @@ $reladdr\@:
  */
 .macro ldsample type, portNum
     .if \type == LDSAMPLE_INST
-        _wr_cmd_id  ldsample, ,ASEQ_CMD_ID_CHANNEL_10,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_CMD_ID_CHANNEL_LDSAMPLE,,,,,,, \portNum, 3
     .elif \type == LDSAMPLE_SFX
-        _wr_cmd_id  ldsample, ,ASEQ_CMD_ID_CHANNEL_10 | 8,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_CMD_ID_CHANNEL_LDSAMPLE | 8,,,,,,, \portNum, 3
     .else
         .error "ldsample: invalid type"
     .endif
@@ -1979,7 +1981,7 @@ $reladdr\@:
  *  Stores the contents of TR into CIO[channelNum][portNum]
  */
 .macro stcio channelNum, portNum
-    _wr_cmd_id  stcio, ,ASEQ_CMD_ID_CHANNEL_30,,,,,,, \channelNum, 4
+    _wr_cmd_id  stcio, ,ASEQ_CMD_ID_CHANNEL_STCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -1989,7 +1991,7 @@ $reladdr\@:
  *  Loads the contents of CIO[channelNum][portNum] into TR.
  */
 .macro ldcio channelNum, portNum
-    _wr_cmd_id  ldcio, ,ASEQ_CMD_ID_CHANNEL_40,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldcio, ,ASEQ_CMD_ID_CHANNEL_LDCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -2001,7 +2003,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldlayer layerNum, label
-    _wr_cmd_id  rldlayer, ,ASEQ_CMD_ID_CHANNEL_78,,,,,,, \layerNum, 3
+    _wr_cmd_id  rldlayer, ,ASEQ_CMD_ID_CHANNEL_RLDLAYER,,,,,,, \layerNum, 3
     _wr_16_rel  \label
 .endm
 
@@ -2015,7 +2017,7 @@ $reladdr\@:
  *   - -1 if layer does not exist.
  */
 .macro testlayer layerNum
-    _wr_cmd_id  testlayer, ,ASEQ_CMD_ID_CHANNEL_80,,,,,,, \layerNum, 3
+    _wr_cmd_id  testlayer, ,ASEQ_CMD_ID_CHANNEL_TESTLAYER,,,,,,, \layerNum, 3
 .endm
 
 /**
@@ -2024,7 +2026,7 @@ $reladdr\@:
  *  Opens the note layer at `label` for index `layerNum`.
  */
 .macro ldlayer layerNum, label
-    _wr_cmd_id  ldlayer, ,ASEQ_CMD_ID_CHANNEL_88,,,,,,, \layerNum, 3
+    _wr_cmd_id  ldlayer, ,ASEQ_CMD_ID_CHANNEL_LDLAYER,,,,,,, \layerNum, 3
     _wr_lbl     \label
 .endm
 
@@ -2034,7 +2036,7 @@ $reladdr\@:
  *  Deletes the layer specified by index `layerNum`.
  */
 .macro dellayer arg
-    _wr_cmd_id  dellayer, ,ASEQ_CMD_ID_CHANNEL_90,,,,,,, \arg, 3
+    _wr_cmd_id  dellayer, ,ASEQ_CMD_ID_CHANNEL_DELLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2043,7 +2045,7 @@ $reladdr\@:
  *  Allocates a new layer starting at the pointer read from DYNTBL16[TR]
  */
 .macro dynldlayer arg
-    _wr_cmd_id  dynldlayer, ,ASEQ_CMD_ID_CHANNEL_98,,,,,,, \arg, 3
+    _wr_cmd_id  dynldlayer, ,ASEQ_CMD_ID_CHANNEL_DYNLDLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2055,7 +2057,7 @@ $reladdr\@:
  *   - 1 if disabled
  */
 .macro testchan channelNum
-    _wr_cmd_id  testchan, ASEQ_CMD_ID_SEQUENCE_00,,,,,,,, \channelNum, 4
+    _wr_cmd_id  testchan, ASEQ_CMD_ID_SEQUENCE_TESTCHAN,,,,,,,, \channelNum, 4
 .endm
 
 /**
@@ -2065,9 +2067,9 @@ $reladdr\@:
  */
 .macro stopchan channelNum
     .if ASEQ_MODE == ASEQ_MODE_SEQUENCE
-        _wr_cmd_id  stopchan, ASEQ_CMD_ID_SEQUENCE_40,,,,,,,, \channelNum, 4
+        _wr_cmd_id  stopchan, ASEQ_CMD_ID_SEQUENCE_STOPCHAN,,,,,,,, \channelNum, 4
     .else
-        _wr_cmd_id  stopchan, ,ASEQ_CMD_ID_CHANNEL_CD,,,,,,, 0, 0
+        _wr_cmd_id  stopchan, ,ASEQ_CMD_ID_CHANNEL_STOPCHAN,,,,,,, 0, 0
         _wr_u8      \channelNum
     .endif
 .endm
@@ -2082,7 +2084,7 @@ $reladdr\@:
  *      Computes TR = TR - CIO[CUR_CHANNEL][portNum]
  */
 .macro subio portNum
-    _wr_cmd_id  subio, ASEQ_CMD_ID_SEQUENCE_50,ASEQ_CMD_ID_CHANNEL_50,,,,,,, \portNum, 4
+    _wr_cmd_id  subio, ASEQ_CMD_ID_SEQUENCE_SUBIO,ASEQ_CMD_ID_CHANNEL_SUBIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2099,7 +2101,7 @@ $reladdr\@:
  *  Load status is made available in SIO[portNum].
  */
 .macro ldres portNum, resType, resId
-    _wr_cmd_id  ldres, ASEQ_CMD_ID_SEQUENCE_60,,,,,,,, \portNum, 4
+    _wr_cmd_id  ldres, ASEQ_CMD_ID_SEQUENCE_LDRES,,,,,,,, \portNum, 4
     _wr_u8      \resType
     _wr_u8      \resId
 .endm
@@ -2113,9 +2115,9 @@ $reladdr\@:
  */
 .macro stio portNum
     .if ASEQ_MODE == ASEQ_MODE_CHANNEL
-        _wr_cmd_id  stio, ,ASEQ_CMD_ID_CHANNEL_70,,,,,,, \portNum, 3
+        _wr_cmd_id  stio, ,ASEQ_CMD_ID_CHANNEL_STIO,,,,,,, \portNum, 3
     .else
-        _wr_cmd_id  stio, ASEQ_CMD_ID_SEQUENCE_70,,,,,,,, \portNum, 4
+        _wr_cmd_id  stio, ASEQ_CMD_ID_SEQUENCE_STIO,,,,,,,, \portNum, 4
     .endif
 .endm
 
@@ -2126,7 +2128,7 @@ $reladdr\@:
  *  depending on current section.
  */
 .macro ldio portNum
-    _wr_cmd_id  ldio, ASEQ_CMD_ID_SEQUENCE_80,ASEQ_CMD_ID_CHANNEL_60,,,,,,, \portNum, 4
+    _wr_cmd_id  ldio, ASEQ_CMD_ID_SEQUENCE_LDIO,ASEQ_CMD_ID_CHANNEL_LDIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2135,7 +2137,7 @@ $reladdr\@:
  *  Opens the sequence channel for index `channelNum` with data beginning at `label`.
  */
 .macro ldchan channelNum, label
-    _wr_cmd_id  ldchan, ASEQ_CMD_ID_SEQUENCE_90,ASEQ_CMD_ID_CHANNEL_20,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldchan, ASEQ_CMD_ID_SEQUENCE_LDCHAN,ASEQ_CMD_ID_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
     _wr_lbl     \label
 .endm
 
@@ -2147,7 +2149,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldchan channelNum, label
-    _wr_cmd_id  rldchan, ASEQ_CMD_ID_SEQUENCE_A0,,,,,,,, \channelNum, 4
+    _wr_cmd_id  rldchan, ASEQ_CMD_ID_SEQUENCE_RLDCHAN,,,,,,,, \channelNum, 4
     _wr_16_rel  \label
 .endm
 
@@ -2157,7 +2159,7 @@ $reladdr\@:
  *  Delay for `delay` ticks.
  */
 .macro ldelay delay
-    _wr_cmd_id  ldelay, ,,ASEQ_CMD_ID_LAYER_STEP3_C0,,,,,, 0, 0
+    _wr_cmd_id  ldelay, ,,ASEQ_CMD_ID_LAYER_STEP3_LDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2168,7 +2170,7 @@ $reladdr\@:
  * Should never be used when not required for matching purposes.
  */
 .macro lldelay delay
-    _wr_cmd_id  lldelay, ,ASEQ_CMD_ID_CHANNEL_FD,ASEQ_CMD_ID_LAYER_STEP3_C0,,,,,, 0, 0
+    _wr_cmd_id  lldelay, ,ASEQ_CMD_ID_CTRLFLOW_DELAY,ASEQ_CMD_ID_LAYER_STEP3_LDELAY,,,,,, 0, 0
     _var_long   \delay
 .endm
 
@@ -2178,7 +2180,7 @@ $reladdr\@:
  * Set velocity used by short notes.
  */
 .macro shortvel velocity
-    _wr_cmd_id  shortvel, ,,ASEQ_CMD_ID_LAYER_C1,,,,,, 0, 0
+    _wr_cmd_id  shortvel, ,,ASEQ_CMD_ID_LAYER_SHORTVEL,,,,,, 0, 0
     _wr_u8      \velocity
 .endm
 
@@ -2188,7 +2190,7 @@ $reladdr\@:
  * Set delay used by short notes.
  */
 .macro shortdelay delay
-    _wr_cmd_id  shortdelay, ,,ASEQ_CMD_ID_LAYER_C3,,,,,, 0, 0
+    _wr_cmd_id  shortdelay, ,,ASEQ_CMD_ID_LAYER_SHORTDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2198,7 +2200,7 @@ $reladdr\@:
  *  Enables legato on the current layer.
  */
 .macro legato
-    _wr_cmd_id  legato, ,,ASEQ_CMD_ID_LAYER_C4,,,,,, 0, 0
+    _wr_cmd_id  legato, ,,ASEQ_CMD_ID_LAYER_LEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2207,7 +2209,7 @@ $reladdr\@:
  *  Disables legato on the current layer.
  */
 .macro nolegato
-    _wr_cmd_id  nolegato, ,,ASEQ_CMD_ID_LAYER_C5,,,,,, 0, 0
+    _wr_cmd_id  nolegato, ,,ASEQ_CMD_ID_LAYER_NOLEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2216,7 +2218,7 @@ $reladdr\@:
  *  The time argument is either a var or a u8 depending on mode
  */
 .macro portamento mode, target, time
-    _wr_cmd_id  portamento, ,,ASEQ_CMD_ID_LAYER_C7,,,,,, 0, 0
+    _wr_cmd_id  portamento, ,,ASEQ_CMD_ID_LAYER_PORTAMENTO,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u8      \target
     .if (\mode & 0x80) != 0
@@ -2232,7 +2234,7 @@ $reladdr\@:
  *  Disables portamento on the current layer.
  */
 .macro noportamento
-    _wr_cmd_id  noportamento, ,,ASEQ_CMD_ID_LAYER_C8,,,,,, 0, 0
+    _wr_cmd_id  noportamento, ,,ASEQ_CMD_ID_LAYER_NOPORTAMENTO,,,,,, 0, 0
 .endm
 
 /**
@@ -2241,7 +2243,7 @@ $reladdr\@:
  *  Sets gate time for short notes.
  */
 .macro shortgate gateTime
-    _wr_cmd_id  shortgate, ,,ASEQ_CMD_ID_LAYER_C9,,,,,, 0, 0
+    _wr_cmd_id  shortgate, ,,ASEQ_CMD_ID_LAYER_SHORTGATE,,,,,, 0, 0
     _wr_u8      \gateTime
 .endm
 
@@ -2253,7 +2255,7 @@ $reladdr\@:
 .macro notepan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  notepan, ,,ASEQ_CMD_ID_LAYER_CA,,,,,, 0, 0
+    _wr_cmd_id  notepan, ,,ASEQ_CMD_ID_LAYER_NOTEPAN,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -2264,7 +2266,7 @@ $reladdr\@:
  *  use pan set in the layer.
  */
 .macro nodrumpan
-    _wr_cmd_id  nodrumpan, ,,ASEQ_CMD_ID_LAYER_CC,,,,,, 0, 0
+    _wr_cmd_id  nodrumpan, ,,ASEQ_CMD_ID_LAYER_NODRUMPAN,,,,,, 0, 0
 .endm
 
 /**
@@ -2272,7 +2274,7 @@ $reladdr\@:
  *
  *  TODO DESCRIPTION
  */
-#define STEREO_OPCODE ASEQ_CMD_ID_LAYER_CD
+#define STEREO_OPCODE ASEQ_CMD_ID_LAYER_STEREO
 .macro stereo type, strongR, strongL, strongRvrbR, strongRvrbL
     _check_arg_bitwidth_u \type, 2
     _check_arg_bitwidth_u \strongR, 1
@@ -2280,7 +2282,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  stereo, ,,STEREO_OPCODE,,,,,, 0, 0
+    _wr_cmd_id  stereo, ,,ASEQ_CMD_ID_LAYER_STEREO,,,,,, 0, 0
     _wr_u8      (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -2290,7 +2292,7 @@ $reladdr\@:
  *  Sets the velocity used in short notes by reading from SHORTVELTBL[velocity]
  */
 .macro ldshortvel velocity
-    _wr_cmd_id  ldshortvel, ,,ASEQ_CMD_ID_LAYER_D0,,,,,, \velocity, 4
+    _wr_cmd_id  ldshortvel, ,,ASEQ_CMD_ID_LAYER_LDSHORTVEL,,,,,, \velocity, 4
 .endm
 
 /**
@@ -2299,7 +2301,7 @@ $reladdr\@:
  *  Sets the gate time used in short notes by reading from SHORTGATETBL[gateTime]
  */
 .macro ldshortgate gateTime
-    _wr_cmd_id  ldshortgate, ,,ASEQ_CMD_ID_LAYER_E0,,,,,, \gateTime, 4
+    _wr_cmd_id  ldshortgate, ,,ASEQ_CMD_ID_LAYER_LDSHORTGATE,,,,,, \gateTime, 4
 .endm
 
 #if (MML_VERSION == MML_VERSION_MM)
@@ -2340,9 +2342,9 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDVG_OPCODE ASEQ_CMD_ID_LAYER_STEP3_00
+#define NOTEDVG_OPCODE ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG
 .macro notedvg pitch, delay, velocity, gateTime
-    _wr_cmd_id  notedvg, ,,ASEQ_CMD_ID_LAYER_STEP3_00,,,,,, \pitch, 6
+    _wr_cmd_id  notedvg, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
     _wr_u8      \gateTime
@@ -2355,16 +2357,16 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDV_OPCODE ASEQ_CMD_ID_LAYER_STEP3_40
+#define NOTEDV_OPCODE ASEQ_CMD_ID_LAYER_STEP3_NOTEDV
 .macro notedv pitch, delay, velocity
-    _wr_cmd_id  notedv, ,,ASEQ_CMD_ID_LAYER_STEP3_40,,,,,, \pitch, 6
+    _wr_cmd_id  notedv, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
 .endm
 
 /* Workaround for bugs in vanilla sequences, force long encoding for delay. This should not typically be used. */
 .macro noteldv pitch, delay, velocity
-    _wr_cmd_id  noteldv, ,,ASEQ_CMD_ID_LAYER_STEP3_40,,,,,, \pitch, 6
+    _wr_cmd_id  noteldv, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
     _var_long   \delay
     _wr_u8      \velocity
 .endm
@@ -2377,7 +2379,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notevg pitch, velocity, gateTime
-    _wr_cmd_id  notevg, ,,ASEQ_CMD_ID_LAYER_STEP3_80,,,,,, \pitch, 6
+    _wr_cmd_id  notevg, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEVG,,,,,, \pitch, 6
     _wr_u8      \velocity
     _wr_u8      \gateTime
 .endm
@@ -2391,7 +2393,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdvg pitch, delay
-    _wr_cmd_id  shortdvg, ,,ASEQ_CMD_ID_LAYER_STEP3_00,,,,,, \pitch, 6
+    _wr_cmd_id  shortdvg, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
 .endm
 
@@ -2404,7 +2406,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdv pitch
-    _wr_cmd_id  shortdv, ,,ASEQ_CMD_ID_LAYER_STEP3_40,,,,,, \pitch, 6
+    _wr_cmd_id  shortdv, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
 .endm
 
 /**
@@ -2416,7 +2418,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortvg pitch
-    _wr_cmd_id  shortvg, ,,ASEQ_CMD_ID_LAYER_STEP3_80,,,,,, \pitch, 6
+    _wr_cmd_id  shortvg, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEVG,,,,,, \pitch, 6
 .endm
 
 /**

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -253,46 +253,46 @@
 #define ASEQ_OP_END     0xFF
 
 // sequence commands
-#define ASEQ_OP_SEQUENCE_TESTCHAN          0x00 // low nibble used as argument
-#define ASEQ_OP_SEQUENCE_STOPCHAN          0x40 // low nibble used as argument
-#define ASEQ_OP_SEQUENCE_SUBIO             0x50 // low nibble used as argument
-#define ASEQ_OP_SEQUENCE_LDRES             0x60 // low nibble used as argument
-#define ASEQ_OP_SEQUENCE_STIO              0x70 // low nibble used as argument
-#define ASEQ_OP_SEQUENCE_LDIO              0x80 // low nibble used as argument
-#define ASEQ_OP_SEQUENCE_LDCHAN            0x90 // low nibble used as argument
-#define ASEQ_OP_SEQUENCE_RLDCHAN           0xA0 // low nibble used as argument
-#define ASEQ_OP_SEQUENCE_LDSEQ             0xB0 // low nibble used as argument
+#define ASEQ_OP_SEQ_TESTCHAN        0x00 // low nibble used as argument
+#define ASEQ_OP_SEQ_STOPCHAN        0x40 // low nibble used as argument
+#define ASEQ_OP_SEQ_SUBIO           0x50 // low nibble used as argument
+#define ASEQ_OP_SEQ_LDRES           0x60 // low nibble used as argument
+#define ASEQ_OP_SEQ_STIO            0x70 // low nibble used as argument
+#define ASEQ_OP_SEQ_LDIO            0x80 // low nibble used as argument
+#define ASEQ_OP_SEQ_LDCHAN          0x90 // low nibble used as argument
+#define ASEQ_OP_SEQ_RLDCHAN         0xA0 // low nibble used as argument
+#define ASEQ_OP_SEQ_LDSEQ           0xB0 // low nibble used as argument
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OP_SEQUENCE_C2                0xC2
-#define ASEQ_OP_SEQUENCE_C3                0xC3
+#define ASEQ_OP_SEQ_C2              0xC2
+#define ASEQ_OP_SEQ_C3              0xC3
 #endif
-#define ASEQ_OP_SEQUENCE_RUNSEQ            0xC4
-#define ASEQ_OP_SEQUENCE_SCRIPTCTR         0xC5
-#define ASEQ_OP_SEQUENCE_STOP              0xC6
-#define ASEQ_OP_SEQUENCE_STSEQ             0xC7
-#define ASEQ_OP_SEQUENCE_SUB               0xC8
-#define ASEQ_OP_SEQUENCE_AND               0xC9
-#define ASEQ_OP_SEQUENCE_LDI               0xCC
-#define ASEQ_OP_SEQUENCE_DYNCALL           0xCD
-#define ASEQ_OP_SEQUENCE_RAND              0xCE
-#define ASEQ_OP_SEQUENCE_NOTEALLOC         0xD0
-#define ASEQ_OP_SEQUENCE_LDSHORTGATEARR    0xD1
-#define ASEQ_OP_SEQUENCE_LDSHORTVELARR     0xD2
-#define ASEQ_OP_SEQUENCE_MUTEBHV           0xD3
-#define ASEQ_OP_SEQUENCE_MUTE              0xD4
-#define ASEQ_OP_SEQUENCE_MUTESCALE         0xD5
-#define ASEQ_OP_SEQUENCE_FREECHAN          0xD6
-#define ASEQ_OP_SEQUENCE_INITCHAN          0xD7
-#define ASEQ_OP_SEQUENCE_VOLSCALE          0xD9
-#define ASEQ_OP_SEQUENCE_VOLMODE           0xDA
-#define ASEQ_OP_SEQUENCE_VOL               0xDB
-#define ASEQ_OP_SEQUENCE_TEMPOCHG          0xDC
-#define ASEQ_OP_SEQUENCE_TEMPO             0xDD
-#define ASEQ_OP_SEQUENCE_RTRANSPOSE        0xDE
-#define ASEQ_OP_SEQUENCE_TRANSPOSE         0xDF
-#define ASEQ_OP_SEQUENCE_EF                0xEF
-#define ASEQ_OP_SEQUENCE_FREENOTELIST      0xF0
-#define ASEQ_OP_SEQUENCE_ALLOCNOTELIST     0xF1
+#define ASEQ_OP_SEQ_RUNSEQ          0xC4
+#define ASEQ_OP_SEQ_SCRIPTCTR       0xC5
+#define ASEQ_OP_SEQ_STOP            0xC6
+#define ASEQ_OP_SEQ_STSEQ           0xC7
+#define ASEQ_OP_SEQ_SUB             0xC8
+#define ASEQ_OP_SEQ_AND             0xC9
+#define ASEQ_OP_SEQ_LDI             0xCC
+#define ASEQ_OP_SEQ_DYNCALL         0xCD
+#define ASEQ_OP_SEQ_RAND            0xCE
+#define ASEQ_OP_SEQ_NOTEALLOC       0xD0
+#define ASEQ_OP_SEQ_LDSHORTGATEARR  0xD1
+#define ASEQ_OP_SEQ_LDSHORTVELARR   0xD2
+#define ASEQ_OP_SEQ_MUTEBHV         0xD3
+#define ASEQ_OP_SEQ_MUTE            0xD4
+#define ASEQ_OP_SEQ_MUTESCALE       0xD5
+#define ASEQ_OP_SEQ_FREECHAN        0xD6
+#define ASEQ_OP_SEQ_INITCHAN        0xD7
+#define ASEQ_OP_SEQ_VOLSCALE        0xD9
+#define ASEQ_OP_SEQ_VOLMODE         0xDA
+#define ASEQ_OP_SEQ_VOL             0xDB
+#define ASEQ_OP_SEQ_TEMPOCHG        0xDC
+#define ASEQ_OP_SEQ_TEMPO           0xDD
+#define ASEQ_OP_SEQ_RTRANSPOSE      0xDE
+#define ASEQ_OP_SEQ_TRANSPOSE       0xDF
+#define ASEQ_OP_SEQ_EF              0xEF
+#define ASEQ_OP_SEQ_FREENOTELIST    0xF0
+#define ASEQ_OP_SEQ_ALLOCNOTELIST   0xF1
 
 // channel commands
 #define ASEQ_OP_CHANNEL_CDELAY         0x00 // low nibble used as argument
@@ -571,7 +571,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq ioPortNum, seqId, label
-        _wr_cmd_id  ldseq, ASEQ_OP_SEQUENCE_LDSEQ,,,,,,,, \ioPortNum, 4
+        _wr_cmd_id  ldseq, ASEQ_OP_SEQ_LDSEQ,,,,,,,, \ioPortNum, 4
         _wr_u8      \seqId
         _wr_lbl     \label
     .endm
@@ -1075,7 +1075,7 @@ $reladdr\@:
  *  Clears the channel note pool and reallocates it with space for `num` notes.
  */
 .macro allocnotelist num
-    _wr_cmd_id  allocnotelist, ASEQ_OP_SEQUENCE_ALLOCNOTELIST,ASEQ_OP_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  allocnotelist, ASEQ_OP_SEQ_ALLOCNOTELIST,ASEQ_OP_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -1085,7 +1085,7 @@ $reladdr\@:
  *  Clears the channel note pool.
  */
 .macro freenotelist
-    _wr_cmd_id  freenotelist, ASEQ_OP_SEQUENCE_FREENOTELIST,ASEQ_OP_CHANNEL_FREENOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  freenotelist, ASEQ_OP_SEQ_FREENOTELIST,ASEQ_OP_CHANNEL_FREENOTELIST,,,,,,, 0, 0
 .endm
 
 /**
@@ -1094,7 +1094,7 @@ $reladdr\@:
  *  Has no function.
  */
 .macro unk_EF arg1, arg2
-    _wr_cmd_id  unk_EF, ASEQ_OP_SEQUENCE_EF,,,,,,,, 0, 0
+    _wr_cmd_id  unk_EF, ASEQ_OP_SEQ_EF,,,,,,,, 0, 0
     _wr_s16     \arg1
     _w_u8       \arg2
 .endm
@@ -1251,7 +1251,7 @@ $reladdr\@:
  *  provided number of semitones.
  */
 .macro transpose semitones
-    _wr_cmd_id  transpose, ASEQ_OP_SEQUENCE_TRANSPOSE,ASEQ_OP_CHANNEL_TRANSPOSE,ASEQ_OP_LAYER_TRANSPOSE,,,,,, 0, 0
+    _wr_cmd_id  transpose, ASEQ_OP_SEQ_TRANSPOSE,ASEQ_OP_CHANNEL_TRANSPOSE,ASEQ_OP_LAYER_TRANSPOSE,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1261,7 +1261,7 @@ $reladdr\@:
  *  Adjusts the transposition amount. This is only available at the top sequence level.
  */
 .macro rtranspose semitones
-    _wr_cmd_id  rtranspose, ASEQ_OP_SEQUENCE_RTRANSPOSE,,,,,,,, 0, 0
+    _wr_cmd_id  rtranspose, ASEQ_OP_SEQ_RTRANSPOSE,,,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1281,7 +1281,7 @@ $reladdr\@:
  *  Changes the tempo of the sequence.
  */
 .macro tempo bpm
-    _wr_cmd_id  tempo, ASEQ_OP_SEQUENCE_TEMPO,,,,,,,, 0, 0
+    _wr_cmd_id  tempo, ASEQ_OP_SEQ_TEMPO,,,,,,,, 0, 0
     _wr_u8      \bpm
 .endm
 
@@ -1291,7 +1291,7 @@ $reladdr\@:
  *  Sets the tempoChange for the sequence.
  */
 .macro tempochg arg
-    _wr_cmd_id  tempochg, ASEQ_OP_SEQUENCE_TEMPOCHG,,,,,,,, 0, 0
+    _wr_cmd_id  tempochg, ASEQ_OP_SEQ_TEMPOCHG,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1329,7 +1329,7 @@ $reladdr\@:
  *  Sets the volume amount for this sequence or channel.
  */
 .macro vol amt
-    _wr_cmd_id  vol, ASEQ_OP_SEQUENCE_VOL,ASEQ_OP_CHANNEL_VOL,,,,,,, 0, 0
+    _wr_cmd_id  vol, ASEQ_OP_SEQ_VOL,ASEQ_OP_CHANNEL_VOL,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1339,7 +1339,7 @@ $reladdr\@:
  *  TODO DESCRIPTION
  */
 .macro volmode mode, fadeTimer
-    _wr_cmd_id  volmode, ASEQ_OP_SEQUENCE_VOLMODE,,,,,,,, 0, 0
+    _wr_cmd_id  volmode, ASEQ_OP_SEQ_VOLMODE,,,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u16     \fadeTimer
 .endm
@@ -1350,7 +1350,7 @@ $reladdr\@:
  *  Sets the fadeVolumeScale for the sequence.
  */
 .macro volscale arg
-    _wr_cmd_id  volscale, ASEQ_OP_SEQUENCE_VOLSCALE,,,,,,,, 0, 0
+    _wr_cmd_id  volscale, ASEQ_OP_SEQ_VOLSCALE,,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1393,7 +1393,7 @@ $reladdr\@:
  *       initchan 0b101 initializes channels 0 and 2.
  */
 .macro initchan bitmask
-    _wr_cmd_id  initchan, ASEQ_OP_SEQUENCE_INITCHAN,,,,,,,, 0, 0
+    _wr_cmd_id  initchan, ASEQ_OP_SEQ_INITCHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1403,7 +1403,7 @@ $reladdr\@:
  *  Frees the channels marked in the provided bitmask.
  */
 .macro freechan bitmask
-    _wr_cmd_id  freechan, ASEQ_OP_SEQUENCE_FREECHAN,,,,,,,, 0, 0
+    _wr_cmd_id  freechan, ASEQ_OP_SEQ_FREECHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1413,7 +1413,7 @@ $reladdr\@:
  *  Sets the muteVolumeScale for the sequence.
  */
 .macro mutescale arg
-    _wr_cmd_id  mutescale, ASEQ_OP_SEQUENCE_MUTESCALE,,,,,,,, 0, 0
+    _wr_cmd_id  mutescale, ASEQ_OP_SEQ_MUTESCALE,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1423,7 +1423,7 @@ $reladdr\@:
  *  Mutes the sequence player.
  */
 .macro mute
-    _wr_cmd_id  mute, ASEQ_OP_SEQUENCE_MUTE,,,,,,,, 0, 0
+    _wr_cmd_id  mute, ASEQ_OP_SEQ_MUTE,,,,,,,, 0, 0
 .endm
 
 /**
@@ -1442,7 +1442,7 @@ $reladdr\@:
  *  Sets mute behavior for this sequence or channel.
  */
 .macro mutebhv flags
-    _wr_cmd_id  mutebhv, ASEQ_OP_SEQUENCE_MUTEBHV,ASEQ_OP_CHANNEL_MUTEBHV,,,,,,, 0, 0
+    _wr_cmd_id  mutebhv, ASEQ_OP_SEQ_MUTEBHV,ASEQ_OP_CHANNEL_MUTEBHV,,,,,,, 0, 0
     _wr_u8      \flags
 .endm
 
@@ -1462,7 +1462,7 @@ $reladdr\@:
  *  Sets the location of SHORTVELTBL.
  */
 .macro ldshortvelarr label
-    _wr_cmd_id  ldshortvelarr, ASEQ_OP_SEQUENCE_LDSHORTVELARR,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortvelarr, ASEQ_OP_SEQ_LDSHORTVELARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1482,7 +1482,7 @@ $reladdr\@:
  *  Sets the location of SHORTGATETBL.
  */
 .macro ldshortgatearr label
-    _wr_cmd_id  ldshortgatearr, ASEQ_OP_SEQUENCE_LDSHORTGATEARR,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortgatearr, ASEQ_OP_SEQ_LDSHORTGATEARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1492,7 +1492,7 @@ $reladdr\@:
  *  Sets the noteAllocPolicy for either the sequence or the current channel.
  */
 .macro notealloc arg
-    _wr_cmd_id  notealloc, ASEQ_OP_SEQUENCE_NOTEALLOC,ASEQ_OP_CHANNEL_NOTEALLOC,,,,,,, 0, 0
+    _wr_cmd_id  notealloc, ASEQ_OP_SEQ_NOTEALLOC,ASEQ_OP_CHANNEL_NOTEALLOC,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1549,7 +1549,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TR. If max is 0 the range is [0, 255]
  */
 .macro rand max
-    _wr_cmd_id  rand, ASEQ_OP_SEQUENCE_RAND,ASEQ_OP_CHANNEL_RAND,,,,,,, 0, 0
+    _wr_cmd_id  rand, ASEQ_OP_SEQ_RAND,ASEQ_OP_CHANNEL_RAND,,,,,,, 0, 0
     _wr_u8      \max
 .endm
 
@@ -1566,7 +1566,7 @@ $reladdr\@:
     .if \table == -1
         _wr_cmd_id  dyncall, ,ASEQ_OP_CHANNEL_DYNCALL,,,,,,, 0, 0
     .else
-        _wr_cmd_id  dyncall, ASEQ_OP_SEQUENCE_DYNCALL,,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ASEQ_OP_SEQ_DYNCALL,,,,,,,, 0, 0
         _wr_lbl     \table
     .endif
 .endm
@@ -1577,7 +1577,7 @@ $reladdr\@:
  *  Loads the immediate value `imm` into TR.
  */
 .macro ldi imm
-    _wr_cmd_id  ldi, ASEQ_OP_SEQUENCE_LDI,ASEQ_OP_CHANNEL_LDI,,,,,,, 0, 0
+    _wr_cmd_id  ldi, ASEQ_OP_SEQ_LDI,ASEQ_OP_CHANNEL_LDI,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1587,7 +1587,7 @@ $reladdr\@:
  *  Computes TR = TR & imm
  */
 .macro and imm
-    _wr_cmd_id  and, ASEQ_OP_SEQUENCE_AND,ASEQ_OP_CHANNEL_AND,,,,,,, 0, 0
+    _wr_cmd_id  and, ASEQ_OP_SEQ_AND,ASEQ_OP_CHANNEL_AND,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1597,7 +1597,7 @@ $reladdr\@:
  *  Computes TR = TR - imm
  */
 .macro sub imm
-    _wr_cmd_id  sub, ASEQ_OP_SEQUENCE_SUB,ASEQ_OP_CHANNEL_SUB,,,,,,, 0, 0
+    _wr_cmd_id  sub, ASEQ_OP_SEQ_SUB,ASEQ_OP_CHANNEL_SUB,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1607,7 +1607,7 @@ $reladdr\@:
  *  Stores the u8 value `TR + imm` to the location specified by `label`.
  */
 .macro stseq imm, label
-    _wr_cmd_id  stseq, ASEQ_OP_SEQUENCE_STSEQ,ASEQ_OP_CHANNEL_STSEQ,,,,,,, 0, 0
+    _wr_cmd_id  stseq, ASEQ_OP_SEQ_STSEQ,ASEQ_OP_CHANNEL_STSEQ,,,,,,, 0, 0
     _wr_u8      \imm
     _wr_lbl     \label
 .endm
@@ -1618,7 +1618,7 @@ $reladdr\@:
  *  Immediately stops the sequence or channel.
  */
 .macro stop
-    _wr_cmd_id  stop, ASEQ_OP_SEQUENCE_STOP,ASEQ_OP_CHANNEL_STOP,,,,,,, 0, 0
+    _wr_cmd_id  stop, ASEQ_OP_SEQ_STOP,ASEQ_OP_CHANNEL_STOP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1640,7 +1640,7 @@ $reladdr\@:
  *  never used, so changing it with this instruction has no useful effects.
  */
 .macro scriptctr arg
-    _wr_cmd_id  scriptctr, ASEQ_OP_SEQUENCE_SCRIPTCTR,,,,,,,, 0, 0
+    _wr_cmd_id  scriptctr, ASEQ_OP_SEQ_SCRIPTCTR,,,,,,,, 0, 0
     _wr_u16     \arg
 .endm
 
@@ -1660,7 +1660,7 @@ $reladdr\@:
  *  Plays the sequence seqId on seqPlayer.
  */
 .macro runseq seqPlayer, seqId
-    _wr_cmd_id  runseq, ASEQ_OP_SEQUENCE_RUNSEQ,,,,,,,, 0, 0
+    _wr_cmd_id  runseq, ASEQ_OP_SEQ_RUNSEQ,,,,,,,, 0, 0
     _wr_u8      \seqPlayer
     _wr_u8      \seqId
 .endm
@@ -1673,7 +1673,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro mutechan arg0
-        _wr_cmd_id  mutechan, ASEQ_OP_SEQUENCE_C3,,,,,,,, 0, 0
+        _wr_cmd_id  mutechan, ASEQ_OP_SEQ_C3,,,,,,,, 0, 0
         _wr_s16     \arg0
     .endm
 
@@ -2073,7 +2073,7 @@ $reladdr\@:
  *   - 1 if disabled
  */
 .macro testchan channelNum
-    _wr_cmd_id  testchan, ASEQ_OP_SEQUENCE_TESTCHAN,,,,,,,, \channelNum, 4
+    _wr_cmd_id  testchan, ASEQ_OP_SEQ_TESTCHAN,,,,,,,, \channelNum, 4
 .endm
 
 /**
@@ -2083,7 +2083,7 @@ $reladdr\@:
  */
 .macro stopchan channelNum
     .if ASEQ_MODE == ASEQ_MODE_SEQUENCE
-        _wr_cmd_id  stopchan, ASEQ_OP_SEQUENCE_STOPCHAN,,,,,,,, \channelNum, 4
+        _wr_cmd_id  stopchan, ASEQ_OP_SEQ_STOPCHAN,,,,,,,, \channelNum, 4
     .else
         _wr_cmd_id  stopchan, ,ASEQ_OP_CHANNEL_STOPCHAN,,,,,,, 0, 0
         _wr_u8      \channelNum
@@ -2100,7 +2100,7 @@ $reladdr\@:
  *      Computes TR = TR - CIO[CUR_CHANNEL][portNum]
  */
 .macro subio portNum
-    _wr_cmd_id  subio, ASEQ_OP_SEQUENCE_SUBIO,ASEQ_OP_CHANNEL_SUBIO,,,,,,, \portNum, 4
+    _wr_cmd_id  subio, ASEQ_OP_SEQ_SUBIO,ASEQ_OP_CHANNEL_SUBIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2117,7 +2117,7 @@ $reladdr\@:
  *  Load status is made available in SIO[portNum].
  */
 .macro ldres portNum, resType, resId
-    _wr_cmd_id  ldres, ASEQ_OP_SEQUENCE_LDRES,,,,,,,, \portNum, 4
+    _wr_cmd_id  ldres, ASEQ_OP_SEQ_LDRES,,,,,,,, \portNum, 4
     _wr_u8      \resType
     _wr_u8      \resId
 .endm
@@ -2133,7 +2133,7 @@ $reladdr\@:
     .if ASEQ_MODE == ASEQ_MODE_CHANNEL
         _wr_cmd_id  stio, ,ASEQ_OP_CHANNEL_STIO,,,,,,, \portNum, 3
     .else
-        _wr_cmd_id  stio, ASEQ_OP_SEQUENCE_STIO,,,,,,,, \portNum, 4
+        _wr_cmd_id  stio, ASEQ_OP_SEQ_STIO,,,,,,,, \portNum, 4
     .endif
 .endm
 
@@ -2144,7 +2144,7 @@ $reladdr\@:
  *  depending on current section.
  */
 .macro ldio portNum
-    _wr_cmd_id  ldio, ASEQ_OP_SEQUENCE_LDIO,ASEQ_OP_CHANNEL_LDIO,,,,,,, \portNum, 4
+    _wr_cmd_id  ldio, ASEQ_OP_SEQ_LDIO,ASEQ_OP_CHANNEL_LDIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2153,7 +2153,7 @@ $reladdr\@:
  *  Opens the sequence channel for index `channelNum` with data beginning at `label`.
  */
 .macro ldchan channelNum, label
-    _wr_cmd_id  ldchan, ASEQ_OP_SEQUENCE_LDCHAN,ASEQ_OP_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldchan, ASEQ_OP_SEQ_LDCHAN,ASEQ_OP_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
     _wr_lbl     \label
 .endm
 
@@ -2165,7 +2165,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldchan channelNum, label
-    _wr_cmd_id  rldchan, ASEQ_OP_SEQUENCE_RLDCHAN,,,,,,,, \channelNum, 4
+    _wr_cmd_id  rldchan, ASEQ_OP_SEQ_RLDCHAN,,,,,,,, \channelNum, 4
     _wr_16_rel  \label
 .endm
 

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -295,96 +295,96 @@
 #define ASEQ_OP_SEQ_ALLOCNOTELIST   0xF1
 
 // channel commands
-#define ASEQ_OP_CHANNEL_CDELAY         0x00 // low nibble used as argument
-#define ASEQ_OP_CHANNEL_LDSAMPLE       0x10 // low nibble used as argument
-#define ASEQ_OP_CHANNEL_LDCHAN         0x20 // low nibble used as argument
-#define ASEQ_OP_CHANNEL_STCIO          0x30 // low nibble used as argument
-#define ASEQ_OP_CHANNEL_LDCIO          0x40 // low nibble used as argument
-#define ASEQ_OP_CHANNEL_SUBIO          0x50 // low nibble used as argument
-#define ASEQ_OP_CHANNEL_LDIO           0x60 // low nibble used as argument
-#define ASEQ_OP_CHANNEL_STIO           0x70 // lower 3 bits used as argument
-#define ASEQ_OP_CHANNEL_RLDLAYER       0x78 // lower 3 bits used as argument
-#define ASEQ_OP_CHANNEL_TESTLAYER      0x80 // lower 3 bits used as argument
-#define ASEQ_OP_CHANNEL_LDLAYER        0x88 // lower 3 bits used as argument
-#define ASEQ_OP_CHANNEL_DELLAYER       0x90 // lower 3 bits used as argument
-#define ASEQ_OP_CHANNEL_DYNLDLAYER     0x98 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_CDELAY         0x00 // low nibble used as argument
+#define ASEQ_OP_CHAN_LDSAMPLE       0x10 // low nibble used as argument
+#define ASEQ_OP_CHAN_LDCHAN         0x20 // low nibble used as argument
+#define ASEQ_OP_CHAN_STCIO          0x30 // low nibble used as argument
+#define ASEQ_OP_CHAN_LDCIO          0x40 // low nibble used as argument
+#define ASEQ_OP_CHAN_SUBIO          0x50 // low nibble used as argument
+#define ASEQ_OP_CHAN_LDIO           0x60 // low nibble used as argument
+#define ASEQ_OP_CHAN_STIO           0x70 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_RLDLAYER       0x78 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_TESTLAYER      0x80 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_LDLAYER        0x88 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_DELLAYER       0x90 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_DYNLDLAYER     0x98 // lower 3 bits used as argument
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OP_CHANNEL_A0             0xA0
-#define ASEQ_OP_CHANNEL_A1             0xA1
-#define ASEQ_OP_CHANNEL_A2             0xA2
-#define ASEQ_OP_CHANNEL_A3             0xA3
-#define ASEQ_OP_CHANNEL_A4             0xA4
-#define ASEQ_OP_CHANNEL_A5             0xA5
-#define ASEQ_OP_CHANNEL_A6             0xA6
-#define ASEQ_OP_CHANNEL_A7             0xA7
-#define ASEQ_OP_CHANNEL_RANDPTR        0xA8
+#define ASEQ_OP_CHAN_A0             0xA0
+#define ASEQ_OP_CHAN_A1             0xA1
+#define ASEQ_OP_CHAN_A2             0xA2
+#define ASEQ_OP_CHAN_A3             0xA3
+#define ASEQ_OP_CHAN_A4             0xA4
+#define ASEQ_OP_CHAN_A5             0xA5
+#define ASEQ_OP_CHAN_A6             0xA6
+#define ASEQ_OP_CHAN_A7             0xA7
+#define ASEQ_OP_CHAN_RANDPTR        0xA8
 #endif
-#define ASEQ_OP_CHANNEL_LDFILTER       0xB0
-#define ASEQ_OP_CHANNEL_FREEFILTER     0xB1
-#define ASEQ_OP_CHANNEL_LDSEQTOPTR     0xB2
-#define ASEQ_OP_CHANNEL_FILTER         0xB3
-#define ASEQ_OP_CHANNEL_PTRTODYNTBL    0xB4
-#define ASEQ_OP_CHANNEL_DYNTBLTOPTR    0xB5
-#define ASEQ_OP_CHANNEL_DYNTBLV        0xB6
-#define ASEQ_OP_CHANNEL_RANDTOPTR      0xB7
-#define ASEQ_OP_CHANNEL_RAND           0xB8
-#define ASEQ_OP_CHANNEL_RANDVEL        0xB9
-#define ASEQ_OP_CHANNEL_RANDGATE       0xBA
-#define ASEQ_OP_CHANNEL_COMBFILTER     0xBB
-#define ASEQ_OP_CHANNEL_PTRADD         0xBC
+#define ASEQ_OP_CHAN_LDFILTER       0xB0
+#define ASEQ_OP_CHAN_FREEFILTER     0xB1
+#define ASEQ_OP_CHAN_LDSEQTOPTR     0xB2
+#define ASEQ_OP_CHAN_FILTER         0xB3
+#define ASEQ_OP_CHAN_PTRTODYNTBL    0xB4
+#define ASEQ_OP_CHAN_DYNTBLTOPTR    0xB5
+#define ASEQ_OP_CHAN_DYNTBLV        0xB6
+#define ASEQ_OP_CHAN_RANDTOPTR      0xB7
+#define ASEQ_OP_CHAN_RAND           0xB8
+#define ASEQ_OP_CHAN_RANDVEL        0xB9
+#define ASEQ_OP_CHAN_RANDGATE       0xBA
+#define ASEQ_OP_CHAN_COMBFILTER     0xBB
+#define ASEQ_OP_CHAN_PTRADD         0xBC
 #if (MML_VERSION == MML_VERSION_OOT)
-#define ASEQ_OP_CHANNEL_RANDPTR        0xBD
+#define ASEQ_OP_CHAN_RANDPTR        0xBD
 #endif
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OP_CHANNEL_SAMPLESTART    0xBD
-#define ASEQ_OP_CHANNEL_UNK_BE         0xBE
+#define ASEQ_OP_CHAN_SAMPLESTART    0xBD
+#define ASEQ_OP_CHAN_UNK_BE         0xBE
 #endif
-#define ASEQ_OP_CHANNEL_INSTR          0xC1
-#define ASEQ_OP_CHANNEL_DYNTBL         0xC2
-#define ASEQ_OP_CHANNEL_SHORT          0xC3
-#define ASEQ_OP_CHANNEL_NOSHORT        0xC4
-#define ASEQ_OP_CHANNEL_DYNTBLLOOKUP   0xC5
-#define ASEQ_OP_CHANNEL_FONT           0xC6
-#define ASEQ_OP_CHANNEL_STSEQ          0xC7
-#define ASEQ_OP_CHANNEL_SUB            0xC8
-#define ASEQ_OP_CHANNEL_AND            0xC9
-#define ASEQ_OP_CHANNEL_MUTEBHV        0xCA
-#define ASEQ_OP_CHANNEL_LDSEQ          0xCB
-#define ASEQ_OP_CHANNEL_LDI            0xCC
-#define ASEQ_OP_CHANNEL_STOPCHAN       0xCD
-#define ASEQ_OP_CHANNEL_LDPTR          0xCE
-#define ASEQ_OP_CHANNEL_STPTRTOSEQ     0xCF
-#define ASEQ_OP_CHANNEL_EFFECTS        0xD0
-#define ASEQ_OP_CHANNEL_NOTEALLOC      0xD1
-#define ASEQ_OP_CHANNEL_SUSTAIN        0xD2
-#define ASEQ_OP_CHANNEL_BEND           0xD3
-#define ASEQ_OP_CHANNEL_REVERB         0xD4
-#define ASEQ_OP_CHANNEL_VIBFREQ        0xD7
-#define ASEQ_OP_CHANNEL_VIBDEPTH       0xD8
-#define ASEQ_OP_CHANNEL_RELEASERATE    0xD9
-#define ASEQ_OP_CHANNEL_ENV            0xDA
-#define ASEQ_OP_CHANNEL_TRANSPOSE      0xDB
-#define ASEQ_OP_CHANNEL_PANWEIGHT      0xDC
-#define ASEQ_OP_CHANNEL_PAN            0xDD
-#define ASEQ_OP_CHANNEL_FREQSCALE      0xDE
-#define ASEQ_OP_CHANNEL_VOL            0xDF
-#define ASEQ_OP_CHANNEL_VOLEXP         0xE0
-#define ASEQ_OP_CHANNEL_VIBFREQGRAD    0xE1
-#define ASEQ_OP_CHANNEL_VIBDEPTHGRAD   0xE2
-#define ASEQ_OP_CHANNEL_VIBDELAY       0xE3
-#define ASEQ_OP_CHANNEL_DYNCALL        0xE4
-#define ASEQ_OP_CHANNEL_REVERBIDX      0xE5
-#define ASEQ_OP_CHANNEL_SAMPLEBOOK     0xE6
-#define ASEQ_OP_CHANNEL_LDPARAMS       0xE7
-#define ASEQ_OP_CHANNEL_PARAMS         0xE8
-#define ASEQ_OP_CHANNEL_NOTEPRI        0xE9
-#define ASEQ_OP_CHANNEL_STOP           0xEA
-#define ASEQ_OP_CHANNEL_FONTINSTR      0xEB
-#define ASEQ_OP_CHANNEL_VIBRESET       0xEC
-#define ASEQ_OP_CHANNEL_GAIN           0xED
-#define ASEQ_OP_CHANNEL_BENDFINE       0xEE
-#define ASEQ_OP_CHANNEL_FREENOTELIST   0xF0
-#define ASEQ_OP_CHANNEL_ALLOCNOTELIST  0xF1
+#define ASEQ_OP_CHAN_INSTR          0xC1
+#define ASEQ_OP_CHAN_DYNTBL         0xC2
+#define ASEQ_OP_CHAN_SHORT          0xC3
+#define ASEQ_OP_CHAN_NOSHORT        0xC4
+#define ASEQ_OP_CHAN_DYNTBLLOOKUP   0xC5
+#define ASEQ_OP_CHAN_FONT           0xC6
+#define ASEQ_OP_CHAN_STSEQ          0xC7
+#define ASEQ_OP_CHAN_SUB            0xC8
+#define ASEQ_OP_CHAN_AND            0xC9
+#define ASEQ_OP_CHAN_MUTEBHV        0xCA
+#define ASEQ_OP_CHAN_LDSEQ          0xCB
+#define ASEQ_OP_CHAN_LDI            0xCC
+#define ASEQ_OP_CHAN_STOPCHAN       0xCD
+#define ASEQ_OP_CHAN_LDPTR          0xCE
+#define ASEQ_OP_CHAN_STPTRTOSEQ     0xCF
+#define ASEQ_OP_CHAN_EFFECTS        0xD0
+#define ASEQ_OP_CHAN_NOTEALLOC      0xD1
+#define ASEQ_OP_CHAN_SUSTAIN        0xD2
+#define ASEQ_OP_CHAN_BEND           0xD3
+#define ASEQ_OP_CHAN_REVERB         0xD4
+#define ASEQ_OP_CHAN_VIBFREQ        0xD7
+#define ASEQ_OP_CHAN_VIBDEPTH       0xD8
+#define ASEQ_OP_CHAN_RELEASERATE    0xD9
+#define ASEQ_OP_CHAN_ENV            0xDA
+#define ASEQ_OP_CHAN_TRANSPOSE      0xDB
+#define ASEQ_OP_CHAN_PANWEIGHT      0xDC
+#define ASEQ_OP_CHAN_PAN            0xDD
+#define ASEQ_OP_CHAN_FREQSCALE      0xDE
+#define ASEQ_OP_CHAN_VOL            0xDF
+#define ASEQ_OP_CHAN_VOLEXP         0xE0
+#define ASEQ_OP_CHAN_VIBFREQGRAD    0xE1
+#define ASEQ_OP_CHAN_VIBDEPTHGRAD   0xE2
+#define ASEQ_OP_CHAN_VIBDELAY       0xE3
+#define ASEQ_OP_CHAN_DYNCALL        0xE4
+#define ASEQ_OP_CHAN_REVERBIDX      0xE5
+#define ASEQ_OP_CHAN_SAMPLEBOOK     0xE6
+#define ASEQ_OP_CHAN_LDPARAMS       0xE7
+#define ASEQ_OP_CHAN_PARAMS         0xE8
+#define ASEQ_OP_CHAN_NOTEPRI        0xE9
+#define ASEQ_OP_CHAN_STOP           0xEA
+#define ASEQ_OP_CHAN_FONTINSTR      0xEB
+#define ASEQ_OP_CHAN_VIBRESET       0xEC
+#define ASEQ_OP_CHAN_GAIN           0xED
+#define ASEQ_OP_CHAN_BENDFINE       0xEE
+#define ASEQ_OP_CHAN_FREENOTELIST   0xF0
+#define ASEQ_OP_CHAN_ALLOCNOTELIST  0xF1
 
 // layer commands
 #define ASEQ_OP_LAYER_NOTEDVG       0x00
@@ -589,7 +589,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq label
-        _wr_cmd_id  ldseq, ,ASEQ_OP_CHANNEL_LDSEQ,,,,,,, 0, 0
+        _wr_cmd_id  ldseq, ,ASEQ_OP_CHAN_LDSEQ,,,,,,, 0, 0
         _wr_lbl     \label
     .endm
 
@@ -599,14 +599,14 @@ _RESET_SECTION
         _check_arg_bitwidth_u \lowpassCutoff, 4
         _check_arg_bitwidth_u \highpassCutoff, 4
 
-        _wr_cmd_id filter, ,ASEQ_OP_CHANNEL_FILTER,,,,,,, 0, 0
+        _wr_cmd_id filter, ,ASEQ_OP_CHAN_FILTER,,,,,,, 0, 0
         _wr_u8 (\lowpassCutoff << 4) | (\highpassCutoff)
     .endm
 
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label
-        _wr_cmd_id env, ,ASEQ_OP_CHANNEL_ENV,,,,,,, 0, 0
+        _wr_cmd_id env, ,ASEQ_OP_CHAN_ENV,,,,,,, 0, 0
         _wr_lbl \label
     .endm
 
@@ -1075,7 +1075,7 @@ $reladdr\@:
  *  Clears the channel note pool and reallocates it with space for `num` notes.
  */
 .macro allocnotelist num
-    _wr_cmd_id  allocnotelist, ASEQ_OP_SEQ_ALLOCNOTELIST,ASEQ_OP_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  allocnotelist, ASEQ_OP_SEQ_ALLOCNOTELIST,ASEQ_OP_CHAN_ALLOCNOTELIST,,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -1085,7 +1085,7 @@ $reladdr\@:
  *  Clears the channel note pool.
  */
 .macro freenotelist
-    _wr_cmd_id  freenotelist, ASEQ_OP_SEQ_FREENOTELIST,ASEQ_OP_CHANNEL_FREENOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  freenotelist, ASEQ_OP_SEQ_FREENOTELIST,ASEQ_OP_CHAN_FREENOTELIST,,,,,,, 0, 0
 .endm
 
 /**
@@ -1105,7 +1105,7 @@ $reladdr\@:
  *  Fine-tunes the pitch bend amount for the channel or layer.
  */
 .macro bendfine amt
-    _wr_cmd_id  bendfine, ,ASEQ_OP_CHANNEL_BENDFINE,ASEQ_OP_LAYER_BENDFINE,,,,,, 0, 0
+    _wr_cmd_id  bendfine, ,ASEQ_OP_CHAN_BENDFINE,ASEQ_OP_LAYER_BENDFINE,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1115,7 +1115,7 @@ $reladdr\@:
  *  Sets the channel gain (multiplicative volume scale factor) to the provided qu4.4 fixed-point value.
  */
 .macro gain value
-    _wr_cmd_id  gain, ,ASEQ_OP_CHANNEL_GAIN,,,,,,, 0, 0
+    _wr_cmd_id  gain, ,ASEQ_OP_CHAN_GAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1125,7 +1125,7 @@ $reladdr\@:
  *  Resets channel vibrato, filter, gain, sustain, etc. state.
  */
 .macro vibreset
-    _wr_cmd_id  vibreset, ,ASEQ_OP_CHANNEL_VIBRESET,,,,,,, 0, 0
+    _wr_cmd_id  vibreset, ,ASEQ_OP_CHAN_VIBRESET,,,,,,, 0, 0
 .endm
 
 /**
@@ -1134,7 +1134,7 @@ $reladdr\@:
  *  Updates the soundfont and instrument for the channel simultaneously.
  */
 .macro fontinstr fontId, instId
-    _wr_cmd_id  fontinstr, ,ASEQ_OP_CHANNEL_FONTINSTR,,,,,,, 0, 0
+    _wr_cmd_id  fontinstr, ,ASEQ_OP_CHAN_FONTINSTR,,,,,,, 0, 0
     _wr_u8      \fontId
     _wr_u8      \instId
 .endm
@@ -1147,7 +1147,7 @@ $reladdr\@:
 .macro notepri priority1, priority2
     _check_arg_bitwidth_u \priority1, 4
     _check_arg_bitwidth_u \priority2, 4
-    _wr_cmd_id  notepri, ,ASEQ_OP_CHANNEL_NOTEPRI,,,,,,, 0, 0
+    _wr_cmd_id  notepri, ,ASEQ_OP_CHAN_NOTEPRI,,,,,,, 0, 0
     _wr_u8      (\priority1 << 4) | \priority2
 .endm
 
@@ -1158,7 +1158,7 @@ $reladdr\@:
  *  Sets various channel parameters.
  */
 .macro params muteBhv, noteAllocPolicy, channelPriority, transposition, pan, panWeight, reverb, reverbIndex
-    _wr_cmd_id  params, ,ASEQ_OP_CHANNEL_PARAMS,,,,,,, 0, 0
+    _wr_cmd_id  params, ,ASEQ_OP_CHAN_PARAMS,,,,,,, 0, 0
     _wr_u8      \muteBhv
     _wr_u8      \noteAllocPolicy
     _wr_u8      \channelPriority
@@ -1176,7 +1176,7 @@ $reladdr\@:
  *  is ordered in the same way as the arguments in `params`.
  */
 .macro ldparams label
-    _wr_cmd_id  ldparams, ,ASEQ_OP_CHANNEL_LDPARAMS,,,,,,, 0, 0
+    _wr_cmd_id  ldparams, ,ASEQ_OP_CHAN_LDPARAMS,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1186,7 +1186,7 @@ $reladdr\@:
  *  Sets the sample book mode.
  */
 .macro samplebook value
-    _wr_cmd_id  samplebook, ,ASEQ_OP_CHANNEL_SAMPLEBOOK,,,,,,, 0, 0
+    _wr_cmd_id  samplebook, ,ASEQ_OP_CHAN_SAMPLEBOOK,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1196,7 +1196,7 @@ $reladdr\@:
  *  Sets the channel reverb.
  */
 .macro reverbidx arg
-    _wr_cmd_id  reverbidx, ,ASEQ_OP_CHANNEL_REVERBIDX,,,,,,, 0, 0
+    _wr_cmd_id  reverbidx, ,ASEQ_OP_CHAN_REVERBIDX,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1206,7 +1206,7 @@ $reladdr\@:
  *  Sets the channel vibrato delay.
  */
 .macro vibdelay arg
-    _wr_cmd_id  vibdelay, ,ASEQ_OP_CHANNEL_VIBDELAY,,,,,,, 0, 0
+    _wr_cmd_id  vibdelay, ,ASEQ_OP_CHAN_VIBDELAY,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1216,7 +1216,7 @@ $reladdr\@:
  *  Sets the vibrato extent.
  */
 .macro vibdepthgrad arg0, arg1, arg2
-    _wr_cmd_id  vibdepthgrad, ,ASEQ_OP_CHANNEL_VIBDEPTHGRAD,,,,,,, 0, 0
+    _wr_cmd_id  vibdepthgrad, ,ASEQ_OP_CHAN_VIBDEPTHGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1228,7 +1228,7 @@ $reladdr\@:
  *  Sets the vibrato rate.
  */
 .macro vibfreqgrad arg0, arg1, arg2
-    _wr_cmd_id  vibfreqgrad, ,ASEQ_OP_CHANNEL_VIBFREQGRAD,,,,,,, 0, 0
+    _wr_cmd_id  vibfreqgrad, ,ASEQ_OP_CHAN_VIBFREQGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1240,7 +1240,7 @@ $reladdr\@:
  *  Changes the expression amount for the channel.
  */
 .macro volexp amt
-    _wr_cmd_id  volexp, ,ASEQ_OP_CHANNEL_VOLEXP,,,,,,, 0, 0
+    _wr_cmd_id  volexp, ,ASEQ_OP_CHAN_VOLEXP,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1251,7 +1251,7 @@ $reladdr\@:
  *  provided number of semitones.
  */
 .macro transpose semitones
-    _wr_cmd_id  transpose, ASEQ_OP_SEQ_TRANSPOSE,ASEQ_OP_CHANNEL_TRANSPOSE,ASEQ_OP_LAYER_TRANSPOSE,,,,,, 0, 0
+    _wr_cmd_id  transpose, ASEQ_OP_SEQ_TRANSPOSE,ASEQ_OP_CHAN_TRANSPOSE,ASEQ_OP_LAYER_TRANSPOSE,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1271,7 +1271,7 @@ $reladdr\@:
  *  Sets the freqScale for the current channel.
  */
 .macro freqscale arg
-    _wr_cmd_id  freqscale, ,ASEQ_OP_CHANNEL_FREQSCALE,,,,,,, 0, 0
+    _wr_cmd_id  freqscale, ,ASEQ_OP_CHAN_FREQSCALE,,,,,,, 0, 0
     _wr_s16     \arg
 .endm
 
@@ -1303,7 +1303,7 @@ $reladdr\@:
 .macro pan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  pan, ,ASEQ_OP_CHANNEL_PAN,,,,,,, 0, 0
+    _wr_cmd_id  pan, ,ASEQ_OP_CHAN_PAN,,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -1319,7 +1319,7 @@ $reladdr\@:
 .macro panweight weight
     /* weight can only take values in 0..127 */
     _check_arg_bitwidth_u \weight, 7
-    _wr_cmd_id  panweight, ,ASEQ_OP_CHANNEL_PANWEIGHT,,,,,,, 0, 0
+    _wr_cmd_id  panweight, ,ASEQ_OP_CHAN_PANWEIGHT,,,,,,, 0, 0
     _wr_u8      \weight
 .endm
 
@@ -1329,7 +1329,7 @@ $reladdr\@:
  *  Sets the volume amount for this sequence or channel.
  */
 .macro vol amt
-    _wr_cmd_id  vol, ASEQ_OP_SEQ_VOL,ASEQ_OP_CHANNEL_VOL,,,,,,, 0, 0
+    _wr_cmd_id  vol, ASEQ_OP_SEQ_VOL,ASEQ_OP_CHAN_VOL,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1360,7 +1360,7 @@ $reladdr\@:
  *  Sets the envelope release rate for this channel or layer.
  */
 .macro releaserate release
-    _wr_cmd_id  releaserate, ,ASEQ_OP_CHANNEL_RELEASERATE,ASEQ_OP_LAYER_RELEASERATE,,,,,, 0, 0
+    _wr_cmd_id  releaserate, ,ASEQ_OP_CHAN_RELEASERATE,ASEQ_OP_LAYER_RELEASERATE,,,,,, 0, 0
     _wr_u8      \release
 .endm
 
@@ -1370,7 +1370,7 @@ $reladdr\@:
  *  Sets the vibrato depth for the channel.
  */
 .macro vibdepth arg
-    _wr_cmd_id  vibdepth, ,ASEQ_OP_CHANNEL_VIBDEPTH,,,,,,, 0, 0
+    _wr_cmd_id  vibdepth, ,ASEQ_OP_CHAN_VIBDEPTH,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1380,7 +1380,7 @@ $reladdr\@:
  *  Sets the vibrato rate for the channel.
  */
 .macro vibfreq arg
-    _wr_cmd_id  vibfreq, ,ASEQ_OP_CHANNEL_VIBFREQ,,,,,,, 0, 0
+    _wr_cmd_id  vibfreq, ,ASEQ_OP_CHAN_VIBFREQ,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1432,7 +1432,7 @@ $reladdr\@:
  *  Sets the reverb amount for this channel.
  */
 .macro reverb amt
-    _wr_cmd_id  reverb, ,ASEQ_OP_CHANNEL_REVERB,,,,,,, 0, 0
+    _wr_cmd_id  reverb, ,ASEQ_OP_CHAN_REVERB,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1442,7 +1442,7 @@ $reladdr\@:
  *  Sets mute behavior for this sequence or channel.
  */
 .macro mutebhv flags
-    _wr_cmd_id  mutebhv, ASEQ_OP_SEQ_MUTEBHV,ASEQ_OP_CHANNEL_MUTEBHV,,,,,,, 0, 0
+    _wr_cmd_id  mutebhv, ASEQ_OP_SEQ_MUTEBHV,ASEQ_OP_CHAN_MUTEBHV,,,,,,, 0, 0
     _wr_u8      \flags
 .endm
 
@@ -1452,7 +1452,7 @@ $reladdr\@:
  *  Sets the pitch bend amount for this channel.
  */
 .macro bend amt
-    _wr_cmd_id  bend, ,ASEQ_OP_CHANNEL_BEND,,,,,,, 0, 0
+    _wr_cmd_id  bend, ,ASEQ_OP_CHAN_BEND,,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1472,7 +1472,7 @@ $reladdr\@:
  *  Sets the adsr sustain value for this channel.
  */
 .macro sustain value
-    _wr_cmd_id  sustain, ,ASEQ_OP_CHANNEL_SUSTAIN,,,,,,, 0, 0
+    _wr_cmd_id  sustain, ,ASEQ_OP_CHAN_SUSTAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1492,7 +1492,7 @@ $reladdr\@:
  *  Sets the noteAllocPolicy for either the sequence or the current channel.
  */
 .macro notealloc arg
-    _wr_cmd_id  notealloc, ASEQ_OP_SEQ_NOTEALLOC,ASEQ_OP_CHANNEL_NOTEALLOC,,,,,,, 0, 0
+    _wr_cmd_id  notealloc, ASEQ_OP_SEQ_NOTEALLOC,ASEQ_OP_CHAN_NOTEALLOC,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1509,7 +1509,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  effects, ,ASEQ_OP_CHANNEL_EFFECTS,,,,,,, 0, 0
+    _wr_cmd_id  effects, ,ASEQ_OP_CHAN_EFFECTS,,,,,,, 0, 0
     _wr_u8      (\headset << 7) | (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -1519,7 +1519,7 @@ $reladdr\@:
  *  Stores TP -> label
  */
 .macro stptrtoseq label
-    _wr_cmd_id  stptrtoseq, ,ASEQ_OP_CHANNEL_STPTRTOSEQ,,,,,,, 0, 0
+    _wr_cmd_id  stptrtoseq, ,ASEQ_OP_CHAN_STPTRTOSEQ,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1529,7 +1529,7 @@ $reladdr\@:
  *  Loads label -> TP
  */
 .macro ldptr label
-    _wr_cmd_id  ldptr, ,ASEQ_OP_CHANNEL_LDPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OP_CHAN_LDPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1539,7 +1539,7 @@ $reladdr\@:
  *  Loads imm -> TP
  */
 .macro ldptri imm
-    _wr_cmd_id  ldptr, ,ASEQ_OP_CHANNEL_LDPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OP_CHAN_LDPTR,,,,,,, 0, 0
     _wr_u16     \imm
 .endm
 
@@ -1549,7 +1549,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TR. If max is 0 the range is [0, 255]
  */
 .macro rand max
-    _wr_cmd_id  rand, ASEQ_OP_SEQ_RAND,ASEQ_OP_CHANNEL_RAND,,,,,,, 0, 0
+    _wr_cmd_id  rand, ASEQ_OP_SEQ_RAND,ASEQ_OP_CHAN_RAND,,,,,,, 0, 0
     _wr_u8      \max
 .endm
 
@@ -1564,7 +1564,7 @@ $reladdr\@:
  */
 .macro dyncall table=-1
     .if \table == -1
-        _wr_cmd_id  dyncall, ,ASEQ_OP_CHANNEL_DYNCALL,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ,ASEQ_OP_CHAN_DYNCALL,,,,,,, 0, 0
     .else
         _wr_cmd_id  dyncall, ASEQ_OP_SEQ_DYNCALL,,,,,,,, 0, 0
         _wr_lbl     \table
@@ -1577,7 +1577,7 @@ $reladdr\@:
  *  Loads the immediate value `imm` into TR.
  */
 .macro ldi imm
-    _wr_cmd_id  ldi, ASEQ_OP_SEQ_LDI,ASEQ_OP_CHANNEL_LDI,,,,,,, 0, 0
+    _wr_cmd_id  ldi, ASEQ_OP_SEQ_LDI,ASEQ_OP_CHAN_LDI,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1587,7 +1587,7 @@ $reladdr\@:
  *  Computes TR = TR & imm
  */
 .macro and imm
-    _wr_cmd_id  and, ASEQ_OP_SEQ_AND,ASEQ_OP_CHANNEL_AND,,,,,,, 0, 0
+    _wr_cmd_id  and, ASEQ_OP_SEQ_AND,ASEQ_OP_CHAN_AND,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1597,7 +1597,7 @@ $reladdr\@:
  *  Computes TR = TR - imm
  */
 .macro sub imm
-    _wr_cmd_id  sub, ASEQ_OP_SEQ_SUB,ASEQ_OP_CHANNEL_SUB,,,,,,, 0, 0
+    _wr_cmd_id  sub, ASEQ_OP_SEQ_SUB,ASEQ_OP_CHAN_SUB,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1607,7 +1607,7 @@ $reladdr\@:
  *  Stores the u8 value `TR + imm` to the location specified by `label`.
  */
 .macro stseq imm, label
-    _wr_cmd_id  stseq, ASEQ_OP_SEQ_STSEQ,ASEQ_OP_CHANNEL_STSEQ,,,,,,, 0, 0
+    _wr_cmd_id  stseq, ASEQ_OP_SEQ_STSEQ,ASEQ_OP_CHAN_STSEQ,,,,,,, 0, 0
     _wr_u8      \imm
     _wr_lbl     \label
 .endm
@@ -1618,7 +1618,7 @@ $reladdr\@:
  *  Immediately stops the sequence or channel.
  */
 .macro stop
-    _wr_cmd_id  stop, ASEQ_OP_SEQ_STOP,ASEQ_OP_CHANNEL_STOP,,,,,,, 0, 0
+    _wr_cmd_id  stop, ASEQ_OP_SEQ_STOP,ASEQ_OP_CHAN_STOP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1627,7 +1627,7 @@ $reladdr\@:
  *  Set the current soundfont for this channel to `fontId`.
  */
 .macro font fontId
-    _wr_cmd_id  font, ,ASEQ_OP_CHANNEL_FONT,,,,,,, 0, 0
+    _wr_cmd_id  font, ,ASEQ_OP_CHAN_FONT,,,,,,, 0, 0
     _wr_u8      \fontId
 .endm
 
@@ -1651,7 +1651,7 @@ $reladdr\@:
  *  unless TR is -1, in which case nothing happens.
  */
 .macro dyntbllookup
-    _wr_cmd_id  dyntbllookup, ,ASEQ_OP_CHANNEL_DYNTBLLOOKUP,,,,,,, 0, 0
+    _wr_cmd_id  dyntbllookup, ,ASEQ_OP_CHAN_DYNTBLLOOKUP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1685,7 +1685,7 @@ $reladdr\@:
  *  Disable short notes encoding.
  */
 .macro noshort
-    _wr_cmd_id  noshort, ,ASEQ_OP_CHANNEL_NOSHORT,,,,,,, 0, 0
+    _wr_cmd_id  noshort, ,ASEQ_OP_CHAN_NOSHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1694,7 +1694,7 @@ $reladdr\@:
  *  Enable short notes encoding.
  */
 .macro short
-    _wr_cmd_id  short, ,ASEQ_OP_CHANNEL_SHORT,,,,,,, 0, 0
+    _wr_cmd_id  short, ,ASEQ_OP_CHAN_SHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1703,7 +1703,7 @@ $reladdr\@:
  *  Loads label -> DYNTBL
  */
 .macro dyntbl label
-    _wr_cmd_id  dyntbl, ,ASEQ_OP_CHANNEL_DYNTBL,,,,,,, 0, 0
+    _wr_cmd_id  dyntbl, ,ASEQ_OP_CHAN_DYNTBL,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1713,7 +1713,7 @@ $reladdr\@:
  *  Set instrument `instNum` from the current soundfont as the active instrument for this channel or layer.
  */
 .macro instr instNum
-    _wr_cmd_id  instr, ,ASEQ_OP_CHANNEL_INSTR,ASEQ_OP_LAYER_INSTR,,,,,, 0, 0
+    _wr_cmd_id  instr, ,ASEQ_OP_CHAN_INSTR,ASEQ_OP_LAYER_INSTR,,,,,, 0, 0
     _wr_u8      \instNum
 .endm
 
@@ -1725,7 +1725,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_BE arg0
-        _wr_cmd_id  unk_BE, ,ASEQ_OP_CHANNEL_UNK_BE,,,,,,, 0, 0
+        _wr_cmd_id  unk_BE, ,ASEQ_OP_CHAN_UNK_BE,,,,,,, 0, 0
         _wr_u8      \arg0
     .endm
 
@@ -1739,7 +1739,7 @@ $reladdr\@:
  *  If range is 0, it is treated as 65536.
  */
 .macro randptr range, offset
-    _wr_cmd_id  randptr, ,ASEQ_OP_CHANNEL_RANDPTR,,,,,,, 0, 0
+    _wr_cmd_id  randptr, ,ASEQ_OP_CHAN_RANDPTR,,,,,,, 0, 0
     _wr_u16     \range
     _wr_u16     \offset
 .endm
@@ -1752,7 +1752,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro samplestart arg
-        _wr_cmd_id  samplestart, ,ASEQ_OP_CHANNEL_SAMPLESTART,,,,,,, 0, 0
+        _wr_cmd_id  samplestart, ,ASEQ_OP_CHAN_SAMPLESTART,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1762,7 +1762,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A7 arg
-        _wr_cmd_id  unk_A7, ,ASEQ_OP_CHANNEL_A7,,,,,,, 0, 0
+        _wr_cmd_id  unk_A7, ,ASEQ_OP_CHAN_A7,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1772,7 +1772,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A6 arg0, arg1
-        _wr_cmd_id  unk_A6, ,ASEQ_OP_CHANNEL_A6,,,,,,, 0, 0
+        _wr_cmd_id  unk_A6, ,ASEQ_OP_CHAN_A6,,,,,,, 0, 0
         _wr_u8      \arg0
         _wr_s16     \arg1
     .endm
@@ -1783,7 +1783,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A5
-        _wr_cmd_id  unk_A5, ,ASEQ_OP_CHANNEL_A5,,,,,,, 0, 0
+        _wr_cmd_id  unk_A5, ,ASEQ_OP_CHAN_A5,,,,,,, 0, 0
     .endm
 
     /**
@@ -1792,7 +1792,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A4 arg
-        _wr_cmd_id  unk_A4, ,ASEQ_OP_CHANNEL_A4,,,,,,, 0, 0
+        _wr_cmd_id  unk_A4, ,ASEQ_OP_CHAN_A4,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1802,7 +1802,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A3
-        _wr_cmd_id  unk_A3, ,ASEQ_OP_CHANNEL_A3,,,,,,, 0, 0
+        _wr_cmd_id  unk_A3, ,ASEQ_OP_CHAN_A3,,,,,,, 0, 0
     .endm
 
     /**
@@ -1811,7 +1811,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A2 arg
-        _wr_cmd_id  unk_A2, ,ASEQ_OP_CHANNEL_A2,,,,,,, 0, 0
+        _wr_cmd_id  unk_A2, ,ASEQ_OP_CHAN_A2,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1821,7 +1821,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A1
-        _wr_cmd_id  unk_A1, ,ASEQ_OP_CHANNEL_A1,,,,,,, 0, 0
+        _wr_cmd_id  unk_A1, ,ASEQ_OP_CHAN_A1,,,,,,, 0, 0
     .endm
 
     /**
@@ -1830,7 +1830,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A0 arg
-        _wr_cmd_id  unk_A0, ,ASEQ_OP_CHANNEL_A0,,,,,,, 0, 0
+        _wr_cmd_id  unk_A0, ,ASEQ_OP_CHAN_A0,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1842,7 +1842,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptradd value
-    _wr_cmd_id  ptradd, ,ASEQ_OP_CHANNEL_PTRADD,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OP_CHAN_PTRADD,,,,,,, 0, 0
     _wr_lbl     \value
 .endm
 
@@ -1854,7 +1854,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptraddi value
-    _wr_cmd_id  ptradd, ,ASEQ_OP_CHANNEL_PTRADD,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OP_CHAN_PTRADD,,,,,,, 0, 0
     _wr_u16     \value
 .endm
 
@@ -1865,7 +1865,7 @@ $reladdr\@:
  *  TODO args? arg0=16,arg1=val<<8 maps well to midi chorus
  */
 .macro combfilter arg0, arg1
-    _wr_cmd_id  combfilter, ,ASEQ_OP_CHANNEL_COMBFILTER,,,,,,, 0, 0
+    _wr_cmd_id  combfilter, ,ASEQ_OP_CHAN_COMBFILTER,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u16     \arg1
 .endm
@@ -1878,7 +1878,7 @@ $reladdr\@:
  *  NOTE: This feature is bugged. If this is non-zero it will actually use the range set by randvel.
  */
 .macro randgate range
-    _wr_cmd_id  randgate, ,ASEQ_OP_CHANNEL_RANDGATE,,,,,,, 0, 0
+    _wr_cmd_id  randgate, ,ASEQ_OP_CHAN_RANDGATE,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1888,7 +1888,7 @@ $reladdr\@:
  *  Sets the range for random note velocity fluctuations.
  */
 .macro randvel range
-    _wr_cmd_id  randvel, ,ASEQ_OP_CHANNEL_RANDVEL,,,,,,, 0, 0
+    _wr_cmd_id  randvel, ,ASEQ_OP_CHAN_RANDVEL,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1898,7 +1898,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TP. If max is 0 the range is [0, 65535]
  */
 .macro randtoptr max
-    _wr_cmd_id  randtoptr, ,ASEQ_OP_CHANNEL_RANDTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  randtoptr, ,ASEQ_OP_CHAN_RANDTOPTR,,,,,,, 0, 0
     _wr_u16     \max
 .endm
 
@@ -1908,7 +1908,7 @@ $reladdr\@:
  *  Loads DYNTBL8[TR] -> TR
  */
 .macro dyntblv
-    _wr_cmd_id  dyntblv, ,ASEQ_OP_CHANNEL_DYNTBLV,,,,,,, 0, 0
+    _wr_cmd_id  dyntblv, ,ASEQ_OP_CHAN_DYNTBLV,,,,,,, 0, 0
 .endm
 
 /**
@@ -1917,7 +1917,7 @@ $reladdr\@:
  *  Loads DYNTBL16[TR] -> TP
  */
 .macro dyntbltoptr
-    _wr_cmd_id  dyntbltoptr, ,ASEQ_OP_CHANNEL_DYNTBLTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  dyntbltoptr, ,ASEQ_OP_CHAN_DYNTBLTOPTR,,,,,,, 0, 0
 .endm
 
 /**
@@ -1926,7 +1926,7 @@ $reladdr\@:
  *  Transfers TP -> DYNTBL
  */
 .macro ptrtodyntbl
-    _wr_cmd_id  ptrtodyntbl, ,ASEQ_OP_CHANNEL_PTRTODYNTBL,,,,,,, 0, 0
+    _wr_cmd_id  ptrtodyntbl, ,ASEQ_OP_CHAN_PTRTODYNTBL,,,,,,, 0, 0
 .endm
 
 /**
@@ -1937,7 +1937,7 @@ $reladdr\@:
  *  Note that TR acts as an index into an array of u16 starting at label.
  */
 .macro ldseqtoptr label
-    _wr_cmd_id  ldseqtoptr, ,ASEQ_OP_CHANNEL_LDSEQTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldseqtoptr, ,ASEQ_OP_CHAN_LDSEQTOPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1947,7 +1947,7 @@ $reladdr\@:
  *  Invalidates the current active filter buffer.
  */
 .macro freefilter
-    _wr_cmd_id  freefilter, ,ASEQ_OP_CHANNEL_FREEFILTER,,,,,,, 0, 0
+    _wr_cmd_id  freefilter, ,ASEQ_OP_CHAN_FREEFILTER,,,,,,, 0, 0
 .endm
 
 /**
@@ -1956,7 +1956,7 @@ $reladdr\@:
  *  Sets the active filter buffer to the location specified by `filter`.
  */
 .macro ldfilter filter
-    _wr_cmd_id  ldfilter, ,ASEQ_OP_CHANNEL_LDFILTER,,,,,,, 0, 0
+    _wr_cmd_id  ldfilter, ,ASEQ_OP_CHAN_LDFILTER,,,,,,, 0, 0
     _wr_lbl     \filter
 .endm
 
@@ -1967,7 +1967,7 @@ $reladdr\@:
  *  Delays by `delay` ticks.
  */
 .macro cdelay delay
-    _wr_cmd_id  cdelay, ,ASEQ_OP_CHANNEL_CDELAY,,,,,,, \delay, 4
+    _wr_cmd_id  cdelay, ,ASEQ_OP_CHAN_CDELAY,,,,,,, \delay, 4
 .endm
 
 /**
@@ -1981,9 +1981,9 @@ $reladdr\@:
  */
 .macro ldsample type, portNum
     .if \type == LDSAMPLE_INST
-        _wr_cmd_id  ldsample, ,ASEQ_OP_CHANNEL_LDSAMPLE,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OP_CHAN_LDSAMPLE,,,,,,, \portNum, 3
     .elif \type == LDSAMPLE_SFX
-        _wr_cmd_id  ldsample, ,ASEQ_OP_CHANNEL_LDSAMPLE | 8,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OP_CHAN_LDSAMPLE | 8,,,,,,, \portNum, 3
     .else
         .error "ldsample: invalid type"
     .endif
@@ -1997,7 +1997,7 @@ $reladdr\@:
  *  Stores the contents of TR into CIO[channelNum][portNum]
  */
 .macro stcio channelNum, portNum
-    _wr_cmd_id  stcio, ,ASEQ_OP_CHANNEL_STCIO,,,,,,, \channelNum, 4
+    _wr_cmd_id  stcio, ,ASEQ_OP_CHAN_STCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -2007,7 +2007,7 @@ $reladdr\@:
  *  Loads the contents of CIO[channelNum][portNum] into TR.
  */
 .macro ldcio channelNum, portNum
-    _wr_cmd_id  ldcio, ,ASEQ_OP_CHANNEL_LDCIO,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldcio, ,ASEQ_OP_CHAN_LDCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -2019,7 +2019,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldlayer layerNum, label
-    _wr_cmd_id  rldlayer, ,ASEQ_OP_CHANNEL_RLDLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  rldlayer, ,ASEQ_OP_CHAN_RLDLAYER,,,,,,, \layerNum, 3
     _wr_16_rel  \label
 .endm
 
@@ -2033,7 +2033,7 @@ $reladdr\@:
  *   - -1 if layer does not exist.
  */
 .macro testlayer layerNum
-    _wr_cmd_id  testlayer, ,ASEQ_OP_CHANNEL_TESTLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  testlayer, ,ASEQ_OP_CHAN_TESTLAYER,,,,,,, \layerNum, 3
 .endm
 
 /**
@@ -2042,7 +2042,7 @@ $reladdr\@:
  *  Opens the note layer at `label` for index `layerNum`.
  */
 .macro ldlayer layerNum, label
-    _wr_cmd_id  ldlayer, ,ASEQ_OP_CHANNEL_LDLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  ldlayer, ,ASEQ_OP_CHAN_LDLAYER,,,,,,, \layerNum, 3
     _wr_lbl     \label
 .endm
 
@@ -2052,7 +2052,7 @@ $reladdr\@:
  *  Deletes the layer specified by index `layerNum`.
  */
 .macro dellayer arg
-    _wr_cmd_id  dellayer, ,ASEQ_OP_CHANNEL_DELLAYER,,,,,,, \arg, 3
+    _wr_cmd_id  dellayer, ,ASEQ_OP_CHAN_DELLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2061,7 +2061,7 @@ $reladdr\@:
  *  Allocates a new layer starting at the pointer read from DYNTBL16[TR]
  */
 .macro dynldlayer arg
-    _wr_cmd_id  dynldlayer, ,ASEQ_OP_CHANNEL_DYNLDLAYER,,,,,,, \arg, 3
+    _wr_cmd_id  dynldlayer, ,ASEQ_OP_CHAN_DYNLDLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2085,7 +2085,7 @@ $reladdr\@:
     .if ASEQ_MODE == ASEQ_MODE_SEQUENCE
         _wr_cmd_id  stopchan, ASEQ_OP_SEQ_STOPCHAN,,,,,,,, \channelNum, 4
     .else
-        _wr_cmd_id  stopchan, ,ASEQ_OP_CHANNEL_STOPCHAN,,,,,,, 0, 0
+        _wr_cmd_id  stopchan, ,ASEQ_OP_CHAN_STOPCHAN,,,,,,, 0, 0
         _wr_u8      \channelNum
     .endif
 .endm
@@ -2100,7 +2100,7 @@ $reladdr\@:
  *      Computes TR = TR - CIO[CUR_CHANNEL][portNum]
  */
 .macro subio portNum
-    _wr_cmd_id  subio, ASEQ_OP_SEQ_SUBIO,ASEQ_OP_CHANNEL_SUBIO,,,,,,, \portNum, 4
+    _wr_cmd_id  subio, ASEQ_OP_SEQ_SUBIO,ASEQ_OP_CHAN_SUBIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2131,7 +2131,7 @@ $reladdr\@:
  */
 .macro stio portNum
     .if ASEQ_MODE == ASEQ_MODE_CHANNEL
-        _wr_cmd_id  stio, ,ASEQ_OP_CHANNEL_STIO,,,,,,, \portNum, 3
+        _wr_cmd_id  stio, ,ASEQ_OP_CHAN_STIO,,,,,,, \portNum, 3
     .else
         _wr_cmd_id  stio, ASEQ_OP_SEQ_STIO,,,,,,,, \portNum, 4
     .endif
@@ -2144,7 +2144,7 @@ $reladdr\@:
  *  depending on current section.
  */
 .macro ldio portNum
-    _wr_cmd_id  ldio, ASEQ_OP_SEQ_LDIO,ASEQ_OP_CHANNEL_LDIO,,,,,,, \portNum, 4
+    _wr_cmd_id  ldio, ASEQ_OP_SEQ_LDIO,ASEQ_OP_CHAN_LDIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2153,7 +2153,7 @@ $reladdr\@:
  *  Opens the sequence channel for index `channelNum` with data beginning at `label`.
  */
 .macro ldchan channelNum, label
-    _wr_cmd_id  ldchan, ASEQ_OP_SEQ_LDCHAN,ASEQ_OP_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldchan, ASEQ_OP_SEQ_LDCHAN,ASEQ_OP_CHAN_LDCHAN,,,,,,, \channelNum, 4
     _wr_lbl     \label
 .endm
 

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -52,7 +52,18 @@
 #ifndef ASEQ_H
 #define ASEQ_H
 
-#include "versions.h"
+/**
+ *  MML Version
+ */
+
+#ifndef MML_VERSION
+    #error "MML version not defined, define MML_VERSION in the cpp invocation"
+#endif
+
+#define MML_VERSION_OOT  0
+#define MML_VERSION_MM   1
+
+
 
 /**
  *  IO Ports
@@ -251,6 +262,10 @@
 #define ASEQ_OPC_SEQUENCE_LDCHAN            0x90 // low nibble used as argument
 #define ASEQ_OPC_SEQUENCE_RLDCHAN           0xA0 // low nibble used as argument
 #define ASEQ_OPC_SEQUENCE_LDSEQ             0xB0 // low nibble used as argument
+#if (MML_VERSION == MML_VERSION_MM)
+#define ASEQ_OPC_SEQUENCE_C2                0xC2
+#define ASEQ_OPC_SEQUENCE_C3                0xC3
+#endif
 #define ASEQ_OPC_SEQUENCE_RUNSEQ            0xC4
 #define ASEQ_OPC_SEQUENCE_SCRIPTCTR         0xC5
 #define ASEQ_OPC_SEQUENCE_STOP              0xC6
@@ -280,7 +295,7 @@
 #define ASEQ_OPC_SEQUENCE_ALLOCNOTELIST     0xF1
 
 // channel commands
-#define ASEQ_OPC_CHANNEL_STOPCHANELAY   0x00 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_CDELAY         0x00 // low nibble used as argument
 #define ASEQ_OPC_CHANNEL_LDSAMPLE       0x10 // low nibble used as argument
 #define ASEQ_OPC_CHANNEL_LDCHAN         0x20 // low nibble used as argument
 #define ASEQ_OPC_CHANNEL_STCIO          0x30 // low nibble used as argument
@@ -293,6 +308,17 @@
 #define ASEQ_OPC_CHANNEL_LDLAYER        0x88 // lower 3 bits used as argument
 #define ASEQ_OPC_CHANNEL_DELLAYER       0x90 // lower 3 bits used as argument
 #define ASEQ_OPC_CHANNEL_DYNLDLAYER     0x98 // lower 3 bits used as argument
+#if (MML_VERSION == MML_VERSION_MM)
+#define ASEQ_OPC_CHANNEL_A0             0xA0
+#define ASEQ_OPC_CHANNEL_A1             0xA1
+#define ASEQ_OPC_CHANNEL_A2             0xA2
+#define ASEQ_OPC_CHANNEL_A3             0xA3
+#define ASEQ_OPC_CHANNEL_A4             0xA4
+#define ASEQ_OPC_CHANNEL_A5             0xA5
+#define ASEQ_OPC_CHANNEL_A6             0xA6
+#define ASEQ_OPC_CHANNEL_A7             0xA7
+#define ASEQ_OPC_CHANNEL_RANDPTR        0xA8
+#endif
 #define ASEQ_OPC_CHANNEL_LDFILTER       0xB0
 #define ASEQ_OPC_CHANNEL_FREEFILTER     0xB1
 #define ASEQ_OPC_CHANNEL_LDSEQTOPTR     0xB2
@@ -306,9 +332,13 @@
 #define ASEQ_OPC_CHANNEL_RANDGATE       0xBA
 #define ASEQ_OPC_CHANNEL_COMBFILTER     0xBB
 #define ASEQ_OPC_CHANNEL_PTRADD         0xBC
-#if (MML_VERSION == MML_VERSION_OOT)    
+#if (MML_VERSION == MML_VERSION_OOT)
 #define ASEQ_OPC_CHANNEL_RANDPTR        0xBD
-#endif  
+#endif
+#if (MML_VERSION == MML_VERSION_MM)
+#define ASEQ_OPC_CHANNEL_SAMPLESTART    0xBD
+#define ASEQ_OPC_CHANNEL_UNK_BE         0xBE
+#endif
 #define ASEQ_OPC_CHANNEL_INSTR          0xC1
 #define ASEQ_OPC_CHANNEL_DYNTBL         0xC2
 #define ASEQ_OPC_CHANNEL_SHORT          0xC3
@@ -378,23 +408,13 @@
 #define ASEQ_OPC_LAYER_RELEASERATE  0xCF
 #define ASEQ_OPC_LAYER_LDSHORTVEL   0xD0 // low nibble used as an argument
 #define ASEQ_OPC_LAYER_LDSHORTGATE  0xE0 // low nibble used as an argument
-
+#if (MML_VERSION == MML_VERSION_MM)
+#define ASEQ_OPC_LAYER_F0           0xF0
+#define ASEQ_OPC_LAYER_F1           0xF1
+#endif
 
 
 #ifdef _LANGUAGE_ASEQ
-
-/**
- *  MML Version
- */
-
-#ifndef MML_VERSION
-    #error "MML version not defined, define MML_VERSION in the cpp invocation"
-#endif
-
-#define MML_VERSION_OOT  0
-#define MML_VERSION_MM   1
-
-
 
 /**
  *  IDENT
@@ -1705,7 +1725,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_BE arg0
-        _wr_cmd_id  unk_BE, ,0xBE,,,,,,, 0, 0
+        _wr_cmd_id  unk_BE, ,ASEQ_OPC_CHANNEL_UNK_BE,,,,,,, 0, 0
         _wr_u8      \arg0
     .endm
 
@@ -1719,13 +1739,9 @@ $reladdr\@:
  *  If range is 0, it is treated as 65536.
  */
 .macro randptr range, offset
-    #if (MML_VERSION == MML_VERSION_OOT)
-        _wr_cmd_id  randptr, ,ASEQ_OPC_CHANNEL_RANDPTR,,,,,,, 0, 0
-    #else
-        _wr_cmd_id  randptr, ,0xA8,,,,,,, 0, 0
-    #endif
-    _wr_u16         \range
-    _wr_u16         \offset
+    _wr_cmd_id  randptr, ,ASEQ_OPC_CHANNEL_RANDPTR,,,,,,, 0, 0
+    _wr_u16     \range
+    _wr_u16     \offset
 .endm
 
 #if (MML_VERSION == MML_VERSION_MM)
@@ -1736,7 +1752,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro samplestart arg
-        _wr_cmd_id  samplestart, ,0xBD,,,,,,, 0, 0
+        _wr_cmd_id  samplestart, ,ASEQ_OPC_CHANNEL_SAMPLESTART,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1746,7 +1762,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A7 arg
-        _wr_cmd_id  unk_A7, ,0xA7,,,,,,, 0, 0
+        _wr_cmd_id  unk_A7, ,ASEQ_OPC_CHANNEL_A7,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1756,7 +1772,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A6 arg0, arg1
-        _wr_cmd_id  unk_A6, ,0xA6,,,,,,, 0, 0
+        _wr_cmd_id  unk_A6, ,ASEQ_OPC_CHANNEL_A6,,,,,,, 0, 0
         _wr_u8      \arg0
         _wr_s16     \arg1
     .endm
@@ -1767,7 +1783,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A5
-        _wr_cmd_id  unk_A5, ,0xA5,,,,,,, 0, 0
+        _wr_cmd_id  unk_A5, ,ASEQ_OPC_CHANNEL_A5,,,,,,, 0, 0
     .endm
 
     /**
@@ -1776,7 +1792,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A4 arg
-        _wr_cmd_id  unk_A4, ,0xA4,,,,,,, 0, 0
+        _wr_cmd_id  unk_A4, ,ASEQ_OPC_CHANNEL_A4,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1786,7 +1802,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A3
-        _wr_cmd_id  unk_A3, ,0xA3,,,,,,, 0, 0
+        _wr_cmd_id  unk_A3, ,ASEQ_OPC_CHANNEL_A3,,,,,,, 0, 0
     .endm
 
     /**
@@ -1795,7 +1811,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A2 arg
-        _wr_cmd_id  unk_A2, ,0xA2,,,,,,, 0, 0
+        _wr_cmd_id  unk_A2, ,ASEQ_OPC_CHANNEL_A2,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1805,7 +1821,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A1
-        _wr_cmd_id  unk_A1, ,0xA1,,,,,,, 0, 0
+        _wr_cmd_id  unk_A1, ,ASEQ_OPC_CHANNEL_A1,,,,,,, 0, 0
     .endm
 
     /**
@@ -1814,7 +1830,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A0 arg
-        _wr_cmd_id  unk_A0, ,0xA0,,,,,,, 0, 0
+        _wr_cmd_id  unk_A0, ,ASEQ_OPC_CHANNEL_A0,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1951,7 +1967,7 @@ $reladdr\@:
  *  Delays by `delay` ticks.
  */
 .macro cdelay delay
-    _wr_cmd_id  cdelay, ,ASEQ_OPC_CHANNEL_STOPCHANELAY,,,,,,, \delay, 4
+    _wr_cmd_id  cdelay, ,ASEQ_OPC_CHANNEL_CDELAY,,,,,,, \delay, 4
 .endm
 
 /**
@@ -2311,7 +2327,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_F0 arg
-        _wr_cmd_id  unk_F0, ,,0xF0,,,,,, 0, 0
+        _wr_cmd_id  unk_F0, ,,ASEQ_OPC_LAYER_F0,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -2320,9 +2336,8 @@ $reladdr\@:
      *
      *  TODO DESCRIPTION
      */
-    #define SURROUNDEFFECT_OPCODE 0xF1
     .macro surroundeffect arg
-        _wr_cmd_id  surroundeffect, ,,SURROUNDEFFECT_OPCODE,,,,,, 0, 0
+        _wr_cmd_id  surroundeffect, ,,ASEQ_OPC_LAYER_F1,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -237,20 +237,20 @@
 
 // control flow commands
 #define ASEQ_OP_CONTROL_FLOW_FIRST 0xF2
-#define ASEQ_OP_CTRLFLOW_RBLTZ     0xF2
-#define ASEQ_OP_CTRLFLOW_RBEQZ     0xF3
-#define ASEQ_OP_CTRLFLOW_RJUMP     0xF4
-#define ASEQ_OP_CTRLFLOW_BGEZ      0xF5
-#define ASEQ_OP_CTRLFLOW_BREAK     0xF6
-#define ASEQ_OP_CTRLFLOW_LOOPEND   0xF7
-#define ASEQ_OP_CTRLFLOW_LOOP      0xF8
-#define ASEQ_OP_CTRLFLOW_BLTZ      0xF9
-#define ASEQ_OP_CTRLFLOW_BEQZ      0xFA
-#define ASEQ_OP_CTRLFLOW_JUMP      0xFB
-#define ASEQ_OP_CTRLFLOW_CALL      0xFC
-#define ASEQ_OP_CTRLFLOW_DELAY     0xFD
-#define ASEQ_OP_CTRLFLOW_DELAY1    0xFE
-#define ASEQ_OP_CTRLFLOW_END       0xFF
+#define ASEQ_OP_RBLTZ     0xF2
+#define ASEQ_OP_RBEQZ     0xF3
+#define ASEQ_OP_RJUMP     0xF4
+#define ASEQ_OP_BGEZ      0xF5
+#define ASEQ_OP_BREAK     0xF6
+#define ASEQ_OP_LOOPEND   0xF7
+#define ASEQ_OP_LOOP      0xF8
+#define ASEQ_OP_BLTZ      0xF9
+#define ASEQ_OP_BEQZ      0xFA
+#define ASEQ_OP_JUMP      0xFB
+#define ASEQ_OP_CALL      0xFC
+#define ASEQ_OP_DELAY     0xFD
+#define ASEQ_OP_DELAY1    0xFE
+#define ASEQ_OP_END       0xFF
 
 // sequence commands
 #define ASEQ_OP_SEQUENCE_TESTCHAN          0x00 // low nibble used as argument
@@ -914,7 +914,7 @@ $reladdr\@:
  *  closed, so are its layers.
  */
 .macro end
-    _wr_cmd_id  end, ASEQ_OP_CTRLFLOW_END,ASEQ_OP_CTRLFLOW_END,ASEQ_OP_CTRLFLOW_END,,,,,, 0, 0
+    _wr_cmd_id  end, ASEQ_OP_END,ASEQ_OP_END,ASEQ_OP_END,,,,,, 0, 0
 .endm
 
 /**
@@ -923,7 +923,7 @@ $reladdr\@:
  *  Delays for one tick.
  */
 .macro delay1
-    _wr_cmd_id  delay1, ASEQ_OP_CTRLFLOW_DELAY1,ASEQ_OP_CTRLFLOW_DELAY1,,,,,,, 0, 0
+    _wr_cmd_id  delay1, ASEQ_OP_DELAY1,ASEQ_OP_DELAY1,,,,,,, 0, 0
 .endm
 
 /**
@@ -932,7 +932,7 @@ $reladdr\@:
  *  Delays for `delay` ticks.
  */
 .macro delay delay
-    _wr_cmd_id  delay, ASEQ_OP_CTRLFLOW_DELAY,ASEQ_OP_CTRLFLOW_DELAY,,,,,,, 0, 0
+    _wr_cmd_id  delay, ASEQ_OP_DELAY,ASEQ_OP_DELAY,,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -943,7 +943,7 @@ $reladdr\@:
  *  subroutine encounters an `end` instruction.
  */
 .macro call label
-    _wr_cmd_id  call, ASEQ_OP_CTRLFLOW_CALL,ASEQ_OP_CTRLFLOW_CALL,ASEQ_OP_CTRLFLOW_CALL,,,,,, 0, 0
+    _wr_cmd_id  call, ASEQ_OP_CALL,ASEQ_OP_CALL,ASEQ_OP_CALL,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -953,7 +953,7 @@ $reladdr\@:
  *  Branches to `label` unconditionally.
  */
 .macro jump label
-    _wr_cmd_id  jump, ASEQ_OP_CTRLFLOW_JUMP,ASEQ_OP_CTRLFLOW_JUMP,ASEQ_OP_CTRLFLOW_JUMP,,,,,, 0, 0
+    _wr_cmd_id  jump, ASEQ_OP_JUMP,ASEQ_OP_JUMP,ASEQ_OP_JUMP,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -963,7 +963,7 @@ $reladdr\@:
  *  Branches to `label` if TR == 0.
  */
 .macro beqz label
-    _wr_cmd_id  beqz, ASEQ_OP_CTRLFLOW_BEQZ,ASEQ_OP_CTRLFLOW_BEQZ,ASEQ_OP_CTRLFLOW_BEQZ,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OP_BEQZ,ASEQ_OP_BEQZ,ASEQ_OP_BEQZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -973,7 +973,7 @@ $reladdr\@:
  *  Branches to `label` if TR < 0.
  */
 .macro bltz label
-    _wr_cmd_id  beqz, ASEQ_OP_CTRLFLOW_BLTZ,ASEQ_OP_CTRLFLOW_BLTZ,ASEQ_OP_CTRLFLOW_BLTZ,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OP_BLTZ,ASEQ_OP_BLTZ,ASEQ_OP_BLTZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -987,7 +987,7 @@ $reladdr\@:
  *  becomes full.
  */
 .macro loop num
-    _wr_cmd_id  loop, ASEQ_OP_CTRLFLOW_LOOP,ASEQ_OP_CTRLFLOW_LOOP,ASEQ_OP_CTRLFLOW_LOOP,,,,,, 0, 0
+    _wr_cmd_id  loop, ASEQ_OP_LOOP,ASEQ_OP_LOOP,ASEQ_OP_LOOP,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -1001,7 +1001,7 @@ $reladdr\@:
  *  stack is popped.
  */
 .macro loopend
-    _wr_cmd_id  loopend, ASEQ_OP_CTRLFLOW_LOOPEND,ASEQ_OP_CTRLFLOW_LOOPEND,ASEQ_OP_CTRLFLOW_LOOPEND,,,,,, 0, 0
+    _wr_cmd_id  loopend, ASEQ_OP_LOOPEND,ASEQ_OP_LOOPEND,ASEQ_OP_LOOPEND,,,,,, 0, 0
 .endm
 
 /**
@@ -1014,7 +1014,7 @@ $reladdr\@:
  *  the call stack would be popped twice.
  */
 .macro break
-    _wr_cmd_id  break, ASEQ_OP_CTRLFLOW_BREAK,ASEQ_OP_CTRLFLOW_BREAK,ASEQ_OP_CTRLFLOW_BREAK,,,,,, 0, 0
+    _wr_cmd_id  break, ASEQ_OP_BREAK,ASEQ_OP_BREAK,ASEQ_OP_BREAK,,,,,, 0, 0
 .endm
 
 /**
@@ -1023,7 +1023,7 @@ $reladdr\@:
  *  Branches to `label` if TR >= 0.
  */
 .macro bgez label
-    _wr_cmd_id  bgez, ASEQ_OP_CTRLFLOW_BGEZ,ASEQ_OP_CTRLFLOW_BGEZ,ASEQ_OP_CTRLFLOW_BGEZ,,,,,, 0, 0
+    _wr_cmd_id  bgez, ASEQ_OP_BGEZ,ASEQ_OP_BGEZ,ASEQ_OP_BGEZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1037,7 +1037,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rjump label
-    _wr_cmd_id  rjump, ASEQ_OP_CTRLFLOW_RJUMP,ASEQ_OP_CTRLFLOW_RJUMP,ASEQ_OP_CTRLFLOW_RJUMP,,,,,, 0, 0
+    _wr_cmd_id  rjump, ASEQ_OP_RJUMP,ASEQ_OP_RJUMP,ASEQ_OP_RJUMP,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1051,7 +1051,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbeqz label
-    _wr_cmd_id  rbeqz, ASEQ_OP_CTRLFLOW_RBEQZ,ASEQ_OP_CTRLFLOW_RBEQZ,ASEQ_OP_CTRLFLOW_RBEQZ,,,,,, 0, 0
+    _wr_cmd_id  rbeqz, ASEQ_OP_RBEQZ,ASEQ_OP_RBEQZ,ASEQ_OP_RBEQZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1065,7 +1065,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbltz label
-    _wr_cmd_id  rbltz, ASEQ_OP_CTRLFLOW_RBLTZ,ASEQ_OP_CTRLFLOW_RBLTZ,ASEQ_OP_CTRLFLOW_RBLTZ,,,,,, 0, 0
+    _wr_cmd_id  rbltz, ASEQ_OP_RBLTZ,ASEQ_OP_RBLTZ,ASEQ_OP_RBLTZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -2186,7 +2186,7 @@ $reladdr\@:
  * Should never be used when not required for matching purposes.
  */
 .macro lldelay delay
-    _wr_cmd_id  lldelay, ,ASEQ_OP_CTRLFLOW_DELAY,ASEQ_OP_LAYER_LDELAY,,,,,, 0, 0
+    _wr_cmd_id  lldelay, ,ASEQ_OP_DELAY,ASEQ_OP_LAYER_LDELAY,,,,,, 0, 0
     _var_long   \delay
 .endm
 

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -2274,7 +2274,6 @@ $reladdr\@:
  *
  *  TODO DESCRIPTION
  */
-#define STEREO_OPCODE ASEQ_OPC_LAYER_STEREO
 .macro stereo type, strongR, strongL, strongRvrbR, strongRvrbL
     _check_arg_bitwidth_u \type, 2
     _check_arg_bitwidth_u \strongR, 1
@@ -2342,7 +2341,6 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDVG_OPCODE ASEQ_OPC_LAYER_STEP3_NOTEDVG
 .macro notedvg pitch, delay, velocity, gateTime
     _wr_cmd_id  notedvg, ,,ASEQ_OPC_LAYER_STEP3_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
@@ -2357,7 +2355,6 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDV_OPCODE ASEQ_OPC_LAYER_STEP3_NOTEDV
 .macro notedv pitch, delay, velocity
     _wr_cmd_id  notedv, ,,ASEQ_OPC_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
     _var        \delay

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -220,6 +220,164 @@
 #define FONTANY_INSTR_ASM_NOISE    136
 
 
+/**
+ *  Command Opcode IDs
+ */
+
+// control flow commands
+#define ASEQ_CMD_ID_CONTROL_FLOW_FIRST 0xF2
+#define ASEQ_CMD_ID_CTRLFLOW_F2 0xF2
+#define ASEQ_CMD_ID_CTRLFLOW_F3 0xF3
+#define ASEQ_CMD_ID_CTRLFLOW_F4 0xF4
+#define ASEQ_CMD_ID_CTRLFLOW_F5 0xF5
+#define ASEQ_CMD_ID_CTRLFLOW_F6 0xF6
+#define ASEQ_CMD_ID_CTRLFLOW_F7 0xF7
+#define ASEQ_CMD_ID_CTRLFLOW_F8 0xF8
+#define ASEQ_CMD_ID_CTRLFLOW_F9 0xF9
+#define ASEQ_CMD_ID_CTRLFLOW_FA 0xFA
+#define ASEQ_CMD_ID_CTRLFLOW_FB 0xFB
+#define ASEQ_CMD_ID_CTRLFLOW_FC 0xFC
+#define ASEQ_CMD_ID_CTRLFLOW_FD 0xFD
+#define ASEQ_CMD_ID_CTRLFLOW_FE 0xFE
+#define ASEQ_CMD_ID_CTRLFLOW_FF 0xFF
+
+// sequence commands
+#define ASEQ_CMD_ID_SEQUENCE_00 0x00 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_40 0x40 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_50 0x50 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_60 0x60 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_70 0x70 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_80 0x80 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_90 0x90 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_A0 0xA0 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_B0 0xB0 // low nibble used as argument
+#define ASEQ_CMD_ID_SEQUENCE_C4 0xC4
+#define ASEQ_CMD_ID_SEQUENCE_C5 0xC5
+#define ASEQ_CMD_ID_SEQUENCE_C6 0xC6
+#define ASEQ_CMD_ID_SEQUENCE_C7 0xC7
+#define ASEQ_CMD_ID_SEQUENCE_C8 0xC8
+#define ASEQ_CMD_ID_SEQUENCE_C9 0xC9
+#define ASEQ_CMD_ID_SEQUENCE_CC 0xCC
+#define ASEQ_CMD_ID_SEQUENCE_CD 0xCD
+#define ASEQ_CMD_ID_SEQUENCE_CE 0xCE
+#define ASEQ_CMD_ID_SEQUENCE_D0 0xD0
+#define ASEQ_CMD_ID_SEQUENCE_D1 0xD1
+#define ASEQ_CMD_ID_SEQUENCE_D2 0xD2
+#define ASEQ_CMD_ID_SEQUENCE_D3 0xD3
+#define ASEQ_CMD_ID_SEQUENCE_D4 0xD4
+#define ASEQ_CMD_ID_SEQUENCE_D5 0xD5
+#define ASEQ_CMD_ID_SEQUENCE_D6 0xD6
+#define ASEQ_CMD_ID_SEQUENCE_D7 0xD7
+#define ASEQ_CMD_ID_SEQUENCE_D9 0xD9
+#define ASEQ_CMD_ID_SEQUENCE_DA 0xDA
+#define ASEQ_CMD_ID_SEQUENCE_DB 0xDB
+#define ASEQ_CMD_ID_SEQUENCE_DC 0xDC
+#define ASEQ_CMD_ID_SEQUENCE_DD 0xDD
+#define ASEQ_CMD_ID_SEQUENCE_DE 0xDE
+#define ASEQ_CMD_ID_SEQUENCE_DF 0xDF
+#define ASEQ_CMD_ID_SEQUENCE_EF 0xEF
+#define ASEQ_CMD_ID_SEQUENCE_F0 0xF0
+#define ASEQ_CMD_ID_SEQUENCE_F1 0xF1
+
+// channel commands
+#define ASEQ_CMD_ID_CHANNEL_00 0x00 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_10 0x10 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_20 0x20 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_30 0x30 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_40 0x40 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_50 0x50 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_60 0x60 // low nibble used as argument
+#define ASEQ_CMD_ID_CHANNEL_70 0x70 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_78 0x78 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_80 0x80 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_88 0x88 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_90 0x90 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_98 0x98 // lower 3 bits used as argument
+#define ASEQ_CMD_ID_CHANNEL_B0 0xB0
+#define ASEQ_CMD_ID_CHANNEL_B1 0xB1
+#define ASEQ_CMD_ID_CHANNEL_B2 0xB2
+#define ASEQ_CMD_ID_CHANNEL_B3 0xB3
+#define ASEQ_CMD_ID_CHANNEL_B4 0xB4
+#define ASEQ_CMD_ID_CHANNEL_B5 0xB5
+#define ASEQ_CMD_ID_CHANNEL_B6 0xB6
+#define ASEQ_CMD_ID_CHANNEL_B7 0xB7
+#define ASEQ_CMD_ID_CHANNEL_B8 0xB8
+#define ASEQ_CMD_ID_CHANNEL_B9 0xB9
+#define ASEQ_CMD_ID_CHANNEL_BA 0xBA
+#define ASEQ_CMD_ID_CHANNEL_BB 0xBB
+#define ASEQ_CMD_ID_CHANNEL_BC 0xBC
+#define ASEQ_CMD_ID_CHANNEL_BD 0xBD
+#define ASEQ_CMD_ID_CHANNEL_C1 0xC1
+#define ASEQ_CMD_ID_CHANNEL_C2 0xC2
+#define ASEQ_CMD_ID_CHANNEL_C3 0xC3
+#define ASEQ_CMD_ID_CHANNEL_C4 0xC4
+#define ASEQ_CMD_ID_CHANNEL_C5 0xC5
+#define ASEQ_CMD_ID_CHANNEL_C6 0xC6
+#define ASEQ_CMD_ID_CHANNEL_C7 0xC7
+#define ASEQ_CMD_ID_CHANNEL_C8 0xC8
+#define ASEQ_CMD_ID_CHANNEL_C9 0xC9
+#define ASEQ_CMD_ID_CHANNEL_CA 0xCA
+#define ASEQ_CMD_ID_CHANNEL_CB 0xCB
+#define ASEQ_CMD_ID_CHANNEL_CC 0xCC
+#define ASEQ_CMD_ID_CHANNEL_CD 0xCD
+#define ASEQ_CMD_ID_CHANNEL_CE 0xCE
+#define ASEQ_CMD_ID_CHANNEL_CF 0xCF
+#define ASEQ_CMD_ID_CHANNEL_D0 0xD0
+#define ASEQ_CMD_ID_CHANNEL_D1 0xD1
+#define ASEQ_CMD_ID_CHANNEL_D2 0xD2
+#define ASEQ_CMD_ID_CHANNEL_D3 0xD3
+#define ASEQ_CMD_ID_CHANNEL_D4 0xD4
+#define ASEQ_CMD_ID_CHANNEL_D7 0xD7
+#define ASEQ_CMD_ID_CHANNEL_D8 0xD8
+#define ASEQ_CMD_ID_CHANNEL_D9 0xD9
+#define ASEQ_CMD_ID_CHANNEL_DA 0xDA
+#define ASEQ_CMD_ID_CHANNEL_DB 0xDB
+#define ASEQ_CMD_ID_CHANNEL_DC 0xDC
+#define ASEQ_CMD_ID_CHANNEL_DD 0xDD
+#define ASEQ_CMD_ID_CHANNEL_DE 0xDE
+#define ASEQ_CMD_ID_CHANNEL_DF 0xDF
+#define ASEQ_CMD_ID_CHANNEL_E0 0xE0
+#define ASEQ_CMD_ID_CHANNEL_E1 0xE1
+#define ASEQ_CMD_ID_CHANNEL_E2 0xE2
+#define ASEQ_CMD_ID_CHANNEL_E3 0xE3
+#define ASEQ_CMD_ID_CHANNEL_E4 0xE4
+#define ASEQ_CMD_ID_CHANNEL_E5 0xE5
+#define ASEQ_CMD_ID_CHANNEL_E6 0xE6
+#define ASEQ_CMD_ID_CHANNEL_E7 0xE7
+#define ASEQ_CMD_ID_CHANNEL_E8 0xE8
+#define ASEQ_CMD_ID_CHANNEL_E9 0xE9
+#define ASEQ_CMD_ID_CHANNEL_EA 0xEA
+#define ASEQ_CMD_ID_CHANNEL_EB 0xEB
+#define ASEQ_CMD_ID_CHANNEL_EC 0xEC
+#define ASEQ_CMD_ID_CHANNEL_ED 0xED
+#define ASEQ_CMD_ID_CHANNEL_EE 0xEE
+#define ASEQ_CMD_ID_CHANNEL_F0 0xF0
+#define ASEQ_CMD_ID_CHANNEL_F1 0xF1
+
+// layer commands
+#define ASEQ_CMD_ID_LAYER_STEP3_00 0x00
+#define ASEQ_CMD_ID_LAYER_STEP3_40 0x40
+#define ASEQ_CMD_ID_LAYER_STEP3_80 0x80
+#define ASEQ_CMD_ID_LAYER_STEP3_C0 0xC0
+#define ASEQ_CMD_ID_LAYER_C1 0xC1
+#define ASEQ_CMD_ID_LAYER_C2 0xC2
+#define ASEQ_CMD_ID_LAYER_C3 0xC3
+#define ASEQ_CMD_ID_LAYER_C4 0xC4
+#define ASEQ_CMD_ID_LAYER_C5 0xC5
+#define ASEQ_CMD_ID_LAYER_C6 0xC6
+#define ASEQ_CMD_ID_LAYER_C7 0xC7
+#define ASEQ_CMD_ID_LAYER_C8 0xC8
+#define ASEQ_CMD_ID_LAYER_C9 0xC9
+#define ASEQ_CMD_ID_LAYER_CA 0xCA
+#define ASEQ_CMD_ID_LAYER_CB 0xCB
+#define ASEQ_CMD_ID_LAYER_CC 0xCC
+#define ASEQ_CMD_ID_LAYER_CD 0xCD
+#define ASEQ_CMD_ID_LAYER_CE 0xCE
+#define ASEQ_CMD_ID_LAYER_CF 0xCF
+#define ASEQ_CMD_ID_LAYER_D0 0xD0 // low nibble used as an argument
+#define ASEQ_CMD_ID_LAYER_E0 0xE0 // low nibble used as an argument
+
+
 
 #ifdef _LANGUAGE_ASEQ
 
@@ -391,7 +549,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq ioPortNum, seqId, label
-        _wr_cmd_id  ldseq, 0xB0,,,,,,,, \ioPortNum, 4
+        _wr_cmd_id  ldseq, ASEQ_CMD_ID_SEQUENCE_B0,,,,,,,, \ioPortNum, 4
         _wr_u8      \seqId
         _wr_lbl     \label
     .endm
@@ -409,7 +567,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq label
-        _wr_cmd_id  ldseq, ,0xCB,,,,,,, 0, 0
+        _wr_cmd_id  ldseq, ,ASEQ_CMD_ID_CHANNEL_CB,,,,,,, 0, 0
         _wr_lbl     \label
     .endm
 
@@ -419,14 +577,14 @@ _RESET_SECTION
         _check_arg_bitwidth_u \lowpassCutoff, 4
         _check_arg_bitwidth_u \highpassCutoff, 4
 
-        _wr_cmd_id filter, ,0xB3,,,,,,, 0, 0
+        _wr_cmd_id filter, ,ASEQ_CMD_ID_CHANNEL_B3,,,,,,, 0, 0
         _wr_u8 (\lowpassCutoff << 4) | (\highpassCutoff)
     .endm
 
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label
-        _wr_cmd_id env, ,0xDA,,,,,,, 0, 0
+        _wr_cmd_id env, ,ASEQ_CMD_ID_CHANNEL_DA,,,,,,, 0, 0
         _wr_lbl \label
     .endm
 
@@ -443,7 +601,7 @@ _RESET_SECTION
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label, arg
-        _wr_cmd_id env, ,,0xCB,,,,,, 0, 0
+        _wr_cmd_id env, ,,ASEQ_CMD_ID_LAYER_CB,,,,,, 0, 0
         _wr_lbl \label
         _wr_u8 \arg
     .endm
@@ -734,7 +892,7 @@ $reladdr\@:
  *  closed, so are its layers.
  */
 .macro end
-    _wr_cmd_id  end, 0xFF,0xFF,0xFF,,,,,, 0, 0
+    _wr_cmd_id  end, ASEQ_CMD_ID_CTRLFLOW_FF,ASEQ_CMD_ID_CTRLFLOW_FF,ASEQ_CMD_ID_CTRLFLOW_FF,,,,,, 0, 0
 .endm
 
 /**
@@ -743,7 +901,7 @@ $reladdr\@:
  *  Delays for one tick.
  */
 .macro delay1
-    _wr_cmd_id  delay1, 0xFE,0xFE,,,,,,, 0, 0
+    _wr_cmd_id  delay1, ASEQ_CMD_ID_CTRLFLOW_FE,ASEQ_CMD_ID_CTRLFLOW_FE,,,,,,, 0, 0
 .endm
 
 /**
@@ -752,7 +910,7 @@ $reladdr\@:
  *  Delays for `delay` ticks.
  */
 .macro delay delay
-    _wr_cmd_id  delay, 0xFD,0xFD,,,,,,, 0, 0
+    _wr_cmd_id  delay, ASEQ_CMD_ID_CTRLFLOW_FD,ASEQ_CMD_ID_CTRLFLOW_FD,,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -763,7 +921,7 @@ $reladdr\@:
  *  subroutine encounters an `end` instruction.
  */
 .macro call label
-    _wr_cmd_id  call, 0xFC,0xFC,0xFC,,,,,, 0, 0
+    _wr_cmd_id  call, ASEQ_CMD_ID_CTRLFLOW_FC,ASEQ_CMD_ID_CTRLFLOW_FC,ASEQ_CMD_ID_CTRLFLOW_FC,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -773,7 +931,7 @@ $reladdr\@:
  *  Branches to `label` unconditionally.
  */
 .macro jump label
-    _wr_cmd_id  jump, 0xFB,0xFB,0xFB,,,,,, 0, 0
+    _wr_cmd_id  jump, ASEQ_CMD_ID_CTRLFLOW_FB,ASEQ_CMD_ID_CTRLFLOW_FB,ASEQ_CMD_ID_CTRLFLOW_FB,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -783,7 +941,7 @@ $reladdr\@:
  *  Branches to `label` if TR == 0.
  */
 .macro beqz label
-    _wr_cmd_id  beqz, 0xFA,0xFA,0xFA,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_CMD_ID_CTRLFLOW_FA,ASEQ_CMD_ID_CTRLFLOW_FA,ASEQ_CMD_ID_CTRLFLOW_FA,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -793,7 +951,7 @@ $reladdr\@:
  *  Branches to `label` if TR < 0.
  */
 .macro bltz label
-    _wr_cmd_id  beqz, 0xF9,0xF9,0xF9,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_CMD_ID_CTRLFLOW_F9,ASEQ_CMD_ID_CTRLFLOW_F9,ASEQ_CMD_ID_CTRLFLOW_F9,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -807,7 +965,7 @@ $reladdr\@:
  *  becomes full.
  */
 .macro loop num
-    _wr_cmd_id  loop, 0xF8,0xF8,0xF8,,,,,, 0, 0
+    _wr_cmd_id  loop, ASEQ_CMD_ID_CTRLFLOW_F8,ASEQ_CMD_ID_CTRLFLOW_F8,ASEQ_CMD_ID_CTRLFLOW_F8,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -821,7 +979,7 @@ $reladdr\@:
  *  stack is popped.
  */
 .macro loopend
-    _wr_cmd_id  loopend, 0xF7,0xF7,0xF7,,,,,, 0, 0
+    _wr_cmd_id  loopend, ASEQ_CMD_ID_CTRLFLOW_F7,ASEQ_CMD_ID_CTRLFLOW_F7,ASEQ_CMD_ID_CTRLFLOW_F7,,,,,, 0, 0
 .endm
 
 /**
@@ -834,7 +992,7 @@ $reladdr\@:
  *  the call stack would be popped twice.
  */
 .macro break
-    _wr_cmd_id  break, 0xF6,0xF6,0xF6,,,,,, 0, 0
+    _wr_cmd_id  break, ASEQ_CMD_ID_CTRLFLOW_F6,ASEQ_CMD_ID_CTRLFLOW_F6,ASEQ_CMD_ID_CTRLFLOW_F6,,,,,, 0, 0
 .endm
 
 /**
@@ -843,7 +1001,7 @@ $reladdr\@:
  *  Branches to `label` if TR >= 0.
  */
 .macro bgez label
-    _wr_cmd_id  bgez, 0xF5,0xF5,0xF5,,,,,, 0, 0
+    _wr_cmd_id  bgez, ASEQ_CMD_ID_CTRLFLOW_F5,ASEQ_CMD_ID_CTRLFLOW_F5,ASEQ_CMD_ID_CTRLFLOW_F5,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -857,7 +1015,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rjump label
-    _wr_cmd_id  rjump, 0xF4,0xF4,0xF4,,,,,, 0, 0
+    _wr_cmd_id  rjump, ASEQ_CMD_ID_CTRLFLOW_F4,ASEQ_CMD_ID_CTRLFLOW_F4,ASEQ_CMD_ID_CTRLFLOW_F4,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -871,7 +1029,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbeqz label
-    _wr_cmd_id  rbeqz, 0xF3,0xF3,0xF3,,,,,, 0, 0
+    _wr_cmd_id  rbeqz, ASEQ_CMD_ID_CTRLFLOW_F3,ASEQ_CMD_ID_CTRLFLOW_F3,ASEQ_CMD_ID_CTRLFLOW_F3,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -885,7 +1043,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbltz label
-    _wr_cmd_id  rbltz, 0xF2,0xF2,0xF2,,,,,, 0, 0
+    _wr_cmd_id  rbltz, ASEQ_CMD_ID_CTRLFLOW_F2,ASEQ_CMD_ID_CTRLFLOW_F2,ASEQ_CMD_ID_CTRLFLOW_F2,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -895,7 +1053,7 @@ $reladdr\@:
  *  Clears the channel note pool and reallocates it with space for `num` notes.
  */
 .macro allocnotelist num
-    _wr_cmd_id  allocnotelist, 0xF1,0xF1,,,,,,, 0, 0
+    _wr_cmd_id  allocnotelist, ASEQ_CMD_ID_SEQUENCE_F1,ASEQ_CMD_ID_CHANNEL_F1,,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -905,7 +1063,7 @@ $reladdr\@:
  *  Clears the channel note pool.
  */
 .macro freenotelist
-    _wr_cmd_id  freenotelist, 0xF0,0xF0,,,,,,, 0, 0
+    _wr_cmd_id  freenotelist, ASEQ_CMD_ID_SEQUENCE_F0,ASEQ_CMD_ID_CHANNEL_F0,,,,,,, 0, 0
 .endm
 
 /**
@@ -914,7 +1072,7 @@ $reladdr\@:
  *  Has no function.
  */
 .macro unk_EF arg1, arg2
-    _wr_cmd_id  unk_EF, 0xEF,,,,,,,, 0, 0
+    _wr_cmd_id  unk_EF, ASEQ_CMD_ID_SEQUENCE_EF,,,,,,,, 0, 0
     _wr_s16     \arg1
     _w_u8       \arg2
 .endm
@@ -925,7 +1083,7 @@ $reladdr\@:
  *  Fine-tunes the pitch bend amount for the channel or layer.
  */
 .macro bendfine amt
-    _wr_cmd_id  bendfine, ,0xEE,0xCE,,,,,, 0, 0
+    _wr_cmd_id  bendfine, ,ASEQ_CMD_ID_CHANNEL_EE,ASEQ_CMD_ID_LAYER_CE,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -935,7 +1093,7 @@ $reladdr\@:
  *  Sets the channel gain (multiplicative volume scale factor) to the provided qu4.4 fixed-point value.
  */
 .macro gain value
-    _wr_cmd_id  gain, ,0xED,,,,,,, 0, 0
+    _wr_cmd_id  gain, ,ASEQ_CMD_ID_CHANNEL_ED,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -945,7 +1103,7 @@ $reladdr\@:
  *  Resets channel vibrato, filter, gain, sustain, etc. state.
  */
 .macro vibreset
-    _wr_cmd_id  vibreset, ,0xEC,,,,,,, 0, 0
+    _wr_cmd_id  vibreset, ,ASEQ_CMD_ID_CHANNEL_EC,,,,,,, 0, 0
 .endm
 
 /**
@@ -954,7 +1112,7 @@ $reladdr\@:
  *  Updates the soundfont and instrument for the channel simultaneously.
  */
 .macro fontinstr fontId, instId
-    _wr_cmd_id  fontinstr, ,0xEB,,,,,,, 0, 0
+    _wr_cmd_id  fontinstr, ,ASEQ_CMD_ID_CHANNEL_EB,,,,,,, 0, 0
     _wr_u8      \fontId
     _wr_u8      \instId
 .endm
@@ -967,7 +1125,7 @@ $reladdr\@:
 .macro notepri priority1, priority2
     _check_arg_bitwidth_u \priority1, 4
     _check_arg_bitwidth_u \priority2, 4
-    _wr_cmd_id  notepri, ,0xE9,,,,,,, 0, 0
+    _wr_cmd_id  notepri, ,ASEQ_CMD_ID_CHANNEL_E9,,,,,,, 0, 0
     _wr_u8      (\priority1 << 4) | \priority2
 .endm
 
@@ -978,7 +1136,7 @@ $reladdr\@:
  *  Sets various channel parameters.
  */
 .macro params muteBhv, noteAllocPolicy, channelPriority, transposition, pan, panWeight, reverb, reverbIndex
-    _wr_cmd_id  params, ,0xE8,,,,,,, 0, 0
+    _wr_cmd_id  params, ,ASEQ_CMD_ID_CHANNEL_E8,,,,,,, 0, 0
     _wr_u8      \muteBhv
     _wr_u8      \noteAllocPolicy
     _wr_u8      \channelPriority
@@ -996,7 +1154,7 @@ $reladdr\@:
  *  is ordered in the same way as the arguments in `params`.
  */
 .macro ldparams label
-    _wr_cmd_id  ldparams, ,0xE7,,,,,,, 0, 0
+    _wr_cmd_id  ldparams, ,ASEQ_CMD_ID_CHANNEL_E7,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1006,7 +1164,7 @@ $reladdr\@:
  *  Sets the sample book mode.
  */
 .macro samplebook value
-    _wr_cmd_id  samplebook, ,0xE6,,,,,,, 0, 0
+    _wr_cmd_id  samplebook, ,ASEQ_CMD_ID_CHANNEL_E6,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1016,7 +1174,7 @@ $reladdr\@:
  *  Sets the channel reverb.
  */
 .macro reverbidx arg
-    _wr_cmd_id  reverbidx, ,0xE5,,,,,,, 0, 0
+    _wr_cmd_id  reverbidx, ,ASEQ_CMD_ID_CHANNEL_E5,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1026,7 +1184,7 @@ $reladdr\@:
  *  Sets the channel vibrato delay.
  */
 .macro vibdelay arg
-    _wr_cmd_id  vibdelay, ,0xE3,,,,,,, 0, 0
+    _wr_cmd_id  vibdelay, ,ASEQ_CMD_ID_CHANNEL_E3,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1036,7 +1194,7 @@ $reladdr\@:
  *  Sets the vibrato extent.
  */
 .macro vibdepthgrad arg0, arg1, arg2
-    _wr_cmd_id  vibdepthgrad, ,0xE2,,,,,,, 0, 0
+    _wr_cmd_id  vibdepthgrad, ,ASEQ_CMD_ID_CHANNEL_E2,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1048,7 +1206,7 @@ $reladdr\@:
  *  Sets the vibrato rate.
  */
 .macro vibfreqgrad arg0, arg1, arg2
-    _wr_cmd_id  vibfreqgrad, ,0xE1,,,,,,, 0, 0
+    _wr_cmd_id  vibfreqgrad, ,ASEQ_CMD_ID_CHANNEL_E1,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1060,7 +1218,7 @@ $reladdr\@:
  *  Changes the expression amount for the channel.
  */
 .macro volexp amt
-    _wr_cmd_id  volexp, ,0xE0,,,,,,, 0, 0
+    _wr_cmd_id  volexp, ,ASEQ_CMD_ID_CHANNEL_E0,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1071,7 +1229,7 @@ $reladdr\@:
  *  provided number of semitones.
  */
 .macro transpose semitones
-    _wr_cmd_id  transpose, 0xDF,0xDB,0xC2,,,,,, 0, 0
+    _wr_cmd_id  transpose, ASEQ_CMD_ID_SEQUENCE_DF,ASEQ_CMD_ID_CHANNEL_DB,ASEQ_CMD_ID_LAYER_C2,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1081,7 +1239,7 @@ $reladdr\@:
  *  Adjusts the transposition amount. This is only available at the top sequence level.
  */
 .macro rtranspose semitones
-    _wr_cmd_id  rtranspose, 0xDE,,,,,,,, 0, 0
+    _wr_cmd_id  rtranspose, ASEQ_CMD_ID_SEQUENCE_DE,,,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1091,7 +1249,7 @@ $reladdr\@:
  *  Sets the freqScale for the current channel.
  */
 .macro freqscale arg
-    _wr_cmd_id  freqscale, ,0xDE,,,,,,, 0, 0
+    _wr_cmd_id  freqscale, ,ASEQ_CMD_ID_CHANNEL_DE,,,,,,, 0, 0
     _wr_s16     \arg
 .endm
 
@@ -1101,7 +1259,7 @@ $reladdr\@:
  *  Changes the tempo of the sequence.
  */
 .macro tempo bpm
-    _wr_cmd_id  tempo, 0xDD,,,,,,,, 0, 0
+    _wr_cmd_id  tempo, ASEQ_CMD_ID_SEQUENCE_DD,,,,,,,, 0, 0
     _wr_u8      \bpm
 .endm
 
@@ -1111,7 +1269,7 @@ $reladdr\@:
  *  Sets the tempoChange for the sequence.
  */
 .macro tempochg arg
-    _wr_cmd_id  tempochg, 0xDC,,,,,,,, 0, 0
+    _wr_cmd_id  tempochg, ASEQ_CMD_ID_SEQUENCE_DC,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1123,7 +1281,7 @@ $reladdr\@:
 .macro pan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  pan, ,0xDD,,,,,,, 0, 0
+    _wr_cmd_id  pan, ,ASEQ_CMD_ID_CHANNEL_DD,,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -1139,7 +1297,7 @@ $reladdr\@:
 .macro panweight weight
     /* weight can only take values in 0..127 */
     _check_arg_bitwidth_u \weight, 7
-    _wr_cmd_id  panweight, ,0xDC,,,,,,, 0, 0
+    _wr_cmd_id  panweight, ,ASEQ_CMD_ID_CHANNEL_DC,,,,,,, 0, 0
     _wr_u8      \weight
 .endm
 
@@ -1149,7 +1307,7 @@ $reladdr\@:
  *  Sets the volume amount for this sequence or channel.
  */
 .macro vol amt
-    _wr_cmd_id  vol, 0xDB,0xDF,,,,,,, 0, 0
+    _wr_cmd_id  vol, ASEQ_CMD_ID_SEQUENCE_DB,ASEQ_CMD_ID_CHANNEL_DF,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1159,7 +1317,7 @@ $reladdr\@:
  *  TODO DESCRIPTION
  */
 .macro volmode mode, fadeTimer
-    _wr_cmd_id  volmode, 0xDA,,,,,,,, 0, 0
+    _wr_cmd_id  volmode, ASEQ_CMD_ID_SEQUENCE_DA,,,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u16     \fadeTimer
 .endm
@@ -1170,7 +1328,7 @@ $reladdr\@:
  *  Sets the fadeVolumeScale for the sequence.
  */
 .macro volscale arg
-    _wr_cmd_id  volscale, 0xD9,,,,,,,, 0, 0
+    _wr_cmd_id  volscale, ASEQ_CMD_ID_SEQUENCE_D9,,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1180,7 +1338,7 @@ $reladdr\@:
  *  Sets the envelope release rate for this channel or layer.
  */
 .macro releaserate release
-    _wr_cmd_id  releaserate, ,0xD9,0xCF,,,,,, 0, 0
+    _wr_cmd_id  releaserate, ,ASEQ_CMD_ID_CHANNEL_D9,ASEQ_CMD_ID_LAYER_CF,,,,,, 0, 0
     _wr_u8      \release
 .endm
 
@@ -1190,7 +1348,7 @@ $reladdr\@:
  *  Sets the vibrato depth for the channel.
  */
 .macro vibdepth arg
-    _wr_cmd_id  vibdepth, ,0xD8,,,,,,, 0, 0
+    _wr_cmd_id  vibdepth, ,ASEQ_CMD_ID_CHANNEL_D8,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1200,7 +1358,7 @@ $reladdr\@:
  *  Sets the vibrato rate for the channel.
  */
 .macro vibfreq arg
-    _wr_cmd_id  vibfreq, ,0xD7,,,,,,, 0, 0
+    _wr_cmd_id  vibfreq, ,ASEQ_CMD_ID_CHANNEL_D7,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1213,7 +1371,7 @@ $reladdr\@:
  *       initchan 0b101 initializes channels 0 and 2.
  */
 .macro initchan bitmask
-    _wr_cmd_id  initchan, 0xD7,,,,,,,, 0, 0
+    _wr_cmd_id  initchan, ASEQ_CMD_ID_SEQUENCE_D7,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1223,7 +1381,7 @@ $reladdr\@:
  *  Frees the channels marked in the provided bitmask.
  */
 .macro freechan bitmask
-    _wr_cmd_id  freechan, 0xD6,,,,,,,, 0, 0
+    _wr_cmd_id  freechan, ASEQ_CMD_ID_SEQUENCE_D6,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1233,7 +1391,7 @@ $reladdr\@:
  *  Sets the muteVolumeScale for the sequence.
  */
 .macro mutescale arg
-    _wr_cmd_id  mutescale, 0xD5,,,,,,,, 0, 0
+    _wr_cmd_id  mutescale, ASEQ_CMD_ID_SEQUENCE_D5,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1243,7 +1401,7 @@ $reladdr\@:
  *  Mutes the sequence player.
  */
 .macro mute
-    _wr_cmd_id  mute, 0xD4,,,,,,,, 0, 0
+    _wr_cmd_id  mute, ASEQ_CMD_ID_SEQUENCE_D4,,,,,,,, 0, 0
 .endm
 
 /**
@@ -1252,7 +1410,7 @@ $reladdr\@:
  *  Sets the reverb amount for this channel.
  */
 .macro reverb amt
-    _wr_cmd_id  reverb, ,0xD4,,,,,,, 0, 0
+    _wr_cmd_id  reverb, ,ASEQ_CMD_ID_CHANNEL_D4,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1262,7 +1420,7 @@ $reladdr\@:
  *  Sets mute behavior for this sequence or channel.
  */
 .macro mutebhv flags
-    _wr_cmd_id  mutebhv, 0xD3,0xCA,,,,,,, 0, 0
+    _wr_cmd_id  mutebhv, ASEQ_CMD_ID_SEQUENCE_D3,ASEQ_CMD_ID_CHANNEL_CA,,,,,,, 0, 0
     _wr_u8      \flags
 .endm
 
@@ -1272,7 +1430,7 @@ $reladdr\@:
  *  Sets the pitch bend amount for this channel.
  */
 .macro bend amt
-    _wr_cmd_id  bend, ,0xD3,,,,,,, 0, 0
+    _wr_cmd_id  bend, ,ASEQ_CMD_ID_CHANNEL_D3,,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1282,7 +1440,7 @@ $reladdr\@:
  *  Sets the location of SHORTVELTBL.
  */
 .macro ldshortvelarr label
-    _wr_cmd_id  ldshortvelarr, 0xD2,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortvelarr, ASEQ_CMD_ID_SEQUENCE_D2,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1292,7 +1450,7 @@ $reladdr\@:
  *  Sets the adsr sustain value for this channel.
  */
 .macro sustain value
-    _wr_cmd_id  sustain, ,0xD2,,,,,,, 0, 0
+    _wr_cmd_id  sustain, ,ASEQ_CMD_ID_CHANNEL_D2,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1302,7 +1460,7 @@ $reladdr\@:
  *  Sets the location of SHORTGATETBL.
  */
 .macro ldshortgatearr label
-    _wr_cmd_id  ldshortgatearr, 0xD1,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortgatearr, ASEQ_CMD_ID_SEQUENCE_D1,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1312,7 +1470,7 @@ $reladdr\@:
  *  Sets the noteAllocPolicy for either the sequence or the current channel.
  */
 .macro notealloc arg
-    _wr_cmd_id  notealloc, 0xD0,0xD1,,,,,,, 0, 0
+    _wr_cmd_id  notealloc, ASEQ_CMD_ID_SEQUENCE_D0,ASEQ_CMD_ID_CHANNEL_D1,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1329,7 +1487,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  effects, ,0xD0,,,,,,, 0, 0
+    _wr_cmd_id  effects, ,ASEQ_CMD_ID_CHANNEL_D0,,,,,,, 0, 0
     _wr_u8      (\headset << 7) | (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -1339,7 +1497,7 @@ $reladdr\@:
  *  Stores TP -> label
  */
 .macro stptrtoseq label
-    _wr_cmd_id  stptrtoseq, ,0xCF,,,,,,, 0, 0
+    _wr_cmd_id  stptrtoseq, ,ASEQ_CMD_ID_CHANNEL_CF,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1349,7 +1507,7 @@ $reladdr\@:
  *  Loads label -> TP
  */
 .macro ldptr label
-    _wr_cmd_id  ldptr, ,0xCE,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_CMD_ID_CHANNEL_CE,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1359,7 +1517,7 @@ $reladdr\@:
  *  Loads imm -> TP
  */
 .macro ldptri imm
-    _wr_cmd_id  ldptr, ,0xCE,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_CMD_ID_CHANNEL_CE,,,,,,, 0, 0
     _wr_u16     \imm
 .endm
 
@@ -1369,7 +1527,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TR. If max is 0 the range is [0, 255]
  */
 .macro rand max
-    _wr_cmd_id  rand, 0xCE,0xB8,,,,,,, 0, 0
+    _wr_cmd_id  rand, ASEQ_CMD_ID_SEQUENCE_CE,ASEQ_CMD_ID_CHANNEL_B8,,,,,,, 0, 0
     _wr_u8      \max
 .endm
 
@@ -1384,9 +1542,9 @@ $reladdr\@:
  */
 .macro dyncall table=-1
     .if \table == -1
-        _wr_cmd_id  dyncall, ,0xE4,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ,ASEQ_CMD_ID_CHANNEL_E4,,,,,,, 0, 0
     .else
-        _wr_cmd_id  dyncall, 0xCD,,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ASEQ_CMD_ID_SEQUENCE_CD,,,,,,,, 0, 0
         _wr_lbl     \table
     .endif
 .endm
@@ -1397,7 +1555,7 @@ $reladdr\@:
  *  Loads the immediate value `imm` into TR.
  */
 .macro ldi imm
-    _wr_cmd_id  ldi, 0xCC,0xCC,,,,,,, 0, 0
+    _wr_cmd_id  ldi, ASEQ_CMD_ID_SEQUENCE_CC,ASEQ_CMD_ID_CHANNEL_CC,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1407,7 +1565,7 @@ $reladdr\@:
  *  Computes TR = TR & imm
  */
 .macro and imm
-    _wr_cmd_id  and, 0xC9,0xC9,,,,,,, 0, 0
+    _wr_cmd_id  and, ASEQ_CMD_ID_SEQUENCE_C9,ASEQ_CMD_ID_CHANNEL_C9,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1417,7 +1575,7 @@ $reladdr\@:
  *  Computes TR = TR - imm
  */
 .macro sub imm
-    _wr_cmd_id  sub, 0xC8,0xC8,,,,,,, 0, 0
+    _wr_cmd_id  sub, ASEQ_CMD_ID_SEQUENCE_C8,ASEQ_CMD_ID_CHANNEL_C8,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1427,7 +1585,7 @@ $reladdr\@:
  *  Stores the u8 value `TR + imm` to the location specified by `label`.
  */
 .macro stseq imm, label
-    _wr_cmd_id  stseq, 0xC7,0xC7,,,,,,, 0, 0
+    _wr_cmd_id  stseq, ASEQ_CMD_ID_SEQUENCE_C7,ASEQ_CMD_ID_CHANNEL_C7,,,,,,, 0, 0
     _wr_u8      \imm
     _wr_lbl     \label
 .endm
@@ -1438,7 +1596,7 @@ $reladdr\@:
  *  Immediately stops the sequence or channel.
  */
 .macro stop
-    _wr_cmd_id  stop, 0xC6,0xEA,,,,,,, 0, 0
+    _wr_cmd_id  stop, ASEQ_CMD_ID_SEQUENCE_C6,ASEQ_CMD_ID_CHANNEL_EA,,,,,,, 0, 0
 .endm
 
 /**
@@ -1447,7 +1605,7 @@ $reladdr\@:
  *  Set the current soundfont for this channel to `fontId`.
  */
 .macro font fontId
-    _wr_cmd_id  font, ,0xC6,,,,,,, 0, 0
+    _wr_cmd_id  font, ,ASEQ_CMD_ID_CHANNEL_C6,,,,,,, 0, 0
     _wr_u8      \fontId
 .endm
 
@@ -1460,7 +1618,7 @@ $reladdr\@:
  *  never used, so changing it with this instruction has no useful effects.
  */
 .macro scriptctr arg
-    _wr_cmd_id  scriptctr, 0xC5,,,,,,,, 0, 0
+    _wr_cmd_id  scriptctr, ASEQ_CMD_ID_SEQUENCE_C5,,,,,,,, 0, 0
     _wr_u16     \arg
 .endm
 
@@ -1471,7 +1629,7 @@ $reladdr\@:
  *  unless TR is -1, in which case nothing happens.
  */
 .macro dyntbllookup
-    _wr_cmd_id  dyntbllookup, ,0xC5,,,,,,, 0, 0
+    _wr_cmd_id  dyntbllookup, ,ASEQ_CMD_ID_CHANNEL_C5,,,,,,, 0, 0
 .endm
 
 /**
@@ -1480,7 +1638,7 @@ $reladdr\@:
  *  Plays the sequence seqId on seqPlayer.
  */
 .macro runseq seqPlayer, seqId
-    _wr_cmd_id  runseq, 0xC4,,,,,,,, 0, 0
+    _wr_cmd_id  runseq, ASEQ_CMD_ID_SEQUENCE_C4,,,,,,,, 0, 0
     _wr_u8      \seqPlayer
     _wr_u8      \seqId
 .endm
@@ -1493,7 +1651,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro mutechan arg0
-        _wr_cmd_id  mutechan, 0xC3,,,,,,,, 0, 0
+        _wr_cmd_id  mutechan, ASEQ_CMD_ID_SEQUENCE_C3,,,,,,,, 0, 0
         _wr_s16     \arg0
     .endm
 
@@ -1505,7 +1663,7 @@ $reladdr\@:
  *  Disable short notes encoding.
  */
 .macro noshort
-    _wr_cmd_id  noshort, ,0xC4,,,,,,, 0, 0
+    _wr_cmd_id  noshort, ,ASEQ_CMD_ID_CHANNEL_C4,,,,,,, 0, 0
 .endm
 
 /**
@@ -1514,7 +1672,7 @@ $reladdr\@:
  *  Enable short notes encoding.
  */
 .macro short
-    _wr_cmd_id  short, ,0xC3,,,,,,, 0, 0
+    _wr_cmd_id  short, ,ASEQ_CMD_ID_CHANNEL_C3,,,,,,, 0, 0
 .endm
 
 /**
@@ -1523,7 +1681,7 @@ $reladdr\@:
  *  Loads label -> DYNTBL
  */
 .macro dyntbl label
-    _wr_cmd_id  dyntbl, ,0xC2,,,,,,, 0, 0
+    _wr_cmd_id  dyntbl, ,ASEQ_CMD_ID_CHANNEL_C2,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1533,7 +1691,7 @@ $reladdr\@:
  *  Set instrument `instNum` from the current soundfont as the active instrument for this channel or layer.
  */
 .macro instr instNum
-    _wr_cmd_id  instr, ,0xC1,0xC6,,,,,, 0, 0
+    _wr_cmd_id  instr, ,ASEQ_CMD_ID_CHANNEL_C1,ASEQ_CMD_ID_LAYER_C6,,,,,, 0, 0
     _wr_u8      \instNum
 .endm
 
@@ -1560,7 +1718,7 @@ $reladdr\@:
  */
 .macro randptr range, offset
     #if (MML_VERSION == MML_VERSION_OOT)
-        _wr_cmd_id  randptr, ,0xBD,,,,,,, 0, 0
+        _wr_cmd_id  randptr, ,ASEQ_CMD_ID_CHANNEL_BD,,,,,,, 0, 0
     #else
         _wr_cmd_id  randptr, ,0xA8,,,,,,, 0, 0
     #endif
@@ -1666,7 +1824,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptradd value
-    _wr_cmd_id  ptradd, ,0xBC,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_CMD_ID_CHANNEL_BC,,,,,,, 0, 0
     _wr_lbl     \value
 .endm
 
@@ -1678,7 +1836,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptraddi value
-    _wr_cmd_id  ptradd, ,0xBC,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_CMD_ID_CHANNEL_BC,,,,,,, 0, 0
     _wr_u16     \value
 .endm
 
@@ -1689,7 +1847,7 @@ $reladdr\@:
  *  TODO args? arg0=16,arg1=val<<8 maps well to midi chorus
  */
 .macro combfilter arg0, arg1
-    _wr_cmd_id  combfilter, ,0xBB,,,,,,, 0, 0
+    _wr_cmd_id  combfilter, ,ASEQ_CMD_ID_CHANNEL_BB,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u16     \arg1
 .endm
@@ -1702,7 +1860,7 @@ $reladdr\@:
  *  NOTE: This feature is bugged. If this is non-zero it will actually use the range set by randvel.
  */
 .macro randgate range
-    _wr_cmd_id  randgate, ,0xBA,,,,,,, 0, 0
+    _wr_cmd_id  randgate, ,ASEQ_CMD_ID_CHANNEL_BA,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1712,7 +1870,7 @@ $reladdr\@:
  *  Sets the range for random note velocity fluctuations.
  */
 .macro randvel range
-    _wr_cmd_id  randvel, ,0xB9,,,,,,, 0, 0
+    _wr_cmd_id  randvel, ,ASEQ_CMD_ID_CHANNEL_B9,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1722,7 +1880,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TP. If max is 0 the range is [0, 65535]
  */
 .macro randtoptr max
-    _wr_cmd_id  randtoptr, ,0xB7,,,,,,, 0, 0
+    _wr_cmd_id  randtoptr, ,ASEQ_CMD_ID_CHANNEL_B7,,,,,,, 0, 0
     _wr_u16     \max
 .endm
 
@@ -1732,7 +1890,7 @@ $reladdr\@:
  *  Loads DYNTBL8[TR] -> TR
  */
 .macro dyntblv
-    _wr_cmd_id  dyntblv, ,0xB6,,,,,,, 0, 0
+    _wr_cmd_id  dyntblv, ,ASEQ_CMD_ID_CHANNEL_B6,,,,,,, 0, 0
 .endm
 
 /**
@@ -1741,7 +1899,7 @@ $reladdr\@:
  *  Loads DYNTBL16[TR] -> TP
  */
 .macro dyntbltoptr
-    _wr_cmd_id  dyntbltoptr, ,0xB5,,,,,,, 0, 0
+    _wr_cmd_id  dyntbltoptr, ,ASEQ_CMD_ID_CHANNEL_B5,,,,,,, 0, 0
 .endm
 
 /**
@@ -1750,7 +1908,7 @@ $reladdr\@:
  *  Transfers TP -> DYNTBL
  */
 .macro ptrtodyntbl
-    _wr_cmd_id  ptrtodyntbl, ,0xB4,,,,,,, 0, 0
+    _wr_cmd_id  ptrtodyntbl, ,ASEQ_CMD_ID_CHANNEL_B4,,,,,,, 0, 0
 .endm
 
 /**
@@ -1761,7 +1919,7 @@ $reladdr\@:
  *  Note that TR acts as an index into an array of u16 starting at label.
  */
 .macro ldseqtoptr label
-    _wr_cmd_id  ldseqtoptr, ,0xB2,,,,,,, 0, 0
+    _wr_cmd_id  ldseqtoptr, ,ASEQ_CMD_ID_CHANNEL_B2,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1771,7 +1929,7 @@ $reladdr\@:
  *  Invalidates the current active filter buffer.
  */
 .macro freefilter
-    _wr_cmd_id  freefilter, ,0xB1,,,,,,, 0, 0
+    _wr_cmd_id  freefilter, ,ASEQ_CMD_ID_CHANNEL_B1,,,,,,, 0, 0
 .endm
 
 /**
@@ -1780,7 +1938,7 @@ $reladdr\@:
  *  Sets the active filter buffer to the location specified by `filter`.
  */
 .macro ldfilter filter
-    _wr_cmd_id  ldfilter, ,0xB0,,,,,,, 0, 0
+    _wr_cmd_id  ldfilter, ,ASEQ_CMD_ID_CHANNEL_B0,,,,,,, 0, 0
     _wr_lbl     \filter
 .endm
 
@@ -1791,7 +1949,7 @@ $reladdr\@:
  *  Delays by `delay` ticks.
  */
 .macro cdelay delay
-    _wr_cmd_id  cdelay, ,0x00,,,,,,, \delay, 4
+    _wr_cmd_id  cdelay, ,ASEQ_CMD_ID_CHANNEL_00,,,,,,, \delay, 4
 .endm
 
 /**
@@ -1805,9 +1963,9 @@ $reladdr\@:
  */
 .macro ldsample type, portNum
     .if \type == LDSAMPLE_INST
-        _wr_cmd_id  ldsample, ,0x10,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_CMD_ID_CHANNEL_10,,,,,,, \portNum, 3
     .elif \type == LDSAMPLE_SFX
-        _wr_cmd_id  ldsample, ,0x18,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_CMD_ID_CHANNEL_10 | 8,,,,,,, \portNum, 3
     .else
         .error "ldsample: invalid type"
     .endif
@@ -1821,7 +1979,7 @@ $reladdr\@:
  *  Stores the contents of TR into CIO[channelNum][portNum]
  */
 .macro stcio channelNum, portNum
-    _wr_cmd_id  stcio, ,0x30,,,,,,, \channelNum, 4
+    _wr_cmd_id  stcio, ,ASEQ_CMD_ID_CHANNEL_30,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -1831,7 +1989,7 @@ $reladdr\@:
  *  Loads the contents of CIO[channelNum][portNum] into TR.
  */
 .macro ldcio channelNum, portNum
-    _wr_cmd_id  ldcio, ,0x40,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldcio, ,ASEQ_CMD_ID_CHANNEL_40,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -1843,7 +2001,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldlayer layerNum, label
-    _wr_cmd_id  rldlayer, ,0x78,,,,,,, \layerNum, 3
+    _wr_cmd_id  rldlayer, ,ASEQ_CMD_ID_CHANNEL_78,,,,,,, \layerNum, 3
     _wr_16_rel  \label
 .endm
 
@@ -1857,7 +2015,7 @@ $reladdr\@:
  *   - -1 if layer does not exist.
  */
 .macro testlayer layerNum
-    _wr_cmd_id  testlayer, ,0x80,,,,,,, \layerNum, 3
+    _wr_cmd_id  testlayer, ,ASEQ_CMD_ID_CHANNEL_80,,,,,,, \layerNum, 3
 .endm
 
 /**
@@ -1866,7 +2024,7 @@ $reladdr\@:
  *  Opens the note layer at `label` for index `layerNum`.
  */
 .macro ldlayer layerNum, label
-    _wr_cmd_id  ldlayer, ,0x88,,,,,,, \layerNum, 3
+    _wr_cmd_id  ldlayer, ,ASEQ_CMD_ID_CHANNEL_88,,,,,,, \layerNum, 3
     _wr_lbl     \label
 .endm
 
@@ -1876,7 +2034,7 @@ $reladdr\@:
  *  Deletes the layer specified by index `layerNum`.
  */
 .macro dellayer arg
-    _wr_cmd_id  dellayer, ,0x90,,,,,,, \arg, 3
+    _wr_cmd_id  dellayer, ,ASEQ_CMD_ID_CHANNEL_90,,,,,,, \arg, 3
 .endm
 
 /**
@@ -1885,7 +2043,7 @@ $reladdr\@:
  *  Allocates a new layer starting at the pointer read from DYNTBL16[TR]
  */
 .macro dynldlayer arg
-    _wr_cmd_id  dynldlayer, ,0x98,,,,,,, \arg, 3
+    _wr_cmd_id  dynldlayer, ,ASEQ_CMD_ID_CHANNEL_98,,,,,,, \arg, 3
 .endm
 
 /**
@@ -1897,7 +2055,7 @@ $reladdr\@:
  *   - 1 if disabled
  */
 .macro testchan channelNum
-    _wr_cmd_id  testchan, 0x00,,,,,,,, \channelNum, 4
+    _wr_cmd_id  testchan, ASEQ_CMD_ID_SEQUENCE_00,,,,,,,, \channelNum, 4
 .endm
 
 /**
@@ -1907,9 +2065,9 @@ $reladdr\@:
  */
 .macro stopchan channelNum
     .if ASEQ_MODE == ASEQ_MODE_SEQUENCE
-        _wr_cmd_id  stopchan, 0x40,,,,,,,, \channelNum, 4
+        _wr_cmd_id  stopchan, ASEQ_CMD_ID_SEQUENCE_40,,,,,,,, \channelNum, 4
     .else
-        _wr_cmd_id  stopchan, ,0xCD,,,,,,, 0, 0
+        _wr_cmd_id  stopchan, ,ASEQ_CMD_ID_CHANNEL_CD,,,,,,, 0, 0
         _wr_u8      \channelNum
     .endif
 .endm
@@ -1924,7 +2082,7 @@ $reladdr\@:
  *      Computes TR = TR - CIO[CUR_CHANNEL][portNum]
  */
 .macro subio portNum
-    _wr_cmd_id  subio, 0x50,0x50,,,,,,, \portNum, 4
+    _wr_cmd_id  subio, ASEQ_CMD_ID_SEQUENCE_50,ASEQ_CMD_ID_CHANNEL_50,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -1941,7 +2099,7 @@ $reladdr\@:
  *  Load status is made available in SIO[portNum].
  */
 .macro ldres portNum, resType, resId
-    _wr_cmd_id  ldres, 0x60,,,,,,,, \portNum, 4
+    _wr_cmd_id  ldres, ASEQ_CMD_ID_SEQUENCE_60,,,,,,,, \portNum, 4
     _wr_u8      \resType
     _wr_u8      \resId
 .endm
@@ -1955,9 +2113,9 @@ $reladdr\@:
  */
 .macro stio portNum
     .if ASEQ_MODE == ASEQ_MODE_CHANNEL
-        _wr_cmd_id  stio, ,0x70,,,,,,, \portNum, 3
+        _wr_cmd_id  stio, ,ASEQ_CMD_ID_CHANNEL_70,,,,,,, \portNum, 3
     .else
-        _wr_cmd_id  stio, 0x70,,,,,,,, \portNum, 4
+        _wr_cmd_id  stio, ASEQ_CMD_ID_SEQUENCE_70,,,,,,,, \portNum, 4
     .endif
 .endm
 
@@ -1968,7 +2126,7 @@ $reladdr\@:
  *  depending on current section.
  */
 .macro ldio portNum
-    _wr_cmd_id  ldio, 0x80,0x60,,,,,,, \portNum, 4
+    _wr_cmd_id  ldio, ASEQ_CMD_ID_SEQUENCE_80,ASEQ_CMD_ID_CHANNEL_60,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -1977,7 +2135,7 @@ $reladdr\@:
  *  Opens the sequence channel for index `channelNum` with data beginning at `label`.
  */
 .macro ldchan channelNum, label
-    _wr_cmd_id  ldchan, 0x90,0x20,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldchan, ASEQ_CMD_ID_SEQUENCE_90,ASEQ_CMD_ID_CHANNEL_20,,,,,,, \channelNum, 4
     _wr_lbl     \label
 .endm
 
@@ -1989,7 +2147,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldchan channelNum, label
-    _wr_cmd_id  rldchan, 0xA0,,,,,,,, \channelNum, 4
+    _wr_cmd_id  rldchan, ASEQ_CMD_ID_SEQUENCE_A0,,,,,,,, \channelNum, 4
     _wr_16_rel  \label
 .endm
 
@@ -1999,7 +2157,7 @@ $reladdr\@:
  *  Delay for `delay` ticks.
  */
 .macro ldelay delay
-    _wr_cmd_id  ldelay, ,,0xC0,,,,,, 0, 0
+    _wr_cmd_id  ldelay, ,,ASEQ_CMD_ID_LAYER_STEP3_C0,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2010,7 +2168,7 @@ $reladdr\@:
  * Should never be used when not required for matching purposes.
  */
 .macro lldelay delay
-    _wr_cmd_id  lldelay, ,0xFD,0xC0,,,,,, 0, 0
+    _wr_cmd_id  lldelay, ,ASEQ_CMD_ID_CHANNEL_FD,ASEQ_CMD_ID_LAYER_STEP3_C0,,,,,, 0, 0
     _var_long   \delay
 .endm
 
@@ -2020,7 +2178,7 @@ $reladdr\@:
  * Set velocity used by short notes.
  */
 .macro shortvel velocity
-    _wr_cmd_id  shortvel, ,,0xC1,,,,,, 0, 0
+    _wr_cmd_id  shortvel, ,,ASEQ_CMD_ID_LAYER_C1,,,,,, 0, 0
     _wr_u8      \velocity
 .endm
 
@@ -2030,7 +2188,7 @@ $reladdr\@:
  * Set delay used by short notes.
  */
 .macro shortdelay delay
-    _wr_cmd_id  shortdelay, ,,0xC3,,,,,, 0, 0
+    _wr_cmd_id  shortdelay, ,,ASEQ_CMD_ID_LAYER_C3,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2040,7 +2198,7 @@ $reladdr\@:
  *  Enables legato on the current layer.
  */
 .macro legato
-    _wr_cmd_id  legato, ,,0xC4,,,,,, 0, 0
+    _wr_cmd_id  legato, ,,ASEQ_CMD_ID_LAYER_C4,,,,,, 0, 0
 .endm
 
 /**
@@ -2049,7 +2207,7 @@ $reladdr\@:
  *  Disables legato on the current layer.
  */
 .macro nolegato
-    _wr_cmd_id  nolegato, ,,0xC5,,,,,, 0, 0
+    _wr_cmd_id  nolegato, ,,ASEQ_CMD_ID_LAYER_C5,,,,,, 0, 0
 .endm
 
 /**
@@ -2058,7 +2216,7 @@ $reladdr\@:
  *  The time argument is either a var or a u8 depending on mode
  */
 .macro portamento mode, target, time
-    _wr_cmd_id  portamento, ,,0xC7,,,,,, 0, 0
+    _wr_cmd_id  portamento, ,,ASEQ_CMD_ID_LAYER_C7,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u8      \target
     .if (\mode & 0x80) != 0
@@ -2074,7 +2232,7 @@ $reladdr\@:
  *  Disables portamento on the current layer.
  */
 .macro noportamento
-    _wr_cmd_id  noportamento, ,,0xC8,,,,,, 0, 0
+    _wr_cmd_id  noportamento, ,,ASEQ_CMD_ID_LAYER_C8,,,,,, 0, 0
 .endm
 
 /**
@@ -2083,7 +2241,7 @@ $reladdr\@:
  *  Sets gate time for short notes.
  */
 .macro shortgate gateTime
-    _wr_cmd_id  shortgate, ,,0xC9,,,,,, 0, 0
+    _wr_cmd_id  shortgate, ,,ASEQ_CMD_ID_LAYER_C9,,,,,, 0, 0
     _wr_u8      \gateTime
 .endm
 
@@ -2095,7 +2253,7 @@ $reladdr\@:
 .macro notepan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  notepan, ,,0xCA,,,,,, 0, 0
+    _wr_cmd_id  notepan, ,,ASEQ_CMD_ID_LAYER_CA,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -2106,7 +2264,7 @@ $reladdr\@:
  *  use pan set in the layer.
  */
 .macro nodrumpan
-    _wr_cmd_id  nodrumpan, ,,0xCC,,,,,, 0, 0
+    _wr_cmd_id  nodrumpan, ,,ASEQ_CMD_ID_LAYER_CC,,,,,, 0, 0
 .endm
 
 /**
@@ -2114,7 +2272,7 @@ $reladdr\@:
  *
  *  TODO DESCRIPTION
  */
-#define STEREO_OPCODE 0xCD
+#define STEREO_OPCODE ASEQ_CMD_ID_LAYER_CD
 .macro stereo type, strongR, strongL, strongRvrbR, strongRvrbL
     _check_arg_bitwidth_u \type, 2
     _check_arg_bitwidth_u \strongR, 1
@@ -2132,7 +2290,7 @@ $reladdr\@:
  *  Sets the velocity used in short notes by reading from SHORTVELTBL[velocity]
  */
 .macro ldshortvel velocity
-    _wr_cmd_id  ldshortvel, ,,0xD0,,,,,, \velocity, 4
+    _wr_cmd_id  ldshortvel, ,,ASEQ_CMD_ID_LAYER_D0,,,,,, \velocity, 4
 .endm
 
 /**
@@ -2141,7 +2299,7 @@ $reladdr\@:
  *  Sets the gate time used in short notes by reading from SHORTGATETBL[gateTime]
  */
 .macro ldshortgate gateTime
-    _wr_cmd_id  ldshortgate, ,,0xE0,,,,,, \gateTime, 4
+    _wr_cmd_id  ldshortgate, ,,ASEQ_CMD_ID_LAYER_E0,,,,,, \gateTime, 4
 .endm
 
 #if (MML_VERSION == MML_VERSION_MM)
@@ -2182,9 +2340,9 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDVG_OPCODE 0x00
+#define NOTEDVG_OPCODE ASEQ_CMD_ID_LAYER_STEP3_00
 .macro notedvg pitch, delay, velocity, gateTime
-    _wr_cmd_id  notedvg, ,,0x00,,,,,, \pitch, 6
+    _wr_cmd_id  notedvg, ,,ASEQ_CMD_ID_LAYER_STEP3_00,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
     _wr_u8      \gateTime
@@ -2197,16 +2355,16 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDV_OPCODE 0x40
+#define NOTEDV_OPCODE ASEQ_CMD_ID_LAYER_STEP3_40
 .macro notedv pitch, delay, velocity
-    _wr_cmd_id  notedv, ,,NOTEDV_OPCODE,,,,,, \pitch, 6
+    _wr_cmd_id  notedv, ,,ASEQ_CMD_ID_LAYER_STEP3_40,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
 .endm
 
 /* Workaround for bugs in vanilla sequences, force long encoding for delay. This should not typically be used. */
 .macro noteldv pitch, delay, velocity
-    _wr_cmd_id  noteldv, ,,0x40,,,,,, \pitch, 6
+    _wr_cmd_id  noteldv, ,,ASEQ_CMD_ID_LAYER_STEP3_40,,,,,, \pitch, 6
     _var_long   \delay
     _wr_u8      \velocity
 .endm
@@ -2219,7 +2377,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notevg pitch, velocity, gateTime
-    _wr_cmd_id  notevg, ,,0x80,,,,,, \pitch, 6
+    _wr_cmd_id  notevg, ,,ASEQ_CMD_ID_LAYER_STEP3_80,,,,,, \pitch, 6
     _wr_u8      \velocity
     _wr_u8      \gateTime
 .endm
@@ -2233,7 +2391,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdvg pitch, delay
-    _wr_cmd_id  shortdvg, ,,0x00,,,,,, \pitch, 6
+    _wr_cmd_id  shortdvg, ,,ASEQ_CMD_ID_LAYER_STEP3_00,,,,,, \pitch, 6
     _var        \delay
 .endm
 
@@ -2246,7 +2404,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdv pitch
-    _wr_cmd_id  shortdv, ,,0x40,,,,,, \pitch, 6
+    _wr_cmd_id  shortdv, ,,ASEQ_CMD_ID_LAYER_STEP3_40,,,,,, \pitch, 6
 .endm
 
 /**
@@ -2258,7 +2416,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortvg pitch
-    _wr_cmd_id  shortvg, ,,0x80,,,,,, \pitch, 6
+    _wr_cmd_id  shortvg, ,,ASEQ_CMD_ID_LAYER_STEP3_80,,,,,, \pitch, 6
 .endm
 
 /**

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -236,181 +236,181 @@
  */
 
 // control flow commands
-#define ASEQ_OPC_CONTROL_FLOW_FIRST 0xF2
-#define ASEQ_OPC_CTRLFLOW_RBLTZ     0xF2
-#define ASEQ_OPC_CTRLFLOW_RBEQZ     0xF3
-#define ASEQ_OPC_CTRLFLOW_RJUMP     0xF4
-#define ASEQ_OPC_CTRLFLOW_BGEZ      0xF5
-#define ASEQ_OPC_CTRLFLOW_BREAK     0xF6
-#define ASEQ_OPC_CTRLFLOW_LOOPEND   0xF7
-#define ASEQ_OPC_CTRLFLOW_LOOP      0xF8
-#define ASEQ_OPC_CTRLFLOW_BLTZ      0xF9
-#define ASEQ_OPC_CTRLFLOW_BEQZ      0xFA
-#define ASEQ_OPC_CTRLFLOW_JUMP      0xFB
-#define ASEQ_OPC_CTRLFLOW_CALL      0xFC
-#define ASEQ_OPC_CTRLFLOW_DELAY     0xFD
-#define ASEQ_OPC_CTRLFLOW_DELAY1    0xFE
-#define ASEQ_OPC_CTRLFLOW_END       0xFF
+#define ASEQ_OP_CONTROL_FLOW_FIRST 0xF2
+#define ASEQ_OP_CTRLFLOW_RBLTZ     0xF2
+#define ASEQ_OP_CTRLFLOW_RBEQZ     0xF3
+#define ASEQ_OP_CTRLFLOW_RJUMP     0xF4
+#define ASEQ_OP_CTRLFLOW_BGEZ      0xF5
+#define ASEQ_OP_CTRLFLOW_BREAK     0xF6
+#define ASEQ_OP_CTRLFLOW_LOOPEND   0xF7
+#define ASEQ_OP_CTRLFLOW_LOOP      0xF8
+#define ASEQ_OP_CTRLFLOW_BLTZ      0xF9
+#define ASEQ_OP_CTRLFLOW_BEQZ      0xFA
+#define ASEQ_OP_CTRLFLOW_JUMP      0xFB
+#define ASEQ_OP_CTRLFLOW_CALL      0xFC
+#define ASEQ_OP_CTRLFLOW_DELAY     0xFD
+#define ASEQ_OP_CTRLFLOW_DELAY1    0xFE
+#define ASEQ_OP_CTRLFLOW_END       0xFF
 
 // sequence commands
-#define ASEQ_OPC_SEQUENCE_TESTCHAN          0x00 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_STOPCHAN          0x40 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_SUBIO             0x50 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_LDRES             0x60 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_STIO              0x70 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_LDIO              0x80 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_LDCHAN            0x90 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_RLDCHAN           0xA0 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_LDSEQ             0xB0 // low nibble used as argument
+#define ASEQ_OP_SEQUENCE_TESTCHAN          0x00 // low nibble used as argument
+#define ASEQ_OP_SEQUENCE_STOPCHAN          0x40 // low nibble used as argument
+#define ASEQ_OP_SEQUENCE_SUBIO             0x50 // low nibble used as argument
+#define ASEQ_OP_SEQUENCE_LDRES             0x60 // low nibble used as argument
+#define ASEQ_OP_SEQUENCE_STIO              0x70 // low nibble used as argument
+#define ASEQ_OP_SEQUENCE_LDIO              0x80 // low nibble used as argument
+#define ASEQ_OP_SEQUENCE_LDCHAN            0x90 // low nibble used as argument
+#define ASEQ_OP_SEQUENCE_RLDCHAN           0xA0 // low nibble used as argument
+#define ASEQ_OP_SEQUENCE_LDSEQ             0xB0 // low nibble used as argument
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OPC_SEQUENCE_C2                0xC2
-#define ASEQ_OPC_SEQUENCE_C3                0xC3
+#define ASEQ_OP_SEQUENCE_C2                0xC2
+#define ASEQ_OP_SEQUENCE_C3                0xC3
 #endif
-#define ASEQ_OPC_SEQUENCE_RUNSEQ            0xC4
-#define ASEQ_OPC_SEQUENCE_SCRIPTCTR         0xC5
-#define ASEQ_OPC_SEQUENCE_STOP              0xC6
-#define ASEQ_OPC_SEQUENCE_STSEQ             0xC7
-#define ASEQ_OPC_SEQUENCE_SUB               0xC8
-#define ASEQ_OPC_SEQUENCE_AND               0xC9
-#define ASEQ_OPC_SEQUENCE_LDI               0xCC
-#define ASEQ_OPC_SEQUENCE_DYNCALL           0xCD
-#define ASEQ_OPC_SEQUENCE_RAND              0xCE
-#define ASEQ_OPC_SEQUENCE_NOTEALLOC         0xD0
-#define ASEQ_OPC_SEQUENCE_LDSHORTGATEARR    0xD1
-#define ASEQ_OPC_SEQUENCE_LDSHORTVELARR     0xD2
-#define ASEQ_OPC_SEQUENCE_MUTEBHV           0xD3
-#define ASEQ_OPC_SEQUENCE_MUTE              0xD4
-#define ASEQ_OPC_SEQUENCE_MUTESCALE         0xD5
-#define ASEQ_OPC_SEQUENCE_FREECHAN          0xD6
-#define ASEQ_OPC_SEQUENCE_INITCHAN          0xD7
-#define ASEQ_OPC_SEQUENCE_VOLSCALE          0xD9
-#define ASEQ_OPC_SEQUENCE_VOLMODE           0xDA
-#define ASEQ_OPC_SEQUENCE_VOL               0xDB
-#define ASEQ_OPC_SEQUENCE_TEMPOCHG          0xDC
-#define ASEQ_OPC_SEQUENCE_TEMPO             0xDD
-#define ASEQ_OPC_SEQUENCE_RTRANSPOSE        0xDE
-#define ASEQ_OPC_SEQUENCE_TRANSPOSE         0xDF
-#define ASEQ_OPC_SEQUENCE_EF                0xEF
-#define ASEQ_OPC_SEQUENCE_FREENOTELIST      0xF0
-#define ASEQ_OPC_SEQUENCE_ALLOCNOTELIST     0xF1
+#define ASEQ_OP_SEQUENCE_RUNSEQ            0xC4
+#define ASEQ_OP_SEQUENCE_SCRIPTCTR         0xC5
+#define ASEQ_OP_SEQUENCE_STOP              0xC6
+#define ASEQ_OP_SEQUENCE_STSEQ             0xC7
+#define ASEQ_OP_SEQUENCE_SUB               0xC8
+#define ASEQ_OP_SEQUENCE_AND               0xC9
+#define ASEQ_OP_SEQUENCE_LDI               0xCC
+#define ASEQ_OP_SEQUENCE_DYNCALL           0xCD
+#define ASEQ_OP_SEQUENCE_RAND              0xCE
+#define ASEQ_OP_SEQUENCE_NOTEALLOC         0xD0
+#define ASEQ_OP_SEQUENCE_LDSHORTGATEARR    0xD1
+#define ASEQ_OP_SEQUENCE_LDSHORTVELARR     0xD2
+#define ASEQ_OP_SEQUENCE_MUTEBHV           0xD3
+#define ASEQ_OP_SEQUENCE_MUTE              0xD4
+#define ASEQ_OP_SEQUENCE_MUTESCALE         0xD5
+#define ASEQ_OP_SEQUENCE_FREECHAN          0xD6
+#define ASEQ_OP_SEQUENCE_INITCHAN          0xD7
+#define ASEQ_OP_SEQUENCE_VOLSCALE          0xD9
+#define ASEQ_OP_SEQUENCE_VOLMODE           0xDA
+#define ASEQ_OP_SEQUENCE_VOL               0xDB
+#define ASEQ_OP_SEQUENCE_TEMPOCHG          0xDC
+#define ASEQ_OP_SEQUENCE_TEMPO             0xDD
+#define ASEQ_OP_SEQUENCE_RTRANSPOSE        0xDE
+#define ASEQ_OP_SEQUENCE_TRANSPOSE         0xDF
+#define ASEQ_OP_SEQUENCE_EF                0xEF
+#define ASEQ_OP_SEQUENCE_FREENOTELIST      0xF0
+#define ASEQ_OP_SEQUENCE_ALLOCNOTELIST     0xF1
 
 // channel commands
-#define ASEQ_OPC_CHANNEL_CDELAY         0x00 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_LDSAMPLE       0x10 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_LDCHAN         0x20 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_STCIO          0x30 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_LDCIO          0x40 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_SUBIO          0x50 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_LDIO           0x60 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_STIO           0x70 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_RLDLAYER       0x78 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_TESTLAYER      0x80 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_LDLAYER        0x88 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_DELLAYER       0x90 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_DYNLDLAYER     0x98 // lower 3 bits used as argument
+#define ASEQ_OP_CHANNEL_CDELAY         0x00 // low nibble used as argument
+#define ASEQ_OP_CHANNEL_LDSAMPLE       0x10 // low nibble used as argument
+#define ASEQ_OP_CHANNEL_LDCHAN         0x20 // low nibble used as argument
+#define ASEQ_OP_CHANNEL_STCIO          0x30 // low nibble used as argument
+#define ASEQ_OP_CHANNEL_LDCIO          0x40 // low nibble used as argument
+#define ASEQ_OP_CHANNEL_SUBIO          0x50 // low nibble used as argument
+#define ASEQ_OP_CHANNEL_LDIO           0x60 // low nibble used as argument
+#define ASEQ_OP_CHANNEL_STIO           0x70 // lower 3 bits used as argument
+#define ASEQ_OP_CHANNEL_RLDLAYER       0x78 // lower 3 bits used as argument
+#define ASEQ_OP_CHANNEL_TESTLAYER      0x80 // lower 3 bits used as argument
+#define ASEQ_OP_CHANNEL_LDLAYER        0x88 // lower 3 bits used as argument
+#define ASEQ_OP_CHANNEL_DELLAYER       0x90 // lower 3 bits used as argument
+#define ASEQ_OP_CHANNEL_DYNLDLAYER     0x98 // lower 3 bits used as argument
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OPC_CHANNEL_A0             0xA0
-#define ASEQ_OPC_CHANNEL_A1             0xA1
-#define ASEQ_OPC_CHANNEL_A2             0xA2
-#define ASEQ_OPC_CHANNEL_A3             0xA3
-#define ASEQ_OPC_CHANNEL_A4             0xA4
-#define ASEQ_OPC_CHANNEL_A5             0xA5
-#define ASEQ_OPC_CHANNEL_A6             0xA6
-#define ASEQ_OPC_CHANNEL_A7             0xA7
-#define ASEQ_OPC_CHANNEL_RANDPTR        0xA8
+#define ASEQ_OP_CHANNEL_A0             0xA0
+#define ASEQ_OP_CHANNEL_A1             0xA1
+#define ASEQ_OP_CHANNEL_A2             0xA2
+#define ASEQ_OP_CHANNEL_A3             0xA3
+#define ASEQ_OP_CHANNEL_A4             0xA4
+#define ASEQ_OP_CHANNEL_A5             0xA5
+#define ASEQ_OP_CHANNEL_A6             0xA6
+#define ASEQ_OP_CHANNEL_A7             0xA7
+#define ASEQ_OP_CHANNEL_RANDPTR        0xA8
 #endif
-#define ASEQ_OPC_CHANNEL_LDFILTER       0xB0
-#define ASEQ_OPC_CHANNEL_FREEFILTER     0xB1
-#define ASEQ_OPC_CHANNEL_LDSEQTOPTR     0xB2
-#define ASEQ_OPC_CHANNEL_FILTER         0xB3
-#define ASEQ_OPC_CHANNEL_PTRTODYNTBL    0xB4
-#define ASEQ_OPC_CHANNEL_DYNTBLTOPTR    0xB5
-#define ASEQ_OPC_CHANNEL_DYNTBLV        0xB6
-#define ASEQ_OPC_CHANNEL_RANDTOPTR      0xB7
-#define ASEQ_OPC_CHANNEL_RAND           0xB8
-#define ASEQ_OPC_CHANNEL_RANDVEL        0xB9
-#define ASEQ_OPC_CHANNEL_RANDGATE       0xBA
-#define ASEQ_OPC_CHANNEL_COMBFILTER     0xBB
-#define ASEQ_OPC_CHANNEL_PTRADD         0xBC
+#define ASEQ_OP_CHANNEL_LDFILTER       0xB0
+#define ASEQ_OP_CHANNEL_FREEFILTER     0xB1
+#define ASEQ_OP_CHANNEL_LDSEQTOPTR     0xB2
+#define ASEQ_OP_CHANNEL_FILTER         0xB3
+#define ASEQ_OP_CHANNEL_PTRTODYNTBL    0xB4
+#define ASEQ_OP_CHANNEL_DYNTBLTOPTR    0xB5
+#define ASEQ_OP_CHANNEL_DYNTBLV        0xB6
+#define ASEQ_OP_CHANNEL_RANDTOPTR      0xB7
+#define ASEQ_OP_CHANNEL_RAND           0xB8
+#define ASEQ_OP_CHANNEL_RANDVEL        0xB9
+#define ASEQ_OP_CHANNEL_RANDGATE       0xBA
+#define ASEQ_OP_CHANNEL_COMBFILTER     0xBB
+#define ASEQ_OP_CHANNEL_PTRADD         0xBC
 #if (MML_VERSION == MML_VERSION_OOT)
-#define ASEQ_OPC_CHANNEL_RANDPTR        0xBD
+#define ASEQ_OP_CHANNEL_RANDPTR        0xBD
 #endif
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OPC_CHANNEL_SAMPLESTART    0xBD
-#define ASEQ_OPC_CHANNEL_UNK_BE         0xBE
+#define ASEQ_OP_CHANNEL_SAMPLESTART    0xBD
+#define ASEQ_OP_CHANNEL_UNK_BE         0xBE
 #endif
-#define ASEQ_OPC_CHANNEL_INSTR          0xC1
-#define ASEQ_OPC_CHANNEL_DYNTBL         0xC2
-#define ASEQ_OPC_CHANNEL_SHORT          0xC3
-#define ASEQ_OPC_CHANNEL_NOSHORT        0xC4
-#define ASEQ_OPC_CHANNEL_DYNTBLLOOKUP   0xC5
-#define ASEQ_OPC_CHANNEL_FONT           0xC6
-#define ASEQ_OPC_CHANNEL_STSEQ          0xC7
-#define ASEQ_OPC_CHANNEL_SUB            0xC8
-#define ASEQ_OPC_CHANNEL_AND            0xC9
-#define ASEQ_OPC_CHANNEL_MUTEBHV        0xCA
-#define ASEQ_OPC_CHANNEL_LDSEQ          0xCB
-#define ASEQ_OPC_CHANNEL_LDI            0xCC
-#define ASEQ_OPC_CHANNEL_STOPCHAN       0xCD
-#define ASEQ_OPC_CHANNEL_LDPTR          0xCE
-#define ASEQ_OPC_CHANNEL_STPTRTOSEQ     0xCF
-#define ASEQ_OPC_CHANNEL_EFFECTS        0xD0
-#define ASEQ_OPC_CHANNEL_NOTEALLOC      0xD1
-#define ASEQ_OPC_CHANNEL_SUSTAIN        0xD2
-#define ASEQ_OPC_CHANNEL_BEND           0xD3
-#define ASEQ_OPC_CHANNEL_REVERB         0xD4
-#define ASEQ_OPC_CHANNEL_VIBFREQ        0xD7
-#define ASEQ_OPC_CHANNEL_VIBDEPTH       0xD8
-#define ASEQ_OPC_CHANNEL_RELEASERATE    0xD9
-#define ASEQ_OPC_CHANNEL_ENV            0xDA
-#define ASEQ_OPC_CHANNEL_TRANSPOSE      0xDB
-#define ASEQ_OPC_CHANNEL_PANWEIGHT      0xDC
-#define ASEQ_OPC_CHANNEL_PAN            0xDD
-#define ASEQ_OPC_CHANNEL_FREQSCALE      0xDE
-#define ASEQ_OPC_CHANNEL_VOL            0xDF
-#define ASEQ_OPC_CHANNEL_VOLEXP         0xE0
-#define ASEQ_OPC_CHANNEL_VIBFREQGRAD    0xE1
-#define ASEQ_OPC_CHANNEL_VIBDEPTHGRAD   0xE2
-#define ASEQ_OPC_CHANNEL_VIBDELAY       0xE3
-#define ASEQ_OPC_CHANNEL_DYNCALL        0xE4
-#define ASEQ_OPC_CHANNEL_REVERBIDX      0xE5
-#define ASEQ_OPC_CHANNEL_SAMPLEBOOK     0xE6
-#define ASEQ_OPC_CHANNEL_LDPARAMS       0xE7
-#define ASEQ_OPC_CHANNEL_PARAMS         0xE8
-#define ASEQ_OPC_CHANNEL_NOTEPRI        0xE9
-#define ASEQ_OPC_CHANNEL_STOP           0xEA
-#define ASEQ_OPC_CHANNEL_FONTINSTR      0xEB
-#define ASEQ_OPC_CHANNEL_VIBRESET       0xEC
-#define ASEQ_OPC_CHANNEL_GAIN           0xED
-#define ASEQ_OPC_CHANNEL_BENDFINE       0xEE
-#define ASEQ_OPC_CHANNEL_FREENOTELIST   0xF0
-#define ASEQ_OPC_CHANNEL_ALLOCNOTELIST  0xF1
+#define ASEQ_OP_CHANNEL_INSTR          0xC1
+#define ASEQ_OP_CHANNEL_DYNTBL         0xC2
+#define ASEQ_OP_CHANNEL_SHORT          0xC3
+#define ASEQ_OP_CHANNEL_NOSHORT        0xC4
+#define ASEQ_OP_CHANNEL_DYNTBLLOOKUP   0xC5
+#define ASEQ_OP_CHANNEL_FONT           0xC6
+#define ASEQ_OP_CHANNEL_STSEQ          0xC7
+#define ASEQ_OP_CHANNEL_SUB            0xC8
+#define ASEQ_OP_CHANNEL_AND            0xC9
+#define ASEQ_OP_CHANNEL_MUTEBHV        0xCA
+#define ASEQ_OP_CHANNEL_LDSEQ          0xCB
+#define ASEQ_OP_CHANNEL_LDI            0xCC
+#define ASEQ_OP_CHANNEL_STOPCHAN       0xCD
+#define ASEQ_OP_CHANNEL_LDPTR          0xCE
+#define ASEQ_OP_CHANNEL_STPTRTOSEQ     0xCF
+#define ASEQ_OP_CHANNEL_EFFECTS        0xD0
+#define ASEQ_OP_CHANNEL_NOTEALLOC      0xD1
+#define ASEQ_OP_CHANNEL_SUSTAIN        0xD2
+#define ASEQ_OP_CHANNEL_BEND           0xD3
+#define ASEQ_OP_CHANNEL_REVERB         0xD4
+#define ASEQ_OP_CHANNEL_VIBFREQ        0xD7
+#define ASEQ_OP_CHANNEL_VIBDEPTH       0xD8
+#define ASEQ_OP_CHANNEL_RELEASERATE    0xD9
+#define ASEQ_OP_CHANNEL_ENV            0xDA
+#define ASEQ_OP_CHANNEL_TRANSPOSE      0xDB
+#define ASEQ_OP_CHANNEL_PANWEIGHT      0xDC
+#define ASEQ_OP_CHANNEL_PAN            0xDD
+#define ASEQ_OP_CHANNEL_FREQSCALE      0xDE
+#define ASEQ_OP_CHANNEL_VOL            0xDF
+#define ASEQ_OP_CHANNEL_VOLEXP         0xE0
+#define ASEQ_OP_CHANNEL_VIBFREQGRAD    0xE1
+#define ASEQ_OP_CHANNEL_VIBDEPTHGRAD   0xE2
+#define ASEQ_OP_CHANNEL_VIBDELAY       0xE3
+#define ASEQ_OP_CHANNEL_DYNCALL        0xE4
+#define ASEQ_OP_CHANNEL_REVERBIDX      0xE5
+#define ASEQ_OP_CHANNEL_SAMPLEBOOK     0xE6
+#define ASEQ_OP_CHANNEL_LDPARAMS       0xE7
+#define ASEQ_OP_CHANNEL_PARAMS         0xE8
+#define ASEQ_OP_CHANNEL_NOTEPRI        0xE9
+#define ASEQ_OP_CHANNEL_STOP           0xEA
+#define ASEQ_OP_CHANNEL_FONTINSTR      0xEB
+#define ASEQ_OP_CHANNEL_VIBRESET       0xEC
+#define ASEQ_OP_CHANNEL_GAIN           0xED
+#define ASEQ_OP_CHANNEL_BENDFINE       0xEE
+#define ASEQ_OP_CHANNEL_FREENOTELIST   0xF0
+#define ASEQ_OP_CHANNEL_ALLOCNOTELIST  0xF1
 
 // layer commands
-#define ASEQ_OPC_LAYER_NOTEDVG      0x00
-#define ASEQ_OPC_LAYER_NOTEDV       0x40
-#define ASEQ_OPC_LAYER_NOTEVG       0x80
-#define ASEQ_OPC_LAYER_LDELAY       0xC0
-#define ASEQ_OPC_LAYER_SHORTVEL     0xC1
-#define ASEQ_OPC_LAYER_TRANSPOSE    0xC2
-#define ASEQ_OPC_LAYER_SHORTDELAY   0xC3
-#define ASEQ_OPC_LAYER_LEGATO       0xC4
-#define ASEQ_OPC_LAYER_NOLEGATO     0xC5
-#define ASEQ_OPC_LAYER_INSTR        0xC6
-#define ASEQ_OPC_LAYER_PORTAMENTO   0xC7
-#define ASEQ_OPC_LAYER_NOPORTAMENTO 0xC8
-#define ASEQ_OPC_LAYER_SHORTGATE    0xC9
-#define ASEQ_OPC_LAYER_NOTEPAN      0xCA
-#define ASEQ_OPC_LAYER_ENV          0xCB
-#define ASEQ_OPC_LAYER_NODRUMPAN    0xCC
-#define ASEQ_OPC_LAYER_STEREO       0xCD
-#define ASEQ_OPC_LAYER_BENDFINE     0xCE
-#define ASEQ_OPC_LAYER_RELEASERATE  0xCF
-#define ASEQ_OPC_LAYER_LDSHORTVEL   0xD0 // low nibble used as an argument
-#define ASEQ_OPC_LAYER_LDSHORTGATE  0xE0 // low nibble used as an argument
+#define ASEQ_OP_LAYER_NOTEDVG      0x00
+#define ASEQ_OP_LAYER_NOTEDV       0x40
+#define ASEQ_OP_LAYER_NOTEVG       0x80
+#define ASEQ_OP_LAYER_LDELAY       0xC0
+#define ASEQ_OP_LAYER_SHORTVEL     0xC1
+#define ASEQ_OP_LAYER_TRANSPOSE    0xC2
+#define ASEQ_OP_LAYER_SHORTDELAY   0xC3
+#define ASEQ_OP_LAYER_LEGATO       0xC4
+#define ASEQ_OP_LAYER_NOLEGATO     0xC5
+#define ASEQ_OP_LAYER_INSTR        0xC6
+#define ASEQ_OP_LAYER_PORTAMENTO   0xC7
+#define ASEQ_OP_LAYER_NOPORTAMENTO 0xC8
+#define ASEQ_OP_LAYER_SHORTGATE    0xC9
+#define ASEQ_OP_LAYER_NOTEPAN      0xCA
+#define ASEQ_OP_LAYER_ENV          0xCB
+#define ASEQ_OP_LAYER_NODRUMPAN    0xCC
+#define ASEQ_OP_LAYER_STEREO       0xCD
+#define ASEQ_OP_LAYER_BENDFINE     0xCE
+#define ASEQ_OP_LAYER_RELEASERATE  0xCF
+#define ASEQ_OP_LAYER_LDSHORTVEL   0xD0 // low nibble used as an argument
+#define ASEQ_OP_LAYER_LDSHORTGATE  0xE0 // low nibble used as an argument
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OPC_LAYER_F0           0xF0
-#define ASEQ_OPC_LAYER_F1           0xF1
+#define ASEQ_OP_LAYER_F0           0xF0
+#define ASEQ_OP_LAYER_F1           0xF1
 #endif
 
 
@@ -571,7 +571,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq ioPortNum, seqId, label
-        _wr_cmd_id  ldseq, ASEQ_OPC_SEQUENCE_LDSEQ,,,,,,,, \ioPortNum, 4
+        _wr_cmd_id  ldseq, ASEQ_OP_SEQUENCE_LDSEQ,,,,,,,, \ioPortNum, 4
         _wr_u8      \seqId
         _wr_lbl     \label
     .endm
@@ -589,7 +589,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq label
-        _wr_cmd_id  ldseq, ,ASEQ_OPC_CHANNEL_LDSEQ,,,,,,, 0, 0
+        _wr_cmd_id  ldseq, ,ASEQ_OP_CHANNEL_LDSEQ,,,,,,, 0, 0
         _wr_lbl     \label
     .endm
 
@@ -599,14 +599,14 @@ _RESET_SECTION
         _check_arg_bitwidth_u \lowpassCutoff, 4
         _check_arg_bitwidth_u \highpassCutoff, 4
 
-        _wr_cmd_id filter, ,ASEQ_OPC_CHANNEL_FILTER,,,,,,, 0, 0
+        _wr_cmd_id filter, ,ASEQ_OP_CHANNEL_FILTER,,,,,,, 0, 0
         _wr_u8 (\lowpassCutoff << 4) | (\highpassCutoff)
     .endm
 
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label
-        _wr_cmd_id env, ,ASEQ_OPC_CHANNEL_ENV,,,,,,, 0, 0
+        _wr_cmd_id env, ,ASEQ_OP_CHANNEL_ENV,,,,,,, 0, 0
         _wr_lbl \label
     .endm
 
@@ -623,7 +623,7 @@ _RESET_SECTION
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label, arg
-        _wr_cmd_id env, ,,ASEQ_OPC_LAYER_ENV,,,,,, 0, 0
+        _wr_cmd_id env, ,,ASEQ_OP_LAYER_ENV,,,,,, 0, 0
         _wr_lbl \label
         _wr_u8 \arg
     .endm
@@ -914,7 +914,7 @@ $reladdr\@:
  *  closed, so are its layers.
  */
 .macro end
-    _wr_cmd_id  end, ASEQ_OPC_CTRLFLOW_END,ASEQ_OPC_CTRLFLOW_END,ASEQ_OPC_CTRLFLOW_END,,,,,, 0, 0
+    _wr_cmd_id  end, ASEQ_OP_CTRLFLOW_END,ASEQ_OP_CTRLFLOW_END,ASEQ_OP_CTRLFLOW_END,,,,,, 0, 0
 .endm
 
 /**
@@ -923,7 +923,7 @@ $reladdr\@:
  *  Delays for one tick.
  */
 .macro delay1
-    _wr_cmd_id  delay1, ASEQ_OPC_CTRLFLOW_DELAY1,ASEQ_OPC_CTRLFLOW_DELAY1,,,,,,, 0, 0
+    _wr_cmd_id  delay1, ASEQ_OP_CTRLFLOW_DELAY1,ASEQ_OP_CTRLFLOW_DELAY1,,,,,,, 0, 0
 .endm
 
 /**
@@ -932,7 +932,7 @@ $reladdr\@:
  *  Delays for `delay` ticks.
  */
 .macro delay delay
-    _wr_cmd_id  delay, ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_CTRLFLOW_DELAY,,,,,,, 0, 0
+    _wr_cmd_id  delay, ASEQ_OP_CTRLFLOW_DELAY,ASEQ_OP_CTRLFLOW_DELAY,,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -943,7 +943,7 @@ $reladdr\@:
  *  subroutine encounters an `end` instruction.
  */
 .macro call label
-    _wr_cmd_id  call, ASEQ_OPC_CTRLFLOW_CALL,ASEQ_OPC_CTRLFLOW_CALL,ASEQ_OPC_CTRLFLOW_CALL,,,,,, 0, 0
+    _wr_cmd_id  call, ASEQ_OP_CTRLFLOW_CALL,ASEQ_OP_CTRLFLOW_CALL,ASEQ_OP_CTRLFLOW_CALL,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -953,7 +953,7 @@ $reladdr\@:
  *  Branches to `label` unconditionally.
  */
 .macro jump label
-    _wr_cmd_id  jump, ASEQ_OPC_CTRLFLOW_JUMP,ASEQ_OPC_CTRLFLOW_JUMP,ASEQ_OPC_CTRLFLOW_JUMP,,,,,, 0, 0
+    _wr_cmd_id  jump, ASEQ_OP_CTRLFLOW_JUMP,ASEQ_OP_CTRLFLOW_JUMP,ASEQ_OP_CTRLFLOW_JUMP,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -963,7 +963,7 @@ $reladdr\@:
  *  Branches to `label` if TR == 0.
  */
 .macro beqz label
-    _wr_cmd_id  beqz, ASEQ_OPC_CTRLFLOW_BEQZ,ASEQ_OPC_CTRLFLOW_BEQZ,ASEQ_OPC_CTRLFLOW_BEQZ,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OP_CTRLFLOW_BEQZ,ASEQ_OP_CTRLFLOW_BEQZ,ASEQ_OP_CTRLFLOW_BEQZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -973,7 +973,7 @@ $reladdr\@:
  *  Branches to `label` if TR < 0.
  */
 .macro bltz label
-    _wr_cmd_id  beqz, ASEQ_OPC_CTRLFLOW_BLTZ,ASEQ_OPC_CTRLFLOW_BLTZ,ASEQ_OPC_CTRLFLOW_BLTZ,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OP_CTRLFLOW_BLTZ,ASEQ_OP_CTRLFLOW_BLTZ,ASEQ_OP_CTRLFLOW_BLTZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -987,7 +987,7 @@ $reladdr\@:
  *  becomes full.
  */
 .macro loop num
-    _wr_cmd_id  loop, ASEQ_OPC_CTRLFLOW_LOOP,ASEQ_OPC_CTRLFLOW_LOOP,ASEQ_OPC_CTRLFLOW_LOOP,,,,,, 0, 0
+    _wr_cmd_id  loop, ASEQ_OP_CTRLFLOW_LOOP,ASEQ_OP_CTRLFLOW_LOOP,ASEQ_OP_CTRLFLOW_LOOP,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -1001,7 +1001,7 @@ $reladdr\@:
  *  stack is popped.
  */
 .macro loopend
-    _wr_cmd_id  loopend, ASEQ_OPC_CTRLFLOW_LOOPEND,ASEQ_OPC_CTRLFLOW_LOOPEND,ASEQ_OPC_CTRLFLOW_LOOPEND,,,,,, 0, 0
+    _wr_cmd_id  loopend, ASEQ_OP_CTRLFLOW_LOOPEND,ASEQ_OP_CTRLFLOW_LOOPEND,ASEQ_OP_CTRLFLOW_LOOPEND,,,,,, 0, 0
 .endm
 
 /**
@@ -1014,7 +1014,7 @@ $reladdr\@:
  *  the call stack would be popped twice.
  */
 .macro break
-    _wr_cmd_id  break, ASEQ_OPC_CTRLFLOW_BREAK,ASEQ_OPC_CTRLFLOW_BREAK,ASEQ_OPC_CTRLFLOW_BREAK,,,,,, 0, 0
+    _wr_cmd_id  break, ASEQ_OP_CTRLFLOW_BREAK,ASEQ_OP_CTRLFLOW_BREAK,ASEQ_OP_CTRLFLOW_BREAK,,,,,, 0, 0
 .endm
 
 /**
@@ -1023,7 +1023,7 @@ $reladdr\@:
  *  Branches to `label` if TR >= 0.
  */
 .macro bgez label
-    _wr_cmd_id  bgez, ASEQ_OPC_CTRLFLOW_BGEZ,ASEQ_OPC_CTRLFLOW_BGEZ,ASEQ_OPC_CTRLFLOW_BGEZ,,,,,, 0, 0
+    _wr_cmd_id  bgez, ASEQ_OP_CTRLFLOW_BGEZ,ASEQ_OP_CTRLFLOW_BGEZ,ASEQ_OP_CTRLFLOW_BGEZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1037,7 +1037,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rjump label
-    _wr_cmd_id  rjump, ASEQ_OPC_CTRLFLOW_RJUMP,ASEQ_OPC_CTRLFLOW_RJUMP,ASEQ_OPC_CTRLFLOW_RJUMP,,,,,, 0, 0
+    _wr_cmd_id  rjump, ASEQ_OP_CTRLFLOW_RJUMP,ASEQ_OP_CTRLFLOW_RJUMP,ASEQ_OP_CTRLFLOW_RJUMP,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1051,7 +1051,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbeqz label
-    _wr_cmd_id  rbeqz, ASEQ_OPC_CTRLFLOW_RBEQZ,ASEQ_OPC_CTRLFLOW_RBEQZ,ASEQ_OPC_CTRLFLOW_RBEQZ,,,,,, 0, 0
+    _wr_cmd_id  rbeqz, ASEQ_OP_CTRLFLOW_RBEQZ,ASEQ_OP_CTRLFLOW_RBEQZ,ASEQ_OP_CTRLFLOW_RBEQZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1065,7 +1065,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbltz label
-    _wr_cmd_id  rbltz, ASEQ_OPC_CTRLFLOW_RBLTZ,ASEQ_OPC_CTRLFLOW_RBLTZ,ASEQ_OPC_CTRLFLOW_RBLTZ,,,,,, 0, 0
+    _wr_cmd_id  rbltz, ASEQ_OP_CTRLFLOW_RBLTZ,ASEQ_OP_CTRLFLOW_RBLTZ,ASEQ_OP_CTRLFLOW_RBLTZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1075,7 +1075,7 @@ $reladdr\@:
  *  Clears the channel note pool and reallocates it with space for `num` notes.
  */
 .macro allocnotelist num
-    _wr_cmd_id  allocnotelist, ASEQ_OPC_SEQUENCE_ALLOCNOTELIST,ASEQ_OPC_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  allocnotelist, ASEQ_OP_SEQUENCE_ALLOCNOTELIST,ASEQ_OP_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -1085,7 +1085,7 @@ $reladdr\@:
  *  Clears the channel note pool.
  */
 .macro freenotelist
-    _wr_cmd_id  freenotelist, ASEQ_OPC_SEQUENCE_FREENOTELIST,ASEQ_OPC_CHANNEL_FREENOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  freenotelist, ASEQ_OP_SEQUENCE_FREENOTELIST,ASEQ_OP_CHANNEL_FREENOTELIST,,,,,,, 0, 0
 .endm
 
 /**
@@ -1094,7 +1094,7 @@ $reladdr\@:
  *  Has no function.
  */
 .macro unk_EF arg1, arg2
-    _wr_cmd_id  unk_EF, ASEQ_OPC_SEQUENCE_EF,,,,,,,, 0, 0
+    _wr_cmd_id  unk_EF, ASEQ_OP_SEQUENCE_EF,,,,,,,, 0, 0
     _wr_s16     \arg1
     _w_u8       \arg2
 .endm
@@ -1105,7 +1105,7 @@ $reladdr\@:
  *  Fine-tunes the pitch bend amount for the channel or layer.
  */
 .macro bendfine amt
-    _wr_cmd_id  bendfine, ,ASEQ_OPC_CHANNEL_BENDFINE,ASEQ_OPC_LAYER_BENDFINE,,,,,, 0, 0
+    _wr_cmd_id  bendfine, ,ASEQ_OP_CHANNEL_BENDFINE,ASEQ_OP_LAYER_BENDFINE,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1115,7 +1115,7 @@ $reladdr\@:
  *  Sets the channel gain (multiplicative volume scale factor) to the provided qu4.4 fixed-point value.
  */
 .macro gain value
-    _wr_cmd_id  gain, ,ASEQ_OPC_CHANNEL_GAIN,,,,,,, 0, 0
+    _wr_cmd_id  gain, ,ASEQ_OP_CHANNEL_GAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1125,7 +1125,7 @@ $reladdr\@:
  *  Resets channel vibrato, filter, gain, sustain, etc. state.
  */
 .macro vibreset
-    _wr_cmd_id  vibreset, ,ASEQ_OPC_CHANNEL_VIBRESET,,,,,,, 0, 0
+    _wr_cmd_id  vibreset, ,ASEQ_OP_CHANNEL_VIBRESET,,,,,,, 0, 0
 .endm
 
 /**
@@ -1134,7 +1134,7 @@ $reladdr\@:
  *  Updates the soundfont and instrument for the channel simultaneously.
  */
 .macro fontinstr fontId, instId
-    _wr_cmd_id  fontinstr, ,ASEQ_OPC_CHANNEL_FONTINSTR,,,,,,, 0, 0
+    _wr_cmd_id  fontinstr, ,ASEQ_OP_CHANNEL_FONTINSTR,,,,,,, 0, 0
     _wr_u8      \fontId
     _wr_u8      \instId
 .endm
@@ -1147,7 +1147,7 @@ $reladdr\@:
 .macro notepri priority1, priority2
     _check_arg_bitwidth_u \priority1, 4
     _check_arg_bitwidth_u \priority2, 4
-    _wr_cmd_id  notepri, ,ASEQ_OPC_CHANNEL_NOTEPRI,,,,,,, 0, 0
+    _wr_cmd_id  notepri, ,ASEQ_OP_CHANNEL_NOTEPRI,,,,,,, 0, 0
     _wr_u8      (\priority1 << 4) | \priority2
 .endm
 
@@ -1158,7 +1158,7 @@ $reladdr\@:
  *  Sets various channel parameters.
  */
 .macro params muteBhv, noteAllocPolicy, channelPriority, transposition, pan, panWeight, reverb, reverbIndex
-    _wr_cmd_id  params, ,ASEQ_OPC_CHANNEL_PARAMS,,,,,,, 0, 0
+    _wr_cmd_id  params, ,ASEQ_OP_CHANNEL_PARAMS,,,,,,, 0, 0
     _wr_u8      \muteBhv
     _wr_u8      \noteAllocPolicy
     _wr_u8      \channelPriority
@@ -1176,7 +1176,7 @@ $reladdr\@:
  *  is ordered in the same way as the arguments in `params`.
  */
 .macro ldparams label
-    _wr_cmd_id  ldparams, ,ASEQ_OPC_CHANNEL_LDPARAMS,,,,,,, 0, 0
+    _wr_cmd_id  ldparams, ,ASEQ_OP_CHANNEL_LDPARAMS,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1186,7 +1186,7 @@ $reladdr\@:
  *  Sets the sample book mode.
  */
 .macro samplebook value
-    _wr_cmd_id  samplebook, ,ASEQ_OPC_CHANNEL_SAMPLEBOOK,,,,,,, 0, 0
+    _wr_cmd_id  samplebook, ,ASEQ_OP_CHANNEL_SAMPLEBOOK,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1196,7 +1196,7 @@ $reladdr\@:
  *  Sets the channel reverb.
  */
 .macro reverbidx arg
-    _wr_cmd_id  reverbidx, ,ASEQ_OPC_CHANNEL_REVERBIDX,,,,,,, 0, 0
+    _wr_cmd_id  reverbidx, ,ASEQ_OP_CHANNEL_REVERBIDX,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1206,7 +1206,7 @@ $reladdr\@:
  *  Sets the channel vibrato delay.
  */
 .macro vibdelay arg
-    _wr_cmd_id  vibdelay, ,ASEQ_OPC_CHANNEL_VIBDELAY,,,,,,, 0, 0
+    _wr_cmd_id  vibdelay, ,ASEQ_OP_CHANNEL_VIBDELAY,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1216,7 +1216,7 @@ $reladdr\@:
  *  Sets the vibrato extent.
  */
 .macro vibdepthgrad arg0, arg1, arg2
-    _wr_cmd_id  vibdepthgrad, ,ASEQ_OPC_CHANNEL_VIBDEPTHGRAD,,,,,,, 0, 0
+    _wr_cmd_id  vibdepthgrad, ,ASEQ_OP_CHANNEL_VIBDEPTHGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1228,7 +1228,7 @@ $reladdr\@:
  *  Sets the vibrato rate.
  */
 .macro vibfreqgrad arg0, arg1, arg2
-    _wr_cmd_id  vibfreqgrad, ,ASEQ_OPC_CHANNEL_VIBFREQGRAD,,,,,,, 0, 0
+    _wr_cmd_id  vibfreqgrad, ,ASEQ_OP_CHANNEL_VIBFREQGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1240,7 +1240,7 @@ $reladdr\@:
  *  Changes the expression amount for the channel.
  */
 .macro volexp amt
-    _wr_cmd_id  volexp, ,ASEQ_OPC_CHANNEL_VOLEXP,,,,,,, 0, 0
+    _wr_cmd_id  volexp, ,ASEQ_OP_CHANNEL_VOLEXP,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1251,7 +1251,7 @@ $reladdr\@:
  *  provided number of semitones.
  */
 .macro transpose semitones
-    _wr_cmd_id  transpose, ASEQ_OPC_SEQUENCE_TRANSPOSE,ASEQ_OPC_CHANNEL_TRANSPOSE,ASEQ_OPC_LAYER_TRANSPOSE,,,,,, 0, 0
+    _wr_cmd_id  transpose, ASEQ_OP_SEQUENCE_TRANSPOSE,ASEQ_OP_CHANNEL_TRANSPOSE,ASEQ_OP_LAYER_TRANSPOSE,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1261,7 +1261,7 @@ $reladdr\@:
  *  Adjusts the transposition amount. This is only available at the top sequence level.
  */
 .macro rtranspose semitones
-    _wr_cmd_id  rtranspose, ASEQ_OPC_SEQUENCE_RTRANSPOSE,,,,,,,, 0, 0
+    _wr_cmd_id  rtranspose, ASEQ_OP_SEQUENCE_RTRANSPOSE,,,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1271,7 +1271,7 @@ $reladdr\@:
  *  Sets the freqScale for the current channel.
  */
 .macro freqscale arg
-    _wr_cmd_id  freqscale, ,ASEQ_OPC_CHANNEL_FREQSCALE,,,,,,, 0, 0
+    _wr_cmd_id  freqscale, ,ASEQ_OP_CHANNEL_FREQSCALE,,,,,,, 0, 0
     _wr_s16     \arg
 .endm
 
@@ -1281,7 +1281,7 @@ $reladdr\@:
  *  Changes the tempo of the sequence.
  */
 .macro tempo bpm
-    _wr_cmd_id  tempo, ASEQ_OPC_SEQUENCE_TEMPO,,,,,,,, 0, 0
+    _wr_cmd_id  tempo, ASEQ_OP_SEQUENCE_TEMPO,,,,,,,, 0, 0
     _wr_u8      \bpm
 .endm
 
@@ -1291,7 +1291,7 @@ $reladdr\@:
  *  Sets the tempoChange for the sequence.
  */
 .macro tempochg arg
-    _wr_cmd_id  tempochg, ASEQ_OPC_SEQUENCE_TEMPOCHG,,,,,,,, 0, 0
+    _wr_cmd_id  tempochg, ASEQ_OP_SEQUENCE_TEMPOCHG,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1303,7 +1303,7 @@ $reladdr\@:
 .macro pan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  pan, ,ASEQ_OPC_CHANNEL_PAN,,,,,,, 0, 0
+    _wr_cmd_id  pan, ,ASEQ_OP_CHANNEL_PAN,,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -1319,7 +1319,7 @@ $reladdr\@:
 .macro panweight weight
     /* weight can only take values in 0..127 */
     _check_arg_bitwidth_u \weight, 7
-    _wr_cmd_id  panweight, ,ASEQ_OPC_CHANNEL_PANWEIGHT,,,,,,, 0, 0
+    _wr_cmd_id  panweight, ,ASEQ_OP_CHANNEL_PANWEIGHT,,,,,,, 0, 0
     _wr_u8      \weight
 .endm
 
@@ -1329,7 +1329,7 @@ $reladdr\@:
  *  Sets the volume amount for this sequence or channel.
  */
 .macro vol amt
-    _wr_cmd_id  vol, ASEQ_OPC_SEQUENCE_VOL,ASEQ_OPC_CHANNEL_VOL,,,,,,, 0, 0
+    _wr_cmd_id  vol, ASEQ_OP_SEQUENCE_VOL,ASEQ_OP_CHANNEL_VOL,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1339,7 +1339,7 @@ $reladdr\@:
  *  TODO DESCRIPTION
  */
 .macro volmode mode, fadeTimer
-    _wr_cmd_id  volmode, ASEQ_OPC_SEQUENCE_VOLMODE,,,,,,,, 0, 0
+    _wr_cmd_id  volmode, ASEQ_OP_SEQUENCE_VOLMODE,,,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u16     \fadeTimer
 .endm
@@ -1350,7 +1350,7 @@ $reladdr\@:
  *  Sets the fadeVolumeScale for the sequence.
  */
 .macro volscale arg
-    _wr_cmd_id  volscale, ASEQ_OPC_SEQUENCE_VOLSCALE,,,,,,,, 0, 0
+    _wr_cmd_id  volscale, ASEQ_OP_SEQUENCE_VOLSCALE,,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1360,7 +1360,7 @@ $reladdr\@:
  *  Sets the envelope release rate for this channel or layer.
  */
 .macro releaserate release
-    _wr_cmd_id  releaserate, ,ASEQ_OPC_CHANNEL_RELEASERATE,ASEQ_OPC_LAYER_RELEASERATE,,,,,, 0, 0
+    _wr_cmd_id  releaserate, ,ASEQ_OP_CHANNEL_RELEASERATE,ASEQ_OP_LAYER_RELEASERATE,,,,,, 0, 0
     _wr_u8      \release
 .endm
 
@@ -1370,7 +1370,7 @@ $reladdr\@:
  *  Sets the vibrato depth for the channel.
  */
 .macro vibdepth arg
-    _wr_cmd_id  vibdepth, ,ASEQ_OPC_CHANNEL_VIBDEPTH,,,,,,, 0, 0
+    _wr_cmd_id  vibdepth, ,ASEQ_OP_CHANNEL_VIBDEPTH,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1380,7 +1380,7 @@ $reladdr\@:
  *  Sets the vibrato rate for the channel.
  */
 .macro vibfreq arg
-    _wr_cmd_id  vibfreq, ,ASEQ_OPC_CHANNEL_VIBFREQ,,,,,,, 0, 0
+    _wr_cmd_id  vibfreq, ,ASEQ_OP_CHANNEL_VIBFREQ,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1393,7 +1393,7 @@ $reladdr\@:
  *       initchan 0b101 initializes channels 0 and 2.
  */
 .macro initchan bitmask
-    _wr_cmd_id  initchan, ASEQ_OPC_SEQUENCE_INITCHAN,,,,,,,, 0, 0
+    _wr_cmd_id  initchan, ASEQ_OP_SEQUENCE_INITCHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1403,7 +1403,7 @@ $reladdr\@:
  *  Frees the channels marked in the provided bitmask.
  */
 .macro freechan bitmask
-    _wr_cmd_id  freechan, ASEQ_OPC_SEQUENCE_FREECHAN,,,,,,,, 0, 0
+    _wr_cmd_id  freechan, ASEQ_OP_SEQUENCE_FREECHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1413,7 +1413,7 @@ $reladdr\@:
  *  Sets the muteVolumeScale for the sequence.
  */
 .macro mutescale arg
-    _wr_cmd_id  mutescale, ASEQ_OPC_SEQUENCE_MUTESCALE,,,,,,,, 0, 0
+    _wr_cmd_id  mutescale, ASEQ_OP_SEQUENCE_MUTESCALE,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1423,7 +1423,7 @@ $reladdr\@:
  *  Mutes the sequence player.
  */
 .macro mute
-    _wr_cmd_id  mute, ASEQ_OPC_SEQUENCE_MUTE,,,,,,,, 0, 0
+    _wr_cmd_id  mute, ASEQ_OP_SEQUENCE_MUTE,,,,,,,, 0, 0
 .endm
 
 /**
@@ -1432,7 +1432,7 @@ $reladdr\@:
  *  Sets the reverb amount for this channel.
  */
 .macro reverb amt
-    _wr_cmd_id  reverb, ,ASEQ_OPC_CHANNEL_REVERB,,,,,,, 0, 0
+    _wr_cmd_id  reverb, ,ASEQ_OP_CHANNEL_REVERB,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1442,7 +1442,7 @@ $reladdr\@:
  *  Sets mute behavior for this sequence or channel.
  */
 .macro mutebhv flags
-    _wr_cmd_id  mutebhv, ASEQ_OPC_SEQUENCE_MUTEBHV,ASEQ_OPC_CHANNEL_MUTEBHV,,,,,,, 0, 0
+    _wr_cmd_id  mutebhv, ASEQ_OP_SEQUENCE_MUTEBHV,ASEQ_OP_CHANNEL_MUTEBHV,,,,,,, 0, 0
     _wr_u8      \flags
 .endm
 
@@ -1452,7 +1452,7 @@ $reladdr\@:
  *  Sets the pitch bend amount for this channel.
  */
 .macro bend amt
-    _wr_cmd_id  bend, ,ASEQ_OPC_CHANNEL_BEND,,,,,,, 0, 0
+    _wr_cmd_id  bend, ,ASEQ_OP_CHANNEL_BEND,,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1462,7 +1462,7 @@ $reladdr\@:
  *  Sets the location of SHORTVELTBL.
  */
 .macro ldshortvelarr label
-    _wr_cmd_id  ldshortvelarr, ASEQ_OPC_SEQUENCE_LDSHORTVELARR,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortvelarr, ASEQ_OP_SEQUENCE_LDSHORTVELARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1472,7 +1472,7 @@ $reladdr\@:
  *  Sets the adsr sustain value for this channel.
  */
 .macro sustain value
-    _wr_cmd_id  sustain, ,ASEQ_OPC_CHANNEL_SUSTAIN,,,,,,, 0, 0
+    _wr_cmd_id  sustain, ,ASEQ_OP_CHANNEL_SUSTAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1482,7 +1482,7 @@ $reladdr\@:
  *  Sets the location of SHORTGATETBL.
  */
 .macro ldshortgatearr label
-    _wr_cmd_id  ldshortgatearr, ASEQ_OPC_SEQUENCE_LDSHORTGATEARR,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortgatearr, ASEQ_OP_SEQUENCE_LDSHORTGATEARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1492,7 +1492,7 @@ $reladdr\@:
  *  Sets the noteAllocPolicy for either the sequence or the current channel.
  */
 .macro notealloc arg
-    _wr_cmd_id  notealloc, ASEQ_OPC_SEQUENCE_NOTEALLOC,ASEQ_OPC_CHANNEL_NOTEALLOC,,,,,,, 0, 0
+    _wr_cmd_id  notealloc, ASEQ_OP_SEQUENCE_NOTEALLOC,ASEQ_OP_CHANNEL_NOTEALLOC,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1509,7 +1509,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  effects, ,ASEQ_OPC_CHANNEL_EFFECTS,,,,,,, 0, 0
+    _wr_cmd_id  effects, ,ASEQ_OP_CHANNEL_EFFECTS,,,,,,, 0, 0
     _wr_u8      (\headset << 7) | (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -1519,7 +1519,7 @@ $reladdr\@:
  *  Stores TP -> label
  */
 .macro stptrtoseq label
-    _wr_cmd_id  stptrtoseq, ,ASEQ_OPC_CHANNEL_STPTRTOSEQ,,,,,,, 0, 0
+    _wr_cmd_id  stptrtoseq, ,ASEQ_OP_CHANNEL_STPTRTOSEQ,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1529,7 +1529,7 @@ $reladdr\@:
  *  Loads label -> TP
  */
 .macro ldptr label
-    _wr_cmd_id  ldptr, ,ASEQ_OPC_CHANNEL_LDPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OP_CHANNEL_LDPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1539,7 +1539,7 @@ $reladdr\@:
  *  Loads imm -> TP
  */
 .macro ldptri imm
-    _wr_cmd_id  ldptr, ,ASEQ_OPC_CHANNEL_LDPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OP_CHANNEL_LDPTR,,,,,,, 0, 0
     _wr_u16     \imm
 .endm
 
@@ -1549,7 +1549,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TR. If max is 0 the range is [0, 255]
  */
 .macro rand max
-    _wr_cmd_id  rand, ASEQ_OPC_SEQUENCE_RAND,ASEQ_OPC_CHANNEL_RAND,,,,,,, 0, 0
+    _wr_cmd_id  rand, ASEQ_OP_SEQUENCE_RAND,ASEQ_OP_CHANNEL_RAND,,,,,,, 0, 0
     _wr_u8      \max
 .endm
 
@@ -1564,9 +1564,9 @@ $reladdr\@:
  */
 .macro dyncall table=-1
     .if \table == -1
-        _wr_cmd_id  dyncall, ,ASEQ_OPC_CHANNEL_DYNCALL,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ,ASEQ_OP_CHANNEL_DYNCALL,,,,,,, 0, 0
     .else
-        _wr_cmd_id  dyncall, ASEQ_OPC_SEQUENCE_DYNCALL,,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ASEQ_OP_SEQUENCE_DYNCALL,,,,,,,, 0, 0
         _wr_lbl     \table
     .endif
 .endm
@@ -1577,7 +1577,7 @@ $reladdr\@:
  *  Loads the immediate value `imm` into TR.
  */
 .macro ldi imm
-    _wr_cmd_id  ldi, ASEQ_OPC_SEQUENCE_LDI,ASEQ_OPC_CHANNEL_LDI,,,,,,, 0, 0
+    _wr_cmd_id  ldi, ASEQ_OP_SEQUENCE_LDI,ASEQ_OP_CHANNEL_LDI,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1587,7 +1587,7 @@ $reladdr\@:
  *  Computes TR = TR & imm
  */
 .macro and imm
-    _wr_cmd_id  and, ASEQ_OPC_SEQUENCE_AND,ASEQ_OPC_CHANNEL_AND,,,,,,, 0, 0
+    _wr_cmd_id  and, ASEQ_OP_SEQUENCE_AND,ASEQ_OP_CHANNEL_AND,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1597,7 +1597,7 @@ $reladdr\@:
  *  Computes TR = TR - imm
  */
 .macro sub imm
-    _wr_cmd_id  sub, ASEQ_OPC_SEQUENCE_SUB,ASEQ_OPC_CHANNEL_SUB,,,,,,, 0, 0
+    _wr_cmd_id  sub, ASEQ_OP_SEQUENCE_SUB,ASEQ_OP_CHANNEL_SUB,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1607,7 +1607,7 @@ $reladdr\@:
  *  Stores the u8 value `TR + imm` to the location specified by `label`.
  */
 .macro stseq imm, label
-    _wr_cmd_id  stseq, ASEQ_OPC_SEQUENCE_STSEQ,ASEQ_OPC_CHANNEL_STSEQ,,,,,,, 0, 0
+    _wr_cmd_id  stseq, ASEQ_OP_SEQUENCE_STSEQ,ASEQ_OP_CHANNEL_STSEQ,,,,,,, 0, 0
     _wr_u8      \imm
     _wr_lbl     \label
 .endm
@@ -1618,7 +1618,7 @@ $reladdr\@:
  *  Immediately stops the sequence or channel.
  */
 .macro stop
-    _wr_cmd_id  stop, ASEQ_OPC_SEQUENCE_STOP,ASEQ_OPC_CHANNEL_STOP,,,,,,, 0, 0
+    _wr_cmd_id  stop, ASEQ_OP_SEQUENCE_STOP,ASEQ_OP_CHANNEL_STOP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1627,7 +1627,7 @@ $reladdr\@:
  *  Set the current soundfont for this channel to `fontId`.
  */
 .macro font fontId
-    _wr_cmd_id  font, ,ASEQ_OPC_CHANNEL_FONT,,,,,,, 0, 0
+    _wr_cmd_id  font, ,ASEQ_OP_CHANNEL_FONT,,,,,,, 0, 0
     _wr_u8      \fontId
 .endm
 
@@ -1640,7 +1640,7 @@ $reladdr\@:
  *  never used, so changing it with this instruction has no useful effects.
  */
 .macro scriptctr arg
-    _wr_cmd_id  scriptctr, ASEQ_OPC_SEQUENCE_SCRIPTCTR,,,,,,,, 0, 0
+    _wr_cmd_id  scriptctr, ASEQ_OP_SEQUENCE_SCRIPTCTR,,,,,,,, 0, 0
     _wr_u16     \arg
 .endm
 
@@ -1651,7 +1651,7 @@ $reladdr\@:
  *  unless TR is -1, in which case nothing happens.
  */
 .macro dyntbllookup
-    _wr_cmd_id  dyntbllookup, ,ASEQ_OPC_CHANNEL_DYNTBLLOOKUP,,,,,,, 0, 0
+    _wr_cmd_id  dyntbllookup, ,ASEQ_OP_CHANNEL_DYNTBLLOOKUP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1660,7 +1660,7 @@ $reladdr\@:
  *  Plays the sequence seqId on seqPlayer.
  */
 .macro runseq seqPlayer, seqId
-    _wr_cmd_id  runseq, ASEQ_OPC_SEQUENCE_RUNSEQ,,,,,,,, 0, 0
+    _wr_cmd_id  runseq, ASEQ_OP_SEQUENCE_RUNSEQ,,,,,,,, 0, 0
     _wr_u8      \seqPlayer
     _wr_u8      \seqId
 .endm
@@ -1673,7 +1673,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro mutechan arg0
-        _wr_cmd_id  mutechan, ASEQ_OPC_SEQUENCE_C3,,,,,,,, 0, 0
+        _wr_cmd_id  mutechan, ASEQ_OP_SEQUENCE_C3,,,,,,,, 0, 0
         _wr_s16     \arg0
     .endm
 
@@ -1685,7 +1685,7 @@ $reladdr\@:
  *  Disable short notes encoding.
  */
 .macro noshort
-    _wr_cmd_id  noshort, ,ASEQ_OPC_CHANNEL_NOSHORT,,,,,,, 0, 0
+    _wr_cmd_id  noshort, ,ASEQ_OP_CHANNEL_NOSHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1694,7 +1694,7 @@ $reladdr\@:
  *  Enable short notes encoding.
  */
 .macro short
-    _wr_cmd_id  short, ,ASEQ_OPC_CHANNEL_SHORT,,,,,,, 0, 0
+    _wr_cmd_id  short, ,ASEQ_OP_CHANNEL_SHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1703,7 +1703,7 @@ $reladdr\@:
  *  Loads label -> DYNTBL
  */
 .macro dyntbl label
-    _wr_cmd_id  dyntbl, ,ASEQ_OPC_CHANNEL_DYNTBL,,,,,,, 0, 0
+    _wr_cmd_id  dyntbl, ,ASEQ_OP_CHANNEL_DYNTBL,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1713,7 +1713,7 @@ $reladdr\@:
  *  Set instrument `instNum` from the current soundfont as the active instrument for this channel or layer.
  */
 .macro instr instNum
-    _wr_cmd_id  instr, ,ASEQ_OPC_CHANNEL_INSTR,ASEQ_OPC_LAYER_INSTR,,,,,, 0, 0
+    _wr_cmd_id  instr, ,ASEQ_OP_CHANNEL_INSTR,ASEQ_OP_LAYER_INSTR,,,,,, 0, 0
     _wr_u8      \instNum
 .endm
 
@@ -1725,7 +1725,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_BE arg0
-        _wr_cmd_id  unk_BE, ,ASEQ_OPC_CHANNEL_UNK_BE,,,,,,, 0, 0
+        _wr_cmd_id  unk_BE, ,ASEQ_OP_CHANNEL_UNK_BE,,,,,,, 0, 0
         _wr_u8      \arg0
     .endm
 
@@ -1739,7 +1739,7 @@ $reladdr\@:
  *  If range is 0, it is treated as 65536.
  */
 .macro randptr range, offset
-    _wr_cmd_id  randptr, ,ASEQ_OPC_CHANNEL_RANDPTR,,,,,,, 0, 0
+    _wr_cmd_id  randptr, ,ASEQ_OP_CHANNEL_RANDPTR,,,,,,, 0, 0
     _wr_u16     \range
     _wr_u16     \offset
 .endm
@@ -1752,7 +1752,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro samplestart arg
-        _wr_cmd_id  samplestart, ,ASEQ_OPC_CHANNEL_SAMPLESTART,,,,,,, 0, 0
+        _wr_cmd_id  samplestart, ,ASEQ_OP_CHANNEL_SAMPLESTART,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1762,7 +1762,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A7 arg
-        _wr_cmd_id  unk_A7, ,ASEQ_OPC_CHANNEL_A7,,,,,,, 0, 0
+        _wr_cmd_id  unk_A7, ,ASEQ_OP_CHANNEL_A7,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1772,7 +1772,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A6 arg0, arg1
-        _wr_cmd_id  unk_A6, ,ASEQ_OPC_CHANNEL_A6,,,,,,, 0, 0
+        _wr_cmd_id  unk_A6, ,ASEQ_OP_CHANNEL_A6,,,,,,, 0, 0
         _wr_u8      \arg0
         _wr_s16     \arg1
     .endm
@@ -1783,7 +1783,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A5
-        _wr_cmd_id  unk_A5, ,ASEQ_OPC_CHANNEL_A5,,,,,,, 0, 0
+        _wr_cmd_id  unk_A5, ,ASEQ_OP_CHANNEL_A5,,,,,,, 0, 0
     .endm
 
     /**
@@ -1792,7 +1792,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A4 arg
-        _wr_cmd_id  unk_A4, ,ASEQ_OPC_CHANNEL_A4,,,,,,, 0, 0
+        _wr_cmd_id  unk_A4, ,ASEQ_OP_CHANNEL_A4,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1802,7 +1802,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A3
-        _wr_cmd_id  unk_A3, ,ASEQ_OPC_CHANNEL_A3,,,,,,, 0, 0
+        _wr_cmd_id  unk_A3, ,ASEQ_OP_CHANNEL_A3,,,,,,, 0, 0
     .endm
 
     /**
@@ -1811,7 +1811,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A2 arg
-        _wr_cmd_id  unk_A2, ,ASEQ_OPC_CHANNEL_A2,,,,,,, 0, 0
+        _wr_cmd_id  unk_A2, ,ASEQ_OP_CHANNEL_A2,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1821,7 +1821,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A1
-        _wr_cmd_id  unk_A1, ,ASEQ_OPC_CHANNEL_A1,,,,,,, 0, 0
+        _wr_cmd_id  unk_A1, ,ASEQ_OP_CHANNEL_A1,,,,,,, 0, 0
     .endm
 
     /**
@@ -1830,7 +1830,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A0 arg
-        _wr_cmd_id  unk_A0, ,ASEQ_OPC_CHANNEL_A0,,,,,,, 0, 0
+        _wr_cmd_id  unk_A0, ,ASEQ_OP_CHANNEL_A0,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1842,7 +1842,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptradd value
-    _wr_cmd_id  ptradd, ,ASEQ_OPC_CHANNEL_PTRADD,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OP_CHANNEL_PTRADD,,,,,,, 0, 0
     _wr_lbl     \value
 .endm
 
@@ -1854,7 +1854,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptraddi value
-    _wr_cmd_id  ptradd, ,ASEQ_OPC_CHANNEL_PTRADD,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OP_CHANNEL_PTRADD,,,,,,, 0, 0
     _wr_u16     \value
 .endm
 
@@ -1865,7 +1865,7 @@ $reladdr\@:
  *  TODO args? arg0=16,arg1=val<<8 maps well to midi chorus
  */
 .macro combfilter arg0, arg1
-    _wr_cmd_id  combfilter, ,ASEQ_OPC_CHANNEL_COMBFILTER,,,,,,, 0, 0
+    _wr_cmd_id  combfilter, ,ASEQ_OP_CHANNEL_COMBFILTER,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u16     \arg1
 .endm
@@ -1878,7 +1878,7 @@ $reladdr\@:
  *  NOTE: This feature is bugged. If this is non-zero it will actually use the range set by randvel.
  */
 .macro randgate range
-    _wr_cmd_id  randgate, ,ASEQ_OPC_CHANNEL_RANDGATE,,,,,,, 0, 0
+    _wr_cmd_id  randgate, ,ASEQ_OP_CHANNEL_RANDGATE,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1888,7 +1888,7 @@ $reladdr\@:
  *  Sets the range for random note velocity fluctuations.
  */
 .macro randvel range
-    _wr_cmd_id  randvel, ,ASEQ_OPC_CHANNEL_RANDVEL,,,,,,, 0, 0
+    _wr_cmd_id  randvel, ,ASEQ_OP_CHANNEL_RANDVEL,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1898,7 +1898,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TP. If max is 0 the range is [0, 65535]
  */
 .macro randtoptr max
-    _wr_cmd_id  randtoptr, ,ASEQ_OPC_CHANNEL_RANDTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  randtoptr, ,ASEQ_OP_CHANNEL_RANDTOPTR,,,,,,, 0, 0
     _wr_u16     \max
 .endm
 
@@ -1908,7 +1908,7 @@ $reladdr\@:
  *  Loads DYNTBL8[TR] -> TR
  */
 .macro dyntblv
-    _wr_cmd_id  dyntblv, ,ASEQ_OPC_CHANNEL_DYNTBLV,,,,,,, 0, 0
+    _wr_cmd_id  dyntblv, ,ASEQ_OP_CHANNEL_DYNTBLV,,,,,,, 0, 0
 .endm
 
 /**
@@ -1917,7 +1917,7 @@ $reladdr\@:
  *  Loads DYNTBL16[TR] -> TP
  */
 .macro dyntbltoptr
-    _wr_cmd_id  dyntbltoptr, ,ASEQ_OPC_CHANNEL_DYNTBLTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  dyntbltoptr, ,ASEQ_OP_CHANNEL_DYNTBLTOPTR,,,,,,, 0, 0
 .endm
 
 /**
@@ -1926,7 +1926,7 @@ $reladdr\@:
  *  Transfers TP -> DYNTBL
  */
 .macro ptrtodyntbl
-    _wr_cmd_id  ptrtodyntbl, ,ASEQ_OPC_CHANNEL_PTRTODYNTBL,,,,,,, 0, 0
+    _wr_cmd_id  ptrtodyntbl, ,ASEQ_OP_CHANNEL_PTRTODYNTBL,,,,,,, 0, 0
 .endm
 
 /**
@@ -1937,7 +1937,7 @@ $reladdr\@:
  *  Note that TR acts as an index into an array of u16 starting at label.
  */
 .macro ldseqtoptr label
-    _wr_cmd_id  ldseqtoptr, ,ASEQ_OPC_CHANNEL_LDSEQTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldseqtoptr, ,ASEQ_OP_CHANNEL_LDSEQTOPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1947,7 +1947,7 @@ $reladdr\@:
  *  Invalidates the current active filter buffer.
  */
 .macro freefilter
-    _wr_cmd_id  freefilter, ,ASEQ_OPC_CHANNEL_FREEFILTER,,,,,,, 0, 0
+    _wr_cmd_id  freefilter, ,ASEQ_OP_CHANNEL_FREEFILTER,,,,,,, 0, 0
 .endm
 
 /**
@@ -1956,7 +1956,7 @@ $reladdr\@:
  *  Sets the active filter buffer to the location specified by `filter`.
  */
 .macro ldfilter filter
-    _wr_cmd_id  ldfilter, ,ASEQ_OPC_CHANNEL_LDFILTER,,,,,,, 0, 0
+    _wr_cmd_id  ldfilter, ,ASEQ_OP_CHANNEL_LDFILTER,,,,,,, 0, 0
     _wr_lbl     \filter
 .endm
 
@@ -1967,7 +1967,7 @@ $reladdr\@:
  *  Delays by `delay` ticks.
  */
 .macro cdelay delay
-    _wr_cmd_id  cdelay, ,ASEQ_OPC_CHANNEL_CDELAY,,,,,,, \delay, 4
+    _wr_cmd_id  cdelay, ,ASEQ_OP_CHANNEL_CDELAY,,,,,,, \delay, 4
 .endm
 
 /**
@@ -1981,9 +1981,9 @@ $reladdr\@:
  */
 .macro ldsample type, portNum
     .if \type == LDSAMPLE_INST
-        _wr_cmd_id  ldsample, ,ASEQ_OPC_CHANNEL_LDSAMPLE,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OP_CHANNEL_LDSAMPLE,,,,,,, \portNum, 3
     .elif \type == LDSAMPLE_SFX
-        _wr_cmd_id  ldsample, ,ASEQ_OPC_CHANNEL_LDSAMPLE | 8,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OP_CHANNEL_LDSAMPLE | 8,,,,,,, \portNum, 3
     .else
         .error "ldsample: invalid type"
     .endif
@@ -1997,7 +1997,7 @@ $reladdr\@:
  *  Stores the contents of TR into CIO[channelNum][portNum]
  */
 .macro stcio channelNum, portNum
-    _wr_cmd_id  stcio, ,ASEQ_OPC_CHANNEL_STCIO,,,,,,, \channelNum, 4
+    _wr_cmd_id  stcio, ,ASEQ_OP_CHANNEL_STCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -2007,7 +2007,7 @@ $reladdr\@:
  *  Loads the contents of CIO[channelNum][portNum] into TR.
  */
 .macro ldcio channelNum, portNum
-    _wr_cmd_id  ldcio, ,ASEQ_OPC_CHANNEL_LDCIO,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldcio, ,ASEQ_OP_CHANNEL_LDCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -2019,7 +2019,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldlayer layerNum, label
-    _wr_cmd_id  rldlayer, ,ASEQ_OPC_CHANNEL_RLDLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  rldlayer, ,ASEQ_OP_CHANNEL_RLDLAYER,,,,,,, \layerNum, 3
     _wr_16_rel  \label
 .endm
 
@@ -2033,7 +2033,7 @@ $reladdr\@:
  *   - -1 if layer does not exist.
  */
 .macro testlayer layerNum
-    _wr_cmd_id  testlayer, ,ASEQ_OPC_CHANNEL_TESTLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  testlayer, ,ASEQ_OP_CHANNEL_TESTLAYER,,,,,,, \layerNum, 3
 .endm
 
 /**
@@ -2042,7 +2042,7 @@ $reladdr\@:
  *  Opens the note layer at `label` for index `layerNum`.
  */
 .macro ldlayer layerNum, label
-    _wr_cmd_id  ldlayer, ,ASEQ_OPC_CHANNEL_LDLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  ldlayer, ,ASEQ_OP_CHANNEL_LDLAYER,,,,,,, \layerNum, 3
     _wr_lbl     \label
 .endm
 
@@ -2052,7 +2052,7 @@ $reladdr\@:
  *  Deletes the layer specified by index `layerNum`.
  */
 .macro dellayer arg
-    _wr_cmd_id  dellayer, ,ASEQ_OPC_CHANNEL_DELLAYER,,,,,,, \arg, 3
+    _wr_cmd_id  dellayer, ,ASEQ_OP_CHANNEL_DELLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2061,7 +2061,7 @@ $reladdr\@:
  *  Allocates a new layer starting at the pointer read from DYNTBL16[TR]
  */
 .macro dynldlayer arg
-    _wr_cmd_id  dynldlayer, ,ASEQ_OPC_CHANNEL_DYNLDLAYER,,,,,,, \arg, 3
+    _wr_cmd_id  dynldlayer, ,ASEQ_OP_CHANNEL_DYNLDLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2073,7 +2073,7 @@ $reladdr\@:
  *   - 1 if disabled
  */
 .macro testchan channelNum
-    _wr_cmd_id  testchan, ASEQ_OPC_SEQUENCE_TESTCHAN,,,,,,,, \channelNum, 4
+    _wr_cmd_id  testchan, ASEQ_OP_SEQUENCE_TESTCHAN,,,,,,,, \channelNum, 4
 .endm
 
 /**
@@ -2083,9 +2083,9 @@ $reladdr\@:
  */
 .macro stopchan channelNum
     .if ASEQ_MODE == ASEQ_MODE_SEQUENCE
-        _wr_cmd_id  stopchan, ASEQ_OPC_SEQUENCE_STOPCHAN,,,,,,,, \channelNum, 4
+        _wr_cmd_id  stopchan, ASEQ_OP_SEQUENCE_STOPCHAN,,,,,,,, \channelNum, 4
     .else
-        _wr_cmd_id  stopchan, ,ASEQ_OPC_CHANNEL_STOPCHAN,,,,,,, 0, 0
+        _wr_cmd_id  stopchan, ,ASEQ_OP_CHANNEL_STOPCHAN,,,,,,, 0, 0
         _wr_u8      \channelNum
     .endif
 .endm
@@ -2100,7 +2100,7 @@ $reladdr\@:
  *      Computes TR = TR - CIO[CUR_CHANNEL][portNum]
  */
 .macro subio portNum
-    _wr_cmd_id  subio, ASEQ_OPC_SEQUENCE_SUBIO,ASEQ_OPC_CHANNEL_SUBIO,,,,,,, \portNum, 4
+    _wr_cmd_id  subio, ASEQ_OP_SEQUENCE_SUBIO,ASEQ_OP_CHANNEL_SUBIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2117,7 +2117,7 @@ $reladdr\@:
  *  Load status is made available in SIO[portNum].
  */
 .macro ldres portNum, resType, resId
-    _wr_cmd_id  ldres, ASEQ_OPC_SEQUENCE_LDRES,,,,,,,, \portNum, 4
+    _wr_cmd_id  ldres, ASEQ_OP_SEQUENCE_LDRES,,,,,,,, \portNum, 4
     _wr_u8      \resType
     _wr_u8      \resId
 .endm
@@ -2131,9 +2131,9 @@ $reladdr\@:
  */
 .macro stio portNum
     .if ASEQ_MODE == ASEQ_MODE_CHANNEL
-        _wr_cmd_id  stio, ,ASEQ_OPC_CHANNEL_STIO,,,,,,, \portNum, 3
+        _wr_cmd_id  stio, ,ASEQ_OP_CHANNEL_STIO,,,,,,, \portNum, 3
     .else
-        _wr_cmd_id  stio, ASEQ_OPC_SEQUENCE_STIO,,,,,,,, \portNum, 4
+        _wr_cmd_id  stio, ASEQ_OP_SEQUENCE_STIO,,,,,,,, \portNum, 4
     .endif
 .endm
 
@@ -2144,7 +2144,7 @@ $reladdr\@:
  *  depending on current section.
  */
 .macro ldio portNum
-    _wr_cmd_id  ldio, ASEQ_OPC_SEQUENCE_LDIO,ASEQ_OPC_CHANNEL_LDIO,,,,,,, \portNum, 4
+    _wr_cmd_id  ldio, ASEQ_OP_SEQUENCE_LDIO,ASEQ_OP_CHANNEL_LDIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2153,7 +2153,7 @@ $reladdr\@:
  *  Opens the sequence channel for index `channelNum` with data beginning at `label`.
  */
 .macro ldchan channelNum, label
-    _wr_cmd_id  ldchan, ASEQ_OPC_SEQUENCE_LDCHAN,ASEQ_OPC_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldchan, ASEQ_OP_SEQUENCE_LDCHAN,ASEQ_OP_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
     _wr_lbl     \label
 .endm
 
@@ -2165,7 +2165,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldchan channelNum, label
-    _wr_cmd_id  rldchan, ASEQ_OPC_SEQUENCE_RLDCHAN,,,,,,,, \channelNum, 4
+    _wr_cmd_id  rldchan, ASEQ_OP_SEQUENCE_RLDCHAN,,,,,,,, \channelNum, 4
     _wr_16_rel  \label
 .endm
 
@@ -2175,7 +2175,7 @@ $reladdr\@:
  *  Delay for `delay` ticks.
  */
 .macro ldelay delay
-    _wr_cmd_id  ldelay, ,,ASEQ_OPC_LAYER_LDELAY,,,,,, 0, 0
+    _wr_cmd_id  ldelay, ,,ASEQ_OP_LAYER_LDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2186,7 +2186,7 @@ $reladdr\@:
  * Should never be used when not required for matching purposes.
  */
 .macro lldelay delay
-    _wr_cmd_id  lldelay, ,ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_LAYER_LDELAY,,,,,, 0, 0
+    _wr_cmd_id  lldelay, ,ASEQ_OP_CTRLFLOW_DELAY,ASEQ_OP_LAYER_LDELAY,,,,,, 0, 0
     _var_long   \delay
 .endm
 
@@ -2196,7 +2196,7 @@ $reladdr\@:
  * Set velocity used by short notes.
  */
 .macro shortvel velocity
-    _wr_cmd_id  shortvel, ,,ASEQ_OPC_LAYER_SHORTVEL,,,,,, 0, 0
+    _wr_cmd_id  shortvel, ,,ASEQ_OP_LAYER_SHORTVEL,,,,,, 0, 0
     _wr_u8      \velocity
 .endm
 
@@ -2206,7 +2206,7 @@ $reladdr\@:
  * Set delay used by short notes.
  */
 .macro shortdelay delay
-    _wr_cmd_id  shortdelay, ,,ASEQ_OPC_LAYER_SHORTDELAY,,,,,, 0, 0
+    _wr_cmd_id  shortdelay, ,,ASEQ_OP_LAYER_SHORTDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2216,7 +2216,7 @@ $reladdr\@:
  *  Enables legato on the current layer.
  */
 .macro legato
-    _wr_cmd_id  legato, ,,ASEQ_OPC_LAYER_LEGATO,,,,,, 0, 0
+    _wr_cmd_id  legato, ,,ASEQ_OP_LAYER_LEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2225,7 +2225,7 @@ $reladdr\@:
  *  Disables legato on the current layer.
  */
 .macro nolegato
-    _wr_cmd_id  nolegato, ,,ASEQ_OPC_LAYER_NOLEGATO,,,,,, 0, 0
+    _wr_cmd_id  nolegato, ,,ASEQ_OP_LAYER_NOLEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2234,7 +2234,7 @@ $reladdr\@:
  *  The time argument is either a var or a u8 depending on mode
  */
 .macro portamento mode, target, time
-    _wr_cmd_id  portamento, ,,ASEQ_OPC_LAYER_PORTAMENTO,,,,,, 0, 0
+    _wr_cmd_id  portamento, ,,ASEQ_OP_LAYER_PORTAMENTO,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u8      \target
     .if (\mode & 0x80) != 0
@@ -2250,7 +2250,7 @@ $reladdr\@:
  *  Disables portamento on the current layer.
  */
 .macro noportamento
-    _wr_cmd_id  noportamento, ,,ASEQ_OPC_LAYER_NOPORTAMENTO,,,,,, 0, 0
+    _wr_cmd_id  noportamento, ,,ASEQ_OP_LAYER_NOPORTAMENTO,,,,,, 0, 0
 .endm
 
 /**
@@ -2259,7 +2259,7 @@ $reladdr\@:
  *  Sets gate time for short notes.
  */
 .macro shortgate gateTime
-    _wr_cmd_id  shortgate, ,,ASEQ_OPC_LAYER_SHORTGATE,,,,,, 0, 0
+    _wr_cmd_id  shortgate, ,,ASEQ_OP_LAYER_SHORTGATE,,,,,, 0, 0
     _wr_u8      \gateTime
 .endm
 
@@ -2271,7 +2271,7 @@ $reladdr\@:
 .macro notepan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  notepan, ,,ASEQ_OPC_LAYER_NOTEPAN,,,,,, 0, 0
+    _wr_cmd_id  notepan, ,,ASEQ_OP_LAYER_NOTEPAN,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -2282,7 +2282,7 @@ $reladdr\@:
  *  use pan set in the layer.
  */
 .macro nodrumpan
-    _wr_cmd_id  nodrumpan, ,,ASEQ_OPC_LAYER_NODRUMPAN,,,,,, 0, 0
+    _wr_cmd_id  nodrumpan, ,,ASEQ_OP_LAYER_NODRUMPAN,,,,,, 0, 0
 .endm
 
 /**
@@ -2297,7 +2297,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  stereo, ,,ASEQ_OPC_LAYER_STEREO,,,,,, 0, 0
+    _wr_cmd_id  stereo, ,,ASEQ_OP_LAYER_STEREO,,,,,, 0, 0
     _wr_u8      (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -2307,7 +2307,7 @@ $reladdr\@:
  *  Sets the velocity used in short notes by reading from SHORTVELTBL[velocity]
  */
 .macro ldshortvel velocity
-    _wr_cmd_id  ldshortvel, ,,ASEQ_OPC_LAYER_LDSHORTVEL,,,,,, \velocity, 4
+    _wr_cmd_id  ldshortvel, ,,ASEQ_OP_LAYER_LDSHORTVEL,,,,,, \velocity, 4
 .endm
 
 /**
@@ -2316,7 +2316,7 @@ $reladdr\@:
  *  Sets the gate time used in short notes by reading from SHORTGATETBL[gateTime]
  */
 .macro ldshortgate gateTime
-    _wr_cmd_id  ldshortgate, ,,ASEQ_OPC_LAYER_LDSHORTGATE,,,,,, \gateTime, 4
+    _wr_cmd_id  ldshortgate, ,,ASEQ_OP_LAYER_LDSHORTGATE,,,,,, \gateTime, 4
 .endm
 
 #if (MML_VERSION == MML_VERSION_MM)
@@ -2327,7 +2327,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_F0 arg
-        _wr_cmd_id  unk_F0, ,,ASEQ_OPC_LAYER_F0,,,,,, 0, 0
+        _wr_cmd_id  unk_F0, ,,ASEQ_OP_LAYER_F0,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -2337,7 +2337,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro surroundeffect arg
-        _wr_cmd_id  surroundeffect, ,,ASEQ_OPC_LAYER_F1,,,,,, 0, 0
+        _wr_cmd_id  surroundeffect, ,,ASEQ_OP_LAYER_F1,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -2357,7 +2357,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notedvg pitch, delay, velocity, gateTime
-    _wr_cmd_id  notedvg, ,,ASEQ_OPC_LAYER_NOTEDVG,,,,,, \pitch, 6
+    _wr_cmd_id  notedvg, ,,ASEQ_OP_LAYER_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
     _wr_u8      \gateTime
@@ -2371,14 +2371,14 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notedv pitch, delay, velocity
-    _wr_cmd_id  notedv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  notedv, ,,ASEQ_OP_LAYER_NOTEDV,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
 .endm
 
 /* Workaround for bugs in vanilla sequences, force long encoding for delay. This should not typically be used. */
 .macro noteldv pitch, delay, velocity
-    _wr_cmd_id  noteldv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  noteldv, ,,ASEQ_OP_LAYER_NOTEDV,,,,,, \pitch, 6
     _var_long   \delay
     _wr_u8      \velocity
 .endm
@@ -2391,7 +2391,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notevg pitch, velocity, gateTime
-    _wr_cmd_id  notevg, ,,ASEQ_OPC_LAYER_NOTEVG,,,,,, \pitch, 6
+    _wr_cmd_id  notevg, ,,ASEQ_OP_LAYER_NOTEVG,,,,,, \pitch, 6
     _wr_u8      \velocity
     _wr_u8      \gateTime
 .endm
@@ -2405,7 +2405,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdvg pitch, delay
-    _wr_cmd_id  shortdvg, ,,ASEQ_OPC_LAYER_NOTEDVG,,,,,, \pitch, 6
+    _wr_cmd_id  shortdvg, ,,ASEQ_OP_LAYER_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
 .endm
 
@@ -2418,7 +2418,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdv pitch
-    _wr_cmd_id  shortdv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  shortdv, ,,ASEQ_OP_LAYER_NOTEDV,,,,,, \pitch, 6
 .endm
 
 /**
@@ -2430,7 +2430,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortvg pitch
-    _wr_cmd_id  shortvg, ,,ASEQ_OPC_LAYER_NOTEVG,,,,,, \pitch, 6
+    _wr_cmd_id  shortvg, ,,ASEQ_OP_LAYER_NOTEVG,,,,,, \pitch, 6
 .endm
 
 /**

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -225,159 +225,159 @@
  */
 
 // control flow commands
-#define ASEQ_CMD_ID_CONTROL_FLOW_FIRST  0xF2
-#define ASEQ_CMD_ID_CTRLFLOW_RBLTZ      0xF2
-#define ASEQ_CMD_ID_CTRLFLOW_RBEQZ      0xF3
-#define ASEQ_CMD_ID_CTRLFLOW_RJUMP      0xF4
-#define ASEQ_CMD_ID_CTRLFLOW_BGEZ       0xF5
-#define ASEQ_CMD_ID_CTRLFLOW_BREAK      0xF6
-#define ASEQ_CMD_ID_CTRLFLOW_LOOPEND    0xF7
-#define ASEQ_CMD_ID_CTRLFLOW_LOOP       0xF8
-#define ASEQ_CMD_ID_CTRLFLOW_BLTZ       0xF9
-#define ASEQ_CMD_ID_CTRLFLOW_BEQZ       0xFA
-#define ASEQ_CMD_ID_CTRLFLOW_JUMP       0xFB
-#define ASEQ_CMD_ID_CTRLFLOW_CALL       0xFC
-#define ASEQ_CMD_ID_CTRLFLOW_DELAY      0xFD
-#define ASEQ_CMD_ID_CTRLFLOW_DELAY1     0xFE
-#define ASEQ_CMD_ID_CTRLFLOW_END        0xFF
+#define ASEQ_OPC_CONTROL_FLOW_FIRST 0xF2
+#define ASEQ_OPC_CTRLFLOW_RBLTZ     0xF2
+#define ASEQ_OPC_CTRLFLOW_RBEQZ     0xF3
+#define ASEQ_OPC_CTRLFLOW_RJUMP     0xF4
+#define ASEQ_OPC_CTRLFLOW_BGEZ      0xF5
+#define ASEQ_OPC_CTRLFLOW_BREAK     0xF6
+#define ASEQ_OPC_CTRLFLOW_LOOPEND   0xF7
+#define ASEQ_OPC_CTRLFLOW_LOOP      0xF8
+#define ASEQ_OPC_CTRLFLOW_BLTZ      0xF9
+#define ASEQ_OPC_CTRLFLOW_BEQZ      0xFA
+#define ASEQ_OPC_CTRLFLOW_JUMP      0xFB
+#define ASEQ_OPC_CTRLFLOW_CALL      0xFC
+#define ASEQ_OPC_CTRLFLOW_DELAY     0xFD
+#define ASEQ_OPC_CTRLFLOW_DELAY1    0xFE
+#define ASEQ_OPC_CTRLFLOW_END       0xFF
 
 // sequence commands
-#define ASEQ_CMD_ID_SEQUENCE_TESTCHAN       0x00 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_STOPCHAN       0x40 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_SUBIO          0x50 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_LDRES          0x60 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_STIO           0x70 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_LDIO           0x80 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_LDCHAN         0x90 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_RLDCHAN        0xA0 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_LDSEQ          0xB0 // low nibble used as argument
-#define ASEQ_CMD_ID_SEQUENCE_RUNSEQ         0xC4
-#define ASEQ_CMD_ID_SEQUENCE_SCRIPTCTR      0xC5
-#define ASEQ_CMD_ID_SEQUENCE_STOP           0xC6
-#define ASEQ_CMD_ID_SEQUENCE_STSEQ          0xC7
-#define ASEQ_CMD_ID_SEQUENCE_SUB            0xC8
-#define ASEQ_CMD_ID_SEQUENCE_AND            0xC9
-#define ASEQ_CMD_ID_SEQUENCE_LDI            0xCC
-#define ASEQ_CMD_ID_SEQUENCE_DYNCALL        0xCD
-#define ASEQ_CMD_ID_SEQUENCE_RAND           0xCE
-#define ASEQ_CMD_ID_SEQUENCE_NOTEALLOC      0xD0
-#define ASEQ_CMD_ID_SEQUENCE_LDSHORTGATEARR 0xD1
-#define ASEQ_CMD_ID_SEQUENCE_LDSHORTVELARR  0xD2
-#define ASEQ_CMD_ID_SEQUENCE_MUTEBHV        0xD3
-#define ASEQ_CMD_ID_SEQUENCE_MUTE           0xD4
-#define ASEQ_CMD_ID_SEQUENCE_MUTESCALE      0xD5
-#define ASEQ_CMD_ID_SEQUENCE_FREECHAN       0xD6
-#define ASEQ_CMD_ID_SEQUENCE_INITCHAN       0xD7
-#define ASEQ_CMD_ID_SEQUENCE_VOLSCALE       0xD9
-#define ASEQ_CMD_ID_SEQUENCE_VOLMODE        0xDA
-#define ASEQ_CMD_ID_SEQUENCE_VOL            0xDB
-#define ASEQ_CMD_ID_SEQUENCE_TEMPOCHG       0xDC
-#define ASEQ_CMD_ID_SEQUENCE_TEMPO          0xDD
-#define ASEQ_CMD_ID_SEQUENCE_RTRANSPOSE     0xDE
-#define ASEQ_CMD_ID_SEQUENCE_TRANSPOSE      0xDF
-#define ASEQ_CMD_ID_SEQUENCE_EF             0xEF
-#define ASEQ_CMD_ID_SEQUENCE_FREENOTELIST   0xF0
-#define ASEQ_CMD_ID_SEQUENCE_ALLOCNOTELIST  0xF1
+#define ASEQ_OPC_SEQUENCE_TESTCHAN          0x00 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_STOPCHAN          0x40 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_SUBIO             0x50 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_LDRES             0x60 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_STIO              0x70 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_LDIO              0x80 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_LDCHAN            0x90 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_RLDCHAN           0xA0 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_LDSEQ             0xB0 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_RUNSEQ            0xC4
+#define ASEQ_OPC_SEQUENCE_SCRIPTCTR         0xC5
+#define ASEQ_OPC_SEQUENCE_STOP              0xC6
+#define ASEQ_OPC_SEQUENCE_STSEQ             0xC7
+#define ASEQ_OPC_SEQUENCE_SUB               0xC8
+#define ASEQ_OPC_SEQUENCE_AND               0xC9
+#define ASEQ_OPC_SEQUENCE_LDI               0xCC
+#define ASEQ_OPC_SEQUENCE_DYNCALL           0xCD
+#define ASEQ_OPC_SEQUENCE_RAND              0xCE
+#define ASEQ_OPC_SEQUENCE_NOTEALLOC         0xD0
+#define ASEQ_OPC_SEQUENCE_LDSHORTGATEARR    0xD1
+#define ASEQ_OPC_SEQUENCE_LDSHORTVELARR     0xD2
+#define ASEQ_OPC_SEQUENCE_MUTEBHV           0xD3
+#define ASEQ_OPC_SEQUENCE_MUTE              0xD4
+#define ASEQ_OPC_SEQUENCE_MUTESCALE         0xD5
+#define ASEQ_OPC_SEQUENCE_FREECHAN          0xD6
+#define ASEQ_OPC_SEQUENCE_INITCHAN          0xD7
+#define ASEQ_OPC_SEQUENCE_VOLSCALE          0xD9
+#define ASEQ_OPC_SEQUENCE_VOLMODE           0xDA
+#define ASEQ_OPC_SEQUENCE_VOL               0xDB
+#define ASEQ_OPC_SEQUENCE_TEMPOCHG          0xDC
+#define ASEQ_OPC_SEQUENCE_TEMPO             0xDD
+#define ASEQ_OPC_SEQUENCE_RTRANSPOSE        0xDE
+#define ASEQ_OPC_SEQUENCE_TRANSPOSE         0xDF
+#define ASEQ_OPC_SEQUENCE_EF                0xEF
+#define ASEQ_OPC_SEQUENCE_FREENOTELIST      0xF0
+#define ASEQ_OPC_SEQUENCE_ALLOCNOTELIST     0xF1
 
 // channel commands
-#define ASEQ_CMD_ID_CHANNEL_STOPCHANELAY    0x00 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_LDSAMPLE        0x10 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_LDCHAN          0x20 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_STCIO           0x30 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_LDCIO           0x40 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_SUBIO           0x50 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_LDIO            0x60 // low nibble used as argument
-#define ASEQ_CMD_ID_CHANNEL_STIO            0x70 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_RLDLAYER        0x78 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_TESTLAYER       0x80 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_LDLAYER         0x88 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_DELLAYER        0x90 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_DYNLDLAYER      0x98 // lower 3 bits used as argument
-#define ASEQ_CMD_ID_CHANNEL_LDFILTER        0xB0
-#define ASEQ_CMD_ID_CHANNEL_FREEFILTER      0xB1
-#define ASEQ_CMD_ID_CHANNEL_LDSEQTOPTR      0xB2
-#define ASEQ_CMD_ID_CHANNEL_FILTER          0xB3
-#define ASEQ_CMD_ID_CHANNEL_PTRTODYNTBL     0xB4
-#define ASEQ_CMD_ID_CHANNEL_DYNTBLTOPTR     0xB5
-#define ASEQ_CMD_ID_CHANNEL_DYNTBLV         0xB6
-#define ASEQ_CMD_ID_CHANNEL_RANDTOPTR       0xB7
-#define ASEQ_CMD_ID_CHANNEL_RAND            0xB8
-#define ASEQ_CMD_ID_CHANNEL_RANDVEL         0xB9
-#define ASEQ_CMD_ID_CHANNEL_RANDGATE        0xBA
-#define ASEQ_CMD_ID_CHANNEL_COMBFILTER      0xBB
-#define ASEQ_CMD_ID_CHANNEL_PTRADD          0xBC
-#if (MML_VERSION == MML_VERSION_OOT)
-#define ASEQ_CMD_ID_CHANNEL_RANDPTR         0xBD
-#endif
-#define ASEQ_CMD_ID_CHANNEL_INSTR           0xC1
-#define ASEQ_CMD_ID_CHANNEL_DYNTBL          0xC2
-#define ASEQ_CMD_ID_CHANNEL_SHORT           0xC3
-#define ASEQ_CMD_ID_CHANNEL_NOSHORT         0xC4
-#define ASEQ_CMD_ID_CHANNEL_DYNTBLLOOKUP    0xC5
-#define ASEQ_CMD_ID_CHANNEL_FONT            0xC6
-#define ASEQ_CMD_ID_CHANNEL_STSEQ           0xC7
-#define ASEQ_CMD_ID_CHANNEL_SUB             0xC8
-#define ASEQ_CMD_ID_CHANNEL_AND             0xC9
-#define ASEQ_CMD_ID_CHANNEL_MUTEBHV         0xCA
-#define ASEQ_CMD_ID_CHANNEL_LDSEQ           0xCB
-#define ASEQ_CMD_ID_CHANNEL_LDI             0xCC
-#define ASEQ_CMD_ID_CHANNEL_STOPCHAN        0xCD
-#define ASEQ_CMD_ID_CHANNEL_LDPTR           0xCE
-#define ASEQ_CMD_ID_CHANNEL_STPTRTOSEQ      0xCF
-#define ASEQ_CMD_ID_CHANNEL_EFFECTS         0xD0
-#define ASEQ_CMD_ID_CHANNEL_NOTEALLOC       0xD1
-#define ASEQ_CMD_ID_CHANNEL_SUSTAIN         0xD2
-#define ASEQ_CMD_ID_CHANNEL_BEND            0xD3
-#define ASEQ_CMD_ID_CHANNEL_REVERB          0xD4
-#define ASEQ_CMD_ID_CHANNEL_VIBFREQ         0xD7
-#define ASEQ_CMD_ID_CHANNEL_VIBDEPTH        0xD8
-#define ASEQ_CMD_ID_CHANNEL_RELEASERATE     0xD9
-#define ASEQ_CMD_ID_CHANNEL_ENV             0xDA
-#define ASEQ_CMD_ID_CHANNEL_TRANSPOSE       0xDB
-#define ASEQ_CMD_ID_CHANNEL_PANWEIGHT       0xDC
-#define ASEQ_CMD_ID_CHANNEL_PAN             0xDD
-#define ASEQ_CMD_ID_CHANNEL_FREQSCALE       0xDE
-#define ASEQ_CMD_ID_CHANNEL_VOL             0xDF
-#define ASEQ_CMD_ID_CHANNEL_VOLEXP          0xE0
-#define ASEQ_CMD_ID_CHANNEL_VIBFREQGRAD     0xE1
-#define ASEQ_CMD_ID_CHANNEL_VIBDEPTHGRAD    0xE2
-#define ASEQ_CMD_ID_CHANNEL_VIBDELAY        0xE3
-#define ASEQ_CMD_ID_CHANNEL_DYNCALL         0xE4
-#define ASEQ_CMD_ID_CHANNEL_REVERBIDX       0xE5
-#define ASEQ_CMD_ID_CHANNEL_SAMPLEBOOK      0xE6
-#define ASEQ_CMD_ID_CHANNEL_LDPARAMS        0xE7
-#define ASEQ_CMD_ID_CHANNEL_PARAMS          0xE8
-#define ASEQ_CMD_ID_CHANNEL_NOTEPRI         0xE9
-#define ASEQ_CMD_ID_CHANNEL_STOP            0xEA
-#define ASEQ_CMD_ID_CHANNEL_FONTINSTR       0xEB
-#define ASEQ_CMD_ID_CHANNEL_VIBRESET        0xEC
-#define ASEQ_CMD_ID_CHANNEL_GAIN            0xED
-#define ASEQ_CMD_ID_CHANNEL_BENDFINE        0xEE
-#define ASEQ_CMD_ID_CHANNEL_FREENOTELIST    0xF0
-#define ASEQ_CMD_ID_CHANNEL_ALLOCNOTELIST   0xF1
+#define ASEQ_OPC_CHANNEL_STOPCHANELAY   0x00 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_LDSAMPLE       0x10 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_LDCHAN         0x20 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_STCIO          0x30 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_LDCIO          0x40 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_SUBIO          0x50 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_LDIO           0x60 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_STIO           0x70 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_RLDLAYER       0x78 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_TESTLAYER      0x80 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_LDLAYER        0x88 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_DELLAYER       0x90 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_DYNLDLAYER     0x98 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_LDFILTER       0xB0
+#define ASEQ_OPC_CHANNEL_FREEFILTER     0xB1
+#define ASEQ_OPC_CHANNEL_LDSEQTOPTR     0xB2
+#define ASEQ_OPC_CHANNEL_FILTER         0xB3
+#define ASEQ_OPC_CHANNEL_PTRTODYNTBL    0xB4
+#define ASEQ_OPC_CHANNEL_DYNTBLTOPTR    0xB5
+#define ASEQ_OPC_CHANNEL_DYNTBLV        0xB6
+#define ASEQ_OPC_CHANNEL_RANDTOPTR      0xB7
+#define ASEQ_OPC_CHANNEL_RAND           0xB8
+#define ASEQ_OPC_CHANNEL_RANDVEL        0xB9
+#define ASEQ_OPC_CHANNEL_RANDGATE       0xBA
+#define ASEQ_OPC_CHANNEL_COMBFILTER     0xBB
+#define ASEQ_OPC_CHANNEL_PTRADD         0xBC
+#if (MML_VERSION == MML_VERSION_OOT)    
+#define ASEQ_OPC_CHANNEL_RANDPTR        0xBD
+#endif  
+#define ASEQ_OPC_CHANNEL_INSTR          0xC1
+#define ASEQ_OPC_CHANNEL_DYNTBL         0xC2
+#define ASEQ_OPC_CHANNEL_SHORT          0xC3
+#define ASEQ_OPC_CHANNEL_NOSHORT        0xC4
+#define ASEQ_OPC_CHANNEL_DYNTBLLOOKUP   0xC5
+#define ASEQ_OPC_CHANNEL_FONT           0xC6
+#define ASEQ_OPC_CHANNEL_STSEQ          0xC7
+#define ASEQ_OPC_CHANNEL_SUB            0xC8
+#define ASEQ_OPC_CHANNEL_AND            0xC9
+#define ASEQ_OPC_CHANNEL_MUTEBHV        0xCA
+#define ASEQ_OPC_CHANNEL_LDSEQ          0xCB
+#define ASEQ_OPC_CHANNEL_LDI            0xCC
+#define ASEQ_OPC_CHANNEL_STOPCHAN       0xCD
+#define ASEQ_OPC_CHANNEL_LDPTR          0xCE
+#define ASEQ_OPC_CHANNEL_STPTRTOSEQ     0xCF
+#define ASEQ_OPC_CHANNEL_EFFECTS        0xD0
+#define ASEQ_OPC_CHANNEL_NOTEALLOC      0xD1
+#define ASEQ_OPC_CHANNEL_SUSTAIN        0xD2
+#define ASEQ_OPC_CHANNEL_BEND           0xD3
+#define ASEQ_OPC_CHANNEL_REVERB         0xD4
+#define ASEQ_OPC_CHANNEL_VIBFREQ        0xD7
+#define ASEQ_OPC_CHANNEL_VIBDEPTH       0xD8
+#define ASEQ_OPC_CHANNEL_RELEASERATE    0xD9
+#define ASEQ_OPC_CHANNEL_ENV            0xDA
+#define ASEQ_OPC_CHANNEL_TRANSPOSE      0xDB
+#define ASEQ_OPC_CHANNEL_PANWEIGHT      0xDC
+#define ASEQ_OPC_CHANNEL_PAN            0xDD
+#define ASEQ_OPC_CHANNEL_FREQSCALE      0xDE
+#define ASEQ_OPC_CHANNEL_VOL            0xDF
+#define ASEQ_OPC_CHANNEL_VOLEXP         0xE0
+#define ASEQ_OPC_CHANNEL_VIBFREQGRAD    0xE1
+#define ASEQ_OPC_CHANNEL_VIBDEPTHGRAD   0xE2
+#define ASEQ_OPC_CHANNEL_VIBDELAY       0xE3
+#define ASEQ_OPC_CHANNEL_DYNCALL        0xE4
+#define ASEQ_OPC_CHANNEL_REVERBIDX      0xE5
+#define ASEQ_OPC_CHANNEL_SAMPLEBOOK     0xE6
+#define ASEQ_OPC_CHANNEL_LDPARAMS       0xE7
+#define ASEQ_OPC_CHANNEL_PARAMS         0xE8
+#define ASEQ_OPC_CHANNEL_NOTEPRI        0xE9
+#define ASEQ_OPC_CHANNEL_STOP           0xEA
+#define ASEQ_OPC_CHANNEL_FONTINSTR      0xEB
+#define ASEQ_OPC_CHANNEL_VIBRESET       0xEC
+#define ASEQ_OPC_CHANNEL_GAIN           0xED
+#define ASEQ_OPC_CHANNEL_BENDFINE       0xEE
+#define ASEQ_OPC_CHANNEL_FREENOTELIST   0xF0
+#define ASEQ_OPC_CHANNEL_ALLOCNOTELIST  0xF1
 
 // layer commands
-#define ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG 0x00
-#define ASEQ_CMD_ID_LAYER_STEP3_NOTEDV  0x40
-#define ASEQ_CMD_ID_LAYER_STEP3_NOTEVG  0x80
-#define ASEQ_CMD_ID_LAYER_STEP3_LDELAY  0xC0
-#define ASEQ_CMD_ID_LAYER_SHORTVEL      0xC1
-#define ASEQ_CMD_ID_LAYER_TRANSPOSE     0xC2
-#define ASEQ_CMD_ID_LAYER_SHORTDELAY    0xC3
-#define ASEQ_CMD_ID_LAYER_LEGATO        0xC4
-#define ASEQ_CMD_ID_LAYER_NOLEGATO      0xC5
-#define ASEQ_CMD_ID_LAYER_INSTR         0xC6
-#define ASEQ_CMD_ID_LAYER_PORTAMENTO    0xC7
-#define ASEQ_CMD_ID_LAYER_NOPORTAMENTO  0xC8
-#define ASEQ_CMD_ID_LAYER_SHORTGATE     0xC9
-#define ASEQ_CMD_ID_LAYER_NOTEPAN       0xCA
-#define ASEQ_CMD_ID_LAYER_ENV           0xCB
-#define ASEQ_CMD_ID_LAYER_NODRUMPAN     0xCC
-#define ASEQ_CMD_ID_LAYER_STEREO        0xCD
-#define ASEQ_CMD_ID_LAYER_BENDFINE      0xCE
-#define ASEQ_CMD_ID_LAYER_RELEASERATE   0xCF
-#define ASEQ_CMD_ID_LAYER_LDSHORTVEL    0xD0 // low nibble used as an argument
-#define ASEQ_CMD_ID_LAYER_LDSHORTGATE   0xE0 // low nibble used as an argument
+#define ASEQ_OPC_LAYER_STEP3_NOTEDVG    0x00
+#define ASEQ_OPC_LAYER_STEP3_NOTEDV     0x40
+#define ASEQ_OPC_LAYER_STEP3_NOTEVG     0x80
+#define ASEQ_OPC_LAYER_STEP3_LDELAY     0xC0
+#define ASEQ_OPC_LAYER_SHORTVEL         0xC1
+#define ASEQ_OPC_LAYER_TRANSPOSE        0xC2
+#define ASEQ_OPC_LAYER_SHORTDELAY       0xC3
+#define ASEQ_OPC_LAYER_LEGATO           0xC4
+#define ASEQ_OPC_LAYER_NOLEGATO         0xC5
+#define ASEQ_OPC_LAYER_INSTR            0xC6
+#define ASEQ_OPC_LAYER_PORTAMENTO       0xC7
+#define ASEQ_OPC_LAYER_NOPORTAMENTO     0xC8
+#define ASEQ_OPC_LAYER_SHORTGATE        0xC9
+#define ASEQ_OPC_LAYER_NOTEPAN          0xCA
+#define ASEQ_OPC_LAYER_ENV              0xCB
+#define ASEQ_OPC_LAYER_NODRUMPAN        0xCC
+#define ASEQ_OPC_LAYER_STEREO           0xCD
+#define ASEQ_OPC_LAYER_BENDFINE         0xCE
+#define ASEQ_OPC_LAYER_RELEASERATE      0xCF
+#define ASEQ_OPC_LAYER_LDSHORTVEL       0xD0 // low nibble used as an argument
+#define ASEQ_OPC_LAYER_LDSHORTGATE      0xE0 // low nibble used as an argument
 
 
 
@@ -551,7 +551,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq ioPortNum, seqId, label
-        _wr_cmd_id  ldseq, ASEQ_CMD_ID_SEQUENCE_LDSEQ,,,,,,,, \ioPortNum, 4
+        _wr_cmd_id  ldseq, ASEQ_OPC_SEQUENCE_LDSEQ,,,,,,,, \ioPortNum, 4
         _wr_u8      \seqId
         _wr_lbl     \label
     .endm
@@ -569,7 +569,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq label
-        _wr_cmd_id  ldseq, ,ASEQ_CMD_ID_CHANNEL_LDSEQ,,,,,,, 0, 0
+        _wr_cmd_id  ldseq, ,ASEQ_OPC_CHANNEL_LDSEQ,,,,,,, 0, 0
         _wr_lbl     \label
     .endm
 
@@ -579,14 +579,14 @@ _RESET_SECTION
         _check_arg_bitwidth_u \lowpassCutoff, 4
         _check_arg_bitwidth_u \highpassCutoff, 4
 
-        _wr_cmd_id filter, ,ASEQ_CMD_ID_CHANNEL_FILTER,,,,,,, 0, 0
+        _wr_cmd_id filter, ,ASEQ_OPC_CHANNEL_FILTER,,,,,,, 0, 0
         _wr_u8 (\lowpassCutoff << 4) | (\highpassCutoff)
     .endm
 
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label
-        _wr_cmd_id env, ,ASEQ_CMD_ID_CHANNEL_ENV,,,,,,, 0, 0
+        _wr_cmd_id env, ,ASEQ_OPC_CHANNEL_ENV,,,,,,, 0, 0
         _wr_lbl \label
     .endm
 
@@ -603,7 +603,7 @@ _RESET_SECTION
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label, arg
-        _wr_cmd_id env, ,,ASEQ_CMD_ID_LAYER_ENV,,,,,, 0, 0
+        _wr_cmd_id env, ,,ASEQ_OPC_LAYER_ENV,,,,,, 0, 0
         _wr_lbl \label
         _wr_u8 \arg
     .endm
@@ -894,7 +894,7 @@ $reladdr\@:
  *  closed, so are its layers.
  */
 .macro end
-    _wr_cmd_id  end, ASEQ_CMD_ID_CTRLFLOW_END,ASEQ_CMD_ID_CTRLFLOW_END,ASEQ_CMD_ID_CTRLFLOW_END,,,,,, 0, 0
+    _wr_cmd_id  end, ASEQ_OPC_CTRLFLOW_END,ASEQ_OPC_CTRLFLOW_END,ASEQ_OPC_CTRLFLOW_END,,,,,, 0, 0
 .endm
 
 /**
@@ -903,7 +903,7 @@ $reladdr\@:
  *  Delays for one tick.
  */
 .macro delay1
-    _wr_cmd_id  delay1, ASEQ_CMD_ID_CTRLFLOW_DELAY1,ASEQ_CMD_ID_CTRLFLOW_DELAY1,,,,,,, 0, 0
+    _wr_cmd_id  delay1, ASEQ_OPC_CTRLFLOW_DELAY1,ASEQ_OPC_CTRLFLOW_DELAY1,,,,,,, 0, 0
 .endm
 
 /**
@@ -912,7 +912,7 @@ $reladdr\@:
  *  Delays for `delay` ticks.
  */
 .macro delay delay
-    _wr_cmd_id  delay, ASEQ_CMD_ID_CTRLFLOW_DELAY,ASEQ_CMD_ID_CTRLFLOW_DELAY,,,,,,, 0, 0
+    _wr_cmd_id  delay, ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_CTRLFLOW_DELAY,,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -923,7 +923,7 @@ $reladdr\@:
  *  subroutine encounters an `end` instruction.
  */
 .macro call label
-    _wr_cmd_id  call, ASEQ_CMD_ID_CTRLFLOW_CALL,ASEQ_CMD_ID_CTRLFLOW_CALL,ASEQ_CMD_ID_CTRLFLOW_CALL,,,,,, 0, 0
+    _wr_cmd_id  call, ASEQ_OPC_CTRLFLOW_CALL,ASEQ_OPC_CTRLFLOW_CALL,ASEQ_OPC_CTRLFLOW_CALL,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -933,7 +933,7 @@ $reladdr\@:
  *  Branches to `label` unconditionally.
  */
 .macro jump label
-    _wr_cmd_id  jump, ASEQ_CMD_ID_CTRLFLOW_JUMP,ASEQ_CMD_ID_CTRLFLOW_JUMP,ASEQ_CMD_ID_CTRLFLOW_JUMP,,,,,, 0, 0
+    _wr_cmd_id  jump, ASEQ_OPC_CTRLFLOW_JUMP,ASEQ_OPC_CTRLFLOW_JUMP,ASEQ_OPC_CTRLFLOW_JUMP,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -943,7 +943,7 @@ $reladdr\@:
  *  Branches to `label` if TR == 0.
  */
 .macro beqz label
-    _wr_cmd_id  beqz, ASEQ_CMD_ID_CTRLFLOW_BEQZ,ASEQ_CMD_ID_CTRLFLOW_BEQZ,ASEQ_CMD_ID_CTRLFLOW_BEQZ,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OPC_CTRLFLOW_BEQZ,ASEQ_OPC_CTRLFLOW_BEQZ,ASEQ_OPC_CTRLFLOW_BEQZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -953,7 +953,7 @@ $reladdr\@:
  *  Branches to `label` if TR < 0.
  */
 .macro bltz label
-    _wr_cmd_id  beqz, ASEQ_CMD_ID_CTRLFLOW_BLTZ,ASEQ_CMD_ID_CTRLFLOW_BLTZ,ASEQ_CMD_ID_CTRLFLOW_BLTZ,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OPC_CTRLFLOW_BLTZ,ASEQ_OPC_CTRLFLOW_BLTZ,ASEQ_OPC_CTRLFLOW_BLTZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -967,7 +967,7 @@ $reladdr\@:
  *  becomes full.
  */
 .macro loop num
-    _wr_cmd_id  loop, ASEQ_CMD_ID_CTRLFLOW_LOOP,ASEQ_CMD_ID_CTRLFLOW_LOOP,ASEQ_CMD_ID_CTRLFLOW_LOOP,,,,,, 0, 0
+    _wr_cmd_id  loop, ASEQ_OPC_CTRLFLOW_LOOP,ASEQ_OPC_CTRLFLOW_LOOP,ASEQ_OPC_CTRLFLOW_LOOP,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -981,7 +981,7 @@ $reladdr\@:
  *  stack is popped.
  */
 .macro loopend
-    _wr_cmd_id  loopend, ASEQ_CMD_ID_CTRLFLOW_LOOPEND,ASEQ_CMD_ID_CTRLFLOW_LOOPEND,ASEQ_CMD_ID_CTRLFLOW_LOOPEND,,,,,, 0, 0
+    _wr_cmd_id  loopend, ASEQ_OPC_CTRLFLOW_LOOPEND,ASEQ_OPC_CTRLFLOW_LOOPEND,ASEQ_OPC_CTRLFLOW_LOOPEND,,,,,, 0, 0
 .endm
 
 /**
@@ -994,7 +994,7 @@ $reladdr\@:
  *  the call stack would be popped twice.
  */
 .macro break
-    _wr_cmd_id  break, ASEQ_CMD_ID_CTRLFLOW_BREAK,ASEQ_CMD_ID_CTRLFLOW_BREAK,ASEQ_CMD_ID_CTRLFLOW_BREAK,,,,,, 0, 0
+    _wr_cmd_id  break, ASEQ_OPC_CTRLFLOW_BREAK,ASEQ_OPC_CTRLFLOW_BREAK,ASEQ_OPC_CTRLFLOW_BREAK,,,,,, 0, 0
 .endm
 
 /**
@@ -1003,7 +1003,7 @@ $reladdr\@:
  *  Branches to `label` if TR >= 0.
  */
 .macro bgez label
-    _wr_cmd_id  bgez, ASEQ_CMD_ID_CTRLFLOW_BGEZ,ASEQ_CMD_ID_CTRLFLOW_BGEZ,ASEQ_CMD_ID_CTRLFLOW_BGEZ,,,,,, 0, 0
+    _wr_cmd_id  bgez, ASEQ_OPC_CTRLFLOW_BGEZ,ASEQ_OPC_CTRLFLOW_BGEZ,ASEQ_OPC_CTRLFLOW_BGEZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1017,7 +1017,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rjump label
-    _wr_cmd_id  rjump, ASEQ_CMD_ID_CTRLFLOW_RJUMP,ASEQ_CMD_ID_CTRLFLOW_RJUMP,ASEQ_CMD_ID_CTRLFLOW_RJUMP,,,,,, 0, 0
+    _wr_cmd_id  rjump, ASEQ_OPC_CTRLFLOW_RJUMP,ASEQ_OPC_CTRLFLOW_RJUMP,ASEQ_OPC_CTRLFLOW_RJUMP,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1031,7 +1031,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbeqz label
-    _wr_cmd_id  rbeqz, ASEQ_CMD_ID_CTRLFLOW_RBEQZ,ASEQ_CMD_ID_CTRLFLOW_RBEQZ,ASEQ_CMD_ID_CTRLFLOW_RBEQZ,,,,,, 0, 0
+    _wr_cmd_id  rbeqz, ASEQ_OPC_CTRLFLOW_RBEQZ,ASEQ_OPC_CTRLFLOW_RBEQZ,ASEQ_OPC_CTRLFLOW_RBEQZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1045,7 +1045,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbltz label
-    _wr_cmd_id  rbltz, ASEQ_CMD_ID_CTRLFLOW_RBLTZ,ASEQ_CMD_ID_CTRLFLOW_RBLTZ,ASEQ_CMD_ID_CTRLFLOW_RBLTZ,,,,,, 0, 0
+    _wr_cmd_id  rbltz, ASEQ_OPC_CTRLFLOW_RBLTZ,ASEQ_OPC_CTRLFLOW_RBLTZ,ASEQ_OPC_CTRLFLOW_RBLTZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1055,7 +1055,7 @@ $reladdr\@:
  *  Clears the channel note pool and reallocates it with space for `num` notes.
  */
 .macro allocnotelist num
-    _wr_cmd_id  allocnotelist, ASEQ_CMD_ID_SEQUENCE_ALLOCNOTELIST,ASEQ_CMD_ID_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  allocnotelist, ASEQ_OPC_SEQUENCE_ALLOCNOTELIST,ASEQ_OPC_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -1065,7 +1065,7 @@ $reladdr\@:
  *  Clears the channel note pool.
  */
 .macro freenotelist
-    _wr_cmd_id  freenotelist, ASEQ_CMD_ID_SEQUENCE_FREENOTELIST,ASEQ_CMD_ID_CHANNEL_FREENOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  freenotelist, ASEQ_OPC_SEQUENCE_FREENOTELIST,ASEQ_OPC_CHANNEL_FREENOTELIST,,,,,,, 0, 0
 .endm
 
 /**
@@ -1074,7 +1074,7 @@ $reladdr\@:
  *  Has no function.
  */
 .macro unk_EF arg1, arg2
-    _wr_cmd_id  unk_EF, ASEQ_CMD_ID_SEQUENCE_EF,,,,,,,, 0, 0
+    _wr_cmd_id  unk_EF, ASEQ_OPC_SEQUENCE_EF,,,,,,,, 0, 0
     _wr_s16     \arg1
     _w_u8       \arg2
 .endm
@@ -1085,7 +1085,7 @@ $reladdr\@:
  *  Fine-tunes the pitch bend amount for the channel or layer.
  */
 .macro bendfine amt
-    _wr_cmd_id  bendfine, ,ASEQ_CMD_ID_CHANNEL_BENDFINE,ASEQ_CMD_ID_LAYER_BENDFINE,,,,,, 0, 0
+    _wr_cmd_id  bendfine, ,ASEQ_OPC_CHANNEL_BENDFINE,ASEQ_OPC_LAYER_BENDFINE,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1095,7 +1095,7 @@ $reladdr\@:
  *  Sets the channel gain (multiplicative volume scale factor) to the provided qu4.4 fixed-point value.
  */
 .macro gain value
-    _wr_cmd_id  gain, ,ASEQ_CMD_ID_CHANNEL_GAIN,,,,,,, 0, 0
+    _wr_cmd_id  gain, ,ASEQ_OPC_CHANNEL_GAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1105,7 +1105,7 @@ $reladdr\@:
  *  Resets channel vibrato, filter, gain, sustain, etc. state.
  */
 .macro vibreset
-    _wr_cmd_id  vibreset, ,ASEQ_CMD_ID_CHANNEL_VIBRESET,,,,,,, 0, 0
+    _wr_cmd_id  vibreset, ,ASEQ_OPC_CHANNEL_VIBRESET,,,,,,, 0, 0
 .endm
 
 /**
@@ -1114,7 +1114,7 @@ $reladdr\@:
  *  Updates the soundfont and instrument for the channel simultaneously.
  */
 .macro fontinstr fontId, instId
-    _wr_cmd_id  fontinstr, ,ASEQ_CMD_ID_CHANNEL_FONTINSTR,,,,,,, 0, 0
+    _wr_cmd_id  fontinstr, ,ASEQ_OPC_CHANNEL_FONTINSTR,,,,,,, 0, 0
     _wr_u8      \fontId
     _wr_u8      \instId
 .endm
@@ -1127,7 +1127,7 @@ $reladdr\@:
 .macro notepri priority1, priority2
     _check_arg_bitwidth_u \priority1, 4
     _check_arg_bitwidth_u \priority2, 4
-    _wr_cmd_id  notepri, ,ASEQ_CMD_ID_CHANNEL_NOTEPRI,,,,,,, 0, 0
+    _wr_cmd_id  notepri, ,ASEQ_OPC_CHANNEL_NOTEPRI,,,,,,, 0, 0
     _wr_u8      (\priority1 << 4) | \priority2
 .endm
 
@@ -1138,7 +1138,7 @@ $reladdr\@:
  *  Sets various channel parameters.
  */
 .macro params muteBhv, noteAllocPolicy, channelPriority, transposition, pan, panWeight, reverb, reverbIndex
-    _wr_cmd_id  params, ,ASEQ_CMD_ID_CHANNEL_PARAMS,,,,,,, 0, 0
+    _wr_cmd_id  params, ,ASEQ_OPC_CHANNEL_PARAMS,,,,,,, 0, 0
     _wr_u8      \muteBhv
     _wr_u8      \noteAllocPolicy
     _wr_u8      \channelPriority
@@ -1156,7 +1156,7 @@ $reladdr\@:
  *  is ordered in the same way as the arguments in `params`.
  */
 .macro ldparams label
-    _wr_cmd_id  ldparams, ,ASEQ_CMD_ID_CHANNEL_LDPARAMS,,,,,,, 0, 0
+    _wr_cmd_id  ldparams, ,ASEQ_OPC_CHANNEL_LDPARAMS,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1166,7 +1166,7 @@ $reladdr\@:
  *  Sets the sample book mode.
  */
 .macro samplebook value
-    _wr_cmd_id  samplebook, ,ASEQ_CMD_ID_CHANNEL_SAMPLEBOOK,,,,,,, 0, 0
+    _wr_cmd_id  samplebook, ,ASEQ_OPC_CHANNEL_SAMPLEBOOK,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1176,7 +1176,7 @@ $reladdr\@:
  *  Sets the channel reverb.
  */
 .macro reverbidx arg
-    _wr_cmd_id  reverbidx, ,ASEQ_CMD_ID_CHANNEL_REVERBIDX,,,,,,, 0, 0
+    _wr_cmd_id  reverbidx, ,ASEQ_OPC_CHANNEL_REVERBIDX,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1186,7 +1186,7 @@ $reladdr\@:
  *  Sets the channel vibrato delay.
  */
 .macro vibdelay arg
-    _wr_cmd_id  vibdelay, ,ASEQ_CMD_ID_CHANNEL_VIBDELAY,,,,,,, 0, 0
+    _wr_cmd_id  vibdelay, ,ASEQ_OPC_CHANNEL_VIBDELAY,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1196,7 +1196,7 @@ $reladdr\@:
  *  Sets the vibrato extent.
  */
 .macro vibdepthgrad arg0, arg1, arg2
-    _wr_cmd_id  vibdepthgrad, ,ASEQ_CMD_ID_CHANNEL_VIBDEPTHGRAD,,,,,,, 0, 0
+    _wr_cmd_id  vibdepthgrad, ,ASEQ_OPC_CHANNEL_VIBDEPTHGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1208,7 +1208,7 @@ $reladdr\@:
  *  Sets the vibrato rate.
  */
 .macro vibfreqgrad arg0, arg1, arg2
-    _wr_cmd_id  vibfreqgrad, ,ASEQ_CMD_ID_CHANNEL_VIBFREQGRAD,,,,,,, 0, 0
+    _wr_cmd_id  vibfreqgrad, ,ASEQ_OPC_CHANNEL_VIBFREQGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1220,7 +1220,7 @@ $reladdr\@:
  *  Changes the expression amount for the channel.
  */
 .macro volexp amt
-    _wr_cmd_id  volexp, ,ASEQ_CMD_ID_CHANNEL_VOLEXP,,,,,,, 0, 0
+    _wr_cmd_id  volexp, ,ASEQ_OPC_CHANNEL_VOLEXP,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1231,7 +1231,7 @@ $reladdr\@:
  *  provided number of semitones.
  */
 .macro transpose semitones
-    _wr_cmd_id  transpose, ASEQ_CMD_ID_SEQUENCE_TRANSPOSE,ASEQ_CMD_ID_CHANNEL_TRANSPOSE,ASEQ_CMD_ID_LAYER_TRANSPOSE,,,,,, 0, 0
+    _wr_cmd_id  transpose, ASEQ_OPC_SEQUENCE_TRANSPOSE,ASEQ_OPC_CHANNEL_TRANSPOSE,ASEQ_OPC_LAYER_TRANSPOSE,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1241,7 +1241,7 @@ $reladdr\@:
  *  Adjusts the transposition amount. This is only available at the top sequence level.
  */
 .macro rtranspose semitones
-    _wr_cmd_id  rtranspose, ASEQ_CMD_ID_SEQUENCE_RTRANSPOSE,,,,,,,, 0, 0
+    _wr_cmd_id  rtranspose, ASEQ_OPC_SEQUENCE_RTRANSPOSE,,,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1251,7 +1251,7 @@ $reladdr\@:
  *  Sets the freqScale for the current channel.
  */
 .macro freqscale arg
-    _wr_cmd_id  freqscale, ,ASEQ_CMD_ID_CHANNEL_FREQSCALE,,,,,,, 0, 0
+    _wr_cmd_id  freqscale, ,ASEQ_OPC_CHANNEL_FREQSCALE,,,,,,, 0, 0
     _wr_s16     \arg
 .endm
 
@@ -1261,7 +1261,7 @@ $reladdr\@:
  *  Changes the tempo of the sequence.
  */
 .macro tempo bpm
-    _wr_cmd_id  tempo, ASEQ_CMD_ID_SEQUENCE_TEMPO,,,,,,,, 0, 0
+    _wr_cmd_id  tempo, ASEQ_OPC_SEQUENCE_TEMPO,,,,,,,, 0, 0
     _wr_u8      \bpm
 .endm
 
@@ -1271,7 +1271,7 @@ $reladdr\@:
  *  Sets the tempoChange for the sequence.
  */
 .macro tempochg arg
-    _wr_cmd_id  tempochg, ASEQ_CMD_ID_SEQUENCE_TEMPOCHG,,,,,,,, 0, 0
+    _wr_cmd_id  tempochg, ASEQ_OPC_SEQUENCE_TEMPOCHG,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1283,7 +1283,7 @@ $reladdr\@:
 .macro pan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  pan, ,ASEQ_CMD_ID_CHANNEL_PAN,,,,,,, 0, 0
+    _wr_cmd_id  pan, ,ASEQ_OPC_CHANNEL_PAN,,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -1299,7 +1299,7 @@ $reladdr\@:
 .macro panweight weight
     /* weight can only take values in 0..127 */
     _check_arg_bitwidth_u \weight, 7
-    _wr_cmd_id  panweight, ,ASEQ_CMD_ID_CHANNEL_PANWEIGHT,,,,,,, 0, 0
+    _wr_cmd_id  panweight, ,ASEQ_OPC_CHANNEL_PANWEIGHT,,,,,,, 0, 0
     _wr_u8      \weight
 .endm
 
@@ -1309,7 +1309,7 @@ $reladdr\@:
  *  Sets the volume amount for this sequence or channel.
  */
 .macro vol amt
-    _wr_cmd_id  vol, ASEQ_CMD_ID_SEQUENCE_VOL,ASEQ_CMD_ID_CHANNEL_VOL,,,,,,, 0, 0
+    _wr_cmd_id  vol, ASEQ_OPC_SEQUENCE_VOL,ASEQ_OPC_CHANNEL_VOL,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1319,7 +1319,7 @@ $reladdr\@:
  *  TODO DESCRIPTION
  */
 .macro volmode mode, fadeTimer
-    _wr_cmd_id  volmode, ASEQ_CMD_ID_SEQUENCE_VOLMODE,,,,,,,, 0, 0
+    _wr_cmd_id  volmode, ASEQ_OPC_SEQUENCE_VOLMODE,,,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u16     \fadeTimer
 .endm
@@ -1330,7 +1330,7 @@ $reladdr\@:
  *  Sets the fadeVolumeScale for the sequence.
  */
 .macro volscale arg
-    _wr_cmd_id  volscale, ASEQ_CMD_ID_SEQUENCE_VOLSCALE,,,,,,,, 0, 0
+    _wr_cmd_id  volscale, ASEQ_OPC_SEQUENCE_VOLSCALE,,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1340,7 +1340,7 @@ $reladdr\@:
  *  Sets the envelope release rate for this channel or layer.
  */
 .macro releaserate release
-    _wr_cmd_id  releaserate, ,ASEQ_CMD_ID_CHANNEL_RELEASERATE,ASEQ_CMD_ID_LAYER_RELEASERATE,,,,,, 0, 0
+    _wr_cmd_id  releaserate, ,ASEQ_OPC_CHANNEL_RELEASERATE,ASEQ_OPC_LAYER_RELEASERATE,,,,,, 0, 0
     _wr_u8      \release
 .endm
 
@@ -1350,7 +1350,7 @@ $reladdr\@:
  *  Sets the vibrato depth for the channel.
  */
 .macro vibdepth arg
-    _wr_cmd_id  vibdepth, ,ASEQ_CMD_ID_CHANNEL_VIBDEPTH,,,,,,, 0, 0
+    _wr_cmd_id  vibdepth, ,ASEQ_OPC_CHANNEL_VIBDEPTH,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1360,7 +1360,7 @@ $reladdr\@:
  *  Sets the vibrato rate for the channel.
  */
 .macro vibfreq arg
-    _wr_cmd_id  vibfreq, ,ASEQ_CMD_ID_CHANNEL_VIBFREQ,,,,,,, 0, 0
+    _wr_cmd_id  vibfreq, ,ASEQ_OPC_CHANNEL_VIBFREQ,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1373,7 +1373,7 @@ $reladdr\@:
  *       initchan 0b101 initializes channels 0 and 2.
  */
 .macro initchan bitmask
-    _wr_cmd_id  initchan, ASEQ_CMD_ID_SEQUENCE_INITCHAN,,,,,,,, 0, 0
+    _wr_cmd_id  initchan, ASEQ_OPC_SEQUENCE_INITCHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1383,7 +1383,7 @@ $reladdr\@:
  *  Frees the channels marked in the provided bitmask.
  */
 .macro freechan bitmask
-    _wr_cmd_id  freechan, ASEQ_CMD_ID_SEQUENCE_FREECHAN,,,,,,,, 0, 0
+    _wr_cmd_id  freechan, ASEQ_OPC_SEQUENCE_FREECHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1393,7 +1393,7 @@ $reladdr\@:
  *  Sets the muteVolumeScale for the sequence.
  */
 .macro mutescale arg
-    _wr_cmd_id  mutescale, ASEQ_CMD_ID_SEQUENCE_MUTESCALE,,,,,,,, 0, 0
+    _wr_cmd_id  mutescale, ASEQ_OPC_SEQUENCE_MUTESCALE,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1403,7 +1403,7 @@ $reladdr\@:
  *  Mutes the sequence player.
  */
 .macro mute
-    _wr_cmd_id  mute, ASEQ_CMD_ID_SEQUENCE_MUTE,,,,,,,, 0, 0
+    _wr_cmd_id  mute, ASEQ_OPC_SEQUENCE_MUTE,,,,,,,, 0, 0
 .endm
 
 /**
@@ -1412,7 +1412,7 @@ $reladdr\@:
  *  Sets the reverb amount for this channel.
  */
 .macro reverb amt
-    _wr_cmd_id  reverb, ,ASEQ_CMD_ID_CHANNEL_REVERB,,,,,,, 0, 0
+    _wr_cmd_id  reverb, ,ASEQ_OPC_CHANNEL_REVERB,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1422,7 +1422,7 @@ $reladdr\@:
  *  Sets mute behavior for this sequence or channel.
  */
 .macro mutebhv flags
-    _wr_cmd_id  mutebhv, ASEQ_CMD_ID_SEQUENCE_MUTEBHV,ASEQ_CMD_ID_CHANNEL_MUTEBHV,,,,,,, 0, 0
+    _wr_cmd_id  mutebhv, ASEQ_OPC_SEQUENCE_MUTEBHV,ASEQ_OPC_CHANNEL_MUTEBHV,,,,,,, 0, 0
     _wr_u8      \flags
 .endm
 
@@ -1432,7 +1432,7 @@ $reladdr\@:
  *  Sets the pitch bend amount for this channel.
  */
 .macro bend amt
-    _wr_cmd_id  bend, ,ASEQ_CMD_ID_CHANNEL_BEND,,,,,,, 0, 0
+    _wr_cmd_id  bend, ,ASEQ_OPC_CHANNEL_BEND,,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1442,7 +1442,7 @@ $reladdr\@:
  *  Sets the location of SHORTVELTBL.
  */
 .macro ldshortvelarr label
-    _wr_cmd_id  ldshortvelarr, ASEQ_CMD_ID_SEQUENCE_LDSHORTVELARR,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortvelarr, ASEQ_OPC_SEQUENCE_LDSHORTVELARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1452,7 +1452,7 @@ $reladdr\@:
  *  Sets the adsr sustain value for this channel.
  */
 .macro sustain value
-    _wr_cmd_id  sustain, ,ASEQ_CMD_ID_CHANNEL_SUSTAIN,,,,,,, 0, 0
+    _wr_cmd_id  sustain, ,ASEQ_OPC_CHANNEL_SUSTAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1462,7 +1462,7 @@ $reladdr\@:
  *  Sets the location of SHORTGATETBL.
  */
 .macro ldshortgatearr label
-    _wr_cmd_id  ldshortgatearr, ASEQ_CMD_ID_SEQUENCE_LDSHORTGATEARR,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortgatearr, ASEQ_OPC_SEQUENCE_LDSHORTGATEARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1472,7 +1472,7 @@ $reladdr\@:
  *  Sets the noteAllocPolicy for either the sequence or the current channel.
  */
 .macro notealloc arg
-    _wr_cmd_id  notealloc, ASEQ_CMD_ID_SEQUENCE_NOTEALLOC,ASEQ_CMD_ID_CHANNEL_NOTEALLOC,,,,,,, 0, 0
+    _wr_cmd_id  notealloc, ASEQ_OPC_SEQUENCE_NOTEALLOC,ASEQ_OPC_CHANNEL_NOTEALLOC,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1489,7 +1489,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  effects, ,ASEQ_CMD_ID_CHANNEL_EFFECTS,,,,,,, 0, 0
+    _wr_cmd_id  effects, ,ASEQ_OPC_CHANNEL_EFFECTS,,,,,,, 0, 0
     _wr_u8      (\headset << 7) | (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -1499,7 +1499,7 @@ $reladdr\@:
  *  Stores TP -> label
  */
 .macro stptrtoseq label
-    _wr_cmd_id  stptrtoseq, ,ASEQ_CMD_ID_CHANNEL_STPTRTOSEQ,,,,,,, 0, 0
+    _wr_cmd_id  stptrtoseq, ,ASEQ_OPC_CHANNEL_STPTRTOSEQ,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1509,7 +1509,7 @@ $reladdr\@:
  *  Loads label -> TP
  */
 .macro ldptr label
-    _wr_cmd_id  ldptr, ,ASEQ_CMD_ID_CHANNEL_LDPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OPC_CHANNEL_LDPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1519,7 +1519,7 @@ $reladdr\@:
  *  Loads imm -> TP
  */
 .macro ldptri imm
-    _wr_cmd_id  ldptr, ,ASEQ_CMD_ID_CHANNEL_LDPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OPC_CHANNEL_LDPTR,,,,,,, 0, 0
     _wr_u16     \imm
 .endm
 
@@ -1529,7 +1529,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TR. If max is 0 the range is [0, 255]
  */
 .macro rand max
-    _wr_cmd_id  rand, ASEQ_CMD_ID_SEQUENCE_RAND,ASEQ_CMD_ID_CHANNEL_RAND,,,,,,, 0, 0
+    _wr_cmd_id  rand, ASEQ_OPC_SEQUENCE_RAND,ASEQ_OPC_CHANNEL_RAND,,,,,,, 0, 0
     _wr_u8      \max
 .endm
 
@@ -1544,9 +1544,9 @@ $reladdr\@:
  */
 .macro dyncall table=-1
     .if \table == -1
-        _wr_cmd_id  dyncall, ,ASEQ_CMD_ID_CHANNEL_DYNCALL,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ,ASEQ_OPC_CHANNEL_DYNCALL,,,,,,, 0, 0
     .else
-        _wr_cmd_id  dyncall, ASEQ_CMD_ID_SEQUENCE_DYNCALL,,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ASEQ_OPC_SEQUENCE_DYNCALL,,,,,,,, 0, 0
         _wr_lbl     \table
     .endif
 .endm
@@ -1557,7 +1557,7 @@ $reladdr\@:
  *  Loads the immediate value `imm` into TR.
  */
 .macro ldi imm
-    _wr_cmd_id  ldi, ASEQ_CMD_ID_SEQUENCE_LDI,ASEQ_CMD_ID_CHANNEL_LDI,,,,,,, 0, 0
+    _wr_cmd_id  ldi, ASEQ_OPC_SEQUENCE_LDI,ASEQ_OPC_CHANNEL_LDI,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1567,7 +1567,7 @@ $reladdr\@:
  *  Computes TR = TR & imm
  */
 .macro and imm
-    _wr_cmd_id  and, ASEQ_CMD_ID_SEQUENCE_AND,ASEQ_CMD_ID_CHANNEL_AND,,,,,,, 0, 0
+    _wr_cmd_id  and, ASEQ_OPC_SEQUENCE_AND,ASEQ_OPC_CHANNEL_AND,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1577,7 +1577,7 @@ $reladdr\@:
  *  Computes TR = TR - imm
  */
 .macro sub imm
-    _wr_cmd_id  sub, ASEQ_CMD_ID_SEQUENCE_SUB,ASEQ_CMD_ID_CHANNEL_SUB,,,,,,, 0, 0
+    _wr_cmd_id  sub, ASEQ_OPC_SEQUENCE_SUB,ASEQ_OPC_CHANNEL_SUB,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1587,7 +1587,7 @@ $reladdr\@:
  *  Stores the u8 value `TR + imm` to the location specified by `label`.
  */
 .macro stseq imm, label
-    _wr_cmd_id  stseq, ASEQ_CMD_ID_SEQUENCE_STSEQ,ASEQ_CMD_ID_CHANNEL_STSEQ,,,,,,, 0, 0
+    _wr_cmd_id  stseq, ASEQ_OPC_SEQUENCE_STSEQ,ASEQ_OPC_CHANNEL_STSEQ,,,,,,, 0, 0
     _wr_u8      \imm
     _wr_lbl     \label
 .endm
@@ -1598,7 +1598,7 @@ $reladdr\@:
  *  Immediately stops the sequence or channel.
  */
 .macro stop
-    _wr_cmd_id  stop, ASEQ_CMD_ID_SEQUENCE_STOP,ASEQ_CMD_ID_CHANNEL_STOP,,,,,,, 0, 0
+    _wr_cmd_id  stop, ASEQ_OPC_SEQUENCE_STOP,ASEQ_OPC_CHANNEL_STOP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1607,7 +1607,7 @@ $reladdr\@:
  *  Set the current soundfont for this channel to `fontId`.
  */
 .macro font fontId
-    _wr_cmd_id  font, ,ASEQ_CMD_ID_CHANNEL_FONT,,,,,,, 0, 0
+    _wr_cmd_id  font, ,ASEQ_OPC_CHANNEL_FONT,,,,,,, 0, 0
     _wr_u8      \fontId
 .endm
 
@@ -1620,7 +1620,7 @@ $reladdr\@:
  *  never used, so changing it with this instruction has no useful effects.
  */
 .macro scriptctr arg
-    _wr_cmd_id  scriptctr, ASEQ_CMD_ID_SEQUENCE_SCRIPTCTR,,,,,,,, 0, 0
+    _wr_cmd_id  scriptctr, ASEQ_OPC_SEQUENCE_SCRIPTCTR,,,,,,,, 0, 0
     _wr_u16     \arg
 .endm
 
@@ -1631,7 +1631,7 @@ $reladdr\@:
  *  unless TR is -1, in which case nothing happens.
  */
 .macro dyntbllookup
-    _wr_cmd_id  dyntbllookup, ,ASEQ_CMD_ID_CHANNEL_DYNTBLLOOKUP,,,,,,, 0, 0
+    _wr_cmd_id  dyntbllookup, ,ASEQ_OPC_CHANNEL_DYNTBLLOOKUP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1640,7 +1640,7 @@ $reladdr\@:
  *  Plays the sequence seqId on seqPlayer.
  */
 .macro runseq seqPlayer, seqId
-    _wr_cmd_id  runseq, ASEQ_CMD_ID_SEQUENCE_RUNSEQ,,,,,,,, 0, 0
+    _wr_cmd_id  runseq, ASEQ_OPC_SEQUENCE_RUNSEQ,,,,,,,, 0, 0
     _wr_u8      \seqPlayer
     _wr_u8      \seqId
 .endm
@@ -1653,7 +1653,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro mutechan arg0
-        _wr_cmd_id  mutechan, ASEQ_CMD_ID_SEQUENCE_C3,,,,,,,, 0, 0
+        _wr_cmd_id  mutechan, ASEQ_OPC_SEQUENCE_C3,,,,,,,, 0, 0
         _wr_s16     \arg0
     .endm
 
@@ -1665,7 +1665,7 @@ $reladdr\@:
  *  Disable short notes encoding.
  */
 .macro noshort
-    _wr_cmd_id  noshort, ,ASEQ_CMD_ID_CHANNEL_NOSHORT,,,,,,, 0, 0
+    _wr_cmd_id  noshort, ,ASEQ_OPC_CHANNEL_NOSHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1674,7 +1674,7 @@ $reladdr\@:
  *  Enable short notes encoding.
  */
 .macro short
-    _wr_cmd_id  short, ,ASEQ_CMD_ID_CHANNEL_SHORT,,,,,,, 0, 0
+    _wr_cmd_id  short, ,ASEQ_OPC_CHANNEL_SHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1683,7 +1683,7 @@ $reladdr\@:
  *  Loads label -> DYNTBL
  */
 .macro dyntbl label
-    _wr_cmd_id  dyntbl, ,ASEQ_CMD_ID_CHANNEL_DYNTBL,,,,,,, 0, 0
+    _wr_cmd_id  dyntbl, ,ASEQ_OPC_CHANNEL_DYNTBL,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1693,7 +1693,7 @@ $reladdr\@:
  *  Set instrument `instNum` from the current soundfont as the active instrument for this channel or layer.
  */
 .macro instr instNum
-    _wr_cmd_id  instr, ,ASEQ_CMD_ID_CHANNEL_INSTR,ASEQ_CMD_ID_LAYER_INSTR,,,,,, 0, 0
+    _wr_cmd_id  instr, ,ASEQ_OPC_CHANNEL_INSTR,ASEQ_OPC_LAYER_INSTR,,,,,, 0, 0
     _wr_u8      \instNum
 .endm
 
@@ -1720,7 +1720,7 @@ $reladdr\@:
  */
 .macro randptr range, offset
     #if (MML_VERSION == MML_VERSION_OOT)
-        _wr_cmd_id  randptr, ,ASEQ_CMD_ID_CHANNEL_RANDPTR,,,,,,, 0, 0
+        _wr_cmd_id  randptr, ,ASEQ_OPC_CHANNEL_RANDPTR,,,,,,, 0, 0
     #else
         _wr_cmd_id  randptr, ,0xA8,,,,,,, 0, 0
     #endif
@@ -1826,7 +1826,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptradd value
-    _wr_cmd_id  ptradd, ,ASEQ_CMD_ID_CHANNEL_PTRADD,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OPC_CHANNEL_PTRADD,,,,,,, 0, 0
     _wr_lbl     \value
 .endm
 
@@ -1838,7 +1838,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptraddi value
-    _wr_cmd_id  ptradd, ,ASEQ_CMD_ID_CHANNEL_PTRADD,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OPC_CHANNEL_PTRADD,,,,,,, 0, 0
     _wr_u16     \value
 .endm
 
@@ -1849,7 +1849,7 @@ $reladdr\@:
  *  TODO args? arg0=16,arg1=val<<8 maps well to midi chorus
  */
 .macro combfilter arg0, arg1
-    _wr_cmd_id  combfilter, ,ASEQ_CMD_ID_CHANNEL_COMBFILTER,,,,,,, 0, 0
+    _wr_cmd_id  combfilter, ,ASEQ_OPC_CHANNEL_COMBFILTER,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u16     \arg1
 .endm
@@ -1862,7 +1862,7 @@ $reladdr\@:
  *  NOTE: This feature is bugged. If this is non-zero it will actually use the range set by randvel.
  */
 .macro randgate range
-    _wr_cmd_id  randgate, ,ASEQ_CMD_ID_CHANNEL_RANDGATE,,,,,,, 0, 0
+    _wr_cmd_id  randgate, ,ASEQ_OPC_CHANNEL_RANDGATE,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1872,7 +1872,7 @@ $reladdr\@:
  *  Sets the range for random note velocity fluctuations.
  */
 .macro randvel range
-    _wr_cmd_id  randvel, ,ASEQ_CMD_ID_CHANNEL_RANDVEL,,,,,,, 0, 0
+    _wr_cmd_id  randvel, ,ASEQ_OPC_CHANNEL_RANDVEL,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1882,7 +1882,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TP. If max is 0 the range is [0, 65535]
  */
 .macro randtoptr max
-    _wr_cmd_id  randtoptr, ,ASEQ_CMD_ID_CHANNEL_RANDTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  randtoptr, ,ASEQ_OPC_CHANNEL_RANDTOPTR,,,,,,, 0, 0
     _wr_u16     \max
 .endm
 
@@ -1892,7 +1892,7 @@ $reladdr\@:
  *  Loads DYNTBL8[TR] -> TR
  */
 .macro dyntblv
-    _wr_cmd_id  dyntblv, ,ASEQ_CMD_ID_CHANNEL_DYNTBLV,,,,,,, 0, 0
+    _wr_cmd_id  dyntblv, ,ASEQ_OPC_CHANNEL_DYNTBLV,,,,,,, 0, 0
 .endm
 
 /**
@@ -1901,7 +1901,7 @@ $reladdr\@:
  *  Loads DYNTBL16[TR] -> TP
  */
 .macro dyntbltoptr
-    _wr_cmd_id  dyntbltoptr, ,ASEQ_CMD_ID_CHANNEL_DYNTBLTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  dyntbltoptr, ,ASEQ_OPC_CHANNEL_DYNTBLTOPTR,,,,,,, 0, 0
 .endm
 
 /**
@@ -1910,7 +1910,7 @@ $reladdr\@:
  *  Transfers TP -> DYNTBL
  */
 .macro ptrtodyntbl
-    _wr_cmd_id  ptrtodyntbl, ,ASEQ_CMD_ID_CHANNEL_PTRTODYNTBL,,,,,,, 0, 0
+    _wr_cmd_id  ptrtodyntbl, ,ASEQ_OPC_CHANNEL_PTRTODYNTBL,,,,,,, 0, 0
 .endm
 
 /**
@@ -1921,7 +1921,7 @@ $reladdr\@:
  *  Note that TR acts as an index into an array of u16 starting at label.
  */
 .macro ldseqtoptr label
-    _wr_cmd_id  ldseqtoptr, ,ASEQ_CMD_ID_CHANNEL_LDSEQTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldseqtoptr, ,ASEQ_OPC_CHANNEL_LDSEQTOPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1931,7 +1931,7 @@ $reladdr\@:
  *  Invalidates the current active filter buffer.
  */
 .macro freefilter
-    _wr_cmd_id  freefilter, ,ASEQ_CMD_ID_CHANNEL_FREEFILTER,,,,,,, 0, 0
+    _wr_cmd_id  freefilter, ,ASEQ_OPC_CHANNEL_FREEFILTER,,,,,,, 0, 0
 .endm
 
 /**
@@ -1940,7 +1940,7 @@ $reladdr\@:
  *  Sets the active filter buffer to the location specified by `filter`.
  */
 .macro ldfilter filter
-    _wr_cmd_id  ldfilter, ,ASEQ_CMD_ID_CHANNEL_LDFILTER,,,,,,, 0, 0
+    _wr_cmd_id  ldfilter, ,ASEQ_OPC_CHANNEL_LDFILTER,,,,,,, 0, 0
     _wr_lbl     \filter
 .endm
 
@@ -1951,7 +1951,7 @@ $reladdr\@:
  *  Delays by `delay` ticks.
  */
 .macro cdelay delay
-    _wr_cmd_id  cdelay, ,ASEQ_CMD_ID_CHANNEL_STOPCHANELAY,,,,,,, \delay, 4
+    _wr_cmd_id  cdelay, ,ASEQ_OPC_CHANNEL_STOPCHANELAY,,,,,,, \delay, 4
 .endm
 
 /**
@@ -1965,9 +1965,9 @@ $reladdr\@:
  */
 .macro ldsample type, portNum
     .if \type == LDSAMPLE_INST
-        _wr_cmd_id  ldsample, ,ASEQ_CMD_ID_CHANNEL_LDSAMPLE,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OPC_CHANNEL_LDSAMPLE,,,,,,, \portNum, 3
     .elif \type == LDSAMPLE_SFX
-        _wr_cmd_id  ldsample, ,ASEQ_CMD_ID_CHANNEL_LDSAMPLE | 8,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OPC_CHANNEL_LDSAMPLE | 8,,,,,,, \portNum, 3
     .else
         .error "ldsample: invalid type"
     .endif
@@ -1981,7 +1981,7 @@ $reladdr\@:
  *  Stores the contents of TR into CIO[channelNum][portNum]
  */
 .macro stcio channelNum, portNum
-    _wr_cmd_id  stcio, ,ASEQ_CMD_ID_CHANNEL_STCIO,,,,,,, \channelNum, 4
+    _wr_cmd_id  stcio, ,ASEQ_OPC_CHANNEL_STCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -1991,7 +1991,7 @@ $reladdr\@:
  *  Loads the contents of CIO[channelNum][portNum] into TR.
  */
 .macro ldcio channelNum, portNum
-    _wr_cmd_id  ldcio, ,ASEQ_CMD_ID_CHANNEL_LDCIO,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldcio, ,ASEQ_OPC_CHANNEL_LDCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -2003,7 +2003,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldlayer layerNum, label
-    _wr_cmd_id  rldlayer, ,ASEQ_CMD_ID_CHANNEL_RLDLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  rldlayer, ,ASEQ_OPC_CHANNEL_RLDLAYER,,,,,,, \layerNum, 3
     _wr_16_rel  \label
 .endm
 
@@ -2017,7 +2017,7 @@ $reladdr\@:
  *   - -1 if layer does not exist.
  */
 .macro testlayer layerNum
-    _wr_cmd_id  testlayer, ,ASEQ_CMD_ID_CHANNEL_TESTLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  testlayer, ,ASEQ_OPC_CHANNEL_TESTLAYER,,,,,,, \layerNum, 3
 .endm
 
 /**
@@ -2026,7 +2026,7 @@ $reladdr\@:
  *  Opens the note layer at `label` for index `layerNum`.
  */
 .macro ldlayer layerNum, label
-    _wr_cmd_id  ldlayer, ,ASEQ_CMD_ID_CHANNEL_LDLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  ldlayer, ,ASEQ_OPC_CHANNEL_LDLAYER,,,,,,, \layerNum, 3
     _wr_lbl     \label
 .endm
 
@@ -2036,7 +2036,7 @@ $reladdr\@:
  *  Deletes the layer specified by index `layerNum`.
  */
 .macro dellayer arg
-    _wr_cmd_id  dellayer, ,ASEQ_CMD_ID_CHANNEL_DELLAYER,,,,,,, \arg, 3
+    _wr_cmd_id  dellayer, ,ASEQ_OPC_CHANNEL_DELLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2045,7 +2045,7 @@ $reladdr\@:
  *  Allocates a new layer starting at the pointer read from DYNTBL16[TR]
  */
 .macro dynldlayer arg
-    _wr_cmd_id  dynldlayer, ,ASEQ_CMD_ID_CHANNEL_DYNLDLAYER,,,,,,, \arg, 3
+    _wr_cmd_id  dynldlayer, ,ASEQ_OPC_CHANNEL_DYNLDLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2057,7 +2057,7 @@ $reladdr\@:
  *   - 1 if disabled
  */
 .macro testchan channelNum
-    _wr_cmd_id  testchan, ASEQ_CMD_ID_SEQUENCE_TESTCHAN,,,,,,,, \channelNum, 4
+    _wr_cmd_id  testchan, ASEQ_OPC_SEQUENCE_TESTCHAN,,,,,,,, \channelNum, 4
 .endm
 
 /**
@@ -2067,9 +2067,9 @@ $reladdr\@:
  */
 .macro stopchan channelNum
     .if ASEQ_MODE == ASEQ_MODE_SEQUENCE
-        _wr_cmd_id  stopchan, ASEQ_CMD_ID_SEQUENCE_STOPCHAN,,,,,,,, \channelNum, 4
+        _wr_cmd_id  stopchan, ASEQ_OPC_SEQUENCE_STOPCHAN,,,,,,,, \channelNum, 4
     .else
-        _wr_cmd_id  stopchan, ,ASEQ_CMD_ID_CHANNEL_STOPCHAN,,,,,,, 0, 0
+        _wr_cmd_id  stopchan, ,ASEQ_OPC_CHANNEL_STOPCHAN,,,,,,, 0, 0
         _wr_u8      \channelNum
     .endif
 .endm
@@ -2084,7 +2084,7 @@ $reladdr\@:
  *      Computes TR = TR - CIO[CUR_CHANNEL][portNum]
  */
 .macro subio portNum
-    _wr_cmd_id  subio, ASEQ_CMD_ID_SEQUENCE_SUBIO,ASEQ_CMD_ID_CHANNEL_SUBIO,,,,,,, \portNum, 4
+    _wr_cmd_id  subio, ASEQ_OPC_SEQUENCE_SUBIO,ASEQ_OPC_CHANNEL_SUBIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2101,7 +2101,7 @@ $reladdr\@:
  *  Load status is made available in SIO[portNum].
  */
 .macro ldres portNum, resType, resId
-    _wr_cmd_id  ldres, ASEQ_CMD_ID_SEQUENCE_LDRES,,,,,,,, \portNum, 4
+    _wr_cmd_id  ldres, ASEQ_OPC_SEQUENCE_LDRES,,,,,,,, \portNum, 4
     _wr_u8      \resType
     _wr_u8      \resId
 .endm
@@ -2115,9 +2115,9 @@ $reladdr\@:
  */
 .macro stio portNum
     .if ASEQ_MODE == ASEQ_MODE_CHANNEL
-        _wr_cmd_id  stio, ,ASEQ_CMD_ID_CHANNEL_STIO,,,,,,, \portNum, 3
+        _wr_cmd_id  stio, ,ASEQ_OPC_CHANNEL_STIO,,,,,,, \portNum, 3
     .else
-        _wr_cmd_id  stio, ASEQ_CMD_ID_SEQUENCE_STIO,,,,,,,, \portNum, 4
+        _wr_cmd_id  stio, ASEQ_OPC_SEQUENCE_STIO,,,,,,,, \portNum, 4
     .endif
 .endm
 
@@ -2128,7 +2128,7 @@ $reladdr\@:
  *  depending on current section.
  */
 .macro ldio portNum
-    _wr_cmd_id  ldio, ASEQ_CMD_ID_SEQUENCE_LDIO,ASEQ_CMD_ID_CHANNEL_LDIO,,,,,,, \portNum, 4
+    _wr_cmd_id  ldio, ASEQ_OPC_SEQUENCE_LDIO,ASEQ_OPC_CHANNEL_LDIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2137,7 +2137,7 @@ $reladdr\@:
  *  Opens the sequence channel for index `channelNum` with data beginning at `label`.
  */
 .macro ldchan channelNum, label
-    _wr_cmd_id  ldchan, ASEQ_CMD_ID_SEQUENCE_LDCHAN,ASEQ_CMD_ID_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldchan, ASEQ_OPC_SEQUENCE_LDCHAN,ASEQ_OPC_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
     _wr_lbl     \label
 .endm
 
@@ -2149,7 +2149,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldchan channelNum, label
-    _wr_cmd_id  rldchan, ASEQ_CMD_ID_SEQUENCE_RLDCHAN,,,,,,,, \channelNum, 4
+    _wr_cmd_id  rldchan, ASEQ_OPC_SEQUENCE_RLDCHAN,,,,,,,, \channelNum, 4
     _wr_16_rel  \label
 .endm
 
@@ -2159,7 +2159,7 @@ $reladdr\@:
  *  Delay for `delay` ticks.
  */
 .macro ldelay delay
-    _wr_cmd_id  ldelay, ,,ASEQ_CMD_ID_LAYER_STEP3_LDELAY,,,,,, 0, 0
+    _wr_cmd_id  ldelay, ,,ASEQ_OPC_LAYER_STEP3_LDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2170,7 +2170,7 @@ $reladdr\@:
  * Should never be used when not required for matching purposes.
  */
 .macro lldelay delay
-    _wr_cmd_id  lldelay, ,ASEQ_CMD_ID_CTRLFLOW_DELAY,ASEQ_CMD_ID_LAYER_STEP3_LDELAY,,,,,, 0, 0
+    _wr_cmd_id  lldelay, ,ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_LAYER_STEP3_LDELAY,,,,,, 0, 0
     _var_long   \delay
 .endm
 
@@ -2180,7 +2180,7 @@ $reladdr\@:
  * Set velocity used by short notes.
  */
 .macro shortvel velocity
-    _wr_cmd_id  shortvel, ,,ASEQ_CMD_ID_LAYER_SHORTVEL,,,,,, 0, 0
+    _wr_cmd_id  shortvel, ,,ASEQ_OPC_LAYER_SHORTVEL,,,,,, 0, 0
     _wr_u8      \velocity
 .endm
 
@@ -2190,7 +2190,7 @@ $reladdr\@:
  * Set delay used by short notes.
  */
 .macro shortdelay delay
-    _wr_cmd_id  shortdelay, ,,ASEQ_CMD_ID_LAYER_SHORTDELAY,,,,,, 0, 0
+    _wr_cmd_id  shortdelay, ,,ASEQ_OPC_LAYER_SHORTDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2200,7 +2200,7 @@ $reladdr\@:
  *  Enables legato on the current layer.
  */
 .macro legato
-    _wr_cmd_id  legato, ,,ASEQ_CMD_ID_LAYER_LEGATO,,,,,, 0, 0
+    _wr_cmd_id  legato, ,,ASEQ_OPC_LAYER_LEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2209,7 +2209,7 @@ $reladdr\@:
  *  Disables legato on the current layer.
  */
 .macro nolegato
-    _wr_cmd_id  nolegato, ,,ASEQ_CMD_ID_LAYER_NOLEGATO,,,,,, 0, 0
+    _wr_cmd_id  nolegato, ,,ASEQ_OPC_LAYER_NOLEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2218,7 +2218,7 @@ $reladdr\@:
  *  The time argument is either a var or a u8 depending on mode
  */
 .macro portamento mode, target, time
-    _wr_cmd_id  portamento, ,,ASEQ_CMD_ID_LAYER_PORTAMENTO,,,,,, 0, 0
+    _wr_cmd_id  portamento, ,,ASEQ_OPC_LAYER_PORTAMENTO,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u8      \target
     .if (\mode & 0x80) != 0
@@ -2234,7 +2234,7 @@ $reladdr\@:
  *  Disables portamento on the current layer.
  */
 .macro noportamento
-    _wr_cmd_id  noportamento, ,,ASEQ_CMD_ID_LAYER_NOPORTAMENTO,,,,,, 0, 0
+    _wr_cmd_id  noportamento, ,,ASEQ_OPC_LAYER_NOPORTAMENTO,,,,,, 0, 0
 .endm
 
 /**
@@ -2243,7 +2243,7 @@ $reladdr\@:
  *  Sets gate time for short notes.
  */
 .macro shortgate gateTime
-    _wr_cmd_id  shortgate, ,,ASEQ_CMD_ID_LAYER_SHORTGATE,,,,,, 0, 0
+    _wr_cmd_id  shortgate, ,,ASEQ_OPC_LAYER_SHORTGATE,,,,,, 0, 0
     _wr_u8      \gateTime
 .endm
 
@@ -2255,7 +2255,7 @@ $reladdr\@:
 .macro notepan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  notepan, ,,ASEQ_CMD_ID_LAYER_NOTEPAN,,,,,, 0, 0
+    _wr_cmd_id  notepan, ,,ASEQ_OPC_LAYER_NOTEPAN,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -2266,7 +2266,7 @@ $reladdr\@:
  *  use pan set in the layer.
  */
 .macro nodrumpan
-    _wr_cmd_id  nodrumpan, ,,ASEQ_CMD_ID_LAYER_NODRUMPAN,,,,,, 0, 0
+    _wr_cmd_id  nodrumpan, ,,ASEQ_OPC_LAYER_NODRUMPAN,,,,,, 0, 0
 .endm
 
 /**
@@ -2274,7 +2274,7 @@ $reladdr\@:
  *
  *  TODO DESCRIPTION
  */
-#define STEREO_OPCODE ASEQ_CMD_ID_LAYER_STEREO
+#define STEREO_OPCODE ASEQ_OPC_LAYER_STEREO
 .macro stereo type, strongR, strongL, strongRvrbR, strongRvrbL
     _check_arg_bitwidth_u \type, 2
     _check_arg_bitwidth_u \strongR, 1
@@ -2282,7 +2282,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  stereo, ,,ASEQ_CMD_ID_LAYER_STEREO,,,,,, 0, 0
+    _wr_cmd_id  stereo, ,,ASEQ_OPC_LAYER_STEREO,,,,,, 0, 0
     _wr_u8      (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -2292,7 +2292,7 @@ $reladdr\@:
  *  Sets the velocity used in short notes by reading from SHORTVELTBL[velocity]
  */
 .macro ldshortvel velocity
-    _wr_cmd_id  ldshortvel, ,,ASEQ_CMD_ID_LAYER_LDSHORTVEL,,,,,, \velocity, 4
+    _wr_cmd_id  ldshortvel, ,,ASEQ_OPC_LAYER_LDSHORTVEL,,,,,, \velocity, 4
 .endm
 
 /**
@@ -2301,7 +2301,7 @@ $reladdr\@:
  *  Sets the gate time used in short notes by reading from SHORTGATETBL[gateTime]
  */
 .macro ldshortgate gateTime
-    _wr_cmd_id  ldshortgate, ,,ASEQ_CMD_ID_LAYER_LDSHORTGATE,,,,,, \gateTime, 4
+    _wr_cmd_id  ldshortgate, ,,ASEQ_OPC_LAYER_LDSHORTGATE,,,,,, \gateTime, 4
 .endm
 
 #if (MML_VERSION == MML_VERSION_MM)
@@ -2342,9 +2342,9 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDVG_OPCODE ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG
+#define NOTEDVG_OPCODE ASEQ_OPC_LAYER_STEP3_NOTEDVG
 .macro notedvg pitch, delay, velocity, gateTime
-    _wr_cmd_id  notedvg, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG,,,,,, \pitch, 6
+    _wr_cmd_id  notedvg, ,,ASEQ_OPC_LAYER_STEP3_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
     _wr_u8      \gateTime
@@ -2357,16 +2357,16 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDV_OPCODE ASEQ_CMD_ID_LAYER_STEP3_NOTEDV
+#define NOTEDV_OPCODE ASEQ_OPC_LAYER_STEP3_NOTEDV
 .macro notedv pitch, delay, velocity
-    _wr_cmd_id  notedv, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  notedv, ,,ASEQ_OPC_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
 .endm
 
 /* Workaround for bugs in vanilla sequences, force long encoding for delay. This should not typically be used. */
 .macro noteldv pitch, delay, velocity
-    _wr_cmd_id  noteldv, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  noteldv, ,,ASEQ_OPC_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
     _var_long   \delay
     _wr_u8      \velocity
 .endm
@@ -2379,7 +2379,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notevg pitch, velocity, gateTime
-    _wr_cmd_id  notevg, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEVG,,,,,, \pitch, 6
+    _wr_cmd_id  notevg, ,,ASEQ_OPC_LAYER_STEP3_NOTEVG,,,,,, \pitch, 6
     _wr_u8      \velocity
     _wr_u8      \gateTime
 .endm
@@ -2393,7 +2393,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdvg pitch, delay
-    _wr_cmd_id  shortdvg, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG,,,,,, \pitch, 6
+    _wr_cmd_id  shortdvg, ,,ASEQ_OPC_LAYER_STEP3_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
 .endm
 
@@ -2406,7 +2406,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdv pitch
-    _wr_cmd_id  shortdv, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  shortdv, ,,ASEQ_OPC_LAYER_STEP3_NOTEDV,,,,,, \pitch, 6
 .endm
 
 /**
@@ -2418,7 +2418,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortvg pitch
-    _wr_cmd_id  shortvg, ,,ASEQ_CMD_ID_LAYER_STEP3_NOTEVG,,,,,, \pitch, 6
+    _wr_cmd_id  shortvg, ,,ASEQ_OPC_LAYER_STEP3_NOTEVG,,,,,, \pitch, 6
 .endm
 
 /**

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -1799,7 +1799,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
 
             if (cmd >= 0xC0) {
                 switch (cmd) {
-                    case ASEQ_OP_SEQUENCE_ALLOCNOTELIST:
+                    case ASEQ_OP_SEQ_ALLOCNOTELIST:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         Audio_NotePoolFill(&seqPlayer->notePool, cmd);
@@ -1815,18 +1815,18 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         if (dummy) {}
                         break;
 
-                    case ASEQ_OP_SEQUENCE_FREENOTELIST:
+                    case ASEQ_OP_SEQ_FREENOTELIST:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_TRANSPOSE:
+                    case ASEQ_OP_SEQ_TRANSPOSE:
                         seqPlayer->transposition = 0;
                         FALLTHROUGH;
-                    case ASEQ_OP_SEQUENCE_RTRANSPOSE:
+                    case ASEQ_OP_SEQ_RTRANSPOSE:
                         seqPlayer->transposition += (s8)AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_TEMPO:
+                    case ASEQ_OP_SEQ_TEMPO:
                         seqPlayer->tempo = AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         if (seqPlayer->tempo > gAudioCtx.maxTempo) {
                             seqPlayer->tempo = (u16)gAudioCtx.maxTempo;
@@ -1837,11 +1837,11 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OP_SEQUENCE_TEMPOCHG:
+                    case ASEQ_OP_SEQ_TEMPOCHG:
                         seqPlayer->tempoChange = (s8)AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         break;
 
-                    case ASEQ_OP_SEQUENCE_VOLMODE:
+                    case ASEQ_OP_SEQ_VOLMODE:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         switch (cmd) {
@@ -1861,7 +1861,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OP_SEQUENCE_VOL:
+                    case ASEQ_OP_SEQ_VOL:
                         value = AudioSeq_ScriptReadU8(seqScript);
                         switch (seqPlayer->state) {
                             case 1:
@@ -1883,47 +1883,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OP_SEQUENCE_VOLSCALE:
+                    case ASEQ_OP_SEQ_VOLSCALE:
                         seqPlayer->fadeVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case ASEQ_OP_SEQUENCE_INITCHAN:
+                    case ASEQ_OP_SEQ_INITCHAN:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         AudioSeq_SequencePlayerSetupChannels(seqPlayer, temp);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_FREECHAN:
+                    case ASEQ_OP_SEQ_FREECHAN:
                         AudioSeq_ScriptReadS16(seqScript);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_MUTESCALE:
+                    case ASEQ_OP_SEQ_MUTESCALE:
                         seqPlayer->muteVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case ASEQ_OP_SEQUENCE_MUTE:
+                    case ASEQ_OP_SEQ_MUTE:
                         seqPlayer->muted = true;
                         break;
 
-                    case ASEQ_OP_SEQUENCE_MUTEBHV:
+                    case ASEQ_OP_SEQ_MUTEBHV:
                         seqPlayer->muteBehavior = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_LDSHORTGATEARR:
-                    case ASEQ_OP_SEQUENCE_LDSHORTVELARR:
+                    case ASEQ_OP_SEQ_LDSHORTGATEARR:
+                    case ASEQ_OP_SEQ_LDSHORTVELARR:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data3 = &seqPlayer->seqData[temp];
-                        if (cmd == ASEQ_OP_SEQUENCE_LDSHORTVELARR) {
+                        if (cmd == ASEQ_OP_SEQ_LDSHORTVELARR) {
                             seqPlayer->shortNoteVelocityTable = data3;
                         } else {
                             seqPlayer->shortNoteGateTimeTable = data3;
                         }
                         break;
 
-                    case ASEQ_OP_SEQUENCE_NOTEALLOC:
+                    case ASEQ_OP_SEQ_NOTEALLOC:
                         seqPlayer->noteAllocPolicy = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_RAND:
+                    case ASEQ_OP_SEQ_RAND:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0) {
                             seqScript->value = (gAudioCtx.audioRandom >> 2) & 0xFF;
@@ -1932,7 +1932,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OP_SEQUENCE_DYNCALL:
+                    case ASEQ_OP_SEQ_DYNCALL:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         if ((seqScript->value != -1) && (seqScript->depth != 3)) {
                             data = seqPlayer->seqData + (u32)(temp + (seqScript->value << 1));
@@ -1944,39 +1944,39 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OP_SEQUENCE_LDI:
+                    case ASEQ_OP_SEQ_LDI:
                         seqScript->value = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_AND:
+                    case ASEQ_OP_SEQ_AND:
                         seqScript->value &= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_SUB:
+                    case ASEQ_OP_SEQ_SUB:
                         seqScript->value -= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_STSEQ:
+                    case ASEQ_OP_SEQ_STSEQ:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data2 = &seqPlayer->seqData[temp];
                         *data2 = (u8)seqScript->value + cmd;
                         break;
 
-                    case ASEQ_OP_SEQUENCE_STOP:
+                    case ASEQ_OP_SEQ_STOP:
                         seqPlayer->stopScript = true;
                         return;
 
-                    case ASEQ_OP_SEQUENCE_SCRIPTCTR:
+                    case ASEQ_OP_SEQ_SCRIPTCTR:
                         seqPlayer->scriptCounter = (u16)AudioSeq_ScriptReadS16(seqScript);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_EF:
+                    case ASEQ_OP_SEQ_EF:
                         AudioSeq_ScriptReadS16(seqScript);
                         AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OP_SEQUENCE_RUNSEQ:
+                    case ASEQ_OP_SEQ_RUNSEQ:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0xFF) {
                             cmd = seqPlayer->playerIdx;
@@ -1994,47 +1994,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmdLowBits = cmd & 0x0F;
 
             switch (cmd & 0xF0) {
-                case ASEQ_OP_SEQUENCE_TESTCHAN:
+                case ASEQ_OP_SEQ_TESTCHAN:
                     seqScript->value = seqPlayer->channels[cmdLowBits]->enabled ^ 1;
                     break;
 
-                case ASEQ_OP_SEQUENCE_SUBIO:
+                case ASEQ_OP_SEQ_SUBIO:
                     seqScript->value -= seqPlayer->seqScriptIO[cmdLowBits];
                     break;
 
-                case ASEQ_OP_SEQUENCE_STIO:
+                case ASEQ_OP_SEQ_STIO:
                     seqPlayer->seqScriptIO[cmdLowBits] = seqScript->value;
                     break;
 
-                case ASEQ_OP_SEQUENCE_LDIO:
+                case ASEQ_OP_SEQ_LDIO:
                     seqScript->value = seqPlayer->seqScriptIO[cmdLowBits];
                     if (cmdLowBits < 2) {
                         seqPlayer->seqScriptIO[cmdLowBits] = SEQ_IO_VAL_NONE;
                     }
                     break;
 
-                case ASEQ_OP_SEQUENCE_STOPCHAN:
+                case ASEQ_OP_SEQ_STOPCHAN:
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmdLowBits]);
                     break;
 
-                case ASEQ_OP_SEQUENCE_LDCHAN:
+                case ASEQ_OP_SEQ_LDCHAN:
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqPlayer->seqData[temp]);
                     break;
 
-                case ASEQ_OP_SEQUENCE_RLDCHAN:
+                case ASEQ_OP_SEQ_RLDCHAN:
                     tempS = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqScript->pc[tempS]);
                     break;
 
-                case ASEQ_OP_SEQUENCE_LDSEQ:
+                case ASEQ_OP_SEQ_LDSEQ:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     data2 = &seqPlayer->seqData[temp];
                     AudioLoad_SlowLoadSeq(cmd, data2, &seqPlayer->seqScriptIO[cmdLowBits]);
                     break;
 
-                case ASEQ_OP_SEQUENCE_LDRES:
+                case ASEQ_OP_SEQ_LDRES:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     value = cmd;
                     temp = AudioSeq_ScriptReadU8(seqScript);

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -1001,7 +1001,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
     s32 intDelta;
     f32 floatDelta;
 
-    if (cmd == ASEQ_OPC_LAYER_STEP3_LDELAY) {
+    if (cmd == ASEQ_OPC_LAYER_LDELAY) {
         layer->delay = AudioSeq_ScriptReadCompressedU16(state);
         layer->muted = true;
         layer->bit1 = false;
@@ -1012,21 +1012,21 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
 
     if (channel->largeNotes == true) {
         switch (cmd & 0xC0) {
-            case ASEQ_OPC_LAYER_STEP3_NOTEDVG:
+            case ASEQ_OPC_LAYER_NOTEDVG:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_OPC_LAYER_STEP3_NOTEDV:
+            case ASEQ_OPC_LAYER_NOTEDV:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = 0;
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_OPC_LAYER_STEP3_NOTEVG:
+            case ASEQ_OPC_LAYER_NOTEVG:
                 delay = layer->lastDelay;
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
@@ -1040,16 +1040,16 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
         cmd -= (cmd & 0xC0);
     } else {
         switch (cmd & 0xC0) {
-            case ASEQ_OPC_LAYER_STEP3_NOTEDVG:
+            case ASEQ_OPC_LAYER_NOTEDVG:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_OPC_LAYER_STEP3_NOTEDV:
+            case ASEQ_OPC_LAYER_NOTEDV:
                 delay = layer->shortNoteDefaultDelay;
                 break;
 
-            case ASEQ_OPC_LAYER_STEP3_NOTEVG:
+            case ASEQ_OPC_LAYER_NOTEVG:
                 delay = layer->lastDelay;
                 break;
         }

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -71,92 +71,92 @@ u8 AudioSeq_GetInstrument(SequenceChannel* channel, u8 instId, Instrument** inst
     (((sizeof(arg0Type) - 1) << 7) | ((sizeof(arg1Type) - 1) << 6) | ((sizeof(arg2Type) - 1) << 5) | 3)
 
 u8 sSeqInstructionArgsTable[] = {
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDFILTER
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_FREEFILTER
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDSEQTOPTR
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_FILTER
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_PTRTODYNTBL
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_DYNTBLTOPTR
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_DYNTBLV
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_RANDTOPTR
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_RAND
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_RANDVEL
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_RANDGATE
-    CMD_ARGS_2(u8, s16),    // ASEQ_CMD_ID_CHANNEL_COMBFILTER
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_PTRADD
-    CMD_ARGS_2(s16, s16),   // ASEQ_CMD_ID_CHANNEL_RANDPTR
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDFILTER
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_FREEFILTER
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDSEQTOPTR
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_FILTER
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_PTRTODYNTBL
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_DYNTBLTOPTR
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_DYNTBLV
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_RANDTOPTR
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_RAND
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_RANDVEL
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_RANDGATE
+    CMD_ARGS_2(u8, s16),    // ASEQ_OPC_CHANNEL_COMBFILTER
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_PTRADD
+    CMD_ARGS_2(s16, s16),   // ASEQ_OPC_CHANNEL_RANDPTR
     CMD_ARGS_0(),           // 0xBE
     CMD_ARGS_0(),           // 0xBF
     CMD_ARGS_0(),           // 0xC0
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_INSTR
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_DYNTBL
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_SHORT
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_NOSHORT
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_DYNTBLLOOKUP
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_FONT
-    CMD_ARGS_2(u8, s16),    // ASEQ_CMD_ID_CHANNEL_STSEQ
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_SUB
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_AND
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_MUTEBHV
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDSEQ
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_LDI
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_STOPCHAN
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDPTR
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_STPTRTOSEQ
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_EFFECTS
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_NOTEALLOC
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_SUSTAIN
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_BEND
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_REVERB
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_INSTR
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_DYNTBL
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_SHORT
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_NOSHORT
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_DYNTBLLOOKUP
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_FONT
+    CMD_ARGS_2(u8, s16),    // ASEQ_OPC_CHANNEL_STSEQ
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_SUB
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_AND
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_MUTEBHV
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDSEQ
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_LDI
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_STOPCHAN
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDPTR
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_STPTRTOSEQ
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_EFFECTS
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_NOTEALLOC
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_SUSTAIN
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_BEND
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_REVERB
     CMD_ARGS_1(u8),         // 0xD5
     CMD_ARGS_1(u8),         // 0xD6
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VIBFREQ
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VIBDEPTH
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_RELEASERATE
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_ENV
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_TRANSPOSE
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_PANWEIGHT
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_PAN
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_FREQSCALE
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VOL
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VOLEXP
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_VIBFREQGRAD
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_VIBDEPTHGRAD
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VIBDELAY
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_DYNCALL
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_REVERBIDX
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_SAMPLEBOOK
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDPARAMS
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_PARAMS
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_NOTEPRI
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_STOP
-    CMD_ARGS_2(u8, u8),     // ASEQ_CMD_ID_CHANNEL_FONTINSTR
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_VIBRESET
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_GAIN
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_BENDFINE
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VIBFREQ
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VIBDEPTH
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_RELEASERATE
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_ENV
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_TRANSPOSE
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_PANWEIGHT
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_PAN
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_FREQSCALE
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VOL
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VOLEXP
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_OPC_CHANNEL_VIBFREQGRAD
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_OPC_CHANNEL_VIBDEPTHGRAD
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VIBDELAY
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_DYNCALL
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_REVERBIDX
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_SAMPLEBOOK
+    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDPARAMS
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_OPC_CHANNEL_PARAMS
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_NOTEPRI
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_STOP
+    CMD_ARGS_2(u8, u8),     // ASEQ_OPC_CHANNEL_FONTINSTR
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_VIBRESET
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_GAIN
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_BENDFINE
     CMD_ARGS_2(s16, u8),    // 0xEF
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_FREENOTELIST
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_ALLOCNOTELIST
-    // Control flow instructions (>= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) can only have 0 or 1 args
-    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_RBLTZ
-    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_RBEQZ
-    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_RJUMP
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_BGEZ
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_BREAK
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_LOOPEND
-    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_LOOP
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_BLTZ
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_BEQZ
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_JUMP
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_CALL
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_DELAY
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_DELAY1
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_END
+    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_FREENOTELIST
+    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_ALLOCNOTELIST
+    // Control flow instructions (>= ASEQ_OPC_CONTROL_FLOW_FIRST) can only have 0 or 1 args
+    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_RBLTZ
+    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_RBEQZ
+    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_RJUMP
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_BGEZ
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_BREAK
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_LOOPEND
+    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_LOOP
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_BLTZ
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_BEQZ
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_JUMP
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_CALL
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_DELAY
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_DELAY1
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_END
 };
 
 /**
  * Read and return the argument from the sequence script for a control flow instruction.
- * Control flow instructions (>= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) can only have 0 or 1 args.
+ * Control flow instructions (>= ASEQ_OPC_CONTROL_FLOW_FIRST) can only have 0 or 1 args.
  * @return the argument value for a control flow instruction, or 0 if there is no argument
  */
 u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
@@ -182,30 +182,30 @@ u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
  */
 s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* state, s32 cmd, s32 cmdArg) {
     switch (cmd) {
-        case ASEQ_CMD_ID_CTRLFLOW_END:
+        case ASEQ_OPC_CTRLFLOW_END:
             if (state->depth == 0) {
                 return PROCESS_SCRIPT_END;
             }
             state->pc = state->stack[--state->depth];
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_DELAY:
+        case ASEQ_OPC_CTRLFLOW_DELAY:
             return AudioSeq_ScriptReadCompressedU16(state);
 
-        case ASEQ_CMD_ID_CTRLFLOW_DELAY1:
+        case ASEQ_OPC_CTRLFLOW_DELAY1:
             return 1;
 
-        case ASEQ_CMD_ID_CTRLFLOW_CALL:
+        case ASEQ_OPC_CTRLFLOW_CALL:
             state->stack[state->depth++] = state->pc;
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_LOOP:
+        case ASEQ_OPC_CTRLFLOW_LOOP:
             state->remLoopIters[state->depth] = cmdArg;
             state->stack[state->depth++] = state->pc;
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_LOOPEND:
+        case ASEQ_OPC_CTRLFLOW_LOOPEND:
             state->remLoopIters[state->depth - 1]--;
             if (state->remLoopIters[state->depth - 1] != 0) {
                 state->pc = state->stack[state->depth - 1];
@@ -214,33 +214,33 @@ s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* 
             }
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_BREAK:
+        case ASEQ_OPC_CTRLFLOW_BREAK:
             state->depth--;
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_BGEZ:
-        case ASEQ_CMD_ID_CTRLFLOW_BLTZ:
-        case ASEQ_CMD_ID_CTRLFLOW_BEQZ:
-        case ASEQ_CMD_ID_CTRLFLOW_JUMP:
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_BEQZ && state->value != 0) {
+        case ASEQ_OPC_CTRLFLOW_BGEZ:
+        case ASEQ_OPC_CTRLFLOW_BLTZ:
+        case ASEQ_OPC_CTRLFLOW_BEQZ:
+        case ASEQ_OPC_CTRLFLOW_JUMP:
+            if (cmd == ASEQ_OPC_CTRLFLOW_BEQZ && state->value != 0) {
                 break;
             }
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_BLTZ && state->value >= 0) {
+            if (cmd == ASEQ_OPC_CTRLFLOW_BLTZ && state->value >= 0) {
                 break;
             }
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_BGEZ && state->value < 0) {
+            if (cmd == ASEQ_OPC_CTRLFLOW_BGEZ && state->value < 0) {
                 break;
             }
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_RBLTZ:
-        case ASEQ_CMD_ID_CTRLFLOW_RBEQZ:
-        case ASEQ_CMD_ID_CTRLFLOW_RJUMP:
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_RBEQZ && state->value != 0) {
+        case ASEQ_OPC_CTRLFLOW_RBLTZ:
+        case ASEQ_OPC_CTRLFLOW_RBEQZ:
+        case ASEQ_OPC_CTRLFLOW_RJUMP:
+            if (cmd == ASEQ_OPC_CTRLFLOW_RBEQZ && state->value != 0) {
                 break;
             }
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_RBLTZ && state->value >= 0) {
+            if (cmd == ASEQ_OPC_CTRLFLOW_RBLTZ && state->value >= 0) {
                 break;
             }
             state->pc += (s8)(cmdArg & 0xFF);
@@ -646,7 +646,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
         }
 
         // Control Flow Commands
-        if (cmd >= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) {
+        if (cmd >= ASEQ_OPC_CONTROL_FLOW_FIRST) {
             cmdArg16 = AudioSeq_GetScriptControlFlowArgument(state, cmd);
 
             if (AudioSeq_HandleScriptFlowControl(seqPlayer, state, cmd, cmdArg16) == 0) {
@@ -657,29 +657,29 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
         }
 
         switch (cmd) {
-            case ASEQ_CMD_ID_LAYER_SHORTVEL: // layer_setshortnotevelocity
-            case ASEQ_CMD_ID_LAYER_NOTEPAN: // layer_setpan
+            case ASEQ_OPC_LAYER_SHORTVEL: // layer_setshortnotevelocity
+            case ASEQ_OPC_LAYER_NOTEPAN: // layer_setpan
                 cmdArg8 = *(state->pc++);
-                if (cmd == ASEQ_CMD_ID_LAYER_SHORTVEL) {
+                if (cmd == ASEQ_OPC_LAYER_SHORTVEL) {
                     layer->velocitySquare = SQ(cmdArg8) / SQ(127.0f);
                 } else {
                     layer->pan = cmdArg8;
                 }
                 break;
 
-            case ASEQ_CMD_ID_LAYER_SHORTGATE: // layer_setshortnotegatetime
-            case ASEQ_CMD_ID_LAYER_TRANSPOSE: // layer_transpose; set transposition in semitones
+            case ASEQ_OPC_LAYER_SHORTGATE: // layer_setshortnotegatetime
+            case ASEQ_OPC_LAYER_TRANSPOSE: // layer_transpose; set transposition in semitones
                 cmdArg8 = *(state->pc++);
-                if (cmd == ASEQ_CMD_ID_LAYER_SHORTGATE) {
+                if (cmd == ASEQ_OPC_LAYER_SHORTGATE) {
                     layer->gateTime = cmdArg8;
                 } else {
                     layer->transposition = cmdArg8;
                 }
                 break;
 
-            case ASEQ_CMD_ID_LAYER_LEGATO: // layer_continuousnoteson
-            case ASEQ_CMD_ID_LAYER_NOLEGATO: // layer_continuousnotesoff
-                if (cmd == ASEQ_CMD_ID_LAYER_LEGATO) {
+            case ASEQ_OPC_LAYER_LEGATO: // layer_continuousnoteson
+            case ASEQ_OPC_LAYER_NOLEGATO: // layer_continuousnotesoff
+                if (cmd == ASEQ_OPC_LAYER_LEGATO) {
                     layer->continuousNotes = true;
                 } else {
                     layer->continuousNotes = false;
@@ -688,12 +688,12 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 Audio_SeqLayerNoteDecay(layer);
                 break;
 
-            case ASEQ_CMD_ID_LAYER_SHORTDELAY: // layer_setshortnotedefaultdelay
+            case ASEQ_OPC_LAYER_SHORTDELAY: // layer_setshortnotedefaultdelay
                 cmdArg16 = AudioSeq_ScriptReadCompressedU16(state);
                 layer->shortNoteDefaultDelay = cmdArg16;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_INSTR: // layer_setinstr
+            case ASEQ_OPC_LAYER_INSTR: // layer_setinstr
                 cmd = AudioSeq_ScriptReadU8(state);
                 if (cmd >= 0x7E) {
                     if (cmd == 0x7E) {
@@ -720,7 +720,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 }
                 break;
 
-            case ASEQ_CMD_ID_LAYER_PORTAMENTO: // layer_portamento
+            case ASEQ_OPC_LAYER_PORTAMENTO: // layer_portamento
                 layer->portamento.mode = AudioSeq_ScriptReadU8(state);
 
                 cmd = AudioSeq_ScriptReadU8(state);
@@ -744,39 +744,39 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 layer->portamentoTime = cmdArg16;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_NOPORTAMENTO: // layer_disableportamento
+            case ASEQ_OPC_LAYER_NOPORTAMENTO: // layer_disableportamento
                 layer->portamento.mode = PORTAMENTO_MODE_OFF;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_ENV:
+            case ASEQ_OPC_LAYER_ENV:
                 cmdArg16 = AudioSeq_ScriptReadS16(state);
                 layer->adsr.envelope = (EnvelopePoint*)(seqPlayer->seqData + cmdArg16);
                 FALLTHROUGH;
-            case ASEQ_CMD_ID_LAYER_RELEASERATE:
+            case ASEQ_OPC_LAYER_RELEASERATE:
                 layer->adsr.decayIndex = AudioSeq_ScriptReadU8(state);
                 break;
 
-            case ASEQ_CMD_ID_LAYER_NODRUMPAN:
+            case ASEQ_OPC_LAYER_NODRUMPAN:
                 layer->ignoreDrumPan = true;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_STEREO:
+            case ASEQ_OPC_LAYER_STEREO:
                 layer->stereo.asByte = AudioSeq_ScriptReadU8(state);
                 break;
 
-            case ASEQ_CMD_ID_LAYER_BENDFINE:
+            case ASEQ_OPC_LAYER_BENDFINE:
                 cmdArg8 = AudioSeq_ScriptReadU8(state);
                 layer->bend = gBendPitchTwoSemitonesFrequencies[(u8)(cmdArg8 + 0x80)];
                 break;
 
             default:
                 switch (cmd & 0xF0) {
-                    case ASEQ_CMD_ID_LAYER_LDSHORTVEL: // layer_setshortnotevelocityfromtable
+                    case ASEQ_OPC_LAYER_LDSHORTVEL: // layer_setshortnotevelocityfromtable
                         velocity = seqPlayer->shortNoteVelocityTable[cmd & 0xF];
                         layer->velocitySquare = SQ(velocity) / SQ(127.0f);
                         break;
 
-                    case ASEQ_CMD_ID_LAYER_LDSHORTGATE: // layer_setshortnotegatetimefromtable
+                    case ASEQ_OPC_LAYER_LDSHORTGATE: // layer_setshortnotegatetimefromtable
                         layer->gateTime = seqPlayer->shortNoteGateTimeTable[cmd & 0xF];
                         break;
                 }
@@ -1001,7 +1001,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
     s32 intDelta;
     f32 floatDelta;
 
-    if (cmd == ASEQ_CMD_ID_LAYER_STEP3_LDELAY) {
+    if (cmd == ASEQ_OPC_LAYER_STEP3_LDELAY) {
         layer->delay = AudioSeq_ScriptReadCompressedU16(state);
         layer->muted = true;
         layer->bit1 = false;
@@ -1012,21 +1012,21 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
 
     if (channel->largeNotes == true) {
         switch (cmd & 0xC0) {
-            case ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG:
+            case ASEQ_OPC_LAYER_STEP3_NOTEDVG:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_STEP3_NOTEDV:
+            case ASEQ_OPC_LAYER_STEP3_NOTEDV:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = 0;
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_STEP3_NOTEVG:
+            case ASEQ_OPC_LAYER_STEP3_NOTEVG:
                 delay = layer->lastDelay;
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
@@ -1040,16 +1040,16 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
         cmd -= (cmd & 0xC0);
     } else {
         switch (cmd & 0xC0) {
-            case ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG:
+            case ASEQ_OPC_LAYER_STEP3_NOTEDVG:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_STEP3_NOTEDV:
+            case ASEQ_OPC_LAYER_STEP3_NOTEDV:
                 delay = layer->shortNoteDefaultDelay;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_STEP3_NOTEVG:
+            case ASEQ_OPC_LAYER_STEP3_NOTEVG:
                 delay = layer->lastDelay;
                 break;
         }
@@ -1211,7 +1211,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             // Control Flow Commands
-            if (cmd >= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) {
+            if (cmd >= ASEQ_OPC_CONTROL_FLOW_FIRST) {
                 delay = AudioSeq_HandleScriptFlowControl(seqPlayer, scriptState, cmd, cmdArgs[0]);
 
                 if (delay != 0) {
@@ -1226,26 +1226,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             switch (cmd) {
-                case ASEQ_CMD_ID_CHANNEL_STOP:
+                case ASEQ_OPC_CHANNEL_STOP:
                     channel->stopScript = true;
                     goto exit_loop;
 
-                case ASEQ_CMD_ID_CHANNEL_ALLOCNOTELIST:
+                case ASEQ_OPC_CHANNEL_ALLOCNOTELIST:
                     Audio_NotePoolClear(&channel->notePool);
                     cmd = (u8)cmdArgs[0];
                     Audio_NotePoolFill(&channel->notePool, cmd);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_FREENOTELIST:
+                case ASEQ_OPC_CHANNEL_FREENOTELIST:
                     Audio_NotePoolClear(&channel->notePool);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DYNTBL:
+                case ASEQ_OPC_CHANNEL_DYNTBL:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->dynTable = (void*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DYNTBLLOOKUP:
+                case ASEQ_OPC_CHANNEL_DYNTBLLOOKUP:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (u16)((data[0] << 8) + data[1]);
@@ -1254,7 +1254,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_FONTINSTR:
+                case ASEQ_OPC_CHANNEL_FONTINSTR:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1269,93 +1269,93 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
 
                     cmdArgs[0] = cmdArgs[1];
                     FALLTHROUGH;
-                case ASEQ_CMD_ID_CHANNEL_INSTR:
+                case ASEQ_OPC_CHANNEL_INSTR:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SetInstrument(channel, cmd);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_SHORT:
+                case ASEQ_OPC_CHANNEL_SHORT:
                     channel->largeNotes = false;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_NOSHORT:
+                case ASEQ_OPC_CHANNEL_NOSHORT:
                     channel->largeNotes = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_VOL:
+                case ASEQ_OPC_CHANNEL_VOL:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelSetVolume(channel, cmd);
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_VOLEXP:
+                case ASEQ_OPC_CHANNEL_VOLEXP:
                     cmd = (u8)cmdArgs[0];
                     channel->volumeScale = (s32)cmd / 128.0f;
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_FREQSCALE:
+                case ASEQ_OPC_CHANNEL_FREQSCALE:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->freqScale = (s32)cmdArgU16 / 32768.0f;
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_BEND:
+                case ASEQ_OPC_CHANNEL_BEND:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchOneOctaveFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_BENDFINE:
+                case ASEQ_OPC_CHANNEL_BENDFINE:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchTwoSemitonesFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_PAN:
+                case ASEQ_OPC_CHANNEL_PAN:
                     cmd = (u8)cmdArgs[0];
                     channel->newPan = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_PANWEIGHT:
+                case ASEQ_OPC_CHANNEL_PANWEIGHT:
                     cmd = (u8)cmdArgs[0];
                     channel->panChannelWeight = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_TRANSPOSE:
+                case ASEQ_OPC_CHANNEL_TRANSPOSE:
                     cmdArgS8 = (s8)cmdArgs[0];
                     channel->transposition = cmdArgS8;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_ENV:
+                case ASEQ_OPC_CHANNEL_ENV:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->adsr.envelope = (EnvelopePoint*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_RELEASERATE:
+                case ASEQ_OPC_CHANNEL_RELEASERATE:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.decayIndex = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_VIBDEPTH:
+                case ASEQ_OPC_CHANNEL_VIBDEPTH:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthTarget = cmd * 8;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_VIBFREQ:
+                case ASEQ_OPC_CHANNEL_VIBFREQ:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateChangeDelay = 0;
                     channel->vibratoRateTarget = cmd * 32;
                     channel->vibratoRateStart = cmd * 32;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_VIBDEPTHGRAD:
+                case ASEQ_OPC_CHANNEL_VIBDEPTHGRAD:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthStart = cmd * 8;
                     cmd = (u8)cmdArgs[1];
@@ -1364,7 +1364,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoDepthChangeDelay = cmd * 16;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_VIBFREQGRAD:
+                case ASEQ_OPC_CHANNEL_VIBFREQGRAD:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateStart = cmd * 32;
                     cmd = (u8)cmdArgs[1];
@@ -1373,17 +1373,17 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoRateChangeDelay = cmd * 16;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_VIBDELAY:
+                case ASEQ_OPC_CHANNEL_VIBDELAY:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDelay = cmd * 16;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_REVERB:
+                case ASEQ_OPC_CHANNEL_REVERB:
                     cmd = (u8)cmdArgs[0];
                     channel->targetReverbVol = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_FONT:
+                case ASEQ_OPC_CHANNEL_FONT:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1397,56 +1397,56 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_STSEQ:
+                case ASEQ_OPC_CHANNEL_STSEQ:
                     cmd = (u8)cmdArgs[0];
                     cmdArgU16 = (u16)cmdArgs[1];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (u8)scriptState->value + cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_SUB:
-                case ASEQ_CMD_ID_CHANNEL_LDI:
-                case ASEQ_CMD_ID_CHANNEL_AND:
+                case ASEQ_OPC_CHANNEL_SUB:
+                case ASEQ_OPC_CHANNEL_LDI:
+                case ASEQ_OPC_CHANNEL_AND:
                     cmdArgS8 = (s8)cmdArgs[0];
 
-                    if (cmd == ASEQ_CMD_ID_CHANNEL_SUB) {
+                    if (cmd == ASEQ_OPC_CHANNEL_SUB) {
                         scriptState->value -= cmdArgS8;
-                    } else if (cmd == ASEQ_CMD_ID_CHANNEL_LDI) {
+                    } else if (cmd == ASEQ_OPC_CHANNEL_LDI) {
                         scriptState->value = cmdArgS8;
                     } else {
                         scriptState->value &= cmdArgS8;
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_STOPCHAN:
+                case ASEQ_OPC_CHANNEL_STOPCHAN:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmd]);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_MUTEBHV:
+                case ASEQ_OPC_CHANNEL_MUTEBHV:
                     cmd = (u8)cmdArgs[0];
                     channel->muteBehavior = cmd;
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_LDSEQ:
+                case ASEQ_OPC_CHANNEL_LDSEQ:
                     cmdArgU16 = (u16)cmdArgs[0];
                     scriptState->value = *(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value));
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_LDPTR:
+                case ASEQ_OPC_CHANNEL_LDPTR:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = cmdArgU16;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_STPTRTOSEQ:
+                case ASEQ_OPC_CHANNEL_STPTRTOSEQ:
                     cmdArgU16 = (u16)cmdArgs[0];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (channel->unk_22 >> 8) & 0xFF;
                     seqData[1] = channel->unk_22 & 0xFF;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_EFFECTS:
+                case ASEQ_OPC_CHANNEL_EFFECTS:
                     cmd = (u8)cmdArgs[0];
                     if (cmd & 0x80) {
                         channel->stereoHeadsetEffects = true;
@@ -1456,22 +1456,22 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->stereo.asByte = cmd & 0x7F;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_NOTEALLOC:
+                case ASEQ_OPC_CHANNEL_NOTEALLOC:
                     cmd = (u8)cmdArgs[0];
                     channel->noteAllocPolicy = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_SUSTAIN:
+                case ASEQ_OPC_CHANNEL_SUSTAIN:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.sustain = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_REVERBIDX:
+                case ASEQ_OPC_CHANNEL_REVERBIDX:
                     cmd = (u8)cmdArgs[0];
                     channel->reverbIndex = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DYNCALL:
+                case ASEQ_OPC_CHANNEL_DYNCALL:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         //! @bug: Missing a stack depth check here
@@ -1481,12 +1481,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_SAMPLEBOOK:
+                case ASEQ_OPC_CHANNEL_SAMPLEBOOK:
                     cmd = (u8)cmdArgs[0];
                     channel->bookOffset = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_LDPARAMS:
+                case ASEQ_OPC_CHANNEL_LDPARAMS:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = &seqPlayer->seqData[cmdArgU16];
                     channel->muteBehavior = *data++;
@@ -1501,7 +1501,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_PARAMS:
+                case ASEQ_OPC_CHANNEL_PARAMS:
                     channel->muteBehavior = cmdArgs[0];
                     channel->noteAllocPolicy = cmdArgs[1];
                     cmd = (u8)cmdArgs[2];
@@ -1515,7 +1515,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_VIBRESET:
+                case ASEQ_OPC_CHANNEL_VIBRESET:
                     channel->vibratoDepthTarget = 0;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
@@ -1533,26 +1533,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->freqScale = 1.0f;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_NOTEPRI:
+                case ASEQ_OPC_CHANNEL_NOTEPRI:
                     AudioSeq_SetChannelPriorities(channel, (u8)cmdArgs[0]);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_GAIN:
+                case ASEQ_OPC_CHANNEL_GAIN:
                     cmd = (u8)cmdArgs[0];
                     channel->gain = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_LDFILTER:
+                case ASEQ_OPC_CHANNEL_LDFILTER:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = seqPlayer->seqData + cmdArgU16;
                     channel->filter = (s16*)data;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_FREEFILTER:
+                case ASEQ_OPC_CHANNEL_FREEFILTER:
                     channel->filter = NULL;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_FILTER:
+                case ASEQ_OPC_CHANNEL_FILTER:
                     cmd = cmdArgs[0];
 
                     if (channel->filter != NULL) {
@@ -1562,34 +1562,34 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_LDSEQTOPTR:
+                case ASEQ_OPC_CHANNEL_LDSEQTOPTR:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = *(u16*)(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value * 2));
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_PTRTODYNTBL:
+                case ASEQ_OPC_CHANNEL_PTRTODYNTBL:
                     channel->dynTable = (void*)&seqPlayer->seqData[channel->unk_22];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DYNTBLTOPTR:
+                case ASEQ_OPC_CHANNEL_DYNTBLTOPTR:
                     channel->unk_22 = ((u16*)(channel->dynTable))[scriptState->value];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DYNTBLV:
+                case ASEQ_OPC_CHANNEL_DYNTBLV:
                     scriptState->value = (*channel->dynTable)[0][scriptState->value];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_RANDTOPTR:
+                case ASEQ_OPC_CHANNEL_RANDTOPTR:
                     channel->unk_22 =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_RAND:
+                case ASEQ_OPC_CHANNEL_RAND:
                     scriptState->value =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_RANDPTR:
+                case ASEQ_OPC_CHANNEL_RANDPTR:
                     temp2 = AudioThread_NextRandom();
                     channel->unk_22 = (cmdArgs[0] == 0) ? (temp2 & 0xFFFF) : (temp2 % cmdArgs[0]);
                     channel->unk_22 += cmdArgs[1];
@@ -1598,20 +1598,20 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->unk_22 = (temp2 << 8) | param;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_RANDVEL:
+                case ASEQ_OPC_CHANNEL_RANDVEL:
                     channel->velocityRandomVariance = cmdArgs[0];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_RANDGATE:
+                case ASEQ_OPC_CHANNEL_RANDGATE:
                     channel->gateTimeRandomVariance = cmdArgs[0];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_COMBFILTER:
+                case ASEQ_OPC_CHANNEL_COMBFILTER:
                     channel->combFilterSize = cmdArgs[0];
                     channel->combFilterGain = cmdArgs[1];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_PTRADD:
+                case ASEQ_OPC_CHANNEL_PTRADD:
                     channel->unk_22 += cmdArgs[0];
                     break;
             }
@@ -1621,12 +1621,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         if (cmd >= 0x70) {
             lowBits = cmd & 0x7;
 
-            if ((cmd & 0xF8) != ASEQ_CMD_ID_CHANNEL_STIO && lowBits >= 4) {
+            if ((cmd & 0xF8) != ASEQ_OPC_CHANNEL_STIO && lowBits >= 4) {
                 lowBits = 0;
             }
 
             switch (cmd & 0xF8) {
-                case ASEQ_CMD_ID_CHANNEL_TESTLAYER:
+                case ASEQ_OPC_CHANNEL_TESTLAYER:
                     if (channel->layers[lowBits] != NULL) {
                         scriptState->value = channel->layers[lowBits]->finished;
                     } else {
@@ -1634,18 +1634,18 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_LDLAYER:
+                case ASEQ_OPC_CHANNEL_LDLAYER:
                     cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &seqPlayer->seqData[cmdArgU16];
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DELLAYER:
+                case ASEQ_OPC_CHANNEL_DELLAYER:
                     AudioSeq_SeqLayerFree(channel, lowBits);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DYNLDLAYER:
+                case ASEQ_OPC_CHANNEL_DYNLDLAYER:
                     if (scriptState->value != -1 && AudioSeq_SeqChannelSetLayer(channel, lowBits) != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (data[0] << 8) + data[1];
@@ -1653,11 +1653,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_STIO:
+                case ASEQ_OPC_CHANNEL_STIO:
                     channel->seqScriptIO[lowBits] = scriptState->value;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_RLDLAYER:
+                case ASEQ_OPC_CHANNEL_RLDLAYER:
                     temp1 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &scriptState->pc[temp1];
@@ -1670,11 +1670,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         lowBits = cmd & 0xF;
 
         switch (cmd & 0xF0) {
-            case ASEQ_CMD_ID_CHANNEL_STOPCHANELAY:
+            case ASEQ_OPC_CHANNEL_STOPCHANELAY:
                 channel->delay = lowBits;
                 goto exit_loop;
 
-            case ASEQ_CMD_ID_CHANNEL_LDSAMPLE:
+            case ASEQ_OPC_CHANNEL_LDSAMPLE:
                 if (lowBits < 8) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                     if (AudioLoad_SlowLoadSample(channel->fontId, scriptState->value, &channel->seqScriptIO[lowBits]) ==
@@ -1687,28 +1687,28 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                 }
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_LDIO:
+            case ASEQ_OPC_CHANNEL_LDIO:
                 scriptState->value = channel->seqScriptIO[lowBits];
                 if (lowBits < 2) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                 }
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_SUBIO:
+            case ASEQ_OPC_CHANNEL_SUBIO:
                 scriptState->value -= channel->seqScriptIO[lowBits];
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_LDCHAN:
+            case ASEQ_OPC_CHANNEL_LDCHAN:
                 cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                 AudioSeq_SequenceChannelEnable(seqPlayer, lowBits, &seqPlayer->seqData[cmdArgU16]);
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_STCIO:
+            case ASEQ_OPC_CHANNEL_STCIO:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 seqPlayer->channels[lowBits]->seqScriptIO[cmd] = scriptState->value;
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_LDCIO:
+            case ASEQ_OPC_CHANNEL_LDCIO:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 scriptState->value = seqPlayer->channels[lowBits]->seqScriptIO[cmd];
                 break;
@@ -1781,7 +1781,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmd = AudioSeq_ScriptReadU8(seqScript);
 
             // 0xF2 and above are "flow control" commands, including termination.
-            if (cmd >= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) {
+            if (cmd >= ASEQ_OPC_CONTROL_FLOW_FIRST) {
                 delay = AudioSeq_HandleScriptFlowControl(
                     seqPlayer, seqScript, cmd, AudioSeq_GetScriptControlFlowArgument(&seqPlayer->scriptState, cmd));
 
@@ -1798,7 +1798,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
 
             if (cmd >= 0xC0) {
                 switch (cmd) {
-                    case ASEQ_CMD_ID_SEQUENCE_ALLOCNOTELIST:
+                    case ASEQ_OPC_SEQUENCE_ALLOCNOTELIST:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         Audio_NotePoolFill(&seqPlayer->notePool, cmd);
@@ -1814,18 +1814,18 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         if (dummy) {}
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_FREENOTELIST:
+                    case ASEQ_OPC_SEQUENCE_FREENOTELIST:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_TRANSPOSE:
+                    case ASEQ_OPC_SEQUENCE_TRANSPOSE:
                         seqPlayer->transposition = 0;
                         FALLTHROUGH;
-                    case ASEQ_CMD_ID_SEQUENCE_RTRANSPOSE:
+                    case ASEQ_OPC_SEQUENCE_RTRANSPOSE:
                         seqPlayer->transposition += (s8)AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_TEMPO:
+                    case ASEQ_OPC_SEQUENCE_TEMPO:
                         seqPlayer->tempo = AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         if (seqPlayer->tempo > gAudioCtx.maxTempo) {
                             seqPlayer->tempo = (u16)gAudioCtx.maxTempo;
@@ -1836,11 +1836,11 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_TEMPOCHG:
+                    case ASEQ_OPC_SEQUENCE_TEMPOCHG:
                         seqPlayer->tempoChange = (s8)AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_VOLMODE:
+                    case ASEQ_OPC_SEQUENCE_VOLMODE:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         switch (cmd) {
@@ -1860,7 +1860,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_VOL:
+                    case ASEQ_OPC_SEQUENCE_VOL:
                         value = AudioSeq_ScriptReadU8(seqScript);
                         switch (seqPlayer->state) {
                             case 1:
@@ -1882,47 +1882,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_VOLSCALE:
+                    case ASEQ_OPC_SEQUENCE_VOLSCALE:
                         seqPlayer->fadeVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_INITCHAN:
+                    case ASEQ_OPC_SEQUENCE_INITCHAN:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         AudioSeq_SequencePlayerSetupChannels(seqPlayer, temp);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_FREECHAN:
+                    case ASEQ_OPC_SEQUENCE_FREECHAN:
                         AudioSeq_ScriptReadS16(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_MUTESCALE:
+                    case ASEQ_OPC_SEQUENCE_MUTESCALE:
                         seqPlayer->muteVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_MUTE:
+                    case ASEQ_OPC_SEQUENCE_MUTE:
                         seqPlayer->muted = true;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_MUTEBHV:
+                    case ASEQ_OPC_SEQUENCE_MUTEBHV:
                         seqPlayer->muteBehavior = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_LDSHORTGATEARR:
-                    case ASEQ_CMD_ID_SEQUENCE_LDSHORTVELARR:
+                    case ASEQ_OPC_SEQUENCE_LDSHORTGATEARR:
+                    case ASEQ_OPC_SEQUENCE_LDSHORTVELARR:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data3 = &seqPlayer->seqData[temp];
-                        if (cmd == ASEQ_CMD_ID_SEQUENCE_LDSHORTVELARR) {
+                        if (cmd == ASEQ_OPC_SEQUENCE_LDSHORTVELARR) {
                             seqPlayer->shortNoteVelocityTable = data3;
                         } else {
                             seqPlayer->shortNoteGateTimeTable = data3;
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_NOTEALLOC:
+                    case ASEQ_OPC_SEQUENCE_NOTEALLOC:
                         seqPlayer->noteAllocPolicy = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_RAND:
+                    case ASEQ_OPC_SEQUENCE_RAND:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0) {
                             seqScript->value = (gAudioCtx.audioRandom >> 2) & 0xFF;
@@ -1931,7 +1931,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_DYNCALL:
+                    case ASEQ_OPC_SEQUENCE_DYNCALL:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         if ((seqScript->value != -1) && (seqScript->depth != 3)) {
                             data = seqPlayer->seqData + (u32)(temp + (seqScript->value << 1));
@@ -1943,39 +1943,39 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_LDI:
+                    case ASEQ_OPC_SEQUENCE_LDI:
                         seqScript->value = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_AND:
+                    case ASEQ_OPC_SEQUENCE_AND:
                         seqScript->value &= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_SUB:
+                    case ASEQ_OPC_SEQUENCE_SUB:
                         seqScript->value -= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_STSEQ:
+                    case ASEQ_OPC_SEQUENCE_STSEQ:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data2 = &seqPlayer->seqData[temp];
                         *data2 = (u8)seqScript->value + cmd;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_STOP:
+                    case ASEQ_OPC_SEQUENCE_STOP:
                         seqPlayer->stopScript = true;
                         return;
 
-                    case ASEQ_CMD_ID_SEQUENCE_SCRIPTCTR:
+                    case ASEQ_OPC_SEQUENCE_SCRIPTCTR:
                         seqPlayer->scriptCounter = (u16)AudioSeq_ScriptReadS16(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_EF:
+                    case ASEQ_OPC_SEQUENCE_EF:
                         AudioSeq_ScriptReadS16(seqScript);
                         AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_RUNSEQ:
+                    case ASEQ_OPC_SEQUENCE_RUNSEQ:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0xFF) {
                             cmd = seqPlayer->playerIdx;
@@ -1993,47 +1993,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmdLowBits = cmd & 0x0F;
 
             switch (cmd & 0xF0) {
-                case ASEQ_CMD_ID_SEQUENCE_TESTCHAN:
+                case ASEQ_OPC_SEQUENCE_TESTCHAN:
                     seqScript->value = seqPlayer->channels[cmdLowBits]->enabled ^ 1;
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_SUBIO:
+                case ASEQ_OPC_SEQUENCE_SUBIO:
                     seqScript->value -= seqPlayer->seqScriptIO[cmdLowBits];
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_STIO:
+                case ASEQ_OPC_SEQUENCE_STIO:
                     seqPlayer->seqScriptIO[cmdLowBits] = seqScript->value;
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_LDIO:
+                case ASEQ_OPC_SEQUENCE_LDIO:
                     seqScript->value = seqPlayer->seqScriptIO[cmdLowBits];
                     if (cmdLowBits < 2) {
                         seqPlayer->seqScriptIO[cmdLowBits] = SEQ_IO_VAL_NONE;
                     }
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_STOPCHAN:
+                case ASEQ_OPC_SEQUENCE_STOPCHAN:
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmdLowBits]);
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_LDCHAN:
+                case ASEQ_OPC_SEQUENCE_LDCHAN:
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqPlayer->seqData[temp]);
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_RLDCHAN:
+                case ASEQ_OPC_SEQUENCE_RLDCHAN:
                     tempS = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqScript->pc[tempS]);
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_LDSEQ:
+                case ASEQ_OPC_SEQUENCE_LDSEQ:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     data2 = &seqPlayer->seqData[temp];
                     AudioLoad_SlowLoadSeq(cmd, data2, &seqPlayer->seqScriptIO[cmdLowBits]);
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_LDRES:
+                case ASEQ_OPC_SEQUENCE_LDRES:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     value = cmd;
                     temp = AudioSeq_ScriptReadU8(seqScript);

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -14,6 +14,7 @@
  *     Otherwise, each set of instructions has its own command interpreter
  */
 #include "ultra64.h"
+#include "audio/aseq.h"
 #include "global.h"
 
 #define PORTAMENTO_IS_SPECIAL(x) ((x).mode & 0x80)
@@ -70,92 +71,92 @@ u8 AudioSeq_GetInstrument(SequenceChannel* channel, u8 instId, Instrument** inst
     (((sizeof(arg0Type) - 1) << 7) | ((sizeof(arg1Type) - 1) << 6) | ((sizeof(arg2Type) - 1) << 5) | 3)
 
 u8 sSeqInstructionArgsTable[] = {
-    CMD_ARGS_1(s16),        // 0xB0
-    CMD_ARGS_0(),           // 0xB1
-    CMD_ARGS_1(s16),        // 0xB2
-    CMD_ARGS_1(u8),         // 0xB3
-    CMD_ARGS_0(),           // 0xB4
-    CMD_ARGS_0(),           // 0xB5
-    CMD_ARGS_0(),           // 0xB6
-    CMD_ARGS_1(s16),        // 0xB7
-    CMD_ARGS_1(u8),         // 0xB8
-    CMD_ARGS_1(u8),         // 0xB9
-    CMD_ARGS_1(u8),         // 0xBA
-    CMD_ARGS_2(u8, s16),    // 0xBB
-    CMD_ARGS_1(s16),        // 0xBC
-    CMD_ARGS_2(s16, s16),   // 0xBD
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_B0
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_B1
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_B2
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_B3
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_B4
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_B5
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_B6
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_B7
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_B8
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_B9
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_BA
+    CMD_ARGS_2(u8, s16),    // ASEQ_CMD_ID_CHANNEL_BB
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_BC
+    CMD_ARGS_2(s16, s16),   // ASEQ_CMD_ID_CHANNEL_BD
     CMD_ARGS_0(),           // 0xBE
     CMD_ARGS_0(),           // 0xBF
     CMD_ARGS_0(),           // 0xC0
-    CMD_ARGS_1(u8),         // 0xC1
-    CMD_ARGS_1(s16),        // 0xC2
-    CMD_ARGS_0(),           // 0xC3
-    CMD_ARGS_0(),           // 0xC4
-    CMD_ARGS_0(),           // 0xC5
-    CMD_ARGS_1(u8),         // 0xC6
-    CMD_ARGS_2(u8, s16),    // 0xC7
-    CMD_ARGS_1(u8),         // 0xC8
-    CMD_ARGS_1(u8),         // 0xC9
-    CMD_ARGS_1(u8),         // 0xCA
-    CMD_ARGS_1(s16),        // 0xCB
-    CMD_ARGS_1(u8),         // 0xCC
-    CMD_ARGS_1(u8),         // 0xCD
-    CMD_ARGS_1(s16),        // 0xCE
-    CMD_ARGS_1(s16),        // 0xCF
-    CMD_ARGS_1(u8),         // 0xD0
-    CMD_ARGS_1(u8),         // 0xD1
-    CMD_ARGS_1(u8),         // 0xD2
-    CMD_ARGS_1(u8),         // 0xD3
-    CMD_ARGS_1(u8),         // 0xD4
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_C1
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_C2
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_C3
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_C4
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_C5
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_C6
+    CMD_ARGS_2(u8, s16),    // ASEQ_CMD_ID_CHANNEL_C7
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_C8
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_C9
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_CA
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_CB
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_CC
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_CD
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_CE
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_CF
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D0
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D1
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D2
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D3
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D4
     CMD_ARGS_1(u8),         // 0xD5
     CMD_ARGS_1(u8),         // 0xD6
-    CMD_ARGS_1(u8),         // 0xD7
-    CMD_ARGS_1(u8),         // 0xD8
-    CMD_ARGS_1(u8),         // 0xD9
-    CMD_ARGS_1(s16),        // 0xDA
-    CMD_ARGS_1(u8),         // 0xDB
-    CMD_ARGS_1(u8),         // 0xDC
-    CMD_ARGS_1(u8),         // 0xDD
-    CMD_ARGS_1(s16),        // 0xDE
-    CMD_ARGS_1(u8),         // 0xDF
-    CMD_ARGS_1(u8),         // 0xE0
-    CMD_ARGS_3(u8, u8, u8), // 0xE1
-    CMD_ARGS_3(u8, u8, u8), // 0xE2
-    CMD_ARGS_1(u8),         // 0xE3
-    CMD_ARGS_0(),           // 0xE4
-    CMD_ARGS_1(u8),         // 0xE5
-    CMD_ARGS_1(u8),         // 0xE6
-    CMD_ARGS_1(s16),        // 0xE7
-    CMD_ARGS_3(u8, u8, u8), // 0xE8
-    CMD_ARGS_1(u8),         // 0xE9
-    CMD_ARGS_0(),           // 0xEA
-    CMD_ARGS_2(u8, u8),     // 0xEB
-    CMD_ARGS_0(),           // 0xEC
-    CMD_ARGS_1(u8),         // 0xED
-    CMD_ARGS_1(u8),         // 0xEE
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D7
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D8
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D9
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_DA
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_DB
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_DC
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_DD
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_DE
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_DF
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E0
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_E1
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_E2
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E3
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_E4
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E5
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E6
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_E7
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_E8
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E9
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_EA
+    CMD_ARGS_2(u8, u8),     // ASEQ_CMD_ID_CHANNEL_EB
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_EC
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_ED
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_EE
     CMD_ARGS_2(s16, u8),    // 0xEF
-    CMD_ARGS_0(),           // 0xF0
-    CMD_ARGS_1(u8),         // 0xF1
-    // Control flow instructions (>= 0xF2) can only have 0 or 1 args
-    CMD_ARGS_1(u8),  // 0xF2
-    CMD_ARGS_1(u8),  // 0xF3
-    CMD_ARGS_1(u8),  // 0xF4
-    CMD_ARGS_1(s16), // 0xF5
-    CMD_ARGS_0(),    // 0xF6
-    CMD_ARGS_0(),    // 0xF7
-    CMD_ARGS_1(u8),  // 0xF8
-    CMD_ARGS_1(s16), // 0xF9
-    CMD_ARGS_1(s16), // 0xFA
-    CMD_ARGS_1(s16), // 0xFB
-    CMD_ARGS_1(s16), // 0xFC
-    CMD_ARGS_0(),    // 0xFD
-    CMD_ARGS_0(),    // 0xFE
-    CMD_ARGS_0(),    // 0xFF
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_F0
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_F1
+    // Control flow instructions (>= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) can only have 0 or 1 args
+    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_F2
+    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_F3
+    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_F4
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_F5
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_F6
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_F7
+    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_F8
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_F9
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_FA
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_FB
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_FC
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_FD
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_FE
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_FF
 };
 
 /**
  * Read and return the argument from the sequence script for a control flow instruction.
- * Control flow instructions (>= 0xF2) can only have 0 or 1 args.
+ * Control flow instructions (>= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) can only have 0 or 1 args.
  * @return the argument value for a control flow instruction, or 0 if there is no argument
  */
 u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
@@ -181,30 +182,30 @@ u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
  */
 s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* state, s32 cmd, s32 cmdArg) {
     switch (cmd) {
-        case 0xFF:
+        case ASEQ_CMD_ID_CTRLFLOW_FF:
             if (state->depth == 0) {
                 return PROCESS_SCRIPT_END;
             }
             state->pc = state->stack[--state->depth];
             break;
 
-        case 0xFD:
+        case ASEQ_CMD_ID_CTRLFLOW_FD:
             return AudioSeq_ScriptReadCompressedU16(state);
 
-        case 0xFE:
+        case ASEQ_CMD_ID_CTRLFLOW_FE:
             return 1;
 
-        case 0xFC:
+        case ASEQ_CMD_ID_CTRLFLOW_FC:
             state->stack[state->depth++] = state->pc;
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case 0xF8:
+        case ASEQ_CMD_ID_CTRLFLOW_F8:
             state->remLoopIters[state->depth] = cmdArg;
             state->stack[state->depth++] = state->pc;
             break;
 
-        case 0xF7:
+        case ASEQ_CMD_ID_CTRLFLOW_F7:
             state->remLoopIters[state->depth - 1]--;
             if (state->remLoopIters[state->depth - 1] != 0) {
                 state->pc = state->stack[state->depth - 1];
@@ -213,33 +214,33 @@ s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* 
             }
             break;
 
-        case 0xF6:
+        case ASEQ_CMD_ID_CTRLFLOW_F6:
             state->depth--;
             break;
 
-        case 0xF5:
-        case 0xF9:
-        case 0xFA:
-        case 0xFB:
-            if (cmd == 0xFA && state->value != 0) {
+        case ASEQ_CMD_ID_CTRLFLOW_F5:
+        case ASEQ_CMD_ID_CTRLFLOW_F9:
+        case ASEQ_CMD_ID_CTRLFLOW_FA:
+        case ASEQ_CMD_ID_CTRLFLOW_FB:
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_FA && state->value != 0) {
                 break;
             }
-            if (cmd == 0xF9 && state->value >= 0) {
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_F9 && state->value >= 0) {
                 break;
             }
-            if (cmd == 0xF5 && state->value < 0) {
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_F5 && state->value < 0) {
                 break;
             }
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case 0xF2:
-        case 0xF3:
-        case 0xF4:
-            if (cmd == 0xF3 && state->value != 0) {
+        case ASEQ_CMD_ID_CTRLFLOW_F2:
+        case ASEQ_CMD_ID_CTRLFLOW_F3:
+        case ASEQ_CMD_ID_CTRLFLOW_F4:
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_F3 && state->value != 0) {
                 break;
             }
-            if (cmd == 0xF2 && state->value >= 0) {
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_F2 && state->value >= 0) {
                 break;
             }
             state->pc += (s8)(cmdArg & 0xFF);
@@ -645,7 +646,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
         }
 
         // Control Flow Commands
-        if (cmd >= 0xF2) {
+        if (cmd >= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) {
             cmdArg16 = AudioSeq_GetScriptControlFlowArgument(state, cmd);
 
             if (AudioSeq_HandleScriptFlowControl(seqPlayer, state, cmd, cmdArg16) == 0) {
@@ -656,29 +657,29 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
         }
 
         switch (cmd) {
-            case 0xC1: // layer_setshortnotevelocity
-            case 0xCA: // layer_setpan
+            case ASEQ_CMD_ID_LAYER_C1: // layer_setshortnotevelocity
+            case ASEQ_CMD_ID_LAYER_CA: // layer_setpan
                 cmdArg8 = *(state->pc++);
-                if (cmd == 0xC1) {
+                if (cmd == ASEQ_CMD_ID_LAYER_C1) {
                     layer->velocitySquare = SQ(cmdArg8) / SQ(127.0f);
                 } else {
                     layer->pan = cmdArg8;
                 }
                 break;
 
-            case 0xC9: // layer_setshortnotegatetime
-            case 0xC2: // layer_transpose; set transposition in semitones
+            case ASEQ_CMD_ID_LAYER_C9: // layer_setshortnotegatetime
+            case ASEQ_CMD_ID_LAYER_C2: // layer_transpose; set transposition in semitones
                 cmdArg8 = *(state->pc++);
-                if (cmd == 0xC9) {
+                if (cmd == ASEQ_CMD_ID_LAYER_C9) {
                     layer->gateTime = cmdArg8;
                 } else {
                     layer->transposition = cmdArg8;
                 }
                 break;
 
-            case 0xC4: // layer_continuousnoteson
-            case 0xC5: // layer_continuousnotesoff
-                if (cmd == 0xC4) {
+            case ASEQ_CMD_ID_LAYER_C4: // layer_continuousnoteson
+            case ASEQ_CMD_ID_LAYER_C5: // layer_continuousnotesoff
+                if (cmd == ASEQ_CMD_ID_LAYER_C4) {
                     layer->continuousNotes = true;
                 } else {
                     layer->continuousNotes = false;
@@ -687,12 +688,12 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 Audio_SeqLayerNoteDecay(layer);
                 break;
 
-            case 0xC3: // layer_setshortnotedefaultdelay
+            case ASEQ_CMD_ID_LAYER_C3: // layer_setshortnotedefaultdelay
                 cmdArg16 = AudioSeq_ScriptReadCompressedU16(state);
                 layer->shortNoteDefaultDelay = cmdArg16;
                 break;
 
-            case 0xC6: // layer_setinstr
+            case ASEQ_CMD_ID_LAYER_C6: // layer_setinstr
                 cmd = AudioSeq_ScriptReadU8(state);
                 if (cmd >= 0x7E) {
                     if (cmd == 0x7E) {
@@ -719,7 +720,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 }
                 break;
 
-            case 0xC7: // layer_portamento
+            case ASEQ_CMD_ID_LAYER_C7: // layer_portamento
                 layer->portamento.mode = AudioSeq_ScriptReadU8(state);
 
                 cmd = AudioSeq_ScriptReadU8(state);
@@ -743,39 +744,39 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 layer->portamentoTime = cmdArg16;
                 break;
 
-            case 0xC8: // layer_disableportamento
+            case ASEQ_CMD_ID_LAYER_C8: // layer_disableportamento
                 layer->portamento.mode = PORTAMENTO_MODE_OFF;
                 break;
 
-            case 0xCB:
+            case ASEQ_CMD_ID_LAYER_CB:
                 cmdArg16 = AudioSeq_ScriptReadS16(state);
                 layer->adsr.envelope = (EnvelopePoint*)(seqPlayer->seqData + cmdArg16);
                 FALLTHROUGH;
-            case 0xCF:
+            case ASEQ_CMD_ID_LAYER_CF:
                 layer->adsr.decayIndex = AudioSeq_ScriptReadU8(state);
                 break;
 
-            case 0xCC:
+            case ASEQ_CMD_ID_LAYER_CC:
                 layer->ignoreDrumPan = true;
                 break;
 
-            case 0xCD:
+            case ASEQ_CMD_ID_LAYER_CD:
                 layer->stereo.asByte = AudioSeq_ScriptReadU8(state);
                 break;
 
-            case 0xCE:
+            case ASEQ_CMD_ID_LAYER_CE:
                 cmdArg8 = AudioSeq_ScriptReadU8(state);
                 layer->bend = gBendPitchTwoSemitonesFrequencies[(u8)(cmdArg8 + 0x80)];
                 break;
 
             default:
                 switch (cmd & 0xF0) {
-                    case 0xD0: // layer_setshortnotevelocityfromtable
+                    case ASEQ_CMD_ID_LAYER_D0: // layer_setshortnotevelocityfromtable
                         velocity = seqPlayer->shortNoteVelocityTable[cmd & 0xF];
                         layer->velocitySquare = SQ(velocity) / SQ(127.0f);
                         break;
 
-                    case 0xE0: // layer_setshortnotegatetimefromtable
+                    case ASEQ_CMD_ID_LAYER_E0: // layer_setshortnotegatetimefromtable
                         layer->gateTime = seqPlayer->shortNoteGateTimeTable[cmd & 0xF];
                         break;
                 }
@@ -1000,7 +1001,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
     s32 intDelta;
     f32 floatDelta;
 
-    if (cmd == 0xC0) {
+    if (cmd == ASEQ_CMD_ID_LAYER_STEP3_C0) {
         layer->delay = AudioSeq_ScriptReadCompressedU16(state);
         layer->muted = true;
         layer->bit1 = false;
@@ -1011,21 +1012,21 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
 
     if (channel->largeNotes == true) {
         switch (cmd & 0xC0) {
-            case 0x00:
+            case ASEQ_CMD_ID_LAYER_STEP3_00:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
                 layer->lastDelay = delay;
                 break;
 
-            case 0x40:
+            case ASEQ_CMD_ID_LAYER_STEP3_40:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = 0;
                 layer->lastDelay = delay;
                 break;
 
-            case 0x80:
+            case ASEQ_CMD_ID_LAYER_STEP3_80:
                 delay = layer->lastDelay;
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
@@ -1039,16 +1040,16 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
         cmd -= (cmd & 0xC0);
     } else {
         switch (cmd & 0xC0) {
-            case 0x00:
+            case ASEQ_CMD_ID_LAYER_STEP3_00:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 layer->lastDelay = delay;
                 break;
 
-            case 0x40:
+            case ASEQ_CMD_ID_LAYER_STEP3_40:
                 delay = layer->shortNoteDefaultDelay;
                 break;
 
-            case 0x80:
+            case ASEQ_CMD_ID_LAYER_STEP3_80:
                 delay = layer->lastDelay;
                 break;
         }
@@ -1210,7 +1211,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             // Control Flow Commands
-            if (cmd >= 0xF2) {
+            if (cmd >= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) {
                 delay = AudioSeq_HandleScriptFlowControl(seqPlayer, scriptState, cmd, cmdArgs[0]);
 
                 if (delay != 0) {
@@ -1225,26 +1226,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             switch (cmd) {
-                case 0xEA:
+                case ASEQ_CMD_ID_CHANNEL_EA:
                     channel->stopScript = true;
                     goto exit_loop;
 
-                case 0xF1:
+                case ASEQ_CMD_ID_CHANNEL_F1:
                     Audio_NotePoolClear(&channel->notePool);
                     cmd = (u8)cmdArgs[0];
                     Audio_NotePoolFill(&channel->notePool, cmd);
                     break;
 
-                case 0xF0:
+                case ASEQ_CMD_ID_CHANNEL_F0:
                     Audio_NotePoolClear(&channel->notePool);
                     break;
 
-                case 0xC2:
+                case ASEQ_CMD_ID_CHANNEL_C2:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->dynTable = (void*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case 0xC5:
+                case ASEQ_CMD_ID_CHANNEL_C5:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (u16)((data[0] << 8) + data[1]);
@@ -1253,7 +1254,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xEB:
+                case ASEQ_CMD_ID_CHANNEL_EB:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1268,93 +1269,93 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
 
                     cmdArgs[0] = cmdArgs[1];
                     FALLTHROUGH;
-                case 0xC1:
+                case ASEQ_CMD_ID_CHANNEL_C1:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SetInstrument(channel, cmd);
                     break;
 
-                case 0xC3:
+                case ASEQ_CMD_ID_CHANNEL_C3:
                     channel->largeNotes = false;
                     break;
 
-                case 0xC4:
+                case ASEQ_CMD_ID_CHANNEL_C4:
                     channel->largeNotes = true;
                     break;
 
-                case 0xDF:
+                case ASEQ_CMD_ID_CHANNEL_DF:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelSetVolume(channel, cmd);
                     channel->changes.s.volume = true;
                     break;
 
-                case 0xE0:
+                case ASEQ_CMD_ID_CHANNEL_E0:
                     cmd = (u8)cmdArgs[0];
                     channel->volumeScale = (s32)cmd / 128.0f;
                     channel->changes.s.volume = true;
                     break;
 
-                case 0xDE:
+                case ASEQ_CMD_ID_CHANNEL_DE:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->freqScale = (s32)cmdArgU16 / 32768.0f;
                     channel->changes.s.freqScale = true;
                     break;
 
-                case 0xD3:
+                case ASEQ_CMD_ID_CHANNEL_D3:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchOneOctaveFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case 0xEE:
+                case ASEQ_CMD_ID_CHANNEL_EE:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchTwoSemitonesFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case 0xDD:
+                case ASEQ_CMD_ID_CHANNEL_DD:
                     cmd = (u8)cmdArgs[0];
                     channel->newPan = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case 0xDC:
+                case ASEQ_CMD_ID_CHANNEL_DC:
                     cmd = (u8)cmdArgs[0];
                     channel->panChannelWeight = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case 0xDB:
+                case ASEQ_CMD_ID_CHANNEL_DB:
                     cmdArgS8 = (s8)cmdArgs[0];
                     channel->transposition = cmdArgS8;
                     break;
 
-                case 0xDA:
+                case ASEQ_CMD_ID_CHANNEL_DA:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->adsr.envelope = (EnvelopePoint*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case 0xD9:
+                case ASEQ_CMD_ID_CHANNEL_D9:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.decayIndex = cmd;
                     break;
 
-                case 0xD8:
+                case ASEQ_CMD_ID_CHANNEL_D8:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthTarget = cmd * 8;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
                     break;
 
-                case 0xD7:
+                case ASEQ_CMD_ID_CHANNEL_D7:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateChangeDelay = 0;
                     channel->vibratoRateTarget = cmd * 32;
                     channel->vibratoRateStart = cmd * 32;
                     break;
 
-                case 0xE2:
+                case ASEQ_CMD_ID_CHANNEL_E2:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthStart = cmd * 8;
                     cmd = (u8)cmdArgs[1];
@@ -1363,7 +1364,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoDepthChangeDelay = cmd * 16;
                     break;
 
-                case 0xE1:
+                case ASEQ_CMD_ID_CHANNEL_E1:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateStart = cmd * 32;
                     cmd = (u8)cmdArgs[1];
@@ -1372,17 +1373,17 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoRateChangeDelay = cmd * 16;
                     break;
 
-                case 0xE3:
+                case ASEQ_CMD_ID_CHANNEL_E3:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDelay = cmd * 16;
                     break;
 
-                case 0xD4:
+                case ASEQ_CMD_ID_CHANNEL_D4:
                     cmd = (u8)cmdArgs[0];
                     channel->targetReverbVol = cmd;
                     break;
 
-                case 0xC6:
+                case ASEQ_CMD_ID_CHANNEL_C6:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1396,56 +1397,56 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xC7:
+                case ASEQ_CMD_ID_CHANNEL_C7:
                     cmd = (u8)cmdArgs[0];
                     cmdArgU16 = (u16)cmdArgs[1];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (u8)scriptState->value + cmd;
                     break;
 
-                case 0xC8:
-                case 0xCC:
-                case 0xC9:
+                case ASEQ_CMD_ID_CHANNEL_C8:
+                case ASEQ_CMD_ID_CHANNEL_CC:
+                case ASEQ_CMD_ID_CHANNEL_C9:
                     cmdArgS8 = (s8)cmdArgs[0];
 
-                    if (cmd == 0xC8) {
+                    if (cmd == ASEQ_CMD_ID_CHANNEL_C8) {
                         scriptState->value -= cmdArgS8;
-                    } else if (cmd == 0xCC) {
+                    } else if (cmd == ASEQ_CMD_ID_CHANNEL_CC) {
                         scriptState->value = cmdArgS8;
                     } else {
                         scriptState->value &= cmdArgS8;
                     }
                     break;
 
-                case 0xCD:
+                case ASEQ_CMD_ID_CHANNEL_CD:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmd]);
                     break;
 
-                case 0xCA:
+                case ASEQ_CMD_ID_CHANNEL_CA:
                     cmd = (u8)cmdArgs[0];
                     channel->muteBehavior = cmd;
                     channel->changes.s.volume = true;
                     break;
 
-                case 0xCB:
+                case ASEQ_CMD_ID_CHANNEL_CB:
                     cmdArgU16 = (u16)cmdArgs[0];
                     scriptState->value = *(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value));
                     break;
 
-                case 0xCE:
+                case ASEQ_CMD_ID_CHANNEL_CE:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = cmdArgU16;
                     break;
 
-                case 0xCF:
+                case ASEQ_CMD_ID_CHANNEL_CF:
                     cmdArgU16 = (u16)cmdArgs[0];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (channel->unk_22 >> 8) & 0xFF;
                     seqData[1] = channel->unk_22 & 0xFF;
                     break;
 
-                case 0xD0:
+                case ASEQ_CMD_ID_CHANNEL_D0:
                     cmd = (u8)cmdArgs[0];
                     if (cmd & 0x80) {
                         channel->stereoHeadsetEffects = true;
@@ -1455,22 +1456,22 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->stereo.asByte = cmd & 0x7F;
                     break;
 
-                case 0xD1:
+                case ASEQ_CMD_ID_CHANNEL_D1:
                     cmd = (u8)cmdArgs[0];
                     channel->noteAllocPolicy = cmd;
                     break;
 
-                case 0xD2:
+                case ASEQ_CMD_ID_CHANNEL_D2:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.sustain = cmd;
                     break;
 
-                case 0xE5:
+                case ASEQ_CMD_ID_CHANNEL_E5:
                     cmd = (u8)cmdArgs[0];
                     channel->reverbIndex = cmd;
                     break;
 
-                case 0xE4:
+                case ASEQ_CMD_ID_CHANNEL_E4:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         //! @bug: Missing a stack depth check here
@@ -1480,12 +1481,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xE6:
+                case ASEQ_CMD_ID_CHANNEL_E6:
                     cmd = (u8)cmdArgs[0];
                     channel->bookOffset = cmd;
                     break;
 
-                case 0xE7:
+                case ASEQ_CMD_ID_CHANNEL_E7:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = &seqPlayer->seqData[cmdArgU16];
                     channel->muteBehavior = *data++;
@@ -1500,7 +1501,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case 0xE8:
+                case ASEQ_CMD_ID_CHANNEL_E8:
                     channel->muteBehavior = cmdArgs[0];
                     channel->noteAllocPolicy = cmdArgs[1];
                     cmd = (u8)cmdArgs[2];
@@ -1514,7 +1515,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case 0xEC:
+                case ASEQ_CMD_ID_CHANNEL_EC:
                     channel->vibratoDepthTarget = 0;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
@@ -1532,26 +1533,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->freqScale = 1.0f;
                     break;
 
-                case 0xE9:
+                case ASEQ_CMD_ID_CHANNEL_E9:
                     AudioSeq_SetChannelPriorities(channel, (u8)cmdArgs[0]);
                     break;
 
-                case 0xED:
+                case ASEQ_CMD_ID_CHANNEL_ED:
                     cmd = (u8)cmdArgs[0];
                     channel->gain = cmd;
                     break;
 
-                case 0xB0:
+                case ASEQ_CMD_ID_CHANNEL_B0:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = seqPlayer->seqData + cmdArgU16;
                     channel->filter = (s16*)data;
                     break;
 
-                case 0xB1:
+                case ASEQ_CMD_ID_CHANNEL_B1:
                     channel->filter = NULL;
                     break;
 
-                case 0xB3:
+                case ASEQ_CMD_ID_CHANNEL_B3:
                     cmd = cmdArgs[0];
 
                     if (channel->filter != NULL) {
@@ -1561,34 +1562,34 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xB2:
+                case ASEQ_CMD_ID_CHANNEL_B2:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = *(u16*)(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value * 2));
                     break;
 
-                case 0xB4:
+                case ASEQ_CMD_ID_CHANNEL_B4:
                     channel->dynTable = (void*)&seqPlayer->seqData[channel->unk_22];
                     break;
 
-                case 0xB5:
+                case ASEQ_CMD_ID_CHANNEL_B5:
                     channel->unk_22 = ((u16*)(channel->dynTable))[scriptState->value];
                     break;
 
-                case 0xB6:
+                case ASEQ_CMD_ID_CHANNEL_B6:
                     scriptState->value = (*channel->dynTable)[0][scriptState->value];
                     break;
 
-                case 0xB7:
+                case ASEQ_CMD_ID_CHANNEL_B7:
                     channel->unk_22 =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case 0xB8:
+                case ASEQ_CMD_ID_CHANNEL_B8:
                     scriptState->value =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case 0xBD:
+                case ASEQ_CMD_ID_CHANNEL_BD:
                     temp2 = AudioThread_NextRandom();
                     channel->unk_22 = (cmdArgs[0] == 0) ? (temp2 & 0xFFFF) : (temp2 % cmdArgs[0]);
                     channel->unk_22 += cmdArgs[1];
@@ -1597,20 +1598,20 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->unk_22 = (temp2 << 8) | param;
                     break;
 
-                case 0xB9:
+                case ASEQ_CMD_ID_CHANNEL_B9:
                     channel->velocityRandomVariance = cmdArgs[0];
                     break;
 
-                case 0xBA:
+                case ASEQ_CMD_ID_CHANNEL_BA:
                     channel->gateTimeRandomVariance = cmdArgs[0];
                     break;
 
-                case 0xBB:
+                case ASEQ_CMD_ID_CHANNEL_BB:
                     channel->combFilterSize = cmdArgs[0];
                     channel->combFilterGain = cmdArgs[1];
                     break;
 
-                case 0xBC:
+                case ASEQ_CMD_ID_CHANNEL_BC:
                     channel->unk_22 += cmdArgs[0];
                     break;
             }
@@ -1620,12 +1621,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         if (cmd >= 0x70) {
             lowBits = cmd & 0x7;
 
-            if ((cmd & 0xF8) != 0x70 && lowBits >= 4) {
+            if ((cmd & 0xF8) != ASEQ_CMD_ID_CHANNEL_70 && lowBits >= 4) {
                 lowBits = 0;
             }
 
             switch (cmd & 0xF8) {
-                case 0x80:
+                case ASEQ_CMD_ID_CHANNEL_80:
                     if (channel->layers[lowBits] != NULL) {
                         scriptState->value = channel->layers[lowBits]->finished;
                     } else {
@@ -1633,18 +1634,18 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0x88:
+                case ASEQ_CMD_ID_CHANNEL_88:
                     cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &seqPlayer->seqData[cmdArgU16];
                     }
                     break;
 
-                case 0x90:
+                case ASEQ_CMD_ID_CHANNEL_90:
                     AudioSeq_SeqLayerFree(channel, lowBits);
                     break;
 
-                case 0x98:
+                case ASEQ_CMD_ID_CHANNEL_98:
                     if (scriptState->value != -1 && AudioSeq_SeqChannelSetLayer(channel, lowBits) != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (data[0] << 8) + data[1];
@@ -1652,11 +1653,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0x70:
+                case ASEQ_CMD_ID_CHANNEL_70:
                     channel->seqScriptIO[lowBits] = scriptState->value;
                     break;
 
-                case 0x78:
+                case ASEQ_CMD_ID_CHANNEL_78:
                     temp1 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &scriptState->pc[temp1];
@@ -1669,11 +1670,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         lowBits = cmd & 0xF;
 
         switch (cmd & 0xF0) {
-            case 0x00:
+            case ASEQ_CMD_ID_CHANNEL_00:
                 channel->delay = lowBits;
                 goto exit_loop;
 
-            case 0x10:
+            case ASEQ_CMD_ID_CHANNEL_10:
                 if (lowBits < 8) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                     if (AudioLoad_SlowLoadSample(channel->fontId, scriptState->value, &channel->seqScriptIO[lowBits]) ==
@@ -1686,28 +1687,28 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                 }
                 break;
 
-            case 0x60:
+            case ASEQ_CMD_ID_CHANNEL_60:
                 scriptState->value = channel->seqScriptIO[lowBits];
                 if (lowBits < 2) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                 }
                 break;
 
-            case 0x50:
+            case ASEQ_CMD_ID_CHANNEL_50:
                 scriptState->value -= channel->seqScriptIO[lowBits];
                 break;
 
-            case 0x20:
+            case ASEQ_CMD_ID_CHANNEL_20:
                 cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                 AudioSeq_SequenceChannelEnable(seqPlayer, lowBits, &seqPlayer->seqData[cmdArgU16]);
                 break;
 
-            case 0x30:
+            case ASEQ_CMD_ID_CHANNEL_30:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 seqPlayer->channels[lowBits]->seqScriptIO[cmd] = scriptState->value;
                 break;
 
-            case 0x40:
+            case ASEQ_CMD_ID_CHANNEL_40:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 scriptState->value = seqPlayer->channels[lowBits]->seqScriptIO[cmd];
                 break;
@@ -1780,7 +1781,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmd = AudioSeq_ScriptReadU8(seqScript);
 
             // 0xF2 and above are "flow control" commands, including termination.
-            if (cmd >= 0xF2) {
+            if (cmd >= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) {
                 delay = AudioSeq_HandleScriptFlowControl(
                     seqPlayer, seqScript, cmd, AudioSeq_GetScriptControlFlowArgument(&seqPlayer->scriptState, cmd));
 
@@ -1797,7 +1798,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
 
             if (cmd >= 0xC0) {
                 switch (cmd) {
-                    case 0xF1:
+                    case ASEQ_CMD_ID_SEQUENCE_F1:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         Audio_NotePoolFill(&seqPlayer->notePool, cmd);
@@ -1813,18 +1814,18 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         if (dummy) {}
                         break;
 
-                    case 0xF0:
+                    case ASEQ_CMD_ID_SEQUENCE_F0:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         break;
 
-                    case 0xDF:
+                    case ASEQ_CMD_ID_SEQUENCE_DF:
                         seqPlayer->transposition = 0;
                         FALLTHROUGH;
-                    case 0xDE:
+                    case ASEQ_CMD_ID_SEQUENCE_DE:
                         seqPlayer->transposition += (s8)AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xDD:
+                    case ASEQ_CMD_ID_SEQUENCE_DD:
                         seqPlayer->tempo = AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         if (seqPlayer->tempo > gAudioCtx.maxTempo) {
                             seqPlayer->tempo = (u16)gAudioCtx.maxTempo;
@@ -1835,11 +1836,11 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xDC:
+                    case ASEQ_CMD_ID_SEQUENCE_DC:
                         seqPlayer->tempoChange = (s8)AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         break;
 
-                    case 0xDA:
+                    case ASEQ_CMD_ID_SEQUENCE_DA:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         switch (cmd) {
@@ -1859,7 +1860,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xDB:
+                    case ASEQ_CMD_ID_SEQUENCE_DB:
                         value = AudioSeq_ScriptReadU8(seqScript);
                         switch (seqPlayer->state) {
                             case 1:
@@ -1881,47 +1882,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xD9:
+                    case ASEQ_CMD_ID_SEQUENCE_D9:
                         seqPlayer->fadeVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case 0xD7:
+                    case ASEQ_CMD_ID_SEQUENCE_D7:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         AudioSeq_SequencePlayerSetupChannels(seqPlayer, temp);
                         break;
 
-                    case 0xD6:
+                    case ASEQ_CMD_ID_SEQUENCE_D6:
                         AudioSeq_ScriptReadS16(seqScript);
                         break;
 
-                    case 0xD5:
+                    case ASEQ_CMD_ID_SEQUENCE_D5:
                         seqPlayer->muteVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case 0xD4:
+                    case ASEQ_CMD_ID_SEQUENCE_D4:
                         seqPlayer->muted = true;
                         break;
 
-                    case 0xD3:
+                    case ASEQ_CMD_ID_SEQUENCE_D3:
                         seqPlayer->muteBehavior = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xD1:
-                    case 0xD2:
+                    case ASEQ_CMD_ID_SEQUENCE_D1:
+                    case ASEQ_CMD_ID_SEQUENCE_D2:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data3 = &seqPlayer->seqData[temp];
-                        if (cmd == 0xD2) {
+                        if (cmd == ASEQ_CMD_ID_SEQUENCE_D2) {
                             seqPlayer->shortNoteVelocityTable = data3;
                         } else {
                             seqPlayer->shortNoteGateTimeTable = data3;
                         }
                         break;
 
-                    case 0xD0:
+                    case ASEQ_CMD_ID_SEQUENCE_D0:
                         seqPlayer->noteAllocPolicy = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xCE:
+                    case ASEQ_CMD_ID_SEQUENCE_CE:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0) {
                             seqScript->value = (gAudioCtx.audioRandom >> 2) & 0xFF;
@@ -1930,7 +1931,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xCD:
+                    case ASEQ_CMD_ID_SEQUENCE_CD:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         if ((seqScript->value != -1) && (seqScript->depth != 3)) {
                             data = seqPlayer->seqData + (u32)(temp + (seqScript->value << 1));
@@ -1942,39 +1943,39 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xCC:
+                    case ASEQ_CMD_ID_SEQUENCE_CC:
                         seqScript->value = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xC9:
+                    case ASEQ_CMD_ID_SEQUENCE_C9:
                         seqScript->value &= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xC8:
+                    case ASEQ_CMD_ID_SEQUENCE_C8:
                         seqScript->value -= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xC7:
+                    case ASEQ_CMD_ID_SEQUENCE_C7:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data2 = &seqPlayer->seqData[temp];
                         *data2 = (u8)seqScript->value + cmd;
                         break;
 
-                    case 0xC6:
+                    case ASEQ_CMD_ID_SEQUENCE_C6:
                         seqPlayer->stopScript = true;
                         return;
 
-                    case 0xC5:
+                    case ASEQ_CMD_ID_SEQUENCE_C5:
                         seqPlayer->scriptCounter = (u16)AudioSeq_ScriptReadS16(seqScript);
                         break;
 
-                    case 0xEF:
+                    case ASEQ_CMD_ID_SEQUENCE_EF:
                         AudioSeq_ScriptReadS16(seqScript);
                         AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xC4:
+                    case ASEQ_CMD_ID_SEQUENCE_C4:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0xFF) {
                             cmd = seqPlayer->playerIdx;
@@ -1992,47 +1993,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmdLowBits = cmd & 0x0F;
 
             switch (cmd & 0xF0) {
-                case 0x00:
+                case ASEQ_CMD_ID_SEQUENCE_00:
                     seqScript->value = seqPlayer->channels[cmdLowBits]->enabled ^ 1;
                     break;
 
-                case 0x50:
+                case ASEQ_CMD_ID_SEQUENCE_50:
                     seqScript->value -= seqPlayer->seqScriptIO[cmdLowBits];
                     break;
 
-                case 0x70:
+                case ASEQ_CMD_ID_SEQUENCE_70:
                     seqPlayer->seqScriptIO[cmdLowBits] = seqScript->value;
                     break;
 
-                case 0x80:
+                case ASEQ_CMD_ID_SEQUENCE_80:
                     seqScript->value = seqPlayer->seqScriptIO[cmdLowBits];
                     if (cmdLowBits < 2) {
                         seqPlayer->seqScriptIO[cmdLowBits] = SEQ_IO_VAL_NONE;
                     }
                     break;
 
-                case 0x40:
+                case ASEQ_CMD_ID_SEQUENCE_40:
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmdLowBits]);
                     break;
 
-                case 0x90:
+                case ASEQ_CMD_ID_SEQUENCE_90:
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqPlayer->seqData[temp]);
                     break;
 
-                case 0xA0:
+                case ASEQ_CMD_ID_SEQUENCE_A0:
                     tempS = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqScript->pc[tempS]);
                     break;
 
-                case 0xB0:
+                case ASEQ_CMD_ID_SEQUENCE_B0:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     data2 = &seqPlayer->seqData[temp];
                     AudioLoad_SlowLoadSeq(cmd, data2, &seqPlayer->seqScriptIO[cmdLowBits]);
                     break;
 
-                case 0x60:
+                case ASEQ_CMD_ID_SEQUENCE_60:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     value = cmd;
                     temp = AudioSeq_ScriptReadU8(seqScript);

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -71,87 +71,87 @@ u8 AudioSeq_GetInstrument(SequenceChannel* channel, u8 instId, Instrument** inst
     (((sizeof(arg0Type) - 1) << 7) | ((sizeof(arg1Type) - 1) << 6) | ((sizeof(arg2Type) - 1) << 5) | 3)
 
 u8 sSeqInstructionArgsTable[] = {
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_B0
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_B1
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_B2
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_B3
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_B4
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_B5
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_B6
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_B7
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_B8
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_B9
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_BA
-    CMD_ARGS_2(u8, s16),    // ASEQ_CMD_ID_CHANNEL_BB
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_BC
-    CMD_ARGS_2(s16, s16),   // ASEQ_CMD_ID_CHANNEL_BD
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDFILTER
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_FREEFILTER
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDSEQTOPTR
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_FILTER
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_PTRTODYNTBL
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_DYNTBLTOPTR
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_DYNTBLV
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_RANDTOPTR
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_RAND
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_RANDVEL
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_RANDGATE
+    CMD_ARGS_2(u8, s16),    // ASEQ_CMD_ID_CHANNEL_COMBFILTER
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_PTRADD
+    CMD_ARGS_2(s16, s16),   // ASEQ_CMD_ID_CHANNEL_RANDPTR
     CMD_ARGS_0(),           // 0xBE
     CMD_ARGS_0(),           // 0xBF
     CMD_ARGS_0(),           // 0xC0
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_C1
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_C2
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_C3
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_C4
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_C5
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_C6
-    CMD_ARGS_2(u8, s16),    // ASEQ_CMD_ID_CHANNEL_C7
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_C8
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_C9
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_CA
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_CB
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_CC
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_CD
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_CE
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_CF
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D0
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D1
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D2
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D3
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D4
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_INSTR
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_DYNTBL
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_SHORT
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_NOSHORT
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_DYNTBLLOOKUP
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_FONT
+    CMD_ARGS_2(u8, s16),    // ASEQ_CMD_ID_CHANNEL_STSEQ
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_SUB
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_AND
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_MUTEBHV
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDSEQ
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_LDI
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_STOPCHAN
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDPTR
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_STPTRTOSEQ
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_EFFECTS
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_NOTEALLOC
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_SUSTAIN
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_BEND
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_REVERB
     CMD_ARGS_1(u8),         // 0xD5
     CMD_ARGS_1(u8),         // 0xD6
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D7
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D8
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_D9
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_DA
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_DB
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_DC
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_DD
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_DE
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_DF
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E0
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_E1
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_E2
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E3
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_E4
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E5
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E6
-    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_E7
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_E8
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_E9
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_EA
-    CMD_ARGS_2(u8, u8),     // ASEQ_CMD_ID_CHANNEL_EB
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_EC
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_ED
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_EE
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VIBFREQ
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VIBDEPTH
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_RELEASERATE
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_ENV
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_TRANSPOSE
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_PANWEIGHT
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_PAN
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_FREQSCALE
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VOL
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VOLEXP
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_VIBFREQGRAD
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_VIBDEPTHGRAD
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_VIBDELAY
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_DYNCALL
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_REVERBIDX
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_SAMPLEBOOK
+    CMD_ARGS_1(s16),        // ASEQ_CMD_ID_CHANNEL_LDPARAMS
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_CMD_ID_CHANNEL_PARAMS
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_NOTEPRI
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_STOP
+    CMD_ARGS_2(u8, u8),     // ASEQ_CMD_ID_CHANNEL_FONTINSTR
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_VIBRESET
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_GAIN
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_BENDFINE
     CMD_ARGS_2(s16, u8),    // 0xEF
-    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_F0
-    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_F1
+    CMD_ARGS_0(),           // ASEQ_CMD_ID_CHANNEL_FREENOTELIST
+    CMD_ARGS_1(u8),         // ASEQ_CMD_ID_CHANNEL_ALLOCNOTELIST
     // Control flow instructions (>= ASEQ_CMD_ID_CONTROL_FLOW_FIRST) can only have 0 or 1 args
-    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_F2
-    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_F3
-    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_F4
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_F5
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_F6
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_F7
-    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_F8
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_F9
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_FA
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_FB
-    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_FC
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_FD
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_FE
-    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_FF
+    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_RBLTZ
+    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_RBEQZ
+    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_RJUMP
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_BGEZ
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_BREAK
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_LOOPEND
+    CMD_ARGS_1(u8),  // ASEQ_CMD_ID_CTRLFLOW_LOOP
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_BLTZ
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_BEQZ
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_JUMP
+    CMD_ARGS_1(s16), // ASEQ_CMD_ID_CTRLFLOW_CALL
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_DELAY
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_DELAY1
+    CMD_ARGS_0(),    // ASEQ_CMD_ID_CTRLFLOW_END
 };
 
 /**
@@ -182,30 +182,30 @@ u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
  */
 s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* state, s32 cmd, s32 cmdArg) {
     switch (cmd) {
-        case ASEQ_CMD_ID_CTRLFLOW_FF:
+        case ASEQ_CMD_ID_CTRLFLOW_END:
             if (state->depth == 0) {
                 return PROCESS_SCRIPT_END;
             }
             state->pc = state->stack[--state->depth];
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_FD:
+        case ASEQ_CMD_ID_CTRLFLOW_DELAY:
             return AudioSeq_ScriptReadCompressedU16(state);
 
-        case ASEQ_CMD_ID_CTRLFLOW_FE:
+        case ASEQ_CMD_ID_CTRLFLOW_DELAY1:
             return 1;
 
-        case ASEQ_CMD_ID_CTRLFLOW_FC:
+        case ASEQ_CMD_ID_CTRLFLOW_CALL:
             state->stack[state->depth++] = state->pc;
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_F8:
+        case ASEQ_CMD_ID_CTRLFLOW_LOOP:
             state->remLoopIters[state->depth] = cmdArg;
             state->stack[state->depth++] = state->pc;
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_F7:
+        case ASEQ_CMD_ID_CTRLFLOW_LOOPEND:
             state->remLoopIters[state->depth - 1]--;
             if (state->remLoopIters[state->depth - 1] != 0) {
                 state->pc = state->stack[state->depth - 1];
@@ -214,33 +214,33 @@ s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* 
             }
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_F6:
+        case ASEQ_CMD_ID_CTRLFLOW_BREAK:
             state->depth--;
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_F5:
-        case ASEQ_CMD_ID_CTRLFLOW_F9:
-        case ASEQ_CMD_ID_CTRLFLOW_FA:
-        case ASEQ_CMD_ID_CTRLFLOW_FB:
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_FA && state->value != 0) {
+        case ASEQ_CMD_ID_CTRLFLOW_BGEZ:
+        case ASEQ_CMD_ID_CTRLFLOW_BLTZ:
+        case ASEQ_CMD_ID_CTRLFLOW_BEQZ:
+        case ASEQ_CMD_ID_CTRLFLOW_JUMP:
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_BEQZ && state->value != 0) {
                 break;
             }
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_F9 && state->value >= 0) {
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_BLTZ && state->value >= 0) {
                 break;
             }
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_F5 && state->value < 0) {
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_BGEZ && state->value < 0) {
                 break;
             }
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case ASEQ_CMD_ID_CTRLFLOW_F2:
-        case ASEQ_CMD_ID_CTRLFLOW_F3:
-        case ASEQ_CMD_ID_CTRLFLOW_F4:
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_F3 && state->value != 0) {
+        case ASEQ_CMD_ID_CTRLFLOW_RBLTZ:
+        case ASEQ_CMD_ID_CTRLFLOW_RBEQZ:
+        case ASEQ_CMD_ID_CTRLFLOW_RJUMP:
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_RBEQZ && state->value != 0) {
                 break;
             }
-            if (cmd == ASEQ_CMD_ID_CTRLFLOW_F2 && state->value >= 0) {
+            if (cmd == ASEQ_CMD_ID_CTRLFLOW_RBLTZ && state->value >= 0) {
                 break;
             }
             state->pc += (s8)(cmdArg & 0xFF);
@@ -657,29 +657,29 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
         }
 
         switch (cmd) {
-            case ASEQ_CMD_ID_LAYER_C1: // layer_setshortnotevelocity
-            case ASEQ_CMD_ID_LAYER_CA: // layer_setpan
+            case ASEQ_CMD_ID_LAYER_SHORTVEL: // layer_setshortnotevelocity
+            case ASEQ_CMD_ID_LAYER_NOTEPAN: // layer_setpan
                 cmdArg8 = *(state->pc++);
-                if (cmd == ASEQ_CMD_ID_LAYER_C1) {
+                if (cmd == ASEQ_CMD_ID_LAYER_SHORTVEL) {
                     layer->velocitySquare = SQ(cmdArg8) / SQ(127.0f);
                 } else {
                     layer->pan = cmdArg8;
                 }
                 break;
 
-            case ASEQ_CMD_ID_LAYER_C9: // layer_setshortnotegatetime
-            case ASEQ_CMD_ID_LAYER_C2: // layer_transpose; set transposition in semitones
+            case ASEQ_CMD_ID_LAYER_SHORTGATE: // layer_setshortnotegatetime
+            case ASEQ_CMD_ID_LAYER_TRANSPOSE: // layer_transpose; set transposition in semitones
                 cmdArg8 = *(state->pc++);
-                if (cmd == ASEQ_CMD_ID_LAYER_C9) {
+                if (cmd == ASEQ_CMD_ID_LAYER_SHORTGATE) {
                     layer->gateTime = cmdArg8;
                 } else {
                     layer->transposition = cmdArg8;
                 }
                 break;
 
-            case ASEQ_CMD_ID_LAYER_C4: // layer_continuousnoteson
-            case ASEQ_CMD_ID_LAYER_C5: // layer_continuousnotesoff
-                if (cmd == ASEQ_CMD_ID_LAYER_C4) {
+            case ASEQ_CMD_ID_LAYER_LEGATO: // layer_continuousnoteson
+            case ASEQ_CMD_ID_LAYER_NOLEGATO: // layer_continuousnotesoff
+                if (cmd == ASEQ_CMD_ID_LAYER_LEGATO) {
                     layer->continuousNotes = true;
                 } else {
                     layer->continuousNotes = false;
@@ -688,12 +688,12 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 Audio_SeqLayerNoteDecay(layer);
                 break;
 
-            case ASEQ_CMD_ID_LAYER_C3: // layer_setshortnotedefaultdelay
+            case ASEQ_CMD_ID_LAYER_SHORTDELAY: // layer_setshortnotedefaultdelay
                 cmdArg16 = AudioSeq_ScriptReadCompressedU16(state);
                 layer->shortNoteDefaultDelay = cmdArg16;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_C6: // layer_setinstr
+            case ASEQ_CMD_ID_LAYER_INSTR: // layer_setinstr
                 cmd = AudioSeq_ScriptReadU8(state);
                 if (cmd >= 0x7E) {
                     if (cmd == 0x7E) {
@@ -720,7 +720,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 }
                 break;
 
-            case ASEQ_CMD_ID_LAYER_C7: // layer_portamento
+            case ASEQ_CMD_ID_LAYER_PORTAMENTO: // layer_portamento
                 layer->portamento.mode = AudioSeq_ScriptReadU8(state);
 
                 cmd = AudioSeq_ScriptReadU8(state);
@@ -744,39 +744,39 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 layer->portamentoTime = cmdArg16;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_C8: // layer_disableportamento
+            case ASEQ_CMD_ID_LAYER_NOPORTAMENTO: // layer_disableportamento
                 layer->portamento.mode = PORTAMENTO_MODE_OFF;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_CB:
+            case ASEQ_CMD_ID_LAYER_ENV:
                 cmdArg16 = AudioSeq_ScriptReadS16(state);
                 layer->adsr.envelope = (EnvelopePoint*)(seqPlayer->seqData + cmdArg16);
                 FALLTHROUGH;
-            case ASEQ_CMD_ID_LAYER_CF:
+            case ASEQ_CMD_ID_LAYER_RELEASERATE:
                 layer->adsr.decayIndex = AudioSeq_ScriptReadU8(state);
                 break;
 
-            case ASEQ_CMD_ID_LAYER_CC:
+            case ASEQ_CMD_ID_LAYER_NODRUMPAN:
                 layer->ignoreDrumPan = true;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_CD:
+            case ASEQ_CMD_ID_LAYER_STEREO:
                 layer->stereo.asByte = AudioSeq_ScriptReadU8(state);
                 break;
 
-            case ASEQ_CMD_ID_LAYER_CE:
+            case ASEQ_CMD_ID_LAYER_BENDFINE:
                 cmdArg8 = AudioSeq_ScriptReadU8(state);
                 layer->bend = gBendPitchTwoSemitonesFrequencies[(u8)(cmdArg8 + 0x80)];
                 break;
 
             default:
                 switch (cmd & 0xF0) {
-                    case ASEQ_CMD_ID_LAYER_D0: // layer_setshortnotevelocityfromtable
+                    case ASEQ_CMD_ID_LAYER_LDSHORTVEL: // layer_setshortnotevelocityfromtable
                         velocity = seqPlayer->shortNoteVelocityTable[cmd & 0xF];
                         layer->velocitySquare = SQ(velocity) / SQ(127.0f);
                         break;
 
-                    case ASEQ_CMD_ID_LAYER_E0: // layer_setshortnotegatetimefromtable
+                    case ASEQ_CMD_ID_LAYER_LDSHORTGATE: // layer_setshortnotegatetimefromtable
                         layer->gateTime = seqPlayer->shortNoteGateTimeTable[cmd & 0xF];
                         break;
                 }
@@ -1001,7 +1001,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
     s32 intDelta;
     f32 floatDelta;
 
-    if (cmd == ASEQ_CMD_ID_LAYER_STEP3_C0) {
+    if (cmd == ASEQ_CMD_ID_LAYER_STEP3_LDELAY) {
         layer->delay = AudioSeq_ScriptReadCompressedU16(state);
         layer->muted = true;
         layer->bit1 = false;
@@ -1012,21 +1012,21 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
 
     if (channel->largeNotes == true) {
         switch (cmd & 0xC0) {
-            case ASEQ_CMD_ID_LAYER_STEP3_00:
+            case ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_STEP3_40:
+            case ASEQ_CMD_ID_LAYER_STEP3_NOTEDV:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = 0;
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_STEP3_80:
+            case ASEQ_CMD_ID_LAYER_STEP3_NOTEVG:
                 delay = layer->lastDelay;
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
@@ -1040,16 +1040,16 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
         cmd -= (cmd & 0xC0);
     } else {
         switch (cmd & 0xC0) {
-            case ASEQ_CMD_ID_LAYER_STEP3_00:
+            case ASEQ_CMD_ID_LAYER_STEP3_NOTEDVG:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_STEP3_40:
+            case ASEQ_CMD_ID_LAYER_STEP3_NOTEDV:
                 delay = layer->shortNoteDefaultDelay;
                 break;
 
-            case ASEQ_CMD_ID_LAYER_STEP3_80:
+            case ASEQ_CMD_ID_LAYER_STEP3_NOTEVG:
                 delay = layer->lastDelay;
                 break;
         }
@@ -1226,26 +1226,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             switch (cmd) {
-                case ASEQ_CMD_ID_CHANNEL_EA:
+                case ASEQ_CMD_ID_CHANNEL_STOP:
                     channel->stopScript = true;
                     goto exit_loop;
 
-                case ASEQ_CMD_ID_CHANNEL_F1:
+                case ASEQ_CMD_ID_CHANNEL_ALLOCNOTELIST:
                     Audio_NotePoolClear(&channel->notePool);
                     cmd = (u8)cmdArgs[0];
                     Audio_NotePoolFill(&channel->notePool, cmd);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_F0:
+                case ASEQ_CMD_ID_CHANNEL_FREENOTELIST:
                     Audio_NotePoolClear(&channel->notePool);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_C2:
+                case ASEQ_CMD_ID_CHANNEL_DYNTBL:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->dynTable = (void*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_C5:
+                case ASEQ_CMD_ID_CHANNEL_DYNTBLLOOKUP:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (u16)((data[0] << 8) + data[1]);
@@ -1254,7 +1254,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_EB:
+                case ASEQ_CMD_ID_CHANNEL_FONTINSTR:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1269,93 +1269,93 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
 
                     cmdArgs[0] = cmdArgs[1];
                     FALLTHROUGH;
-                case ASEQ_CMD_ID_CHANNEL_C1:
+                case ASEQ_CMD_ID_CHANNEL_INSTR:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SetInstrument(channel, cmd);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_C3:
+                case ASEQ_CMD_ID_CHANNEL_SHORT:
                     channel->largeNotes = false;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_C4:
+                case ASEQ_CMD_ID_CHANNEL_NOSHORT:
                     channel->largeNotes = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DF:
+                case ASEQ_CMD_ID_CHANNEL_VOL:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelSetVolume(channel, cmd);
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E0:
+                case ASEQ_CMD_ID_CHANNEL_VOLEXP:
                     cmd = (u8)cmdArgs[0];
                     channel->volumeScale = (s32)cmd / 128.0f;
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DE:
+                case ASEQ_CMD_ID_CHANNEL_FREQSCALE:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->freqScale = (s32)cmdArgU16 / 32768.0f;
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_D3:
+                case ASEQ_CMD_ID_CHANNEL_BEND:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchOneOctaveFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_EE:
+                case ASEQ_CMD_ID_CHANNEL_BENDFINE:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchTwoSemitonesFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DD:
+                case ASEQ_CMD_ID_CHANNEL_PAN:
                     cmd = (u8)cmdArgs[0];
                     channel->newPan = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DC:
+                case ASEQ_CMD_ID_CHANNEL_PANWEIGHT:
                     cmd = (u8)cmdArgs[0];
                     channel->panChannelWeight = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DB:
+                case ASEQ_CMD_ID_CHANNEL_TRANSPOSE:
                     cmdArgS8 = (s8)cmdArgs[0];
                     channel->transposition = cmdArgS8;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_DA:
+                case ASEQ_CMD_ID_CHANNEL_ENV:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->adsr.envelope = (EnvelopePoint*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_D9:
+                case ASEQ_CMD_ID_CHANNEL_RELEASERATE:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.decayIndex = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_D8:
+                case ASEQ_CMD_ID_CHANNEL_VIBDEPTH:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthTarget = cmd * 8;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_D7:
+                case ASEQ_CMD_ID_CHANNEL_VIBFREQ:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateChangeDelay = 0;
                     channel->vibratoRateTarget = cmd * 32;
                     channel->vibratoRateStart = cmd * 32;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E2:
+                case ASEQ_CMD_ID_CHANNEL_VIBDEPTHGRAD:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthStart = cmd * 8;
                     cmd = (u8)cmdArgs[1];
@@ -1364,7 +1364,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoDepthChangeDelay = cmd * 16;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E1:
+                case ASEQ_CMD_ID_CHANNEL_VIBFREQGRAD:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateStart = cmd * 32;
                     cmd = (u8)cmdArgs[1];
@@ -1373,17 +1373,17 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoRateChangeDelay = cmd * 16;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E3:
+                case ASEQ_CMD_ID_CHANNEL_VIBDELAY:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDelay = cmd * 16;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_D4:
+                case ASEQ_CMD_ID_CHANNEL_REVERB:
                     cmd = (u8)cmdArgs[0];
                     channel->targetReverbVol = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_C6:
+                case ASEQ_CMD_ID_CHANNEL_FONT:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1397,56 +1397,56 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_C7:
+                case ASEQ_CMD_ID_CHANNEL_STSEQ:
                     cmd = (u8)cmdArgs[0];
                     cmdArgU16 = (u16)cmdArgs[1];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (u8)scriptState->value + cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_C8:
-                case ASEQ_CMD_ID_CHANNEL_CC:
-                case ASEQ_CMD_ID_CHANNEL_C9:
+                case ASEQ_CMD_ID_CHANNEL_SUB:
+                case ASEQ_CMD_ID_CHANNEL_LDI:
+                case ASEQ_CMD_ID_CHANNEL_AND:
                     cmdArgS8 = (s8)cmdArgs[0];
 
-                    if (cmd == ASEQ_CMD_ID_CHANNEL_C8) {
+                    if (cmd == ASEQ_CMD_ID_CHANNEL_SUB) {
                         scriptState->value -= cmdArgS8;
-                    } else if (cmd == ASEQ_CMD_ID_CHANNEL_CC) {
+                    } else if (cmd == ASEQ_CMD_ID_CHANNEL_LDI) {
                         scriptState->value = cmdArgS8;
                     } else {
                         scriptState->value &= cmdArgS8;
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_CD:
+                case ASEQ_CMD_ID_CHANNEL_STOPCHAN:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmd]);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_CA:
+                case ASEQ_CMD_ID_CHANNEL_MUTEBHV:
                     cmd = (u8)cmdArgs[0];
                     channel->muteBehavior = cmd;
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_CB:
+                case ASEQ_CMD_ID_CHANNEL_LDSEQ:
                     cmdArgU16 = (u16)cmdArgs[0];
                     scriptState->value = *(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value));
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_CE:
+                case ASEQ_CMD_ID_CHANNEL_LDPTR:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = cmdArgU16;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_CF:
+                case ASEQ_CMD_ID_CHANNEL_STPTRTOSEQ:
                     cmdArgU16 = (u16)cmdArgs[0];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (channel->unk_22 >> 8) & 0xFF;
                     seqData[1] = channel->unk_22 & 0xFF;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_D0:
+                case ASEQ_CMD_ID_CHANNEL_EFFECTS:
                     cmd = (u8)cmdArgs[0];
                     if (cmd & 0x80) {
                         channel->stereoHeadsetEffects = true;
@@ -1456,22 +1456,22 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->stereo.asByte = cmd & 0x7F;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_D1:
+                case ASEQ_CMD_ID_CHANNEL_NOTEALLOC:
                     cmd = (u8)cmdArgs[0];
                     channel->noteAllocPolicy = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_D2:
+                case ASEQ_CMD_ID_CHANNEL_SUSTAIN:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.sustain = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E5:
+                case ASEQ_CMD_ID_CHANNEL_REVERBIDX:
                     cmd = (u8)cmdArgs[0];
                     channel->reverbIndex = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E4:
+                case ASEQ_CMD_ID_CHANNEL_DYNCALL:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         //! @bug: Missing a stack depth check here
@@ -1481,12 +1481,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E6:
+                case ASEQ_CMD_ID_CHANNEL_SAMPLEBOOK:
                     cmd = (u8)cmdArgs[0];
                     channel->bookOffset = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E7:
+                case ASEQ_CMD_ID_CHANNEL_LDPARAMS:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = &seqPlayer->seqData[cmdArgU16];
                     channel->muteBehavior = *data++;
@@ -1501,7 +1501,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E8:
+                case ASEQ_CMD_ID_CHANNEL_PARAMS:
                     channel->muteBehavior = cmdArgs[0];
                     channel->noteAllocPolicy = cmdArgs[1];
                     cmd = (u8)cmdArgs[2];
@@ -1515,7 +1515,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_EC:
+                case ASEQ_CMD_ID_CHANNEL_VIBRESET:
                     channel->vibratoDepthTarget = 0;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
@@ -1533,26 +1533,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->freqScale = 1.0f;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_E9:
+                case ASEQ_CMD_ID_CHANNEL_NOTEPRI:
                     AudioSeq_SetChannelPriorities(channel, (u8)cmdArgs[0]);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_ED:
+                case ASEQ_CMD_ID_CHANNEL_GAIN:
                     cmd = (u8)cmdArgs[0];
                     channel->gain = cmd;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B0:
+                case ASEQ_CMD_ID_CHANNEL_LDFILTER:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = seqPlayer->seqData + cmdArgU16;
                     channel->filter = (s16*)data;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B1:
+                case ASEQ_CMD_ID_CHANNEL_FREEFILTER:
                     channel->filter = NULL;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B3:
+                case ASEQ_CMD_ID_CHANNEL_FILTER:
                     cmd = cmdArgs[0];
 
                     if (channel->filter != NULL) {
@@ -1562,34 +1562,34 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B2:
+                case ASEQ_CMD_ID_CHANNEL_LDSEQTOPTR:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = *(u16*)(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value * 2));
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B4:
+                case ASEQ_CMD_ID_CHANNEL_PTRTODYNTBL:
                     channel->dynTable = (void*)&seqPlayer->seqData[channel->unk_22];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B5:
+                case ASEQ_CMD_ID_CHANNEL_DYNTBLTOPTR:
                     channel->unk_22 = ((u16*)(channel->dynTable))[scriptState->value];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B6:
+                case ASEQ_CMD_ID_CHANNEL_DYNTBLV:
                     scriptState->value = (*channel->dynTable)[0][scriptState->value];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B7:
+                case ASEQ_CMD_ID_CHANNEL_RANDTOPTR:
                     channel->unk_22 =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B8:
+                case ASEQ_CMD_ID_CHANNEL_RAND:
                     scriptState->value =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_BD:
+                case ASEQ_CMD_ID_CHANNEL_RANDPTR:
                     temp2 = AudioThread_NextRandom();
                     channel->unk_22 = (cmdArgs[0] == 0) ? (temp2 & 0xFFFF) : (temp2 % cmdArgs[0]);
                     channel->unk_22 += cmdArgs[1];
@@ -1598,20 +1598,20 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->unk_22 = (temp2 << 8) | param;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_B9:
+                case ASEQ_CMD_ID_CHANNEL_RANDVEL:
                     channel->velocityRandomVariance = cmdArgs[0];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_BA:
+                case ASEQ_CMD_ID_CHANNEL_RANDGATE:
                     channel->gateTimeRandomVariance = cmdArgs[0];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_BB:
+                case ASEQ_CMD_ID_CHANNEL_COMBFILTER:
                     channel->combFilterSize = cmdArgs[0];
                     channel->combFilterGain = cmdArgs[1];
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_BC:
+                case ASEQ_CMD_ID_CHANNEL_PTRADD:
                     channel->unk_22 += cmdArgs[0];
                     break;
             }
@@ -1621,12 +1621,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         if (cmd >= 0x70) {
             lowBits = cmd & 0x7;
 
-            if ((cmd & 0xF8) != ASEQ_CMD_ID_CHANNEL_70 && lowBits >= 4) {
+            if ((cmd & 0xF8) != ASEQ_CMD_ID_CHANNEL_STIO && lowBits >= 4) {
                 lowBits = 0;
             }
 
             switch (cmd & 0xF8) {
-                case ASEQ_CMD_ID_CHANNEL_80:
+                case ASEQ_CMD_ID_CHANNEL_TESTLAYER:
                     if (channel->layers[lowBits] != NULL) {
                         scriptState->value = channel->layers[lowBits]->finished;
                     } else {
@@ -1634,18 +1634,18 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_88:
+                case ASEQ_CMD_ID_CHANNEL_LDLAYER:
                     cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &seqPlayer->seqData[cmdArgU16];
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_90:
+                case ASEQ_CMD_ID_CHANNEL_DELLAYER:
                     AudioSeq_SeqLayerFree(channel, lowBits);
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_98:
+                case ASEQ_CMD_ID_CHANNEL_DYNLDLAYER:
                     if (scriptState->value != -1 && AudioSeq_SeqChannelSetLayer(channel, lowBits) != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (data[0] << 8) + data[1];
@@ -1653,11 +1653,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_70:
+                case ASEQ_CMD_ID_CHANNEL_STIO:
                     channel->seqScriptIO[lowBits] = scriptState->value;
                     break;
 
-                case ASEQ_CMD_ID_CHANNEL_78:
+                case ASEQ_CMD_ID_CHANNEL_RLDLAYER:
                     temp1 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &scriptState->pc[temp1];
@@ -1670,11 +1670,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         lowBits = cmd & 0xF;
 
         switch (cmd & 0xF0) {
-            case ASEQ_CMD_ID_CHANNEL_00:
+            case ASEQ_CMD_ID_CHANNEL_STOPCHANELAY:
                 channel->delay = lowBits;
                 goto exit_loop;
 
-            case ASEQ_CMD_ID_CHANNEL_10:
+            case ASEQ_CMD_ID_CHANNEL_LDSAMPLE:
                 if (lowBits < 8) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                     if (AudioLoad_SlowLoadSample(channel->fontId, scriptState->value, &channel->seqScriptIO[lowBits]) ==
@@ -1687,28 +1687,28 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                 }
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_60:
+            case ASEQ_CMD_ID_CHANNEL_LDIO:
                 scriptState->value = channel->seqScriptIO[lowBits];
                 if (lowBits < 2) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                 }
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_50:
+            case ASEQ_CMD_ID_CHANNEL_SUBIO:
                 scriptState->value -= channel->seqScriptIO[lowBits];
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_20:
+            case ASEQ_CMD_ID_CHANNEL_LDCHAN:
                 cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                 AudioSeq_SequenceChannelEnable(seqPlayer, lowBits, &seqPlayer->seqData[cmdArgU16]);
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_30:
+            case ASEQ_CMD_ID_CHANNEL_STCIO:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 seqPlayer->channels[lowBits]->seqScriptIO[cmd] = scriptState->value;
                 break;
 
-            case ASEQ_CMD_ID_CHANNEL_40:
+            case ASEQ_CMD_ID_CHANNEL_LDCIO:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 scriptState->value = seqPlayer->channels[lowBits]->seqScriptIO[cmd];
                 break;
@@ -1798,7 +1798,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
 
             if (cmd >= 0xC0) {
                 switch (cmd) {
-                    case ASEQ_CMD_ID_SEQUENCE_F1:
+                    case ASEQ_CMD_ID_SEQUENCE_ALLOCNOTELIST:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         Audio_NotePoolFill(&seqPlayer->notePool, cmd);
@@ -1814,18 +1814,18 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         if (dummy) {}
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_F0:
+                    case ASEQ_CMD_ID_SEQUENCE_FREENOTELIST:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_DF:
+                    case ASEQ_CMD_ID_SEQUENCE_TRANSPOSE:
                         seqPlayer->transposition = 0;
                         FALLTHROUGH;
-                    case ASEQ_CMD_ID_SEQUENCE_DE:
+                    case ASEQ_CMD_ID_SEQUENCE_RTRANSPOSE:
                         seqPlayer->transposition += (s8)AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_DD:
+                    case ASEQ_CMD_ID_SEQUENCE_TEMPO:
                         seqPlayer->tempo = AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         if (seqPlayer->tempo > gAudioCtx.maxTempo) {
                             seqPlayer->tempo = (u16)gAudioCtx.maxTempo;
@@ -1836,11 +1836,11 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_DC:
+                    case ASEQ_CMD_ID_SEQUENCE_TEMPOCHG:
                         seqPlayer->tempoChange = (s8)AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_DA:
+                    case ASEQ_CMD_ID_SEQUENCE_VOLMODE:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         switch (cmd) {
@@ -1860,7 +1860,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_DB:
+                    case ASEQ_CMD_ID_SEQUENCE_VOL:
                         value = AudioSeq_ScriptReadU8(seqScript);
                         switch (seqPlayer->state) {
                             case 1:
@@ -1882,47 +1882,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_D9:
+                    case ASEQ_CMD_ID_SEQUENCE_VOLSCALE:
                         seqPlayer->fadeVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_D7:
+                    case ASEQ_CMD_ID_SEQUENCE_INITCHAN:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         AudioSeq_SequencePlayerSetupChannels(seqPlayer, temp);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_D6:
+                    case ASEQ_CMD_ID_SEQUENCE_FREECHAN:
                         AudioSeq_ScriptReadS16(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_D5:
+                    case ASEQ_CMD_ID_SEQUENCE_MUTESCALE:
                         seqPlayer->muteVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_D4:
+                    case ASEQ_CMD_ID_SEQUENCE_MUTE:
                         seqPlayer->muted = true;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_D3:
+                    case ASEQ_CMD_ID_SEQUENCE_MUTEBHV:
                         seqPlayer->muteBehavior = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_D1:
-                    case ASEQ_CMD_ID_SEQUENCE_D2:
+                    case ASEQ_CMD_ID_SEQUENCE_LDSHORTGATEARR:
+                    case ASEQ_CMD_ID_SEQUENCE_LDSHORTVELARR:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data3 = &seqPlayer->seqData[temp];
-                        if (cmd == ASEQ_CMD_ID_SEQUENCE_D2) {
+                        if (cmd == ASEQ_CMD_ID_SEQUENCE_LDSHORTVELARR) {
                             seqPlayer->shortNoteVelocityTable = data3;
                         } else {
                             seqPlayer->shortNoteGateTimeTable = data3;
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_D0:
+                    case ASEQ_CMD_ID_SEQUENCE_NOTEALLOC:
                         seqPlayer->noteAllocPolicy = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_CE:
+                    case ASEQ_CMD_ID_SEQUENCE_RAND:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0) {
                             seqScript->value = (gAudioCtx.audioRandom >> 2) & 0xFF;
@@ -1931,7 +1931,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_CD:
+                    case ASEQ_CMD_ID_SEQUENCE_DYNCALL:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         if ((seqScript->value != -1) && (seqScript->depth != 3)) {
                             data = seqPlayer->seqData + (u32)(temp + (seqScript->value << 1));
@@ -1943,30 +1943,30 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_CC:
+                    case ASEQ_CMD_ID_SEQUENCE_LDI:
                         seqScript->value = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_C9:
+                    case ASEQ_CMD_ID_SEQUENCE_AND:
                         seqScript->value &= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_C8:
+                    case ASEQ_CMD_ID_SEQUENCE_SUB:
                         seqScript->value -= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_C7:
+                    case ASEQ_CMD_ID_SEQUENCE_STSEQ:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data2 = &seqPlayer->seqData[temp];
                         *data2 = (u8)seqScript->value + cmd;
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_C6:
+                    case ASEQ_CMD_ID_SEQUENCE_STOP:
                         seqPlayer->stopScript = true;
                         return;
 
-                    case ASEQ_CMD_ID_SEQUENCE_C5:
+                    case ASEQ_CMD_ID_SEQUENCE_SCRIPTCTR:
                         seqPlayer->scriptCounter = (u16)AudioSeq_ScriptReadS16(seqScript);
                         break;
 
@@ -1975,7 +1975,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_CMD_ID_SEQUENCE_C4:
+                    case ASEQ_CMD_ID_SEQUENCE_RUNSEQ:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0xFF) {
                             cmd = seqPlayer->playerIdx;
@@ -1993,47 +1993,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmdLowBits = cmd & 0x0F;
 
             switch (cmd & 0xF0) {
-                case ASEQ_CMD_ID_SEQUENCE_00:
+                case ASEQ_CMD_ID_SEQUENCE_TESTCHAN:
                     seqScript->value = seqPlayer->channels[cmdLowBits]->enabled ^ 1;
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_50:
+                case ASEQ_CMD_ID_SEQUENCE_SUBIO:
                     seqScript->value -= seqPlayer->seqScriptIO[cmdLowBits];
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_70:
+                case ASEQ_CMD_ID_SEQUENCE_STIO:
                     seqPlayer->seqScriptIO[cmdLowBits] = seqScript->value;
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_80:
+                case ASEQ_CMD_ID_SEQUENCE_LDIO:
                     seqScript->value = seqPlayer->seqScriptIO[cmdLowBits];
                     if (cmdLowBits < 2) {
                         seqPlayer->seqScriptIO[cmdLowBits] = SEQ_IO_VAL_NONE;
                     }
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_40:
+                case ASEQ_CMD_ID_SEQUENCE_STOPCHAN:
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmdLowBits]);
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_90:
+                case ASEQ_CMD_ID_SEQUENCE_LDCHAN:
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqPlayer->seqData[temp]);
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_A0:
+                case ASEQ_CMD_ID_SEQUENCE_RLDCHAN:
                     tempS = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqScript->pc[tempS]);
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_B0:
+                case ASEQ_CMD_ID_SEQUENCE_LDSEQ:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     data2 = &seqPlayer->seqData[temp];
                     AudioLoad_SlowLoadSeq(cmd, data2, &seqPlayer->seqScriptIO[cmdLowBits]);
                     break;
 
-                case ASEQ_CMD_ID_SEQUENCE_60:
+                case ASEQ_CMD_ID_SEQUENCE_LDRES:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     value = cmd;
                     temp = AudioSeq_ScriptReadU8(seqScript);

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -14,6 +14,7 @@
  *     Otherwise, each set of instructions has its own command interpreter
  */
 #include "ultra64.h"
+#define MML_VERSION MML_VERSION_OOT
 #include "audio/aseq.h"
 #include "global.h"
 
@@ -1670,7 +1671,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         lowBits = cmd & 0xF;
 
         switch (cmd & 0xF0) {
-            case ASEQ_OPC_CHANNEL_STOPCHANELAY:
+            case ASEQ_OPC_CHANNEL_CDELAY:
                 channel->delay = lowBits;
                 goto exit_loop;
 

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -139,20 +139,20 @@ u8 sSeqInstructionArgsTable[] = {
     CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_FREENOTELIST
     CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_ALLOCNOTELIST
     // Control flow instructions (>= ASEQ_OP_CONTROL_FLOW_FIRST) can only have 0 or 1 args
-    CMD_ARGS_1(u8),  // ASEQ_OP_CTRLFLOW_RBLTZ
-    CMD_ARGS_1(u8),  // ASEQ_OP_CTRLFLOW_RBEQZ
-    CMD_ARGS_1(u8),  // ASEQ_OP_CTRLFLOW_RJUMP
-    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_BGEZ
-    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_BREAK
-    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_LOOPEND
-    CMD_ARGS_1(u8),  // ASEQ_OP_CTRLFLOW_LOOP
-    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_BLTZ
-    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_BEQZ
-    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_JUMP
-    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_CALL
-    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_DELAY
-    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_DELAY1
-    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_END
+    CMD_ARGS_1(u8),  // ASEQ_OP_RBLTZ
+    CMD_ARGS_1(u8),  // ASEQ_OP_RBEQZ
+    CMD_ARGS_1(u8),  // ASEQ_OP_RJUMP
+    CMD_ARGS_1(s16), // ASEQ_OP_BGEZ
+    CMD_ARGS_0(),    // ASEQ_OP_BREAK
+    CMD_ARGS_0(),    // ASEQ_OP_LOOPEND
+    CMD_ARGS_1(u8),  // ASEQ_OP_LOOP
+    CMD_ARGS_1(s16), // ASEQ_OP_BLTZ
+    CMD_ARGS_1(s16), // ASEQ_OP_BEQZ
+    CMD_ARGS_1(s16), // ASEQ_OP_JUMP
+    CMD_ARGS_1(s16), // ASEQ_OP_CALL
+    CMD_ARGS_0(),    // ASEQ_OP_DELAY
+    CMD_ARGS_0(),    // ASEQ_OP_DELAY1
+    CMD_ARGS_0(),    // ASEQ_OP_END
 };
 
 /**
@@ -183,30 +183,30 @@ u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
  */
 s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* state, s32 cmd, s32 cmdArg) {
     switch (cmd) {
-        case ASEQ_OP_CTRLFLOW_END:
+        case ASEQ_OP_END:
             if (state->depth == 0) {
                 return PROCESS_SCRIPT_END;
             }
             state->pc = state->stack[--state->depth];
             break;
 
-        case ASEQ_OP_CTRLFLOW_DELAY:
+        case ASEQ_OP_DELAY:
             return AudioSeq_ScriptReadCompressedU16(state);
 
-        case ASEQ_OP_CTRLFLOW_DELAY1:
+        case ASEQ_OP_DELAY1:
             return 1;
 
-        case ASEQ_OP_CTRLFLOW_CALL:
+        case ASEQ_OP_CALL:
             state->stack[state->depth++] = state->pc;
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case ASEQ_OP_CTRLFLOW_LOOP:
+        case ASEQ_OP_LOOP:
             state->remLoopIters[state->depth] = cmdArg;
             state->stack[state->depth++] = state->pc;
             break;
 
-        case ASEQ_OP_CTRLFLOW_LOOPEND:
+        case ASEQ_OP_LOOPEND:
             state->remLoopIters[state->depth - 1]--;
             if (state->remLoopIters[state->depth - 1] != 0) {
                 state->pc = state->stack[state->depth - 1];
@@ -215,33 +215,33 @@ s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* 
             }
             break;
 
-        case ASEQ_OP_CTRLFLOW_BREAK:
+        case ASEQ_OP_BREAK:
             state->depth--;
             break;
 
-        case ASEQ_OP_CTRLFLOW_BGEZ:
-        case ASEQ_OP_CTRLFLOW_BLTZ:
-        case ASEQ_OP_CTRLFLOW_BEQZ:
-        case ASEQ_OP_CTRLFLOW_JUMP:
-            if (cmd == ASEQ_OP_CTRLFLOW_BEQZ && state->value != 0) {
+        case ASEQ_OP_BGEZ:
+        case ASEQ_OP_BLTZ:
+        case ASEQ_OP_BEQZ:
+        case ASEQ_OP_JUMP:
+            if (cmd == ASEQ_OP_BEQZ && state->value != 0) {
                 break;
             }
-            if (cmd == ASEQ_OP_CTRLFLOW_BLTZ && state->value >= 0) {
+            if (cmd == ASEQ_OP_BLTZ && state->value >= 0) {
                 break;
             }
-            if (cmd == ASEQ_OP_CTRLFLOW_BGEZ && state->value < 0) {
+            if (cmd == ASEQ_OP_BGEZ && state->value < 0) {
                 break;
             }
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case ASEQ_OP_CTRLFLOW_RBLTZ:
-        case ASEQ_OP_CTRLFLOW_RBEQZ:
-        case ASEQ_OP_CTRLFLOW_RJUMP:
-            if (cmd == ASEQ_OP_CTRLFLOW_RBEQZ && state->value != 0) {
+        case ASEQ_OP_RBLTZ:
+        case ASEQ_OP_RBEQZ:
+        case ASEQ_OP_RJUMP:
+            if (cmd == ASEQ_OP_RBEQZ && state->value != 0) {
                 break;
             }
-            if (cmd == ASEQ_OP_CTRLFLOW_RBLTZ && state->value >= 0) {
+            if (cmd == ASEQ_OP_RBLTZ && state->value >= 0) {
                 break;
             }
             state->pc += (s8)(cmdArg & 0xFF);

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -72,72 +72,72 @@ u8 AudioSeq_GetInstrument(SequenceChannel* channel, u8 instId, Instrument** inst
     (((sizeof(arg0Type) - 1) << 7) | ((sizeof(arg1Type) - 1) << 6) | ((sizeof(arg2Type) - 1) << 5) | 3)
 
 u8 sSeqInstructionArgsTable[] = {
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDFILTER
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_FREEFILTER
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDSEQTOPTR
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_FILTER
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_PTRTODYNTBL
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_DYNTBLTOPTR
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_DYNTBLV
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_RANDTOPTR
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_RAND
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_RANDVEL
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_RANDGATE
-    CMD_ARGS_2(u8, s16),    // ASEQ_OP_CHANNEL_COMBFILTER
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_PTRADD
-    CMD_ARGS_2(s16, s16),   // ASEQ_OP_CHANNEL_RANDPTR
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_LDFILTER
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_FREEFILTER
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_LDSEQTOPTR
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_FILTER
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_PTRTODYNTBL
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_DYNTBLTOPTR
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_DYNTBLV
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_RANDTOPTR
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_RAND
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_RANDVEL
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_RANDGATE
+    CMD_ARGS_2(u8, s16),    // ASEQ_OP_CHAN_COMBFILTER
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_PTRADD
+    CMD_ARGS_2(s16, s16),   // ASEQ_OP_CHAN_RANDPTR
     CMD_ARGS_0(),           // 0xBE
     CMD_ARGS_0(),           // 0xBF
     CMD_ARGS_0(),           // 0xC0
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_INSTR
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_DYNTBL
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_SHORT
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_NOSHORT
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_DYNTBLLOOKUP
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_FONT
-    CMD_ARGS_2(u8, s16),    // ASEQ_OP_CHANNEL_STSEQ
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_SUB
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_AND
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_MUTEBHV
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDSEQ
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_LDI
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_STOPCHAN
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDPTR
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_STPTRTOSEQ
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_EFFECTS
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_NOTEALLOC
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_SUSTAIN
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_BEND
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_REVERB
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_INSTR
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_DYNTBL
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_SHORT
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_NOSHORT
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_DYNTBLLOOKUP
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_FONT
+    CMD_ARGS_2(u8, s16),    // ASEQ_OP_CHAN_STSEQ
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_SUB
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_AND
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_MUTEBHV
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_LDSEQ
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_LDI
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_STOPCHAN
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_LDPTR
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_STPTRTOSEQ
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_EFFECTS
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_NOTEALLOC
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_SUSTAIN
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_BEND
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_REVERB
     CMD_ARGS_1(u8),         // 0xD5
     CMD_ARGS_1(u8),         // 0xD6
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VIBFREQ
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VIBDEPTH
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_RELEASERATE
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_ENV
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_TRANSPOSE
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_PANWEIGHT
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_PAN
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_FREQSCALE
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VOL
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VOLEXP
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_OP_CHANNEL_VIBFREQGRAD
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_OP_CHANNEL_VIBDEPTHGRAD
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VIBDELAY
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_DYNCALL
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_REVERBIDX
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_SAMPLEBOOK
-    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDPARAMS
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_OP_CHANNEL_PARAMS
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_NOTEPRI
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_STOP
-    CMD_ARGS_2(u8, u8),     // ASEQ_OP_CHANNEL_FONTINSTR
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_VIBRESET
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_GAIN
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_BENDFINE
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_VIBFREQ
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_VIBDEPTH
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_RELEASERATE
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_ENV
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_TRANSPOSE
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_PANWEIGHT
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_PAN
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_FREQSCALE
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_VOL
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_VOLEXP
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_OP_CHAN_VIBFREQGRAD
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_OP_CHAN_VIBDEPTHGRAD
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_VIBDELAY
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_DYNCALL
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_REVERBIDX
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_SAMPLEBOOK
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHAN_LDPARAMS
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_OP_CHAN_PARAMS
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_NOTEPRI
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_STOP
+    CMD_ARGS_2(u8, u8),     // ASEQ_OP_CHAN_FONTINSTR
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_VIBRESET
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_GAIN
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_BENDFINE
     CMD_ARGS_2(s16, u8),    // 0xEF
-    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_FREENOTELIST
-    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_ALLOCNOTELIST
+    CMD_ARGS_0(),           // ASEQ_OP_CHAN_FREENOTELIST
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHAN_ALLOCNOTELIST
     // Control flow instructions (>= ASEQ_OP_CONTROL_FLOW_FIRST) can only have 0 or 1 args
     CMD_ARGS_1(u8),  // ASEQ_OP_RBLTZ
     CMD_ARGS_1(u8),  // ASEQ_OP_RBEQZ
@@ -1227,26 +1227,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             switch (cmd) {
-                case ASEQ_OP_CHANNEL_STOP:
+                case ASEQ_OP_CHAN_STOP:
                     channel->stopScript = true;
                     goto exit_loop;
 
-                case ASEQ_OP_CHANNEL_ALLOCNOTELIST:
+                case ASEQ_OP_CHAN_ALLOCNOTELIST:
                     Audio_NotePoolClear(&channel->notePool);
                     cmd = (u8)cmdArgs[0];
                     Audio_NotePoolFill(&channel->notePool, cmd);
                     break;
 
-                case ASEQ_OP_CHANNEL_FREENOTELIST:
+                case ASEQ_OP_CHAN_FREENOTELIST:
                     Audio_NotePoolClear(&channel->notePool);
                     break;
 
-                case ASEQ_OP_CHANNEL_DYNTBL:
+                case ASEQ_OP_CHAN_DYNTBL:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->dynTable = (void*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case ASEQ_OP_CHANNEL_DYNTBLLOOKUP:
+                case ASEQ_OP_CHAN_DYNTBLLOOKUP:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (u16)((data[0] << 8) + data[1]);
@@ -1255,7 +1255,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OP_CHANNEL_FONTINSTR:
+                case ASEQ_OP_CHAN_FONTINSTR:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1270,93 +1270,93 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
 
                     cmdArgs[0] = cmdArgs[1];
                     FALLTHROUGH;
-                case ASEQ_OP_CHANNEL_INSTR:
+                case ASEQ_OP_CHAN_INSTR:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SetInstrument(channel, cmd);
                     break;
 
-                case ASEQ_OP_CHANNEL_SHORT:
+                case ASEQ_OP_CHAN_SHORT:
                     channel->largeNotes = false;
                     break;
 
-                case ASEQ_OP_CHANNEL_NOSHORT:
+                case ASEQ_OP_CHAN_NOSHORT:
                     channel->largeNotes = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_VOL:
+                case ASEQ_OP_CHAN_VOL:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelSetVolume(channel, cmd);
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_VOLEXP:
+                case ASEQ_OP_CHAN_VOLEXP:
                     cmd = (u8)cmdArgs[0];
                     channel->volumeScale = (s32)cmd / 128.0f;
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_FREQSCALE:
+                case ASEQ_OP_CHAN_FREQSCALE:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->freqScale = (s32)cmdArgU16 / 32768.0f;
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_BEND:
+                case ASEQ_OP_CHAN_BEND:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchOneOctaveFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_BENDFINE:
+                case ASEQ_OP_CHAN_BENDFINE:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchTwoSemitonesFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_PAN:
+                case ASEQ_OP_CHAN_PAN:
                     cmd = (u8)cmdArgs[0];
                     channel->newPan = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_PANWEIGHT:
+                case ASEQ_OP_CHAN_PANWEIGHT:
                     cmd = (u8)cmdArgs[0];
                     channel->panChannelWeight = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_TRANSPOSE:
+                case ASEQ_OP_CHAN_TRANSPOSE:
                     cmdArgS8 = (s8)cmdArgs[0];
                     channel->transposition = cmdArgS8;
                     break;
 
-                case ASEQ_OP_CHANNEL_ENV:
+                case ASEQ_OP_CHAN_ENV:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->adsr.envelope = (EnvelopePoint*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case ASEQ_OP_CHANNEL_RELEASERATE:
+                case ASEQ_OP_CHAN_RELEASERATE:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.decayIndex = cmd;
                     break;
 
-                case ASEQ_OP_CHANNEL_VIBDEPTH:
+                case ASEQ_OP_CHAN_VIBDEPTH:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthTarget = cmd * 8;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
                     break;
 
-                case ASEQ_OP_CHANNEL_VIBFREQ:
+                case ASEQ_OP_CHAN_VIBFREQ:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateChangeDelay = 0;
                     channel->vibratoRateTarget = cmd * 32;
                     channel->vibratoRateStart = cmd * 32;
                     break;
 
-                case ASEQ_OP_CHANNEL_VIBDEPTHGRAD:
+                case ASEQ_OP_CHAN_VIBDEPTHGRAD:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthStart = cmd * 8;
                     cmd = (u8)cmdArgs[1];
@@ -1365,7 +1365,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoDepthChangeDelay = cmd * 16;
                     break;
 
-                case ASEQ_OP_CHANNEL_VIBFREQGRAD:
+                case ASEQ_OP_CHAN_VIBFREQGRAD:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateStart = cmd * 32;
                     cmd = (u8)cmdArgs[1];
@@ -1374,17 +1374,17 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoRateChangeDelay = cmd * 16;
                     break;
 
-                case ASEQ_OP_CHANNEL_VIBDELAY:
+                case ASEQ_OP_CHAN_VIBDELAY:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDelay = cmd * 16;
                     break;
 
-                case ASEQ_OP_CHANNEL_REVERB:
+                case ASEQ_OP_CHAN_REVERB:
                     cmd = (u8)cmdArgs[0];
                     channel->targetReverbVol = cmd;
                     break;
 
-                case ASEQ_OP_CHANNEL_FONT:
+                case ASEQ_OP_CHAN_FONT:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1398,56 +1398,56 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OP_CHANNEL_STSEQ:
+                case ASEQ_OP_CHAN_STSEQ:
                     cmd = (u8)cmdArgs[0];
                     cmdArgU16 = (u16)cmdArgs[1];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (u8)scriptState->value + cmd;
                     break;
 
-                case ASEQ_OP_CHANNEL_SUB:
-                case ASEQ_OP_CHANNEL_LDI:
-                case ASEQ_OP_CHANNEL_AND:
+                case ASEQ_OP_CHAN_SUB:
+                case ASEQ_OP_CHAN_LDI:
+                case ASEQ_OP_CHAN_AND:
                     cmdArgS8 = (s8)cmdArgs[0];
 
-                    if (cmd == ASEQ_OP_CHANNEL_SUB) {
+                    if (cmd == ASEQ_OP_CHAN_SUB) {
                         scriptState->value -= cmdArgS8;
-                    } else if (cmd == ASEQ_OP_CHANNEL_LDI) {
+                    } else if (cmd == ASEQ_OP_CHAN_LDI) {
                         scriptState->value = cmdArgS8;
                     } else {
                         scriptState->value &= cmdArgS8;
                     }
                     break;
 
-                case ASEQ_OP_CHANNEL_STOPCHAN:
+                case ASEQ_OP_CHAN_STOPCHAN:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmd]);
                     break;
 
-                case ASEQ_OP_CHANNEL_MUTEBHV:
+                case ASEQ_OP_CHAN_MUTEBHV:
                     cmd = (u8)cmdArgs[0];
                     channel->muteBehavior = cmd;
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_LDSEQ:
+                case ASEQ_OP_CHAN_LDSEQ:
                     cmdArgU16 = (u16)cmdArgs[0];
                     scriptState->value = *(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value));
                     break;
 
-                case ASEQ_OP_CHANNEL_LDPTR:
+                case ASEQ_OP_CHAN_LDPTR:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = cmdArgU16;
                     break;
 
-                case ASEQ_OP_CHANNEL_STPTRTOSEQ:
+                case ASEQ_OP_CHAN_STPTRTOSEQ:
                     cmdArgU16 = (u16)cmdArgs[0];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (channel->unk_22 >> 8) & 0xFF;
                     seqData[1] = channel->unk_22 & 0xFF;
                     break;
 
-                case ASEQ_OP_CHANNEL_EFFECTS:
+                case ASEQ_OP_CHAN_EFFECTS:
                     cmd = (u8)cmdArgs[0];
                     if (cmd & 0x80) {
                         channel->stereoHeadsetEffects = true;
@@ -1457,22 +1457,22 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->stereo.asByte = cmd & 0x7F;
                     break;
 
-                case ASEQ_OP_CHANNEL_NOTEALLOC:
+                case ASEQ_OP_CHAN_NOTEALLOC:
                     cmd = (u8)cmdArgs[0];
                     channel->noteAllocPolicy = cmd;
                     break;
 
-                case ASEQ_OP_CHANNEL_SUSTAIN:
+                case ASEQ_OP_CHAN_SUSTAIN:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.sustain = cmd;
                     break;
 
-                case ASEQ_OP_CHANNEL_REVERBIDX:
+                case ASEQ_OP_CHAN_REVERBIDX:
                     cmd = (u8)cmdArgs[0];
                     channel->reverbIndex = cmd;
                     break;
 
-                case ASEQ_OP_CHANNEL_DYNCALL:
+                case ASEQ_OP_CHAN_DYNCALL:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         //! @bug: Missing a stack depth check here
@@ -1482,12 +1482,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OP_CHANNEL_SAMPLEBOOK:
+                case ASEQ_OP_CHAN_SAMPLEBOOK:
                     cmd = (u8)cmdArgs[0];
                     channel->bookOffset = cmd;
                     break;
 
-                case ASEQ_OP_CHANNEL_LDPARAMS:
+                case ASEQ_OP_CHAN_LDPARAMS:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = &seqPlayer->seqData[cmdArgU16];
                     channel->muteBehavior = *data++;
@@ -1502,7 +1502,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_PARAMS:
+                case ASEQ_OP_CHAN_PARAMS:
                     channel->muteBehavior = cmdArgs[0];
                     channel->noteAllocPolicy = cmdArgs[1];
                     cmd = (u8)cmdArgs[2];
@@ -1516,7 +1516,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_OP_CHANNEL_VIBRESET:
+                case ASEQ_OP_CHAN_VIBRESET:
                     channel->vibratoDepthTarget = 0;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
@@ -1534,26 +1534,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->freqScale = 1.0f;
                     break;
 
-                case ASEQ_OP_CHANNEL_NOTEPRI:
+                case ASEQ_OP_CHAN_NOTEPRI:
                     AudioSeq_SetChannelPriorities(channel, (u8)cmdArgs[0]);
                     break;
 
-                case ASEQ_OP_CHANNEL_GAIN:
+                case ASEQ_OP_CHAN_GAIN:
                     cmd = (u8)cmdArgs[0];
                     channel->gain = cmd;
                     break;
 
-                case ASEQ_OP_CHANNEL_LDFILTER:
+                case ASEQ_OP_CHAN_LDFILTER:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = seqPlayer->seqData + cmdArgU16;
                     channel->filter = (s16*)data;
                     break;
 
-                case ASEQ_OP_CHANNEL_FREEFILTER:
+                case ASEQ_OP_CHAN_FREEFILTER:
                     channel->filter = NULL;
                     break;
 
-                case ASEQ_OP_CHANNEL_FILTER:
+                case ASEQ_OP_CHAN_FILTER:
                     cmd = cmdArgs[0];
 
                     if (channel->filter != NULL) {
@@ -1563,34 +1563,34 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OP_CHANNEL_LDSEQTOPTR:
+                case ASEQ_OP_CHAN_LDSEQTOPTR:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = *(u16*)(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value * 2));
                     break;
 
-                case ASEQ_OP_CHANNEL_PTRTODYNTBL:
+                case ASEQ_OP_CHAN_PTRTODYNTBL:
                     channel->dynTable = (void*)&seqPlayer->seqData[channel->unk_22];
                     break;
 
-                case ASEQ_OP_CHANNEL_DYNTBLTOPTR:
+                case ASEQ_OP_CHAN_DYNTBLTOPTR:
                     channel->unk_22 = ((u16*)(channel->dynTable))[scriptState->value];
                     break;
 
-                case ASEQ_OP_CHANNEL_DYNTBLV:
+                case ASEQ_OP_CHAN_DYNTBLV:
                     scriptState->value = (*channel->dynTable)[0][scriptState->value];
                     break;
 
-                case ASEQ_OP_CHANNEL_RANDTOPTR:
+                case ASEQ_OP_CHAN_RANDTOPTR:
                     channel->unk_22 =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case ASEQ_OP_CHANNEL_RAND:
+                case ASEQ_OP_CHAN_RAND:
                     scriptState->value =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case ASEQ_OP_CHANNEL_RANDPTR:
+                case ASEQ_OP_CHAN_RANDPTR:
                     temp2 = AudioThread_NextRandom();
                     channel->unk_22 = (cmdArgs[0] == 0) ? (temp2 & 0xFFFF) : (temp2 % cmdArgs[0]);
                     channel->unk_22 += cmdArgs[1];
@@ -1599,20 +1599,20 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->unk_22 = (temp2 << 8) | param;
                     break;
 
-                case ASEQ_OP_CHANNEL_RANDVEL:
+                case ASEQ_OP_CHAN_RANDVEL:
                     channel->velocityRandomVariance = cmdArgs[0];
                     break;
 
-                case ASEQ_OP_CHANNEL_RANDGATE:
+                case ASEQ_OP_CHAN_RANDGATE:
                     channel->gateTimeRandomVariance = cmdArgs[0];
                     break;
 
-                case ASEQ_OP_CHANNEL_COMBFILTER:
+                case ASEQ_OP_CHAN_COMBFILTER:
                     channel->combFilterSize = cmdArgs[0];
                     channel->combFilterGain = cmdArgs[1];
                     break;
 
-                case ASEQ_OP_CHANNEL_PTRADD:
+                case ASEQ_OP_CHAN_PTRADD:
                     channel->unk_22 += cmdArgs[0];
                     break;
             }
@@ -1622,12 +1622,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         if (cmd >= 0x70) {
             lowBits = cmd & 0x7;
 
-            if ((cmd & 0xF8) != ASEQ_OP_CHANNEL_STIO && lowBits >= 4) {
+            if ((cmd & 0xF8) != ASEQ_OP_CHAN_STIO && lowBits >= 4) {
                 lowBits = 0;
             }
 
             switch (cmd & 0xF8) {
-                case ASEQ_OP_CHANNEL_TESTLAYER:
+                case ASEQ_OP_CHAN_TESTLAYER:
                     if (channel->layers[lowBits] != NULL) {
                         scriptState->value = channel->layers[lowBits]->finished;
                     } else {
@@ -1635,18 +1635,18 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OP_CHANNEL_LDLAYER:
+                case ASEQ_OP_CHAN_LDLAYER:
                     cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &seqPlayer->seqData[cmdArgU16];
                     }
                     break;
 
-                case ASEQ_OP_CHANNEL_DELLAYER:
+                case ASEQ_OP_CHAN_DELLAYER:
                     AudioSeq_SeqLayerFree(channel, lowBits);
                     break;
 
-                case ASEQ_OP_CHANNEL_DYNLDLAYER:
+                case ASEQ_OP_CHAN_DYNLDLAYER:
                     if (scriptState->value != -1 && AudioSeq_SeqChannelSetLayer(channel, lowBits) != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (data[0] << 8) + data[1];
@@ -1654,11 +1654,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OP_CHANNEL_STIO:
+                case ASEQ_OP_CHAN_STIO:
                     channel->seqScriptIO[lowBits] = scriptState->value;
                     break;
 
-                case ASEQ_OP_CHANNEL_RLDLAYER:
+                case ASEQ_OP_CHAN_RLDLAYER:
                     temp1 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &scriptState->pc[temp1];
@@ -1671,11 +1671,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         lowBits = cmd & 0xF;
 
         switch (cmd & 0xF0) {
-            case ASEQ_OP_CHANNEL_CDELAY:
+            case ASEQ_OP_CHAN_CDELAY:
                 channel->delay = lowBits;
                 goto exit_loop;
 
-            case ASEQ_OP_CHANNEL_LDSAMPLE:
+            case ASEQ_OP_CHAN_LDSAMPLE:
                 if (lowBits < 8) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                     if (AudioLoad_SlowLoadSample(channel->fontId, scriptState->value, &channel->seqScriptIO[lowBits]) ==
@@ -1688,28 +1688,28 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                 }
                 break;
 
-            case ASEQ_OP_CHANNEL_LDIO:
+            case ASEQ_OP_CHAN_LDIO:
                 scriptState->value = channel->seqScriptIO[lowBits];
                 if (lowBits < 2) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                 }
                 break;
 
-            case ASEQ_OP_CHANNEL_SUBIO:
+            case ASEQ_OP_CHAN_SUBIO:
                 scriptState->value -= channel->seqScriptIO[lowBits];
                 break;
 
-            case ASEQ_OP_CHANNEL_LDCHAN:
+            case ASEQ_OP_CHAN_LDCHAN:
                 cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                 AudioSeq_SequenceChannelEnable(seqPlayer, lowBits, &seqPlayer->seqData[cmdArgU16]);
                 break;
 
-            case ASEQ_OP_CHANNEL_STCIO:
+            case ASEQ_OP_CHAN_STCIO:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 seqPlayer->channels[lowBits]->seqScriptIO[cmd] = scriptState->value;
                 break;
 
-            case ASEQ_OP_CHANNEL_LDCIO:
+            case ASEQ_OP_CHAN_LDCIO:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 scriptState->value = seqPlayer->channels[lowBits]->seqScriptIO[cmd];
                 break;

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -659,7 +659,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
 
         switch (cmd) {
             case ASEQ_OPC_LAYER_SHORTVEL: // layer_setshortnotevelocity
-            case ASEQ_OPC_LAYER_NOTEPAN: // layer_setpan
+            case ASEQ_OPC_LAYER_NOTEPAN:  // layer_setpan
                 cmdArg8 = *(state->pc++);
                 if (cmd == ASEQ_OPC_LAYER_SHORTVEL) {
                     layer->velocitySquare = SQ(cmdArg8) / SQ(127.0f);
@@ -678,7 +678,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 }
                 break;
 
-            case ASEQ_OPC_LAYER_LEGATO: // layer_continuousnoteson
+            case ASEQ_OPC_LAYER_LEGATO:   // layer_continuousnoteson
             case ASEQ_OPC_LAYER_NOLEGATO: // layer_continuousnotesoff
                 if (cmd == ASEQ_OPC_LAYER_LEGATO) {
                     layer->continuousNotes = true;

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -14,9 +14,11 @@
  *     Otherwise, each set of instructions has its own command interpreter
  */
 #include "ultra64.h"
-#define MML_VERSION MML_VERSION_OOT
+#include "assert.h"
 #include "audio/aseq.h"
 #include "global.h"
+
+static_assert(MML_VERSION == MML_VERSION_OOT, "This file implements the OoT version of the MML");
 
 #define PORTAMENTO_IS_SPECIAL(x) ((x).mode & 0x80)
 #define PORTAMENTO_MODE(x) ((x).mode & ~0x80)

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -72,92 +72,92 @@ u8 AudioSeq_GetInstrument(SequenceChannel* channel, u8 instId, Instrument** inst
     (((sizeof(arg0Type) - 1) << 7) | ((sizeof(arg1Type) - 1) << 6) | ((sizeof(arg2Type) - 1) << 5) | 3)
 
 u8 sSeqInstructionArgsTable[] = {
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDFILTER
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_FREEFILTER
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDSEQTOPTR
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_FILTER
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_PTRTODYNTBL
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_DYNTBLTOPTR
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_DYNTBLV
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_RANDTOPTR
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_RAND
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_RANDVEL
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_RANDGATE
-    CMD_ARGS_2(u8, s16),    // ASEQ_OPC_CHANNEL_COMBFILTER
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_PTRADD
-    CMD_ARGS_2(s16, s16),   // ASEQ_OPC_CHANNEL_RANDPTR
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDFILTER
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_FREEFILTER
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDSEQTOPTR
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_FILTER
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_PTRTODYNTBL
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_DYNTBLTOPTR
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_DYNTBLV
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_RANDTOPTR
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_RAND
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_RANDVEL
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_RANDGATE
+    CMD_ARGS_2(u8, s16),    // ASEQ_OP_CHANNEL_COMBFILTER
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_PTRADD
+    CMD_ARGS_2(s16, s16),   // ASEQ_OP_CHANNEL_RANDPTR
     CMD_ARGS_0(),           // 0xBE
     CMD_ARGS_0(),           // 0xBF
     CMD_ARGS_0(),           // 0xC0
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_INSTR
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_DYNTBL
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_SHORT
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_NOSHORT
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_DYNTBLLOOKUP
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_FONT
-    CMD_ARGS_2(u8, s16),    // ASEQ_OPC_CHANNEL_STSEQ
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_SUB
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_AND
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_MUTEBHV
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDSEQ
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_LDI
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_STOPCHAN
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDPTR
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_STPTRTOSEQ
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_EFFECTS
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_NOTEALLOC
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_SUSTAIN
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_BEND
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_REVERB
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_INSTR
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_DYNTBL
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_SHORT
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_NOSHORT
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_DYNTBLLOOKUP
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_FONT
+    CMD_ARGS_2(u8, s16),    // ASEQ_OP_CHANNEL_STSEQ
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_SUB
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_AND
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_MUTEBHV
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDSEQ
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_LDI
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_STOPCHAN
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDPTR
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_STPTRTOSEQ
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_EFFECTS
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_NOTEALLOC
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_SUSTAIN
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_BEND
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_REVERB
     CMD_ARGS_1(u8),         // 0xD5
     CMD_ARGS_1(u8),         // 0xD6
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VIBFREQ
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VIBDEPTH
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_RELEASERATE
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_ENV
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_TRANSPOSE
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_PANWEIGHT
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_PAN
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_FREQSCALE
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VOL
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VOLEXP
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_OPC_CHANNEL_VIBFREQGRAD
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_OPC_CHANNEL_VIBDEPTHGRAD
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_VIBDELAY
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_DYNCALL
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_REVERBIDX
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_SAMPLEBOOK
-    CMD_ARGS_1(s16),        // ASEQ_OPC_CHANNEL_LDPARAMS
-    CMD_ARGS_3(u8, u8, u8), // ASEQ_OPC_CHANNEL_PARAMS
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_NOTEPRI
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_STOP
-    CMD_ARGS_2(u8, u8),     // ASEQ_OPC_CHANNEL_FONTINSTR
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_VIBRESET
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_GAIN
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_BENDFINE
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VIBFREQ
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VIBDEPTH
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_RELEASERATE
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_ENV
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_TRANSPOSE
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_PANWEIGHT
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_PAN
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_FREQSCALE
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VOL
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VOLEXP
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_OP_CHANNEL_VIBFREQGRAD
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_OP_CHANNEL_VIBDEPTHGRAD
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_VIBDELAY
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_DYNCALL
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_REVERBIDX
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_SAMPLEBOOK
+    CMD_ARGS_1(s16),        // ASEQ_OP_CHANNEL_LDPARAMS
+    CMD_ARGS_3(u8, u8, u8), // ASEQ_OP_CHANNEL_PARAMS
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_NOTEPRI
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_STOP
+    CMD_ARGS_2(u8, u8),     // ASEQ_OP_CHANNEL_FONTINSTR
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_VIBRESET
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_GAIN
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_BENDFINE
     CMD_ARGS_2(s16, u8),    // 0xEF
-    CMD_ARGS_0(),           // ASEQ_OPC_CHANNEL_FREENOTELIST
-    CMD_ARGS_1(u8),         // ASEQ_OPC_CHANNEL_ALLOCNOTELIST
-    // Control flow instructions (>= ASEQ_OPC_CONTROL_FLOW_FIRST) can only have 0 or 1 args
-    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_RBLTZ
-    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_RBEQZ
-    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_RJUMP
-    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_BGEZ
-    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_BREAK
-    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_LOOPEND
-    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_LOOP
-    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_BLTZ
-    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_BEQZ
-    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_JUMP
-    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_CALL
-    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_DELAY
-    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_DELAY1
-    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_END
+    CMD_ARGS_0(),           // ASEQ_OP_CHANNEL_FREENOTELIST
+    CMD_ARGS_1(u8),         // ASEQ_OP_CHANNEL_ALLOCNOTELIST
+    // Control flow instructions (>= ASEQ_OP_CONTROL_FLOW_FIRST) can only have 0 or 1 args
+    CMD_ARGS_1(u8),  // ASEQ_OP_CTRLFLOW_RBLTZ
+    CMD_ARGS_1(u8),  // ASEQ_OP_CTRLFLOW_RBEQZ
+    CMD_ARGS_1(u8),  // ASEQ_OP_CTRLFLOW_RJUMP
+    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_BGEZ
+    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_BREAK
+    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_LOOPEND
+    CMD_ARGS_1(u8),  // ASEQ_OP_CTRLFLOW_LOOP
+    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_BLTZ
+    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_BEQZ
+    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_JUMP
+    CMD_ARGS_1(s16), // ASEQ_OP_CTRLFLOW_CALL
+    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_DELAY
+    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_DELAY1
+    CMD_ARGS_0(),    // ASEQ_OP_CTRLFLOW_END
 };
 
 /**
  * Read and return the argument from the sequence script for a control flow instruction.
- * Control flow instructions (>= ASEQ_OPC_CONTROL_FLOW_FIRST) can only have 0 or 1 args.
+ * Control flow instructions (>= ASEQ_OP_CONTROL_FLOW_FIRST) can only have 0 or 1 args.
  * @return the argument value for a control flow instruction, or 0 if there is no argument
  */
 u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
@@ -183,30 +183,30 @@ u16 AudioSeq_GetScriptControlFlowArgument(SeqScriptState* state, u8 cmd) {
  */
 s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* state, s32 cmd, s32 cmdArg) {
     switch (cmd) {
-        case ASEQ_OPC_CTRLFLOW_END:
+        case ASEQ_OP_CTRLFLOW_END:
             if (state->depth == 0) {
                 return PROCESS_SCRIPT_END;
             }
             state->pc = state->stack[--state->depth];
             break;
 
-        case ASEQ_OPC_CTRLFLOW_DELAY:
+        case ASEQ_OP_CTRLFLOW_DELAY:
             return AudioSeq_ScriptReadCompressedU16(state);
 
-        case ASEQ_OPC_CTRLFLOW_DELAY1:
+        case ASEQ_OP_CTRLFLOW_DELAY1:
             return 1;
 
-        case ASEQ_OPC_CTRLFLOW_CALL:
+        case ASEQ_OP_CTRLFLOW_CALL:
             state->stack[state->depth++] = state->pc;
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case ASEQ_OPC_CTRLFLOW_LOOP:
+        case ASEQ_OP_CTRLFLOW_LOOP:
             state->remLoopIters[state->depth] = cmdArg;
             state->stack[state->depth++] = state->pc;
             break;
 
-        case ASEQ_OPC_CTRLFLOW_LOOPEND:
+        case ASEQ_OP_CTRLFLOW_LOOPEND:
             state->remLoopIters[state->depth - 1]--;
             if (state->remLoopIters[state->depth - 1] != 0) {
                 state->pc = state->stack[state->depth - 1];
@@ -215,33 +215,33 @@ s32 AudioSeq_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptState* 
             }
             break;
 
-        case ASEQ_OPC_CTRLFLOW_BREAK:
+        case ASEQ_OP_CTRLFLOW_BREAK:
             state->depth--;
             break;
 
-        case ASEQ_OPC_CTRLFLOW_BGEZ:
-        case ASEQ_OPC_CTRLFLOW_BLTZ:
-        case ASEQ_OPC_CTRLFLOW_BEQZ:
-        case ASEQ_OPC_CTRLFLOW_JUMP:
-            if (cmd == ASEQ_OPC_CTRLFLOW_BEQZ && state->value != 0) {
+        case ASEQ_OP_CTRLFLOW_BGEZ:
+        case ASEQ_OP_CTRLFLOW_BLTZ:
+        case ASEQ_OP_CTRLFLOW_BEQZ:
+        case ASEQ_OP_CTRLFLOW_JUMP:
+            if (cmd == ASEQ_OP_CTRLFLOW_BEQZ && state->value != 0) {
                 break;
             }
-            if (cmd == ASEQ_OPC_CTRLFLOW_BLTZ && state->value >= 0) {
+            if (cmd == ASEQ_OP_CTRLFLOW_BLTZ && state->value >= 0) {
                 break;
             }
-            if (cmd == ASEQ_OPC_CTRLFLOW_BGEZ && state->value < 0) {
+            if (cmd == ASEQ_OP_CTRLFLOW_BGEZ && state->value < 0) {
                 break;
             }
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case ASEQ_OPC_CTRLFLOW_RBLTZ:
-        case ASEQ_OPC_CTRLFLOW_RBEQZ:
-        case ASEQ_OPC_CTRLFLOW_RJUMP:
-            if (cmd == ASEQ_OPC_CTRLFLOW_RBEQZ && state->value != 0) {
+        case ASEQ_OP_CTRLFLOW_RBLTZ:
+        case ASEQ_OP_CTRLFLOW_RBEQZ:
+        case ASEQ_OP_CTRLFLOW_RJUMP:
+            if (cmd == ASEQ_OP_CTRLFLOW_RBEQZ && state->value != 0) {
                 break;
             }
-            if (cmd == ASEQ_OPC_CTRLFLOW_RBLTZ && state->value >= 0) {
+            if (cmd == ASEQ_OP_CTRLFLOW_RBLTZ && state->value >= 0) {
                 break;
             }
             state->pc += (s8)(cmdArg & 0xFF);
@@ -647,7 +647,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
         }
 
         // Control Flow Commands
-        if (cmd >= ASEQ_OPC_CONTROL_FLOW_FIRST) {
+        if (cmd >= ASEQ_OP_CONTROL_FLOW_FIRST) {
             cmdArg16 = AudioSeq_GetScriptControlFlowArgument(state, cmd);
 
             if (AudioSeq_HandleScriptFlowControl(seqPlayer, state, cmd, cmdArg16) == 0) {
@@ -658,29 +658,29 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
         }
 
         switch (cmd) {
-            case ASEQ_OPC_LAYER_SHORTVEL: // layer_setshortnotevelocity
-            case ASEQ_OPC_LAYER_NOTEPAN:  // layer_setpan
+            case ASEQ_OP_LAYER_SHORTVEL: // layer_setshortnotevelocity
+            case ASEQ_OP_LAYER_NOTEPAN:  // layer_setpan
                 cmdArg8 = *(state->pc++);
-                if (cmd == ASEQ_OPC_LAYER_SHORTVEL) {
+                if (cmd == ASEQ_OP_LAYER_SHORTVEL) {
                     layer->velocitySquare = SQ(cmdArg8) / SQ(127.0f);
                 } else {
                     layer->pan = cmdArg8;
                 }
                 break;
 
-            case ASEQ_OPC_LAYER_SHORTGATE: // layer_setshortnotegatetime
-            case ASEQ_OPC_LAYER_TRANSPOSE: // layer_transpose; set transposition in semitones
+            case ASEQ_OP_LAYER_SHORTGATE: // layer_setshortnotegatetime
+            case ASEQ_OP_LAYER_TRANSPOSE: // layer_transpose; set transposition in semitones
                 cmdArg8 = *(state->pc++);
-                if (cmd == ASEQ_OPC_LAYER_SHORTGATE) {
+                if (cmd == ASEQ_OP_LAYER_SHORTGATE) {
                     layer->gateTime = cmdArg8;
                 } else {
                     layer->transposition = cmdArg8;
                 }
                 break;
 
-            case ASEQ_OPC_LAYER_LEGATO:   // layer_continuousnoteson
-            case ASEQ_OPC_LAYER_NOLEGATO: // layer_continuousnotesoff
-                if (cmd == ASEQ_OPC_LAYER_LEGATO) {
+            case ASEQ_OP_LAYER_LEGATO:   // layer_continuousnoteson
+            case ASEQ_OP_LAYER_NOLEGATO: // layer_continuousnotesoff
+                if (cmd == ASEQ_OP_LAYER_LEGATO) {
                     layer->continuousNotes = true;
                 } else {
                     layer->continuousNotes = false;
@@ -689,12 +689,12 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 Audio_SeqLayerNoteDecay(layer);
                 break;
 
-            case ASEQ_OPC_LAYER_SHORTDELAY: // layer_setshortnotedefaultdelay
+            case ASEQ_OP_LAYER_SHORTDELAY: // layer_setshortnotedefaultdelay
                 cmdArg16 = AudioSeq_ScriptReadCompressedU16(state);
                 layer->shortNoteDefaultDelay = cmdArg16;
                 break;
 
-            case ASEQ_OPC_LAYER_INSTR: // layer_setinstr
+            case ASEQ_OP_LAYER_INSTR: // layer_setinstr
                 cmd = AudioSeq_ScriptReadU8(state);
                 if (cmd >= 0x7E) {
                     if (cmd == 0x7E) {
@@ -721,7 +721,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 }
                 break;
 
-            case ASEQ_OPC_LAYER_PORTAMENTO: // layer_portamento
+            case ASEQ_OP_LAYER_PORTAMENTO: // layer_portamento
                 layer->portamento.mode = AudioSeq_ScriptReadU8(state);
 
                 cmd = AudioSeq_ScriptReadU8(state);
@@ -745,39 +745,39 @@ s32 AudioSeq_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 layer->portamentoTime = cmdArg16;
                 break;
 
-            case ASEQ_OPC_LAYER_NOPORTAMENTO: // layer_disableportamento
+            case ASEQ_OP_LAYER_NOPORTAMENTO: // layer_disableportamento
                 layer->portamento.mode = PORTAMENTO_MODE_OFF;
                 break;
 
-            case ASEQ_OPC_LAYER_ENV:
+            case ASEQ_OP_LAYER_ENV:
                 cmdArg16 = AudioSeq_ScriptReadS16(state);
                 layer->adsr.envelope = (EnvelopePoint*)(seqPlayer->seqData + cmdArg16);
                 FALLTHROUGH;
-            case ASEQ_OPC_LAYER_RELEASERATE:
+            case ASEQ_OP_LAYER_RELEASERATE:
                 layer->adsr.decayIndex = AudioSeq_ScriptReadU8(state);
                 break;
 
-            case ASEQ_OPC_LAYER_NODRUMPAN:
+            case ASEQ_OP_LAYER_NODRUMPAN:
                 layer->ignoreDrumPan = true;
                 break;
 
-            case ASEQ_OPC_LAYER_STEREO:
+            case ASEQ_OP_LAYER_STEREO:
                 layer->stereo.asByte = AudioSeq_ScriptReadU8(state);
                 break;
 
-            case ASEQ_OPC_LAYER_BENDFINE:
+            case ASEQ_OP_LAYER_BENDFINE:
                 cmdArg8 = AudioSeq_ScriptReadU8(state);
                 layer->bend = gBendPitchTwoSemitonesFrequencies[(u8)(cmdArg8 + 0x80)];
                 break;
 
             default:
                 switch (cmd & 0xF0) {
-                    case ASEQ_OPC_LAYER_LDSHORTVEL: // layer_setshortnotevelocityfromtable
+                    case ASEQ_OP_LAYER_LDSHORTVEL: // layer_setshortnotevelocityfromtable
                         velocity = seqPlayer->shortNoteVelocityTable[cmd & 0xF];
                         layer->velocitySquare = SQ(velocity) / SQ(127.0f);
                         break;
 
-                    case ASEQ_OPC_LAYER_LDSHORTGATE: // layer_setshortnotegatetimefromtable
+                    case ASEQ_OP_LAYER_LDSHORTGATE: // layer_setshortnotegatetimefromtable
                         layer->gateTime = seqPlayer->shortNoteGateTimeTable[cmd & 0xF];
                         break;
                 }
@@ -1002,7 +1002,7 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
     s32 intDelta;
     f32 floatDelta;
 
-    if (cmd == ASEQ_OPC_LAYER_LDELAY) {
+    if (cmd == ASEQ_OP_LAYER_LDELAY) {
         layer->delay = AudioSeq_ScriptReadCompressedU16(state);
         layer->muted = true;
         layer->bit1 = false;
@@ -1013,21 +1013,21 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
 
     if (channel->largeNotes == true) {
         switch (cmd & 0xC0) {
-            case ASEQ_OPC_LAYER_NOTEDVG:
+            case ASEQ_OP_LAYER_NOTEDVG:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_OPC_LAYER_NOTEDV:
+            case ASEQ_OP_LAYER_NOTEDV:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = 0;
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_OPC_LAYER_NOTEVG:
+            case ASEQ_OP_LAYER_NOTEVG:
                 delay = layer->lastDelay;
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
@@ -1041,16 +1041,16 @@ s32 AudioSeq_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
         cmd -= (cmd & 0xC0);
     } else {
         switch (cmd & 0xC0) {
-            case ASEQ_OPC_LAYER_NOTEDVG:
+            case ASEQ_OP_LAYER_NOTEDVG:
                 delay = AudioSeq_ScriptReadCompressedU16(state);
                 layer->lastDelay = delay;
                 break;
 
-            case ASEQ_OPC_LAYER_NOTEDV:
+            case ASEQ_OP_LAYER_NOTEDV:
                 delay = layer->shortNoteDefaultDelay;
                 break;
 
-            case ASEQ_OPC_LAYER_NOTEVG:
+            case ASEQ_OP_LAYER_NOTEVG:
                 delay = layer->lastDelay;
                 break;
         }
@@ -1212,7 +1212,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             // Control Flow Commands
-            if (cmd >= ASEQ_OPC_CONTROL_FLOW_FIRST) {
+            if (cmd >= ASEQ_OP_CONTROL_FLOW_FIRST) {
                 delay = AudioSeq_HandleScriptFlowControl(seqPlayer, scriptState, cmd, cmdArgs[0]);
 
                 if (delay != 0) {
@@ -1227,26 +1227,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             switch (cmd) {
-                case ASEQ_OPC_CHANNEL_STOP:
+                case ASEQ_OP_CHANNEL_STOP:
                     channel->stopScript = true;
                     goto exit_loop;
 
-                case ASEQ_OPC_CHANNEL_ALLOCNOTELIST:
+                case ASEQ_OP_CHANNEL_ALLOCNOTELIST:
                     Audio_NotePoolClear(&channel->notePool);
                     cmd = (u8)cmdArgs[0];
                     Audio_NotePoolFill(&channel->notePool, cmd);
                     break;
 
-                case ASEQ_OPC_CHANNEL_FREENOTELIST:
+                case ASEQ_OP_CHANNEL_FREENOTELIST:
                     Audio_NotePoolClear(&channel->notePool);
                     break;
 
-                case ASEQ_OPC_CHANNEL_DYNTBL:
+                case ASEQ_OP_CHANNEL_DYNTBL:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->dynTable = (void*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case ASEQ_OPC_CHANNEL_DYNTBLLOOKUP:
+                case ASEQ_OP_CHANNEL_DYNTBLLOOKUP:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (u16)((data[0] << 8) + data[1]);
@@ -1255,7 +1255,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OPC_CHANNEL_FONTINSTR:
+                case ASEQ_OP_CHANNEL_FONTINSTR:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1270,93 +1270,93 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
 
                     cmdArgs[0] = cmdArgs[1];
                     FALLTHROUGH;
-                case ASEQ_OPC_CHANNEL_INSTR:
+                case ASEQ_OP_CHANNEL_INSTR:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SetInstrument(channel, cmd);
                     break;
 
-                case ASEQ_OPC_CHANNEL_SHORT:
+                case ASEQ_OP_CHANNEL_SHORT:
                     channel->largeNotes = false;
                     break;
 
-                case ASEQ_OPC_CHANNEL_NOSHORT:
+                case ASEQ_OP_CHANNEL_NOSHORT:
                     channel->largeNotes = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_VOL:
+                case ASEQ_OP_CHANNEL_VOL:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelSetVolume(channel, cmd);
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_VOLEXP:
+                case ASEQ_OP_CHANNEL_VOLEXP:
                     cmd = (u8)cmdArgs[0];
                     channel->volumeScale = (s32)cmd / 128.0f;
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_FREQSCALE:
+                case ASEQ_OP_CHANNEL_FREQSCALE:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->freqScale = (s32)cmdArgU16 / 32768.0f;
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_BEND:
+                case ASEQ_OP_CHANNEL_BEND:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchOneOctaveFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_BENDFINE:
+                case ASEQ_OP_CHANNEL_BENDFINE:
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchTwoSemitonesFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_PAN:
+                case ASEQ_OP_CHANNEL_PAN:
                     cmd = (u8)cmdArgs[0];
                     channel->newPan = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_PANWEIGHT:
+                case ASEQ_OP_CHANNEL_PANWEIGHT:
                     cmd = (u8)cmdArgs[0];
                     channel->panChannelWeight = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_TRANSPOSE:
+                case ASEQ_OP_CHANNEL_TRANSPOSE:
                     cmdArgS8 = (s8)cmdArgs[0];
                     channel->transposition = cmdArgS8;
                     break;
 
-                case ASEQ_OPC_CHANNEL_ENV:
+                case ASEQ_OP_CHANNEL_ENV:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->adsr.envelope = (EnvelopePoint*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case ASEQ_OPC_CHANNEL_RELEASERATE:
+                case ASEQ_OP_CHANNEL_RELEASERATE:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.decayIndex = cmd;
                     break;
 
-                case ASEQ_OPC_CHANNEL_VIBDEPTH:
+                case ASEQ_OP_CHANNEL_VIBDEPTH:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthTarget = cmd * 8;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
                     break;
 
-                case ASEQ_OPC_CHANNEL_VIBFREQ:
+                case ASEQ_OP_CHANNEL_VIBFREQ:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateChangeDelay = 0;
                     channel->vibratoRateTarget = cmd * 32;
                     channel->vibratoRateStart = cmd * 32;
                     break;
 
-                case ASEQ_OPC_CHANNEL_VIBDEPTHGRAD:
+                case ASEQ_OP_CHANNEL_VIBDEPTHGRAD:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDepthStart = cmd * 8;
                     cmd = (u8)cmdArgs[1];
@@ -1365,7 +1365,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoDepthChangeDelay = cmd * 16;
                     break;
 
-                case ASEQ_OPC_CHANNEL_VIBFREQGRAD:
+                case ASEQ_OP_CHANNEL_VIBFREQGRAD:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoRateStart = cmd * 32;
                     cmd = (u8)cmdArgs[1];
@@ -1374,17 +1374,17 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibratoRateChangeDelay = cmd * 16;
                     break;
 
-                case ASEQ_OPC_CHANNEL_VIBDELAY:
+                case ASEQ_OP_CHANNEL_VIBDELAY:
                     cmd = (u8)cmdArgs[0];
                     channel->vibratoDelay = cmd * 16;
                     break;
 
-                case ASEQ_OPC_CHANNEL_REVERB:
+                case ASEQ_OP_CHANNEL_REVERB:
                     cmd = (u8)cmdArgs[0];
                     channel->targetReverbVol = cmd;
                     break;
 
-                case ASEQ_OPC_CHANNEL_FONT:
+                case ASEQ_OP_CHANNEL_FONT:
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1398,56 +1398,56 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OPC_CHANNEL_STSEQ:
+                case ASEQ_OP_CHANNEL_STSEQ:
                     cmd = (u8)cmdArgs[0];
                     cmdArgU16 = (u16)cmdArgs[1];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (u8)scriptState->value + cmd;
                     break;
 
-                case ASEQ_OPC_CHANNEL_SUB:
-                case ASEQ_OPC_CHANNEL_LDI:
-                case ASEQ_OPC_CHANNEL_AND:
+                case ASEQ_OP_CHANNEL_SUB:
+                case ASEQ_OP_CHANNEL_LDI:
+                case ASEQ_OP_CHANNEL_AND:
                     cmdArgS8 = (s8)cmdArgs[0];
 
-                    if (cmd == ASEQ_OPC_CHANNEL_SUB) {
+                    if (cmd == ASEQ_OP_CHANNEL_SUB) {
                         scriptState->value -= cmdArgS8;
-                    } else if (cmd == ASEQ_OPC_CHANNEL_LDI) {
+                    } else if (cmd == ASEQ_OP_CHANNEL_LDI) {
                         scriptState->value = cmdArgS8;
                     } else {
                         scriptState->value &= cmdArgS8;
                     }
                     break;
 
-                case ASEQ_OPC_CHANNEL_STOPCHAN:
+                case ASEQ_OP_CHANNEL_STOPCHAN:
                     cmd = (u8)cmdArgs[0];
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmd]);
                     break;
 
-                case ASEQ_OPC_CHANNEL_MUTEBHV:
+                case ASEQ_OP_CHANNEL_MUTEBHV:
                     cmd = (u8)cmdArgs[0];
                     channel->muteBehavior = cmd;
                     channel->changes.s.volume = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_LDSEQ:
+                case ASEQ_OP_CHANNEL_LDSEQ:
                     cmdArgU16 = (u16)cmdArgs[0];
                     scriptState->value = *(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value));
                     break;
 
-                case ASEQ_OPC_CHANNEL_LDPTR:
+                case ASEQ_OP_CHANNEL_LDPTR:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = cmdArgU16;
                     break;
 
-                case ASEQ_OPC_CHANNEL_STPTRTOSEQ:
+                case ASEQ_OP_CHANNEL_STPTRTOSEQ:
                     cmdArgU16 = (u16)cmdArgs[0];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (channel->unk_22 >> 8) & 0xFF;
                     seqData[1] = channel->unk_22 & 0xFF;
                     break;
 
-                case ASEQ_OPC_CHANNEL_EFFECTS:
+                case ASEQ_OP_CHANNEL_EFFECTS:
                     cmd = (u8)cmdArgs[0];
                     if (cmd & 0x80) {
                         channel->stereoHeadsetEffects = true;
@@ -1457,22 +1457,22 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->stereo.asByte = cmd & 0x7F;
                     break;
 
-                case ASEQ_OPC_CHANNEL_NOTEALLOC:
+                case ASEQ_OP_CHANNEL_NOTEALLOC:
                     cmd = (u8)cmdArgs[0];
                     channel->noteAllocPolicy = cmd;
                     break;
 
-                case ASEQ_OPC_CHANNEL_SUSTAIN:
+                case ASEQ_OP_CHANNEL_SUSTAIN:
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.sustain = cmd;
                     break;
 
-                case ASEQ_OPC_CHANNEL_REVERBIDX:
+                case ASEQ_OP_CHANNEL_REVERBIDX:
                     cmd = (u8)cmdArgs[0];
                     channel->reverbIndex = cmd;
                     break;
 
-                case ASEQ_OPC_CHANNEL_DYNCALL:
+                case ASEQ_OP_CHANNEL_DYNCALL:
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         //! @bug: Missing a stack depth check here
@@ -1482,12 +1482,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OPC_CHANNEL_SAMPLEBOOK:
+                case ASEQ_OP_CHANNEL_SAMPLEBOOK:
                     cmd = (u8)cmdArgs[0];
                     channel->bookOffset = cmd;
                     break;
 
-                case ASEQ_OPC_CHANNEL_LDPARAMS:
+                case ASEQ_OP_CHANNEL_LDPARAMS:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = &seqPlayer->seqData[cmdArgU16];
                     channel->muteBehavior = *data++;
@@ -1502,7 +1502,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_PARAMS:
+                case ASEQ_OP_CHANNEL_PARAMS:
                     channel->muteBehavior = cmdArgs[0];
                     channel->noteAllocPolicy = cmdArgs[1];
                     cmd = (u8)cmdArgs[2];
@@ -1516,7 +1516,7 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case ASEQ_OPC_CHANNEL_VIBRESET:
+                case ASEQ_OP_CHANNEL_VIBRESET:
                     channel->vibratoDepthTarget = 0;
                     channel->vibratoDepthStart = 0;
                     channel->vibratoDepthChangeDelay = 0;
@@ -1534,26 +1534,26 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->freqScale = 1.0f;
                     break;
 
-                case ASEQ_OPC_CHANNEL_NOTEPRI:
+                case ASEQ_OP_CHANNEL_NOTEPRI:
                     AudioSeq_SetChannelPriorities(channel, (u8)cmdArgs[0]);
                     break;
 
-                case ASEQ_OPC_CHANNEL_GAIN:
+                case ASEQ_OP_CHANNEL_GAIN:
                     cmd = (u8)cmdArgs[0];
                     channel->gain = cmd;
                     break;
 
-                case ASEQ_OPC_CHANNEL_LDFILTER:
+                case ASEQ_OP_CHANNEL_LDFILTER:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = seqPlayer->seqData + cmdArgU16;
                     channel->filter = (s16*)data;
                     break;
 
-                case ASEQ_OPC_CHANNEL_FREEFILTER:
+                case ASEQ_OP_CHANNEL_FREEFILTER:
                     channel->filter = NULL;
                     break;
 
-                case ASEQ_OPC_CHANNEL_FILTER:
+                case ASEQ_OP_CHANNEL_FILTER:
                     cmd = cmdArgs[0];
 
                     if (channel->filter != NULL) {
@@ -1563,34 +1563,34 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OPC_CHANNEL_LDSEQTOPTR:
+                case ASEQ_OP_CHANNEL_LDSEQTOPTR:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = *(u16*)(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value * 2));
                     break;
 
-                case ASEQ_OPC_CHANNEL_PTRTODYNTBL:
+                case ASEQ_OP_CHANNEL_PTRTODYNTBL:
                     channel->dynTable = (void*)&seqPlayer->seqData[channel->unk_22];
                     break;
 
-                case ASEQ_OPC_CHANNEL_DYNTBLTOPTR:
+                case ASEQ_OP_CHANNEL_DYNTBLTOPTR:
                     channel->unk_22 = ((u16*)(channel->dynTable))[scriptState->value];
                     break;
 
-                case ASEQ_OPC_CHANNEL_DYNTBLV:
+                case ASEQ_OP_CHANNEL_DYNTBLV:
                     scriptState->value = (*channel->dynTable)[0][scriptState->value];
                     break;
 
-                case ASEQ_OPC_CHANNEL_RANDTOPTR:
+                case ASEQ_OP_CHANNEL_RANDTOPTR:
                     channel->unk_22 =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case ASEQ_OPC_CHANNEL_RAND:
+                case ASEQ_OP_CHANNEL_RAND:
                     scriptState->value =
                         (cmdArgs[0] == 0) ? gAudioCtx.audioRandom & 0xFFFF : gAudioCtx.audioRandom % cmdArgs[0];
                     break;
 
-                case ASEQ_OPC_CHANNEL_RANDPTR:
+                case ASEQ_OP_CHANNEL_RANDPTR:
                     temp2 = AudioThread_NextRandom();
                     channel->unk_22 = (cmdArgs[0] == 0) ? (temp2 & 0xFFFF) : (temp2 % cmdArgs[0]);
                     channel->unk_22 += cmdArgs[1];
@@ -1599,20 +1599,20 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->unk_22 = (temp2 << 8) | param;
                     break;
 
-                case ASEQ_OPC_CHANNEL_RANDVEL:
+                case ASEQ_OP_CHANNEL_RANDVEL:
                     channel->velocityRandomVariance = cmdArgs[0];
                     break;
 
-                case ASEQ_OPC_CHANNEL_RANDGATE:
+                case ASEQ_OP_CHANNEL_RANDGATE:
                     channel->gateTimeRandomVariance = cmdArgs[0];
                     break;
 
-                case ASEQ_OPC_CHANNEL_COMBFILTER:
+                case ASEQ_OP_CHANNEL_COMBFILTER:
                     channel->combFilterSize = cmdArgs[0];
                     channel->combFilterGain = cmdArgs[1];
                     break;
 
-                case ASEQ_OPC_CHANNEL_PTRADD:
+                case ASEQ_OP_CHANNEL_PTRADD:
                     channel->unk_22 += cmdArgs[0];
                     break;
             }
@@ -1622,12 +1622,12 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         if (cmd >= 0x70) {
             lowBits = cmd & 0x7;
 
-            if ((cmd & 0xF8) != ASEQ_OPC_CHANNEL_STIO && lowBits >= 4) {
+            if ((cmd & 0xF8) != ASEQ_OP_CHANNEL_STIO && lowBits >= 4) {
                 lowBits = 0;
             }
 
             switch (cmd & 0xF8) {
-                case ASEQ_OPC_CHANNEL_TESTLAYER:
+                case ASEQ_OP_CHANNEL_TESTLAYER:
                     if (channel->layers[lowBits] != NULL) {
                         scriptState->value = channel->layers[lowBits]->finished;
                     } else {
@@ -1635,18 +1635,18 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OPC_CHANNEL_LDLAYER:
+                case ASEQ_OP_CHANNEL_LDLAYER:
                     cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &seqPlayer->seqData[cmdArgU16];
                     }
                     break;
 
-                case ASEQ_OPC_CHANNEL_DELLAYER:
+                case ASEQ_OP_CHANNEL_DELLAYER:
                     AudioSeq_SeqLayerFree(channel, lowBits);
                     break;
 
-                case ASEQ_OPC_CHANNEL_DYNLDLAYER:
+                case ASEQ_OP_CHANNEL_DYNLDLAYER:
                     if (scriptState->value != -1 && AudioSeq_SeqChannelSetLayer(channel, lowBits) != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (data[0] << 8) + data[1];
@@ -1654,11 +1654,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case ASEQ_OPC_CHANNEL_STIO:
+                case ASEQ_OP_CHANNEL_STIO:
                     channel->seqScriptIO[lowBits] = scriptState->value;
                     break;
 
-                case ASEQ_OPC_CHANNEL_RLDLAYER:
+                case ASEQ_OP_CHANNEL_RLDLAYER:
                     temp1 = AudioSeq_ScriptReadS16(scriptState);
                     if (!AudioSeq_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &scriptState->pc[temp1];
@@ -1671,11 +1671,11 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
         lowBits = cmd & 0xF;
 
         switch (cmd & 0xF0) {
-            case ASEQ_OPC_CHANNEL_CDELAY:
+            case ASEQ_OP_CHANNEL_CDELAY:
                 channel->delay = lowBits;
                 goto exit_loop;
 
-            case ASEQ_OPC_CHANNEL_LDSAMPLE:
+            case ASEQ_OP_CHANNEL_LDSAMPLE:
                 if (lowBits < 8) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                     if (AudioLoad_SlowLoadSample(channel->fontId, scriptState->value, &channel->seqScriptIO[lowBits]) ==
@@ -1688,28 +1688,28 @@ void AudioSeq_SequenceChannelProcessScript(SequenceChannel* channel) {
                 }
                 break;
 
-            case ASEQ_OPC_CHANNEL_LDIO:
+            case ASEQ_OP_CHANNEL_LDIO:
                 scriptState->value = channel->seqScriptIO[lowBits];
                 if (lowBits < 2) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                 }
                 break;
 
-            case ASEQ_OPC_CHANNEL_SUBIO:
+            case ASEQ_OP_CHANNEL_SUBIO:
                 scriptState->value -= channel->seqScriptIO[lowBits];
                 break;
 
-            case ASEQ_OPC_CHANNEL_LDCHAN:
+            case ASEQ_OP_CHANNEL_LDCHAN:
                 cmdArgU16 = AudioSeq_ScriptReadS16(scriptState);
                 AudioSeq_SequenceChannelEnable(seqPlayer, lowBits, &seqPlayer->seqData[cmdArgU16]);
                 break;
 
-            case ASEQ_OPC_CHANNEL_STCIO:
+            case ASEQ_OP_CHANNEL_STCIO:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 seqPlayer->channels[lowBits]->seqScriptIO[cmd] = scriptState->value;
                 break;
 
-            case ASEQ_OPC_CHANNEL_LDCIO:
+            case ASEQ_OP_CHANNEL_LDCIO:
                 cmd = AudioSeq_ScriptReadU8(scriptState);
                 scriptState->value = seqPlayer->channels[lowBits]->seqScriptIO[cmd];
                 break;
@@ -1782,7 +1782,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmd = AudioSeq_ScriptReadU8(seqScript);
 
             // 0xF2 and above are "flow control" commands, including termination.
-            if (cmd >= ASEQ_OPC_CONTROL_FLOW_FIRST) {
+            if (cmd >= ASEQ_OP_CONTROL_FLOW_FIRST) {
                 delay = AudioSeq_HandleScriptFlowControl(
                     seqPlayer, seqScript, cmd, AudioSeq_GetScriptControlFlowArgument(&seqPlayer->scriptState, cmd));
 
@@ -1799,7 +1799,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
 
             if (cmd >= 0xC0) {
                 switch (cmd) {
-                    case ASEQ_OPC_SEQUENCE_ALLOCNOTELIST:
+                    case ASEQ_OP_SEQUENCE_ALLOCNOTELIST:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         Audio_NotePoolFill(&seqPlayer->notePool, cmd);
@@ -1815,18 +1815,18 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         if (dummy) {}
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_FREENOTELIST:
+                    case ASEQ_OP_SEQUENCE_FREENOTELIST:
                         Audio_NotePoolClear(&seqPlayer->notePool);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_TRANSPOSE:
+                    case ASEQ_OP_SEQUENCE_TRANSPOSE:
                         seqPlayer->transposition = 0;
                         FALLTHROUGH;
-                    case ASEQ_OPC_SEQUENCE_RTRANSPOSE:
+                    case ASEQ_OP_SEQUENCE_RTRANSPOSE:
                         seqPlayer->transposition += (s8)AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_TEMPO:
+                    case ASEQ_OP_SEQUENCE_TEMPO:
                         seqPlayer->tempo = AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         if (seqPlayer->tempo > gAudioCtx.maxTempo) {
                             seqPlayer->tempo = (u16)gAudioCtx.maxTempo;
@@ -1837,11 +1837,11 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_TEMPOCHG:
+                    case ASEQ_OP_SEQUENCE_TEMPOCHG:
                         seqPlayer->tempoChange = (s8)AudioSeq_ScriptReadU8(seqScript) * SEQTICKS_PER_BEAT;
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_VOLMODE:
+                    case ASEQ_OP_SEQUENCE_VOLMODE:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         switch (cmd) {
@@ -1861,7 +1861,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_VOL:
+                    case ASEQ_OP_SEQUENCE_VOL:
                         value = AudioSeq_ScriptReadU8(seqScript);
                         switch (seqPlayer->state) {
                             case 1:
@@ -1883,47 +1883,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_VOLSCALE:
+                    case ASEQ_OP_SEQUENCE_VOLSCALE:
                         seqPlayer->fadeVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_INITCHAN:
+                    case ASEQ_OP_SEQUENCE_INITCHAN:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         AudioSeq_SequencePlayerSetupChannels(seqPlayer, temp);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_FREECHAN:
+                    case ASEQ_OP_SEQUENCE_FREECHAN:
                         AudioSeq_ScriptReadS16(seqScript);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_MUTESCALE:
+                    case ASEQ_OP_SEQUENCE_MUTESCALE:
                         seqPlayer->muteVolumeScale = (s8)AudioSeq_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_MUTE:
+                    case ASEQ_OP_SEQUENCE_MUTE:
                         seqPlayer->muted = true;
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_MUTEBHV:
+                    case ASEQ_OP_SEQUENCE_MUTEBHV:
                         seqPlayer->muteBehavior = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_LDSHORTGATEARR:
-                    case ASEQ_OPC_SEQUENCE_LDSHORTVELARR:
+                    case ASEQ_OP_SEQUENCE_LDSHORTGATEARR:
+                    case ASEQ_OP_SEQUENCE_LDSHORTVELARR:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data3 = &seqPlayer->seqData[temp];
-                        if (cmd == ASEQ_OPC_SEQUENCE_LDSHORTVELARR) {
+                        if (cmd == ASEQ_OP_SEQUENCE_LDSHORTVELARR) {
                             seqPlayer->shortNoteVelocityTable = data3;
                         } else {
                             seqPlayer->shortNoteGateTimeTable = data3;
                         }
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_NOTEALLOC:
+                    case ASEQ_OP_SEQUENCE_NOTEALLOC:
                         seqPlayer->noteAllocPolicy = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_RAND:
+                    case ASEQ_OP_SEQUENCE_RAND:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0) {
                             seqScript->value = (gAudioCtx.audioRandom >> 2) & 0xFF;
@@ -1932,7 +1932,7 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_DYNCALL:
+                    case ASEQ_OP_SEQUENCE_DYNCALL:
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         if ((seqScript->value != -1) && (seqScript->depth != 3)) {
                             data = seqPlayer->seqData + (u32)(temp + (seqScript->value << 1));
@@ -1944,39 +1944,39 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_LDI:
+                    case ASEQ_OP_SEQUENCE_LDI:
                         seqScript->value = AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_AND:
+                    case ASEQ_OP_SEQUENCE_AND:
                         seqScript->value &= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_SUB:
+                    case ASEQ_OP_SEQUENCE_SUB:
                         seqScript->value -= AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_STSEQ:
+                    case ASEQ_OP_SEQUENCE_STSEQ:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         temp = AudioSeq_ScriptReadS16(seqScript);
                         data2 = &seqPlayer->seqData[temp];
                         *data2 = (u8)seqScript->value + cmd;
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_STOP:
+                    case ASEQ_OP_SEQUENCE_STOP:
                         seqPlayer->stopScript = true;
                         return;
 
-                    case ASEQ_OPC_SEQUENCE_SCRIPTCTR:
+                    case ASEQ_OP_SEQUENCE_SCRIPTCTR:
                         seqPlayer->scriptCounter = (u16)AudioSeq_ScriptReadS16(seqScript);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_EF:
+                    case ASEQ_OP_SEQUENCE_EF:
                         AudioSeq_ScriptReadS16(seqScript);
                         AudioSeq_ScriptReadU8(seqScript);
                         break;
 
-                    case ASEQ_OPC_SEQUENCE_RUNSEQ:
+                    case ASEQ_OP_SEQUENCE_RUNSEQ:
                         cmd = AudioSeq_ScriptReadU8(seqScript);
                         if (cmd == 0xFF) {
                             cmd = seqPlayer->playerIdx;
@@ -1994,47 +1994,47 @@ void AudioSeq_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmdLowBits = cmd & 0x0F;
 
             switch (cmd & 0xF0) {
-                case ASEQ_OPC_SEQUENCE_TESTCHAN:
+                case ASEQ_OP_SEQUENCE_TESTCHAN:
                     seqScript->value = seqPlayer->channels[cmdLowBits]->enabled ^ 1;
                     break;
 
-                case ASEQ_OPC_SEQUENCE_SUBIO:
+                case ASEQ_OP_SEQUENCE_SUBIO:
                     seqScript->value -= seqPlayer->seqScriptIO[cmdLowBits];
                     break;
 
-                case ASEQ_OPC_SEQUENCE_STIO:
+                case ASEQ_OP_SEQUENCE_STIO:
                     seqPlayer->seqScriptIO[cmdLowBits] = seqScript->value;
                     break;
 
-                case ASEQ_OPC_SEQUENCE_LDIO:
+                case ASEQ_OP_SEQUENCE_LDIO:
                     seqScript->value = seqPlayer->seqScriptIO[cmdLowBits];
                     if (cmdLowBits < 2) {
                         seqPlayer->seqScriptIO[cmdLowBits] = SEQ_IO_VAL_NONE;
                     }
                     break;
 
-                case ASEQ_OPC_SEQUENCE_STOPCHAN:
+                case ASEQ_OP_SEQUENCE_STOPCHAN:
                     AudioSeq_SequenceChannelDisable(seqPlayer->channels[cmdLowBits]);
                     break;
 
-                case ASEQ_OPC_SEQUENCE_LDCHAN:
+                case ASEQ_OP_SEQUENCE_LDCHAN:
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqPlayer->seqData[temp]);
                     break;
 
-                case ASEQ_OPC_SEQUENCE_RLDCHAN:
+                case ASEQ_OP_SEQUENCE_RLDCHAN:
                     tempS = AudioSeq_ScriptReadS16(seqScript);
                     AudioSeq_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqScript->pc[tempS]);
                     break;
 
-                case ASEQ_OPC_SEQUENCE_LDSEQ:
+                case ASEQ_OP_SEQUENCE_LDSEQ:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     temp = AudioSeq_ScriptReadS16(seqScript);
                     data2 = &seqPlayer->seqData[temp];
                     AudioLoad_SlowLoadSeq(cmd, data2, &seqPlayer->seqScriptIO[cmdLowBits]);
                     break;
 
-                case ASEQ_OPC_SEQUENCE_LDRES:
+                case ASEQ_OP_SEQUENCE_LDRES:
                     cmd = AudioSeq_ScriptReadU8(seqScript);
                     value = cmd;
                     temp = AudioSeq_ScriptReadU8(seqScript);


### PR DESCRIPTION
Macroify the Music Macro Language (MML) opcodes, and use them in the sequence player interpreter.