### PR TITLE
Fix macOS build for clang 17

### DIFF
--- a/src/libgcc/longlong.h
+++ b/src/libgcc/longlong.h
@@ -92,8 +92,8 @@
     __asm__("multu %2,%3\n\t"    \
             "mflo %0\n\t"        \
             "mfhi %1"            \
-            : "=d"(w0), "=d"(w1) \
-            : "d"((USItype)(u)), "d"((USItype)(v)))
+            : "=r"(w0), "=r"(w1) \
+            : "r"((USItype)(u)), "r"((USItype)(v)))
 #endif
 
 #define udiv_qrnnd(q, r, n1, n0, d)                                             \


### PR DESCRIPTION
Currently, CC_CHECK fails with
```
In file included from src/libgcc/__divdi3.c:2:
./src/libgcc/libgcc2.inc.c:231:17: error: invalid output constraint '=d' in asm
  231 |                 umul_ppmm(m1, m0, q0, d0);
      |                 ^
./src/libgcc/longlong.h:95:15: note: expanded from macro 'umul_ppmm'
   95 |             : "=d"(w0), "=d"(w1) \
      |               ^
```
according to the [GCC docs](https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/Machine-Constraints.html), for MIPS `=d` is the same as `=r`, and clang seems happy with that