### PR TITLE
`Item_Give` slot macro UB comment

### DIFF
--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -1399,6 +1399,10 @@ u8 Item_Give(PlayState* play, u8 item) {
     s16 slot;
     s16 temp;
 
+    //! @bug Undefined behavior: This macro (from save.h) will return a value out of bounds for items
+    //! that are not inventory items. This has no consequences for IDO nor GCC yet, but other compilers
+    //! depending on optimization have removed parts of the function due to UB, resulting in non-inventory
+    //! items ending up in inventory slots.
     slot = SLOT(item);
     if (item >= ITEM_DEKU_STICKS_5) {
         slot = SLOT(sExtraItemBases[item - ITEM_DEKU_STICKS_5]);


### PR DESCRIPTION
A bug comment in `Item_Give` regarding undefined behavior, reported here: https://github.com/HarbourMasters/Shipwright/pull/7021
Compilation with Clang and LTO led to GS tokens ending up in item inventory because the GS token check in the function was removed due to UB.
Was also discussed today on Discord in #oot-decomp.