### PR TITLE
macros.h 3/5: Split various macros

### DIFF
--- a/include/avoid_ub.h
+++ b/include/avoid_ub.h
@@ -1,0 +1,13 @@
+#ifndef AVOID_UB_H
+#define AVOID_UB_H
+
+/**
+ * This macro is used when the return type of a function is incorrect
+ */
+#ifndef AVOID_UB
+#define BAD_RETURN(type) type
+#else
+#define BAD_RETURN(type) void
+#endif
+
+#endif

--- a/include/color.h
+++ b/include/color.h
@@ -33,4 +33,6 @@ typedef union Color_RGBA16 {
     u16 rgba;
 } Color_RGBA16;
 
+#define RGBA8(r, g, b, a) ((((r) & 0xFF) << 24) | (((g) & 0xFF) << 16) | (((b) & 0xFF) << 8) | (((a) & 0xFF) << 0))
+
 #endif

--- a/include/fault.h
+++ b/include/fault.h
@@ -1,9 +1,10 @@
 #ifndef FAULT_H
 #define FAULT_H
 
-#include "ultra64.h"
-#include "attributes.h"
+#include "libu64/debug.h"
 #include "libu64/pad.h"
+#include "attributes.h"
+#include "ultra64.h"
 
 #if !PLATFORM_N64
 // These are the same as the 3-bit ansi color codes
@@ -49,6 +50,12 @@ void Fault_Init(void);
 
 NORETURN void Fault_AddHungupAndCrashImpl(const char* exp1, const char* exp2);
 NORETURN void Fault_AddHungupAndCrash(const char* file, int line);
+
+#if PLATFORM_N64 || DEBUG_FEATURES
+#define HUNGUP_AND_CRASH(file, line) Fault_AddHungupAndCrash(file, line)
+#else
+#define HUNGUP_AND_CRASH(file, line) LogUtils_HungupThread(file, line)
+#endif
 
 // Client Registration
 

--- a/include/gfx.h
+++ b/include/gfx.h
@@ -142,24 +142,24 @@ extern u64 gMojiFontTex[]; // original name: "font_ff"
 
 #define VTX_T(x,y,z,s,t,cr,cg,cb,a) { { x, y, z }, 0, { s, t }, { cr, cg, cb, a } }
 
