### PR TITLE
Don't include calling isPrintfInit in iQue debug builds

### DIFF
--- a/src/boot/boot_main.c
+++ b/src/boot/boot_main.c
@@ -36,7 +36,7 @@ void bootproc(void) {
 
     gCartHandle = osCartRomInit();
     osDriveRomInit();
-#if DEBUG_FEATURES
+#if DEBUG_FEATURES && !PLATFORM_IQUE
     isPrintfInit();
 #endif
     Locale_Init();


### PR DESCRIPTION
When building ique-cn with DEBUG_FEATURES=1, this causes an undefined symbol error. The resolution is to ensure the call is not included, as ISViewer doesn't exist on iQue and probing for it would cause a crash.
