### PR TITLE
Cleanup extracted colliders 1

### DIFF
--- a/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
+++ b/src/overlays/actors/ovl_Bg_Bdan_Objects/z_bg_bdan_objects.c
@@ -86,7 +86,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_NONE,
         OCELEM_NONE,
     },
-    { 0x00BB, 0x0050, 0x0000, { 0 } },
+    { 187, 80, 0, { 0, 0, 0 } },
 };
 
 static InitChainEntry sInitChain[] = {

--- a/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Bombwall/z_bg_bombwall.c
@@ -28,7 +28,7 @@ void func_8086EDFC(BgBombwall* this, PlayState* play);
 void func_8086EE40(BgBombwall* this, PlayState* play);
 void func_8086EE94(BgBombwall* this, PlayState* play);
 
-static ColliderTrisElementInit sTrisElementsInit[3] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Sgami/z_bg_haka_sgami.c
@@ -46,7 +46,7 @@ ActorProfile Bg_Haka_Sgami_Profile = {
     /**/ NULL,
 };
 
-static ColliderTrisElementInit sTrisElementsInit[4] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK2,

--- a/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Trap/z_bg_haka_trap.c
@@ -72,7 +72,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 30, 90, 0, { 0, 0, 0 } },
 };
 
-static ColliderTrisElementInit sTrisElementsInit[2] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Dalm/z_bg_hidan_dalm.c
@@ -39,7 +39,7 @@ ActorProfile Bg_Hidan_Dalm_Profile = {
     /**/ BgHidanDalm_Draw,
 };
 
-static ColliderTrisElementInit sTrisElementInit[4] = {
+static ColliderTrisElementInit sTrisElementInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
@@ -60,7 +60,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_NONE,
         OCELEM_ON,
     },
-    { 30, 83, 0, { 0 } },
+    { 30, 83, 0, { 0, 0, 0 } },
 };
 
 static CollisionCheckInfoInit sColChkInfoInit = { 1, 80, 100, MASS_IMMOVABLE };

--- a/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hamstep/z_bg_hidan_hamstep.c
@@ -41,7 +41,7 @@ static f32 sYPosOffsets[] = {
     -20.0f, -120.0f, -220.0f, -320.0f, -420.0f,
 };
 
-static ColliderTrisElementInit sTrisElementsInit[2] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Hrock/z_bg_hidan_hrock.c
@@ -37,7 +37,7 @@ ActorProfile Bg_Hidan_Hrock_Profile = {
     /**/ BgHidanHrock_Draw,
 };
 
