### PR TITLE
system_heap -> runtime

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -79,6 +79,6 @@ void* SysCfb_GetFbEnd(void);
 void RcpUtils_PrintRegisterStatus(void);
 void RcpUtils_Reset(void);
 
-void RunTime_Init(void* start, u32 size);
+void Runtime_Init(void* start, u32 size);
 
 #endif

--- a/include/functions.h
+++ b/include/functions.h
@@ -79,6 +79,6 @@ void* SysCfb_GetFbEnd(void);
 void RcpUtils_PrintRegisterStatus(void);
 void RcpUtils_Reset(void);
 
-void SystemHeap_Init(void* start, u32 size);
+void RunTime_Init(void* start, u32 size);
 
 #endif

--- a/spec/spec
+++ b/spec/spec
@@ -708,7 +708,7 @@ beginseg
     include "$(BUILD_DIR)/src/libu64/rcp_utils.o"
     include "$(BUILD_DIR)/src/libu64/loadfragment2_n64.o"
     include "$(BUILD_DIR)/src/libu64/pad.o"
-    include "$(BUILD_DIR)/src/libu64/system_heap.o"
+    include "$(BUILD_DIR)/src/libu64/runtime.o"
     include "$(BUILD_DIR)/src/libu64/padsetup.o"
 #elif PLATFORM_GC
     include "$(BUILD_DIR)/src/libu64/logseverity_gc.o"
@@ -720,11 +720,11 @@ beginseg
 #endif
     include "$(BUILD_DIR)/src/libu64/relocation_gc.o"
     include "$(BUILD_DIR)/src/libu64/load_gc.o"
-    include "$(BUILD_DIR)/src/libu64/system_heap.o"
+    include "$(BUILD_DIR)/src/libu64/runtime.o"
     include "$(BUILD_DIR)/src/libu64/pad.o"
     include "$(BUILD_DIR)/src/libu64/padsetup.o"
 #elif PLATFORM_IQUE
