### PR TITLE
Cleanup z64.h

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -2,6 +2,5 @@
 #define GLOBAL_H
 
 #include "macros.h"
-#include "versions.h"
 
 #endif

--- a/include/z64.h
+++ b/include/z64.h
@@ -1,26 +1,18 @@
 #ifndef Z64_H
 #define Z64_H
 
+// TODO: This file still exists ONLY to provide neccesary headers to extracted assets.
+//       After assets are modified to include the headers they need directly, delete this file.
+
+#include "sequence.h"
+#include "sys_matrix.h"
 #include "ultra64.h"
-#include "ultra64/gs2dex.h"
-#include "attributes.h"
-#include "versions.h"
-#include "z64player.h"
-#include "z64audio.h"
-#include "z64ocarina.h"
-#include "z64curve.h"
-#include "z64effect.h"
+#include "z64play.h"
 #include "z64animation.h"
 #include "z64animation_legacy.h"
-#include "z64play.h"
+#include "z64curve.h"
 #include "z64skin.h"
-#include "z64skin_matrix.h"
-#include "alignment.h"
-#include "audiothread_cmd.h"
-#include "sfx.h"
-#include "color.h"
-#include "sys_matrix.h" // in room assets, gIdentityMtx
-
-// TODO: include all files listed above into the right place, and then delete this file.
+#include "z64player.h"
+#include "z64ocarina.h"
 
 #endif

--- a/src/code/z_fbdemo_circle.c
+++ b/src/code/z_fbdemo_circle.c
@@ -1,6 +1,7 @@
 #include "transition_circle.h"
 
 #include "gfx.h"
+#include "sfx.h"
 
 #include "global.h"
 


### PR DESCRIPTION
z64.h is now completely split, no source files with code in them depend on it (except for 1 special case).
Otherwise, assets are the only thing that need z64.h.

It would be better to wait for the new assets system to be able to modify includes based on asset type.
So for now, z64.h is pruned down to the absolute minimum that is required for assets as a whole.

Also unrelated, I removed versions.h from global.h. Only macros.h is left.