### PR TITLE
variables.h: migrate all remaining varaibles, remove other dependencies except z64.h

### DIFF
--- a/include/build.h
+++ b/include/build.h
@@ -1,0 +1,8 @@
+#ifndef BUILD_H
+#define BUILD_H
+
+extern const char gBuildCreator[];
+extern const char gBuildDate[];
+extern const char gBuildMakeOption[];
+
+#endif

--- a/include/carthandle.h
+++ b/include/carthandle.h
@@ -1,0 +1,8 @@
+#ifndef CARTHANDLE_H
+#define CARTHANDLE_H
+
+#include "ultra64.h"
+
+extern OSPiHandle* gCartHandle;
+
+#endif

--- a/include/gfx.h
+++ b/include/gfx.h
@@ -121,4 +121,7 @@ void Graph_CloseDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file,
 
 void Graph_ThreadEntry(void*);
 
+extern u64 gMojiFontTLUTs[4][4]; // original name: "moji_tlut"
+extern u64 gMojiFontTex[]; // original name: "font_ff"
+
 #endif

--- a/include/idle.h
+++ b/include/idle.h
@@ -1,6 +1,12 @@
 #ifndef IDLE_H
 #define IDLE_H
 
+#include "ultra64.h"
+
 void Idle_ThreadEntry(void* arg);
+
+extern OSMesgQueue gPiMgrCmdQueue;
+extern OSViMode gViConfigMode;
+extern u8 gViConfigModeType;
 
 #endif

