### PR TITLE
`AVOID_UB`: `FileSelect_LoadGame` out of bounds `gBitFlags[-1]`

### DIFF
--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -1955,7 +1955,16 @@ void FileSelect_LoadGame(GameState* thisx) {
         swordEquipValue =
             (gEquipMasks[EQUIP_TYPE_SWORD] & gSaveContext.save.info.equips.equipment) >> (EQUIP_TYPE_SWORD * 4);
         gSaveContext.save.info.equips.equipment &= gEquipNegMasks[EQUIP_TYPE_SWORD];
+#ifndef AVOID_UB
+        //! @bug swordEquipValue can be 0 (EQUIP_VALUE_SWORD_NONE) here (typically, when first starting the game).
+        //! This leads to reading gBitFlags[-1] (out of bounds).
+        // gBitFlags[-1] turns out to be 0 in matching versions so this is inconsequential.
         gSaveContext.save.info.inventory.equipment ^= OWNED_EQUIP_FLAG(EQUIP_TYPE_SWORD, swordEquipValue - 1);
+#else
+        if (swordEquipValue != EQUIP_VALUE_SWORD_NONE) {
+            gSaveContext.save.info.inventory.equipment ^= OWNED_EQUIP_FLAG(EQUIP_TYPE_SWORD, swordEquipValue - 1);
+        }
+#endif
     }
 
 #if PLATFORM_N64


### PR DESCRIPTION
Addresses some OoB UB in `FileSelect_LoadGame`

-------

More details:

