### PR TITLE
Remove `Static` from xmls

### DIFF
--- a/assets/xml/objects/object_link_boy.xml
+++ b/assets/xml/objects/object_link_boy.xml
@@ -556,17 +556,17 @@
         <Texture Name="gLinkAdultUnusedSwordGuardTex" Format="ci8" Width="32" Height="32" Offset="0x8E80" TlutOffset="5E00"/>
         <Texture Name="gLinkAdultUnusedSwordEmblemTex" Format="ci8" Width="16" Height="16" Offset="0x9280" TlutOffset="0x5E00"/>
 
-        <Array Name="gLinkAdultVtx_02E120" Count="38" Offset="0x2E120" Static="On">
+        <Array Name="gLinkAdultVtx_02E120" Count="38" Offset="0x2E120">
             <Vtx/>
         </Array>
 
-        <Array Name="gLinkAdultVtx_033760" Count="54" Offset="0x33760" Static="On">
+        <Array Name="gLinkAdultVtx_033760" Count="54" Offset="0x33760">
             <Vtx/>
         </Array>
-        <Array Name="gLinkAdultVtx_0340A0" Count="146" Offset="0x340A0" Static="On">
+        <Array Name="gLinkAdultVtx_0340A0" Count="146" Offset="0x340A0">
             <Vtx/>
         </Array>
-        <Array Name="gLinkAdultVtx_02E7E0" Count="114" Offset="0x2E7E0" Static="On">
+        <Array Name="gLinkAdultVtx_02E7E0" Count="114" Offset="0x2E7E0">
             <Vtx/>
         </Array>
 

--- a/assets/xml/objects/object_link_child.xml
+++ b/assets/xml/objects/object_link_child.xml
@@ -450,27 +450,27 @@
         <Texture Name="gLinkChildMouthSmileTex" Format="ci8" Width="32" Height="32" Offset="0x4C00" TlutOffset="0x5500"/>
 
         <!--Unused Vtx-->
-        <Array Name="gLinkChildVtx_019E08" Count="35" Offset="0x19E08" Static="On">
+        <Array Name="gLinkChildVtx_019E08" Count="35" Offset="0x19E08">
             <Vtx/>
         </Array>
 
-        <Array Name="gLinkChildVtx_01A428" Count="39" Offset="0x1A428" Static="On">
+        <Array Name="gLinkChildVtx_01A428" Count="39" Offset="0x1A428">
             <Vtx/>
         </Array>
 
-        <Array Name="gLinkChildVtx_01AA98" Count="40" Offset="0x1AA98" Static="On">
+        <Array Name="gLinkChildVtx_01AA98" Count="40" Offset="0x1AA98">
             <Vtx/>
         </Array>
 
-        <Array Name="gLinkChildVtx_01EB38" Count="39" Offset="0x1EB38" Static="On">
+        <Array Name="gLinkChildVtx_01EB38" Count="39" Offset="0x1EB38">
             <Vtx/>
         </Array>
 
-        <Array Name="gLinkChildVtx_01F2B8" Count="39" Offset="0x1F2B8" Static="On">
+        <Array Name="gLinkChildVtx_01F2B8" Count="39" Offset="0x1F2B8">
             <Vtx/>
         </Array>
 
-        <Array Name="gLinkChildVtx_01FA28" Count="62" Offset="0x1FA28" Static="On">
+        <Array Name="gLinkChildVtx_01FA28" Count="62" Offset="0x1FA28">
             <Vtx/>
         </Array>
     </File>

--- a/assets/xml/overlays/ovl_Arrow_Fire.xml
+++ b/assets/xml/overlays/ovl_Arrow_Fire.xml
@@ -1,11 +1,11 @@
 <Root>
     <File Name="ovl_Arrow_Fire">
