### PR TITLE
Always use LF line endings, even on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Always use LF instead of CRLF line endings
+* text eol=lf
 # Set browser syntax highlighting for certain files
 *.inc linguist-language=gas
 *.seq linguist-language=gas


### PR DESCRIPTION
We don't support building on Windows anymore, except via Docker, which expects LF line endings since it's Linux. And even if we did support Windows, we probably should use LF anyway since IDO doesn't support CRLF