### PR TITLE
[assets] Fix too long filenames for windows/wsl

### DIFF
--- a/tools/assets/extract/extase_oot64/dlist_resources.py
+++ b/tools/assets/extract/extase_oot64/dlist_resources.py
@@ -43,6 +43,7 @@ VERBOSE_ColorIndexedTexturesManager = False
 VERBOSE_BEST_EFFORT_TLUT_NO_REAL_USER = True
 
 EXPLICIT_DL_AND_TEX_SIZES = True
+TEXS_SHORTER_NAMES = True
 
 
 class MtxResource(CDataResource):
@@ -1159,7 +1160,7 @@ class ColorIndexedTexturesManager:
                     lambda file, offset: TextureResource(
                         file,
                         offset,
-                        f"{reporter.name}_{offset:08X}_CITex",
+                        f"{file.name if TEXS_SHORTER_NAMES else reporter.name}_{offset:08X}_CITex",
                         tex.fmt,
                         tex.siz,
                         tex.width,
@@ -1181,7 +1182,7 @@ class ColorIndexedTexturesManager:
                     lambda file, offset: TLUTResource(
                         file,
                         offset,
-                        f"{reporter.name}_{offset:08X}_TLUT",
+                        f"{file.name if TEXS_SHORTER_NAMES else reporter.name}_{offset:08X}_TLUT",
                         {
                             G_TT.RGBA16: G_IM_FMT.RGBA,
                             G_TT.IA16: G_IM_FMT.IA,
@@ -1249,7 +1250,7 @@ class DListResource(Resource, can_size_be_unknown=True):
                     lambda file, offset: TextureResource(
                         file,
                         offset,
-                        f"{self.name}_{offset:08X}_Tex",
+                        f"{file.name if TEXS_SHORTER_NAMES else self.name}_{offset:08X}_Tex",
                         g_fmt,
                         g_siz,
                         width,


### PR DESCRIPTION
Some filenames, more specifically scene CI textures, can get too long for windows/wsl (?) to handle. In practice this breaks the fast64 blender addon for importing maps.
This PR "fixes" the issue by making the texture names be just `filename_offset_Tex` instead of `usuallyVeryLongReportingResourceName_offset_Tex`