-        <Texture Name="s1Tex" Format="i8" Width="32" Height="64" Offset="0x0" Static="On"/>
-        <Texture Name="s2Tex" Format="i8" Width="32" Height="64" Offset="0x800" Static="On"/>
-        <Array Name="sVtx" Count="43" Offset="0x1000" Static="On">
+        <Texture Name="s1Tex" Format="i8" Width="32" Height="64" Offset="0x0"/>
+        <Texture Name="s2Tex" Format="i8" Width="32" Height="64" Offset="0x800"/>
+        <Array Name="sVtx" Count="43" Offset="0x1000">
             <Vtx/>
         </Array>
-        <DList Name="sMaterialDL" Offset="0x12B0" Static="On"/>
-        <DList Name="sModelDL" Offset="0x1360" Static="On"/>
+        <DList Name="sMaterialDL" Offset="0x12B0"/>
+        <DList Name="sModelDL" Offset="0x1360"/>
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Arrow_Ice.xml
+++ b/assets/xml/overlays/ovl_Arrow_Ice.xml
@@ -1,11 +1,11 @@
 <Root>
     <File Name="ovl_Arrow_Ice">
-        <Texture Name="s1Tex" Format="i8" Width="32" Height="64" Offset="0x0" Static="On"/>
-        <Texture Name="s2Tex" Format="i8" Width="32" Height="64" Offset="0x800" Static="On"/>
-        <Array Name="sVtx" Count="43" Offset="0x1000" Static="On">
+        <Texture Name="s1Tex" Format="i8" Width="32" Height="64" Offset="0x0"/>
+        <Texture Name="s2Tex" Format="i8" Width="32" Height="64" Offset="0x800"/>
+        <Array Name="sVtx" Count="43" Offset="0x1000">
             <Vtx/>
         </Array>
-        <DList Name="sMaterialDL" Offset="0x12B0" Static="On"/>
-        <DList Name="sModelDL" Offset="0x1360" Static="On"/>
+        <DList Name="sMaterialDL" Offset="0x12B0"/>
+        <DList Name="sModelDL" Offset="0x1360"/>
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Arrow_Light.xml
+++ b/assets/xml/overlays/ovl_Arrow_Light.xml
@@ -1,11 +1,11 @@
 <Root>
     <File Name="ovl_Arrow_Light">
-        <Texture Name="s1Tex" Format="i8" Width="32" Height="64" Offset="0x0" Static="On"/>
-        <Texture Name="s2Tex" Format="i8" Width="32" Height="64" Offset="0x800" Static="On"/>
-        <Array Name="sVtx" Count="43" Offset="0x1000" Static="On">
+        <Texture Name="s1Tex" Format="i8" Width="32" Height="64" Offset="0x0"/>
+        <Texture Name="s2Tex" Format="i8" Width="32" Height="64" Offset="0x800"/>
+        <Array Name="sVtx" Count="43" Offset="0x1000">
             <Vtx/>
         </Array>
-        <DList Name="sMaterialDL" Offset="0x12B0" Static="On"/>
-        <DList Name="sModelDL" Offset="0x1360" Static="On"/>
+        <DList Name="sMaterialDL" Offset="0x12B0"/>
+        <DList Name="sModelDL" Offset="0x1360"/>
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Boss_Ganon.xml
+++ b/assets/xml/overlays/ovl_Boss_Ganon.xml
@@ -1,20 +1,20 @@
 <Root>
     <ExternalFile OutPath="assets/objects/gameplay_keep"/>
     <File Name="ovl_Boss_Ganon">