-static ColliderTrisElementInit sTrisElementsInit[2] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Kowarerukabe/z_bg_hidan_kowarerukabe.c
@@ -53,7 +53,7 @@ static Gfx* sBreakableWallDLists[] = {
     gFireTempleLargeBombableWallDL,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
@@ -37,7 +37,7 @@ ActorProfile Bg_Hidan_Rsekizou_Profile = {
     /**/ BgHidanRsekizou_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[6] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
@@ -41,7 +41,7 @@ ActorProfile Bg_Hidan_Sekizou_Profile = {
     /**/ BgHidanSekizou_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[6] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
@@ -46,7 +46,7 @@ ActorProfile Bg_Hidan_Sima_Profile = {
     /**/ BgHidanSima_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[2] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Bombchuiwa/z_bg_jya_bombchuiwa.c
@@ -40,7 +40,7 @@ ActorProfile Bg_Jya_Bombchuiwa_Profile = {
     /**/ BgJyaBombchuiwa_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.c
+++ b/src/overlays/actors/ovl_Bg_Jya_Haheniron/z_bg_jya_haheniron.c
@@ -43,7 +43,7 @@ ActorProfile Bg_Jya_Haheniron_Profile = {
     /**/ BgJyaHaheniron_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
+++ b/src/overlays/actors/ovl_Bg_Menkuri_Eye/z_bg_menkuri_eye.c
@@ -37,7 +37,7 @@ ActorProfile Bg_Menkuri_Eye_Profile = {
 
 static s32 sNumEyesShot;
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK4,

--- a/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
+++ b/src/overlays/actors/ovl_Bg_Mizu_Bwall/z_bg_mizu_bwall.c
@@ -44,7 +44,7 @@ ActorProfile Bg_Mizu_Bwall_Profile = {
     /**/ BgMizuBwall_Draw,
 };
 
-static ColliderTrisElementInit sTrisElementsInitFloor[2] = {
+static ColliderTrisElementInit sTrisElementsInitFloor[] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -82,7 +82,7 @@ static ColliderTrisInit sTrisInitFloor = {
     sTrisElementsInitFloor,
 };
 
-static ColliderTrisElementInit sTrisElementsInitRutoWall[1] = {
+static ColliderTrisElementInit sTrisElementsInitRutoWall[] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -109,7 +109,7 @@ static ColliderTrisInit sTrisInitRutoWall = {
     sTrisElementsInitRutoWall,
 };
 
-static ColliderTrisElementInit sTrisElementsInitWall[2] = {
+static ColliderTrisElementInit sTrisElementsInitWall[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.c
+++ b/src/overlays/actors/ovl_Bg_Mori_Hashigo/z_bg_mori_hashigo.c
@@ -47,7 +47,7 @@ ActorProfile Bg_Mori_Hashigo_Profile = {
     /**/ NULL,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK4,

--- a/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
+++ b/src/overlays/actors/ovl_Bg_Po_Event/z_bg_po_event.c
@@ -55,7 +55,7 @@ ActorProfile Bg_Po_Event_Profile = {
     /**/ BgPoEvent_Draw,
 };
 
-static ColliderTrisElementInit sTrisElementsInit[2] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK4,

--- a/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
+++ b/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
@@ -70,7 +70,7 @@ ActorProfile Bg_Spot06_Objects_Profile = {
     /**/ BgSpot06Objects_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
+++ b/src/overlays/actors/ovl_Bg_Spot18_Basket/z_bg_spot18_basket.c
@@ -49,7 +49,7 @@ ActorProfile Bg_Spot18_Basket_Profile = {
     /**/ BgSpot18Basket_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[2] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -64,7 +64,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_NONE,
         OCELEM_ON,
     },
-    { 10, 70, 0, { 0 } },
+    { 10, 70, 0, { 0, 0, 0 } },
 };
 
 static CollisionCheckInfoInit sColChkInfoInit = { 10, 35, 100, MASS_IMMOVABLE };

--- a/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Maruta/z_bg_ydan_maruta.c
@@ -39,7 +39,7 @@ ActorProfile Bg_Ydan_Maruta_Profile = {
     /**/ BgYdanMaruta_Draw,
 };
 
-static ColliderTrisElementInit sTrisElementsInit[2] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
+++ b/src/overlays/actors/ovl_Bg_Ydan_Sp/z_bg_ydan_sp.c
@@ -51,7 +51,7 @@ ActorProfile Bg_Ydan_Sp_Profile = {
     /**/ BgYdanSp_Draw,
 };
 
-static ColliderTrisElementInit sTrisElementsInit[2] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo_data.inc.c
+++ b/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo_data.inc.c
@@ -10,7 +10,7 @@ static u8 D_808C7000[] = {
     1, 0, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[19] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK3,

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd_colchk.inc.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd_colchk.inc.c
@@ -1,6 +1,6 @@
 #include "collision_check.h"
 
-static ColliderJntSphElementInit sJntSphElementsInit[19] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK3,

--- a/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2_colchk.inc.c
+++ b/src/overlays/actors/ovl_Boss_Fd2/z_boss_fd2_colchk.inc.c
@@ -1,6 +1,6 @@
 #include "collision_check.h"
 
-static ColliderJntSphElementInit sJntSphElementsInit[9] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK3,

--- a/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -92,7 +92,7 @@ ActorProfile Boss_Goma_Profile = {
     /**/ BossGoma_Draw,
 };
 
-static ColliderJntSphElementInit sColliderJntSphElementsInit[13] = {
+static ColliderJntSphElementInit sColliderJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK3,

--- a/src/overlays/actors/ovl_Boss_Mo/z_boss_mo_colchk.inc.c
+++ b/src/overlays/actors/ovl_Boss_Mo/z_boss_mo_colchk.inc.c
@@ -1,6 +1,6 @@
 #include "collision_check.h"
 
-static ColliderJntSphElementInit sJntSphElementsInit[19] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK4,

--- a/src/overlays/actors/ovl_Boss_Sst/z_boss_sst_colchk.inc.c
+++ b/src/overlays/actors/ovl_Boss_Sst/z_boss_sst_colchk.inc.c
@@ -1,6 +1,6 @@
 #include "collision_check.h"
 
-static ColliderJntSphElementInit sJntSphElementsInitHand[11] = {
+static ColliderJntSphElementInit sJntSphElementsInitHand[] = {
     {
         {
             ELEM_MATERIAL_UNK1,
@@ -137,7 +137,7 @@ static ColliderJntSphInit sJntSphInitHand = {
     sJntSphElementsInitHand,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInitHead[11] = {
+static ColliderJntSphElementInit sJntSphElementsInitHead[] = {
     {
         {
             ELEM_MATERIAL_UNK1,

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -245,7 +245,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 85, 120, 0, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInitSupport[1] = {
+static ColliderJntSphElementInit sJntSphElementsInitSupport[] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -272,7 +272,7 @@ static ColliderJntSphInit sJntSphInitSupport = {
     sJntSphElementsInitSupport,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInitBari[1] = {
+static ColliderJntSphElementInit sJntSphElementsInitBari[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -84,7 +84,14 @@ static ColliderCylinderInitType1 sCylinderInit = {
         OC1_ON | OC1_TYPE_PLAYER,
         COLSHAPE_CYLINDER,
     },
-    { 0x00, { 0x00000000, 0x00, 0x00 }, { 0x00000000, 0x00, 0x00 }, 0x00, 0x00, 0x01 },
+    {
+        ELEM_MATERIAL_UNK0,
+        { 0x00000000, 0x00, 0x00 },
+        { 0x00000000, 0x00, 0x00 },
+        ATELEM_NONE,
+        ACELEM_NONE,
+        OCELEM_ON,
+    },
     { 25, 80, 0, { 0, 0, 0 } },
 };
 

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -58,7 +58,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_ON,
         OCELEM_NONE,
     },
-    { 50, 10, 0, { 0 } },
+    { 50, 10, 0, { 0, 0, 0 } },
 };
 
 static s16 sGrottoEntrances[] = {

--- a/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
+++ b/src/overlays/actors/ovl_Door_Killer/z_door_killer.c
@@ -73,7 +73,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 20, 100, 0, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -67,7 +67,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_ON,
         OCELEM_ON,
     },
-    { 30, 40, 0, { 0 } },
+    { 30, 40, 0, { 0, 0, 0 } },
 };
 
 void EnAni_SetupAction(EnAni* this, EnAniActionFunc actionFunc) {

--- a/src/overlays/actors/ovl_En_Ba/z_en_ba.c
+++ b/src/overlays/actors/ovl_En_Ba/z_en_ba.c
@@ -51,7 +51,7 @@ ActorProfile En_Ba_Profile = {
 
 static Vec3f D_809B8080 = { 0.0f, 0.0f, 32.0f };
 
-static ColliderJntSphElementInit sJntSphElementsInit[2] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -225,7 +225,7 @@ ActorProfile En_Bb_Profile = {
     /**/ EnBb_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -62,7 +62,7 @@ ActorProfile En_Bigokuta_Profile = {
     /**/ EnBigokuta_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK1,

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -62,7 +62,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 6, 11, 14, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -66,7 +66,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 9, 18, 10, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -36,7 +36,7 @@ ActorProfile En_Bubble_Profile = {
     /**/ EnBubble_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[2] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -41,15 +41,17 @@ void EnButte_SetupWaitToDie(EnButte* this);
 void EnButte_WaitToDie(EnButte* this, PlayState* play);
 
 static ColliderJntSphElementInit sJntSphElementsInit[] = {
-    { {
-          ELEM_MATERIAL_UNK0,
-          { 0x00000000, 0x00, 0x00 },
-          { 0xFFCFFFFF, 0x000, 0x00 },
-          ATELEM_NONE,
-          ACELEM_NONE,
-          OCELEM_ON,
-      },
-      { 0, { { 0, 0, 0 }, 5 }, 100 } },
+    {
+        {
+            ELEM_MATERIAL_UNK0,
+            { 0x00000000, 0x00, 0x00 },
+            { 0xFFCFFFFF, 0x00, 0x00 },
+            ATELEM_NONE,
+            ACELEM_NONE,
+            OCELEM_ON,
+        },
+        { 0, { { 0, 0, 0 }, 5 }, 100 },
+    },
 };
 static ColliderJntSphInit sColliderJntSphInit = {
     {

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -43,7 +43,7 @@ ActorProfile En_Crow_Profile = {
     /**/ EnCrow_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
@@ -55,7 +55,7 @@ ActorProfile En_Dekubaba_Profile = {
     /**/ EnDekubaba_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[7] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Dh/z_en_dh.c
+++ b/src/overlays/actors/ovl_En_Dh/z_en_dh.c
@@ -90,7 +90,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 35, 70, 0, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
+++ b/src/overlays/actors/ovl_En_Diving_Game/z_en_diving_game.c
@@ -80,7 +80,7 @@ static ColliderCylinderInit sCylinderInit = {
         ELEM_MATERIAL_UNK0,
         { 0x00000000, 0x00, 0x00 },
         { 0x00000000, 0x00, 0x00 },
-        ATELEM_NONE | ATELEM_SFX_NORMAL,
+        ATELEM_NONE,
         ACELEM_NONE,
         OCELEM_ON,
     },

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -63,7 +63,7 @@ ActorProfile En_Dodongo_Profile = {
     /**/ EnDodongo_Draw,
 };
 
-static ColliderJntSphElementInit sBodyElementsInit[6] = {
+static ColliderJntSphElementInit sBodyElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -145,7 +145,7 @@ static ColliderJntSphInit sBodyJntSphInit = {
     sBodyElementsInit,
 };
 
-static ColliderTrisElementInit sHardElementsInit[3] = {
+static ColliderTrisElementInit sHardElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK2,

--- a/src/overlays/actors/ovl_En_Dog/z_en_dog.c
+++ b/src/overlays/actors/ovl_En_Dog/z_en_dog.c
@@ -58,7 +58,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_ON,
         OCELEM_ON,
     },
-    { 16, 20, 0, { 0 } },
+    { 16, 20, 0, { 0, 0, 0 } },
 };
 
 static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, 50 };

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -62,7 +62,7 @@ ActorProfile En_Fd_Profile = {
 #define FLARE_DANCER_BODY_DMG 0x04
 #endif
 
-static ColliderJntSphElementInit sJntSphElementsInit[12] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
+++ b/src/overlays/actors/ovl_En_Fhg_Fire/z_en_fhg_fire.c
@@ -87,7 +87,7 @@ static ColliderCylinderInit sCylinderInit = {
         ELEM_MATERIAL_UNK6,
         { 0x00100700, 0x03, 0x20 },
         { 0x0D900700, 0x00, 0x00 },
-        ATELEM_ON,
+        ATELEM_ON | ATELEM_SFX_NORMAL,
         ACELEM_ON,
         OCELEM_ON,
     },

--- a/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
+++ b/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
@@ -62,7 +62,7 @@ ActorProfile En_Firefly_Profile = {
     /**/ EnFirefly_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -50,7 +50,7 @@ static Actor* D_80A17010 = NULL;
 static f32 D_80A17014 = 0.0f;
 static f32 D_80A17018 = 0.0f;
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Fw/z_en_fw.c
+++ b/src/overlays/actors/ovl_En_Fw/z_en_fw.c
@@ -51,7 +51,7 @@ ActorProfile En_Fw_Profile = {
     /**/ EnFw_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
+++ b/src/overlays/actors/ovl_En_GeldB/z_en_geldb.c
@@ -119,7 +119,7 @@ static ColliderCylinderInit sBodyCylinderInit = {
     { 20, 50, 0, { 0, 0, 0 } },
 };
 
-static ColliderTrisElementInit sBlockTrisElementsInit[2] = {
+static ColliderTrisElementInit sBlockTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK2,

--- a/src/overlays/actors/ovl_En_Guest/z_en_guest.c
+++ b/src/overlays/actors/ovl_En_Guest/z_en_guest.c
@@ -54,7 +54,14 @@ static ColliderCylinderInitType1 sCylinderInit = {
         OC1_ON | OC1_TYPE_ALL,
         COLSHAPE_CYLINDER,
     },
-    { 0x00, { 0x00000000, 0x00, 0x00 }, { 0x00000000, 0x00, 0x00 }, 0x00, 0x00, 0x01 },
+    {
+        ELEM_MATERIAL_UNK0,
+        { 0x00000000, 0x00, 0x00 },
+        { 0x00000000, 0x00, 0x00 },
+        ATELEM_NONE,
+        ACELEM_NONE,
+        OCELEM_ON,
+    },
     { 10, 60, 0, { 0, 0, 0 } },
 };
 

--- a/src/overlays/actors/ovl_En_Hata/z_en_hata.c
+++ b/src/overlays/actors/ovl_En_Hata/z_en_hata.c
@@ -49,7 +49,7 @@ static ColliderCylinderInit sCylinderInit = {
         ELEM_MATERIAL_UNK0,
         { 0x00000000, 0x00, 0x00 },
         { 0x00000080, 0x00, 0x00 },
-        ATELEM_NONE | ATELEM_SFX_NORMAL,
+        ATELEM_NONE,
         ACELEM_ON | ACELEM_HOOKABLE,
         OCELEM_ON,
     },

--- a/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
+++ b/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
@@ -76,7 +76,7 @@ ActorProfile En_Honotrap_Profile = {
     /**/ EnHonotrap_Draw,
 };
 
-static ColliderTrisElementInit sTrisElementsInit[2] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK4,

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -143,7 +143,7 @@ static ColliderCylinderInit sCylinderInit2 = {
     { 20, 70, 0, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
@@ -73,7 +73,7 @@ static ColliderCylinderInitType1 sCylinderInit = {
     { 20, 100, 0, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
+++ b/src/overlays/actors/ovl_En_Horse_Zelda/z_en_horse_zelda.c
@@ -65,7 +65,7 @@ static ColliderCylinderInitType1 sCylinderInit = {
     { 40, 100, 0, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -107,7 +107,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 25, 80, 0, { 0, 0, 0 } },
 };
 
-static ColliderTrisElementInit sTrisElementsInit[2] = {
+static ColliderTrisElementInit sTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK2,

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -70,7 +70,7 @@ ActorProfile En_Insect_Profile = {
     /**/ EnInsect_Draw,
 };
 
-static ColliderJntSphElementInit sColliderElementsInit[1] = {
+static ColliderJntSphElementInit sColliderElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_It/z_en_it.c
+++ b/src/overlays/actors/ovl_En_It/z_en_it.c
@@ -31,7 +31,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_NONE,
         OCELEM_ON,
     },
-    { 40, 10, 0, { 0 } },
+    { 40, 10, 0, { 0, 0, 0 } },
 };
 
 static CollisionCheckInfoInit2 sColChkInfoInit = { 0, 0, 0, 0, MASS_IMMOVABLE };

--- a/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.c
+++ b/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.c
@@ -44,7 +44,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_NONE,
         OCELEM_NONE,
     },
-    { 200, 200, 0, { 0 } },
+    { 200, 200, 0, { 0, 0, 0 } },
 };
 
 void EnMFire1_Init(Actor* thisx, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Mb/z_en_mb.c
+++ b/src/overlays/actors/ovl_En_Mb/z_en_mb.c
@@ -126,7 +126,7 @@ static ColliderCylinderInit sBodyColliderInit = {
     { 20, 70, 0, { 0, 0, 0 } },
 };
 
-static ColliderTrisElementInit sFrontShieldingTrisElementsInit[2] = {
+static ColliderTrisElementInit sFrontShieldingTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK2,

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -49,8 +49,15 @@ static ColliderCylinderInitType1 sCylinderInit = {
         OC1_ON | OC1_TYPE_ALL,
         COLSHAPE_CYLINDER,
     },
-    { 0x00, { 0x00000000, 0x00, 0x00 }, { 0xFFCFFFFF, 0x00, 0x00 }, 0x00, 0x01, 0x01 },
-    { 22, 37, 0, { 0 } },
+    {
+        ELEM_MATERIAL_UNK0,
+        { 0x00000000, 0x00, 0x00 },
+        { 0xFFCFFFFF, 0x00, 0x00 },
+        ATELEM_NONE,
+        ACELEM_ON,
+        OCELEM_ON,
+    },
+    { 22, 37, 0, { 0, 0, 0 } },
 };
 
 static s16 sPrices[] = {

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
@@ -61,7 +61,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_ON,
         OCELEM_ON,
     },
-    { 13, 13, 0, { 0 } },
+    { 13, 13, 0, { 0, 0, 0 } },
 };
 
 static s16 sObjectIds[] = {

--- a/src/overlays/actors/ovl_En_Ny/z_en_ny.c
+++ b/src/overlays/actors/ovl_En_Ny/z_en_ny.c
@@ -51,7 +51,7 @@ ActorProfile En_Ny_Profile = {
     /**/ EnNy_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -155,7 +155,7 @@ static ColliderCylinderInitType1 sCylinderInit = {
         ELEM_MATERIAL_UNK0,
         { 0x00000000, 0x00, 0x00 },
         { 0x00000000, 0x00, 0x00 },
-        ATELEM_NONE | ATELEM_SFX_NORMAL,
+        ATELEM_NONE,
         ACELEM_NONE,
         OCELEM_ON,
     },

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -90,7 +90,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 50, 160, -70, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -90,7 +90,7 @@ static ColliderCylinderInit sCylinderInit = {
     { 20, 40, 20, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
+++ b/src/overlays/actors/ovl_En_Ru1/z_en_ru1.c
@@ -98,8 +98,15 @@ static ColliderCylinderInitType1 sStandingCylinderInit = {
         OC1_ON | OC1_TYPE_PLAYER,
         COLSHAPE_CYLINDER,
     },
-    { 0x00, { 0x00000000, 0x00, 0x00 }, { 0x00000000, 0x00, 0x00 }, 0x00, 0x00, 0x01 },
-    { 25, 80, 0, { 0 } },
+    {
+        ELEM_MATERIAL_UNK0,
+        { 0x00000000, 0x00, 0x00 },
+        { 0x00000000, 0x00, 0x00 },
+        ATELEM_NONE,
+        ACELEM_NONE,
+        OCELEM_ON,
+    },
+    { 25, 80, 0, { 0, 0, 0 } },
 };
 
 static ColliderCylinderInitType1 sSittingCylinderInit = {
@@ -110,8 +117,15 @@ static ColliderCylinderInitType1 sSittingCylinderInit = {
         OC1_ON | OC1_TYPE_PLAYER,
         COLSHAPE_CYLINDER,
     },
-    { 0x00, { 0x00000101, 0x00, 0x00 }, { 0x00000000, 0x00, 0x00 }, 0x01, 0x00, 0x01 },
-    { 20, 30, 0, { 0 } },
+    {
+        ELEM_MATERIAL_UNK0,
+        { 0x00000101, 0x00, 0x00 },
+        { 0x00000000, 0x00, 0x00 },
+        ATELEM_ON | ATELEM_SFX_NORMAL,
+        ACELEM_NONE,
+        OCELEM_ON,
+    },
+    { 20, 30, 0, { 0, 0, 0 } },
 };
 
 static void* sEyeTextures[] = {

--- a/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
+++ b/src/overlays/actors/ovl_En_Ru2/z_en_ru2.c
@@ -97,8 +97,15 @@ static ColliderCylinderInitType1 sCylinderInit = {
         OC1_NONE,
         COLSHAPE_CYLINDER,
     },
-    { 0x00, { 0x00000000, 0x00, 0x00 }, { 0x00000080, 0x00, 0x00 }, 0x00, 0x01, 0x00 },
-    { 30, 100, 0, { 0 } },
+    {
+        ELEM_MATERIAL_UNK0,
+        { 0x00000000, 0x00, 0x00 },
+        { 0x00000080, 0x00, 0x00 },
+        ATELEM_NONE,
+        ACELEM_ON,
+        OCELEM_NONE,
+    },
+    { 30, 100, 0, { 0, 0, 0 } },
 };
 
 static void* sEyeTextures[] = {

--- a/src/overlays/actors/ovl_En_Sb/z_en_sb.c
+++ b/src/overlays/actors/ovl_En_Sb/z_en_sb.c
@@ -57,7 +57,14 @@ static ColliderCylinderInitType1 sCylinderInit = {
         OC1_ON | OC1_TYPE_ALL,
         COLSHAPE_CYLINDER,
     },
-    { 0x00, { 0xFFCFFFFF, 0x04, 0x08 }, { 0xFFCFFFFF, 0x00, 0x00 }, 0x01, 0x01, 0x01 },
+    {
+        ELEM_MATERIAL_UNK0,
+        { 0xFFCFFFFF, 0x04, 0x08 },
+        { 0xFFCFFFFF, 0x00, 0x00 },
+        ATELEM_ON | ATELEM_SFX_NORMAL,
+        ACELEM_ON,
+        OCELEM_ON,
+    },
     { 30, 40, 0, { 0, 0, 0 } },
 };
 

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.c
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.c
@@ -55,7 +55,7 @@ void EnSkb_TakeDamage(EnSkb* this, PlayState* play);
 void EnSkb_SetupDeath(EnSkb* this, PlayState* play);
 void EnSkb_Death(EnSkb* this, PlayState* play);
 
-static ColliderJntSphElementInit sJntSphElementsInit[2] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Skj/z_en_skj.c
+++ b/src/overlays/actors/ovl_En_Skj/z_en_skj.c
@@ -204,8 +204,8 @@ static ColliderCylinderInitType1 D_80B01678 = {
     },
     {
         ELEM_MATERIAL_UNK0,
-        { 0xFFCFFFFF, 0x0, 0x08 },
-        { 0xFFCFFFFF, 0x0, 0x0 },
+        { 0xFFCFFFFF, 0x00, 0x08 },
+        { 0xFFCFFFFF, 0x00, 0x00 },
         ATELEM_ON | ATELEM_SFX_NORMAL,
         ACELEM_ON,
         OCELEM_ON,

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -99,7 +99,7 @@ static ColliderCylinderInit sCylinderInit2 = {
     { 20, 60, -30, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -98,7 +98,7 @@ static ColliderCylinderInit sCylinderInit2 = {
     { 20, 60, -30, { 0, 0, 0 } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -48,15 +48,29 @@ ActorProfile En_Sw_Profile = {
     /**/ EnSw_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
-        { ELEM_MATERIAL_UNK0, { 0xFFCFFFFF, 0x00, 0x08 }, { 0xFFC3FFFE, 0x00, 0x00 }, 0x01, 0x05, 0x01 },
+        {
+            ELEM_MATERIAL_UNK0,
+            { 0xFFCFFFFF, 0x00, 0x08 },
+            { 0xFFC3FFFE, 0x00, 0x00 },
+            ATELEM_ON | ATELEM_SFX_NORMAL,
+            ACELEM_ON | ACELEM_HOOKABLE,
+            OCELEM_ON,
+        },
         { 2, { { 0, -300, 0 }, 21 }, 100 },
     },
 };
 
 static ColliderJntSphInit sJntSphInit = {
-    { COL_MATERIAL_HIT6, 0x11, 0x09, 0x39, 0x10, COLSHAPE_JNTSPH },
+    {
+        COL_MATERIAL_HIT6,
+        AT_ON | AT_TYPE_ENEMY,
+        AC_ON | AC_TYPE_PLAYER,
+        OC1_ON | OC1_TYPE_ALL,
+        OC2_TYPE_1,
+        COLSHAPE_JNTSPH,
+    },
     1,
     sJntSphElementsInit,
 };

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -102,7 +102,7 @@ ActorProfile En_Tite_Profile = {
     /**/ EnTite_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Tp/z_en_tp.c
+++ b/src/overlays/actors/ovl_En_Tp/z_en_tp.c
@@ -68,7 +68,7 @@ ActorProfile En_Tp_Profile = {
     /**/ EnTp_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Trap/z_en_trap.c
+++ b/src/overlays/actors/ovl_En_Trap/z_en_trap.c
@@ -61,7 +61,14 @@ static ColliderCylinderInit sCylinderInit = {
         OC2_TYPE_1,
         COLSHAPE_CYLINDER,
     },
-    { ELEM_MATERIAL_UNK0, { 0x00000000, 0x00, 0x00 }, { 0x00001000, 0x00, 0x00 }, ATELEM_NONE, ACELEM_ON, OCELEM_ON },
+    {
+        ELEM_MATERIAL_UNK0,
+        { 0x00000000, 0x00, 0x00 },
+        { 0x00001000, 0x00, 0x00 },
+        ATELEM_NONE,
+        ACELEM_ON,
+        OCELEM_ON,
+    },
     { 30, 20, 0, { 0, 0, 0 } },
 };
 

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
@@ -50,7 +50,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_ON,
         OCELEM_NONE,
     },
-    { 9, 23, 0, { 0 } },
+    { 9, 23, 0, { 0, 0, 0 } },
 };
 
 ActorProfile En_Tubo_Trap_Profile = {

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -77,7 +77,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_ON,
         OCELEM_ON,
     },
-    { 30, 40, 0, { 0 } },
+    { 30, 40, 0, { 0, 0, 0 } },
 };
 
 static CollisionCheckInfoInit sColChkInfoInit = { 4, 30, 40, 150 };

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -63,7 +63,7 @@ void EnWf_SetupDie(EnWf* this);
 void EnWf_Die(EnWf* this, PlayState* play);
 s32 EnWf_DodgeRanged(PlayState* play, EnWf* this);
 
-static ColliderJntSphElementInit sJntSphElementsInit[4] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
+++ b/src/overlays/actors/ovl_En_Yabusame_Mark/z_en_yabusame_mark.c
@@ -39,7 +39,7 @@ static ColliderQuadInit sQuadInit = {
         ELEM_MATERIAL_UNK0,
         { 0x00000000, 0x00, 0x00 },
         { 0x0001F824, 0x00, 0x00 },
-        ATELEM_NONE | ATELEM_SFX_NORMAL,
+        ATELEM_NONE,
         ACELEM_ON,
         OCELEM_NONE,
     },

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -224,7 +224,7 @@ static u8 sFishingPlayerCinematicState = 0;
 static u8 sFishingCinematicTimer = 0;
 static u8 sSinkingLureFound = false;
 
-static ColliderJntSphElementInit sJntSphElementsInit[12] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -363,7 +363,7 @@ static ColliderJntSphInit sJntSphInit = {
     {
         COL_MATERIAL_NONE,
         AT_TYPE_ENEMY,
-        AC_TYPE_PLAYER,
+        AC_NONE | AC_TYPE_PLAYER,
         OC1_ON | OC1_TYPE_PLAYER,
         OC2_TYPE_1,
         COLSHAPE_JNTSPH,

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
@@ -79,7 +79,7 @@ static ColliderQuadInit sQuadInit = {
     { { { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f, 0.0f } } },
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
+++ b/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
@@ -57,7 +57,7 @@ static ColliderCylinderInit sCylinderInit = {
         ACELEM_ON,
         OCELEM_ON,
     },
-    { 55, 70, 0, { 0 } },
+    { 55, 70, 0, { 0, 0, 0 } },
 };
 
 static CollisionCheckInfoInit sColChkInfoInit = { 0, 12, 60, MASS_IMMOVABLE };

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
@@ -43,7 +43,7 @@ ActorProfile Obj_Comb_Profile = {
     /**/ ObjComb_Draw,
 };
 
-static ColliderJntSphElementInit sJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,

--- a/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
+++ b/src/overlays/actors/ovl_Obj_Dekujr/z_obj_dekujr.c
@@ -39,12 +39,19 @@ ActorProfile Obj_Dekujr_Profile = {
 static ColliderCylinderInitToActor sCylinderInit = {
     {
         NULL,
-        0x00,
-        0x00,
-        0x39,
+        AT_NONE,
+        AC_NONE,
+        OC1_ON | OC1_TYPE_ALL,
         COLSHAPE_CYLINDER,
     },
-    { 0x02, { 0x00000000, 0x00, 0x00 }, { 0xFFCFFFFF, 0x00, 0x00 }, 0x00, 0x00, 0x01 },
+    {
+        ELEM_MATERIAL_UNK2,
+        { 0x00000000, 0x00, 0x00 },
+        { 0xFFCFFFFF, 0x00, 0x00 },
+        ATELEM_NONE,
+        ACELEM_NONE,
+        OCELEM_ON,
+    },
     { 60, 80, 0, { 0, 0, 0 } },
 };
 

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -87,7 +87,7 @@ static f32 sFocusHeights[] = {
     30, // OBJSWITCH_TYPE_CRYSTAL_TARGETABLE
 };
 
-static ColliderTrisElementInit sRustyFloorTrisElementsInit[2] = {
+static ColliderTrisElementInit sRustyFloorTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,
@@ -125,7 +125,7 @@ static ColliderTrisInit sRustyFloorTrisInit = {
     sRustyFloorTrisElementsInit,
 };
 
-static ColliderTrisElementInit sEyeTrisElementsInit[2] = {
+static ColliderTrisElementInit sEyeTrisElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK4,
@@ -163,7 +163,7 @@ static ColliderTrisInit sEyeTrisInit = {
     sEyeTrisElementsInit,
 };
 
-static ColliderJntSphElementInit sCrystalJntSphElementsInit[1] = {
+static ColliderJntSphElementInit sCrystalJntSphElementsInit[] = {
     {
         {
             ELEM_MATERIAL_UNK0,


### PR DESCRIPTION
- implicit size for elements arrays (eg `ColliderTrisElementInit sTrisElementsInit[] = {` instead of `ColliderTrisElementInit sTrisElementsInit[3] = {`)
- various fixes (missing flags, raw hex -> flags, formatting)

On the TODO list, for subsequent PRs:
- use `ARRAY_COUNT` for the elements count
- use `HIT_BACKLASH` and `HIT_SPECIAL_EFFECT` names
- figure out dmgFlags