### PR TITLE
Revert "Always use LF line endings, even on Windows (#2489)"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Always use LF instead of CRLF line endings
-* text eol=lf
+# Auto detect text files and perform LF normalization
+* text=auto
 # Set browser syntax highlighting for certain files
 *.inc linguist-language=gas
 *.seq linguist-language=gas


### PR DESCRIPTION
this seem to want to edit binary files too (and the ZAPD files have CRLF in the repo)
```
warning: in the working copy of 'docs/audio/build_flowchart.png', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'docs/logo.png', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ZAPD/ExporterTest/ExporterTest.vcxproj', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ZAPD/ZAPD/ZAPD.vcxproj', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ZAPD/ZAPD/ZAPD.vcxproj.filters', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ZAPD/ZAPD/ZActorList.cpp', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ZAPD/ZAPD/ZActorList.h', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ZAPD/ZAPD/ZSurfaceType.cpp', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ZAPD/ZAPD/ZSurfaceType.h', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ZAPD/ZAPDUtils/ZAPDUtils.vcxproj', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ZAPD/docs/zapd_warning_example.png', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/asm-differ/screenshot.png', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido5.3_compiler/usr/lib/as1', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido5.3_compiler/usr/lib/cfe', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido5.3_compiler/usr/lib/libc.so.1', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido5.3_compiler/usr/lib/umerge', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido7.1_compiler/lib/libc.so.1', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido7.1_compiler/lib/rld', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido7.1_compiler/usr/lib/as1', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido7.1_compiler/usr/lib/cfe', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido7.1_compiler/usr/lib/libc.so.1', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'tools/ido7.1_compiler/usr/lib/libexc.so', CRLF will be replaced by LF the next time Git touches it
```