-        <Texture Name="gGanondorfLightning1Tex" Format="i8" Width="32" Height="96" Offset="0x2F48" Static="Off"/>
-        <Texture Name="gGanondorfLightning2Tex" Format="i8" Width="32" Height="96" Offset="0x3B48" Static="Off"/>
-        <Texture Name="gGanondorfLightning3Tex" Format="i8" Width="32" Height="96" Offset="0x4748" Static="Off"/>
-        <Texture Name="gGanondorfLightning4Tex" Format="i8" Width="32" Height="96" Offset="0x5348" Static="Off"/>
-        <Texture Name="gGanondorfLightning5Tex" Format="i8" Width="32" Height="96" Offset="0x5F48" Static="Off"/>
-        <Texture Name="gGanondorfLightning6Tex" Format="i8" Width="32" Height="96" Offset="0x6B48" Static="Off"/>
-        <Texture Name="gGanondorfLightning7Tex" Format="i8" Width="32" Height="96" Offset="0x7748" Static="Off"/>
-        <Texture Name="gGanondorfLightning8Tex" Format="i8" Width="32" Height="96" Offset="0x8348" Static="Off"/>
-        <Texture Name="gGanondorfLightning9Tex" Format="i8" Width="32" Height="96" Offset="0x8F48" Static="Off"/>
-        <Texture Name="gGanondorfLightning10Tex" Format="i8" Width="32" Height="96" Offset="0x9B48" Static="Off"/>
-        <Texture Name="gGanondorfLightning11Tex" Format="i8" Width="32" Height="96" Offset="0xA748" Static="Off"/>
-        <Texture Name="gGanondorfLightning12Tex" Format="i8" Width="32" Height="96" Offset="0xB348" Static="Off"/>
+        <Texture Name="gGanondorfLightning1Tex" Format="i8" Width="32" Height="96" Offset="0x2F48"/>
+        <Texture Name="gGanondorfLightning2Tex" Format="i8" Width="32" Height="96" Offset="0x3B48"/>
+        <Texture Name="gGanondorfLightning3Tex" Format="i8" Width="32" Height="96" Offset="0x4748"/>
+        <Texture Name="gGanondorfLightning4Tex" Format="i8" Width="32" Height="96" Offset="0x5348"/>
+        <Texture Name="gGanondorfLightning5Tex" Format="i8" Width="32" Height="96" Offset="0x5F48"/>
+        <Texture Name="gGanondorfLightning6Tex" Format="i8" Width="32" Height="96" Offset="0x6B48"/>
+        <Texture Name="gGanondorfLightning7Tex" Format="i8" Width="32" Height="96" Offset="0x7748"/>
+        <Texture Name="gGanondorfLightning8Tex" Format="i8" Width="32" Height="96" Offset="0x8348"/>
+        <Texture Name="gGanondorfLightning9Tex" Format="i8" Width="32" Height="96" Offset="0x8F48"/>
+        <Texture Name="gGanondorfLightning10Tex" Format="i8" Width="32" Height="96" Offset="0x9B48"/>
+        <Texture Name="gGanondorfLightning11Tex" Format="i8" Width="32" Height="96" Offset="0xA748"/>
+        <Texture Name="gGanondorfLightning12Tex" Format="i8" Width="32" Height="96" Offset="0xB348"/>
 
-        <Texture Name="gGanondorfWindowShatterTemplateTex" Format="i8" Width="32" Height="64" Offset="0x1680" Static="Off"/>
+        <Texture Name="gGanondorfWindowShatterTemplateTex" Format="i8" Width="32" Height="64" Offset="0x1680"/>
 
         <Array Name="gGanondorfLightStreak1Vtx" Count="10" Offset="0x10ED8">
             <Vtx/>
@@ -52,50 +52,50 @@
         <Array Name="gGanondorfLightStreak12Vtx" Count="8" Offset="0x115B8">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfLightStreak1DL" Offset="0x11638" Static="Off"/>
