### PR TITLE
Commit objects 1: `tp`, `triforce_spot`, `umajump`, `vase`, `yukabyun`, `zg`

### DIFF
--- a/assets/objects/object_tp/object_tp.c
+++ b/assets/objects/object_tp/object_tp.c
@@ -1,0 +1,50 @@
+#include "object_tp.h"
+#include "gfx.h"
+
+Gfx gTailpasaranTailSegmentDL[14] = {
+#include "assets/objects/object_tp/gTailpasaranTailSegmentDL.inc.c"
+};
+
+Vtx gTailpasaranTailSegmentVtx[] = {
+#include "assets/objects/object_tp/gTailpasaranTailSegmentVtx.inc.c"
+};
+
+Vtx gTailpasaranHeadClawVtx[] = {
+#include "assets/objects/object_tp/gTailpasaranHeadClawVtx.inc.c"
+};
+
+Vtx gTailpasaranHeadMouthpartsVtx[] = {
+#include "assets/objects/object_tp/gTailpasaranHeadMouthpartsVtx.inc.c"
+};
+
+Gfx gTailpasaranHeadClawDL[54] = {
+#include "assets/objects/object_tp/gTailpasaranHeadClawDL.inc.c"
+};
+
+Gfx gTailpasaranHeadMouthpartsDL[18] = {
+#include "assets/objects/object_tp/gTailpasaranHeadMouthpartsDL.inc.c"
+};
+
+Gfx gTailpasaranHeadDL[3] = {
+#include "assets/objects/object_tp/gTailpasaranHeadDL.inc.c"
+};
+
+u64 gTailpasaranHeadRearTex[TEX_LEN(u64, gTailpasaranHeadRearTex_WIDTH, gTailpasaranHeadRearTex_HEIGHT, 16)] = {
+#include "assets/objects/object_tp/gTailpasaranHeadRearTex.rgba16.inc.c"
+};
+
+u64 gTailpasaranHeadClawBaseTex[TEX_LEN(u64, gTailpasaranHeadClawBaseTex_WIDTH, gTailpasaranHeadClawBaseTex_HEIGHT, 16)] = {
+#include "assets/objects/object_tp/gTailpasaranHeadClawBaseTex.rgba16.inc.c"
+};
+
+u64 gTailpasaranHeadClawTex[TEX_LEN(u64, gTailpasaranHeadClawTex_WIDTH, gTailpasaranHeadClawTex_HEIGHT, 16)] = {
+#include "assets/objects/object_tp/gTailpasaranHeadClawTex.rgba16.inc.c"
+};
+
+u64 gTailpasaranTailSegmentTex[TEX_LEN(u64, gTailpasaranTailSegmentTex_WIDTH, gTailpasaranTailSegmentTex_HEIGHT, 8)] = {
+#include "assets/objects/object_tp/gTailpasaranTailSegmentTex.ia8.inc.c"
+};
+
+u64 gTailpasaranHeadMouthpartsTex[TEX_LEN(u64, gTailpasaranHeadMouthpartsTex_WIDTH, gTailpasaranHeadMouthpartsTex_HEIGHT, 16)] = {
+#include "assets/objects/object_tp/gTailpasaranHeadMouthpartsTex.rgba16.inc.c"
+};

