### PR TITLE
Rename absf to fabsf

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -81,6 +81,4 @@ void RcpUtils_Reset(void);
 
 void SystemHeap_Init(void* start, u32 size);
 
-f32 absf(f32);
-
 #endif

--- a/spec/spec
+++ b/spec/spec
@@ -786,14 +786,14 @@ beginseg
     include "$(BUILD_DIR)/src/libc/memmove.o"
 #elif PLATFORM_GC
     include "$(BUILD_DIR)/src/libc/sqrt.o"
-    include "$(BUILD_DIR)/src/libc/absf.o"
+    include "$(BUILD_DIR)/src/libc/fabsf.o"
     include "$(BUILD_DIR)/src/libc/fmodf.o"
     include "$(BUILD_DIR)/src/libc/memset.o"
     include "$(BUILD_DIR)/src/libc/memmove.o"
 #elif PLATFORM_IQUE
     include "$(BUILD_DIR)/src/libc/fmodf.o"
     include "$(BUILD_DIR)/src/libc/memmove.o"
-    include "$(BUILD_DIR)/src/libc/absf.o"
+    include "$(BUILD_DIR)/src/libc/fabsf.o"
     include "$(BUILD_DIR)/src/libc/sqrt.o"
 #endif
 

--- a/src/libc/fabsf.s
+++ b/src/libc/fabsf.s
@@ -3,7 +3,7 @@
 
 .text
 
-LEAF(absf)
+LEAF(fabsf)
     abs.s       fv0, fa0
     jr          ra
-END(absf)
+END(fabsf)


### PR DESCRIPTION
What is currently `absf` seems to be the non-intrinsic variant of `fabsf` (similar to how `sqrtf` is treated as intrinsic but also has an implementation in `sqrtf.s`). This renames absf -> fabsf to reflect that, which also brings it in-line with the standard C name.