-        <DList Name="gGanondorfLightStreak2DL" Offset="0x11670" Static="Off"/>
-        <DList Name="gGanondorfLightStreak3DL" Offset="0x116A8" Static="Off"/>
-        <DList Name="gGanondorfLightStreak4DL" Offset="0x116E0" Static="Off"/>
-        <DList Name="gGanondorfLightStreak5DL" Offset="0x11718" Static="Off"/>
-        <DList Name="gGanondorfLightStreak6DL" Offset="0x11750" Static="Off"/>
-        <DList Name="gGanondorfLightStreak7DL" Offset="0x11788" Static="Off"/>
-        <DList Name="gGanondorfLightStreak8DL" Offset="0x117C0" Static="Off"/>
-        <DList Name="gGanondorfLightStreak9DL" Offset="0x117F8" Static="Off"/>
-        <DList Name="gGanondorfLightStreak10DL" Offset="0x11830" Static="Off"/>
-        <DList Name="gGanondorfLightStreak11DL" Offset="0x11868" Static="Off"/>
-        <DList Name="gGanondorfLightStreak12DL" Offset="0x118A0" Static="Off"/>
+        <DList Name="gGanondorfLightStreak1DL" Offset="0x11638"/>
+        <DList Name="gGanondorfLightStreak2DL" Offset="0x11670"/>
+        <DList Name="gGanondorfLightStreak3DL" Offset="0x116A8"/>
+        <DList Name="gGanondorfLightStreak4DL" Offset="0x116E0"/>
+        <DList Name="gGanondorfLightStreak5DL" Offset="0x11718"/>
+        <DList Name="gGanondorfLightStreak6DL" Offset="0x11750"/>
+        <DList Name="gGanondorfLightStreak7DL" Offset="0x11788"/>
+        <DList Name="gGanondorfLightStreak8DL" Offset="0x117C0"/>
+        <DList Name="gGanondorfLightStreak9DL" Offset="0x117F8"/>
+        <DList Name="gGanondorfLightStreak10DL" Offset="0x11830"/>
+        <DList Name="gGanondorfLightStreak11DL" Offset="0x11868"/>
+        <DList Name="gGanondorfLightStreak12DL" Offset="0x118A0"/>
 
         <Array Name="gGanondorfShadowModelVtx" Count="4" Offset="0x0">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfShadowSetupDL" Offset="0x40" Static="Off"/>
-        <DList Name="gGanondorfShadowModelDL" Offset="0x60" Static="Off"/>
+        <DList Name="gGanondorfShadowSetupDL" Offset="0x40"/>
+        <DList Name="gGanondorfShadowModelDL" Offset="0x60"/>
         <Array Name="gGanondorfTriforceVtx" Count="4" Offset="0x1090">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfTriforceDL" Offset="0x10D0" Static="Off"/>
+        <DList Name="gGanondorfTriforceDL" Offset="0x10D0"/>
         <Array Name="gGanondorfWindowShardModelVtx" Count="3" Offset="0x1590">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfWindowShardMaterialDL" Offset="0x15C0" Static="Off"/>
-        <DList Name="gGanondorfWindowShardModelDL" Offset="0x1668" Static="Off"/>
+        <DList Name="gGanondorfWindowShardMaterialDL" Offset="0x15C0"/>
+        <DList Name="gGanondorfWindowShardModelDL" Offset="0x1668"/>
         <Array Name="gGanondorfSquareVtx" Count="4" Offset="0x2E80">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfLightBallMaterialDL" Offset="0x2EC0" Static="Off"/>
-        <DList Name="gGanondorfSquareDL" Offset="0x2F30" Static="Off"/>
+        <DList Name="gGanondorfLightBallMaterialDL" Offset="0x2EC0"/>
+        <DList Name="gGanondorfSquareDL" Offset="0x2F30"/>
         <Array Name="gGanondorfLightningVtx" Count="4" Offset="0xBF48">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfLightningDL" Offset="0xBF88" Static="Off"/>
+        <DList Name="gGanondorfLightningDL" Offset="0xBF88"/>
         <Array Name="gGanondorfUnusedVtx" Count="3" Offset="0xC008">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfUnusedDL" Offset="0xC038" Static="Off"/>
+        <DList Name="gGanondorfUnusedDL" Offset="0xC038"/>
         <Array Name="gGanondorfLightRayTriVtx" Count="3" Offset="0xC080">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfLightRayTriDL" Offset="0xC0B0" Static="Off"/>
+        <DList Name="gGanondorfLightRayTriDL" Offset="0xC0B0"/>
         <Array Name="gGanondorfLightFlecksVtx" Count="25" Offset="0xD8F8">
             <Vtx/>
         </Array>
@@ -105,33 +105,33 @@
         <Array Name="gGanondorfDotVtx" Count="4" Offset="0xDAC8">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfLightFlecksDL" Offset="0xDB08" Static="Off"/>
