### PR TITLE
variables.h cleaning: migrate audio variables

### DIFF
--- a/include/sfx.h
+++ b/include/sfx.h
@@ -6,6 +6,8 @@
 #include "z64math.h"
 #include "libc/assert.h"
 
+#define MAX_CHANNELS_PER_BANK 3
+
 typedef enum SfxBankType {
     /* 0 */ BANK_PLAYER,
     /* 1 */ BANK_ITEM,
@@ -177,5 +179,37 @@ void Audio_ResetSfx(void);
 extern Vec3f gSfxDefaultPos;
 extern f32 gSfxDefaultFreqAndVolScale;
 extern s8 gSfxDefaultReverb;
+
+extern SfxParams* gSfxParams[7];
+extern char D_80133390[];
+extern char D_80133398[];
+extern u8 gSfxRequestWriteIndex;
+extern u8 gSfxRequestReadIndex;
+extern SfxBankEntry* gSfxBanks[7];
+extern u8 gSfxBankSizes[];
+extern u8 gSfxChannelLayout;
+extern u16 D_801333D0;
+extern Vec3f gSfxDefaultPos;
+extern f32 gSfxDefaultFreqAndVolScale;
+extern s8 gSfxDefaultReverb;
+
+#if DEBUG_FEATURES
+extern u8 D_801333F0;
+extern u8 gAudioSfxSwapOff;
+extern u8 D_801333F8;
+#endif
+
+extern SfxBankEntry D_8016BAD0[9];
+extern SfxBankEntry D_8016BC80[12];
+extern SfxBankEntry D_8016BEC0[22];
+extern SfxBankEntry D_8016C2E0[20];
+extern SfxBankEntry D_8016C6A0[8];
+extern SfxBankEntry D_8016C820[3];
+extern SfxBankEntry D_8016C8B0[5];
+extern ActiveSfx gActiveSfx[7][MAX_CHANNELS_PER_BANK]; // total size = 0xA8
+extern u8 gSfxBankMuted[];
+extern u16 gAudioSfxSwapSource[10];
+extern u16 gAudioSfxSwapTarget[10];
+extern u8 gAudioSfxSwapMode[10];
 
 #endif

--- a/include/ultra64/siint.h
+++ b/include/ultra64/siint.h
@@ -3,6 +3,6 @@
 
 #include "pfs.h"
 
-extern __OSInode __osPfsInodeCache;
+extern u8 __osPfsInodeCacheBank;
 
 #endif

--- a/include/variables.h
+++ b/include/variables.h
@@ -24,89 +24,10 @@ extern s16 gSpoilingItemReverts[3];
 extern u64 gMojiFontTLUTs[4][4]; // original name: "moji_tlut"
 extern u64 gMojiFontTex[]; // original name: "font_ff"
 
-extern s16* gWaveSamples[9];
-extern f32 gBendPitchOneOctaveFrequencies[256];
-extern f32 gBendPitchTwoSemitonesFrequencies[256];
-extern f32 gPitchFrequencies[];
-extern u8 gDefaultShortNoteVelocityTable[16];
-extern u8 gDefaultShortNoteGateTimeTable[16];
-extern EnvelopePoint gDefaultEnvelope[4];
-extern NoteSubEu gZeroNoteSub;
-extern NoteSubEu gDefaultNoteSub;
-extern u16 gHaasEffectDelaySizes[64];
-extern s16 D_8012FBA8[];
-extern f32 gHeadsetPanVolume[128];
-extern f32 gStereoPanVolume[128];
-extern f32 gDefaultPanVolume[128];
-extern s16 gLowPassFilterData[16 * 8];
-extern s16 gHighPassFilterData[15 * 8];
-extern s32 gAudioContextInitialized;
-extern u8 gIsLargeSfxBank[7];
-extern u8 gChannelsPerBank[4][7];
-extern u8 gUsedChannelsPerBank[4][7];
-extern u8 gMorphaTransposeTable[16];
-extern u8* gFrogsSongPtr;
-extern OcarinaNote* gScarecrowLongSongPtr;
-extern u8* gScarecrowSpawnSongPtr;
-extern OcarinaSongButtons gOcarinaSongButtons[];
-extern SfxParams* gSfxParams[7];
-extern char D_80133390[];
-extern char D_80133398[];
-extern u8 gSfxRequestWriteIndex;
-extern u8 gSfxRequestReadIndex;
-extern SfxBankEntry* gSfxBanks[7];
-extern u8 gSfxBankSizes[];
-extern u8 gSfxChannelLayout;
-extern u16 D_801333D0;
-extern Vec3f gSfxDefaultPos;
-extern f32 gSfxDefaultFreqAndVolScale;
-extern s8 gSfxDefaultReverb;
-#if DEBUG_FEATURES
-extern u8 D_801333F0;
-extern u8 gAudioSfxSwapOff;
-extern u8 D_801333F8;
-#endif
-extern u8 gSeqCmdWritePos;
-extern u8 gSeqCmdReadPos;
-extern u8 gStartSeqDisabled;
-#if DEBUG_FEATURES
-extern u8 gAudioDebugPrintSeqCmd;
-#endif
-extern u8 gSoundOutputModes[];
-extern u8 gAudioSpecId;
-extern u8 D_80133418;
-extern AudioSpec gAudioSpecs[18];
-extern u8 __osPfsInodeCacheBank;
-extern s32 __osPfsLastChannel;
-
-extern TempoData gTempoData;
-extern AudioHeapInitSizes gAudioHeapInitSizes;
-extern s16 gOcarinaSongItemMap[];
-extern AudioTable gSoundFontTable;
-extern u8 gSequenceFontTable[];
-extern u8 gSequenceTable[];
-extern AudioTable gSampleBankTable;
-
 extern struct MapData* gMapData;
 extern u8 gBossMarkState;
 extern f32 gBossMarkScale;
 extern u32 D_8016139C;
 extern PauseMapMarksData* gLoadedPauseMarkDataTable;
-
-extern SfxBankEntry D_8016BAD0[9];
-extern SfxBankEntry D_8016BC80[12];
-extern SfxBankEntry D_8016BEC0[22];
-extern SfxBankEntry D_8016C2E0[20];
-extern SfxBankEntry D_8016C6A0[8];
-extern SfxBankEntry D_8016C820[3];
-extern SfxBankEntry D_8016C8B0[5];
-extern ActiveSfx gActiveSfx[7][MAX_CHANNELS_PER_BANK]; // total size = 0xA8
-extern u8 gSfxBankMuted[];
-extern u16 gAudioSfxSwapSource[10];
-extern u16 gAudioSfxSwapTarget[10];
-extern u8 gAudioSfxSwapMode[10];
-extern ActiveSequence gActiveSeqs[4];
-extern AudioContext gAudioCtx;
-extern AudioCustomUpdateFunction gAudioCustomUpdateFunction;
 
 #endif

--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -1241,9 +1241,6 @@ extern u8 gChannelsPerBank[4][7];
 extern u8 gUsedChannelsPerBank[4][7];
 extern u8 gMorphaTransposeTable[16];
 
-
-
-
 extern u8 gSeqCmdWritePos;
 extern u8 gSeqCmdReadPos;
 extern u8 gStartSeqDisabled;
@@ -1263,7 +1260,6 @@ extern s16 gOcarinaSongItemMap[];
 extern AudioTable gSoundFontTable;
 extern u8 gSequenceFontTable[];
 extern AudioTable gSampleBankTable;
-
 
 extern ActiveSequence gActiveSeqs[4];
 extern AudioContext gAudioCtx;

--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -1257,6 +1257,8 @@ extern AudioSpec gAudioSpecs[18];
 extern TempoData gTempoData;
 extern AudioHeapInitSizes gAudioHeapInitSizes;
 extern s16 gOcarinaSongItemMap[];
+
+extern AudioTable gSequenceTable;
 extern AudioTable gSoundFontTable;
 extern u8 gSequenceFontTable[];
 extern AudioTable gSampleBankTable;

--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -31,8 +31,6 @@ typedef void (*AudioCustomUpdateFunction)(void);
 #define SEQ_NUM_CHANNELS 16
 #define SEQ_IO_VAL_NONE -1
 
-#define MAX_CHANNELS_PER_BANK 3
-
 #define MUTE_BEHAVIOR_3 (1 << 3)           // prevent further noteSubEus from playing
 #define MUTE_BEHAVIOR_4 (1 << 4)           // stop something in seqLayer scripts
 #define MUTE_BEHAVIOR_SOFTEN (1 << 5)      // lower volume, by default to half
@@ -1220,5 +1218,55 @@ void Audio_Init(void);
 void Audio_InitSound(void);
 void func_800F7170(void);
 void func_800F71BC(s32 arg0);
+
+extern s16* gWaveSamples[9];
+extern f32 gBendPitchOneOctaveFrequencies[256];
+extern f32 gBendPitchTwoSemitonesFrequencies[256];
+extern f32 gPitchFrequencies[];
+extern u8 gDefaultShortNoteVelocityTable[16];
+extern u8 gDefaultShortNoteGateTimeTable[16];
+extern EnvelopePoint gDefaultEnvelope[4];
+extern NoteSubEu gZeroNoteSub;
+extern NoteSubEu gDefaultNoteSub;
+extern u16 gHaasEffectDelaySizes[64];
+extern s16 D_8012FBA8[];
+extern f32 gHeadsetPanVolume[128];
+extern f32 gStereoPanVolume[128];
+extern f32 gDefaultPanVolume[128];
+extern s16 gLowPassFilterData[16 * 8];
+extern s16 gHighPassFilterData[15 * 8];
+extern s32 gAudioContextInitialized;
+extern u8 gIsLargeSfxBank[7];
+extern u8 gChannelsPerBank[4][7];
+extern u8 gUsedChannelsPerBank[4][7];
+extern u8 gMorphaTransposeTable[16];
+
+
+
+
+extern u8 gSeqCmdWritePos;
+extern u8 gSeqCmdReadPos;
+extern u8 gStartSeqDisabled;
+
+#if DEBUG_FEATURES
+extern u8 gAudioDebugPrintSeqCmd;
+#endif
+
+extern u8 gSoundOutputModes[];
+extern u8 gAudioSpecId;
+extern u8 D_80133418;
+extern AudioSpec gAudioSpecs[18];
+
+extern TempoData gTempoData;
+extern AudioHeapInitSizes gAudioHeapInitSizes;
+extern s16 gOcarinaSongItemMap[];
+extern AudioTable gSoundFontTable;
+extern u8 gSequenceFontTable[];
+extern AudioTable gSampleBankTable;
+
+
+extern ActiveSequence gActiveSeqs[4];
+extern AudioContext gAudioCtx;
+extern AudioCustomUpdateFunction gAudioCustomUpdateFunction;
 
 #endif

--- a/include/z64ocarina.h
+++ b/include/z64ocarina.h
@@ -188,4 +188,9 @@ void AudioOcarina_MemoryGameInit(u8 minigameRound);
 s32 AudioOcarina_MemoryGameNextNote(void);
 void AudioOcarina_PlayLongScarecrowSong(void);
 
+extern u8* gFrogsSongPtr;
+extern OcarinaNote* gScarecrowLongSongPtr;
+extern u8* gScarecrowSpawnSongPtr;
+extern OcarinaSongButtons gOcarinaSongButtons[];
+
 #endif

--- a/src/audio/lib/load.c
+++ b/src/audio/lib/load.c
@@ -1126,8 +1126,6 @@ void AudioLoad_InitSoundFont(s32 fontId) {
     font->numSfx = entry->shortData3;
 }
 
-extern u8 gSequenceTable[];
-
 void AudioLoad_Init(void* heap, u32 heapSize) {
     s32 pad[18];
     s32 numFonts;
@@ -1230,7 +1228,7 @@ void AudioLoad_Init(void* heap, u32 heapSize) {
     }
 
     // Set audio tables pointers
-    gAudioCtx.sequenceTable = (AudioTable*)gSequenceTable;
+    gAudioCtx.sequenceTable = &gSequenceTable;
     gAudioCtx.soundFontTable = &gSoundFontTable;
     gAudioCtx.sampleBankTable = &gSampleBankTable;
     gAudioCtx.sequenceFontTable = gSequenceFontTable;

--- a/src/audio/lib/load.c
+++ b/src/audio/lib/load.c
@@ -1126,6 +1126,8 @@ void AudioLoad_InitSoundFont(s32 fontId) {
     font->numSfx = entry->shortData3;
 }
 
+extern u8 gSequenceTable[];
+
 void AudioLoad_Init(void* heap, u32 heapSize) {
     s32 pad[18];
     s32 numFonts;

--- a/src/audio/tables/samplebank_table.c
+++ b/src/audio/tables/samplebank_table.c
@@ -3,7 +3,6 @@
 
 // Symbol definition
 
-extern AudioTable gSampleBankTable;
 #pragma weak gSampleBankTable = sSampleBankTableHeader
 
 // Externs for table

--- a/src/audio/tables/sequence_table.c
+++ b/src/audio/tables/sequence_table.c
@@ -4,7 +4,6 @@
 
 // Symbol definition
 
-extern AudioTable gSequenceTable;
 #pragma weak gSequenceTable = sSequenceTableHeader
 
 // Externs for table

--- a/src/audio/tables/soundfont_table.c
+++ b/src/audio/tables/soundfont_table.c
@@ -3,7 +3,6 @@
 
 // Symbol definition
 
-extern AudioTable gSoundFontTable;
 #pragma weak gSoundFontTable = sSoundFontTableHeader
 
 // Externs for table

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -41,8 +41,8 @@
 
 #include "global.h"
 
-#pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ntsc-1.2:20" \
-                               "pal-1.0:18 pal-1.1:18"
+#pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ntsc-1.2:24" \
+                               "pal-1.0:22 pal-1.1:22"
 
 StackEntry sDmaMgrStackInfo;
 OSMesgQueue sDmaMgrMsgQueue;

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -41,8 +41,8 @@
 
 #include "global.h"
 
-#pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ntsc-1.2:24" \
-                               "pal-1.0:22 pal-1.1:22"
+#pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ntsc-1.2:22" \
+                               "pal-1.0:20 pal-1.1:20"
 
 StackEntry sDmaMgrStackInfo;
 OSMesgQueue sDmaMgrMsgQueue;

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -12,7 +12,7 @@
 
 #include "global.h"
 
-#pragma increment_block_number "ntsc-1.0:88 ntsc-1.1:88 ntsc-1.2:88 pal-1.0:88 pal-1.1:88"
+#pragma increment_block_number "ntsc-1.0:88 ntsc-1.1:88 ntsc-1.2:88 pal-1.0:86 pal-1.1:86"
 
 typedef struct FaultMgr {
     OSThread thread;

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -12,7 +12,7 @@
 
 #include "global.h"
 
-#pragma increment_block_number "ntsc-1.0:86 ntsc-1.1:86 ntsc-1.2:86 pal-1.0:84 pal-1.1:84"
+#pragma increment_block_number "ntsc-1.0:88 ntsc-1.1:88 ntsc-1.2:88 pal-1.0:88 pal-1.1:88"
 
 typedef struct FaultMgr {
     OSThread thread;

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -41,7 +41,7 @@ extern struct IrqMgr gIrqMgr;
 #include "global.h"
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ique-cn:0 ntsc-1.0:52 ntsc-1.1:52 ntsc-1.2:52 pal-1.0:50 pal-1.1:50"
+                               "ique-cn:0 ntsc-1.0:51 ntsc-1.1:51 ntsc-1.2:51 pal-1.0:49 pal-1.1:49"
 
 extern u8 _buffersSegmentEnd[];
 

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -41,7 +41,7 @@ extern struct IrqMgr gIrqMgr;
 #include "global.h"
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ique-cn:0 ntsc-1.0:49 ntsc-1.1:49 ntsc-1.2:49 pal-1.0:47 pal-1.1:47"
+                               "ique-cn:0 ntsc-1.0:52 ntsc-1.1:52 ntsc-1.2:52 pal-1.0:50 pal-1.1:50"
 
 extern u8 _buffersSegmentEnd[];
 

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -3658,7 +3658,7 @@ s32 Camera_KeepOn3(Camera* camera) {
 }
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ique-cn:128 ntsc-1.0:104 ntsc-1.1:104 ntsc-1.2:104 pal-1.0:102 pal-1.1:102"
+                               "ique-cn:128 ntsc-1.0:107 ntsc-1.1:107 ntsc-1.2:107 pal-1.0:105 pal-1.1:105"
 
 s32 Camera_KeepOn4(Camera* camera) {
     static Vec3f D_8015BD50;

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -3658,7 +3658,7 @@ s32 Camera_KeepOn3(Camera* camera) {
 }
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ique-cn:128 ntsc-1.0:107 ntsc-1.1:107 ntsc-1.2:107 pal-1.0:105 pal-1.1:105"
+                               "ique-cn:128 ntsc-1.0:106 ntsc-1.1:106 ntsc-1.2:106 pal-1.0:104 pal-1.1:104"
 
 s32 Camera_KeepOn4(Camera* camera) {
     static Vec3f D_8015BD50;

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -15,7 +15,8 @@
 #include "overlays/effects/ovl_Effect_Ss_HitMark/z_eff_ss_hitmark.h"
 #include "z_lib.h"
 
-#pragma increment_block_number "ique-cn:192 ntsc-1.0:200 ntsc-1.1:200 ntsc-1.2:200 pal-1.0:200 pal-1.1:200"
+#pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192 gc-us-mq:192" \
+                               "ique-cn:192 ntsc-1.0:176 ntsc-1.1:176 ntsc-1.2:176 pal-1.0:176 pal-1.1:176"
 
 typedef s32 (*ColChkResetFunc)(PlayState*, Collider*);
 typedef void (*ColChkApplyFunc)(PlayState*, CollisionCheckContext*, Collider*);

--- a/src/code/z_kaleido_scope_call.c
+++ b/src/code/z_kaleido_scope_call.c
@@ -1,5 +1,5 @@
-#pragma increment_block_number "gc-eu:144 gc-eu-mq:144 gc-jp:144 gc-jp-ce:144 gc-jp-mq:144 gc-us:144 gc-us-mq:144" \
-                               "ique-cn:128 ntsc-1.0:144 ntsc-1.1:144 ntsc-1.2:144 pal-1.0:144 pal-1.1:144"
+#pragma increment_block_number "gc-eu:134 gc-eu-mq:134 gc-jp:136 gc-jp-ce:136 gc-jp-mq:136 gc-us:136 gc-us-mq:136" \
+                               "ique-cn:126 ntsc-1.0:145 ntsc-1.1:145 ntsc-1.2:145 pal-1.0:143 pal-1.1:143"
 
 #include "libu64/debug.h"
 #include "kaleido_manager.h"

--- a/src/code/z_kaleido_scope_call.c
+++ b/src/code/z_kaleido_scope_call.c
@@ -1,5 +1,5 @@
-#pragma increment_block_number "gc-eu:134 gc-eu-mq:134 gc-jp:136 gc-jp-ce:136 gc-jp-mq:136 gc-us:136 gc-us-mq:136" \
-                               "ique-cn:126 ntsc-1.0:145 ntsc-1.1:145 ntsc-1.2:145 pal-1.0:143 pal-1.1:143"
+#pragma increment_block_number "gc-eu:133 gc-eu-mq:133 gc-jp:135 gc-jp-ce:135 gc-jp-mq:135 gc-us:135 gc-us-mq:135" \
+                               "ique-cn:125 ntsc-1.0:144 ntsc-1.1:144 ntsc-1.2:144 pal-1.0:142 pal-1.1:142"
 
 #include "libu64/debug.h"
 #include "kaleido_manager.h"

--- a/src/code/z_kankyo.c
+++ b/src/code/z_kankyo.c
@@ -1,5 +1,5 @@
-#pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ique-cn:0" \
-                               "ntsc-1.0:0 ntsc-1.1:0 ntsc-1.2:0 pal-1.0:0 pal-1.1:0"
+#pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192 gc-us-mq:192" \
+                               "ique-cn:192 ntsc-1.0:192 ntsc-1.1:192 ntsc-1.2:192 pal-1.0:192 pal-1.1:192"
 
 #include "libc64/qrand.h"
 #include "libu64/gfxprint.h"

--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -25,7 +25,7 @@
 #include "assets/textures/parameter_static/parameter_static.h"
 
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ntsc-1.0:80 ntsc-1.1:80 ntsc-1.2:80 pal-1.0:128 pal-1.1:128"
+                               "ntsc-1.0:96 ntsc-1.1:96 ntsc-1.2:96 pal-1.0:128 pal-1.1:128"
 
 #if !PLATFORM_IQUE
 #define MSG_BUF_DECODED (msgCtx->msgBufDecoded)

--- a/src/libultra/io/contramwrite.c
+++ b/src/libultra/io/contramwrite.c
@@ -1,6 +1,8 @@
 #include "ultra64.h"
 #include "global.h"
 
+extern s32 __osPfsLastChannel;
+
 s32 __osContRamWrite(OSMesgQueue* mq, s32 channel, u16 address, u8* buffer, s32 force) {
 #ifndef BBPLAYER
     s32 ret = 0;

--- a/src/n64dd/z_n64dd.c
+++ b/src/n64dd/z_n64dd.c
@@ -12,7 +12,7 @@
 #include "z64audio.h"
 #include "z64thread.h"
 
-#pragma increment_block_number "ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
+#pragma increment_block_number "ntsc-1.0:64 ntsc-1.1:64 ntsc-1.2:64 pal-1.0:64 pal-1.1:64"
 
 typedef struct struct_801D9C30 {
     /* 0x000 */ s32 unk_000;       // disk start

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -124,8 +124,8 @@ static ColliderCylinderInit sLightBallCylinderInit = {
 static u8 D_808E4C58[] = { 0, 12, 10, 12, 14, 16, 12, 14, 16, 12, 14, 16, 12, 14, 16, 10, 16, 14 };
 static Vec3f sZeroVec = { 0.0f, 0.0f, 0.0f };
 
-#pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ique-cn:128" \
-                               "ntsc-1.0:0 ntsc-1.1:0 ntsc-1.2:0 pal-1.0:0 pal-1.1:0"
+#pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
+                               "ique-cn:128 ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
 
 static EnGanonMant* sCape;
 

--- a/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -24,6 +24,9 @@
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include "assets/objects/object_tw/object_tw.h"
 
+#pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192 gc-us-mq:192" \
+                               "ique-cn:192 ntsc-1.0:192 ntsc-1.1:192 ntsc-1.2:192 pal-1.0:192 pal-1.1:192"
+
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \
      ACTOR_FLAG_DRAW_CULLING_DISABLED)

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -28,8 +28,8 @@
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include "assets/objects/object_bv/object_bv.h"
 
-#pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
+#pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ntsc-1.0:0" \
+                               "ntsc-1.1:0 ntsc-1.2:0 pal-1.0:128 pal-1.1:128"
 
 #define FLAGS                                                                                 \
     (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE | ACTOR_FLAG_UPDATE_CULLING_DISABLED | \

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -16,6 +16,9 @@
 
 #include "assets/objects/object_warp1/object_warp1.h"
 
+#pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192 gc-us-mq:192" \
+                               "ique-cn:192 ntsc-1.0:192 ntsc-1.1:192 ntsc-1.2:192 pal-1.0:192 pal-1.1:192"
+
 #define FLAGS 0
 
 void DoorWarp1_Init(Actor* thisx, PlayState* play);

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -1413,7 +1413,7 @@ void func_80B3F3D8(void) {
 }
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ique-cn:128 ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
+                               "ique-cn:64 ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
 
 void EnXc_PlayDiveSFX(Vec3f* src, PlayState* play) {
     static Vec3f D_80B42DA0;

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -30,8 +30,8 @@
 #include "assets/scenes/indoors/tokinoma/tokinoma_scene.h"
 #include "assets/scenes/dungeons/ice_doukutu/ice_doukutu_scene.h"
 
-#pragma increment_block_number "gc-eu:0 gc-eu-mq:128 gc-jp:0 gc-jp-ce:0 gc-jp-mq:128 gc-us:0 gc-us-mq:128 ique-cn:128" \
-                               "ntsc-1.0:0 ntsc-1.1:0 ntsc-1.2:0 pal-1.0:0 pal-1.1:0"
+#pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
+                               "ique-cn:128 ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 
@@ -1412,8 +1412,8 @@ void func_80B3F3D8(void) {
     Sfx_PlaySfxCentered2(NA_SE_PL_SKIP);
 }
 
-#pragma increment_block_number "gc-eu:64 gc-eu-mq:128 gc-jp:64 gc-jp-ce:64 gc-jp-mq:128 gc-us:64 gc-us-mq:128" \
-                               "ique-cn:128 ntsc-1.0:64 ntsc-1.1:64 ntsc-1.2:64 pal-1.0:64 pal-1.1:64"
+#pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
+                               "ique-cn:128 ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
 
 void EnXc_PlayDiveSFX(Vec3f* src, PlayState* play) {
     static Vec3f D_80B42DA0;

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -36,7 +36,7 @@
 #include "cic6105.h"
 #endif
 
-#pragma increment_block_number "gc-eu:96 gc-eu-mq:96 gc-jp:96 gc-jp-ce:96 gc-jp-mq:96 gc-us:96 gc-us-mq:96 ntsc-1.0:0" \
+#pragma increment_block_number "gc-eu:32 gc-eu-mq:32 gc-jp:32 gc-jp-ce:32 gc-jp-mq:32 gc-us:32 gc-us-mq:32 ntsc-1.0:0" \
                                "ntsc-1.1:0 ntsc-1.2:0 pal-1.0:0 pal-1.1:0"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -360,14 +360,14 @@ void Player_Action_CsAction(Player* this, PlayState* play);
 // .bss part 1
 
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0 ique-cn:0" \
-                               "ntsc-1.0:0 ntsc-1.1:0 ntsc-1.2:0 pal-1.0:0 pal-1.1:0"
+                               "ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:192 pal-1.1:192"
 
 static s32 D_80858AA0;
 
 // TODO: There's probably a way to match BSS ordering with less padding by spreading the variables out and moving
 // data around. It would be easier if we had more options for controlling BSS ordering in debug.
-#pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192 gc-us-mq:192" \
-                               "ique-cn:192 ntsc-1.0:192 ntsc-1.1:192 ntsc-1.2:192 pal-1.0:192 pal-1.1:192"
+#pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
+                               "ique-cn:128 ntsc-1.0:192 ntsc-1.1:192 ntsc-1.2:192 pal-1.0:192 pal-1.1:192"
 
 static s32 sSavedCurrentMask;
 static Vec3f sInteractWallCheckResult;


### PR DESCRIPTION
This is a pretty rough placement of these variables. I plan to look at this more closely in the future.
I also made a small oopsie in the last PR with a couple libultra variables. This PR fixes that.