[On discord](https://discord.com/channels/688807550715560050/688851317593997489/1370636721716334624)

or:

<details>

<summary>Here</summary>

```c
gSaveContext.save.info.inventory.equipment ^= OWNED_EQUIP_FLAG(EQUIP_TYPE_SWORD, swordEquipValue - 1);
```
expands to
```c
gSaveContext.save.info.inventory.equipment ^= (gBitFlags[swordEquipValue - 1] << gEquipShifts[EQUIP_TYPE_SWORD])
```
assembles to (OK gc-eu-mq-dbg)
```mips
sll     t9,a0,0x2  # a0 = swordEquipValue
lui     t0,%hi(gBitFlags)        
addu    t0,t0,t9                 
lui     t1,%hi(gEquipShifts)     
lbu     t1,%lo(gEquipShifts)(t1) 
lw      t0,%lo(gBitFlags-0x4)(t0)
lhu     t3,0x9c(v0)              
sllv    t2,t0,t1                 
xor     t4,t3,t2                 
sh      t4,0x9c(v0)              
```
so when `swordEquipValue == 0` it reads `gBitFlags[-1]`
I'm not fully sure how to explain this in C, I guess type promotion to int before the subtraction `swordEquipValue - 1`

in gc-eu-mq-dbg `gBitFlags[-1]` is `0xB9E2BC` aka `sRoomDrawHandlers[3]` which is 0
```sh
$ ./sym_info.py gBitFlags
Symbol 'gBitFlags' (VRAM: 0x80127120, VROM: 0xB9E2C0, SIZE: 0x80, build/gc-eu-mq-dbg/src/code/z_inventory.o)
$ ./sym_info.py 0x8012711C
0x8012711C is at 0xC bytes inside 'sRoomDrawHandlers' (VRAM: 0x80127110, VROM: 0xB9E2B0, SIZE: 0x10, build/gc-eu-mq-dbg/src/code/z_room.o)
$ xxd -s 0xB9E2BC -l 4 build/gc-eu-mq-dbg/oot-gc-eu-mq-dbg.z64
00b9e2bc: 0000 0000                                ....
```

and `^= 0` is a no-op



## my gcc build of gc-eu-mq-dbg

`$ mips-linux-gnu-objdump --disassemble --reloc --source build/gcc/src/overlays/gamestates/ovl_file_choose/z_file_choose.o`
```mips
            (gEquipMasks[EQUIP_TYPE_SWORD] & gSaveContext.save.info.equips.equipment) >> (EQUIP_TYPE_SWORD * 4);
    101c:       96030070        lhu     v1,112(s0)  # v1 = gSaveContext.save.info.equips.equipment
        swordEquipValue =
    1020:       3c020000        lui     v0,0x0
                        1020: R_MIPS_HI16       gEquipMasks
    1024:       94420000        lhu     v0,0(v0)
                        1024: R_MIPS_LO16       gEquipMasks
        gSaveContext.save.info.equips.equipment &= gEquipNegMasks[EQUIP_TYPE_SWORD];
    1028:       3c040000        lui     a0,0x0
                        1028: R_MIPS_HI16       gEquipNegMasks
    102c:       94840000        lhu     a0,0(a0)
                        102c: R_MIPS_LO16       gEquipNegMasks
        swordEquipValue =
    1030:       00621024        and     v0,v1,v0  # v0 = swordEquipValue
        gSaveContext.save.info.inventory.equipment ^= OWNED_EQUIP_FLAG(EQUIP_TYPE_SWORD, swordEquipValue - 1);
    1034:       2442ffff        addiu   v0,v0,-1  # swordEquipValue - 1
        gSaveContext.save.info.equips.equipment &= gEquipNegMasks[EQUIP_TYPE_SWORD];
    1038:       00641824        and     v1,v1,a0
    103c:       a6030070        sh      v1,112(s0)
        gSaveContext.save.info.inventory.equipment ^= OWNED_EQUIP_FLAG(EQUIP_TYPE_SWORD, swordEquipValue - 1);
    1040:       00021080        sll     v0,v0,0x2
    1044:       3c030000        lui     v1,0x0
                        1044: R_MIPS_HI16       gBitFlags
    1048:       24630000        addiu   v1,v1,0
                        1048: R_MIPS_LO16       gBitFlags
    104c:       00621021        addu    v0,v1,v0
    1050:       8c420000        lw      v0,0(v0)
    1054:       3c030000        lui     v1,0x0
                        1054: R_MIPS_HI16       gEquipShifts
    1058:       90630000        lbu     v1,0(v1)
                        1058: R_MIPS_LO16       gEquipShifts
        gSaveContext.save.info.equips.buttonItems[0] = ITEM_NONE;
    105c:       a2110068        sb      s1,104(s0)
        gSaveContext.save.info.inventory.equipment ^= OWNED_EQUIP_FLAG(EQUIP_TYPE_SWORD, swordEquipValue - 1);
    1060:       00621004        sllv    v0,v0,v1
    1064:       9603009c        lhu     v1,156(s0)
    1068:       00431026        xor     v0,v0,v1
    106c:       a602009c        sh      v0,156(s0)
```

for `swordEquipValue == 0` it also reads `gBitFlags[-1]` (thankfully)

`build/gcc/oot-gc-eu-mq-dbg.map`:
```
                0x800fcba4                gEquipMasks
                0x800fcbac                gBitFlags
```

```c
u16 gEquipMasks[EQUIP_TYPE_MAX] = {
    0xF << (EQUIP_TYPE_SWORD * 4),  // EQUIP_TYPE_SWORD
    0xF << (EQUIP_TYPE_SHIELD * 4), // EQUIP_TYPE_SHIELD
    0xF << (EQUIP_TYPE_TUNIC * 4),  // EQUIP_TYPE_TUNIC
    0xF << (EQUIP_TYPE_BOOTS * 4),  // EQUIP_TYPE_BOOTS
};
```

`gBitFlags[-1]` is `gEquipMasks[2] , gEquipMasks[3]` aka `0x0F00_F000`

`gSaveContext.save.info.inventory.equipment` is a u16, the `^=` result only considers the lower half `0xF000` which corresponds to boot equips (0x1000 = kokiri (`(1 << EQUIP_INV_BOOTS_KOKIRI) << (EQUIP_TYPE_BOOTS * 4)`), 0x2000 = iron (`(1 << EQUIP_INV_BOOTS_IRON) << (EQUIP_TYPE_BOOTS * 4)`), 0x4000 = hover (`(1 << EQUIP_INV_BOOTS_HOVER) << (EQUIP_TYPE_BOOTS * 4)`) and unused 0x8000)

so with the `^=` that removes kokiri boots that had the bit set, and gives iron/hover that had the bit cleared

![image](https://github.com/user-attachments/assets/db9595f6-5638-4265-81d5-bba43a90ad07)

</details>