### PR TITLE
Compiler binaries download: separate from extract and checksum

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -10,5 +10,6 @@ reloc_prereq
 vtxdis
 yaz0
 
+compiler_archives/archives/
 ido_recomp/
 egcs/

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -42,6 +42,7 @@ all: $(PROGRAMS) $(IDO_RECOMP_5_3_DIR) $(IDO_RECOMP_7_1_DIR) $(EGCS_DIR)
 
 clean:
 	$(RM) $(PROGRAMS) $(addsuffix .exe,$(PROGRAMS))
+	$(RM) -r compiler_archives/archives
 	$(RM) -r ido_recomp egcs
 	$(MAKE) -C fado clean
 	$(MAKE) -C audio clean
@@ -71,15 +72,39 @@ endef
 
 $(foreach p,$(PROGRAMS),$(eval $(call COMPILE,$(p))))
 
-$(IDO_RECOMP_5_3_DIR):
-	mkdir -p $@
-	curl -sL https://github.com/decompals/ido-static-recomp/releases/download/$(IDO_RECOMP_VERSION)/ido-5.3-recomp-$(DETECTED_OS).tar.gz | tar xz -C $@
+compiler_archives/archives/ido-5.3-recomp-$(DETECTED_OS).tar.gz:
+	mkdir -p $(@D)
+	curl -sL https://github.com/decompals/ido-static-recomp/releases/download/$(IDO_RECOMP_VERSION)/ido-5.3-recomp-$(DETECTED_OS).tar.gz -o $@.unverified
+	sha256sum -c compiler_archives/signatures/ido-5.3-recomp-$(DETECTED_OS).tar.gz.sha256
+	mv $@.unverified $@
 
-$(IDO_RECOMP_7_1_DIR):
+$(IDO_RECOMP_5_3_DIR): compiler_archives/archives/ido-5.3-recomp-$(DETECTED_OS).tar.gz
 	mkdir -p $@
-	curl -sL https://github.com/decompals/ido-static-recomp/releases/download/$(IDO_RECOMP_VERSION)/ido-7.1-recomp-$(DETECTED_OS).tar.gz | tar xz -C $@
+	tar xzf $< -C $@
 
-$(EGCS_DIR):
+compiler_archives/archives/ido-7.1-recomp-$(DETECTED_OS).tar.gz:
+	mkdir -p $(@D)
+	curl -sL https://github.com/decompals/ido-static-recomp/releases/download/$(IDO_RECOMP_VERSION)/ido-7.1-recomp-$(DETECTED_OS).tar.gz -o $@.unverified
+	sha256sum -c compiler_archives/signatures/ido-7.1-recomp-$(DETECTED_OS).tar.gz.sha256
+	mv $@.unverified $@
+
+$(IDO_RECOMP_7_1_DIR): compiler_archives/archives/ido-7.1-recomp-$(DETECTED_OS).tar.gz
 	mkdir -p $@
-	curl -sL https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/$(EGCS_BINUTILS_VERSION)/mips-binutils-egcs-2.9.5-$(DETECTED_OS).tar.gz | tar xz -C $@
-	curl -sL https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/$(EGCS_GCC_VERSION)/mips-gcc-egcs-2.91.66-$(DETECTED_OS).tar.gz | tar xz -C $@
+	tar xzf $< -C $@
+
+compiler_archives/archives/mips-binutils-egcs-2.9.5-$(DETECTED_OS).tar.gz:
+	mkdir -p $(@D)
+	curl -sL https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/$(EGCS_BINUTILS_VERSION)/mips-binutils-egcs-2.9.5-$(DETECTED_OS).tar.gz -o $@.unverified
+	sha256sum -c compiler_archives/signatures/mips-binutils-egcs-2.9.5-$(DETECTED_OS).tar.gz.sha256
+	mv $@.unverified $@
+
+compiler_archives/archives/mips-gcc-egcs-2.91.66-$(DETECTED_OS).tar.gz:
+	mkdir -p $(@D)
+	curl -sL https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/$(EGCS_GCC_VERSION)/mips-gcc-egcs-2.91.66-$(DETECTED_OS).tar.gz -o $@.unverified
+	sha256sum -c compiler_archives/signatures/mips-gcc-egcs-2.91.66-$(DETECTED_OS).tar.gz.sha256
+	mv $@.unverified $@
+
+$(EGCS_DIR): compiler_archives/archives/mips-binutils-egcs-2.9.5-$(DETECTED_OS).tar.gz compiler_archives/archives/mips-gcc-egcs-2.91.66-$(DETECTED_OS).tar.gz
+	mkdir -p $@
+	tar xzf compiler_archives/archives/mips-binutils-egcs-2.9.5-$(DETECTED_OS).tar.gz -C $@
+	tar xzf compiler_archives/archives/mips-gcc-egcs-2.91.66-$(DETECTED_OS).tar.gz -C $@