-#define SETUP_LARGE_TEXTURE_TILE(pkt, fmt, siz, uls, ult, lrs, lrt, pal,   \
-                                 cms, cmt, masks, maskt, shifts, shiftt)   \
-do {                                                                       \
-        gDPPipeSync(pkt);                                                  \
-        gDPTileSync(pkt);                                                  \
-        gDPSetTile(pkt, fmt, siz,                                          \
-            (((((lrs) - (uls) + 1) * siz##_TILE_BYTES) + 7) >> 3), 0,      \
-            G_TX_LOADTILE, 0, cmt, maskt, shiftt, cms, masks,              \
-            shifts);                                                       \
-        gDPTileSync(pkt);                                                  \
-        gDPSetTile(pkt, fmt, siz,                                          \
-            (((((lrs) - (uls) + 1) * siz##_LINE_BYTES) + 7) >> 3), 0,      \
-            G_TX_RENDERTILE, pal, cmt, maskt, shiftt, cms, masks, shifts); \
-        gDPSetTileSize(pkt, G_TX_RENDERTILE,                               \
-            (uls) << G_TEXTURE_IMAGE_FRAC,                                 \
-            (ult) << G_TEXTURE_IMAGE_FRAC,                                 \
-            (lrs) << G_TEXTURE_IMAGE_FRAC,                                 \
-            (lrt) << G_TEXTURE_IMAGE_FRAC);                                \
-} while (0)
+#define gDPSetTileCustom(pkt, fmt, siz, uls, ult, lrs, lrt, pal,        \
+                         cms, cmt, masks, maskt, shifts, shiftt)        \
+_DW({                                                                   \
+    gDPPipeSync(pkt);                                                   \
+    gDPTileSync(pkt);                                                   \
+    gDPSetTile(pkt, fmt, siz,                                           \
+        (((((lrs) - (uls) + 1) * siz##_TILE_BYTES) + 7) >> 3), 0,       \
+        G_TX_LOADTILE, 0, cmt, maskt, shiftt, cms, masks,               \
+        shifts);                                                        \
+    gDPTileSync(pkt);                                                   \
+    gDPSetTile(pkt, fmt, siz,                                           \
+        (((((lrs) - (uls) + 1) * siz##_LINE_BYTES) + 7) >> 3), 0,       \
+        G_TX_RENDERTILE, pal, cmt, maskt, shiftt, cms, masks, shifts);  \
+    gDPSetTileSize(pkt, G_TX_RENDERTILE,                                \
+        (uls) << G_TEXTURE_IMAGE_FRAC,                                  \
+        (ult) << G_TEXTURE_IMAGE_FRAC,                                  \
+        (lrs) << G_TEXTURE_IMAGE_FRAC,                                  \
+        (lrt) << G_TEXTURE_IMAGE_FRAC);                                 \
+})
 
 #endif

--- a/include/gfx.h
+++ b/include/gfx.h
@@ -7,6 +7,9 @@
 #include "thga.h"
 #include "versions.h"
 
+#define SCREEN_WIDTH  320
+#define SCREEN_HEIGHT 240
+
 // Texture memory size, 4 KiB
 #define TMEM_SIZE 0x1000
 
@@ -123,5 +126,40 @@ void Graph_ThreadEntry(void*);
 
 extern u64 gMojiFontTLUTs[4][4]; // original name: "moji_tlut"
 extern u64 gMojiFontTex[]; // original name: "font_ff"
+
+/**
+ * `x` vertex x
+ * `y` vertex y
+ * `z` vertex z
+ * `s` texture s coordinate
+ * `t` texture t coordinate
+ * `crnx` red component of color vertex, or x component of normal vertex
+ * `cgny` green component of color vertex, or y component of normal vertex
+ * `cbnz` blue component of color vertex, or z component of normal vertex
+ * `a` alpha
+ */
+#define VTX(x,y,z,s,t,crnx,cgny,cbnz,a) { { { x, y, z }, 0, { s, t }, { crnx, cgny, cbnz, a } } }
+
+#define VTX_T(x,y,z,s,t,cr,cg,cb,a) { { x, y, z }, 0, { s, t }, { cr, cg, cb, a } }
+
+#define SETUP_LARGE_TEXTURE_TILE(pkt, fmt, siz, uls, ult, lrs, lrt, pal,   \
+                                 cms, cmt, masks, maskt, shifts, shiftt)   \
+do {                                                                       \
+        gDPPipeSync(pkt);                                                  \
+        gDPTileSync(pkt);                                                  \
+        gDPSetTile(pkt, fmt, siz,                                          \
+            (((((lrs) - (uls) + 1) * siz##_TILE_BYTES) + 7) >> 3), 0,      \
+            G_TX_LOADTILE, 0, cmt, maskt, shiftt, cms, masks,              \
+            shifts);                                                       \
+        gDPTileSync(pkt);                                                  \
+        gDPSetTile(pkt, fmt, siz,                                          \
+            (((((lrs) - (uls) + 1) * siz##_LINE_BYTES) + 7) >> 3), 0,      \
+            G_TX_RENDERTILE, pal, cmt, maskt, shiftt, cms, masks, shifts); \
+        gDPSetTileSize(pkt, G_TX_RENDERTILE,                               \
+            (uls) << G_TEXTURE_IMAGE_FRAC,                                 \
+            (ult) << G_TEXTURE_IMAGE_FRAC,                                 \
+            (lrs) << G_TEXTURE_IMAGE_FRAC,                                 \
+            (lrt) << G_TEXTURE_IMAGE_FRAC);                                \
+} while (0)
 
 #endif

--- a/include/language_array.h
+++ b/include/language_array.h
@@ -1,0 +1,12 @@
+#ifndef LANGUAGE_ARRAY_H
+#define LANGUAGE_ARRAY_H
+
+#include "versions.h"
+
+#if OOT_NTSC
+#define LANGUAGE_ARRAY(jpn, eng, ger, fra) { jpn, eng }
+#else
+#define LANGUAGE_ARRAY(jpn, eng, ger, fra) { eng, ger, fra }
+#endif
+
+#endif

--- a/include/macros.h
+++ b/include/macros.h
@@ -1,17 +1,6 @@
 #ifndef MACROS_H
 #define MACROS_H
 
-#include "versions.h"
-
-#define SCREEN_WIDTH  320
-#define SCREEN_HEIGHT 240
-
-#ifndef AVOID_UB
-#define BAD_RETURN(type) type
-#else
-#define BAD_RETURN(type) void
-#endif
-
 #define ARRAY_COUNT(arr) (s32)(sizeof(arr) / sizeof(arr[0]))
 #define ARRAY_COUNTU(arr) (u32)(sizeof(arr) / sizeof(arr[0]))
 #define ARRAY_COUNT_2D(arr) (s32)(sizeof(arr) / sizeof(arr[0][0]))
@@ -19,72 +8,6 @@
 #define PHYSICAL_TO_VIRTUAL(addr) (void*)((uintptr_t)(addr) + 0x80000000)
 #define VIRTUAL_TO_PHYSICAL(addr) (uintptr_t)((u8*)(addr) - 0x80000000)
 
-#define ABS(x) ((x) >= 0 ? (x) : -(x))
-#define DECR(x) ((x) == 0 ? 0 : --(x))
-#define CLAMP(x, min, max) ((x) < (min) ? (min) : (x) > (max) ? (max) : (x))
-#define CLAMP_MAX(x, max) ((x) > (max) ? (max) : (x))
-#define CLAMP_MIN(x, min) ((x) < (min) ? (min) : (x))
-
-#define SWAP(type, a, b)    \
-    {                       \
-        type _temp = (a);   \
-        (a) = (b);          \
-        (b) = _temp;        \
-    }                       \
-    (void)0
-
-#define RGBA8(r, g, b, a) ((((r) & 0xFF) << 24) | (((g) & 0xFF) << 16) | (((b) & 0xFF) << 8) | (((a) & 0xFF) << 0))
-
 #define CHECK_FLAG_ALL(flags, mask) (((flags) & (mask)) == (mask))
-
-#if PLATFORM_N64 || DEBUG_FEATURES
-#define HUNGUP_AND_CRASH(file, line) Fault_AddHungupAndCrash(file, line)
-#else
-#define HUNGUP_AND_CRASH(file, line) LogUtils_HungupThread(file, line)
-#endif
-
-#define MATRIX_FINALIZE_AND_LOAD(pkt, gfxCtx, file, line) \
-    gSPMatrix(pkt, MATRIX_FINALIZE(gfxCtx, file, line), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW)
-
-#if OOT_NTSC
-#define LANGUAGE_ARRAY(jpn, eng, ger, fra) { jpn, eng }
-#else
-#define LANGUAGE_ARRAY(jpn, eng, ger, fra) { eng, ger, fra }
-#endif
-
-/**
- * `x` vertex x
- * `y` vertex y
- * `z` vertex z
- * `s` texture s coordinate
- * `t` texture t coordinate
- * `crnx` red component of color vertex, or x component of normal vertex
- * `cgny` green component of color vertex, or y component of normal vertex
- * `cbnz` blue component of color vertex, or z component of normal vertex
- * `a` alpha
- */
-#define VTX(x,y,z,s,t,crnx,cgny,cbnz,a) { { { x, y, z }, 0, { s, t }, { crnx, cgny, cbnz, a } } }
-
-#define VTX_T(x,y,z,s,t,cr,cg,cb,a) { { x, y, z }, 0, { s, t }, { cr, cg, cb, a } }
-
-#define gDPSetTileCustom(pkt, fmt, siz, uls, ult, lrs, lrt, pal,        \
-                         cms, cmt, masks, maskt, shifts, shiftt)        \
-_DW({                                                                   \
-    gDPPipeSync(pkt);                                                   \
-    gDPTileSync(pkt);                                                   \
-    gDPSetTile(pkt, fmt, siz,                                           \
-        (((((lrs) - (uls) + 1) * siz##_TILE_BYTES) + 7) >> 3), 0,       \
-        G_TX_LOADTILE, 0, cmt, maskt, shiftt, cms, masks,               \
-        shifts);                                                        \
-    gDPTileSync(pkt);                                                   \
-    gDPSetTile(pkt, fmt, siz,                                           \
-        (((((lrs) - (uls) + 1) * siz##_LINE_BYTES) + 7) >> 3), 0,       \
-        G_TX_RENDERTILE, pal, cmt, maskt, shiftt, cms, masks, shifts);  \
-    gDPSetTileSize(pkt, G_TX_RENDERTILE,                                \
-        (uls) << G_TEXTURE_IMAGE_FRAC,                                  \
-        (ult) << G_TEXTURE_IMAGE_FRAC,                                  \
-        (lrs) << G_TEXTURE_IMAGE_FRAC,                                  \
-        (lrt) << G_TEXTURE_IMAGE_FRAC);                                 \
-})
 
 #endif

--- a/include/sys_matrix.h
+++ b/include/sys_matrix.h
@@ -64,6 +64,9 @@ Mtx* Matrix_Finalize(struct GraphicsContext* gfxCtx);
 
 #endif
 
+#define MATRIX_FINALIZE_AND_LOAD(pkt, gfxCtx, file, line) \
+    gSPMatrix(pkt, MATRIX_FINALIZE(gfxCtx, file, line), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW)
+
 /* Vector operations */
 
 void Matrix_MultVec3f(Vec3f* src, Vec3f* dest);

--- a/include/z64.h
+++ b/include/z64.h
@@ -4,6 +4,7 @@
 // TODO: This file still exists ONLY to provide neccesary headers to extracted assets.
 //       After assets are modified to include the headers they need directly, delete this file.
 
+#include "gfx.h"
 #include "sequence.h"
 #include "sys_matrix.h"
 #include "ultra64.h"

--- a/include/z64animation.h
+++ b/include/z64animation.h
@@ -1,6 +1,7 @@
 #ifndef Z64_ANIMATION_H
 #define Z64_ANIMATION_H
 
+#include "avoid_ub.h"
 #include "ultra64.h"
 #include "z64dma.h"
 #include "z64math.h"

--- a/include/z64math.h
+++ b/include/z64math.h
@@ -1,7 +1,7 @@
 #ifndef Z64MATH_H
 #define Z64MATH_H
 
-#include "libc/math.h"
+#include "math.h"
 #include "ultra64.h"
 
 typedef union FloatInt {

--- a/include/z64math.h
+++ b/include/z64math.h
@@ -1,11 +1,8 @@
 #ifndef Z64MATH_H
 #define Z64MATH_H
 
+#include "libc/math.h"
 #include "ultra64.h"
-#include "math.h"
-
-#define SQ(x) ((x)*(x))
-#define VEC_SET(V,X,Y,Z) (V).x=(X);(V).y=(Y);(V).z=(Z)
 
 typedef union FloatInt {
     f32 f;
@@ -95,6 +92,27 @@ typedef VecSphGeo VecSph;
 // Pitch is 0 along the xz-plane (horizon)
 typedef VecSphGeo VecGeo;
 
+/**
+ * Macros
+ */
+
+// General number macros
+#define SQ(x) ((x)*(x))
+#define ABS(x) ((x) >= 0 ? (x) : -(x))
+#define DECR(x) ((x) == 0 ? 0 : --(x))
+#define CLAMP(x, min, max) ((x) < (min) ? (min) : (x) > (max) ? (max) : (x))
+#define CLAMP_MAX(x, max) ((x) > (max) ? (max) : (x))
+#define CLAMP_MIN(x, min) ((x) < (min) ? (min) : (x))
+
+#define SWAP(type, a, b)    \
+    {                       \
+        type _temp = (a);   \
+        (a) = (b);          \
+        (b) = _temp;        \
+    }                       \
+    (void)0
+
+// LERP macros
 #define LERP(x, y, scale) (((y) - (x)) * (scale) + (x))
 #define LERP32(x, y, scale) ((s32)(((y) - (x)) * (scale)) + (x))
 #define LERP16(x, y, scale) ((s16)(((y) - (x)) * (scale)) + (x))
@@ -110,6 +128,7 @@ typedef VecSphGeo VecGeo;
     (dst)->z = (v0)->z + (((v1)->z - (v0)->z) * t); \
 }
 
+// Floating point macros
 #define IS_ZERO(f) (fabsf(f) < 0.008f)
 
 // Casting a float to an integer, when the float value is larger than what the integer type can hold,
@@ -145,6 +164,7 @@ typedef VecSphGeo VecGeo;
 #define CAM_BINANG_TO_DEG(binang) ((f32)(binang) * (360.0001525f / 65535.0f))
 
 // Vector macros
+#define VEC_SET(V,X,Y,Z) (V).x=(X);(V).y=(Y);(V).z=(Z)
 #define SQXZ(vec) ((vec).x * (vec).x + (vec).z * (vec).z)
 #define DOTXZ(vec1, vec2) ((vec1).x * (vec2).x + (vec1).z * (vec2).z)
 #define SQXYZ(vec) ((vec).x * (vec).x + (vec).y * (vec).y + (vec).z * (vec).z)

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -1,6 +1,7 @@
 #ifndef Z64SCENE_H
 #define Z64SCENE_H
 
+#include "avoid_ub.h"
 #include "macros.h"
 #include "ultra64.h"
 #include "z64bgcheck.h"

--- a/include/z64view.h
+++ b/include/z64view.h
@@ -1,6 +1,7 @@
 #ifndef Z64VIEW_H
 #define Z64VIEW_H
 
+#include "avoid_ub.h"
 #include "macros.h"
 #include "ultra64.h"
 #include "z64math.h"

--- a/src/code/fault_gc.c
+++ b/src/code/fault_gc.c
@@ -41,13 +41,14 @@
  * DPad-Down disables sending fault pages over osSyncPrintf.
  */
 
-#pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-eu-mq-dbg:192 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192" \
+#pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-eu-mq-dbg:160 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192" \
                                "gc-us-mq:192 ique-cn:192"
 
 #include "libc64/sleep.h"
 #include "libc64/sprintf.h"
 #include "alloca.h"
 #include "controller.h"
+#include "gfx.h"
 #include "padmgr.h"
 #include "fault.h"
 #include "stack.h"

--- a/src/code/fault_gc.c
+++ b/src/code/fault_gc.c
@@ -41,8 +41,8 @@
  * DPad-Down disables sending fault pages over osSyncPrintf.
  */
 
-#pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-eu-mq-dbg:160 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192" \
-                               "gc-us-mq:192 ique-cn:192"
+#pragma increment_block_number "gc-eu:160 gc-eu-mq:160 gc-eu-mq-dbg:160 gc-jp:160 gc-jp-ce:160 gc-jp-mq:160 gc-us:160" \
+                               "gc-us-mq:160 ique-cn:160"
 
 #include "libc64/sleep.h"
 #include "libc64/sprintf.h"

--- a/src/code/fault_gc_drawer.c
+++ b/src/code/fault_gc_drawer.c
@@ -6,6 +6,8 @@
  */
 
 #include "fault.h"
+
+#include "gfx.h"
 #include "terminal.h"
 
 #include "global.h"

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -1,8 +1,10 @@
+#include "fault.h"
+
 #include "libc64/os_malloc.h"
 #include "libc64/sleep.h"
 #include "libc64/sprintf.h"
 #include "controller.h"
-#include "fault.h"
+#include "gfx.h"
 #include "padmgr.h"
 #include "segmented_address.h"
 #include "stack.h"

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -14,7 +14,7 @@
 
 #include "global.h"
 
-#pragma increment_block_number "ntsc-1.0:176 ntsc-1.1:176 ntsc-1.2:176 pal-1.0:176 pal-1.1:176"
+#pragma increment_block_number "ntsc-1.0:144 ntsc-1.1:144 ntsc-1.2:144 pal-1.0:144 pal-1.1:144"
 
 typedef struct FaultMgr {
     OSThread thread;

--- a/src/code/fault_n64.c
+++ b/src/code/fault_n64.c
@@ -1,9 +1,8 @@
-#include "fault.h"
-
 #include "libc64/os_malloc.h"
 #include "libc64/sleep.h"
 #include "libc64/sprintf.h"
 #include "controller.h"
+#include "fault.h"
 #include "gfx.h"
 #include "padmgr.h"
 #include "segmented_address.h"

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -45,7 +45,7 @@ extern struct IrqMgr gIrqMgr;
 #include "global.h"
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ique-cn:0 ntsc-1.0:35 ntsc-1.1:35 ntsc-1.2:35 pal-1.0:33 pal-1.1:33"
+                               "ique-cn:0 ntsc-1.0:34 ntsc-1.1:34 ntsc-1.2:34 pal-1.0:32 pal-1.1:32"
 
 extern u8 _buffersSegmentEnd[];
 

--- a/src/code/sys_cfb.c
+++ b/src/code/sys_cfb.c
@@ -2,6 +2,7 @@
 
 #include "libu64/debug.h"
 #include "attributes.h"
+#include "gfx.h"
 #include "line_numbers.h"
 #include "printf.h"
 #include "translation.h"

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -5,6 +5,7 @@
 #include "attributes.h"
 #include "controller.h"
 #include "db_camera.h"
+#include "gfx.h"
 #include "letterbox.h"
 #include "one_point_cutscene.h"
 #include "quake.h"

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -3661,7 +3661,7 @@ s32 Camera_KeepOn3(Camera* camera) {
 }
 
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
-                               "ique-cn:128 ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
+                               "ique-cn:128 ntsc-1.0:86 ntsc-1.1:86 ntsc-1.2:86 pal-1.0:86 pal-1.1:86"
 
 s32 Camera_KeepOn4(Camera* camera) {
     static Vec3f D_8015BD50;

--- a/src/code/z_fbdemo_circle.c
+++ b/src/code/z_fbdemo_circle.c
@@ -1,5 +1,6 @@
 #include "transition_circle.h"
 
+#include "color.h"
 #include "gfx.h"
 #include "sfx.h"
 

--- a/src/code/z_jpeg.c
+++ b/src/code/z_jpeg.c
@@ -1,11 +1,12 @@
-#include "global.h"
-#include "ultra64.h"
-#include "attributes.h"
 #include "jpeg.h"
+
+#include "attributes.h"
+#include "gfx.h"
 #include "printf.h"
 #include "sys_ucode.h"
 #include "terminal.h"
 #include "translation.h"
+#include "ultra64.h"
 
 #include "macros.h"
 

--- a/src/code/z_lights.c
+++ b/src/code/z_lights.c
@@ -1,3 +1,4 @@
+#include "avoid_ub.h"
 #include "buffers.h"
 #include "gfx.h"
 #include "gfx_setupdl.h"

--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -4,6 +4,7 @@
 #include "gfx.h"
 #include "gfx_setupdl.h"
 #include "gfxalloc.h"
+#include "language_array.h"
 #include "memory_utils.h"
 #include "message_data_static.h"
 #if PLATFORM_N64

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -3,6 +3,7 @@
 #include "flag_set.h"
 #include "gfx.h"
 #include "gfx_setupdl.h"
+#include "language_array.h"
 #include "main.h"
 #include "map.h"
 #include "printf.h"

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -2,6 +2,7 @@
 #include "libc64/qrand.h"
 #include "libu64/debug.h"
 #include "buffers.h"
+#include "color.h"
 #include "controller.h"
 #include "fault.h"
 #include "file_select_state.h"

--- a/src/code/z_scene.c
+++ b/src/code/z_scene.c
@@ -1,3 +1,4 @@
+#include "avoid_ub.h"
 #include "printf.h"
 #include "regs.h"
 #include "romfile.h"

--- a/src/code/z_skelanime.c
+++ b/src/code/z_skelanime.c
@@ -1,4 +1,5 @@
 #include "libu64/debug.h"
+#include "avoid_ub.h"
 #include "gfx.h"
 #include "printf.h"
 #include "regs.h"

--- a/src/code/z_view.c
+++ b/src/code/z_view.c
@@ -2,6 +2,7 @@
 
 #include "libc64/malloc.h"
 #include "libu64/debug.h"
+#include "avoid_ub.h"
 #include "gfx.h"
 #include "letterbox.h"
 #include "main.h"

--- a/src/code/z_vimode.c
+++ b/src/code/z_vimode.c
@@ -3,6 +3,7 @@
 #include "libu64/debug.h"
 #include "ultra64/viint.h"
 #include "controller.h"
+#include "gfx.h"
 #include "main.h"
 #include "printf.h"
 #include "regs.h"

--- a/src/n64dd/z_n64dd.c
+++ b/src/n64dd/z_n64dd.c
@@ -13,7 +13,7 @@
 #include "z64audio.h"
 #include "z64thread.h"
 
-#pragma increment_block_number "ntsc-1.0:64 ntsc-1.1:64 ntsc-1.2:64 pal-1.0:64 pal-1.1:64"
+#pragma increment_block_number "ntsc-1.0:0 ntsc-1.1:0 ntsc-1.2:0 pal-1.0:0 pal-1.1:0"
 
 typedef struct struct_801D9C30 {
     /* 0x000 */ s32 unk_000;       // disk start

--- a/src/n64dd/z_n64dd.c
+++ b/src/n64dd/z_n64dd.c
@@ -2,6 +2,7 @@
 // threads and provides functions to submit commands to them.
 #include "libc64/sleep.h"
 #include "fault.h"
+#include "gfx.h"
 #include "irqmgr.h"
 #include "line_numbers.h"
 #include "n64dd.h"

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -457,9 +457,9 @@ void EnMag_DrawImageRGBA32(Gfx** gfxP, s16 centerX, s16 centerY, u8* source, u32
         textureCount += 1;
     }
 
-    SETUP_LARGE_TEXTURE_TILE(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
-                             G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
-                             G_TX_NOLOD, G_TX_NOLOD);
+    gDPSetTileCustom(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
+                     G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                     G_TX_NOLOD);
 
     remainingSize -= textureSize;
 
@@ -480,9 +480,9 @@ void EnMag_DrawImageRGBA32(Gfx** gfxP, s16 centerX, s16 centerY, u8* source, u32
                 textureHeight = remainingSize / (s32)(width << 2);
                 remainingSize -= textureSize;
 
-                SETUP_LARGE_TEXTURE_TILE(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
-                                         G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK,
-                                         G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                gDPSetTileCustom(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
+                                 G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
+                                 G_TX_NOLOD, G_TX_NOLOD);
             }
         } else {
             remainingSize -= textureSize;

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -6,6 +6,7 @@
 
 #include "z_en_mag.h"
 
+#include "avoid_ub.h"
 #include "controller.h"
 #include "gfx.h"
 #include "gfx_setupdl.h"
@@ -456,9 +457,9 @@ void EnMag_DrawImageRGBA32(Gfx** gfxP, s16 centerX, s16 centerY, u8* source, u32
         textureCount += 1;
     }
 
-    gDPSetTileCustom(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
-                     G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
-                     G_TX_NOLOD);
+    SETUP_LARGE_TEXTURE_TILE(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
+                             G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
+                             G_TX_NOLOD, G_TX_NOLOD);
 
     remainingSize -= textureSize;
 
@@ -479,9 +480,9 @@ void EnMag_DrawImageRGBA32(Gfx** gfxP, s16 centerX, s16 centerY, u8* source, u32
                 textureHeight = remainingSize / (s32)(width << 2);
                 remainingSize -= textureSize;
 
-                gDPSetTileCustom(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
-                                 G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
-                                 G_TX_NOLOD, G_TX_NOLOD);
+                SETUP_LARGE_TEXTURE_TILE(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
+                                         G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK,
+                                         G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
             }
         } else {
             remainingSize -= textureSize;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -18,6 +18,7 @@
 
 #include "libc64/qrand.h"
 #include "libu64/debug.h"
+#include "avoid_ub.h"
 #include "controller.h"
 #include "gfx.h"
 #include "gfx_setupdl.h"

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -5,6 +5,7 @@
 #include "controller.h"
 #include "gfx.h"
 #include "gfx_setupdl.h"
+#include "language_array.h"
 #include "letterbox.h"
 #include "macros.h"
 #include "main.h"
@@ -209,9 +210,9 @@ void FileSelect_DrawImageRGBA32(GraphicsContext* gfxCtx, s16 centerX, s16 center
         textureCount++;
     }
 
-    gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
-                     G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
-                     G_TX_NOLOD);
+    SETUP_LARGE_TEXTURE_TILE(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
+                             G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
+                             G_TX_NOLOD, G_TX_NOLOD);
 
     remainingSize -= textureSize;
 
@@ -232,9 +233,9 @@ void FileSelect_DrawImageRGBA32(GraphicsContext* gfxCtx, s16 centerX, s16 center
                 textureHeight = remainingSize / (s32)(width << 2);
                 remainingSize -= textureSize;
 
-                gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
-                                 G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
-                                 G_TX_NOLOD, G_TX_NOLOD);
+                SETUP_LARGE_TEXTURE_TILE(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1,
+                                         textureHeight - 1, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+                                         G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
             }
         } else {
             remainingSize -= textureSize;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -210,9 +210,9 @@ void FileSelect_DrawImageRGBA32(GraphicsContext* gfxCtx, s16 centerX, s16 center
         textureCount++;
     }
 
-    SETUP_LARGE_TEXTURE_TILE(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
-                             G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
-                             G_TX_NOLOD, G_TX_NOLOD);
+    gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
+                     G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                     G_TX_NOLOD);
 
     remainingSize -= textureSize;
 
@@ -233,9 +233,9 @@ void FileSelect_DrawImageRGBA32(GraphicsContext* gfxCtx, s16 centerX, s16 center
                 textureHeight = remainingSize / (s32)(width << 2);
                 remainingSize -= textureSize;
 
-                SETUP_LARGE_TEXTURE_TILE(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1,
-                                         textureHeight - 1, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
-                                         G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_32b, 0, 0, width - 1, textureHeight - 1, 0,
+                                 G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
+                                 G_TX_NOLOD, G_TX_NOLOD);
             }
         } else {
             remainingSize -= textureSize;

--- a/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_nameset.c
@@ -4,6 +4,7 @@
 #include "controller.h"
 #include "gfx.h"
 #include "gfx_setupdl.h"
+#include "language_array.h"
 #include "printf.h"
 #include "regs.h"
 #include "rumble.h"

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -56,9 +56,9 @@ void KaleidoScope_DrawEquipmentImage(PlayState* play, void* source, u32 width, u
 
     vtxIndex = 80;
 
-    SETUP_LARGE_TEXTURE_TILE(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, width - 1, textureHeight - 1, 0,
-                             G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
-                             G_TX_NOLOD, G_TX_NOLOD);
+    gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, width - 1, textureHeight - 1, 0,
+                     G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                     G_TX_NOLOD);
 
     remainingSize -= textureSize;
 
@@ -79,9 +79,9 @@ void KaleidoScope_DrawEquipmentImage(PlayState* play, void* source, u32 width, u
                 textureHeight = remainingSize / (s32)(width * 2);
                 remainingSize -= textureSize;
 
-                SETUP_LARGE_TEXTURE_TILE(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, width - 1,
-                                         textureHeight - 1, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
-                                         G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, width - 1, textureHeight - 1, 0,
+                                 G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
+                                 G_TX_NOLOD, G_TX_NOLOD);
             }
         } else {
             remainingSize -= textureSize;

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -56,9 +56,9 @@ void KaleidoScope_DrawEquipmentImage(PlayState* play, void* source, u32 width, u
 
     vtxIndex = 80;
 
-    gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, width - 1, textureHeight - 1, 0,
-                     G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
-                     G_TX_NOLOD);
+    SETUP_LARGE_TEXTURE_TILE(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, width - 1, textureHeight - 1, 0,
+                             G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
+                             G_TX_NOLOD, G_TX_NOLOD);
 
     remainingSize -= textureSize;
 
@@ -79,9 +79,9 @@ void KaleidoScope_DrawEquipmentImage(PlayState* play, void* source, u32 width, u
                 textureHeight = remainingSize / (s32)(width * 2);
                 remainingSize -= textureSize;
 
-                gDPSetTileCustom(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, width - 1, textureHeight - 1, 0,
-                                 G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
-                                 G_TX_NOLOD, G_TX_NOLOD);
+                SETUP_LARGE_TEXTURE_TILE(POLY_OPA_DISP++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, width - 1,
+                                         textureHeight - 1, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+                                         G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
             }
         } else {
             remainingSize -= textureSize;

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_map.c
@@ -2,6 +2,7 @@
 
 #include "gfx.h"
 #include "gfx_setupdl.h"
+#include "language_array.h"
 #include "map.h"
 #include "printf.h"
 #include "regs.h"

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.c
@@ -4,6 +4,7 @@
 #include "gfx.h"
 #include "gfx_setupdl.h"
 #include "gfxalloc.h"
+#include "language_array.h"
 #include "map.h"
 #if PLATFORM_N64
 #include "n64dd.h"


### PR DESCRIPTION
This is a grab bag of various macros being split into other files.

I would like to bring special attention to `gDPSetTileCustom` -> `SETUP_LARGE_TEXTURE_TILE` in gfx.h.
I dont think this should be named to look like a gbi macro, as it doesnt belong there. It isnt a standard gbi-provided graphics macro, its a game-side definition.