### PR TITLE
Allow `atblgen` to process `sequence_order.in` with empty lines in between lines for building on Macos

### DIFF
--- a/tools/audio/Makefile
+++ b/tools/audio/Makefile
@@ -46,7 +46,7 @@ sfc_LDFLAGS     := $(XML_LDFLAGS)
 
 define COMPILE =
 $(1): $($1_SOURCES)
-	$(CC) $(CFLAGS) $($1_CFLAGS) $$^ $($1_LDFLAGS) -o $$@
+	$(CC) $(CFLAGS) $(OPTFLAGS) $($1_CFLAGS) $$^ $($1_LDFLAGS) -o $$@
 endef
 
 $(foreach p,$(PROGRAMS),$(eval $(call COMPILE,$(p))))

--- a/tools/audio/aifc.c
+++ b/tools/audio/aifc.c
@@ -96,8 +96,12 @@ f64_to_f80(double f64, uint8_t *f80)
     } f80tmp;
 
     // get f64 bits
-
-    uint64_t f64_bits = *(uint64_t *)&f64;
+    union {
+        double f;
+        uint64_t u;
+    } tp;
+    tp.f = f64;
+    uint64_t f64_bits = tp.u;
 
     int f64_sgn = F64_GET_SGN(f64_bits);
     int f64_exponent = F64_GET_EXP(f64_bits);
@@ -155,8 +159,12 @@ f80_to_f64(double *f64, uint8_t *f80)
                         ((uint64_t)f64_mantissa_hi << 32) | ((uint64_t)f64_mantissa_lo);
 
     // write double
-
-    *f64 = *(double *)&f64_bits;
+    union {
+        double f;
+        uint64_t u;
+    } tp;
+    tp.u = f64_bits;
+    *f64 = tp.f;
 }
 
 static void


### PR DESCRIPTION
The present changes are a direct copy-paste from https://github.com/zeldaret/mm/pull/1850

This fixes building on macos due to a kinda specific issue with Apple clang.

## The issue

When trying to build on Macos (specifically MacOS 12, Monteray with Apple clang 13.0.0 (clang-1300.0.29.30), idk if other versions have this issue too) `make` stops with the following error from `atblgen`:
```
Failed to match line 1: ""
regexec error: "regexec() failed to match"
Error: Malformed build/n64-us/assets/audio/sequence_order.in?
```

`atblgen` makes the assumption that the `sequence_order.in` file has no extra data, spaces, empty lines, etc. but the file somehow ends up having empty lines between each line on macos.

This file is created by using the C preprocessor to process `include/tables/sequence_table.h`. In normal circumstances this file should look like this snip,
```
(Sequence_0,NA_BGM_GENERAL_SFX)
(Sequence_1,NA_BGM_AMBIENCE)
(Sequence_2,NA_BGM_TERMINA_FIELD)
(Sequence_3,NA_BGM_CHASE)
(Sequence_4,NA_BGM_MAJORAS_THEME)
```
but it ends up looking like this instead
```
(Sequence_0,NA_BGM_GENERAL_SFX)

(Sequence_1,NA_BGM_AMBIENCE)

(Sequence_2,NA_BGM_TERMINA_FIELD)

(Sequence_3,NA_BGM_CHASE)

(Sequence_4,NA_BGM_MAJORAS_THEME)
```
which `atblgen` doesn't like.

I believe this happens because there are lines with comments between each macro in [`sequence_table.h`](https://github.com/zeldaret/mm/blob/0877ce4adf28a8e73e05c3c58682273b8bf28749/include/tables/sequence_table.h) and for some reason this Apple clang version decided to preserve those empty lines

## The fix

The fix just makes `atblgen` skip empty lines.

## Misc

I threw `atblgen` to valgrind to check the fix was working as intended and noted a bunch of memory that was being free before exit, so I fixed them.

I also noted the tools/audio makefile was not using `OPTFLAGS` when building those tools, so I fixed that too.