### PR TITLE
Fix fix_bss.py

### DIFF
--- a/tools/ido_block_numbers.py
+++ b/tools/ido_block_numbers.py
@@ -483,7 +483,7 @@ def find_compiler_command_line(
     found = 0
     for line in make_log:
         parts = line.split()
-        if "-o" in parts and str(filename) in parts:
+        if "./tools/preprocess.sh" in parts and "-o" in parts and str(filename) in parts:
             compiler_command_line = parts
             found += 1
 
@@ -551,7 +551,7 @@ def main():
     command_line = find_compiler_command_line(make_log, args.filename)
     if command_line is None:
         print(
-            f"Error: could not determine compiler command line for {filename}",
+            f"Error: could not determine compiler command line for {args.filename}",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
Since #2517 the host compiler command (now used to generate .d dependency files) also matches the heuristic used to find the compile command line, causing two commands to be found for compiling and making the fix_bss.py script fail

Note a similar issue would have prevented using the decomp-permuter's import if not for this check https://github.com/simonlindholm/decomp-permuter/blob/040ef456e02b29646c67692c6a8ca285884b8f03/import.py#L346