### PR TITLE
Add docs/ to doxygen input

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = README.md src/ include/
+INPUT                  = README.md docs/ src/ include/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This causes Doxygen to include docs/ documents, instead of ignoring them.