### PR TITLE
gha: Prevent running outside zeldaret/oot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
 
   # This job does not do anything, its purpose is to be used as a status check in GitHub rules.
   all_versions_built:
+    if: ${{ github.repository == 'zeldaret/oot' }}
     name: All versions built
     needs: [build_repo]
     runs-on: ubuntu-latest
@@ -87,6 +88,7 @@ jobs:
          fi
 
   merge_bss_fixes:
+    if: ${{ github.repository == 'zeldaret/oot' }}
     name: Merge BSS fixes
     runs-on: ubuntu-latest
     needs: [build_repo]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
   build_repo:
     # This is a *private* build container.
     container: ghcr.io/zeldaret/oot-build:main
+    # Prevent running outside zeldaret/oot as fetching the container would fail anyway.
+    if: ${{ github.repository == 'zeldaret/oot' }}
 
     name: Build repo (${{ matrix.version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,11 @@ jobs:
 
   # This job does not do anything, its purpose is to be used as a status check in GitHub rules.
   all_versions_built:
-    if: ${{ github.repository == 'zeldaret/oot' }}
     name: All versions built
     needs: [build_repo]
     runs-on: ubuntu-latest
     # Solution 1 from https://github.com/actions/runner/issues/2566#issuecomment-3053484216
-    if: always()
+    if: 'always() && ${{ github.repository == ''zeldaret/oot'' }}'
     steps:
       - run: |
          if [ "${{ needs.build_repo.result }}" != "success" ]; then
@@ -88,11 +87,10 @@ jobs:
          fi
 
   merge_bss_fixes:
-    if: ${{ github.repository == 'zeldaret/oot' }}
     name: Merge BSS fixes
     runs-on: ubuntu-latest
     needs: [build_repo]
-    if: '!cancelled()'  # Run even if build_repo fails
+    if: '!cancelled() && ${{ github.repository == ''zeldaret/oot'' }}'  # Run even if build_repo fails
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
I've noticed that the ci.yml workflow is always trying to run on my fork which is just wasteful. (it fails to fetch the container)
I could just disable actions in my fork but this seems like a better idea in case someone does want actions running on their fork