### PR TITLE
Assets: Move limb enums into xmls 4

### DIFF
--- a/assets/xml/objects/object_ma2.xml
+++ b/assets/xml/objects/object_ma2.xml
@@ -99,25 +99,25 @@
         <DList Name="gMalonAdultLeftLegDL" Offset="0x8A60"/>
         <DList Name="gMalonAdultLeftFootDL" Offset="0x8B50"/>
 
-        <Skeleton Name="gMalonAdultSkel" Type="Flex" LimbType="Standard" Offset="0x8D90"/>
-        <Limb Name="gMalonAdultRootLimb" LimbType="Standard" Offset="0x8C70"/>
-        <Limb Name="gMalonAdultLowerControlLimb" LimbType="Standard" Offset="0x8C7C"/>
-        <Limb Name="gMalonAdultLeftThighLimb" LimbType="Standard" Offset="0x8C88"/>
-        <Limb Name="gMalonAdultLeftLegLimb" LimbType="Standard" Offset="0x8C94"/>
-        <Limb Name="gMalonAdultLeftFootLimb" LimbType="Standard" Offset="0x8CA0"/>
-        <Limb Name="gMalonAdultRightThighLimb" LimbType="Standard" Offset="0x8CAC"/>
-        <Limb Name="gMalonAdultRightLegLimb" LimbType="Standard" Offset="0x8CB8"/>
-        <Limb Name="gMalonAdultRightFootLimb" LimbType="Standard" Offset="0x8CC4"/>
-        <Limb Name="gMalonAdultTorsoLimb" LimbType="Standard" Offset="0x8CD0"/>
-        <Limb Name="gMalonAdultDressLimb" LimbType="Standard" Offset="0x8CDC"/>
-        <Limb Name="gMalonAdultChestAndNeckLimb" LimbType="Standard" Offset="0x8CE8"/>
-        <Limb Name="gMalonAdultLeftShoulderLimb" LimbType="Standard" Offset="0x8CF4"/>
-        <Limb Name="gMalonAdultLeftArmLimb" LimbType="Standard" Offset="0x8D00"/>
-        <Limb Name="gMalonAdultLeftHandLimb" LimbType="Standard" Offset="0x8D0C"/>
-        <Limb Name="gMalonAdultRightShoulderLimb" LimbType="Standard" Offset="0x8D18"/>
-        <Limb Name="gMalonAdultRightArmLimb" LimbType="Standard" Offset="0x8D24"/>
-        <Limb Name="gMalonAdultRightHandLimb" LimbType="Standard" Offset="0x8D30"/>
-        <Limb Name="gMalonAdultHeadLimb" LimbType="Standard" Offset="0x8D3C"/>
+        <Skeleton Name="gMalonAdultSkel" Type="Flex" LimbType="Standard" LimbNone="MALON_ADULT_LIMB_NONE" LimbMax="MALON_ADULT_LIMB_MAX" EnumName="MalonAdultLimb" Offset="0x8D90"/>
+        <Limb Name="gMalonAdultRootLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_ROOT" Offset="0x8C70"/>
+        <Limb Name="gMalonAdultLowerControlLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_LOWER_CONTROL" Offset="0x8C7C"/>
+        <Limb Name="gMalonAdultLeftThighLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_LEFT_THIGH" Offset="0x8C88"/>
+        <Limb Name="gMalonAdultLeftLegLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_LEFT_LEG" Offset="0x8C94"/>
+        <Limb Name="gMalonAdultLeftFootLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_LEFT_FOOT" Offset="0x8CA0"/>
+        <Limb Name="gMalonAdultRightThighLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_RIGHT_THIGH" Offset="0x8CAC"/>
+        <Limb Name="gMalonAdultRightLegLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_RIGHT_LEG" Offset="0x8CB8"/>
+        <Limb Name="gMalonAdultRightFootLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_RIGHT_FOOT" Offset="0x8CC4"/>
+        <Limb Name="gMalonAdultTorsoLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_TORSO" Offset="0x8CD0"/>
+        <Limb Name="gMalonAdultDressLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_DRESS" Offset="0x8CDC"/>
+        <Limb Name="gMalonAdultChestAndNeckLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_CHEST_AND_NECK" Offset="0x8CE8"/>
+        <Limb Name="gMalonAdultLeftShoulderLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_LEFT_SHOULDER" Offset="0x8CF4"/>
+        <Limb Name="gMalonAdultLeftArmLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_LEFT_ARM" Offset="0x8D00"/>
+        <Limb Name="gMalonAdultLeftHandLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_LEFT_HAND" Offset="0x8D0C"/>
+        <Limb Name="gMalonAdultRightShoulderLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_RIGHT_SHOULDER" Offset="0x8D18"/>
+        <Limb Name="gMalonAdultRightArmLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_RIGHT_ARM" Offset="0x8D24"/>
+        <Limb Name="gMalonAdultRightHandLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_RIGHT_HAND" Offset="0x8D30"/>
+        <Limb Name="gMalonAdultHeadLimb" LimbType="Standard" EnumName="MALON_ADULT_LIMB_HEAD" Offset="0x8D3C"/>
         <Animation Name="gMalonAdultIdleAnim" Offset="0x7D4"/>
         <Animation Name="gMalonAdultSingToIdleAnim" Offset="0x92F0"/> <!-- Unused -->
         <Animation Name="gMalonAdultStandStillAnim" Offset="0x93BC"/>

