### PR TITLE
z_player.c: enum for trade item identification

### DIFF
--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6072,7 +6072,7 @@ s32 Player_ActionHandler_13(Player* this, PlayState* play) {
                         if (sp2C >= 0) {
                             sp2C = sp2C + 1;
                         } else {
-                            sp2C = sp28 + 0x18;
+                            sp2C = sp28 + EXCH_ITEM_BOTTLE_FISH;
                         }
 
                         talkActor = this->talkActor;


### PR DESCRIPTION
Use the enum value from `item.h` instead of the hardcoded `0x18`, which equals the first bottle item, seemingly for identifying trade items.