### PR TITLE
[CI] Fix apply_fix_bss_patches.py

### DIFF
--- a/.github/scripts/apply_fix_bss_patches.py
+++ b/.github/scripts/apply_fix_bss_patches.py
@@ -64,6 +64,7 @@ def set_increment_block_numbers(
     for l in p.read_text().splitlines(keepends=True):
         if l.startswith("#pragma increment_block_number"):
             is_in_pragma = True
+            pragma_lines = []
         if not is_in_pragma:
             new_lines.append(l)
         if is_in_pragma:


### PR DESCRIPTION
Imagine writing buggy code, couldn't be me

This fixes the `set_increment_block_numbers` function to no longer choke when there are several `#pragma increment_block_number` in a file. Before, it choked due to not resetting the list of pragma lines when encountering a new pragma 
Fixes eg https://github.com/zeldaret/oot/actions/runs/31796801252/job/94757012349?pr=2692