--- a/assets/xml/objects/object_md.xml
+++ b/assets/xml/objects/object_md.xml
@@ -1,25 +1,25 @@
 <Root>
     <File Name="object_md" Segment="6">
         <!-- Mido Skeleton -->
-        <Skeleton Name="gMidoSkel" Type="Flex" LimbType="Standard" Offset="0x7FB8"/>
+        <Skeleton Name="gMidoSkel" Type="Flex" LimbType="Standard" LimbNone="MIDO_LIMB_NONE" LimbMax="MIDO_LIMB_MAX" EnumName="MidoLimb" Offset="0x7FB8"/>
 
         <!-- Mido Limbs -->
-        <Limb Name="gMidoRootLimb" LimbType="Standard" Offset="0x7EB8"/>
-        <Limb Name="gMidoWaistLimb" LimbType="Standard" Offset="0x7EC4"/>
-        <Limb Name="gMidoLeftThighLimb" LimbType="Standard" Offset="0x7ED0"/>
-        <Limb Name="gMidoLeftLegLimb" LimbType="Standard" Offset="0x7EDC"/>
-        <Limb Name="gMidoLeftFootLimb" LimbType="Standard" Offset="0x7EE8"/>
-        <Limb Name="gMidoRightThighLimb" LimbType="Standard" Offset="0x7EF4"/>
-        <Limb Name="gMidoRightLegLimb" LimbType="Standard" Offset="0x7F00"/>
-        <Limb Name="gMidoRightFootLimb" LimbType="Standard" Offset="0x7F0C"/>
-        <Limb Name="gMidoTorsoLimb" LimbType="Standard" Offset="0x7F18"/>
-        <Limb Name="gMidoLeftUpperArmLimb" LimbType="Standard" Offset="0x7F24"/>
-        <Limb Name="gMidoLeftForearmLimb" LimbType="Standard" Offset="0x7F30"/>
-        <Limb Name="gMidoLeftHandLimb" LimbType="Standard" Offset="0x7F3C"/>
-        <Limb Name="gMidoRightUpperArmLimb" LimbType="Standard" Offset="0x7F48"/>
-        <Limb Name="gMidoRightForearmLimb" LimbType="Standard" Offset="0x7F54"/>
-        <Limb Name="gMidoRightHandLimb" LimbType="Standard" Offset="0x7F60"/>
-        <Limb Name="gMidoHeadLimb" LimbType="Standard" Offset="0x7F6C"/>
+        <Limb Name="gMidoRootLimb" LimbType="Standard" EnumName="MIDO_LIMB_ROOT" Offset="0x7EB8"/>
+        <Limb Name="gMidoWaistLimb" LimbType="Standard" EnumName="MIDO_LIMB_WAIST" Offset="0x7EC4"/>
+        <Limb Name="gMidoLeftThighLimb" LimbType="Standard" EnumName="MIDO_LIMB_LEFT_THIGH" Offset="0x7ED0"/>
+        <Limb Name="gMidoLeftLegLimb" LimbType="Standard" EnumName="MIDO_LIMB_LEFT_LEG" Offset="0x7EDC"/>
+        <Limb Name="gMidoLeftFootLimb" LimbType="Standard" EnumName="MIDO_LIMB_LEFT_FOOT" Offset="0x7EE8"/>
+        <Limb Name="gMidoRightThighLimb" LimbType="Standard" EnumName="MIDO_LIMB_RIGHT_THIGH" Offset="0x7EF4"/>
+        <Limb Name="gMidoRightLegLimb" LimbType="Standard" EnumName="MIDO_LIMB_RIGHT_LEG" Offset="0x7F00"/>
+        <Limb Name="gMidoRightFootLimb" LimbType="Standard" EnumName="MIDO_LIMB_RIGHT_FOOT" Offset="0x7F0C"/>
+        <Limb Name="gMidoTorsoLimb" LimbType="Standard" EnumName="MIDO_LIMB_TORSO" Offset="0x7F18"/>
+        <Limb Name="gMidoLeftUpperArmLimb" LimbType="Standard" EnumName="MIDO_LIMB_LEFT_UPPER_ARM" Offset="0x7F24"/>
+        <Limb Name="gMidoLeftForearmLimb" LimbType="Standard" EnumName="MIDO_LIMB_LEFT_FOREARM" Offset="0x7F30"/>
+        <Limb Name="gMidoLeftHandLimb" LimbType="Standard" EnumName="MIDO_LIMB_LEFT_HAND" Offset="0x7F3C"/>
+        <Limb Name="gMidoRightUpperArmLimb" LimbType="Standard" EnumName="MIDO_LIMB_RIGHT_UPPER_ARM" Offset="0x7F48"/>
+        <Limb Name="gMidoRightForearmLimb" LimbType="Standard" EnumName="MIDO_LIMB_RIGHT_FOREARM" Offset="0x7F54"/>
+        <Limb Name="gMidoRightHandLimb" LimbType="Standard" EnumName="MIDO_LIMB_RIGHT_HAND" Offset="0x7F60"/>
+        <Limb Name="gMidoHeadLimb" LimbType="Standard" EnumName="MIDO_LIMB_HEAD" Offset="0x7F6C"/>
 
         <!-- Mido Limb Vertices -->
         <Array Name="gMidoLeftHandVtx" Count="48" Offset="0x15E0">

