### PR TITLE
Add `BLEND_RATE_AND_FOG_NEAR`, fix extracted negative `blendRate`

### DIFF
--- a/include/environment.h
+++ b/include/environment.h
@@ -155,8 +155,10 @@ typedef struct CurrentEnvLightSettings {
 // The blendRate determines how fast the current light settings fade to the next one
 // (under LIGHT_MODE_SETTINGS, otherwise unused).
 
+#define ENV_LIGHT_SETTINGS_BLEND_RATE_AND_FOG_NEAR_PACK(blendRate, fogNear) (s16)((((blendRate) / 4) << 10) | (fogNear))
+
 // Get blend rate from `EnvLightSettings.blendRateAndFogNear` in 0-255 range
-#define ENV_LIGHT_SETTINGS_BLEND_RATE_U8(blendRateAndFogNear) (((blendRateAndFogNear) >> 10) * 4)
+#define ENV_LIGHT_SETTINGS_BLEND_RATE_U8(blendRateAndFogNear) (u8)(((blendRateAndFogNear) >> 10) * 4)
 #define ENV_LIGHT_SETTINGS_FOG_NEAR(blendRateAndFogNear) ((blendRateAndFogNear) & 0x3FF)
 
 typedef struct EnvLightSettings {

--- a/include/environment.h
+++ b/include/environment.h
@@ -155,7 +155,7 @@ typedef struct CurrentEnvLightSettings {
 // The blendRate determines how fast the current light settings fade to the next one
 // (under LIGHT_MODE_SETTINGS, otherwise unused).
 
-#define ENV_LIGHT_SETTINGS_BLEND_RATE_AND_FOG_NEAR_PACK(blendRate, fogNear) (s16)((((blendRate) / 4) << 10) | (fogNear))
+#define BLEND_RATE_AND_FOG_NEAR(blendRate, fogNear) (s16)((((blendRate) / 4) << 10) | (fogNear))
 
 // Get blend rate from `EnvLightSettings.blendRateAndFogNear` in 0-255 range
 #define ENV_LIGHT_SETTINGS_BLEND_RATE_U8(blendRateAndFogNear) (u8)(((blendRateAndFogNear) >> 10) * 4)

--- a/tools/assets/extract/extase_oot64/scene_rooms_resources.py
+++ b/tools/assets/extract/extase_oot64/scene_rooms_resources.py
@@ -296,7 +296,7 @@ class EnvLightSettingsListResource(CDataArrayNamedLengthResource):
         if blendRate < 0:
             blendRate += 0x100
         fogNear = v & 0x3FF
-        return f"ENV_LIGHT_SETTINGS_BLEND_RATE_AND_FOG_NEAR_PACK({blendRate}, {fogNear})"
+        return f"BLEND_RATE_AND_FOG_NEAR({blendRate}, {fogNear})"
 
     elem_cdata_ext = CDataExt_Struct(
         (

--- a/tools/assets/extract/extase_oot64/scene_rooms_resources.py
+++ b/tools/assets/extract/extase_oot64/scene_rooms_resources.py
@@ -293,8 +293,10 @@ class EnvLightSettingsListResource(CDataArrayNamedLengthResource):
 
     def write_blendRateAndFogNear(v):
         blendRate = (v >> 10) * 4
+        if blendRate < 0:
+            blendRate += 0x100
         fogNear = v & 0x3FF
-        return f"(({blendRate} / 4) << 10) | {fogNear}"
+        return f"ENV_LIGHT_SETTINGS_BLEND_RATE_AND_FOG_NEAR_PACK({blendRate}, {fogNear})"
 
     elem_cdata_ext = CDataExt_Struct(
         (


### PR DESCRIPTION
Before:
```c
((4 / 4) << 10) | 992, // blendRateAndFogNear
((-4 / 4) << 10) | 978, // blendRateAndFogNear
```

Note the -4

After:
```c
BLEND_RATE_AND_FOG_NEAR(4, 992), // blendRateAndFogNear
BLEND_RATE_AND_FOG_NEAR(252, 978), // blendRateAndFogNear
```