-        <DList Name="gGanondorfBigMagicBGCircleDL" Offset="0xDBF8" Static="Off"/>
-        <DList Name="gGanondorfDotDL" Offset="0xDCA0" Static="Off"/>
+        <DList Name="gGanondorfLightFlecksDL" Offset="0xDB08"/>
+        <DList Name="gGanondorfBigMagicBGCircleDL" Offset="0xDBF8"/>
+        <DList Name="gGanondorfDotDL" Offset="0xDCA0"/>
         <Array Name="gGanondorfShockwaveVtx" Count="26" Offset="0xE568">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfShockwaveDL" Offset="0xE708" Static="Off"/>
+        <DList Name="gGanondorfShockwaveDL" Offset="0xE708"/>
         <Array Name="gGanondorfImpactVtx" Count="26" Offset="0xF400">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfImpactDarkDL" Offset="0xF5A0" Static="Off"/>
-        <DList Name="gGanondorfImpactLightDL" Offset="0xF6B8" Static="Off"/>
+        <DList Name="gGanondorfImpactDarkDL" Offset="0xF5A0"/>
+        <DList Name="gGanondorfImpactLightDL" Offset="0xF6B8"/>
         <Array Name="gGanondorfShockGlowVtx" Count="4" Offset="0x107D0">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfShockGlowDL" Offset="0x10810" Static="Off"/>
+        <DList Name="gGanondorfShockGlowDL" Offset="0x10810"/>
         <Array Name="gGanondorfLightCoreVtx" Count="3" Offset="0x11B40">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfLightCoreDL" Offset="0x11B70" Static="Off"/>
+        <DList Name="gGanondorfLightCoreDL" Offset="0x11B70"/>
         <Array Name="gGanondorfShockVtx" Count="4" Offset="0x11BF8">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfShockDL" Offset="0x11C38" Static="Off"/>
+        <DList Name="gGanondorfShockDL" Offset="0x11C38"/>
         <Array Name="gGanondorfVortexVtx" Count="22" Offset="0x128B8">
             <Vtx/>
         </Array>
-        <DList Name="gGanondorfVortexDL" Offset="0x12A18" Static="Off"/>
+        <DList Name="gGanondorfVortexDL" Offset="0x12A18"/>
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Boss_Ganon2.xml
+++ b/assets/xml/overlays/ovl_Boss_Ganon2.xml
@@ -1,53 +1,53 @@
 <Root>
     <ExternalFile OutPath="assets/objects/gameplay_keep"/>
     <File Name="ovl_Boss_Ganon2">
-        <Texture Name="gGanonLightOrbTex" Format="i8" Width="64" Height="64" Offset="0x0" Static="Off"/>
+        <Texture Name="gGanonLightOrbTex" Format="i8" Width="64" Height="64" Offset="0x0"/>
         <Array Name="gGanonLightOrbModelVtx" Count="4" Offset="0x1000">
             <Vtx/>
         </Array>
-        <DList Name="gGanonLightOrbMaterialDL" Offset="0x1040" Static="Off"/>
-        <DList Name="gGanonLightOrbModelDL" Offset="0x10B0" Static="Off"/>
+        <DList Name="gGanonLightOrbMaterialDL" Offset="0x1040"/>
+        <DList Name="gGanonLightOrbModelDL" Offset="0x10B0"/>
         <Array Name="gGanonShadowModelVtx" Count="4" Offset="0x10C8">
             <Vtx/>
         </Array>