--- a/include/map.h
+++ b/include/map.h
@@ -68,6 +68,7 @@ typedef struct MapData {
 #define MAP_48x85_TEX_SIZE ((MAP_48x85_TEX_WIDTH * MAP_48x85_TEX_HEIGHT) / 2) // 48x85 CI4 texture
 
 extern MapData gMapDataTable;
+extern MapData* gMapData;
 
 void Map_SavePlayerInitialInfo(struct PlayState* play);
 void Map_SetFloorPalettesData(struct PlayState* play, s16 floor);

--- a/include/variables.h
+++ b/include/variables.h
@@ -2,7 +2,9 @@
 #define VARIABLES_H
 
 #include "z64.h"
-#include "libc64/os_malloc.h"
-#include "segment_symbols.h"
+
+// TODO:
+// Plenty of files depend on this file to have access to z64.h, including assets.
+// Fix those cases and then delete this file.
 
 #endif

--- a/include/variables.h
+++ b/include/variables.h
@@ -5,29 +5,4 @@
 #include "libc64/os_malloc.h"
 #include "segment_symbols.h"
 
-struct MapData;
-
-extern OSPiHandle* gCartHandle;
-
-extern const char gBuildCreator[];
-extern const char gBuildDate[];
-extern const char gBuildMakeOption[];
-
-extern OSMesgQueue gPiMgrCmdQueue;
-extern OSViMode gViConfigMode;
-extern u8 gViConfigModeType;
-
-extern s16 gSpoilingItems[3];
-extern s16 gSpoilingItemReverts[3];
-
-// 4 16-colors palettes
-extern u64 gMojiFontTLUTs[4][4]; // original name: "moji_tlut"
-extern u64 gMojiFontTex[]; // original name: "font_ff"
-
-extern struct MapData* gMapData;
-extern u8 gBossMarkState;
-extern f32 gBossMarkScale;
-extern u32 D_8016139C;
-extern PauseMapMarksData* gLoadedPauseMarkDataTable;
-
 #endif

--- a/include/z64interface.h
+++ b/include/z64interface.h
@@ -279,4 +279,7 @@ void Interface_Update(struct PlayState* play);
 void Interface_Destroy(struct PlayState* play);
 void Interface_Init(struct PlayState* play);
 
+extern s16 gSpoilingItems[3];
+extern s16 gSpoilingItemReverts[3];
+
 #endif

--- a/include/z64pause.h
+++ b/include/z64pause.h
@@ -250,4 +250,9 @@ void KaleidoSetup_Update(struct PlayState* play);
 void KaleidoSetup_Init(struct PlayState* play);
 void KaleidoSetup_Destroy(struct PlayState* play);
 
+extern u8 gBossMarkState;
+extern f32 gBossMarkScale;
+extern u32 D_8016139C;
+extern PauseMapMarksData* gLoadedPauseMarkDataTable;
+
 #endif

--- a/src/audio/lib/load.c
+++ b/src/audio/lib/load.c
@@ -1,6 +1,7 @@
-#include "ultra64.h"
 #include "attributes.h"
 #include "buffers.h"
+#include "segment_symbols.h"
+#include "ultra64.h"
 #include "versions.h"
 
 #include "global.h"

--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -1,5 +1,6 @@
 #include "boot.h"
 
+#include "carthandle.h"
 #include "idle.h"
 #include "is_debug.h"
 #include "stack.h"

--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -3,6 +3,7 @@
 #include "carthandle.h"
 #include "idle.h"
 #include "is_debug.h"
+#include "segment_symbols.h"
 #include "stack.h"
 #include "stackcheck.h"
 #if PLATFORM_N64

--- a/src/boot/build.c
+++ b/src/boot/build.c
@@ -1,3 +1,5 @@
+#include "build.h"
+
 #include "versions.h"
 
 const char gBuildCreator[] = BUILD_CREATOR;

--- a/src/boot/carthandle.c
+++ b/src/boot/carthandle.c
@@ -1,3 +1,3 @@
-#include "ultra64.h"
+#include "carthandle.h"
 
 OSPiHandle* gCartHandle = NULL;

--- a/src/boot/cic6105.c
+++ b/src/boot/cic6105.c
@@ -1,10 +1,13 @@
 #pragma increment_block_number "ntsc-1.2:0"
-#include "global.h"
+
 #include "audiomgr.h"
+#include "build.h"
 #include "cic6105.h"
+#include "fault.h"
 #include "regs.h"
 #include "sched.h"
-#include "fault.h"
+
+#include "global.h"
 
 s32 func_80001714(void);
 

--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -1,5 +1,7 @@
-#include "buffers.h"
 #include "idle.h"
+
+#include "buffers.h"
+#include "build.h"
 #include "main.h"
 #include "segment_symbols.h"
 #include "stack.h"

--- a/src/boot/viconfig.c
+++ b/src/boot/viconfig.c
@@ -1,5 +1,7 @@
-#include "global.h"
 #include "terminal.h"
+#include "idle.h"
+
+#include "global.h"
 
 s8 D_80009430 = 1;
 vu8 gViConfigBlack = true;

--- a/src/boot/z_locale.c
+++ b/src/boot/z_locale.c
@@ -1,5 +1,6 @@
 #include "libu64/debug.h"
 #include "alignment.h"
+#include "carthandle.h"
 #include "line_numbers.h"
 #include "padmgr.h"
 #include "region.h"

--- a/src/boot/z_std_dma.c
+++ b/src/boot/z_std_dma.c
@@ -22,7 +22,9 @@
 #include "libc64/sprintf.h"
 #include "libu64/debug.h"
 #include "attributes.h"
+#include "carthandle.h"
 #include "fault.h"
+#include "idle.h"
 #if PLATFORM_IQUE
 #include "inflate.h"
 #endif

--- a/src/code/fault_gc.c
+++ b/src/code/fault_gc.c
@@ -41,7 +41,7 @@
  * DPad-Down disables sending fault pages over osSyncPrintf.
  */
 
-#pragma increment_block_number "gc-eu:96 gc-eu-mq:96 gc-eu-mq-dbg:96 gc-jp:96 gc-jp-ce:96 gc-jp-mq:96 gc-us:96" \
+#pragma increment_block_number "gc-eu:96 gc-eu-mq:96 gc-eu-mq-dbg:128 gc-jp:96 gc-jp-ce:96 gc-jp-mq:96 gc-us:96" \
                                "gc-us-mq:96 ique-cn:96"
 
 #include "libc64/sleep.h"

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -1,4 +1,5 @@
 #include "libc64/malloc.h"
+#include "libc64/os_malloc.h"
 #include "libu64/debug.h"
 #include "libu64/gfxprint.h"
 #include "audiomgr.h"
@@ -8,7 +9,7 @@
 #include "gfx.h"
 #include "gfxalloc.h"
 #include "fault.h"
-#include "libc64/os_malloc.h"
+#include "idle.h"
 #include "line_numbers.h"
 #if PLATFORM_N64
 #include "n64dd.h"

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -23,6 +23,7 @@ extern struct IrqMgr gIrqMgr;
 #include "debug_arena.h"
 #include "fault.h"
 #include "gfx.h"
+#include "idle.h"
 #include "padmgr.h"
 #include "prenmi_buff.h"
 #include "regs.h"

--- a/src/code/object_table.c
+++ b/src/code/object_table.c
@@ -1,4 +1,3 @@
-
 #include "segment_symbols.h"
 #include "romfile.h"
 #include "ultra64.h"

--- a/src/code/object_table.c
+++ b/src/code/object_table.c
@@ -1,4 +1,10 @@
-#include "global.h"
+
+#include "segment_symbols.h"
+#include "romfile.h"
+#include "ultra64.h"
+#include "z64object.h"
+
+#include "macros.h"
 
 s16 gLinkObjectIds[] = { OBJECT_LINK_BOY, OBJECT_LINK_CHILD };
 

--- a/src/code/z_effect_soft_sprite_dlftbls.c
+++ b/src/code/z_effect_soft_sprite_dlftbls.c
@@ -1,4 +1,5 @@
-#include "global.h"
+#include "segment_symbols.h"
+#include "z64effect.h"
 
 // Linker symbol declarations (used in the table below)
 #define DEFINE_EFFECT_SS(name, _1) DECLARE_OVERLAY_SEGMENT(name)

--- a/src/code/z_map_exp.c
+++ b/src/code/z_map_exp.c
@@ -6,6 +6,7 @@
 #include "n64dd.h"
 #endif
 #include "regs.h"
+#include "segment_symbols.h"
 #include "sfx.h"
 #include "sys_matrix.h"
 #include "terminal.h"

--- a/src/code/z_vr_box.c
+++ b/src/code/z_vr_box.c
@@ -1,7 +1,9 @@
-#include "global.h"
+#include "segment_symbols.h"
 #include "terminal.h"
 #include "z64environment.h"
 #include "z64save.h"
+
+#include "global.h"
 
 typedef struct SkyboxFaceParams {
     /* 0x000 */ s32 xStart;

--- a/src/overlays/gamestates/ovl_title/z_title.c
+++ b/src/overlays/gamestates/ovl_title/z_title.c
@@ -11,6 +11,7 @@
 #endif
 
 #include "alloca.h"
+#include "build.h"
 #include "console_logo_state.h"
 #include "gfx.h"
 #include "gfx_setupdl.h"


### PR DESCRIPTION
some files are still depending on variables.h for z64.h. That will be taken care of in a followup PR