### PR TITLE
Add all_versions_built dummy job for github status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
     name: All versions built
     needs: [build_repo]
     runs-on: ubuntu-latest
+    steps:
+      - run: ''
 
   merge_bss_fixes:
     name: Merge BSS fixes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
           name: oot-${{ matrix.version }}.map
           path: build/${{ matrix.version }}/oot-${{ matrix.version }}.map
 
+  # This job does not do anything, its purpose is to be used as a status check in GitHub rules.
+  all_versions_built:
+    name: All versions built
+    needs: [build_repo]
+
   merge_bss_fixes:
     name: Merge BSS fixes
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
   all_versions_built:
     name: All versions built
     needs: [build_repo]
+    runs-on: ubuntu-latest
 
   merge_bss_fixes:
     name: Merge BSS fixes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,13 @@ jobs:
     name: All versions built
     needs: [build_repo]
     runs-on: ubuntu-latest
+    # Solution 1 from https://github.com/actions/runner/issues/2566#issuecomment-3053484216
+    if: always()
     steps:
-      - run: ''
+      - run: |
+         if [ "${{ needs.build_repo.result }}" != "success" ]; then
+           exit 1
+         fi
 
   merge_bss_fixes:
     name: Merge BSS fixes

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -38,7 +38,8 @@
 #include "cic6105.h"
 #endif
 
-#pragma increment_block_number ""
+#pragma increment_block_number "gc-eu:224 gc-eu-mq:224 gc-jp:224 gc-jp-ce:224 gc-jp-mq:224 gc-us:224 gc-us-mq:224" \
+                               "ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -38,8 +38,7 @@
 #include "cic6105.h"
 #endif
 
-#pragma increment_block_number "gc-eu:224 gc-eu-mq:224 gc-jp:224 gc-jp-ce:224 gc-jp-mq:224 gc-us:224 gc-us-mq:224" \
-                               "ntsc-1.0:128 ntsc-1.1:128 ntsc-1.2:128 pal-1.0:128 pal-1.1:128"
+#pragma increment_block_number ""
 
 #define FLAGS ACTOR_FLAG_UPDATE_CULLING_DISABLED
 


### PR DESCRIPTION
Basically, rules can be added to github repos so that "status checks" on a PR have to succeed before a PR can be merged. Status checks can be the result of github actions jobs, which we are interested in.

However status checks can't be the result of whole workflows such as our ci.yml workflow that builds all versions, so we'd need to add the result of every build job (for each version) to the github rule. To avoid having to do that (adding 16 status checks), this PR adds a dummy job depending on the build jobs, and we can then use that dummy job for a single status check