### PR TITLE
`Camera_KeepOn4` docs 2: RO and RW data

### DIFF
--- a/include/camera.h
+++ b/include/camera.h
@@ -334,7 +334,7 @@ typedef enum CameraDataType {
     /* 0x13 */ CAM_DATA_AT_OFFSET_X,
     /* 0x14 */ CAM_DATA_AT_OFFSET_Y,
     /* 0x15 */ CAM_DATA_AT_OFFSET_Z,
-    /* 0x16 */ CAM_DATA_UNK_22,
+    /* 0x16 */ CAM_DATA_INIT_TIMER,
     /* 0x17 */ CAM_DATA_UNK_23,
     /* 0x18 */ CAM_DATA_FOV_SCALE,
     /* 0x19 */ CAM_DATA_YAW_SCALE,
@@ -907,7 +907,7 @@ typedef struct KeepOn4 {
     { fov, CAM_DATA_FOV }, \
     { interfaceField, CAM_DATA_INTERFACE_FIELD }, \
     { unk_14, CAM_DATA_YAW_UPDATE_RATE_TARGET }, \
-    { initTimer, CAM_DATA_UNK_22 }
+    { initTimer, CAM_DATA_INIT_TIMER }
 
 typedef struct KeepOn0ReadOnlyData {
     /* 0x00 */ f32 fovScale;
@@ -1463,7 +1463,7 @@ typedef struct Special5 {
     { yOffset, CAM_DATA_Y_OFFSET }, \
     { eyeDist, CAM_DATA_EYE_DIST }, \
     { eyeDistNext, CAM_DATA_EYE_DIST_NEXT }, \
-    { unk_22, CAM_DATA_UNK_22 }, \
+    { unk_22, CAM_DATA_INIT_TIMER }, \
     { pitchTarget, CAM_DATA_PITCH_TARGET }, \
     { fov, CAM_DATA_FOV }, \
     { atLerpStepScale, CAM_DATA_AT_LERP_STEP_SCALE }, \
@@ -1477,7 +1477,7 @@ typedef struct Special5 {
     { pitchTarget, CAM_DATA_PITCH_TARGET }, \
     { fov, CAM_DATA_FOV }, \
     { atLerpStepScale, CAM_DATA_AT_LERP_STEP_SCALE }, \
-    { unk_22, CAM_DATA_UNK_22 }, \
+    { unk_22, CAM_DATA_INIT_TIMER }, \
     { interfaceField, CAM_DATA_INTERFACE_FIELD }
 
 typedef struct Special7ReadWriteData {

--- a/include/camera.h
+++ b/include/camera.h
@@ -846,15 +846,15 @@ typedef struct KeepOn3 {
     { interfaceField, CAM_DATA_INTERFACE_FIELD }
 
 typedef struct KeepOn4ReadOnlyData {
-    /* 0x00 */ f32 unk_00;
-    /* 0x04 */ f32 unk_04;
-    /* 0x08 */ f32 unk_08;
-    /* 0x0C */ f32 unk_0C;
-    /* 0x10 */ f32 unk_10;
-    /* 0x14 */ f32 unk_14;
-    /* 0x18 */ f32 unk_18;
+    /* 0x00 */ f32 yOffset;
+    /* 0x04 */ f32 eyeDist;
+    /* 0x08 */ f32 pitchTarget; // degrees
+    /* 0x0C */ f32 yawTarget; // degrees
+    /* 0x10 */ f32 atOffsetPlayerForwards; // distance to offset `at` by, in the player's forwards direction
+    /* 0x14 */ f32 unk_14; // scale for stepping yaw and pitch of "at to eye" to target
+    /* 0x18 */ f32 fovTarget;
     /* 0x1C */ s16 interfaceField;
-    /* 0x1E */ s16 unk_1E;
+    /* 0x1E */ s16 initTimer;
 } KeepOn4ReadOnlyData; // size = 0x20
 
 typedef enum CameraItemType {
@@ -874,14 +874,14 @@ typedef enum CameraItemType {
 } CameraItemType;
 
 typedef struct KeepOn4ReadWriteData {
-    /* 0x00 */ f32 unk_00;
-    /* 0x04 */ f32 unk_04;
-    /* 0x08 */ f32 unk_08;
-    /* 0x0C */ s16 unk_0C;
-    /* 0x0E */ s16 unk_0E;
-    /* 0x10 */ s16 unk_10;
-    /* 0x12 */ s16 unk_12;
-    /* 0x14 */ s16 unk_14;
+    /* 0x00 */ f32 atToEyeTargetStepYaw; // binang
+    /* 0x04 */ f32 atToEyeTargetStepPitch; // binang
+    /* 0x08 */ f32 unk_08; // set but unused
+    /* 0x0C */ s16 atToEyeTargetYaw;
+    /* 0x0E */ s16 atToEyeTargetPitch;
+    /* 0x10 */ s16 animTimer;
+    /* 0x12 */ s16 unk_12; // set but unused
+    /* 0x14 */ s16 itemType;
 } KeepOn4ReadWriteData; // size = 0x18
 
 typedef struct KeepOn4 {
@@ -898,16 +898,16 @@ typedef struct KeepOn4 {
 #define KEEPON4_FLAG_6 (1 << 6)
 #define KEEPON4_FLAG_7 (1 << 7)
 
-#define CAM_FUNCDATA_KEEP4(yOffset, eyeDist, pitchTarget, yawTarget, atOffsetZ, fov, interfaceField, yawUpdateRateTarget, unk_22) \
+#define CAM_FUNCDATA_KEEP4(yOffset, eyeDist, pitchTarget, yawTarget, atOffsetPlayerForwards, fov, interfaceField, unk_14, initTimer) \
     { yOffset, CAM_DATA_Y_OFFSET }, \
     { eyeDist, CAM_DATA_EYE_DIST }, \
     { pitchTarget, CAM_DATA_PITCH_TARGET }, \
     { yawTarget, CAM_DATA_YAW_TARGET }, \
-    { atOffsetZ, CAM_DATA_AT_OFFSET_Z }, \
+    { atOffsetPlayerForwards, CAM_DATA_AT_OFFSET_Z }, \
     { fov, CAM_DATA_FOV }, \
     { interfaceField, CAM_DATA_INTERFACE_FIELD }, \
-    { yawUpdateRateTarget, CAM_DATA_YAW_UPDATE_RATE_TARGET }, \
-    { unk_22, CAM_DATA_UNK_22 }
+    { unk_14, CAM_DATA_YAW_UPDATE_RATE_TARGET }, \
+    { initTimer, CAM_DATA_UNK_22 }
 
 typedef struct KeepOn0ReadOnlyData {
     /* 0x00 */ f32 fovScale;

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -3698,11 +3698,11 @@ s32 Camera_KeepOn4(Camera* camera) {
             camera->play->view.unk_124 = camera->camId | 0x50;
             return 1;
         }
-        rwData->unk_14 = *itemType;
+        rwData->itemType = *itemType;
         camera->stateFlags &= ~CAM_STATE_LOCK_MODE;
     }
 
-    if (rwData->unk_14 != *itemType) {
+    if (rwData->itemType != *itemType) {
         PRINTF(VT_COL(YELLOW, BLACK) "camera: item: item type changed %d -> %d\n" VT_RST, rwData->unk_14, *itemType);
         camera->animState = 20;
         camera->stateFlags |= CAM_STATE_LOCK_MODE;
@@ -3717,115 +3717,115 @@ s32 Camera_KeepOn4(Camera* camera) {
         CameraModeValue* values = sCameraSettings[camera->setting].cameraModes[camera->mode].values;
         f32 yNormal = 1.0f + t - (68.0f / playerHeight * t);
 
-        roData->unk_00 = GET_NEXT_SCALED_RO_DATA(values) * playerHeight * yNormal;
-        roData->unk_04 = GET_NEXT_SCALED_RO_DATA(values) * playerHeight * yNormal;
-        roData->unk_08 = GET_NEXT_RO_DATA(values);
-        roData->unk_0C = GET_NEXT_RO_DATA(values);
-        roData->unk_10 = GET_NEXT_RO_DATA(values);
-        roData->unk_18 = GET_NEXT_RO_DATA(values);
+        roData->yOffset = GET_NEXT_SCALED_RO_DATA(values) * playerHeight * yNormal;
+        roData->eyeDist = GET_NEXT_SCALED_RO_DATA(values) * playerHeight * yNormal;
+        roData->pitchTarget = GET_NEXT_RO_DATA(values);
+        roData->yawTarget = GET_NEXT_RO_DATA(values);
+        roData->atOffsetPlayerForwards = GET_NEXT_RO_DATA(values);
+        roData->fovTarget = GET_NEXT_RO_DATA(values);
         roData->interfaceField = GET_NEXT_RO_DATA(values);
         roData->unk_14 = GET_NEXT_SCALED_RO_DATA(values);
-        roData->unk_1E = GET_NEXT_RO_DATA(values);
+        roData->initTimer = GET_NEXT_RO_DATA(values);
         PRINTF("camera: item: type %d\n", *itemType);
         switch (*itemType) {
             case CAM_ITEM_TYPE_1:
-                roData->unk_00 = playerHeight * -0.6f * yNormal;
-                roData->unk_04 = playerHeight * 2.0f * yNormal;
-                roData->unk_08 = 10.0f;
+                roData->yOffset = playerHeight * -0.6f * yNormal;
+                roData->eyeDist = playerHeight * 2.0f * yNormal;
+                roData->pitchTarget = 10.0f;
                 break;
 
             case CAM_ITEM_TYPE_2:
             case CAM_ITEM_TYPE_3:
-                roData->unk_08 = -20.0f;
-                roData->unk_18 = 80.0f;
+                roData->pitchTarget = -20.0f;
+                roData->fovTarget = 80.0f;
                 break;
 
             case CAM_ITEM_TYPE_4:
-                roData->unk_00 = playerHeight * -0.2f * yNormal;
-                roData->unk_08 = 25.0f;
+                roData->yOffset = playerHeight * -0.2f * yNormal;
+                roData->pitchTarget = 25.0f;
                 break;
 
             case CAM_ITEM_TYPE_8:
-                roData->unk_00 = playerHeight * -0.2f * yNormal;
-                roData->unk_04 = playerHeight * 0.8f * yNormal;
-                roData->unk_08 = 50.0f;
-                roData->unk_18 = 70.0f;
+                roData->yOffset = playerHeight * -0.2f * yNormal;
+                roData->eyeDist = playerHeight * 0.8f * yNormal;
+                roData->pitchTarget = 50.0f;
+                roData->fovTarget = 70.0f;
                 break;
 
             case CAM_ITEM_TYPE_9:
-                roData->unk_00 = playerHeight * 0.1f * yNormal;
-                roData->unk_04 = playerHeight * 0.5f * yNormal;
-                roData->unk_08 = -20.0f;
-                roData->unk_0C = 0.0f;
+                roData->yOffset = playerHeight * 0.1f * yNormal;
+                roData->eyeDist = playerHeight * 0.5f * yNormal;
+                roData->pitchTarget = -20.0f;
+                roData->yawTarget = 0.0f;
                 roData->interfaceField =
                     CAM_INTERFACE_FIELD(CAM_LETTERBOX_MEDIUM, CAM_HUD_VISIBILITY_A_HEARTS_MAGIC_FORCE, KEEPON4_FLAG_6);
                 break;
 
             case CAM_ITEM_TYPE_5:
-                roData->unk_00 = playerHeight * -0.4f * yNormal;
-                roData->unk_08 = -10.0f;
-                roData->unk_0C = 45.0f;
+                roData->yOffset = playerHeight * -0.4f * yNormal;
+                roData->pitchTarget = -10.0f;
+                roData->yawTarget = 45.0f;
                 roData->interfaceField =
                     CAM_INTERFACE_FIELD(CAM_LETTERBOX_MEDIUM, CAM_HUD_VISIBILITY_ALL, KEEPON4_FLAG_1);
                 break;
 
             case CAM_ITEM_TYPE_10:
-                roData->unk_00 = playerHeight * -0.5f * yNormal;
-                roData->unk_04 = playerHeight * 1.5f * yNormal;
-                roData->unk_08 = -15.0f;
-                roData->unk_0C = 175.0f;
-                roData->unk_18 = 70.0f;
+                roData->yOffset = playerHeight * -0.5f * yNormal;
+                roData->eyeDist = playerHeight * 1.5f * yNormal;
+                roData->pitchTarget = -15.0f;
+                roData->yawTarget = 175.0f;
+                roData->fovTarget = 70.0f;
                 roData->interfaceField =
                     CAM_INTERFACE_FIELD(CAM_LETTERBOX_MEDIUM, CAM_HUD_VISIBILITY_NOTHING_ALT, KEEPON4_FLAG_1);
-                roData->unk_1E = 0x3C;
+                roData->initTimer = 0x3C;
                 break;
 
             case CAM_ITEM_TYPE_12:
-                roData->unk_00 = playerHeight * -0.6f * yNormal;
-                roData->unk_04 = playerHeight * 1.6f * yNormal;
-                roData->unk_08 = -2.0f;
-                roData->unk_0C = 120.0f;
-                roData->unk_10 = player->stateFlags1 & PLAYER_STATE1_27 ? 0.0f : 20.0f;
+                roData->yOffset = playerHeight * -0.6f * yNormal;
+                roData->eyeDist = playerHeight * 1.6f * yNormal;
+                roData->pitchTarget = -2.0f;
+                roData->yawTarget = 120.0f;
+                roData->atOffsetPlayerForwards = player->stateFlags1 & PLAYER_STATE1_27 ? 0.0f : 20.0f;
                 roData->interfaceField = CAM_INTERFACE_FIELD(CAM_LETTERBOX_LARGE, CAM_HUD_VISIBILITY_NOTHING_ALT,
                                                              KEEPON4_FLAG_4 | KEEPON4_FLAG_1);
-                roData->unk_1E = 0x1E;
-                roData->unk_18 = 50.0f;
+                roData->initTimer = 0x1E;
+                roData->fovTarget = 50.0f;
                 break;
 
             case CAM_ITEM_TYPE_90:
-                roData->unk_00 = playerHeight * -0.3f * yNormal;
-                roData->unk_18 = 45.0f;
+                roData->yOffset = playerHeight * -0.3f * yNormal;
+                roData->fovTarget = 45.0f;
                 roData->interfaceField =
                     CAM_INTERFACE_FIELD(CAM_LETTERBOX_MEDIUM, CAM_HUD_VISIBILITY_IGNORE, KEEPON4_FLAG_1);
                 break;
 
             case CAM_ITEM_TYPE_91:
-                roData->unk_00 = playerHeight * -0.1f * yNormal;
-                roData->unk_04 = playerHeight * 1.5f * yNormal;
-                roData->unk_08 = -3.0f;
-                roData->unk_0C = 10.0f;
-                roData->unk_18 = 55.0f;
+                roData->yOffset = playerHeight * -0.1f * yNormal;
+                roData->eyeDist = playerHeight * 1.5f * yNormal;
+                roData->pitchTarget = -3.0f;
+                roData->yawTarget = 10.0f;
+                roData->fovTarget = 55.0f;
                 roData->interfaceField =
                     CAM_INTERFACE_FIELD(CAM_LETTERBOX_MEDIUM, CAM_HUD_VISIBILITY_IGNORE, KEEPON4_FLAG_3);
                 break;
 
             case CAM_ITEM_TYPE_81:
-                roData->unk_00 = playerHeight * -0.3f * yNormal;
-                roData->unk_04 = playerHeight * 1.5f * yNormal;
-                roData->unk_08 = 2.0f;
-                roData->unk_18 = 45.0f;
-                roData->unk_0C = 20.0f;
-                roData->unk_10 = 20.0f;
+                roData->yOffset = playerHeight * -0.3f * yNormal;
+                roData->eyeDist = playerHeight * 1.5f * yNormal;
+                roData->pitchTarget = 2.0f;
+                roData->fovTarget = 45.0f;
+                roData->yawTarget = 20.0f;
+                roData->atOffsetPlayerForwards = 20.0f;
                 roData->interfaceField =
                     CAM_INTERFACE_FIELD(CAM_LETTERBOX_MEDIUM, CAM_HUD_VISIBILITY_NOTHING_ALT, KEEPON4_FLAG_7);
-                roData->unk_1E = 0x1E;
+                roData->initTimer = 0x1E;
                 break;
 
             case CAM_ITEM_TYPE_11:
-                roData->unk_00 = playerHeight * -0.19f * yNormal;
-                roData->unk_04 = playerHeight * 0.7f * yNormal;
-                roData->unk_0C = 130.0f;
-                roData->unk_10 = 10.0f;
+                roData->yOffset = playerHeight * -0.19f * yNormal;
+                roData->eyeDist = playerHeight * 0.7f * yNormal;
+                roData->yawTarget = 130.0f;
+                roData->atOffsetPlayerForwards = 10.0f;
                 roData->interfaceField = CAM_INTERFACE_FIELD(
                     CAM_LETTERBOX_MEDIUM, CAM_HUD_VISIBILITY_A_HEARTS_MAGIC_FORCE, KEEPON4_FLAG_5 | KEEPON4_FLAG_1);
                 break;
@@ -3844,10 +3844,10 @@ s32 Camera_KeepOn4(Camera* camera) {
     sAtTarget = playerPosRot->pos;
     sAtTarget.y += playerHeight;
     temp_f0_2 = BgCheck_CameraRaycastDown2(&camera->play->colCtx, &spC0, &i, &sAtTarget);
-    if (temp_f0_2 > (roData->unk_00 + sAtTarget.y)) {
+    if (temp_f0_2 > (roData->yOffset + sAtTarget.y)) {
         sAtTarget.y = temp_f0_2 + 10.0f;
     } else {
-        sAtTarget.y += roData->unk_00;
+        sAtTarget.y += roData->yOffset;
     }
 
     lineOCCheckNumExclusions = 0;
@@ -3858,38 +3858,38 @@ s32 Camera_KeepOn4(Camera* camera) {
             lineOCCheckNumExclusions++;
             func_80043ABC(camera);
             camera->stateFlags &= ~(CAM_STATE_CHECK_WATER | CAM_STATE_CHECK_BG);
-            rwData->unk_10 = roData->unk_1E;
+            rwData->animTimer = roData->initTimer;
             rwData->unk_08 = playerPosRot->pos.y - camera->playerPosDelta.y;
             if (roData->interfaceField & KEEPON4_FLAG_1) {
-                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->unk_08);
+                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->pitchTarget);
                 atToEyeBaseYaw = (s16)((s16)(playerPosRot->rot.y - 0x7FFF) - atToEyeNextDir.yaw) > 0
-                                     ? (s16)(playerPosRot->rot.y - 0x7FFF) + CAM_DEG_TO_BINANG(roData->unk_0C)
-                                     : (s16)(playerPosRot->rot.y - 0x7FFF) - CAM_DEG_TO_BINANG(roData->unk_0C);
+                                     ? (s16)(playerPosRot->rot.y - 0x7FFF) + CAM_DEG_TO_BINANG(roData->yawTarget)
+                                     : (s16)(playerPosRot->rot.y - 0x7FFF) - CAM_DEG_TO_BINANG(roData->yawTarget);
             } else if (roData->interfaceField & KEEPON4_FLAG_2) {
-                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->unk_08);
-                atToEyeBaseYaw = CAM_DEG_TO_BINANG(roData->unk_0C);
+                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->pitchTarget);
+                atToEyeBaseYaw = CAM_DEG_TO_BINANG(roData->yawTarget);
             } else if ((roData->interfaceField & KEEPON4_FLAG_3) && camera->target != NULL) {
                 PosRot sp60;
 
                 sp60 = Actor_GetWorldPosShapeRot(camera->target);
-                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->unk_08) - sp60.rot.x;
+                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->pitchTarget) - sp60.rot.x;
                 atToEyeBaseYaw = (s16)((s16)(sp60.rot.y - 0x7FFF) - atToEyeNextDir.yaw) > 0
-                                     ? (s16)(sp60.rot.y - 0x7FFF) + CAM_DEG_TO_BINANG(roData->unk_0C)
-                                     : (s16)(sp60.rot.y - 0x7FFF) - CAM_DEG_TO_BINANG(roData->unk_0C);
+                                     ? (s16)(sp60.rot.y - 0x7FFF) + CAM_DEG_TO_BINANG(roData->yawTarget)
+                                     : (s16)(sp60.rot.y - 0x7FFF) - CAM_DEG_TO_BINANG(roData->yawTarget);
                 lineOCCheckExclusions[1] = camera->target;
                 lineOCCheckNumExclusions++;
             } else if ((roData->interfaceField & KEEPON4_FLAG_7) && camera->target != NULL) {
                 PosRot sp4C;
 
                 sp4C = Actor_GetWorld(camera->target);
-                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->unk_08);
+                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->pitchTarget);
                 sp9E = Camera_XZAngle(&sp4C.pos, &playerPosRot->pos);
-                atToEyeBaseYaw = ((s16)(sp9E - atToEyeNextDir.yaw) > 0) ? sp9E + CAM_DEG_TO_BINANG(roData->unk_0C)
-                                                                        : sp9E - CAM_DEG_TO_BINANG(roData->unk_0C);
+                atToEyeBaseYaw = ((s16)(sp9E - atToEyeNextDir.yaw) > 0) ? sp9E + CAM_DEG_TO_BINANG(roData->yawTarget)
+                                                                        : sp9E - CAM_DEG_TO_BINANG(roData->yawTarget);
                 lineOCCheckExclusions[1] = camera->target;
                 lineOCCheckNumExclusions++;
             } else if (roData->interfaceField & KEEPON4_FLAG_6) {
-                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->unk_08);
+                atToEyeBasePitch = CAM_DEG_TO_BINANG(roData->pitchTarget);
                 atToEyeBaseYaw = atToEyeNextDir.yaw;
             } else {
                 atToEyeBasePitch = atToEyeNextDir.pitch;
@@ -3898,7 +3898,7 @@ s32 Camera_KeepOn4(Camera* camera) {
 
             vecGeo.pitch = atToEyeBasePitch;
             vecGeo.yaw = atToEyeBaseYaw;
-            vecGeo.r = roData->unk_04;
+            vecGeo.r = roData->eyeDist;
             sEyeCandidate = Camera_AddVecGeoToVec3f(&sAtTarget, &vecGeo);
             if (!(roData->interfaceField & KEEPON4_FLAG_0)) {
                 angleCnt = ARRAY_COUNT(sCamCheckAroundOffsetsYaw);
@@ -3916,10 +3916,10 @@ s32 Camera_KeepOn4(Camera* camera) {
                 PRINTF("camera: item: BG&collision check %d time(s)\n", i);
 #endif
             }
-            rwData->unk_04 = (s16)(vecGeo.pitch - atToEyeNextDir.pitch) / (f32)rwData->unk_10;
-            rwData->unk_00 = (s16)(vecGeo.yaw - atToEyeNextDir.yaw) / (f32)rwData->unk_10;
-            rwData->unk_0C = atToEyeNextDir.yaw;
-            rwData->unk_0E = atToEyeNextDir.pitch;
+            rwData->atToEyeTargetStepPitch = (s16)(vecGeo.pitch - atToEyeNextDir.pitch) / (f32)rwData->animTimer;
+            rwData->atToEyeTargetStepYaw = (s16)(vecGeo.yaw - atToEyeNextDir.yaw) / (f32)rwData->animTimer;
+            rwData->atToEyeTargetYaw = atToEyeNextDir.yaw;
+            rwData->atToEyeTargetPitch = atToEyeNextDir.pitch;
             camera->animState++;
             rwData->unk_12 = 1;
             break;
@@ -3932,20 +3932,20 @@ s32 Camera_KeepOn4(Camera* camera) {
     camera->yOffsetUpdateRate = 0.25f;
     camera->atLERPStepScale = 0.75f;
     Camera_LERPCeilVec3f(&sAtTarget, at, 0.5f, 0.5f, 0.2f);
-    if (roData->unk_10 != 0.0f) {
-        vecGeo.r = roData->unk_10;
+    if (roData->atOffsetPlayerForwards != 0.0f) {
+        vecGeo.r = roData->atOffsetPlayerForwards;
         vecGeo.pitch = 0;
         vecGeo.yaw = playerPosRot->rot.y;
         *at = Camera_AddVecGeoToVec3f(at, &vecGeo);
     }
     camera->atLERPStepScale = 0.0f;
-    camera->dist = Camera_LERPCeilF(roData->unk_04, camera->dist, 0.25f, 2.0f);
+    camera->dist = Camera_LERPCeilF(roData->eyeDist, camera->dist, 0.25f, 2.0f);
     vecGeo.r = camera->dist;
-    if (rwData->unk_10 != 0) {
+    if (rwData->animTimer != 0) {
         camera->stateFlags |= CAM_STATE_LOCK_MODE;
-        rwData->unk_0C += (s16)rwData->unk_00;
-        rwData->unk_0E += (s16)rwData->unk_04;
-        rwData->unk_10--;
+        rwData->atToEyeTargetYaw += (s16)rwData->atToEyeTargetStepYaw;
+        rwData->atToEyeTargetPitch += (s16)rwData->atToEyeTargetStepPitch;
+        rwData->animTimer--;
     } else if (roData->interfaceField & KEEPON4_FLAG_4) {
         camera->stateFlags |= (CAM_STATE_CAM_FUNC_FINISH | CAM_STATE_BLOCK_BG);
         camera->stateFlags |= (CAM_STATE_CHECK_WATER | CAM_STATE_CHECK_BG);
@@ -3967,12 +3967,12 @@ s32 Camera_KeepOn4(Camera* camera) {
             }
         }
     }
-    vecGeo.yaw = Camera_LERPCeilS(rwData->unk_0C, atToEyeNextDir.yaw, roData->unk_14, 4);
-    vecGeo.pitch = Camera_LERPCeilS(rwData->unk_0E, atToEyeNextDir.pitch, roData->unk_14, 4);
+    vecGeo.yaw = Camera_LERPCeilS(rwData->atToEyeTargetYaw, atToEyeNextDir.yaw, roData->unk_14, 4);
+    vecGeo.pitch = Camera_LERPCeilS(rwData->atToEyeTargetPitch, atToEyeNextDir.pitch, roData->unk_14, 4);
     *eyeNext = Camera_AddVecGeoToVec3f(at, &vecGeo);
     *eye = *eyeNext;
     Camera_BGCheck(camera, at, eye);
-    camera->fov = Camera_LERPCeilF(roData->unk_18, camera->fov, camera->fovUpdateRate, 1.0f);
+    camera->fov = Camera_LERPCeilF(roData->fovTarget, camera->fov, camera->fovUpdateRate, 1.0f);
     camera->roll = Camera_LERPCeilS(0, camera->roll, 0.5f, 0xA);
     //! @bug Missing return, but the return value is not used.
 }

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -3703,7 +3703,7 @@ s32 Camera_KeepOn4(Camera* camera) {
     }
 
     if (rwData->itemType != *itemType) {
-        PRINTF(VT_COL(YELLOW, BLACK) "camera: item: item type changed %d -> %d\n" VT_RST, rwData->unk_14, *itemType);
+        PRINTF(VT_COL(YELLOW, BLACK) "camera: item: item type changed %d -> %d\n" VT_RST, rwData->itemType, *itemType);
         camera->animState = 20;
         camera->stateFlags |= CAM_STATE_LOCK_MODE;
         camera->stateFlags &= ~(CAM_STATE_CHECK_WATER | CAM_STATE_CHECK_BG);

--- a/src/code/z_camera_data.inc.c
+++ b/src/code/z_camera_data.inc.c
@@ -110,7 +110,7 @@ s16 sCamDataRegsInit[CAM_DATA_MAX] = {
     0,   // CAM_DATA_AT_OFFSET_X
     0,   // CAM_DATA_AT_OFFSET_Y
     0,   // CAM_DATA_AT_OFFSET_Z
-    6,   // CAM_DATA_UNK_22
+    6,   // CAM_DATA_INIT_TIMER
     60,  // CAM_DATA_UNK_23
     30,  // CAM_DATA_FOV_SCALE
     0,   // CAM_DATA_YAW_SCALE


### PR DESCRIPTION
Split from #1456

As a reminder for camera neophytes, "ReadOnlyData" is data taken from z_camera_data.inc.c through `sCameraSettings` and read with the `GET_NEXT_RO_DATA`/`GET_NEXT_SCALED_RO_DATA`, and typically not written to at other times, and "ReadWriteData" is generic data the camera uses for writing as well

Macros like `CAM_FUNCDATA_KEEP4` hold the data that becomes "ReadOnlyData" contents in z_camera_data.inc.c