--- a/assets/objects/object_tp/object_tp.c
+++ b/assets/objects/object_tp/object_tp.c
@@ -33,7 +33,8 @@ u64 gTailpasaranHeadRearTex[TEX_LEN(u64, gTailpasaranHeadRearTex_WIDTH, gTailpas
 #include "assets/objects/object_tp/gTailpasaranHeadRearTex.rgba16.inc.c"
 };
 
-u64 gTailpasaranHeadClawBaseTex[TEX_LEN(u64, gTailpasaranHeadClawBaseTex_WIDTH, gTailpasaranHeadClawBaseTex_HEIGHT, 16)] = {
+u64 gTailpasaranHeadClawBaseTex[TEX_LEN(u64, gTailpasaranHeadClawBaseTex_WIDTH, gTailpasaranHeadClawBaseTex_HEIGHT,
+                                        16)] = {
 #include "assets/objects/object_tp/gTailpasaranHeadClawBaseTex.rgba16.inc.c"
 };
 
@@ -45,6 +46,7 @@ u64 gTailpasaranTailSegmentTex[TEX_LEN(u64, gTailpasaranTailSegmentTex_WIDTH, gT
 #include "assets/objects/object_tp/gTailpasaranTailSegmentTex.ia8.inc.c"
 };
 
-u64 gTailpasaranHeadMouthpartsTex[TEX_LEN(u64, gTailpasaranHeadMouthpartsTex_WIDTH, gTailpasaranHeadMouthpartsTex_HEIGHT, 16)] = {
+u64 gTailpasaranHeadMouthpartsTex[TEX_LEN(u64, gTailpasaranHeadMouthpartsTex_WIDTH,
+                                          gTailpasaranHeadMouthpartsTex_HEIGHT, 16)] = {
 #include "assets/objects/object_tp/gTailpasaranHeadMouthpartsTex.rgba16.inc.c"
 };

--- a/assets/objects/object_tp/object_tp.h
+++ b/assets/objects/object_tp/object_tp.h
@@ -1,0 +1,34 @@
+#ifndef OBJECT_TP_H
+#define OBJECT_TP_H
+
+#include "ultra64.h"
+#include "tex_len.h"
+
+extern Gfx gTailpasaranTailSegmentDL[14];
+extern Vtx gTailpasaranTailSegmentVtx[];
+
+extern Gfx gTailpasaranHeadClawDL[54];
+extern Gfx gTailpasaranHeadMouthpartsDL[18];
+extern Gfx gTailpasaranHeadDL[3];
+
+#define gTailpasaranHeadRearTex_WIDTH 8
+#define gTailpasaranHeadRearTex_HEIGHT 16
+extern u64 gTailpasaranHeadRearTex[TEX_LEN(u64, gTailpasaranHeadRearTex_WIDTH, gTailpasaranHeadRearTex_HEIGHT, 16)];
+
+#define gTailpasaranHeadClawBaseTex_WIDTH 8
+#define gTailpasaranHeadClawBaseTex_HEIGHT 8
+extern u64 gTailpasaranHeadClawBaseTex[TEX_LEN(u64, gTailpasaranHeadClawBaseTex_WIDTH, gTailpasaranHeadClawBaseTex_HEIGHT, 16)];
+
+#define gTailpasaranHeadClawTex_WIDTH 16
+#define gTailpasaranHeadClawTex_HEIGHT 16
+extern u64 gTailpasaranHeadClawTex[TEX_LEN(u64, gTailpasaranHeadClawTex_WIDTH, gTailpasaranHeadClawTex_HEIGHT, 16)];
+
+#define gTailpasaranTailSegmentTex_WIDTH 64
+#define gTailpasaranTailSegmentTex_HEIGHT 64
+extern u64 gTailpasaranTailSegmentTex[TEX_LEN(u64, gTailpasaranTailSegmentTex_WIDTH, gTailpasaranTailSegmentTex_HEIGHT, 8)];
+
+#define gTailpasaranHeadMouthpartsTex_WIDTH 8
+#define gTailpasaranHeadMouthpartsTex_HEIGHT 8
+extern u64 gTailpasaranHeadMouthpartsTex[TEX_LEN(u64, gTailpasaranHeadMouthpartsTex_WIDTH, gTailpasaranHeadMouthpartsTex_HEIGHT, 16)];
+
+#endif

--- a/assets/objects/object_triforce_spot/object_triforce_spot.c
+++ b/assets/objects/object_triforce_spot/object_triforce_spot.c
@@ -1,0 +1,30 @@
+#include "object_triforce_spot.h"
+#include "gfx.h"
+
+Vtx gTriforceVtx[] = {
+#include "assets/objects/object_triforce_spot/gTriforceVtx.inc.c"
+};
+
+Vtx gTriforceLightColumnVtx[] = {
+#include "assets/objects/object_triforce_spot/gTriforceLightColumnVtx.inc.c"
+};
+
+Gfx gTriforceDL[72] = {
+#include "assets/objects/object_triforce_spot/gTriforceDL.inc.c"
+};
+
+Gfx gTriforceLightColumnDL[26] = {
+#include "assets/objects/object_triforce_spot/gTriforceLightColumnDL.inc.c"
+};
+
+u64 gTriforceTex[TEX_LEN(u64, gTriforceTex_WIDTH, gTriforceTex_HEIGHT, 8)] = {
+#include "assets/objects/object_triforce_spot/gTriforceTex.i8.inc.c"
+};
+
+u64 gTriforceColumnSide1Tex[TEX_LEN(u64, gTriforceColumnSide1Tex_WIDTH, gTriforceColumnSide1Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_triforce_spot/gTriforceColumnSide1Tex.i8.inc.c"
+};
+
+u64 gTriforceColumnSide2Tex[TEX_LEN(u64, gTriforceColumnSide2Tex_WIDTH, gTriforceColumnSide2Tex_HEIGHT, 8)] = {
+#include "assets/objects/object_triforce_spot/gTriforceColumnSide2Tex.i8.inc.c"
+};

--- a/assets/objects/object_triforce_spot/object_triforce_spot.h
+++ b/assets/objects/object_triforce_spot/object_triforce_spot.h
@@ -4,7 +4,9 @@
 #include "ultra64.h"
 #include "tex_len.h"
 
+extern Vtx gTriforceVtx[];
 extern Gfx gTriforceDL[72];
+
 extern Gfx gTriforceLightColumnDL[26];
 
 #define gTriforceTex_WIDTH 64

--- a/assets/objects/object_triforce_spot/object_triforce_spot.h
+++ b/assets/objects/object_triforce_spot/object_triforce_spot.h
@@ -1,0 +1,22 @@
+#ifndef OBJECT_TRIFORCE_SPOT_H
+#define OBJECT_TRIFORCE_SPOT_H
+
+#include "ultra64.h"
+#include "tex_len.h"
+
+extern Gfx gTriforceDL[72];
+extern Gfx gTriforceLightColumnDL[26];
+
+#define gTriforceTex_WIDTH 64
+#define gTriforceTex_HEIGHT 64
+extern u64 gTriforceTex[TEX_LEN(u64, gTriforceTex_WIDTH, gTriforceTex_HEIGHT, 8)];
+
+#define gTriforceColumnSide1Tex_WIDTH 64
+#define gTriforceColumnSide1Tex_HEIGHT 32
+extern u64 gTriforceColumnSide1Tex[TEX_LEN(u64, gTriforceColumnSide1Tex_WIDTH, gTriforceColumnSide1Tex_HEIGHT, 8)];
+
+#define gTriforceColumnSide2Tex_WIDTH 64
+#define gTriforceColumnSide2Tex_HEIGHT 32
+extern u64 gTriforceColumnSide2Tex[TEX_LEN(u64, gTriforceColumnSide2Tex_WIDTH, gTriforceColumnSide2Tex_HEIGHT, 8)];
+
+#endif

--- a/assets/objects/object_umajump/gJumpableHorseFenceCol.c
+++ b/assets/objects/object_umajump/gJumpableHorseFenceCol.c
@@ -1,0 +1,24 @@
+#include "object_umajump.h"
+#include "array_count.h"
+#include "camera.h"
+#include "z_math.h"
+
+BgCamInfo gJumpableHorseFenceBgCamList[] = {
+#include "assets/objects/object_umajump/gJumpableHorseFenceBgCamList.inc.c"
+};
+
+SurfaceType gJumpableHorseFenceSurfaceTypes[] = {
+#include "assets/objects/object_umajump/gJumpableHorseFenceSurfaceTypes.inc.c"
+};
+
+CollisionPoly gJumpableHorseFencePolyList[] = {
+#include "assets/objects/object_umajump/gJumpableHorseFencePolyList.inc.c"
+};
+
+Vec3s gJumpableHorseFenceVtxList[] = {
+#include "assets/objects/object_umajump/gJumpableHorseFenceVtxList.inc.c"
+};
+
+CollisionHeader gJumpableHorseFenceCol = {
+#include "assets/objects/object_umajump/gJumpableHorseFenceCol.inc.c"
+};

--- a/assets/objects/object_umajump/gJumpableHorseFenceDL.c
+++ b/assets/objects/object_umajump/gJumpableHorseFenceDL.c
@@ -4,13 +4,15 @@
 
 #define gJumpableHorseFenceBrickTex_WIDTH 16
 #define gJumpableHorseFenceBrickTex_HEIGHT 64
-u64 gJumpableHorseFenceBrickTex[TEX_LEN(u64, gJumpableHorseFenceBrickTex_WIDTH, gJumpableHorseFenceBrickTex_HEIGHT, 16)] = {
+u64 gJumpableHorseFenceBrickTex[TEX_LEN(u64, gJumpableHorseFenceBrickTex_WIDTH, gJumpableHorseFenceBrickTex_HEIGHT,
+                                        16)] = {
 #include "assets/objects/object_umajump/gJumpableHorseFenceBrickTex.rgba16.inc.c"
 };
 
 #define gJumpableHorseFenceMetalBarTex_WIDTH 16
 #define gJumpableHorseFenceMetalBarTex_HEIGHT 64
-u64 gJumpableHorseFenceMetalBarTex[TEX_LEN(u64, gJumpableHorseFenceMetalBarTex_WIDTH, gJumpableHorseFenceMetalBarTex_HEIGHT, 16)] = {
+u64 gJumpableHorseFenceMetalBarTex[TEX_LEN(u64, gJumpableHorseFenceMetalBarTex_WIDTH,
+                                           gJumpableHorseFenceMetalBarTex_HEIGHT, 16)] = {
 #include "assets/objects/object_umajump/gJumpableHorseFenceMetalBarTex.rgba16.inc.c"
 };
 

--- a/assets/objects/object_umajump/gJumpableHorseFenceDL.c
+++ b/assets/objects/object_umajump/gJumpableHorseFenceDL.c
@@ -1,0 +1,23 @@
+#include "object_umajump.h"
+#include "gfx.h"
+#include "tex_len.h"
+
+#define gJumpableHorseFenceBrickTex_WIDTH 16
+#define gJumpableHorseFenceBrickTex_HEIGHT 64
+u64 gJumpableHorseFenceBrickTex[TEX_LEN(u64, gJumpableHorseFenceBrickTex_WIDTH, gJumpableHorseFenceBrickTex_HEIGHT, 16)] = {
+#include "assets/objects/object_umajump/gJumpableHorseFenceBrickTex.rgba16.inc.c"
+};
+
+#define gJumpableHorseFenceMetalBarTex_WIDTH 16
+#define gJumpableHorseFenceMetalBarTex_HEIGHT 64
+u64 gJumpableHorseFenceMetalBarTex[TEX_LEN(u64, gJumpableHorseFenceMetalBarTex_WIDTH, gJumpableHorseFenceMetalBarTex_HEIGHT, 16)] = {
+#include "assets/objects/object_umajump/gJumpableHorseFenceMetalBarTex.rgba16.inc.c"
+};
+
+Vtx gJumpableHorseFenceVtx[] = {
+#include "assets/objects/object_umajump/gJumpableHorseFenceVtx.inc.c"
+};
+
+Gfx gJumpableHorseFenceDL[37] = {
+#include "assets/objects/object_umajump/gJumpableHorseFenceDL.inc.c"
+};

--- a/assets/objects/object_umajump/object_umajump.h
+++ b/assets/objects/object_umajump/object_umajump.h
@@ -1,0 +1,10 @@
+#ifndef OBJECT_UMAJUMP_H
+#define OBJECT_UMAJUMP_H
+
+#include "ultra64.h"
+#include "bgcheck.h"
+
+extern Gfx gJumpableHorseFenceDL[37];
+extern CollisionHeader gJumpableHorseFenceCol;
+
+#endif

--- a/assets/objects/object_vase/gUnusedVaseDL.c
+++ b/assets/objects/object_vase/gUnusedVaseDL.c
@@ -1,0 +1,18 @@
+#include "object_vase.h"
+#include "gfx.h"
+
+Gfx gUnusedVaseDL[52] = {
+#include "assets/objects/object_vase/gUnusedVaseDL.inc.c"
+};
+
+Vtx gUnusedVaseVtx[] = {
+#include "assets/objects/object_vase/gUnusedVaseVtx.inc.c"
+};
+
+u64 gUnusedVaseBodyTex[TEX_LEN(u64, gUnusedVaseBodyTex_WIDTH, gUnusedVaseBodyTex_HEIGHT, 16)] = {
+#include "assets/objects/object_vase/gUnusedVaseBodyTex.rgba16.inc.c"
+};
+
+u64 gUnusedVaseTopTex[TEX_LEN(u64, gUnusedVaseTopTex_WIDTH, gUnusedVaseTopTex_HEIGHT, 16)] = {
+#include "assets/objects/object_vase/gUnusedVaseTopTex.rgba16.inc.c"
+};

--- a/assets/objects/object_vase/object_vase.h
+++ b/assets/objects/object_vase/object_vase.h
@@ -1,0 +1,19 @@
+#ifndef OBJECT_VASE_H
+#define OBJECT_VASE_H
+
+#include "ultra64.h"
+#include "tex_len.h"
+
+extern Gfx gUnusedVaseDL[52];
+
+extern Vtx gUnusedVaseVtx[];
+
+#define gUnusedVaseBodyTex_WIDTH 32
+#define gUnusedVaseBodyTex_HEIGHT 32
+extern u64 gUnusedVaseBodyTex[TEX_LEN(u64, gUnusedVaseBodyTex_WIDTH, gUnusedVaseBodyTex_HEIGHT, 16)];
+
+#define gUnusedVaseTopTex_WIDTH 32
+#define gUnusedVaseTopTex_HEIGHT 32
+extern u64 gUnusedVaseTopTex[TEX_LEN(u64, gUnusedVaseTopTex_WIDTH, gUnusedVaseTopTex_HEIGHT, 16)];
+
+#endif

--- a/assets/objects/object_yukabyun/gFloorTileEnemyDL.c
+++ b/assets/objects/object_yukabyun/gFloorTileEnemyDL.c
@@ -1,0 +1,14 @@
+#include "object_yukabyun.h"
+#include "gfx.h"
+
+u64 gFloorTileEnemyBottomTex[TEX_LEN(u64, gFloorTileEnemyBottomTex_WIDTH, gFloorTileEnemyBottomTex_HEIGHT, 16)] = {
+#include "assets/objects/object_yukabyun/gFloorTileEnemyBottomTex.rgba16.inc.c"
+};
+
+Vtx gFloorTileEnemyVtx[] = {
+#include "assets/objects/object_yukabyun/gFloorTileEnemyVtx.inc.c"
+};
+
+Gfx gFloorTileEnemyDL[23] = {
+#include "assets/objects/object_yukabyun/gFloorTileEnemyDL.inc.c"
+};

--- a/assets/objects/object_yukabyun/gFloorTileEnemyFragmentDL.c
+++ b/assets/objects/object_yukabyun/gFloorTileEnemyFragmentDL.c
@@ -1,0 +1,18 @@
+#include "object_yukabyun.h"
+#include "gfx.h"
+
+Vtx gFloorTileEnemyFragmentVtx[] = {
+#include "assets/objects/object_yukabyun/gFloorTileEnemyFragmentVtx.inc.c"
+};
+
+Gfx gFloorTileEnemyFragmentDL[18] = {
+#include "assets/objects/object_yukabyun/gFloorTileEnemyFragmentDL.inc.c"
+};
+
+u64 gFloorTileEnemyTopTex[TEX_LEN(u64, gFloorTileEnemyTopTex_WIDTH, gFloorTileEnemyTopTex_HEIGHT, 16)] = {
+#include "assets/objects/object_yukabyun/gFloorTileEnemyTopTex.rgba16.inc.c"
+};
+
+u64 gFloorTileEnemyFragmentTex[TEX_LEN(u64, gFloorTileEnemyFragmentTex_WIDTH, gFloorTileEnemyFragmentTex_HEIGHT, 16)] = {
+#include "assets/objects/object_yukabyun/gFloorTileEnemyFragmentTex.rgba16.inc.c"
+};

--- a/assets/objects/object_yukabyun/gFloorTileEnemyFragmentDL.c
+++ b/assets/objects/object_yukabyun/gFloorTileEnemyFragmentDL.c
@@ -13,6 +13,7 @@ u64 gFloorTileEnemyTopTex[TEX_LEN(u64, gFloorTileEnemyTopTex_WIDTH, gFloorTileEn
 #include "assets/objects/object_yukabyun/gFloorTileEnemyTopTex.rgba16.inc.c"
 };
 
-u64 gFloorTileEnemyFragmentTex[TEX_LEN(u64, gFloorTileEnemyFragmentTex_WIDTH, gFloorTileEnemyFragmentTex_HEIGHT, 16)] = {
+u64 gFloorTileEnemyFragmentTex[TEX_LEN(u64, gFloorTileEnemyFragmentTex_WIDTH, gFloorTileEnemyFragmentTex_HEIGHT,
+                                       16)] = {
 #include "assets/objects/object_yukabyun/gFloorTileEnemyFragmentTex.rgba16.inc.c"
 };

--- a/assets/objects/object_yukabyun/object_yukabyun.h
+++ b/assets/objects/object_yukabyun/object_yukabyun.h
@@ -1,0 +1,23 @@
+#ifndef OBJECT_YUKABYUN_H
+#define OBJECT_YUKABYUN_H
+
+#include "ultra64.h"
+#include "tex_len.h"
+
+#define gFloorTileEnemyBottomTex_WIDTH 32
+#define gFloorTileEnemyBottomTex_HEIGHT 32
+extern u64 gFloorTileEnemyBottomTex[TEX_LEN(u64, gFloorTileEnemyBottomTex_WIDTH, gFloorTileEnemyBottomTex_HEIGHT, 16)];
+
+extern Gfx gFloorTileEnemyDL[23];
+
+extern Gfx gFloorTileEnemyFragmentDL[18];
+
+#define gFloorTileEnemyTopTex_WIDTH 32
+#define gFloorTileEnemyTopTex_HEIGHT 32
+extern u64 gFloorTileEnemyTopTex[TEX_LEN(u64, gFloorTileEnemyTopTex_WIDTH, gFloorTileEnemyTopTex_HEIGHT, 16)];
+
+#define gFloorTileEnemyFragmentTex_WIDTH 16
+#define gFloorTileEnemyFragmentTex_HEIGHT 16
+extern u64 gFloorTileEnemyFragmentTex[TEX_LEN(u64, gFloorTileEnemyFragmentTex_WIDTH, gFloorTileEnemyFragmentTex_HEIGHT, 16)];
+
+#endif

--- a/assets/objects/object_zg/gTowerCollapseBarsCol.c
+++ b/assets/objects/object_zg/gTowerCollapseBarsCol.c
@@ -1,0 +1,24 @@
+#include "object_zg.h"
+#include "array_count.h"
+#include "camera.h"
+#include "z_math.h"
+
+BgCamInfo gTowerCollapseBarsBgCamList[] = {
+#include "assets/objects/object_zg/gTowerCollapseBarsBgCamList.inc.c"
+};
+
+SurfaceType gTowerCollapseBarsSurfaceTypes[] = {
+#include "assets/objects/object_zg/gTowerCollapseBarsSurfaceTypes.inc.c"
+};
+
+CollisionPoly gTowerCollapseBarsPolyList[] = {
+#include "assets/objects/object_zg/gTowerCollapseBarsPolyList.inc.c"
+};
+
+Vec3s gTowerCollapseBarsVtxList[] = {
+#include "assets/objects/object_zg/gTowerCollapseBarsVtxList.inc.c"
+};
+
+CollisionHeader gTowerCollapseBarsCol = {
+#include "assets/objects/object_zg/gTowerCollapseBarsCol.inc.c"
+};

--- a/assets/objects/object_zg/gTowerCollapseBarsDL.c
+++ b/assets/objects/object_zg/gTowerCollapseBarsDL.c
@@ -1,0 +1,23 @@
+#include "object_zg.h"
+#include "gfx.h"
+#include "tex_len.h"
+
+#define gTowerCollapseBarMetalTex_WIDTH 32
+#define gTowerCollapseBarMetalTex_HEIGHT 32
+u64 gTowerCollapseBarMetalTex[TEX_LEN(u64, gTowerCollapseBarMetalTex_WIDTH, gTowerCollapseBarMetalTex_HEIGHT, 16)] = {
+#include "assets/objects/object_zg/gTowerCollapseBarMetalTex.rgba16.inc.c"
+};
+
+#define gTowerCollapseBarFlameTex_WIDTH 32
+#define gTowerCollapseBarFlameTex_HEIGHT 32
+u64 gTowerCollapseBarFlameTex[TEX_LEN(u64, gTowerCollapseBarFlameTex_WIDTH, gTowerCollapseBarFlameTex_HEIGHT, 16)] = {
+#include "assets/objects/object_zg/gTowerCollapseBarFlameTex.rgba16.inc.c"
+};
+
+Vtx gTowerCollapseBarsVtx[] = {
+#include "assets/objects/object_zg/gTowerCollapseBarsVtx.inc.c"
+};
+
+Gfx gTowerCollapseBarsDL[28] = {
+#include "assets/objects/object_zg/gTowerCollapseBarsDL.inc.c"
+};

--- a/assets/objects/object_zg/object_zg.h
+++ b/assets/objects/object_zg/object_zg.h
@@ -1,0 +1,11 @@
+#ifndef OBJECT_ZG_H
+#define OBJECT_ZG_H
+
+#include "ultra64.h"
+#include "bgcheck.h"
+
+extern Gfx gTowerCollapseBarsDL[28];
+
+extern CollisionHeader gTowerCollapseBarsCol;
+
+#endif

--- a/spec/spec
+++ b/spec/spec
@@ -1707,7 +1707,8 @@ beginseg
     name "object_yukabyun"
     compress
     romalign 0x1000
-    include "$(BUILD_DIR)/assets/objects/object_yukabyun/object_yukabyun.o"
+    include "$(BUILD_DIR)/assets/objects/object_yukabyun/gFloorTileEnemyDL.o"
+    include "$(BUILD_DIR)/assets/objects/object_yukabyun/gFloorTileEnemyFragmentDL.o"
     number 6
 endseg
 

--- a/spec/spec
+++ b/spec/spec
@@ -1924,7 +1924,7 @@ beginseg
     name "object_vase"
     compress
     romalign 0x1000
-    include "$(BUILD_DIR)/assets/objects/object_vase/object_vase.o"
+    include "$(BUILD_DIR)/assets/objects/object_vase/gUnusedVaseDL.o"
     number 6
 endseg
 

--- a/spec/spec
+++ b/spec/spec
@@ -3555,7 +3555,8 @@ beginseg
     name "object_zg"
     compress
     romalign 0x1000
-    include "$(BUILD_DIR)/assets/objects/object_zg/object_zg.o"
+    include "$(BUILD_DIR)/assets/objects/object_zg/gTowerCollapseBarsDL.o"
+    include "$(BUILD_DIR)/assets/objects/object_zg/gTowerCollapseBarsCol.o"
     number 6
 endseg
 

--- a/spec/spec
+++ b/spec/spec
@@ -2884,7 +2884,8 @@ beginseg
     name "object_umajump"
     compress
     romalign 0x1000
-    include "$(BUILD_DIR)/assets/objects/object_umajump/object_umajump.o"
+    include "$(BUILD_DIR)/assets/objects/object_umajump/gJumpableHorseFenceDL.o"
+    include "$(BUILD_DIR)/assets/objects/object_umajump/gJumpableHorseFenceCol.o"
     number 6
 endseg
 

--- a/tools/assets/extract/write_source.txt
+++ b/tools/assets/extract/write_source.txt
@@ -353,7 +353,6 @@ assets/objects/object_tk/object_tk.c
 assets/objects/object_toki_objects/object_toki_objects.c
 assets/objects/object_torch2/object_torch2.c
 assets/objects/object_toryo/object_toryo.c
-assets/objects/object_tp/object_tp.c
 assets/objects/object_trap/object_trap.c
 assets/objects/object_tr/object_tr.c
 assets/objects/object_ts/object_ts.c

--- a/tools/assets/extract/write_source.txt
+++ b/tools/assets/extract/write_source.txt
@@ -355,7 +355,6 @@ assets/objects/object_torch2/object_torch2.c
 assets/objects/object_toryo/object_toryo.c
 assets/objects/object_tp/object_tp.c
 assets/objects/object_trap/object_trap.c
-assets/objects/object_triforce_spot/object_triforce_spot.c
 assets/objects/object_tr/object_tr.c
 assets/objects/object_ts/object_ts.c
 assets/objects/object_tsubo/object_tsubo.c

--- a/tools/assets/extract/write_source.txt
+++ b/tools/assets/extract/write_source.txt
@@ -372,7 +372,6 @@ assets/objects/object_wood02/object_wood02.c
 assets/objects/object_xc/object_xc.c
 assets/objects/object_yabusame_point/object_yabusame_point.c
 assets/objects/object_ydan_objects/object_ydan_objects.c
-assets/objects/object_yukabyun/object_yukabyun.c
 assets/objects/object_zf/object_zf.c
 assets/objects/object_zl1/object_zl1.c
 assets/objects/object_zl2_anime1/object_zl2_anime1.c

--- a/tools/assets/extract/write_source.txt
+++ b/tools/assets/extract/write_source.txt
@@ -362,7 +362,6 @@ assets/objects/object_tsubo/object_tsubo.c
 assets/objects/object_tw/object_tw.c
 assets/objects/object_umajump/object_umajump.c
 assets/objects/object_vali/object_vali.c
-assets/objects/object_vase/object_vase.c
 assets/objects/object_vm/object_vm.c
 assets/objects/object_wallmaster/object_wallmaster.c
 assets/objects/object_warp1/object_warp1.c

--- a/tools/assets/extract/write_source.txt
+++ b/tools/assets/extract/write_source.txt
@@ -374,7 +374,6 @@ assets/objects/object_yabusame_point/object_yabusame_point.c
 assets/objects/object_ydan_objects/object_ydan_objects.c
 assets/objects/object_yukabyun/object_yukabyun.c
 assets/objects/object_zf/object_zf.c
-assets/objects/object_zg/object_zg.c
 assets/objects/object_zl1/object_zl1.c
 assets/objects/object_zl2_anime1/object_zl2_anime1.c
 assets/objects/object_zl2_anime2/object_zl2_anime2.c

--- a/tools/assets/extract/write_source.txt
+++ b/tools/assets/extract/write_source.txt
@@ -360,7 +360,6 @@ assets/objects/object_tr/object_tr.c
 assets/objects/object_ts/object_ts.c
 assets/objects/object_tsubo/object_tsubo.c
 assets/objects/object_tw/object_tw.c
-assets/objects/object_umajump/object_umajump.c
 assets/objects/object_vali/object_vali.c
 assets/objects/object_vm/object_vm.c
 assets/objects/object_wallmaster/object_wallmaster.c


### PR DESCRIPTION
I'm not sure on the scheme to adopt for what to put in the .h header files. Here, I go with putting the least stuff inside but still putting all declarations inside, even if the declarations could be done in the .c

For example in `object_tp` (tailparasan enemy) textures are at the end of the object, requiring them all to be declared for the dlists to use them. I put the declarations in the .h but they could as well be at the top of the .c (except for `gTailpasaranTailSegmentTex` which is referenced in code so needs to be in the .h)

Note previously (in at least object_link_boy) I declared some stuff in the .c as needed instead of putting declarations in the .h
```c
#define gLinkAdultHookshotChainTex_WIDTH 16
#define gLinkAdultHookshotChainTex_HEIGHT 32
u64 gLinkAdultHookshotChainTex[TEX_LEN(u64, gLinkAdultHookshotChainTex_WIDTH, gLinkAdultHookshotChainTex_HEIGHT, 16)];
```

Also note for now #2612 takes yet another approach of declaring everything in the .h, even things that don't need to be declared at all, but that may just be because cleanup is needed there