-        <DList Name="gGanonShadowMaterialDL" Offset="0x1108" Static="Off"/>
-        <DList Name="gGanonShadowModelDL" Offset="0x1128" Static="Off"/>
-        <Texture Name="gGanonSwordTrailTex" Format="i8" Width="32" Height="32" Offset="0x1158" Static="Off"/>
-        <Texture Name="gGanonSwordTrailMaskTex" Format="i4" Width="32" Height="32" Offset="0x1558" Static="Off"/>
-        <Array Name="gGanonSwordTrailVtx" Count="22" Offset="0x1758" Static="Off">
+        <DList Name="gGanonShadowMaterialDL" Offset="0x1108"/>
+        <DList Name="gGanonShadowModelDL" Offset="0x1128"/>
+        <Texture Name="gGanonSwordTrailTex" Format="i8" Width="32" Height="32" Offset="0x1158"/>
+        <Texture Name="gGanonSwordTrailMaskTex" Format="i4" Width="32" Height="32" Offset="0x1558"/>
+        <Array Name="gGanonSwordTrailVtx" Count="22" Offset="0x1758">
             <Vtx/>
         </Array>
-        <DList Name="gGanonSwordTrailDL" Offset="0x18B8" Static="Off"/>
-        <Texture Name="gGanonTriforceTex" Format="i8" Width="64" Height="64" Offset="0x19D0" Static="Off"/>
+        <DList Name="gGanonSwordTrailDL" Offset="0x18B8"/>
+        <Texture Name="gGanonTriforceTex" Format="i8" Width="64" Height="64" Offset="0x19D0"/>
         <Array Name="gGanonTriforceVtx" Count="4" Offset="0x29D0">
             <Vtx/>
         </Array>
-        <DList Name="gGanonTriforceDL" Offset="0x2A10" Static="Off"/>
-        <Texture Name="gGanonLightningTex" Format="i4" Width="32" Height="160" Offset="0x2A90" Static="Off"/>
+        <DList Name="gGanonTriforceDL" Offset="0x2A10"/>
+        <Texture Name="gGanonLightningTex" Format="i4" Width="32" Height="160" Offset="0x2A90"/>
         <Array Name="gGanonLightningVtx" Count="4" Offset="0x3490">
             <Vtx/>
         </Array>
-        <DList Name="gGanonLightningDL" Offset="0x34D0" Static="Off"/> <!-- Original name might be "efc_fg2_thunder1_modelT" -->
-        <Texture Name="gGanonFireRingTex" Format="i8" Width="32" Height="64" Offset="0x3558" Static="Off"/>
+        <DList Name="gGanonLightningDL" Offset="0x34D0"/> <!-- Original name might be "efc_fg2_thunder1_modelT" -->
+        <Texture Name="gGanonFireRingTex" Format="i8" Width="32" Height="64" Offset="0x3558"/>
         <Array Name="gGanonFireRingVtx" Count="26" Offset="0x3D58">
             <Vtx/>
         </Array>
-        <DList Name="gGanonFireRingDL" Offset="0x3EF8" Static="Off"/> <!-- Original name is "ganon_fire_modelT" -->
-        <Texture Name="gGanonZeldaMagicTex" Format="i8" Width="32" Height="64" Offset="0x4018" Static="Off"/>
+        <DList Name="gGanonFireRingDL" Offset="0x3EF8"/> <!-- Original name is "ganon_fire_modelT" -->
+        <Texture Name="gGanonZeldaMagicTex" Format="i8" Width="32" Height="64" Offset="0x4018"/>
         <Array Name="gGanonZeldaMagicVtx" Count="22" Offset="0x4818">
             <Vtx/>
         </Array>
-        <DList Name="gGanonZeldaMagicDL" Offset="0x4978" Static="Off"/> <!-- Original name is "efc_ganon2_hadou_modelT" ("wave motion; undulation; surge​") -->
-        <Texture Name="gGanonMasterSwordShadowTex" Format="i8" Width="32" Height="32" Offset="0x4A80" Static="Off"/>
+        <DList Name="gGanonZeldaMagicDL" Offset="0x4978"/> <!-- Original name is "efc_ganon2_hadou_modelT" ("wave motion; undulation; surge​") -->
+        <Texture Name="gGanonMasterSwordShadowTex" Format="i8" Width="32" Height="32" Offset="0x4A80"/>
         <Array Name="gGanonMasterSwordShadowVtx" Count="4" Offset="0x4E80">
             <Vtx/>
         </Array>