--- a/assets/xml/objects/object_nb.xml
+++ b/assets/xml/objects/object_nb.xml
@@ -2,27 +2,27 @@
     <File Name="object_nb" Segment="6">
 
         <!-- Nabooru Skeleton -->
-        <Skeleton Name="gNabooruSkel" Type="Flex" LimbType="Standard" Offset="0x181C8"/>
+        <Skeleton Name="gNabooruSkel" Type="Flex" LimbType="Standard" LimbNone="NABOORU_LIMB_NONE" LimbMax="NABOORU_LIMB_MAX" EnumName="NabooruLimb" Offset="0x181C8"/>
 
         <!-- Nabooru Limbs -->
-        <Limb Name="gNabooruRootLimb" LimbType="Standard" Offset="0x180A8"/>
-        <Limb Name="gNabooruLeftThighLimb" LimbType="Standard" Offset="0x180B4"/>
-        <Limb Name="gNabooruLeftShinLimb" LimbType="Standard" Offset="0x180C0"/>
-        <Limb Name="gNabooruLeftFootLimb" LimbType="Standard" Offset="0x180CC"/>
-        <Limb Name="gNabooruRightThighLimb" LimbType="Standard" Offset="0x180D8"/>
-        <Limb Name="gNabooruRightShinLimb" LimbType="Standard" Offset="0x180E4"/>
-        <Limb Name="gNabooruRightFootLimb" LimbType="Standard" Offset="0x180F0"/>
-        <Limb Name="gNabooruTorsoLimb" LimbType="Standard" Offset="0x180FC"/>
-        <Limb Name="gNabooruLeftUpperArmLimb" LimbType="Standard" Offset="0x18108"/>
-        <Limb Name="gNabooruLeftForearmLimb" LimbType="Standard" Offset="0x18114"/>
-        <Limb Name="gNabooruLeftHandLimb" LimbType="Standard" Offset="0x18120"/>
-        <Limb Name="gNabooruRightUpperArmLimb" LimbType="Standard" Offset="0x1812C"/>
-        <Limb Name="gNabooruRightForearmLimb" LimbType="Standard" Offset="0x18138"/>
-        <Limb Name="gNabooruRightHandLimb" LimbType="Standard" Offset="0x18144"/>
-        <Limb Name="gNabooruHeadLimb" LimbType="Standard" Offset="0x18150"/>
-        <Limb Name="gNabooruBlankLimb" LimbType="Standard" Offset="0x1815C"/>
-        <Limb Name="gNabooruPonytailLimb" LimbType="Standard" Offset="0x18168"/>
-        <Limb Name="gNabooruWaistLimb" LimbType="Standard" Offset="0x18174"/>
+        <Limb Name="gNabooruRootLimb" LimbType="Standard" EnumName="NABOORU_LIMB_ROOT" Offset="0x180A8"/>
+        <Limb Name="gNabooruLeftThighLimb" LimbType="Standard" EnumName="NABOORU_LIMB_L_THIGH" Offset="0x180B4"/>
+        <Limb Name="gNabooruLeftShinLimb" LimbType="Standard" EnumName="NABOORU_LIMB_L_SHIN" Offset="0x180C0"/>
+        <Limb Name="gNabooruLeftFootLimb" LimbType="Standard" EnumName="NABOORU_LIMB_L_FOOT" Offset="0x180CC"/>
+        <Limb Name="gNabooruRightThighLimb" LimbType="Standard" EnumName="NABOORU_LIMB_R_THIGH" Offset="0x180D8"/>
+        <Limb Name="gNabooruRightShinLimb" LimbType="Standard" EnumName="NABOORU_LIMB_R_SHIN" Offset="0x180E4"/>
+        <Limb Name="gNabooruRightFootLimb" LimbType="Standard" EnumName="NABOORU_LIMB_R_FOOT" Offset="0x180F0"/>
+        <Limb Name="gNabooruTorsoLimb" LimbType="Standard" EnumName="NABOORU_LIMB_TORSO" Offset="0x180FC"/>
+        <Limb Name="gNabooruLeftUpperArmLimb" LimbType="Standard" EnumName="NABOORU_LIMB_L_UPPER_ARM" Offset="0x18108"/>
+        <Limb Name="gNabooruLeftForearmLimb" LimbType="Standard" EnumName="NABOORU_LIMB_L_FOREARM" Offset="0x18114"/>
+        <Limb Name="gNabooruLeftHandLimb" LimbType="Standard" EnumName="NABOORU_LIMB_L_HAND" Offset="0x18120"/>
+        <Limb Name="gNabooruRightUpperArmLimb" LimbType="Standard" EnumName="NABOORU_LIMB_R_UPPER_ARM" Offset="0x1812C"/>
+        <Limb Name="gNabooruRightForearmLimb" LimbType="Standard" EnumName="NABOORU_LIMB_R_FOREARM" Offset="0x18138"/>
+        <Limb Name="gNabooruRightHandLimb" LimbType="Standard" EnumName="NABOORU_LIMB_R_HAND" Offset="0x18144"/>
+        <Limb Name="gNabooruHeadLimb" LimbType="Standard" EnumName="NABOORU_LIMB_HEAD" Offset="0x18150"/>
+        <Limb Name="gNabooruBlankLimb" LimbType="Standard" EnumName="NABOORU_LIMB_BLANK" Offset="0x1815C"/>
+        <Limb Name="gNabooruPonytailLimb" LimbType="Standard" EnumName="NABOORU_LIMB_PONYTAIL" Offset="0x18168"/>
+        <Limb Name="gNabooruWaistLimb" LimbType="Standard" EnumName="NABOORU_LIMB_WAIST" Offset="0x18174"/>
 
         <!-- Nabooru Limb Vertices -->
         <Array Name="gNabooruHeadMouthClosedVtx" Count="297" Offset="0xDD68">

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.c
@@ -363,23 +363,23 @@ s32 EnMa2_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* p
     EnMa2* this = (EnMa2*)thisx;
     Vec3s limbRot;
 
