### PR TITLE
Force skybox split palettes to always contain 128 colors

### DIFF
--- a/tools/assets/build_from_png/build_from_png.c
+++ b/tools/assets/build_from_png/build_from_png.c
@@ -462,15 +462,23 @@ static bool handle_ci_shared_tlut(const char* png_p, const struct fmt_info* fmt,
         assert(tlut_elem_size == 8 || tlut_elem_size == 4);
         sprintf(pal_inc_c_p, "%s/%s.tlut.rgba16%s.inc.c", out_dir_p, tlut_name, tlut_elem_size == 8 ? "" : ".u32");
 
-        const unsigned int max_colors = fmt->siz == G_IM_SIZ_4b                                  ? 16
-                                        : subfmt == SUBFMT_SPLIT_LO || subfmt == SUBFMT_SPLIT_HI ? 128
-                                                                                                 : 256;
+        const bool is_split_palette = subfmt == SUBFMT_SPLIT_LO || subfmt == SUBFMT_SPLIT_HI;
+        const unsigned int max_colors = fmt->siz == G_IM_SIZ_4b ? 16
+                                             : is_split_palette ? 128
+                                                                : 256;
 
         if (all_other_pngs_match_ref_img_pal && ref_img->pal->count <= max_colors) {
             // write matching palette, and matching color indices for all pngs
 #ifdef VERBOSE
             fprintf(stderr, "Matching data detected!\n");
 #endif
+
+            if (is_split_palette && ref_img->pal->count < max_colors) {
+                // split palettes must be exactly 128 colors, resize to full size
+                void *old_pal = ref_img->pal;
+                ref_img->pal = n64texconv_palette_resize(ref_img->pal, max_colors);
+                free(old_pal);
+            }
 
             // pass pad_to_8b=true to account for the case where this is in fact not matching data
             // (the png was silently palettized by n64texconv)
@@ -535,6 +543,13 @@ static bool handle_ci_shared_tlut(const char* png_p, const struct fmt_info* fmt,
                                                  num_images, max_colors, dither_level) == 0;
             if (!success) {
                 fprintf(stderr, "Could not co-palettize images\n");
+            }
+
+            if (is_split_palette) {
+                for (size_t i = out_pal_count; i < max_colors; i++) {
+                    out_pal[i] = (struct color){ .w = 0 };
+                }
+                out_pal_count = max_colors;
             }
 
             // write palette to .inc.c

--- a/tools/assets/n64texconv/__init__.py
+++ b/tools/assets/n64texconv/__init__.py
@@ -245,6 +245,13 @@ class N64Palette(Structure):
         _object_refcount.add_ref(pal)
         return deref(pal)
 
+    def resize(self, new_count : int) -> Optional["N64Palette"]:
+        pal = ln64texconv.n64texconv_palette_resize(byref(self), new_count)
+        if new_count > 256:
+            raise ValueError("The largest possible palette size is 256")
+        _object_refcount.add_ref(pal)
+        return deref(pal)
+
     @staticmethod
     def from_png(path : str, fmt : int) -> Optional["N64Palette"]:
         if fmt not in (G_IM_FMT_RGBA, G_IM_FMT_IA):
@@ -305,6 +312,10 @@ ln64texconv.n64texconv_palette_copy.restype = POINTER(N64Palette)
 # struct n64_palette *n64texconv_palette_reformat(struct n64_palette *pal, int fmt);
 ln64texconv.n64texconv_palette_reformat.argtypes = [POINTER(N64Palette), c_int]
 ln64texconv.n64texconv_palette_reformat.restype = POINTER(N64Palette)
+
+# struct n64_palette *n64texconv_palette_resize(struct n64_palette *pal, size_t new_count);
+ln64texconv.n64texconv_palette_resize.argtypes = [POINTER(N64Palette), c_size_t]
+ln64texconv.n64texconv_palette_resize.restype = POINTER(N64Palette)
 
 # struct n64_palette *n64texconv_palette_from_png(const char *path, int fmt);
 ln64texconv.n64texconv_palette_from_png.argtypes = [c_char_p, c_int]

--- a/tools/assets/n64texconv/src/libn64texconv/n64texconv.c
+++ b/tools/assets/n64texconv/src/libn64texconv/n64texconv.c
@@ -591,6 +591,24 @@ n64texconv_palette_reformat(struct n64_palette *pal, int fmt)
 }
 
 struct n64_palette *
+n64texconv_palette_resize(struct n64_palette *pal, size_t new_count)
+{
+    assert(pal != NULL);
+
+    struct n64_palette *new_pal = n64texconv_palette_new(new_count, pal->fmt);
+
+    size_t min_count = (new_count < pal->count) ? new_count : pal->count;
+
+    size_t i;
+    for (i = 0; i < min_count; i++)
+        new_pal->texels[i] = pal->texels[i];
+    for (i = min_count; i < new_count; i++)
+        new_pal->texels[i] = (struct color){ .w = 0 };
+
+    return new_pal;
+}
+
+struct n64_palette *
 n64texconv_palette_from_png(const char *path, int fmt)
 {
     assert(path != NULL);

--- a/tools/assets/n64texconv/src/libn64texconv/n64texconv.h
+++ b/tools/assets/n64texconv/src/libn64texconv/n64texconv.h
@@ -56,6 +56,9 @@ struct n64_palette *
 n64texconv_palette_reformat(struct n64_palette *pal, int fmt);
 
 struct n64_palette *
+n64texconv_palette_resize(struct n64_palette *pal, size_t new_count);
+
+struct n64_palette *
 n64texconv_palette_from_png(const char *path, int fmt);
 
 struct n64_palette *


### PR DESCRIPTION
`Skybox_Setup` concatenates the palettes rather than leaving a gap if the palette file is too small, but `gDPLoadTLUT_pal256` expects the second palette to start 256 bytes after the first for correct indexing. For them to agree it's necessary to insert explicit padding to 128 colors during conversion.

