### PR TITLE
Add additional Bazaar display list definitions

### DIFF
--- a/assets/xml/scenes/shops/shop1.xml
+++ b/assets/xml/scenes/shops/shop1.xml
@@ -5,6 +5,7 @@
     <File Name="shop1_room_0" Segment="3">
         <Room Name="shop1_room_0" Offset="0x0"/>
         <DList Name="gShop1DL_003F60" Offset="0x3F60"/>
+        <DList Name="gShop1DL_003F98" Offset="0x3F98"/>
         <DList Name="gShop1DL_003408" Offset="0x3408"/>
         <DList Name="gShop1DL_0034A0" Offset="0x34A0"/>
         <DList Name="gShop1DL_003538" Offset="0x3538"/>

--- a/assets/xml/scenes/shops/shop1.xml
+++ b/assets/xml/scenes/shops/shop1.xml
@@ -4,5 +4,12 @@
     </File>
     <File Name="shop1_room_0" Segment="3">
         <Room Name="shop1_room_0" Offset="0x0"/>
+        <DList Name="shop1_room_0DL_003F60" Offset="0x3F60"/>
+        <DList Name="shop1_room_0DL_003408" Offset="0x3408"/>
+        <DList Name="shop1_room_0DL_0034A0" Offset="0x34A0"/>
+        <DList Name="shop1_room_0DL_003538" Offset="0x3538"/>
+        <DList Name="shop1_room_0DL_0035D0" Offset="0x35D0"/>
+        <DList Name="shop1_room_0DL_003668" Offset="0x3668"/>
+        <DList Name="shop1_room_0DL_003AE0" Offset="0x3AE0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/shops/shop1.xml
+++ b/assets/xml/scenes/shops/shop1.xml
@@ -4,12 +4,12 @@
     </File>
     <File Name="shop1_room_0" Segment="3">
         <Room Name="shop1_room_0" Offset="0x0"/>
-        <DList Name="shop1_room_0DL_003F60" Offset="0x3F60"/>
-        <DList Name="shop1_room_0DL_003408" Offset="0x3408"/>
-        <DList Name="shop1_room_0DL_0034A0" Offset="0x34A0"/>
-        <DList Name="shop1_room_0DL_003538" Offset="0x3538"/>
-        <DList Name="shop1_room_0DL_0035D0" Offset="0x35D0"/>
-        <DList Name="shop1_room_0DL_003668" Offset="0x3668"/>
-        <DList Name="shop1_room_0DL_003AE0" Offset="0x3AE0"/>
+        <DList Name="gShop1DL_003F60" Offset="0x3F60"/>
+        <DList Name="gShop1DL_003408" Offset="0x3408"/>
+        <DList Name="gShop1DL_0034A0" Offset="0x34A0"/>
+        <DList Name="gShop1DL_003538" Offset="0x3538"/>
+        <DList Name="gShop1DL_0035D0" Offset="0x35D0"/>
+        <DList Name="gShop1DL_003668" Offset="0x3668"/>
+        <DList Name="gShop1DL_003AE0" Offset="0x3AE0"/>
     </File>
 </Root>


### PR DESCRIPTION
There were a handful of unaccounted for display lists in the NTSC 1.0 Bazaar room file. They may also be in other versions, but I haven't checked. I can add those to this PR if preferable.