-        <DList Name="gGanonMasterSwordShadowDL" Offset="0x4EC0" Static="Off"/> <!-- Original name is "master_sword_shadow_model" -->
-        <Texture Name="gGanonMasterSwordPommelTex" Format="rgba16" Width="16" Height="16" Offset="0x4F40" Static="Off"/>
-        <Texture Name="gGanonMasterSwordGuardTex" Format="rgba16" Width="32" Height="32" Offset="0x5140" Static="Off"/>
+        <DList Name="gGanonMasterSwordShadowDL" Offset="0x4EC0"/> <!-- Original name is "master_sword_shadow_model" -->
+        <Texture Name="gGanonMasterSwordPommelTex" Format="rgba16" Width="16" Height="16" Offset="0x4F40"/>
+        <Texture Name="gGanonMasterSwordGuardTex" Format="rgba16" Width="32" Height="32" Offset="0x5140"/>
         <Array Name="gGanonMasterSwordVtx" Count="122" Offset="0x5940">
             <Vtx/>
         </Array>
-        <DList Name="gGanonMasterSwordDL" Offset="0x60E0" Static="Off"/> <!-- Original name is "master_gn2_swordB_model" -->
+        <DList Name="gGanonMasterSwordDL" Offset="0x60E0"/> <!-- Original name is "master_gn2_swordB_model" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_file_choose.xml
+++ b/assets/xml/overlays/ovl_file_choose.xml
@@ -1,33 +1,33 @@
 <Root>
     <File Name="ovl_file_choose">
-        <Array Name="gNameEntryVtx" Count="24" Offset="0x0" Static="Off">
+        <Array Name="gNameEntryVtx" Count="24" Offset="0x0">
             <Vtx/>
         </Array>
-        <Array Name="gCharPageHira" Count="65" Offset="0x180" Static="Off">
+        <Array Name="gCharPageHira" Count="65" Offset="0x180">
             <Scalar Type="s16"/>
         </Array>
-        <Array Name="gCharPageKata" Count="65" Offset="0x204" Static="Off">
+        <Array Name="gCharPageKata" Count="65" Offset="0x204">
             <Scalar Type="s16"/>
         </Array>
-        <Array Name="gCharPageEng" Count="65" Offset="0x288" Static="Off">
+        <Array Name="gCharPageEng" Count="65" Offset="0x288">
             <Scalar Type="s16"/>
         </Array>
-        <Array Name="gNextCharPage" Count="9" Offset="0x30C" Static="Off">
+        <Array Name="gNextCharPage" Count="9" Offset="0x30C">
             <Scalar Type="s16"/>
         </Array>
-        <Array Name="gOptionsMenuHeadersVtx" Count="16" Offset="0x320" Static="Off">
+        <Array Name="gOptionsMenuHeadersVtx" Count="16" Offset="0x320">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsMenuSettingsVtx" Count="32" Offset="0x420" Static="Off">
+        <Array Name="gOptionsMenuSettingsVtx" Count="32" Offset="0x420">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerSoundVtx" Count="4" Offset="0x620" Static="Off">
+        <Array Name="gOptionsDividerSoundVtx" Count="4" Offset="0x620">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerZTargetVtx" Count="4" Offset="0x660" Static="Off">
+        <Array Name="gOptionsDividerZTargetVtx" Count="4" Offset="0x660">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerBrightnessVtx" Count="4" Offset="0x6A0" Static="Off">
+        <Array Name="gOptionsDividerBrightnessVtx" Count="4" Offset="0x6A0">
             <Vtx/>
         </Array>
     </File>

--- a/assets/xml/overlays/ovl_file_choose_pal_gc.xml
+++ b/assets/xml/overlays/ovl_file_choose_pal_gc.xml
@@ -1,30 +1,30 @@
 <Root>
     <File Name="ovl_file_choose">