--- a/tools/compiler_archives/signatures/ido-5.3-recomp-linux.tar.gz.sha256
+++ b/tools/compiler_archives/signatures/ido-5.3-recomp-linux.tar.gz.sha256
@@ -1,0 +1,1 @@
+ab5c741561f80913d58c8b074771f23941a3edd312505a8ebed6d1dfeb65e506  compiler_archives/archives/ido-5.3-recomp-linux.tar.gz.unverified

--- a/tools/compiler_archives/signatures/ido-5.3-recomp-macos.tar.gz.sha256
+++ b/tools/compiler_archives/signatures/ido-5.3-recomp-macos.tar.gz.sha256
@@ -1,0 +1,1 @@
+5b1ca006ee4b158ffba0422fc3f00b9b330f9036f279bae2ea1b4703317ad9c0  compiler_archives/archives/ido-5.3-recomp-macos.tar.gz.unverified

--- a/tools/compiler_archives/signatures/ido-7.1-recomp-linux.tar.gz.sha256
+++ b/tools/compiler_archives/signatures/ido-7.1-recomp-linux.tar.gz.sha256
@@ -1,0 +1,1 @@
+0d411696e178fcca34c31c3bf02011b928d7fd9c1fa7f8bf45070e0781b58e15  compiler_archives/archives/ido-7.1-recomp-linux.tar.gz.unverified

--- a/tools/compiler_archives/signatures/ido-7.1-recomp-macos.tar.gz.sha256
+++ b/tools/compiler_archives/signatures/ido-7.1-recomp-macos.tar.gz.sha256
@@ -1,0 +1,1 @@
+7f75570ed1ca14e6161b84b10743d440c685f27291bfbfaf87c6a82236553bc6  compiler_archives/archives/ido-7.1-recomp-macos.tar.gz.unverified

--- a/tools/compiler_archives/signatures/mips-binutils-egcs-2.9.5-linux.tar.gz.sha256
+++ b/tools/compiler_archives/signatures/mips-binutils-egcs-2.9.5-linux.tar.gz.sha256
@@ -1,0 +1,1 @@
+54eb249ccfbc9956048de5c740ff41d6ab6137cfc3a872739e465349327bbcbf  compiler_archives/archives/mips-binutils-egcs-2.9.5-linux.tar.gz.unverified

--- a/tools/compiler_archives/signatures/mips-binutils-egcs-2.9.5-macos.tar.gz.sha256
+++ b/tools/compiler_archives/signatures/mips-binutils-egcs-2.9.5-macos.tar.gz.sha256
@@ -1,0 +1,1 @@
+71d16bb4a0e537ff76421fd5d26aaad44d073dfc0d0ee66344250169500d4706  compiler_archives/archives/mips-binutils-egcs-2.9.5-macos.tar.gz.unverified

--- a/tools/compiler_archives/signatures/mips-gcc-egcs-2.91.66-linux.tar.gz.sha256
+++ b/tools/compiler_archives/signatures/mips-gcc-egcs-2.91.66-linux.tar.gz.sha256
@@ -1,0 +1,1 @@
+47b8cfccbad18fba40daa3fb01f4d71da7895d9183ab3ab91d6d7b1d27a715ab  compiler_archives/archives/mips-gcc-egcs-2.91.66-linux.tar.gz.unverified

--- a/tools/compiler_archives/signatures/mips-gcc-egcs-2.91.66-macos.tar.gz.sha256
+++ b/tools/compiler_archives/signatures/mips-gcc-egcs-2.91.66-macos.tar.gz.sha256
@@ -1,0 +1,1 @@
+ceb26826e708ce484a120b002680dff9f13fd3f71a4b4c51e991994107b29542  compiler_archives/archives/mips-gcc-egcs-2.91.66-macos.tar.gz.unverified


### PR DESCRIPTION
Before (current main):
compilers (ido recomp, gcc-egcs and binutils-egcs) were downloaded and piped to tar directly

Now (this PR):
- compilers archives are downloaded to `tools/compiler_archives/archives/*.unverified`
- then sha256sum checks them
- then their `.unverified` suffix is removed
- then they're extracted

The end goal is to modify the build container image and github actions so that the archives are embedded in the container image, and the actions copy the archives to `tools/compiler_archives/archives/`, so actions will never fail from being unable to download the archives, which seems to be a possibility (rate limits?):

https://github.com/zeldaret/oot/actions/runs/25359018858/job/74354242787?pr=2697
```
mkdir -p egcs/linux
curl -sL https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/0.6/mips-binutils-egcs-2.9.5-linux.tar.gz | tar xz -C egcs/linux

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
make[1]: *** [Makefile:80: ido_recomp/linux/7.1] Error 2
```

And while I was at it I added checksumming for security purposes