-    include "$(BUILD_DIR)/src/libu64/system_heap.o"
+    include "$(BUILD_DIR)/src/libu64/runtime.o"
     include "$(BUILD_DIR)/src/libu64/debug.o"
     include "$(BUILD_DIR)/src/libu64/gfxprint.o"
     include "$(BUILD_DIR)/src/libu64/logseverity_gc.o"

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -109,7 +109,7 @@ void Main(void* arg) {
     gSystemHeapSize = fb - systemHeapStart;
     PRINTF(T("システムヒープ初期化 %08x-%08x %08x\n", "System heap initialization %08x-%08x %08x\n"), systemHeapStart,
            fb, gSystemHeapSize);
-    RunTime_Init((void*)systemHeapStart, gSystemHeapSize);
+    Runtime_Init((void*)systemHeapStart, gSystemHeapSize);
 
 #if DEBUG_FEATURES
     {

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -109,7 +109,7 @@ void Main(void* arg) {
     gSystemHeapSize = fb - systemHeapStart;
     PRINTF(T("システムヒープ初期化 %08x-%08x %08x\n", "System heap initialization %08x-%08x %08x\n"), systemHeapStart,
            fb, gSystemHeapSize);
-    RunTime_Init((void*)systemHeapStart, gSystemHeapSize); // initializes the system heap
+    RunTime_Init((void*)systemHeapStart, gSystemHeapSize);
 
 #if DEBUG_FEATURES
     {

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -109,7 +109,7 @@ void Main(void* arg) {
     gSystemHeapSize = fb - systemHeapStart;
     PRINTF(T("システムヒープ初期化 %08x-%08x %08x\n", "System heap initialization %08x-%08x %08x\n"), systemHeapStart,
            fb, gSystemHeapSize);
-    SystemHeap_Init((void*)systemHeapStart, gSystemHeapSize); // initializes the system heap
+    RunTime_Init((void*)systemHeapStart, gSystemHeapSize); // initializes the system heap
 
 #if DEBUG_FEATURES
     {

--- a/src/libu64/runtime.c
+++ b/src/libu64/runtime.c
@@ -119,7 +119,7 @@ void func_800FCA18(void* blk, u32 nBlk, u32 blkSize, arg3_800FCA18 arg3, s32 arg
     RESTORE_INTERRUPTS();
 }
 
-void RunTime_GlobalCtors(void) {
+void RunTime_ExecuteGlobalCtors(void) {
     CtorEntry* ctorEntry = (CtorEntry*)&sGlobalCtorEntries;
     u32 nextOffset = ctorEntry->nextOffset;
     CtorEntry* prevEntry = NULL;
@@ -146,5 +146,5 @@ void RunTime_Init(void* start, u32 size) {
     SystemArena_Init(start, size);
 #endif
 
-    RunTime_GlobalCtors();
+    RunTime_ExecuteGlobalCtors();
 }

--- a/src/libu64/runtime.c
+++ b/src/libu64/runtime.c
@@ -19,7 +19,7 @@ char sNew[] = "new";
 char sNew[] = "";
 #endif
 
-void* RunTime_New(u32 size) {
+void* Runtime_New(u32 size) {
     DECLARE_INTERRUPT_MASK
     void* ptr;
 
@@ -39,7 +39,7 @@ void* RunTime_New(u32 size) {
     return ptr;
 }
 
-void RunTime_Delete(void* ptr) {
+void Runtime_Delete(void* ptr) {
     DECLARE_INTERRUPT_MASK
 
     DISABLE_INTERRUPTS();
@@ -78,7 +78,7 @@ void* func_800FC948(void* blk, u32 nBlk, u32 blkSize, arg3_800FC948 arg3) {
     DISABLE_INTERRUPTS();
 
     if (blk == NULL) {
-        blk = RunTime_New(nBlk * blkSize);
+        blk = Runtime_New(nBlk * blkSize);
     }
 
     if (blk != NULL && arg3 != NULL) {
@@ -112,14 +112,14 @@ void func_800FCA18(void* blk, u32 nBlk, u32 blkSize, arg3_800FCA18 arg3, s32 arg
         }
 
         if (arg4 != 0) {
-            RunTime_Delete(blk);
+            Runtime_Delete(blk);
         }
     }
 
     RESTORE_INTERRUPTS();
 }
 
-void RunTime_ExecuteGlobalCtors(void) {
+void Runtime_ExecuteGlobalCtors(void) {
     CtorEntry* ctorEntry = (CtorEntry*)&sGlobalCtorEntries;
     u32 nextOffset = ctorEntry->nextOffset;
     CtorEntry* prevEntry = NULL;
@@ -139,12 +139,12 @@ void RunTime_ExecuteGlobalCtors(void) {
     sGlobalCtorEntries = prevEntry;
 }
 
-void RunTime_Init(void* start, u32 size) {
+void Runtime_Init(void* start, u32 size) {
 #if PLATFORM_N64
     __osMallocInit(&gSystemArena, start, size);
 #else
     SystemArena_Init(start, size);
 #endif
 
-    RunTime_ExecuteGlobalCtors();
+    Runtime_ExecuteGlobalCtors();
 }

--- a/src/libu64/runtime.c
+++ b/src/libu64/runtime.c
@@ -11,7 +11,7 @@ typedef struct CtorEntry {
     void (*func)(void);
 } CtorEntry;
 
-void* sGlobalCtors = NULL;
+void* sGlobalCtorEntries = NULL;
 
 #if DEBUG_FEATURES
 char sNew[] = "new";
@@ -120,23 +120,23 @@ void func_800FCA18(void* blk, u32 nBlk, u32 blkSize, arg3_800FCA18 arg3, s32 arg
 }
 
 void RunTime_GlobalCtors(void) {
-    CtorEntry* globalCtor = (CtorEntry*)&sGlobalCtors;
-    u32 nextOffset = globalCtor->nextOffset;
-    CtorEntry* prev = NULL;
+    CtorEntry* ctorEntry = (CtorEntry*)&sGlobalCtorEntries;
+    u32 nextOffset = ctorEntry->nextOffset;
+    CtorEntry* prevEntry = NULL;
 
     while (nextOffset != 0) {
-        globalCtor = (CtorEntry*)((s32)globalCtor + nextOffset);
+        ctorEntry = (CtorEntry*)((s32)ctorEntry + nextOffset);
 
-        if (globalCtor->func != NULL) {
-            globalCtor->func();
+        if (ctorEntry->func != NULL) {
+            ctorEntry->func();
         }
 
-        nextOffset = globalCtor->nextOffset;
-        globalCtor->nextOffset = (s32)prev;
-        prev = globalCtor;
+        nextOffset = ctorEntry->nextOffset;
+        ctorEntry->nextOffset = (s32)prevEntry;
+        prevEntry = ctorEntry;
     }
 
-    sGlobalCtors = prev;
+    sGlobalCtorEntries = prevEntry;
 }
 
 void RunTime_Init(void* start, u32 size) {


### PR DESCRIPTION
This file is full of stuff that is half-baked and unused. The one important thing it does do is initialize the System Heap. However, thats not what this whole system does, its only one small step.

Tharo noted to me that it looks alot like runtime initialization you may see in C++, with global constructors that get executed. Considering when this code runs, and the way it (theoretically) iterates through a list functions and runs them when the game is booting up, I think it makes sense. But, since there are no actual function entries that get run, its hard to tell.

Anyway this file should NOT be named after the system heap, the system heap itself is handled by malloc.c.