-        <Array Name="gNameEntryVtx" Count="24" Offset="0x0" Static="Off">
+        <Array Name="gNameEntryVtx" Count="24" Offset="0x0">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsMenuHeadersVtx" Count="16" Offset="0x180" Static="Off">
+        <Array Name="gOptionsMenuHeadersVtx" Count="16" Offset="0x180">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsMenuHeadersGERVtx" Count="16" Offset="0x280" Static="Off">
+        <Array Name="gOptionsMenuHeadersGERVtx" Count="16" Offset="0x280">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsMenuSettingsVtx" Count="32" Offset="0x380" Static="Off">
+        <Array Name="gOptionsMenuSettingsVtx" Count="32" Offset="0x380">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsMenuSettingsGERVtx" Count="32" Offset="0x580" Static="Off">
+        <Array Name="gOptionsMenuSettingsGERVtx" Count="32" Offset="0x580">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerSoundVtx" Count="4" Offset="0x780" Static="Off">
+        <Array Name="gOptionsDividerSoundVtx" Count="4" Offset="0x780">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerZTargetVtx" Count="4" Offset="0x7C0" Static="Off">
+        <Array Name="gOptionsDividerZTargetVtx" Count="4" Offset="0x7C0">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerBrightnessVtx" Count="4" Offset="0x800" Static="Off">
+        <Array Name="gOptionsDividerBrightnessVtx" Count="4" Offset="0x800">
             <Vtx/>
         </Array>
-        <Array Name="gCharPageEng" Count="65" Offset="0x840" Static="Off">
+        <Array Name="gCharPageEng" Count="65" Offset="0x840">
             <Scalar Type="s16"/>
         </Array>
     </File>

--- a/assets/xml/overlays/ovl_file_choose_pal_n64.xml
+++ b/assets/xml/overlays/ovl_file_choose_pal_n64.xml
@@ -1,33 +1,33 @@
 <Root>
     <File Name="ovl_file_choose">
-        <Array Name="gNameEntryVtx" Count="24" Offset="0x0" Static="Off">
+        <Array Name="gNameEntryVtx" Count="24" Offset="0x0">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsMenuHeadersVtx" Count="24" Offset="0x180" Static="Off">
+        <Array Name="gOptionsMenuHeadersVtx" Count="24" Offset="0x180">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsMenuSettingsVtx" Count="32" Offset="0x300" Static="Off">
+        <Array Name="gOptionsMenuSettingsVtx" Count="32" Offset="0x300">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsMenuBrightnessVtx" Count="8" Offset="0x500" Static="Off">
+        <Array Name="gOptionsMenuBrightnessVtx" Count="8" Offset="0x500">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsMenuLanguageVtx" Count="12" Offset="0x580" Static="Off">
+        <Array Name="gOptionsMenuLanguageVtx" Count="12" Offset="0x580">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerSoundVtx" Count="4" Offset="0x780" Static="Off">
+        <Array Name="gOptionsDividerSoundVtx" Count="4" Offset="0x780">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerZTargetVtx" Count="4" Offset="0x7C0" Static="Off">
+        <Array Name="gOptionsDividerZTargetVtx" Count="4" Offset="0x7C0">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerBrightnessVtx" Count="4" Offset="0x800" Static="Off">
+        <Array Name="gOptionsDividerBrightnessVtx" Count="4" Offset="0x800">
             <Vtx/>
         </Array>
-        <Array Name="gOptionsDividerLanguageVtx" Count="4" Offset="0x840" Static="Off">
+        <Array Name="gOptionsDividerLanguageVtx" Count="4" Offset="0x840">
             <Vtx/>
         </Array>
-        <Array Name="gCharPageEng" Count="65" Offset="0x880" Static="Off">
+        <Array Name="gCharPageEng" Count="65" Offset="0x880">
             <Scalar Type="s16"/>
         </Array>
     </File>


### PR DESCRIPTION
Whether symbols are static or not is handled in source which is bound to be committed, so it has no relevance in the xml.

For current generated source, what drives symbols being static or not is [this code in the assets extraction system](https://github.com/zeldaret/oot/blob/09a179960f1a82e1e337c38e424890c8224e0cd1/tools/assets/extract/extract_xml_z64.py#L91-L92) which enables static for all overlays except ovl_file_choose