### PR TITLE
Assets system utilities

### DIFF
--- a/tools/assets/extract/extase_oot64/dlist_resources.py
+++ b/tools/assets/extract/extase_oot64/dlist_resources.py
@@ -143,6 +143,12 @@ class VtxArrayResource(CDataResource):
         self.cdata_ext = CDataExt_Array(self.element_cdata_ext, num)
         super().__init__(file, range_start, name)
 
+    def get_as_xml(self):
+        return f"""\
+        <Array Name="{self.symbol_name}" Count="{(self.range_end - self.range_start) // self.element_cdata_ext.size}" Offset="0x{self.range_start:X}">
+            <Vtx/>
+        </Array>"""
+
     def get_c_declaration_base(self):
         if hasattr(self, "HACK_IS_STATIC_ON"):
             return f"Vtx {self.symbol_name}[{self.cdata_ext.length}]"


### PR DESCRIPTION
This adds "settings" that can come in handy when working with extracted assets
Those settings come in the form of `CONSTANTS` in the source code:

- `DUMP_REPORTERS_IN_SOURCE`: if `True`, the source .c will indicate which resources led to finding other resources. For example:
  ```c
  //R: object_daiku_DL_007740 object_daiku_DL_007268
  u64 object_daiku_Tex_0029A0[] = {
  #include "assets/objects/object_daiku/object_daiku_Tex_0029A0.ci8.tlut_object_daiku_TLUT_001AC0.inc.c"
  };
  ```
  means `object_daiku_Tex_0029A0` is referenced by `object_daiku_DL_007740` and `object_daiku_DL_007268`.
- `DUMP_XML_IN_SOURCE`: if `True`, the source .c will have xml corresponding to the resource. Currently only implemented for `Vtx[]` resources (which is handy since those are typically missing from our xmls)
- `DONT_MERGE_RESOURCE_BUFFERS_FROM_DIFFERENT_USERS`: if `True`, avoid making a contiguous `Vtx[]` array in case different dlists access successive parts.
  For example if `foo_DL` and `bar_DL` are two dlists, accessing respectively `[0x100;0x200)` and `[0x200;0x300)` of vertices, then the resulting extracted vertices will be either a single contiguous array covering `[0x100-0x300)` "foo_bar_vtx" (setting == `False`) or two separate arrays covering `[0x100;0x200)` "foo_vtx" and `[0x200;0x300)` "bar_vtx" (setting == `True`)