### PR TITLE
C23 Compatibility

### DIFF
--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -125,8 +125,10 @@ void KaleidoScope_DrawPlayerWork(PlayState* play) {
                      BOOTS_EQUIP_TO_PLAYER(CUR_EQUIP_VALUE(EQUIP_TYPE_BOOTS)));
 }
 
+#ifndef AVOID_UB
 // Wrong prototype; this function is called with `play` even though it has no arguments
 void KaleidoScope_ProcessPlayerPreRender(PlayState* play);
+#endif
 
 void KaleidoScope_DrawEquipment(PlayState* play) {
     static s16 sEquipTimer = 0;
@@ -592,8 +594,12 @@ void KaleidoScope_DrawEquipment(PlayState* play) {
     }
 
     if ((pauseCtx->mainState == PAUSE_MAIN_STATE_7) && (sEquipTimer == 9)) {
+#ifndef AVOID_UB
         //! @bug: This function shouldn't take any arguments
         KaleidoScope_ProcessPlayerPreRender(play);
+#else
+        KaleidoScope_ProcessPlayerPreRender();
+#endif
     }
 
     gSPSegment(POLY_OPA_DISP++, 0x07, pauseCtx->playerSegment);

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope.h
@@ -184,7 +184,9 @@ Gfx* KaleidoScope_QuadTextureIA4(Gfx* gfx, void* texture, s16 width, s16 height,
 Gfx* KaleidoScope_QuadTextureIA8(Gfx* gfx, void* texture, s16 width, s16 height, u16 point);
 void KaleidoScope_MoveCursorToSpecialPos(struct PlayState* play, u16 specialPos);
 void KaleidoScope_DrawQuadTextureRGBA32(GraphicsContext* gfxCtx, void* texture, u16 width, u16 height, u16 point);
-void KaleidoScope_ProcessPlayerPreRender();
+#ifdef AVOID_UB
+void KaleidoScope_ProcessPlayerPreRender(void);
+#endif
 void KaleidoScope_SetupPlayerPreRender(struct PlayState* play);
 void KaleidoScope_DrawCursor(struct PlayState* play, u16 pageIndex);
 void KaleidoScope_UpdateDungeonMap(struct PlayState* play);


### PR DESCRIPTION
Allows the repo to be compiled against C23, which was made the default in GCC 15.

The only change required to make the repo buildable is due to how in C23 empty parameter lists `()` are now equivalent to `(void)`, rather than being a stand-in for "any args", this was used in kaleidoscope to work around mismatched prototypes for `KaleidoScope_ProcessPlayerPreRender`.

From https://gcc.gnu.org/gcc-15/porting_to.html
> The meaning of function declarations of the form rettype identifier (); such as char *strstr (); changed in C23.
> 
> In C17 and earlier, such function declarators specified no information about the number or types of the parameters of the function (C17 6.7.6.3), requiring users to know the correct number of arguments, with each passed argument going through default argument promotion.
> 
> In C23 such declarations mean (void) i.e. a function taking no arguments