-    if ((limbIndex == MALON_ADULT_LEFT_THIGH_LIMB) || (limbIndex == MALON_ADULT_RIGHT_THIGH_LIMB)) {
+    if ((limbIndex == MALON_ADULT_LIMB_LEFT_THIGH) || (limbIndex == MALON_ADULT_LIMB_RIGHT_THIGH)) {
         *dList = NULL;
     }
-    if (limbIndex == MALON_ADULT_HEAD_LIMB) {
+    if (limbIndex == MALON_ADULT_LIMB_HEAD) {
         Matrix_Translate(1400.0f, 0.0f, 0.0f, MTXMODE_APPLY);
         limbRot = this->interactInfo.headRot;
         Matrix_RotateX(BINANG_TO_RAD_ALT(limbRot.y), MTXMODE_APPLY);
         Matrix_RotateZ(BINANG_TO_RAD_ALT(limbRot.x), MTXMODE_APPLY);
         Matrix_Translate(-1400.0f, 0.0f, 0.0f, MTXMODE_APPLY);
     }
-    if (limbIndex == MALON_ADULT_CHEST_AND_NECK_LIMB) {
+    if (limbIndex == MALON_ADULT_LIMB_CHEST_AND_NECK) {
         limbRot = this->interactInfo.torsoRot;
         Matrix_RotateY(BINANG_TO_RAD_ALT(-limbRot.y), MTXMODE_APPLY);
         Matrix_RotateX(BINANG_TO_RAD_ALT(-limbRot.x), MTXMODE_APPLY);
     }
-    if ((limbIndex == MALON_ADULT_CHEST_AND_NECK_LIMB) || (limbIndex == MALON_ADULT_LEFT_SHOULDER_LIMB) ||
-        (limbIndex == MALON_ADULT_RIGHT_SHOULDER_LIMB)) {
+    if ((limbIndex == MALON_ADULT_LIMB_CHEST_AND_NECK) || (limbIndex == MALON_ADULT_LIMB_LEFT_SHOULDER) ||
+        (limbIndex == MALON_ADULT_LIMB_RIGHT_SHOULDER)) {
         rot->y += Math_SinS(this->upperBodyRot[limbIndex].y) * 200.0f;
         rot->z += Math_CosS(this->upperBodyRot[limbIndex].z) * 200.0f;
     }
@@ -392,10 +392,10 @@ void EnMa2_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot,
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_ma2.c", 904);
 
-    if (limbIndex == MALON_ADULT_HEAD_LIMB) {
+    if (limbIndex == MALON_ADULT_LIMB_HEAD) {
         Matrix_MultVec3f(&vec, &this->actor.focus.pos);
     }
-    if ((limbIndex == MALON_ADULT_LEFT_HAND_LIMB) && (this->skelAnime.animation == &gMalonAdultStandStillAnim)) {
+    if ((limbIndex == MALON_ADULT_LIMB_LEFT_HAND) && (this->skelAnime.animation == &gMalonAdultStandStillAnim)) {
         gSPDisplayList(POLY_OPA_DISP++, gMalonAdultBasketDL);
     }
 

--- a/src/overlays/actors/ovl_En_Ma2/z_en_ma2.h
+++ b/src/overlays/actors/ovl_En_Ma2/z_en_ma2.h
@@ -3,33 +3,11 @@
 
 #include "ultra64.h"
 #include "actor.h"
+#include "assets/objects/object_ma2/object_ma2.h"
 
 struct EnMa2;
 
 typedef void (*EnMa2ActionFunc)(struct EnMa2*, struct PlayState*);
-
-typedef enum AdultMalonLimb {
-    /* 0x00 */ MALON_ADULT_LIMB_NONE,
-    /* 0x01 */ MALON_ADULT_ROOT_LIMB,
-    /* 0x02 */ MALON_ADULT_LOWER_CONTROL_LIMB,
-    /* 0x03 */ MALON_ADULT_LEFT_THIGH_LIMB,
-    /* 0x04 */ MALON_ADULT_LEFT_LEG_LIMB,
-    /* 0x05 */ MALON_ADULT_LEFT_FOOT_LIMB,
-    /* 0x06 */ MALON_ADULT_RIGHT_THIGH_LIMB,
-    /* 0x07 */ MALON_ADULT_RIGHT_LEG_LIMB,
-    /* 0x08 */ MALON_ADULT_RIGHT_FOOT_LIMB,
-    /* 0x09 */ MALON_ADULT_TORSO_LIMB,
-    /* 0x0A */ MALON_ADULT_DRESS_LIMB,
-    /* 0x0B */ MALON_ADULT_CHEST_AND_NECK_LIMB,
-    /* 0x0C */ MALON_ADULT_LEFT_SHOULDER_LIMB,
-    /* 0x0D */ MALON_ADULT_LEFT_ARM_LIMB,
-    /* 0x0E */ MALON_ADULT_LEFT_HAND_LIMB,
-    /* 0x0F */ MALON_ADULT_RIGHT_SHOULDER_LIMB,
-    /* 0x10 */ MALON_ADULT_RIGHT_ARM_LIMB,
-    /* 0x11 */ MALON_ADULT_RIGHT_HAND_LIMB,
-    /* 0x12 */ MALON_ADULT_HEAD_LIMB,
-    /* 0x13 */ MALON_ADULT_LIMB_MAX
-} AdultMalonLimb;
 
 typedef struct EnMa2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ma3/z_en_ma3.h
+++ b/src/overlays/actors/ovl_En_Ma3/z_en_ma3.h
@@ -3,33 +3,11 @@
 
 #include "ultra64.h"
 #include "actor.h"
+#include "assets/objects/object_ma2/object_ma2.h"
 
 struct EnMa3;
 
 typedef void (*EnMa3ActionFunc)(struct EnMa3*, struct PlayState*);
-
-typedef enum AdultMalonLimb {
-    /* 0x00 */ MALON_ADULT_LIMB_NONE,
-    /* 0x01 */ MALON_ADULT_LIMB_ROOT,
-    /* 0x02 */ MALON_ADULT_LIMB_LOWER_CONTROL,
-    /* 0x03 */ MALON_ADULT_LIMB_LEFT_THIGH,
-    /* 0x04 */ MALON_ADULT_LIMB_LEFT_LEG,
-    /* 0x05 */ MALON_ADULT_LIMB_LEFT_FOOT,
-    /* 0x06 */ MALON_ADULT_LIMB_RIGHT_THIGH,
-    /* 0x07 */ MALON_ADULT_LIMB_RIGHT_LEG,
-    /* 0x08 */ MALON_ADULT_LIMB_RIGHT_FOOT,
-    /* 0x09 */ MALON_ADULT_LIMB_TORSO,
-    /* 0x0A */ MALON_ADULT_LIMB_DRESS,
-    /* 0x0B */ MALON_ADULT_LIMB_CHEST_AND_NECK,
-    /* 0x0C */ MALON_ADULT_LIMB_LEFT_SHOULDER,
-    /* 0x0D */ MALON_ADULT_LIMB_LEFT_ARM,
-    /* 0x0E */ MALON_ADULT_LIMB_LEFT_HAND,
-    /* 0x0F */ MALON_ADULT_LIMB_RIGHT_SHOULDER,
-    /* 0x10 */ MALON_ADULT_LIMB_RIGHT_ARM,
-    /* 0x11 */ MALON_ADULT_LIMB_RIGHT_HAND,
-    /* 0x12 */ MALON_ADULT_LIMB_HEAD,
-    /* 0x13 */ MALON_ADULT_LIMB_MAX
-} AdultMalonLimb;
 
 typedef struct EnMa3 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Md/z_en_md.c
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.c
@@ -687,7 +687,7 @@ void EnMd_Init(Actor* thisx, PlayState* play) {
     s32 pad;
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 24.0f);
-    SkelAnime_InitFlex(play, &this->skelAnime, &gMidoSkel, NULL, this->jointTable, this->morphTable, ENMD_LIMB_MAX);
+    SkelAnime_InitFlex(play, &this->skelAnime, &gMidoSkel, NULL, this->jointTable, this->morphTable, MIDO_LIMB_MAX);
 
     Collider_InitCylinder(play, &this->collider);
     Collider_SetCylinder(play, &this->collider, &this->actor, &sCylinderInit);
@@ -727,7 +727,7 @@ void EnMd_Destroy(Actor* thisx, PlayState* play) {
 
 void EnMd_Idle(EnMd* this, PlayState* play) {
     if (this->skelAnime.animation == &gMidoIdleAnim) {
-        Actor_UpdateFidgetTables(play, this->fidgetTableY, this->fidgetTableZ, ENMD_LIMB_MAX);
+        Actor_UpdateFidgetTables(play, this->fidgetTableY, this->fidgetTableZ, MIDO_LIMB_MAX);
     } else if ((this->interactInfo.talkState == NPC_TALK_STATE_IDLE) &&
                (this->animSequence != ENMD_ANIM_SEQ_SURPRISE_TO_IDLE)) {
         EnMd_SetAnimSequence(this, ENMD_ANIM_SEQ_SURPRISE_TO_IDLE);
@@ -738,7 +738,7 @@ void EnMd_Idle(EnMd* this, PlayState* play) {
 
 void EnMd_Watch(EnMd* this, PlayState* play) {
     if (this->skelAnime.animation == &gMidoIdleAnim) {
-        Actor_UpdateFidgetTables(play, this->fidgetTableY, this->fidgetTableZ, ENMD_LIMB_MAX);
+        Actor_UpdateFidgetTables(play, this->fidgetTableY, this->fidgetTableZ, MIDO_LIMB_MAX);
     }
     EnMd_UpdateAnimSequence(this);
 }
@@ -790,7 +790,7 @@ void EnMd_BlockPath(EnMd* this, PlayState* play) {
     }
 
     if (this->skelAnime.animation == &gMidoIdleAnim) {
-        Actor_UpdateFidgetTables(play, this->fidgetTableY, this->fidgetTableZ, ENMD_LIMB_MAX);
+        Actor_UpdateFidgetTables(play, this->fidgetTableY, this->fidgetTableZ, MIDO_LIMB_MAX);
     }
 
     if ((this->interactInfo.talkState == NPC_TALK_STATE_IDLE) && (play->sceneId == SCENE_LOST_WOODS)) {
@@ -828,7 +828,7 @@ void EnMd_ListenToOcarina(EnMd* this, PlayState* play) {
 }
 
 void EnMd_Walk(EnMd* this, PlayState* play) {
-    Actor_UpdateFidgetTables(play, this->fidgetTableY, this->fidgetTableZ, ENMD_LIMB_MAX);
+    Actor_UpdateFidgetTables(play, this->fidgetTableY, this->fidgetTableZ, MIDO_LIMB_MAX);
     EnMd_UpdateAnimSequence(this);
 
     if (!(EnMd_FollowPath(this, play)) || (this->waypoint != 0)) {
@@ -871,21 +871,21 @@ s32 EnMd_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
     EnMd* this = (EnMd*)thisx;
     Vec3s limbRot;
 
-    if (limbIndex == ENMD_LIMB_HEAD) {
+    if (limbIndex == MIDO_LIMB_HEAD) {
         Matrix_Translate(1200.0f, 0.0f, 0.0f, MTXMODE_APPLY);
         limbRot = this->interactInfo.headRot;
         Matrix_RotateX(BINANG_TO_RAD_ALT(limbRot.y), MTXMODE_APPLY);
         Matrix_RotateZ(BINANG_TO_RAD_ALT(limbRot.x), MTXMODE_APPLY);
         Matrix_Translate(-1200.0f, 0.0f, 0.0f, MTXMODE_APPLY);
     }
-    if (limbIndex == ENMD_LIMB_TORSO) {
+    if (limbIndex == MIDO_LIMB_TORSO) {
         limbRot = this->interactInfo.torsoRot;
         Matrix_RotateX(BINANG_TO_RAD_ALT(limbRot.x), MTXMODE_APPLY);
         Matrix_RotateY(BINANG_TO_RAD_ALT(limbRot.y), MTXMODE_APPLY);
     }
 
-    if (((limbIndex == ENMD_LIMB_TORSO) || (limbIndex == ENMD_LIMB_LEFT_UPPER_ARM)) ||
-        (limbIndex == ENMD_LIMB_RIGHT_UPPER_ARM)) {
+    if (((limbIndex == MIDO_LIMB_TORSO) || (limbIndex == MIDO_LIMB_LEFT_UPPER_ARM)) ||
+        (limbIndex == MIDO_LIMB_RIGHT_UPPER_ARM)) {
         rot->y += Math_SinS(this->fidgetTableY[limbIndex]) * FIDGET_AMPLITUDE;
         rot->z += Math_CosS(this->fidgetTableZ[limbIndex]) * FIDGET_AMPLITUDE;
     }
@@ -897,7 +897,7 @@ void EnMd_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, 
     EnMd* this = (EnMd*)thisx;
     Vec3f vec = { 400.0f, 0.0f, 0.0f };
 
-    if (limbIndex == ENMD_LIMB_HEAD) {
+    if (limbIndex == MIDO_LIMB_HEAD) {
         Matrix_MultVec3f(&vec, &this->actor.focus.pos);
     }
 }

--- a/src/overlays/actors/ovl_En_Md/z_en_md.h
+++ b/src/overlays/actors/ovl_En_Md/z_en_md.h
@@ -3,29 +3,9 @@
 
 #include "ultra64.h"
 #include "actor.h"
+#include "assets/objects/object_md/object_md.h"
 
 struct EnMd;
-
-typedef enum EnMdLimb {
-    ENMD_LIMB_NONE,
-    ENMD_LIMB_ROOT,
-    ENMD_LIMB_WAIST,
-    ENMD_LIMB_LEFT_THIGH,
-    ENMD_LIMB_LEFT_LEG,
-    ENMD_LIMB_LEFT_FOOT,
-    ENMD_LIMB_RIGHT_THIGH,
-    ENMD_LIMB_RIGHT_LEG,
-    ENMD_LIMB_RIGHT_FOOT,
-    ENMD_LIMB_TORSO,
-    ENMD_LIMB_LEFT_UPPER_ARM,
-    ENMD_LIMB_LEFT_FOREARM,
-    ENMD_LIMB_LEFT_HAND,
-    ENMD_LIMB_RIGHT_UPPER_ARM,
-    ENMD_LIMB_RIGHT_FOREARM,
-    ENMD_LIMB_RIGHT_HAND,
-    ENMD_LIMB_HEAD,
-    ENMD_LIMB_MAX
-} EnMdLimb;
 
 typedef void (*EnMdActionFunc)(struct EnMd*, struct PlayState*);
 
@@ -48,10 +28,10 @@ typedef struct EnMd {
     /* 0x020E */ s16 eyeTexIndex;
     /* 0x0210 */ s16 alpha;
     /* 0x0212 */ s16 waypoint;
-    /* 0x0214 */ s16 fidgetTableY[ENMD_LIMB_MAX];
-    /* 0x0236 */ s16 fidgetTableZ[ENMD_LIMB_MAX];
-    /* 0x0258 */ Vec3s jointTable[ENMD_LIMB_MAX];
-    /* 0x02BE */ Vec3s morphTable[ENMD_LIMB_MAX];
+    /* 0x0214 */ s16 fidgetTableY[MIDO_LIMB_MAX];
+    /* 0x0236 */ s16 fidgetTableZ[MIDO_LIMB_MAX];
+    /* 0x0258 */ Vec3s jointTable[MIDO_LIMB_MAX];
+    /* 0x02BE */ Vec3s morphTable[MIDO_LIMB_MAX];
 } EnMd; // size = 0x0324
 
 #endif

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -1011,7 +1011,7 @@ void func_80AB2E70(EnNb* this, PlayState* play) {
 s32 func_80AB2FC0(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {
     EnNb* this = (EnNb*)thisx;
 
-    if (limbIndex == NB_LIMB_HEAD) {
+    if (limbIndex == NABOORU_LIMB_HEAD) {
         *dList = gNabooruHeadMouthOpenDL;
     }
 
@@ -1476,7 +1476,8 @@ void EnNb_Init(Actor* thisx, PlayState* play) {
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 30.0f);
     EnNb_SetupCollider(thisx, play);
-    SkelAnime_InitFlex(play, &this->skelAnime, &gNabooruSkel, NULL, this->jointTable, this->morphTable, NB_LIMB_MAX);
+    SkelAnime_InitFlex(play, &this->skelAnime, &gNabooruSkel, NULL, this->jointTable, this->morphTable,
+                       NABOORU_LIMB_MAX);
 
     switch (EnNb_GetType(this)) {
         case NB_TYPE_DEMO02:
@@ -1506,13 +1507,13 @@ s32 EnNb_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
     s32 ret = false;
 
     if (this->headTurnFlag != 0) {
-        if (limbIndex == NB_LIMB_TORSO) {
+        if (limbIndex == NABOORU_LIMB_TORSO) {
             s32 pad;
 
             rot->x += interactInfo->torsoRot.y;
             rot->y -= interactInfo->torsoRot.x;
             ret = false;
-        } else if (limbIndex == NB_LIMB_HEAD) {
+        } else if (limbIndex == NABOORU_LIMB_HEAD) {
             rot->x += interactInfo->headRot.y;
             rot->z += interactInfo->headRot.x;
             ret = false;
@@ -1525,7 +1526,7 @@ s32 EnNb_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* po
 void EnNb_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, void* thisx) {
     EnNb* this = (EnNb*)thisx;
 
-    if (limbIndex == NB_LIMB_HEAD) {
+    if (limbIndex == NABOORU_LIMB_HEAD) {
         Vec3f vec1 = { 0.0f, 10.0f, 0.0f };
         Vec3f vec2;
 

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.h
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.h
@@ -3,31 +3,9 @@
 
 #include "ultra64.h"
 #include "actor.h"
+#include "assets/objects/object_nb/object_nb.h"
 
 struct EnNb;
-
-typedef enum EnNbLimb {
-    /* 0x00 */ NB_LIMB_NONE,
-    /* 0x01 */ NB_LIMB_ROOT,
-    /* 0x02 */ NB_LIMB_L_THIGH,
-    /* 0x03 */ NB_LIMB_L_SHIN,
-    /* 0x04 */ NB_LIMB_L_FOOT,
-    /* 0x05 */ NB_LIMB_R_THIGH,
-    /* 0x06 */ NB_LIMB_R_SHIN,
-    /* 0x07 */ NB_LIMB_R_FOOT,
-    /* 0x08 */ NB_LIMB_TORSO,
-    /* 0x09 */ NB_LIMB_L_UPPER_ARM,
-    /* 0x0A */ NB_LIMB_L_FOREARM,
-    /* 0x0B */ NB_LIMB_L_HAND,
-    /* 0x0C */ NB_LIMB_R_UPPER_ARM,
-    /* 0x0D */ NB_LIMB_R_FOREARM,
-    /* 0x0E */ NB_LIMB_R_HAND,
-    /* 0x0F */ NB_LIMB_HEAD,
-    /* 0x10 */ NB_LIMB_BLANK,
-    /* 0x11 */ NB_LIMB_PONYTAIL,
-    /* 0x12 */ NB_LIMB_WAIST,
-    /* 0x13 */ NB_LIMB_MAX
-} EnNbLimb;
 
 typedef void (*EnNbActionFunc)(struct EnNb*, struct PlayState*);
 typedef void (*EnNbDrawFunc)(struct EnNb*, struct PlayState*);
@@ -35,8 +13,8 @@ typedef void (*EnNbDrawFunc)(struct EnNb*, struct PlayState*);
 typedef struct EnNb {
     /* 0x0000 */ Actor actor;
     /* 0x014C */ SkelAnime skelAnime;
-    /* 0x0190 */ Vec3s jointTable[NB_LIMB_MAX];
-    /* 0x0202 */ Vec3s morphTable[NB_LIMB_MAX];
+    /* 0x0190 */ Vec3s jointTable[NABOORU_LIMB_MAX];
+    /* 0x0202 */ Vec3s morphTable[NABOORU_LIMB_MAX];
     /* 0x0274 */ s16 eyeIdx;
     /* 0x0276 */ s16 blinkTimer;
     /* 0x0278 */ s32 action;


### PR DESCRIPTION
And that's it for this series of PRs, the remaining limb enums need to wait for other changes:
- ganondorf, ganon, queen gohma, gohmas, kotake/koume/twinrova xmls are waiting for version reconciliation ( #2614 )
- iron knuckle is a mess
- wolfos, redead/gibdo, lizalfos/dinolfos are skeletons who share a hierarchy so need the .h committed to unduplicate the enum (and prevent compilation errors)